### PR TITLE
feat: add GET /health endpoint

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -52,7 +52,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
 }
 
 async fn health_check(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    let count = state.tasks.list_all().len();
+    let count = state.tasks.count();
     Json(json!({"status": "ok", "tasks": count}))
 }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -146,6 +146,10 @@ impl TaskStore {
         self.cache.get(id).map(|r| r.value().clone())
     }
 
+    pub fn count(&self) -> usize {
+        self.cache.len()
+    }
+
     pub fn list_all(&self) -> Vec<TaskState> {
         self.cache.iter().map(|e| e.value().clone()).collect()
     }


### PR DESCRIPTION
Closes #16

Add `GET /health` endpoint returning `{"status": "ok", "tasks": <count>}` for monitoring.