### PR TITLE
fix: wire HTTP route handler to router::handle_request via axum State

### DIFF
--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -162,7 +162,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     } else {
                         config.server.http_addr
                     };
-                    server.serve_http(addr).await?
+                    std::sync::Arc::new(server).serve_http(addr).await?
                 }
                 other => anyhow::bail!("unknown transport: {other}"),
             }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1,5 +1,6 @@
-use crate::server::HarnessServer;
+use crate::{router, server::HarnessServer};
 use axum::{
+    extract::State,
     routing::post,
     Json, Router,
 };
@@ -7,29 +8,21 @@ use harness_protocol::{RpcRequest, RpcResponse};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-#[allow(dead_code)]
-struct AppState {
-    server: Arc<HarnessServer>,
-}
-
-pub async fn serve(_server: &HarnessServer, addr: SocketAddr) -> anyhow::Result<()> {
-    // We need to create a new server reference for the router
-    // In production, the server would be Arc-wrapped from the start
+pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Result<()> {
     tracing::info!("harness: HTTP server listening on {addr}");
 
     let app = Router::new()
-        .route("/rpc", post(handle_rpc));
+        .route("/rpc", post(handle_rpc))
+        .with_state(server);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())
 }
 
-async fn handle_rpc(Json(req): Json<RpcRequest>) -> Json<RpcResponse> {
-    // Placeholder: in production, this would use shared state
-    Json(RpcResponse::error(
-        req.id,
-        harness_protocol::INTERNAL_ERROR,
-        "HTTP transport not fully wired yet",
-    ))
+async fn handle_rpc(
+    State(server): State<Arc<HarnessServer>>,
+    Json(req): Json<RpcRequest>,
+) -> Json<RpcResponse> {
+    Json(router::handle_request(&server, req).await)
 }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -29,7 +29,7 @@ impl HarnessServer {
     }
 
     /// Start in HTTP + WebSocket mode.
-    pub async fn serve_http(&self, addr: SocketAddr) -> anyhow::Result<()> {
+    pub async fn serve_http(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
         crate::http::serve(self, addr).await
     }
 }


### PR DESCRIPTION
Closes #1

## Changes

- `http.rs`: accept `Arc<HarnessServer>` in `serve`, register it as axum `State`, and replace the placeholder `handle_rpc` with one that extracts `State<Arc<HarnessServer>>` and delegates to `router::handle_request`
- `server.rs`: change `serve_http` receiver to `self: Arc<Self>` to match
- `commands.rs`: wrap `HarnessServer` in `Arc::new` at the call site