### PR TITLE
fix: always trigger /gemini review after pushing fixes

### DIFF
--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -81,11 +81,10 @@ async fn run_review_loop(
         println!("[harness] Waiting {wait}s for CI and review bot...");
         sleep(Duration::from_secs(wait)).await;
 
-        let is_last_round = round == max_rounds;
         println!("[harness] Review round {round}/{max_rounds}, PR #{pr}");
 
         let req = AgentRequest {
-            prompt: prompts::review_prompt(issue, pr, round, is_last_round),
+            prompt: prompts::review_prompt(issue, pr, round),
             project_root: project.clone(),
             ..Default::default()
         };

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -38,8 +38,9 @@ pub fn implement_from_prompt(prompt: &str) -> String {
 /// `round` controls convergence behavior:
 /// - Round 2: fix all critical/high/medium comments
 /// - Round 3+: only fix critical/high; skip medium style/design suggestions
-/// - `is_last_round`: controls whether to trigger `/gemini review`
-pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, is_last_round: bool) -> String {
+///
+/// Every round that pushes fixes triggers `/gemini review` to ensure new code is verified.
+pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32) -> String {
     let context = match issue {
         Some(n) => format!("You previously created PR #{pr} for issue #{n}.\n"),
         None => format!("Review PR #{pr}.\n"),
@@ -52,14 +53,10 @@ pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, is_last_round: boo
          Skip medium severity style/design suggestions — they are acceptable for now."
     };
 
-    let push_action = if is_last_round {
-        format!(
-            "commit, push, then run `gh pr comment {pr} --body '/gemini review'` \
-             to trigger a final re-review"
-        )
-    } else {
-        "commit and push (do NOT trigger /gemini review this round to avoid feedback inflation)".into()
-    };
+    let push_action = format!(
+        "commit, push, then run `gh pr comment {pr} --body '/gemini review'` \
+         to trigger re-review on the new code"
+    );
 
     format!(
         "{context}\
@@ -143,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_review_prompt_with_issue() {
-        let p = review_prompt(Some(5), 10, 2, false);
+        let p = review_prompt(Some(5), 10, 2);
         assert!(p.contains("issue #5"));
         assert!(p.contains("PR #10"));
         assert!(p.contains("medium")); // round 2 includes medium
@@ -151,28 +148,28 @@ mod tests {
 
     #[test]
     fn test_review_prompt_without_issue() {
-        let p = review_prompt(None, 10, 2, false);
+        let p = review_prompt(None, 10, 2);
         assert!(p.contains("PR #10"));
         assert!(!p.contains("issue #")); // no issue reference when None
     }
 
     #[test]
     fn test_review_prompt_late_round_skips_medium() {
-        let p = review_prompt(None, 10, 3, false);
+        let p = review_prompt(None, 10, 3);
         assert!(p.contains("Skip medium"));
-        assert!(p.contains("do NOT trigger /gemini review"));
     }
 
     #[test]
-    fn test_review_prompt_last_round_triggers_gemini() {
-        let p = review_prompt(None, 10, 4, true);
+    fn test_review_prompt_always_triggers_gemini_review() {
+        let p = review_prompt(None, 10, 2);
         assert!(p.contains("/gemini review"));
-        assert!(p.contains("final re-review"));
+        let p = review_prompt(None, 10, 4);
+        assert!(p.contains("/gemini review"));
     }
 
     #[test]
     fn test_review_prompt_constraints() {
-        let p = review_prompt(None, 10, 2, false);
+        let p = review_prompt(None, 10, 2);
         assert!(p.contains("NEVER downgrade dependency"));
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -304,11 +304,10 @@ async fn run_task(
 
         update_status(store, task_id, TaskStatus::Reviewing, round).await;
 
-        let is_last_round = round == last_review_round;
         let resp = tokio::time::timeout(
             turn_timeout,
             agent.execute(AgentRequest {
-                prompt: prompts::review_prompt(req.issue, pr_num, round, is_last_round),
+                prompt: prompts::review_prompt(req.issue, pr_num, round),
                 project_root: project.clone(),
                 context: skill_items.clone(),
                 ..Default::default()


### PR DESCRIPTION
## Summary
- Fix review loop skipping re-review after fix commits — new code was merged without Gemini verification
- Remove `is_last_round` gate on `/gemini review` trigger: every round that pushes fixes now triggers re-review
- Remove unused `is_last_round` parameter from `review_prompt`

## Root cause
`review_prompt` for non-last rounds contained: "do NOT trigger /gemini review this round to avoid feedback inflation". This meant after the agent fixed Gemini's comments and pushed, the next round saw only the old (already addressed) review and declared LGTM — merging unreviewed code.

## Test plan
- [x] All 84 tests pass
- [x] Updated test: `test_review_prompt_always_triggers_gemini_review` verifies every round includes `/gemini review`