### PR TITLE
feat: add initialized handshake for JSON-RPC protocol parity

### DIFF
--- a/crates/harness-protocol/src/codec.rs
+++ b/crates/harness-protocol/src/codec.rs
@@ -76,6 +76,21 @@ mod tests {
     }
 
     #[test]
+    fn codec_initialized_roundtrip() -> anyhow::Result<()> {
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: Method::Initialized,
+        };
+        let json = serde_json::to_string(&req)?;
+        // method field must be "initialized"
+        assert!(json.contains("\"initialized\""), "serialized: {json}");
+        let back: RpcRequest = decode_request(&json)?;
+        assert!(matches!(back.method, Method::Initialized));
+        Ok(())
+    }
+
+    #[test]
     fn rpc_error_codes_are_negative() {
         assert!(crate::PARSE_ERROR < 0);
         assert!(crate::INVALID_REQUEST < 0);

--- a/crates/harness-protocol/src/methods.rs
+++ b/crates/harness-protocol/src/methods.rs
@@ -10,6 +10,9 @@ use std::path::PathBuf;
 pub enum Method {
     // === Initialization ===
     Initialize,
+    /// Sent by the client after receiving an `initialize` response to confirm
+    /// the handshake is complete.  No params required.
+    Initialized,
 
     // === Thread management ===
     ThreadStart { cwd: PathBuf },

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -25,6 +25,12 @@ pub(crate) async fn persist_thread_insert(state: &AppState, thread_id: &ThreadId
     }
 }
 
+/// Handle the `initialized` notification sent by the client after `initialize`.
+/// Returns an empty success to confirm the handshake is complete on the server side.
+pub async fn initialized(id: Option<serde_json::Value>) -> RpcResponse {
+    RpcResponse::success(id, serde_json::json!({}))
+}
+
 pub async fn initialize(id: Option<serde_json::Value>) -> RpcResponse {
     RpcResponse::success(
         id,

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -9,6 +9,7 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> RpcResponse {
     match req.method {
         // === Initialization ===
         Method::Initialize => handlers::thread::initialize(id).await,
+        Method::Initialized => handlers::thread::initialized(id).await,
 
         // === Thread management ===
         Method::ThreadStart { cwd } => {
@@ -187,6 +188,65 @@ mod tests {
             thread_db: Some(thread_db),
             interceptors: vec![],
         })
+    }
+
+    #[tokio::test]
+    async fn initialized_returns_success() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: Method::Initialized,
+        };
+        let resp = handle_request(&state, req).await;
+
+        assert!(
+            resp.error.is_none(),
+            "initialized should succeed, got error: {:?}",
+            resp.error
+        );
+        assert!(resp.result.is_some(), "initialized must return a result");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn initialize_then_initialized_succeeds() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        // Step 1: initialize
+        let init_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::Initialize,
+        };
+        let init_resp = handle_request(&state, init_req).await;
+        assert!(
+            init_resp.error.is_none(),
+            "initialize should succeed: {:?}",
+            init_resp.error
+        );
+        let result = init_resp
+            .result
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("initialize must return result"))?;
+        assert!(result["capabilities"].is_object(), "capabilities should be present");
+
+        // Step 2: initialized (notification — id is None)
+        let ack_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: Method::Initialized,
+        };
+        let ack_resp = handle_request(&state, ack_req).await;
+        assert!(
+            ack_resp.error.is_none(),
+            "initialized handshake should succeed: {:?}",
+            ack_resp.error
+        );
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `Initialized` variant to `Method` enum so the JSON-RPC `initialized` notification is a first-class protocol message
- Wire `Method::Initialized` in the router to a new `initialized()` handler that returns `{}`
- The stdio transport now handles the full `initialize → initialized` handshake without parse errors

## Tests

- `codec_initialized_roundtrip` — serialise/deserialise `Initialized` cleanly
- `initialized_returns_success` — handler returns a success result
- `initialize_then_initialized_succeeds` — full two-step handshake via the router

All 51 server tests pass; 6 protocol tests pass.