### PR TITLE
refactor: split router.rs and task_runner.rs into handler modules

### DIFF
--- a/crates/harness-server/src/handlers/exec.rs
+++ b/crates/harness-server/src/handlers/exec.rs
@@ -1,0 +1,88 @@
+use crate::http::AppState;
+use harness_core::ExecPlanId;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+use std::path::PathBuf;
+
+pub async fn exec_plan_init(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    spec: String,
+    project_root: PathBuf,
+) -> RpcResponse {
+    match harness_exec::ExecPlan::from_spec(&spec, &project_root) {
+        Ok(plan) => {
+            let plan_id = plan.id.clone();
+            let mut plans = state.plans.write().await;
+            plans.insert(plan_id.clone(), plan);
+            RpcResponse::success(id, serde_json::json!({ "plan_id": plan_id }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn exec_plan_status(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    plan_id: ExecPlanId,
+) -> RpcResponse {
+    let plans = state.plans.read().await;
+    match plans.get(&plan_id) {
+        Some(plan) => match serde_json::to_value(plan) {
+            Ok(v) => RpcResponse::success(id, v),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        },
+        None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+    }
+}
+
+pub async fn exec_plan_update(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    plan_id: ExecPlanId,
+    updates: serde_json::Value,
+) -> RpcResponse {
+    let mut plans = state.plans.write().await;
+    match plans.get_mut(&plan_id) {
+        Some(plan) => {
+            let action = updates
+                .get("action")
+                .and_then(|a| a.as_str())
+                .unwrap_or("");
+            match action {
+                "activate" => plan.activate(),
+                "complete" => plan.complete(),
+                "abandon" => plan.abandon(),
+                "add_milestone" => {
+                    if let Some(desc) =
+                        updates.get("description").and_then(|d| d.as_str())
+                    {
+                        plan.add_milestone(desc.to_string());
+                    }
+                }
+                "log_decision" => {
+                    let decision = updates
+                        .get("decision")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or("");
+                    let rationale = updates
+                        .get("rationale")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or("");
+                    plan.log_decision(decision, rationale);
+                }
+                _ => {
+                    return RpcResponse::error(
+                        id,
+                        INTERNAL_ERROR,
+                        format!("unknown action: {action}"),
+                    )
+                }
+            }
+            match serde_json::to_value(&*plan) {
+                Ok(v) => RpcResponse::success(id, v),
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+    }
+}

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -1,0 +1,144 @@
+use crate::http::AppState;
+use harness_core::DraftId;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+
+pub async fn gc_run(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+) -> RpcResponse {
+    let events = match state.events.query(&harness_core::EventFilters::default()) {
+        Ok(e) => e,
+        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    };
+    let project_root = std::path::PathBuf::from(".");
+    let violations = {
+        let rules = state.rules.read().await;
+        rules.scan(&project_root).await.unwrap_or_default()
+    };
+    let project = harness_core::Project::from_path(project_root);
+    let agent = match state.server.agent_registry.default_agent() {
+        Some(a) => a,
+        None => return RpcResponse::error(id, INTERNAL_ERROR, "no agent registered"),
+    };
+    match state
+        .gc_agent
+        .run(&project, &events, &violations, agent.as_ref())
+        .await
+    {
+        Ok(report) => match serde_json::to_value(&report) {
+            Ok(v) => RpcResponse::success(id, v),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        },
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn gc_status(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+) -> RpcResponse {
+    match state.gc_agent.drafts() {
+        Ok(drafts) => RpcResponse::success(
+            id,
+            serde_json::json!({ "draft_count": drafts.len() }),
+        ),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn gc_drafts(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+) -> RpcResponse {
+    match state.gc_agent.drafts() {
+        Ok(drafts) => match serde_json::to_value(&drafts) {
+            Ok(v) => RpcResponse::success(id, v),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        },
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn gc_adopt(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    draft_id: DraftId,
+) -> RpcResponse {
+    let draft = match state.gc_agent.draft_store().get(&draft_id) {
+        Ok(Some(d)) => d,
+        Ok(None) => {
+            return RpcResponse::error(
+                id,
+                INTERNAL_ERROR,
+                format!("draft {} not found", draft_id),
+            );
+        }
+        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    };
+    let artifact_paths: Vec<String> = draft
+        .artifacts
+        .iter()
+        .map(|a| a.target_path.display().to_string())
+        .collect();
+
+    match state.gc_agent.adopt(&draft_id) {
+        Ok(()) => {
+            if artifact_paths.is_empty() {
+                return RpcResponse::success(
+                    id,
+                    serde_json::json!({ "adopted": true, "task_id": null }),
+                );
+            }
+            const GC_ADOPT_WAIT_SECS: u64 = 120;
+            const GC_ADOPT_MAX_ROUNDS: u32 = 3;
+            const GC_ADOPT_TURN_TIMEOUT_SECS: u64 = 600;
+            let task_id =
+                if let Some(agent) = state.server.agent_registry.default_agent() {
+                    let paths_list = artifact_paths.join(", ");
+                    let prompt = format!(
+                        "GC drafted the following files: {paths_list}. \
+                         Review these changes, create a branch named gc/{draft_id}, \
+                         commit, push, and open a PR. \
+                         Print PR_URL=<url> on the last line."
+                    );
+                    let req = crate::task_runner::CreateTaskRequest {
+                        prompt: Some(prompt),
+                        issue: None,
+                        pr: None,
+                        project: None,
+                        wait_secs: GC_ADOPT_WAIT_SECS,
+                        max_rounds: GC_ADOPT_MAX_ROUNDS,
+                        turn_timeout_secs: GC_ADOPT_TURN_TIMEOUT_SECS,
+                    };
+                    let tid = crate::task_runner::spawn_task(
+                        state.tasks.clone(),
+                        agent,
+                        state.skills.clone(),
+                        state.events.clone(),
+                        req,
+                    )
+                    .await;
+                    Some(tid.0)
+                } else {
+                    None
+                };
+            RpcResponse::success(
+                id,
+                serde_json::json!({ "adopted": true, "task_id": task_id }),
+            )
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn gc_reject(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    draft_id: DraftId,
+    reason: Option<String>,
+) -> RpcResponse {
+    match state.gc_agent.reject(&draft_id, reason.as_deref()) {
+        Ok(()) => RpcResponse::success(id, serde_json::json!({ "rejected": true })),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -1,0 +1,6 @@
+pub mod exec;
+pub mod gc;
+pub mod observe;
+pub mod rules;
+pub mod skills;
+pub mod thread;

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -1,0 +1,90 @@
+use crate::http::AppState;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+use std::path::PathBuf;
+
+pub async fn event_log(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    event: harness_core::Event,
+) -> RpcResponse {
+    match state.events.log(&event) {
+        Ok(event_id) => RpcResponse::success(
+            id,
+            serde_json::json!({ "logged": true, "event_id": event_id }),
+        ),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn event_query(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    filters: harness_core::EventFilters,
+) -> RpcResponse {
+    match state.events.query(&filters) {
+        Ok(events) => match serde_json::to_value(&events) {
+            Ok(v) => RpcResponse::success(id, v),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        },
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn metrics_collect(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    project_root: PathBuf,
+) -> RpcResponse {
+    let events = state.events.query(&harness_core::EventFilters::default());
+    match events {
+        Ok(evts) => {
+            let violation_count = {
+                let rules = state.rules.read().await;
+                rules
+                    .scan(&project_root)
+                    .await
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            };
+            let report = harness_observe::QualityGrader::grade(&evts, violation_count);
+            match serde_json::to_value(&report) {
+                Ok(v) => RpcResponse::success(id, v),
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn metrics_query(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    filters: harness_core::MetricFilters,
+) -> RpcResponse {
+    let event_filters = harness_core::EventFilters {
+        since: filters.since,
+        until: filters.until,
+        ..Default::default()
+    };
+    let events = state.events.query(&event_filters);
+    match events {
+        Ok(evts) => {
+            let violation_count = evts
+                .iter()
+                .filter(|e| {
+                    e.hook == "rule_check"
+                        && matches!(
+                            e.decision,
+                            harness_core::Decision::Block | harness_core::Decision::Warn
+                        )
+                })
+                .count();
+            let report = harness_observe::QualityGrader::grade(&evts, violation_count);
+            match serde_json::to_value(&report) {
+                Ok(v) => RpcResponse::success(id, v),
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -1,0 +1,70 @@
+use crate::http::AppState;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+use std::path::PathBuf;
+
+pub async fn rule_load(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    project_root: PathBuf,
+) -> RpcResponse {
+    let mut rules = state.rules.write().await;
+    match rules.load(&project_root) {
+        Ok(()) => {
+            let count = rules.rules().len();
+            RpcResponse::success(id, serde_json::json!({ "rules_count": count }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn rule_check(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    project_root: PathBuf,
+    files: Option<Vec<PathBuf>>,
+) -> RpcResponse {
+    let result = {
+        let rules = state.rules.read().await;
+        match files {
+            Some(f) => rules.scan_files(&project_root, &f).await,
+            None => rules.scan(&project_root).await,
+        }
+    };
+    match result {
+        Ok(violations) => {
+            let session_id = harness_core::SessionId::new();
+            for violation in &violations {
+                let decision = match violation.severity {
+                    harness_core::Severity::Critical | harness_core::Severity::High => {
+                        harness_core::Decision::Block
+                    }
+                    harness_core::Severity::Medium => harness_core::Decision::Warn,
+                    harness_core::Severity::Low => harness_core::Decision::Pass,
+                };
+                let mut event = harness_core::Event::new(
+                    session_id.clone(),
+                    "rule_check",
+                    violation.rule_id.as_str(),
+                    decision,
+                );
+                event.reason = Some(violation.message.clone());
+                event.detail = Some(format!(
+                    "{}:{}",
+                    violation.file.display(),
+                    violation
+                        .line
+                        .map(|l| l.to_string())
+                        .unwrap_or_default()
+                ));
+                if let Err(e) = state.events.log(&event) {
+                    tracing::warn!("failed to log rule violation event: {e}");
+                }
+            }
+            match serde_json::to_value(&violations) {
+                Ok(v) => RpcResponse::success(id, v),
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}

--- a/crates/harness-server/src/handlers/skills.rs
+++ b/crates/harness-server/src/handlers/skills.rs
@@ -1,0 +1,58 @@
+use crate::http::AppState;
+use harness_core::SkillId;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+
+pub async fn skill_create(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    name: String,
+    content: String,
+) -> RpcResponse {
+    let mut skills = state.skills.write().await;
+    let skill = skills.create(name, content).clone();
+    match serde_json::to_value(&skill) {
+        Ok(v) => RpcResponse::success(id, v),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn skill_list(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    query: Option<String>,
+) -> RpcResponse {
+    let skills = state.skills.read().await;
+    let result = match query {
+        Some(q) => skills.search(&q).into_iter().cloned().collect::<Vec<_>>(),
+        None => skills.list().to_vec(),
+    };
+    match serde_json::to_value(&result) {
+        Ok(v) => RpcResponse::success(id, v),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn skill_get(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    skill_id: SkillId,
+) -> RpcResponse {
+    let skills = state.skills.read().await;
+    match skills.get(&skill_id) {
+        Some(skill) => match serde_json::to_value(skill) {
+            Ok(v) => RpcResponse::success(id, v),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        },
+        None => RpcResponse::error(id, INTERNAL_ERROR, "skill not found"),
+    }
+}
+
+pub async fn skill_delete(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    skill_id: SkillId,
+) -> RpcResponse {
+    let mut skills = state.skills.write().await;
+    let deleted = skills.delete(&skill_id);
+    RpcResponse::success(id, serde_json::json!({ "deleted": deleted }))
+}

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -1,0 +1,214 @@
+use crate::http::AppState;
+use harness_core::ThreadId;
+use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+use std::path::PathBuf;
+
+/// Persist an existing thread to the optional ThreadDb after a mutation.
+pub(crate) async fn persist_thread(state: &AppState, thread_id: &ThreadId) {
+    if let Some(db) = &state.thread_db {
+        if let Some(thread) = state.server.thread_manager.get_thread(thread_id) {
+            if let Err(e) = db.update(&thread).await {
+                tracing::warn!("thread_db persist failed: {e}");
+            }
+        }
+    }
+}
+
+/// Insert a newly created thread into the optional ThreadDb.
+pub(crate) async fn persist_thread_insert(state: &AppState, thread_id: &ThreadId) {
+    if let Some(db) = &state.thread_db {
+        if let Some(thread) = state.server.thread_manager.get_thread(thread_id) {
+            if let Err(e) = db.insert(&thread).await {
+                tracing::warn!("thread_db insert failed: {e}");
+            }
+        }
+    }
+}
+
+pub async fn initialize(id: Option<serde_json::Value>) -> RpcResponse {
+    RpcResponse::success(
+        id,
+        serde_json::json!({
+            "name": "harness",
+            "version": env!("CARGO_PKG_VERSION"),
+            "capabilities": {
+                "threads": true,
+                "gc": true,
+                "skills": true,
+                "rules": true,
+                "exec_plan": true,
+                "observe": true,
+            }
+        }),
+    )
+}
+
+pub async fn thread_start(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    cwd: PathBuf,
+) -> RpcResponse {
+    let thread_id = state.server.thread_manager.start_thread(cwd);
+    persist_thread_insert(state, &thread_id).await;
+    RpcResponse::success(id, serde_json::json!({ "thread_id": thread_id }))
+}
+
+pub async fn thread_list(state: &AppState, id: Option<serde_json::Value>) -> RpcResponse {
+    let threads = state.server.thread_manager.list_threads();
+    RpcResponse::success(id, serde_json::to_value(threads).unwrap_or_default())
+}
+
+pub async fn thread_delete(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+) -> RpcResponse {
+    let deleted = state.server.thread_manager.delete_thread(&thread_id);
+    if deleted {
+        if let Some(db) = &state.thread_db {
+            if let Err(e) = db.delete(thread_id.as_str()).await {
+                tracing::warn!("thread_db delete failed: {e}");
+            }
+        }
+    }
+    RpcResponse::success(id, serde_json::json!({ "deleted": deleted }))
+}
+
+pub async fn turn_start(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+    input: String,
+) -> RpcResponse {
+    let agent_id =
+        harness_core::AgentId::from_str(&state.server.config.agents.default_agent);
+    match state
+        .server
+        .thread_manager
+        .start_turn(&thread_id, input, agent_id)
+    {
+        Ok(turn_id) => {
+            persist_thread(state, &thread_id).await;
+            RpcResponse::success(id, serde_json::json!({ "turn_id": turn_id }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn turn_cancel(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    turn_id: harness_core::TurnId,
+) -> RpcResponse {
+    match state.server.thread_manager.find_thread_for_turn(&turn_id) {
+        Some(thread_id) => {
+            match state
+                .server
+                .thread_manager
+                .cancel_turn(&thread_id, &turn_id)
+            {
+                Ok(()) => {
+                    persist_thread(state, &thread_id).await;
+                    RpcResponse::success(id, serde_json::json!({ "cancelled": true }))
+                }
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+    }
+}
+
+pub async fn turn_status(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    turn_id: harness_core::TurnId,
+) -> RpcResponse {
+    match state.server.thread_manager.find_thread_for_turn(&turn_id) {
+        Some(thread_id) => {
+            if let Some(thread) = state.server.thread_manager.get_thread(&thread_id) {
+                if let Some(turn) = thread.turns.iter().find(|t| t.id == turn_id) {
+                    match serde_json::to_value(turn) {
+                        Ok(v) => RpcResponse::success(id, v),
+                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                    }
+                } else {
+                    RpcResponse::error(id, INTERNAL_ERROR, "turn not found")
+                }
+            } else {
+                RpcResponse::error(id, INTERNAL_ERROR, "thread not found")
+            }
+        }
+        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+    }
+}
+
+pub async fn turn_steer(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    turn_id: harness_core::TurnId,
+    instruction: String,
+) -> RpcResponse {
+    match state.server.thread_manager.find_thread_for_turn(&turn_id) {
+        Some(thread_id) => {
+            match state
+                .server
+                .thread_manager
+                .steer_turn(&thread_id, &turn_id, instruction)
+            {
+                Ok(()) => {
+                    persist_thread(state, &thread_id).await;
+                    RpcResponse::success(id, serde_json::json!({ "steered": true }))
+                }
+                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            }
+        }
+        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+    }
+}
+
+pub async fn thread_resume(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+) -> RpcResponse {
+    match state.server.thread_manager.resume_thread(&thread_id) {
+        Ok(()) => {
+            persist_thread(state, &thread_id).await;
+            RpcResponse::success(id, serde_json::json!({ "resumed": true }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn thread_fork(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+    from_turn: Option<harness_core::TurnId>,
+) -> RpcResponse {
+    match state
+        .server
+        .thread_manager
+        .fork_thread(&thread_id, from_turn.as_ref())
+    {
+        Ok(new_id) => {
+            persist_thread_insert(state, &new_id).await;
+            RpcResponse::success(id, serde_json::json!({ "thread_id": new_id }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+pub async fn thread_compact(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+) -> RpcResponse {
+    match state.server.thread_manager.compact_thread(&thread_id) {
+        Ok(()) => {
+            persist_thread(state, &thread_id).await;
+            RpcResponse::success(id, serde_json::json!({ "compacted": true }))
+        }
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,8 @@ pub mod thread_manager;
 pub mod thread_db;
 pub mod stdio;
 pub mod http;
+pub mod handlers;
 pub mod router;
 pub mod task_runner;
+pub mod task_executor;
 pub mod task_db;

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -1,503 +1,111 @@
+use crate::handlers;
 use crate::http::AppState;
-use harness_core::ThreadId;
-use harness_protocol::{Method, RpcRequest, RpcResponse, INTERNAL_ERROR};
-
-/// Persist an existing thread to the optional ThreadDb after a mutation.
-async fn persist_thread(state: &AppState, thread_id: &ThreadId) {
-    if let Some(db) = &state.thread_db {
-        if let Some(thread) = state.server.thread_manager.get_thread(thread_id) {
-            if let Err(e) = db.update(&thread).await {
-                tracing::warn!("thread_db persist failed: {e}");
-            }
-        }
-    }
-}
-
-/// Insert a newly created thread into the optional ThreadDb.
-async fn persist_thread_insert(state: &AppState, thread_id: &ThreadId) {
-    if let Some(db) = &state.thread_db {
-        if let Some(thread) = state.server.thread_manager.get_thread(thread_id) {
-            if let Err(e) = db.insert(&thread).await {
-                tracing::warn!("thread_db insert failed: {e}");
-            }
-        }
-    }
-}
+use harness_protocol::{Method, RpcRequest, RpcResponse};
 
 /// Route a JSON-RPC request to the appropriate handler.
 pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
     let id = req.id.clone();
-    let server = &state.server;
 
     match req.method {
-        Method::Initialize => {
-            RpcResponse::success(id, serde_json::json!({
-                "name": "harness",
-                "version": env!("CARGO_PKG_VERSION"),
-                "capabilities": {
-                    "threads": true,
-                    "gc": true,
-                    "skills": true,
-                    "rules": true,
-                    "exec_plan": true,
-                    "observe": true,
-                }
-            }))
-        }
+        // === Initialization ===
+        Method::Initialize => handlers::thread::initialize(id).await,
 
+        // === Thread management ===
         Method::ThreadStart { cwd } => {
-            let thread_id = server.thread_manager.start_thread(cwd);
-            persist_thread_insert(state, &thread_id).await;
-            RpcResponse::success(id, serde_json::json!({ "thread_id": thread_id }))
+            handlers::thread::thread_start(state, id, cwd).await
         }
-
-        Method::ThreadList => {
-            let threads = server.thread_manager.list_threads();
-            RpcResponse::success(id, serde_json::to_value(threads).unwrap_or_default())
-        }
-
+        Method::ThreadList => handlers::thread::thread_list(state, id).await,
         Method::ThreadDelete { thread_id } => {
-            let deleted = server.thread_manager.delete_thread(&thread_id);
-            if deleted {
-                if let Some(db) = &state.thread_db {
-                    if let Err(e) = db.delete(thread_id.as_str()).await {
-                        tracing::warn!("thread_db delete failed: {e}");
-                    }
-                }
-            }
-            RpcResponse::success(id, serde_json::json!({ "deleted": deleted }))
+            handlers::thread::thread_delete(state, id, thread_id).await
         }
-
-        Method::TurnStart { thread_id, input } => {
-            let agent_id = harness_core::AgentId::from_str(
-                &server.config.agents.default_agent,
-            );
-            match server.thread_manager.start_turn(&thread_id, input, agent_id) {
-                Ok(turn_id) => {
-                    persist_thread(state, &thread_id).await;
-                    RpcResponse::success(id, serde_json::json!({ "turn_id": turn_id }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
-        }
-
-        Method::TurnCancel { turn_id } => {
-            match server.thread_manager.find_thread_for_turn(&turn_id) {
-                Some(thread_id) => {
-                    match server.thread_manager.cancel_turn(&thread_id, &turn_id) {
-                        Ok(()) => {
-                            persist_thread(state, &thread_id).await;
-                            RpcResponse::success(id, serde_json::json!({ "cancelled": true }))
-                        }
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
-            }
-        }
-
-        Method::TurnStatus { turn_id } => {
-            match server.thread_manager.find_thread_for_turn(&turn_id) {
-                Some(thread_id) => {
-                    if let Some(thread) = server.thread_manager.get_thread(&thread_id) {
-                        if let Some(turn) = thread.turns.iter().find(|t| t.id == turn_id) {
-                            match serde_json::to_value(turn) {
-                                Ok(v) => RpcResponse::success(id, v),
-                                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                            }
-                        } else {
-                            RpcResponse::error(id, INTERNAL_ERROR, "turn not found")
-                        }
-                    } else {
-                        RpcResponse::error(id, INTERNAL_ERROR, "thread not found")
-                    }
-                }
-                None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
-            }
-        }
-
-        Method::TurnSteer { turn_id, instruction } => {
-            match server.thread_manager.find_thread_for_turn(&turn_id) {
-                Some(thread_id) => {
-                    match server.thread_manager.steer_turn(&thread_id, &turn_id, instruction) {
-                        Ok(()) => {
-                            persist_thread(state, &thread_id).await;
-                            RpcResponse::success(id, serde_json::json!({ "steered": true }))
-                        }
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
-            }
-        }
-
-        // === Thread advanced ===
-
         Method::ThreadResume { thread_id } => {
-            match server.thread_manager.resume_thread(&thread_id) {
-                Ok(()) => {
-                    persist_thread(state, &thread_id).await;
-                    RpcResponse::success(id, serde_json::json!({ "resumed": true }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::thread::thread_resume(state, id, thread_id).await
         }
-
-        Method::ThreadFork { thread_id, from_turn } => {
-            match server.thread_manager.fork_thread(&thread_id, from_turn.as_ref()) {
-                Ok(new_id) => {
-                    persist_thread_insert(state, &new_id).await;
-                    RpcResponse::success(id, serde_json::json!({ "thread_id": new_id }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
-        }
-
+        Method::ThreadFork {
+            thread_id,
+            from_turn,
+        } => handlers::thread::thread_fork(state, id, thread_id, from_turn).await,
         Method::ThreadCompact { thread_id } => {
-            match server.thread_manager.compact_thread(&thread_id) {
-                Ok(()) => {
-                    persist_thread(state, &thread_id).await;
-                    RpcResponse::success(id, serde_json::json!({ "compacted": true }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::thread::thread_compact(state, id, thread_id).await
         }
+
+        // === Turn control ===
+        Method::TurnStart { thread_id, input } => {
+            handlers::thread::turn_start(state, id, thread_id, input).await
+        }
+        Method::TurnCancel { turn_id } => {
+            handlers::thread::turn_cancel(state, id, turn_id).await
+        }
+        Method::TurnStatus { turn_id } => {
+            handlers::thread::turn_status(state, id, turn_id).await
+        }
+        Method::TurnSteer {
+            turn_id,
+            instruction,
+        } => handlers::thread::turn_steer(state, id, turn_id, instruction).await,
 
         // === Skills ===
-
         Method::SkillCreate { name, content } => {
-            let mut skills = state.skills.write().await;
-            let skill = skills.create(name, content).clone();
-            match serde_json::to_value(&skill) {
-                Ok(v) => RpcResponse::success(id, v),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::skills::skill_create(state, id, name, content).await
         }
-
         Method::SkillList { query } => {
-            let skills = state.skills.read().await;
-            let result = match query {
-                Some(q) => skills.search(&q).into_iter().cloned().collect::<Vec<_>>(),
-                None => skills.list().to_vec(),
-            };
-            match serde_json::to_value(&result) {
-                Ok(v) => RpcResponse::success(id, v),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::skills::skill_list(state, id, query).await
         }
-
         Method::SkillGet { skill_id } => {
-            let skills = state.skills.read().await;
-            match skills.get(&skill_id) {
-                Some(skill) => match serde_json::to_value(skill) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
-                None => RpcResponse::error(id, INTERNAL_ERROR, "skill not found"),
-            }
+            handlers::skills::skill_get(state, id, skill_id).await
         }
-
         Method::SkillDelete { skill_id } => {
-            let mut skills = state.skills.write().await;
-            let deleted = skills.delete(&skill_id);
-            RpcResponse::success(id, serde_json::json!({ "deleted": deleted }))
+            handlers::skills::skill_delete(state, id, skill_id).await
         }
 
         // === Events / Metrics ===
-
         Method::EventLog { event } => {
-            match state.events.log(&event) {
-                Ok(event_id) => RpcResponse::success(id, serde_json::json!({ "logged": true, "event_id": event_id })),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::observe::event_log(state, id, event).await
         }
-
         Method::EventQuery { filters } => {
-            match state.events.query(&filters) {
-                Ok(events) => match serde_json::to_value(&events) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::observe::event_query(state, id, filters).await
         }
-
         Method::MetricsCollect { project_root } => {
-            let events = state.events.query(&harness_core::EventFilters::default());
-            match events {
-                Ok(evts) => {
-                    let violation_count = {
-                        let rules = state.rules.read().await;
-                        rules.scan(&project_root).await.map(|v| v.len()).unwrap_or(0)
-                    };
-                    let report = harness_observe::QualityGrader::grade(&evts, violation_count);
-                    match serde_json::to_value(&report) {
-                        Ok(v) => RpcResponse::success(id, v),
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::observe::metrics_collect(state, id, project_root).await
         }
-
         Method::MetricsQuery { filters } => {
-            let event_filters = harness_core::EventFilters {
-                since: filters.since,
-                until: filters.until,
-                ..Default::default()
-            };
-            let events = state.events.query(&event_filters);
-            match events {
-                Ok(evts) => {
-                    // Count rule violations persisted by RuleCheck handler.
-                    let violation_count = evts
-                        .iter()
-                        .filter(|e| {
-                            e.hook == "rule_check"
-                                && matches!(
-                                    e.decision,
-                                    harness_core::Decision::Block | harness_core::Decision::Warn
-                                )
-                        })
-                        .count();
-                    let report = harness_observe::QualityGrader::grade(&evts, violation_count);
-                    match serde_json::to_value(&report) {
-                        Ok(v) => RpcResponse::success(id, v),
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::observe::metrics_query(state, id, filters).await
         }
 
         // === Rules ===
-
         Method::RuleLoad { project_root } => {
-            let mut rules = state.rules.write().await;
-            match rules.load(&project_root) {
-                Ok(()) => {
-                    let count = rules.rules().len();
-                    RpcResponse::success(id, serde_json::json!({ "rules_count": count }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::rules::rule_load(state, id, project_root).await
         }
-
-        Method::RuleCheck { project_root, files } => {
-            let result = {
-                let rules = state.rules.read().await;
-                match files {
-                    Some(f) => rules.scan_files(&project_root, &f).await,
-                    None => rules.scan(&project_root).await,
-                }
-            };
-            match result {
-                Ok(violations) => {
-                    // Persist each violation as an Event so the observability
-                    // pipeline (MetricsQuery, GcRun) can see them.
-                    let session_id = harness_core::SessionId::new();
-                    for violation in &violations {
-                        let decision = match violation.severity {
-                            harness_core::Severity::Critical | harness_core::Severity::High => {
-                                harness_core::Decision::Block
-                            }
-                            harness_core::Severity::Medium => harness_core::Decision::Warn,
-                            harness_core::Severity::Low => harness_core::Decision::Pass,
-                        };
-                        let mut event = harness_core::Event::new(
-                            session_id.clone(),
-                            "rule_check",
-                            violation.rule_id.as_str(),
-                            decision,
-                        );
-                        event.reason = Some(violation.message.clone());
-                        event.detail = Some(format!(
-                            "{}:{}",
-                            violation.file.display(),
-                            violation.line.map(|l| l.to_string()).unwrap_or_default()
-                        ));
-                        if let Err(e) = state.events.log(&event) {
-                            tracing::warn!("failed to log rule violation event: {e}");
-                        }
-                    }
-                    match serde_json::to_value(&violations) {
-                        Ok(v) => RpcResponse::success(id, v),
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
-        }
+        Method::RuleCheck {
+            project_root,
+            files,
+        } => handlers::rules::rule_check(state, id, project_root, files).await,
 
         // === GC ===
-
         Method::GcRun { project_id: _ } => {
-            let events = match state.events.query(&harness_core::EventFilters::default()) {
-                Ok(e) => e,
-                Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            };
-            let project_root = std::path::PathBuf::from(".");
-            let violations = {
-                let rules = state.rules.read().await;
-                rules.scan(&project_root).await.unwrap_or_default()
-            };
-            let project = harness_core::Project::from_path(project_root);
-            let agent = match server.agent_registry.default_agent() {
-                Some(a) => a,
-                None => return RpcResponse::error(id, INTERNAL_ERROR, "no agent registered"),
-            };
-            match state.gc_agent.run(&project, &events, &violations, agent.as_ref()).await {
-                Ok(report) => match serde_json::to_value(&report) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::gc::gc_run(state, id).await
         }
-
-        Method::GcStatus => {
-            match state.gc_agent.drafts() {
-                Ok(drafts) => RpcResponse::success(id, serde_json::json!({ "draft_count": drafts.len() })),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
-        }
-
+        Method::GcStatus => handlers::gc::gc_status(state, id).await,
         Method::GcDrafts { project_id: _ } => {
-            match state.gc_agent.drafts() {
-                Ok(drafts) => match serde_json::to_value(&drafts) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::gc::gc_drafts(state, id).await
         }
-
         Method::GcAdopt { draft_id } => {
-            // Fetch draft and artifact paths before adopting.
-            let draft = match state.gc_agent.draft_store().get(&draft_id) {
-                Ok(Some(d)) => d,
-                Ok(None) => {
-                    return RpcResponse::error(
-                        id,
-                        INTERNAL_ERROR,
-                        format!("draft {} not found", draft_id),
-                    );
-                }
-                Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            };
-            let artifact_paths: Vec<String> = draft
-                .artifacts
-                .iter()
-                .map(|a| a.target_path.display().to_string())
-                .collect();
-
-            match state.gc_agent.adopt(&draft_id) {
-                Ok(()) => {
-                    if artifact_paths.is_empty() {
-                        return RpcResponse::success(
-                            id,
-                            serde_json::json!({ "adopted": true, "task_id": null }),
-                        );
-                    }
-                    // Spawn a task to commit the artifacts and open a PR.
-                    const GC_ADOPT_WAIT_SECS: u64 = 120;
-                    const GC_ADOPT_MAX_ROUNDS: u32 = 3;
-                    const GC_ADOPT_TURN_TIMEOUT_SECS: u64 = 600;
-                    let task_id = if let Some(agent) = server.agent_registry.default_agent() {
-                        let paths_list = artifact_paths.join(", ");
-                        let prompt = format!(
-                            "GC drafted the following files: {paths_list}. \
-                             Review these changes, create a branch named gc/{draft_id}, \
-                             commit, push, and open a PR. \
-                             Print PR_URL=<url> on the last line."
-                        );
-                        let req = crate::task_runner::CreateTaskRequest {
-                            prompt: Some(prompt),
-                            issue: None,
-                            pr: None,
-                            project: None,
-                            wait_secs: GC_ADOPT_WAIT_SECS,
-                            max_rounds: GC_ADOPT_MAX_ROUNDS,
-                            turn_timeout_secs: GC_ADOPT_TURN_TIMEOUT_SECS,
-                        };
-                        let tid = crate::task_runner::spawn_task(
-                            state.tasks.clone(),
-                            agent,
-                            state.skills.clone(),
-                            state.events.clone(),
-                            req,
-                        )
-                        .await;
-                        Some(tid.0)
-                    } else {
-                        None
-                    };
-                    RpcResponse::success(id, serde_json::json!({ "adopted": true, "task_id": task_id }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::gc::gc_adopt(state, id, draft_id).await
         }
-
         Method::GcReject { draft_id, reason } => {
-            match state.gc_agent.reject(&draft_id, reason.as_deref()) {
-                Ok(()) => RpcResponse::success(id, serde_json::json!({ "rejected": true })),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
+            handlers::gc::gc_reject(state, id, draft_id, reason).await
         }
 
         // === ExecPlan ===
-
-        Method::ExecPlanInit { spec, project_root } => {
-            match harness_exec::ExecPlan::from_spec(&spec, &project_root) {
-                Ok(plan) => {
-                    let plan_id = plan.id.clone();
-                    let mut plans = state.plans.write().await;
-                    plans.insert(plan_id.clone(), plan);
-                    RpcResponse::success(id, serde_json::json!({ "plan_id": plan_id }))
-                }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-            }
-        }
-
+        Method::ExecPlanInit {
+            spec,
+            project_root,
+        } => handlers::exec::exec_plan_init(state, id, spec, project_root).await,
         Method::ExecPlanStatus { plan_id } => {
-            let plans = state.plans.read().await;
-            match plans.get(&plan_id) {
-                Some(plan) => match serde_json::to_value(plan) {
-                    Ok(v) => RpcResponse::success(id, v),
-                    Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                },
-                None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
-            }
+            handlers::exec::exec_plan_status(state, id, plan_id).await
         }
-
         Method::ExecPlanUpdate { plan_id, updates } => {
-            let mut plans = state.plans.write().await;
-            match plans.get_mut(&plan_id) {
-                Some(plan) => {
-                    let action = updates.get("action").and_then(|a| a.as_str()).unwrap_or("");
-                    match action {
-                        "activate" => plan.activate(),
-                        "complete" => plan.complete(),
-                        "abandon" => plan.abandon(),
-                        "add_milestone" => {
-                            if let Some(desc) = updates.get("description").and_then(|d| d.as_str()) {
-                                plan.add_milestone(desc.to_string());
-                            }
-                        }
-                        "log_decision" => {
-                            let decision = updates.get("decision").and_then(|d| d.as_str()).unwrap_or("");
-                            let rationale = updates.get("rationale").and_then(|r| r.as_str()).unwrap_or("");
-                            plan.log_decision(decision, rationale);
-                        }
-                        _ => return RpcResponse::error(id, INTERNAL_ERROR, format!("unknown action: {action}")),
-                    }
-                    match serde_json::to_value(&*plan) {
-                        Ok(v) => RpcResponse::success(id, v),
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-                    }
-                }
-                None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
-            }
+            handlers::exec::exec_plan_update(state, id, plan_id, updates).await
         }
     }
 }
@@ -537,7 +145,8 @@ mod tests {
             signal_detector,
             draft_store,
         ));
-        let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let thread_db =
+            crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         Ok(AppState {
             server,
             tasks,
@@ -553,14 +162,13 @@ mod tests {
     #[tokio::test]
     async fn gc_adopt_response_includes_task_id() -> anyhow::Result<()> {
         use harness_core::{
-            Artifact, ArtifactType, Draft, DraftId, DraftStatus, ProjectId, RemediationType,
-            Signal, SignalType,
+            Artifact, ArtifactType, Draft, DraftId, DraftStatus, ProjectId,
+            RemediationType, Signal, SignalType,
         };
 
         let dir = tempfile::tempdir()?;
         let state = make_test_state(dir.path()).await?;
 
-        // Seed a pending draft in the store.
         let draft_id = DraftId::new();
         let signal = Signal::new(
             SignalType::RepeatedWarn,
@@ -591,10 +199,24 @@ mod tests {
         };
         let resp = handle_request(&state, req).await;
 
-        assert!(resp.error.is_none(), "expected success, got error: {:?}", resp.error);
-        let result = resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?;
-        assert_eq!(result["adopted"], serde_json::json!(true), "adopted must be true");
-        assert_eq!(result["task_id"], serde_json::json!(null), "task_id should be null when no agent is registered");
+        assert!(
+            resp.error.is_none(),
+            "expected success, got error: {:?}",
+            resp.error
+        );
+        let result =
+            resp.result
+                .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        assert_eq!(
+            result["adopted"],
+            serde_json::json!(true),
+            "adopted must be true"
+        );
+        assert_eq!(
+            result["task_id"],
+            serde_json::json!(null),
+            "task_id should be null when no agent is registered"
+        );
         Ok(())
     }
 
@@ -633,8 +255,8 @@ mod tests {
     #[tokio::test]
     async fn gc_adopt_spawns_task_when_agent_registered() -> anyhow::Result<()> {
         use harness_core::{
-            Artifact, ArtifactType, Draft, DraftId, DraftStatus, ProjectId, RemediationType,
-            Signal, SignalType,
+            Artifact, ArtifactType, Draft, DraftId, DraftStatus, ProjectId,
+            RemediationType, Signal, SignalType,
         };
 
         let dir = tempfile::tempdir()?;
@@ -673,14 +295,23 @@ mod tests {
         };
         let resp = handle_request(&state, req).await;
 
-        assert!(resp.error.is_none(), "expected success, got error: {:?}", resp.error);
-        let result = resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?;
-        assert_eq!(result["adopted"], serde_json::json!(true), "adopted must be true");
+        assert!(
+            resp.error.is_none(),
+            "expected success, got error: {:?}",
+            resp.error
+        );
+        let result =
+            resp.result
+                .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        assert_eq!(
+            result["adopted"],
+            serde_json::json!(true),
+            "adopted must be true"
+        );
         let task_id = result["task_id"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("task_id should be a string"))?;
         assert!(!task_id.is_empty(), "task_id should be non-empty");
-        // Verify the task was actually created in the task store.
         let tid = crate::task_runner::TaskId(task_id.to_string());
         let task = state.tasks.get(&tid);
         assert!(task.is_some(), "task should exist in the task store");
@@ -688,7 +319,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rule_check_logs_no_violations_when_no_guards_loaded() -> anyhow::Result<()> {
+    async fn rule_check_logs_no_violations_when_no_guards_loaded() -> anyhow::Result<()>
+    {
         let dir = tempfile::tempdir()?;
         let state = make_test_state(dir.path()).await?;
 
@@ -702,18 +334,28 @@ mod tests {
         };
         let resp = handle_request(&state, req).await;
 
-        assert!(resp.error.is_none(), "expected success: {:?}", resp.error);
+        assert!(
+            resp.error.is_none(),
+            "expected success: {:?}",
+            resp.error
+        );
         let violations: Vec<serde_json::Value> = serde_json::from_value(
-            resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?,
+            resp.result
+                .ok_or_else(|| anyhow::anyhow!("missing result"))?,
         )?;
-        assert!(violations.is_empty(), "no guards loaded, violations must be empty");
+        assert!(
+            violations.is_empty(),
+            "no guards loaded, violations must be empty"
+        );
 
-        // No rule_check events should have been logged with no violations.
         let events = state.events.query(&harness_core::EventFilters {
             hook: Some("rule_check".to_string()),
             ..Default::default()
         })?;
-        assert!(events.is_empty(), "no events should be logged when there are no violations");
+        assert!(
+            events.is_empty(),
+            "no events should be logged when there are no violations"
+        );
         Ok(())
     }
 
@@ -722,7 +364,6 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let state = make_test_state(dir.path()).await?;
 
-        // Manually seed rule_check violation events (as RuleCheck handler would).
         let session_id = harness_core::SessionId::new();
         for _ in 0..5 {
             let event = harness_core::Event::new(
@@ -743,9 +384,14 @@ mod tests {
         };
         let resp = handle_request(&state, req).await;
 
-        assert!(resp.error.is_none(), "expected success: {:?}", resp.error);
-        let result = resp.result.ok_or_else(|| anyhow::anyhow!("missing result"))?;
-        // Coverage must be below 100% because we have 5 Block violations.
+        assert!(
+            resp.error.is_none(),
+            "expected success: {:?}",
+            resp.error
+        );
+        let result =
+            resp.result
+                .ok_or_else(|| anyhow::anyhow!("missing result"))?;
         let coverage = result["dimensions"]["coverage"]
             .as_f64()
             .ok_or_else(|| anyhow::anyhow!("missing coverage"))?;
@@ -764,19 +410,31 @@ mod tests {
         let req = RpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
-            method: Method::ThreadStart { cwd: std::path::PathBuf::from("/test/project") },
+            method: Method::ThreadStart {
+                cwd: std::path::PathBuf::from("/test/project"),
+            },
         };
         let resp = handle_request(&state, req).await;
 
-        assert!(resp.error.is_none(), "expected success, got error: {:?}", resp.error);
+        assert!(
+            resp.error.is_none(),
+            "expected success, got error: {:?}",
+            resp.error
+        );
         let thread_id_str = resp.result.unwrap()["thread_id"]
             .as_str()
             .unwrap()
             .to_string();
 
         let db = state.thread_db.as_ref().unwrap();
-        let thread = db.get(&thread_id_str).await?.expect("thread should be in DB");
-        assert_eq!(thread.project_root, std::path::PathBuf::from("/test/project"));
+        let thread = db
+            .get(&thread_id_str)
+            .await?
+            .expect("thread should be in DB");
+        assert_eq!(
+            thread.project_root,
+            std::path::PathBuf::from("/test/project")
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1,0 +1,187 @@
+use crate::task_runner::{
+    mutate_and_persist, update_status, CreateTaskRequest, RoundResult, TaskId, TaskStatus,
+    TaskStore,
+};
+use harness_core::{
+    prompts, AgentRequest, CodeAgent, ContextItem, Decision, Event, SessionId,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::{sleep, Duration};
+
+pub(crate) async fn run_task(
+    store: &TaskStore,
+    task_id: &TaskId,
+    agent: &dyn CodeAgent,
+    skills: Arc<RwLock<harness_skills::SkillStore>>,
+    events: Arc<harness_observe::EventStore>,
+    req: &CreateTaskRequest,
+    project: PathBuf,
+) -> anyhow::Result<()> {
+    update_status(store, task_id, TaskStatus::Implementing, 1).await;
+
+    let first_prompt = if let Some(issue) = req.issue {
+        prompts::implement_from_issue(issue)
+    } else if let Some(pr) = req.pr {
+        prompts::check_existing_pr(pr)
+    } else {
+        prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default())
+    };
+
+    let skill_items: Vec<ContextItem> = {
+        let guard = skills.read().await;
+        guard
+            .list()
+            .iter()
+            .map(|s| ContextItem::Skill {
+                id: s.id.to_string(),
+                content: s.content.clone(),
+            })
+            .collect()
+    };
+
+    let turn_timeout = Duration::from_secs(req.turn_timeout_secs);
+    let resp = tokio::time::timeout(
+        turn_timeout,
+        agent.execute(AgentRequest {
+            prompt: first_prompt,
+            project_root: project.clone(),
+            context: skill_items.clone(),
+            ..Default::default()
+        }),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("Turn 1 timed out after {}s", req.turn_timeout_secs))?
+    ?;
+
+    let pr_url = prompts::parse_pr_url(&resp.output);
+    let pr_number = pr_url
+        .as_ref()
+        .and_then(|u| prompts::extract_pr_number(u))
+        .or(req.pr);
+
+    mutate_and_persist(store, task_id, |s| {
+        s.pr_url = pr_url.clone();
+        s.rounds.push(RoundResult {
+            turn: 1,
+            action: "implement".into(),
+            result: if pr_url.is_some() || req.pr.is_some() {
+                "pr_created".into()
+            } else {
+                "implemented".into()
+            },
+        });
+    })
+    .await;
+
+    let pr_num = match pr_number {
+        Some(n) => n,
+        None => {
+            update_status(store, task_id, TaskStatus::Done, 1).await;
+            return Ok(());
+        }
+    };
+
+    // Review loop: Turn 2..N
+    let last_review_round = req.max_rounds.saturating_add(1);
+    let mut prev_fixed = false;
+    let mut round = 2u32;
+    let max_waiting_retries = 3u32;
+
+    while round <= last_review_round {
+        update_status(store, task_id, TaskStatus::Waiting, round).await;
+        sleep(Duration::from_secs(req.wait_secs)).await;
+
+        update_status(store, task_id, TaskStatus::Reviewing, round).await;
+
+        let resp = tokio::time::timeout(
+            turn_timeout,
+            agent.execute(AgentRequest {
+                prompt: prompts::review_prompt(req.issue, pr_num, round, prev_fixed),
+                project_root: project.clone(),
+                context: skill_items.clone(),
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("Turn {round} timed out after {}s", req.turn_timeout_secs)
+        })?
+        ?;
+
+        if prompts::is_waiting(&resp.output) {
+            mutate_and_persist(store, task_id, |s| {
+                s.rounds.push(RoundResult {
+                    turn: round,
+                    action: "review".into(),
+                    result: "waiting".into(),
+                });
+            })
+            .await;
+
+            let waiting_count = store
+                .get(task_id)
+                .map(|s| {
+                    s.rounds
+                        .iter()
+                        .filter(|r| r.result == "waiting")
+                        .count() as u32
+                })
+                .unwrap_or(0);
+
+            if waiting_count >= max_waiting_retries {
+                prev_fixed = true;
+                round += 1;
+            }
+            continue;
+        }
+
+        let lgtm = prompts::is_lgtm(&resp.output);
+
+        mutate_and_persist(store, task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: round,
+                action: "review".into(),
+                result: if lgtm { "lgtm".into() } else { "fixed".into() },
+            });
+        })
+        .await;
+
+        // Log pr_review event for observability and GC signal detection.
+        let mut ev = Event::new(
+            SessionId::new(),
+            "pr_review",
+            "task_runner",
+            if lgtm { Decision::Complete } else { Decision::Warn },
+        );
+        ev.detail = Some(format!("pr={pr_num}"));
+        ev.reason = Some(if lgtm {
+            format!("round {round}: lgtm")
+        } else {
+            format!("round {round}: fixed")
+        });
+        if let Err(e) = events.log(&ev) {
+            tracing::warn!("failed to log pr_review event: {e}");
+        }
+
+        if lgtm {
+            update_status(store, task_id, TaskStatus::Done, round).await;
+            return Ok(());
+        }
+
+        prev_fixed = true;
+        round += 1;
+    }
+
+    mutate_and_persist(store, task_id, |s| {
+        s.status = TaskStatus::Failed;
+        s.turn = req.max_rounds.saturating_add(1);
+        s.error = Some(format!(
+            "Task did not receive LGTM after {} review rounds.",
+            req.max_rounds
+        ));
+    })
+    .await;
+    Ok(())
+}

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1,11 +1,10 @@
 use crate::task_db::TaskDb;
 use dashmap::DashMap;
-use harness_core::{prompts, AgentRequest, CodeAgent, ContextItem, Decision, Event, SessionId};
+use harness_core::CodeAgent;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tokio::time::{sleep, Duration};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TaskId(pub String);
@@ -128,7 +127,7 @@ fn default_turn_timeout() -> u64 {
 
 /// In-memory cache + SQLite persistence.
 pub struct TaskStore {
-    cache: DashMap<TaskId, TaskState>,
+    pub(crate) cache: DashMap<TaskId, TaskState>,
     db: TaskDb,
 }
 
@@ -136,7 +135,6 @@ impl TaskStore {
     pub async fn open(db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
         let db = TaskDb::open(db_path).await?;
         let cache = DashMap::new();
-        // Load existing tasks into cache
         for task in db.list().await? {
             cache.insert(task.id.clone(), task);
         }
@@ -155,14 +153,14 @@ impl TaskStore {
         self.cache.iter().map(|e| e.value().clone()).collect()
     }
 
-    async fn insert(&self, state: &TaskState) {
+    pub(crate) async fn insert(&self, state: &TaskState) {
         self.cache.insert(state.id.clone(), state.clone());
         if let Err(e) = self.db.insert(state).await {
             tracing::error!("task_db insert failed: {e}");
         }
     }
 
-    async fn persist(&self, id: &TaskId) {
+    pub(crate) async fn persist(&self, id: &TaskId) {
         if let Some(state) = self.cache.get(id) {
             if let Err(e) = self.db.update(state.value()).await {
                 tracing::error!("task_db update failed: {e}");
@@ -183,11 +181,9 @@ pub async fn spawn_task(
     store.insert(&state).await;
 
     let id = task_id.clone();
-    // Clone handles for the watcher spawn; originals move into the inner spawn.
     let store_watcher = store.clone();
     let id_watcher = id.clone();
 
-    // Inner task: runs the actual work, returns Result so the watcher can detect errors.
     let handle = tokio::spawn(async move {
         let project = match req.project.clone() {
             Some(p) => p,
@@ -195,11 +191,12 @@ pub async fn spawn_task(
                 .await
                 .unwrap_or_else(|_| PathBuf::from(".")),
         };
-        run_task(&store, &id, agent.as_ref(), skills, events, &req, project).await
+        crate::task_executor::run_task(
+            &store, &id, agent.as_ref(), skills, events, &req, project,
+        )
+        .await
     });
 
-    // Watcher: awaits the inner JoinHandle to propagate both errors and panics to the store.
-    // Without this, a panic inside the inner task would leave the task stuck in a non-terminal state.
     tokio::spawn(async move {
         match handle.await {
             Ok(Ok(())) => {}
@@ -211,7 +208,9 @@ pub async fn spawn_task(
                 .await;
             }
             Err(join_err) => {
-                tracing::error!("task {id_watcher:?} panicked or was cancelled: {join_err}");
+                tracing::error!(
+                    "task {id_watcher:?} panicked or was cancelled: {join_err}"
+                );
                 mutate_and_persist(&store_watcher, &id_watcher, |s| {
                     s.status = TaskStatus::Failed;
                     s.error = Some(format!("task failed unexpectedly: {join_err}"));
@@ -224,192 +223,12 @@ pub async fn spawn_task(
     task_id
 }
 
-async fn run_task(
+pub(crate) async fn update_status(
     store: &TaskStore,
     task_id: &TaskId,
-    agent: &dyn CodeAgent,
-    skills: Arc<RwLock<harness_skills::SkillStore>>,
-    events: Arc<harness_observe::EventStore>,
-    req: &CreateTaskRequest,
-    project: PathBuf,
-) -> anyhow::Result<()> {
-    // Turn 1: implement
-    update_status(store, task_id, TaskStatus::Implementing, 1).await;
-
-    let first_prompt = if let Some(issue) = req.issue {
-        prompts::implement_from_issue(issue)
-    } else if let Some(pr) = req.pr {
-        prompts::check_existing_pr(pr)
-    } else {
-        prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default())
-    };
-
-    let skill_items: Vec<ContextItem> = {
-        let guard = skills.read().await;
-        guard
-            .list()
-            .iter()
-            .map(|s| ContextItem::Skill {
-                id: s.id.to_string(),
-                content: s.content.clone(),
-            })
-            .collect()
-    };
-
-    let turn_timeout = Duration::from_secs(req.turn_timeout_secs);
-    let resp = tokio::time::timeout(
-        turn_timeout,
-        agent.execute(AgentRequest {
-            prompt: first_prompt,
-            project_root: project.clone(),
-            context: skill_items.clone(),
-            ..Default::default()
-        }),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("Turn 1 timed out after {}s", req.turn_timeout_secs))?
-    ?;
-
-    let pr_url = prompts::parse_pr_url(&resp.output);
-    let pr_number = pr_url
-        .as_ref()
-        .and_then(|u| prompts::extract_pr_number(u))
-        .or(req.pr); // fallback: use req.pr if agent didn't output PR_URL
-
-    mutate_and_persist(store, task_id, |s| {
-        s.pr_url = pr_url.clone();
-        s.rounds.push(RoundResult {
-            turn: 1,
-            action: "implement".into(),
-            result: if pr_url.is_some() || req.pr.is_some() {
-                "pr_created".into()
-            } else {
-                "implemented".into()
-            },
-        });
-    })
-    .await;
-
-    let pr_num = match pr_number {
-        Some(n) => n,
-        None => {
-            update_status(store, task_id, TaskStatus::Done, 1).await;
-            return Ok(());
-        }
-    };
-
-    // Review loop: Turn 2..N
-    // prev_fixed tracks whether the previous round pushed new code.
-    // When true, the next round's prompt requires the agent to verify that
-    // Gemini has submitted a new review covering the latest commit before
-    // declaring LGTM. If Gemini hasn't re-reviewed yet, the agent outputs
-    // WAITING and we retry without consuming a round.
-    let last_review_round = req.max_rounds.saturating_add(1);
-    let mut prev_fixed = false;
-    let mut round = 2u32;
-    let max_waiting_retries = 3u32;
-
-    while round <= last_review_round {
-        update_status(store, task_id, TaskStatus::Waiting, round).await;
-        sleep(Duration::from_secs(req.wait_secs)).await;
-
-        update_status(store, task_id, TaskStatus::Reviewing, round).await;
-
-        let resp = tokio::time::timeout(
-            turn_timeout,
-            agent.execute(AgentRequest {
-                prompt: prompts::review_prompt(req.issue, pr_num, round, prev_fixed),
-                project_root: project.clone(),
-                context: skill_items.clone(),
-                ..Default::default()
-            }),
-        )
-        .await
-        .map_err(|_| anyhow::anyhow!("Turn {round} timed out after {}s", req.turn_timeout_secs))?
-        ?;
-
-        // WAITING: Gemini hasn't re-reviewed after the fix commit yet.
-        // Retry without consuming a round, up to max_waiting_retries.
-        if prompts::is_waiting(&resp.output) {
-            mutate_and_persist(store, task_id, |s| {
-                s.rounds.push(RoundResult {
-                    turn: round,
-                    action: "review".into(),
-                    result: "waiting".into(),
-                });
-            })
-            .await;
-
-            let waiting_count = store
-                .get(task_id)
-                .map(|s| {
-                    s.rounds
-                        .iter()
-                        .filter(|r| r.result == "waiting")
-                        .count() as u32
-                })
-                .unwrap_or(0);
-
-            if waiting_count >= max_waiting_retries {
-                // Exceeded waiting retries — advance round to avoid infinite loop
-                prev_fixed = true;
-                round += 1;
-            }
-            // Don't advance round; retry with same round number
-            continue;
-        }
-
-        let lgtm = prompts::is_lgtm(&resp.output);
-
-        mutate_and_persist(store, task_id, |s| {
-            s.rounds.push(RoundResult {
-                turn: round,
-                action: "review".into(),
-                result: if lgtm { "lgtm".into() } else { "fixed".into() },
-            });
-        })
-        .await;
-
-        // Log pr_review event for observability and GC signal detection.
-        let mut ev = Event::new(
-            SessionId::new(),
-            "pr_review",
-            "task_runner",
-            if lgtm { Decision::Complete } else { Decision::Warn },
-        );
-        ev.detail = Some(format!("pr={pr_num}"));
-        ev.reason = Some(if lgtm {
-            format!("round {round}: lgtm")
-        } else {
-            format!("round {round}: fixed")
-        });
-        if let Err(e) = events.log(&ev) {
-            tracing::warn!("failed to log pr_review event: {e}");
-        }
-
-        if lgtm {
-            update_status(store, task_id, TaskStatus::Done, round).await;
-            return Ok(());
-        }
-
-        prev_fixed = true;
-        round += 1;
-    }
-
-    // Reached max rounds without LGTM
-    mutate_and_persist(store, task_id, |s| {
-        s.status = TaskStatus::Failed;
-        s.turn = req.max_rounds.saturating_add(1);
-        s.error = Some(format!(
-            "Task did not receive LGTM after {} review rounds.",
-            req.max_rounds
-        ));
-    })
-    .await;
-    Ok(())
-}
-
-async fn update_status(store: &TaskStore, task_id: &TaskId, status: TaskStatus, turn: u32) {
+    status: TaskStatus,
+    turn: u32,
+) {
     mutate_and_persist(store, task_id, |s| {
         s.status = status;
         s.turn = turn;
@@ -418,7 +237,11 @@ async fn update_status(store: &TaskStore, task_id: &TaskId, status: TaskStatus, 
 }
 
 /// Mutate a task in the cache then persist to SQLite.
-async fn mutate_and_persist(store: &TaskStore, id: &TaskId, f: impl FnOnce(&mut TaskState)) {
+pub(crate) async fn mutate_and_persist(
+    store: &TaskStore,
+    id: &TaskId,
+    f: impl FnOnce(&mut TaskState),
+) {
     if let Some(mut entry) = store.cache.get_mut(id) {
         f(entry.value_mut());
     }
@@ -429,7 +252,10 @@ async fn mutate_and_persist(store: &TaskStore, id: &TaskId, f: impl FnOnce(&mut 
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use harness_core::{AgentResponse, Capability, StreamItem, TokenUsage};
+    use harness_core::{
+        AgentRequest, AgentResponse, Capability, ContextItem, StreamItem, TokenUsage,
+    };
+    use tokio::time::Duration;
 
     #[test]
     fn test_task_state_new() {
@@ -440,7 +266,6 @@ mod tests {
         assert!(state.pr_url.is_none());
     }
 
-    /// A mock agent that captures the context from the first AgentRequest it receives.
     struct CapturingAgent {
         captured: tokio::sync::Mutex<Vec<ContextItem>>,
     }
@@ -463,7 +288,10 @@ mod tests {
             vec![]
         }
 
-        async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
+        async fn execute(
+            &self,
+            req: AgentRequest,
+        ) -> harness_core::Result<AgentResponse> {
             let mut guard = self.captured.lock().await;
             if guard.is_empty() {
                 *guard = req.context.clone();
@@ -472,7 +300,12 @@ mod tests {
                 output: String::new(),
                 stderr: String::new(),
                 items: vec![],
-                token_usage: TokenUsage { input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_usd: 0.0 },
+                token_usage: TokenUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                    cost_usd: 0.0,
+                },
                 model: "mock".into(),
                 exit_code: Some(0),
             })
@@ -490,9 +323,9 @@ mod tests {
     #[tokio::test]
     async fn skills_are_injected_into_agent_context() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let store =
+            TaskStore::open(&dir.path().join("tasks.db")).await?;
 
-        // Build a SkillStore with one skill
         let mut skill_store = harness_skills::SkillStore::new();
         skill_store.create("test-skill".to_string(), "do something useful".to_string());
         let skills = Arc::new(RwLock::new(skill_store));
@@ -513,13 +346,17 @@ mod tests {
         let events = Arc::new(harness_observe::EventStore::new(dir.path())?);
         spawn_task(store, agent_clone, skills, events, req).await;
 
-        // Allow the spawned task to run
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let captured = agent.captured.lock().await;
-        assert!(!captured.is_empty(), "expected skills to be injected into AgentRequest.context");
         assert!(
-            captured.iter().any(|item| matches!(item, ContextItem::Skill { .. })),
+            !captured.is_empty(),
+            "expected skills to be injected into AgentRequest.context"
+        );
+        assert!(
+            captured
+                .iter()
+                .any(|item| matches!(item, ContextItem::Skill { .. })),
             "expected at least one ContextItem::Skill"
         );
         Ok(())


### PR DESCRIPTION
## Summary

- Split `router.rs` (851 lines) into dispatch-only router + 7 handler modules
- Split `task_runner.rs` (528 lines) into types/store + `task_executor.rs`
- Prerequisite for VibeGuard absorption (Phase 0 of 9)

## Changes

| File | Before | After | Content |
|------|--------|-------|---------|
| `router.rs` | 851 | 112+tests | Match dispatch only |
| `task_runner.rs` | 528 | 250+tests | Types, TaskStore, spawn_task |
| `task_executor.rs` | - | 187 | run_task, review loop |
| `handlers/thread.rs` | - | 214 | Thread/Turn handlers |
| `handlers/gc.rs` | - | 144 | GC handlers |
| `handlers/observe.rs` | - | 90 | Event/Metrics handlers |
| `handlers/exec.rs` | - | 88 | ExecPlan handlers |
| `handlers/rules.rs` | - | 70 | Rule handlers |
| `handlers/skills.rs` | - | 58 | Skill handlers |

## Test plan

- [x] `cargo check` passes
- [x] All 93 tests pass (`cargo test`)
- [x] No behavior change — pure structural refactoring