### PR TITLE
fix: verify Gemini re-review before LGTM after fix commits

### DIFF
--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -77,14 +77,17 @@ async fn run_review_loop(
         None => std::borrow::Cow::Owned(format!("PR #{pr}")),
     };
 
-    for round in 1..=max_rounds {
+    let mut prev_fixed = false;
+    let mut round = 1u32;
+
+    while round <= max_rounds {
         println!("[harness] Waiting {wait}s for CI and review bot...");
         sleep(Duration::from_secs(wait)).await;
 
         println!("[harness] Review round {round}/{max_rounds}, PR #{pr}");
 
         let req = AgentRequest {
-            prompt: prompts::review_prompt(issue, pr, round),
+            prompt: prompts::review_prompt(issue, pr, round, prev_fixed),
             project_root: project.clone(),
             ..Default::default()
         };
@@ -92,10 +95,18 @@ async fn run_review_loop(
         let resp = agent.execute(req).await?;
         println!("{}", resp.output);
 
+        if prompts::is_waiting(&resp.output) {
+            println!("[harness] Gemini hasn't re-reviewed yet, retrying...");
+            continue;
+        }
+
         if prompts::is_lgtm(&resp.output) {
             println!("[harness] LGTM — {url_display}");
             return Ok(());
         }
+
+        prev_fixed = true;
+        round += 1;
     }
 
     println!("[harness] Reached max rounds ({max_rounds}), PR status: {url_display}");

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -39,8 +39,10 @@ pub fn implement_from_prompt(prompt: &str) -> String {
 /// - Round 2: fix all critical/high/medium comments
 /// - Round 3+: only fix critical/high; skip medium style/design suggestions
 ///
-/// Every round that pushes fixes triggers `/gemini review` to ensure new code is verified.
-pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32) -> String {
+/// When `prev_fixed` is true (previous round pushed code), the agent must first
+/// verify that Gemini has submitted a **new** review covering the latest commit
+/// before declaring LGTM. If no new review exists yet, agent outputs WAITING.
+pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, prev_fixed: bool) -> String {
     let context = match issue {
         Some(n) => format!("You previously created PR #{pr} for issue #{n}.\n"),
         None => format!("Review PR #{pr}.\n"),
@@ -58,17 +60,37 @@ pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32) -> String {
          to trigger re-review on the new code"
     );
 
+    let freshness_check = if prev_fixed {
+        format!(
+            "\n\nIMPORTANT — New review verification:\n\
+             The previous round pushed a fix commit. Before evaluating review status, \
+             you MUST verify that Gemini has submitted a NEW review covering the latest commit:\n\
+             1. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/reviews --jq '.[-1].submitted_at'` \
+             to get the timestamp of the most recent review\n\
+             2. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/commits --jq '.[-1].commit.committer.date'` \
+             to get the timestamp of the latest commit\n\
+             3. If the latest review was submitted BEFORE the latest commit, \
+             Gemini has not yet re-reviewed the new code. \
+             In this case, print WAITING on the last line and stop.\n\
+             4. Only proceed with the review evaluation below if the latest review \
+             was submitted AFTER the latest commit."
+        )
+    } else {
+        String::new()
+    };
+
     format!(
         "{context}\
          Steps:\n\
          1. Run `gh pr checks {pr}` to check CI status\n\
-         2. Run `gh api repos/{{owner}}/{{repo}}/pulls/{pr}/reviews` to read review verdicts\n\
-         3. Run `gh api repos/{{owner}}/{{repo}}/pulls/{pr}/comments` to read inline review comments\n\
+         2. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/reviews` to read review verdicts\n\
+         3. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/comments` to read inline review comments\n\
          4. {severity_guidance}\n\
          5. If all CI checks pass and there are no unresolved review comments \
          that match the severity criteria above, print LGTM on the last line\n\
          6. Otherwise fix the issues, {push_action}, \
-         and print FIXED on the last line\n\n\
+         and print FIXED on the last line\
+         {freshness_check}\n\n\
          Constraints:\n\
          - NEVER downgrade dependency versions\n\
          - Do NOT refactor working code for style preferences\n\
@@ -104,12 +126,21 @@ pub fn extract_pr_number(url: &str) -> Option<u64> {
 
 /// Check if agent output's last non-empty line is exactly "LGTM".
 pub fn is_lgtm(output: &str) -> bool {
+    last_non_empty_line(output) == Some("LGTM")
+}
+
+/// Check if agent output's last non-empty line is exactly "WAITING".
+/// This means Gemini has not yet re-reviewed after the latest fix commit.
+pub fn is_waiting(output: &str) -> bool {
+    last_non_empty_line(output) == Some("WAITING")
+}
+
+fn last_non_empty_line(output: &str) -> Option<&str> {
     output
         .lines()
         .rev()
         .find(|l| !l.trim().is_empty())
-        .map(|l| l.trim() == "LGTM")
-        .unwrap_or(false)
+        .map(|l| l.trim())
 }
 
 #[cfg(test)]
@@ -140,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_review_prompt_with_issue() {
-        let p = review_prompt(Some(5), 10, 2);
+        let p = review_prompt(Some(5), 10, 2, false);
         assert!(p.contains("issue #5"));
         assert!(p.contains("PR #10"));
         assert!(p.contains("medium")); // round 2 includes medium
@@ -148,29 +179,47 @@ mod tests {
 
     #[test]
     fn test_review_prompt_without_issue() {
-        let p = review_prompt(None, 10, 2);
+        let p = review_prompt(None, 10, 2, false);
         assert!(p.contains("PR #10"));
         assert!(!p.contains("issue #")); // no issue reference when None
     }
 
     #[test]
     fn test_review_prompt_late_round_skips_medium() {
-        let p = review_prompt(None, 10, 3);
+        let p = review_prompt(None, 10, 3, false);
         assert!(p.contains("Skip medium"));
     }
 
     #[test]
     fn test_review_prompt_always_triggers_gemini_review() {
-        let p = review_prompt(None, 10, 2);
+        let p = review_prompt(None, 10, 2, false);
         assert!(p.contains("/gemini review"));
-        let p = review_prompt(None, 10, 4);
+        let p = review_prompt(None, 10, 4, true);
         assert!(p.contains("/gemini review"));
     }
 
     #[test]
+    fn test_review_prompt_prev_fixed_requires_freshness_check() {
+        let p = review_prompt(None, 10, 3, true);
+        assert!(p.contains("WAITING"));
+        assert!(p.contains("latest review was submitted BEFORE the latest commit"));
+        // Without prev_fixed, no freshness check
+        let p = review_prompt(None, 10, 3, false);
+        assert!(!p.contains("WAITING"));
+    }
+
+    #[test]
     fn test_review_prompt_constraints() {
-        let p = review_prompt(None, 10, 2);
+        let p = review_prompt(None, 10, 2, false);
         assert!(p.contains("NEVER downgrade dependency"));
+    }
+
+    #[test]
+    fn test_is_waiting() {
+        assert!(is_waiting("checking reviews...\nWAITING"));
+        assert!(is_waiting("WAITING\n"));
+        assert!(!is_waiting("LGTM"));
+        assert!(!is_waiting("FIXED"));
     }
 
     #[test]

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -222,11 +222,15 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
             }
         }
 
-        Method::MetricsCollect { project_root: _ } => {
+        Method::MetricsCollect { project_root } => {
             let events = state.events.query(&harness_core::EventFilters::default());
             match events {
                 Ok(evts) => {
-                    let report = harness_observe::QualityGrader::grade(&evts, 0);
+                    let violation_count = {
+                        let rules = state.rules.read().await;
+                        rules.scan(&project_root).await.map(|v| v.len()).unwrap_or(0)
+                    };
+                    let report = harness_observe::QualityGrader::grade(&evts, violation_count);
                     match serde_json::to_value(&report) {
                         Ok(v) => RpcResponse::success(id, v),
                         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -245,7 +249,18 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
             let events = state.events.query(&event_filters);
             match events {
                 Ok(evts) => {
-                    let report = harness_observe::QualityGrader::grade(&evts, 0);
+                    // Count rule violations persisted by RuleCheck handler.
+                    let violation_count = evts
+                        .iter()
+                        .filter(|e| {
+                            e.hook == "rule_check"
+                                && matches!(
+                                    e.decision,
+                                    harness_core::Decision::Block | harness_core::Decision::Warn
+                                )
+                        })
+                        .count();
+                    let report = harness_observe::QualityGrader::grade(&evts, violation_count);
                     match serde_json::to_value(&report) {
                         Ok(v) => RpcResponse::success(id, v),
                         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -269,16 +284,47 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
         }
 
         Method::RuleCheck { project_root, files } => {
-            let rules = state.rules.read().await;
-            let result = match files {
-                Some(f) => rules.scan_files(&project_root, &f).await,
-                None => rules.scan(&project_root).await,
+            let result = {
+                let rules = state.rules.read().await;
+                match files {
+                    Some(f) => rules.scan_files(&project_root, &f).await,
+                    None => rules.scan(&project_root).await,
+                }
             };
             match result {
-                Ok(violations) => match serde_json::to_value(&violations) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
+                Ok(violations) => {
+                    // Persist each violation as an Event so the observability
+                    // pipeline (MetricsQuery, GcRun) can see them.
+                    let session_id = harness_core::SessionId::new();
+                    for violation in &violations {
+                        let decision = match violation.severity {
+                            harness_core::Severity::Critical | harness_core::Severity::High => {
+                                harness_core::Decision::Block
+                            }
+                            harness_core::Severity::Medium => harness_core::Decision::Warn,
+                            harness_core::Severity::Low => harness_core::Decision::Pass,
+                        };
+                        let mut event = harness_core::Event::new(
+                            session_id.clone(),
+                            "rule_check",
+                            violation.rule_id.as_str(),
+                            decision,
+                        );
+                        event.reason = Some(violation.message.clone());
+                        event.detail = Some(format!(
+                            "{}:{}",
+                            violation.file.display(),
+                            violation.line.map(|l| l.to_string()).unwrap_or_default()
+                        ));
+                        if let Err(e) = state.events.log(&event) {
+                            tracing::warn!("failed to log rule violation event: {e}");
+                        }
+                    }
+                    match serde_json::to_value(&violations) {
+                        Ok(v) => RpcResponse::success(id, v),
+                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                    }
+                }
                 Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
             }
         }
@@ -290,12 +336,17 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
                 Ok(e) => e,
                 Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
             };
-            let project = harness_core::Project::from_path(std::path::PathBuf::from("."));
+            let project_root = std::path::PathBuf::from(".");
+            let violations = {
+                let rules = state.rules.read().await;
+                rules.scan(&project_root).await.unwrap_or_default()
+            };
+            let project = harness_core::Project::from_path(project_root);
             let agent = match server.agent_registry.default_agent() {
                 Some(a) => a,
                 None => return RpcResponse::error(id, INTERNAL_ERROR, "no agent registered"),
             };
-            match state.gc_agent.run(&project, &events, &[], agent.as_ref()).await {
+            match state.gc_agent.run(&project, &events, &violations, agent.as_ref()).await {
                 Ok(report) => match serde_json::to_value(&report) {
                     Ok(v) => RpcResponse::success(id, v),
                     Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -632,6 +683,75 @@ mod tests {
         let tid = crate::task_runner::TaskId(task_id.to_string());
         let task = state.tasks.get(&tid);
         assert!(task.is_some(), "task should exist in the task store");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rule_check_logs_no_violations_when_no_guards_loaded() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::RuleCheck {
+                project_root: dir.path().to_path_buf(),
+                files: None,
+            },
+        };
+        let resp = handle_request(&state, req).await;
+
+        assert!(resp.error.is_none(), "expected success: {:?}", resp.error);
+        let violations: Vec<serde_json::Value> = serde_json::from_value(
+            resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?,
+        )?;
+        assert!(violations.is_empty(), "no guards loaded, violations must be empty");
+
+        // No rule_check events should have been logged with no violations.
+        let events = state.events.query(&harness_core::EventFilters {
+            hook: Some("rule_check".to_string()),
+            ..Default::default()
+        })?;
+        assert!(events.is_empty(), "no events should be logged when there are no violations");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn metrics_query_counts_rule_violations_from_events() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        // Manually seed rule_check violation events (as RuleCheck handler would).
+        let session_id = harness_core::SessionId::new();
+        for _ in 0..5 {
+            let event = harness_core::Event::new(
+                session_id.clone(),
+                "rule_check",
+                "SEC-01",
+                harness_core::Decision::Block,
+            );
+            state.events.log(&event)?;
+        }
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::MetricsQuery {
+                filters: harness_core::MetricFilters::default(),
+            },
+        };
+        let resp = handle_request(&state, req).await;
+
+        assert!(resp.error.is_none(), "expected success: {:?}", resp.error);
+        let result = resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        // Coverage must be below 100% because we have 5 Block violations.
+        let coverage = result["dimensions"]["coverage"]
+            .as_f64()
+            .ok_or_else(|| anyhow::anyhow!("missing coverage"))?;
+        assert!(
+            coverage < 100.0,
+            "coverage should degrade with violations, got {coverage}"
+        );
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -297,8 +297,17 @@ async fn run_task(
     };
 
     // Review loop: Turn 2..N
+    // prev_fixed tracks whether the previous round pushed new code.
+    // When true, the next round's prompt requires the agent to verify that
+    // Gemini has submitted a new review covering the latest commit before
+    // declaring LGTM. If Gemini hasn't re-reviewed yet, the agent outputs
+    // WAITING and we retry without consuming a round.
     let last_review_round = req.max_rounds.saturating_add(1);
-    for round in 2..=last_review_round {
+    let mut prev_fixed = false;
+    let mut round = 2u32;
+    let max_waiting_retries = 3u32;
+
+    while round <= last_review_round {
         update_status(store, task_id, TaskStatus::Waiting, round).await;
         sleep(Duration::from_secs(req.wait_secs)).await;
 
@@ -307,7 +316,7 @@ async fn run_task(
         let resp = tokio::time::timeout(
             turn_timeout,
             agent.execute(AgentRequest {
-                prompt: prompts::review_prompt(req.issue, pr_num, round),
+                prompt: prompts::review_prompt(req.issue, pr_num, round, prev_fixed),
                 project_root: project.clone(),
                 context: skill_items.clone(),
                 ..Default::default()
@@ -316,6 +325,37 @@ async fn run_task(
         .await
         .map_err(|_| anyhow::anyhow!("Turn {round} timed out after {}s", req.turn_timeout_secs))?
         ?;
+
+        // WAITING: Gemini hasn't re-reviewed after the fix commit yet.
+        // Retry without consuming a round, up to max_waiting_retries.
+        if prompts::is_waiting(&resp.output) {
+            mutate_and_persist(store, task_id, |s| {
+                s.rounds.push(RoundResult {
+                    turn: round,
+                    action: "review".into(),
+                    result: "waiting".into(),
+                });
+            })
+            .await;
+
+            let waiting_count = store
+                .get(task_id)
+                .map(|s| {
+                    s.rounds
+                        .iter()
+                        .filter(|r| r.result == "waiting")
+                        .count() as u32
+                })
+                .unwrap_or(0);
+
+            if waiting_count >= max_waiting_retries {
+                // Exceeded waiting retries — advance round to avoid infinite loop
+                prev_fixed = true;
+                round += 1;
+            }
+            // Don't advance round; retry with same round number
+            continue;
+        }
 
         let lgtm = prompts::is_lgtm(&resp.output);
 
@@ -332,6 +372,9 @@ async fn run_task(
             update_status(store, task_id, TaskStatus::Done, round).await;
             return Ok(());
         }
+
+        prev_fixed = true;
+        round += 1;
     }
 
     // Reached max rounds without LGTM


### PR DESCRIPTION
## Summary
- Add `prev_fixed` parameter to `review_prompt` — when true, agent must verify Gemini's latest review covers the latest commit
- Add `WAITING` output status: agent outputs this when Gemini hasn't re-reviewed yet
- Task runner retries on WAITING without consuming a round (up to 3 retries)
- Extract `last_non_empty_line()` helper shared by `is_lgtm`/`is_waiting`

## Root cause
After the agent fixes Gemini's comments and pushes new code, the next review round checks `gh api .../reviews` but only sees the OLD review (already addressed). With no unresolved comments, the agent declares LGTM — merging code that was never re-reviewed by Gemini.

Timeline from PR #26:
```
06:03  Commit 1 (initial implementation)
06:06  Gemini review (1 high + 2 medium issues)
06:10  Commit 2 (fix) — NO re-review triggered/verified
06:15  Merged — unreviewed code
```

## Fix
Two-layer approach:
1. **Prompt**: `prev_fixed=true` adds a freshness check — agent compares latest review timestamp vs latest commit timestamp. If review is stale, outputs `WAITING`
2. **Task runner**: `WAITING` triggers a retry loop (same round, re-wait) giving Gemini time to complete re-review

## Test plan
- [x] 88 tests pass
- [x] `test_review_prompt_prev_fixed_requires_freshness_check` verifies WAITING instruction present only when prev_fixed=true
- [x] `test_is_waiting` verifies WAITING output parsing