### PR TITLE
fix: wire rule violations into observability pipeline

### DIFF
--- a/crates/harness-observe/src/lib.rs
+++ b/crates/harness-observe/src/lib.rs
@@ -9,4 +9,4 @@ pub use event_store::EventStore;
 pub use health::HealthReport;
 pub use quality::QualityGrader;
 pub use session::SessionManager;
-pub use stats::{ComplianceTrend, HookStats};
+pub use stats::{ComplianceTrend, HookStats, RuleStats};

--- a/crates/harness-observe/src/stats.rs
+++ b/crates/harness-observe/src/stats.rs
@@ -99,6 +99,42 @@ pub fn compute_trends(events: &[Event], period_days: u32) -> Vec<ComplianceTrend
     trends
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleStats {
+    pub rule_id: String,
+    pub total: usize,
+    pub block_count: usize,
+    pub warn_count: usize,
+    pub pass_count: usize,
+}
+
+/// Aggregate per-rule violation counts from historical rule_check events.
+pub fn aggregate_rule_stats(events: &[Event]) -> Vec<RuleStats> {
+    // rule_check events store the rule_id in the `tool` field
+    let mut map: HashMap<String, (usize, usize, usize, usize)> = HashMap::new();
+    for e in events.iter().filter(|e| e.hook == "rule_check") {
+        let entry = map.entry(e.tool.clone()).or_insert((0, 0, 0, 0));
+        entry.0 += 1;
+        match e.decision {
+            Decision::Pass | Decision::Complete => entry.3 += 1,
+            Decision::Warn => entry.2 += 1,
+            Decision::Block | Decision::Gate | Decision::Escalate => entry.1 += 1,
+        }
+    }
+    let mut stats: Vec<RuleStats> = map
+        .into_iter()
+        .map(|(rule_id, (total, block, warn, pass))| RuleStats {
+            rule_id,
+            total,
+            block_count: block,
+            warn_count: warn,
+            pass_count: pass,
+        })
+        .collect();
+    stats.sort_by(|a, b| b.total.cmp(&a.total));
+    stats
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,6 +196,37 @@ mod tests {
         assert!(!trends.is_empty());
         assert!((trends[0].pass_rate - 1.0).abs() < f64::EPSILON);
         assert_eq!(trends[0].grade, Grade::A);
+    }
+
+    #[test]
+    fn aggregate_rule_stats_empty_returns_empty() {
+        let stats = aggregate_rule_stats(&[]);
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn aggregate_rule_stats_groups_by_rule_id() {
+        let events = vec![
+            make_rule_event("SEC-01", Decision::Block),
+            make_rule_event("SEC-01", Decision::Warn),
+            make_rule_event("SEC-02", Decision::Pass),
+            make_event("other_hook", Decision::Block),
+        ];
+        let stats = aggregate_rule_stats(&events);
+        assert_eq!(stats.len(), 2);
+        assert!(
+            stats.iter().any(|s| s.rule_id == "SEC-01" && s.total == 2
+                && s.block_count == 1 && s.warn_count == 1),
+            "expected SEC-01 with 2 total, 1 block, 1 warn"
+        );
+        assert!(
+            stats.iter().any(|s| s.rule_id == "SEC-02" && s.total == 1 && s.pass_count == 1),
+            "expected SEC-02 with 1 total, 1 pass"
+        );
+    }
+
+    fn make_rule_event(rule_id: &str, decision: Decision) -> Event {
+        Event::new(SessionId::new(), "rule_check", rule_id, decision)
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -15,6 +15,7 @@ pub async fn gc_run(
         let rules = state.rules.read().await;
         rules.scan(&project_root).await.unwrap_or_default()
     };
+    crate::handlers::persist_violations(&state.events, &violations);
     let project = harness_core::Project::from_path(project_root);
     let agent = match state.server.agent_registry.default_agent() {
         Some(a) => a,

--- a/crates/harness-server/src/handlers/health.rs
+++ b/crates/harness-server/src/handlers/health.rs
@@ -23,6 +23,7 @@ pub async fn health_check(
         let rules = state.rules.read().await;
         rules.scan(&project_root).await.unwrap_or_default()
     };
+    crate::handlers::persist_violations(&state.events, &violations);
 
     let report = generate_health_report(&events, &violations);
     match serde_json::to_value(&report) {
@@ -45,10 +46,12 @@ pub async fn stats_query(
 
     let hook_stats = stats::aggregate_hook_stats(&events);
     let trends = stats::compute_trends(&events, 7);
+    let rule_stats = stats::aggregate_rule_stats(&events);
 
     match serde_json::to_value(serde_json::json!({
         "hook_stats": hook_stats,
         "trends": trends,
+        "rule_stats": rule_stats,
     })) {
         Ok(v) => RpcResponse::success(id, v),
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -10,6 +10,38 @@ pub mod rules;
 pub mod skills;
 pub mod thread;
 
+/// Persist rule scan violations to the event store using the same format as rule_check.
+pub(crate) fn persist_violations(
+    events: &harness_observe::EventStore,
+    violations: &[harness_core::Violation],
+) {
+    let session_id = harness_core::SessionId::new();
+    for violation in violations {
+        let decision = match violation.severity {
+            harness_core::Severity::Critical | harness_core::Severity::High => {
+                harness_core::Decision::Block
+            }
+            harness_core::Severity::Medium => harness_core::Decision::Warn,
+            harness_core::Severity::Low => harness_core::Decision::Pass,
+        };
+        let mut event = harness_core::Event::new(
+            session_id.clone(),
+            "rule_check",
+            violation.rule_id.as_str(),
+            decision,
+        );
+        event.reason = Some(violation.message.clone());
+        event.detail = Some(format!(
+            "{}:{}",
+            violation.file.display(),
+            violation.line.map(|l| l.to_string()).unwrap_or_default()
+        ));
+        if let Err(e) = events.log(&event) {
+            tracing::warn!("failed to log rule violation event: {e}");
+        }
+    }
+}
+
 /// Validate that `file` is an existing path within `project_root` (already canonicalized).
 /// Returns the canonicalized file path on success.
 pub(crate) fn validate_file_in_root(

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -42,15 +42,12 @@ pub async fn metrics_collect(
     let events = state.events.query(&harness_core::EventFilters::default());
     match events {
         Ok(evts) => {
-            let violation_count = {
+            let violations = {
                 let rules = state.rules.read().await;
-                rules
-                    .scan(&project_root)
-                    .await
-                    .map(|v| v.len())
-                    .unwrap_or(0)
+                rules.scan(&project_root).await.unwrap_or_default()
             };
-            let report = harness_observe::QualityGrader::grade(&evts, violation_count);
+            crate::handlers::persist_violations(&state.events, &violations);
+            let report = harness_observe::QualityGrader::grade(&evts, violations.len());
             match serde_json::to_value(&report) {
                 Ok(v) => RpcResponse::success(id, v),
                 Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -50,34 +50,7 @@ pub async fn rule_check(
     };
     match result {
         Ok(violations) => {
-            let session_id = harness_core::SessionId::new();
-            for violation in &violations {
-                let decision = match violation.severity {
-                    harness_core::Severity::Critical | harness_core::Severity::High => {
-                        harness_core::Decision::Block
-                    }
-                    harness_core::Severity::Medium => harness_core::Decision::Warn,
-                    harness_core::Severity::Low => harness_core::Decision::Pass,
-                };
-                let mut event = harness_core::Event::new(
-                    session_id.clone(),
-                    "rule_check",
-                    violation.rule_id.as_str(),
-                    decision,
-                );
-                event.reason = Some(violation.message.clone());
-                event.detail = Some(format!(
-                    "{}:{}",
-                    violation.file.display(),
-                    violation
-                        .line
-                        .map(|l| l.to_string())
-                        .unwrap_or_default()
-                ));
-                if let Err(e) = state.events.log(&event) {
-                    tracing::warn!("failed to log rule violation event: {e}");
-                }
-            }
+            crate::handlers::persist_violations(&state.events, &violations);
             match serde_json::to_value(&violations) {
                 Ok(v) => RpcResponse::success(id, v),
                 Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),


### PR DESCRIPTION
Closes #29

## Summary

- All `rules.scan()` call sites now persist violations to the event store via a shared `persist_violations()` helper
- `metrics_collect`, `health_check`, and `gc_run` no longer silently discard scan results
- Added `aggregate_rule_stats()` to surface per-rule violation history from stored events
- `StatsQuery` response now includes `rule_stats` (per-rule totals, block/warn/pass counts)

## Pipeline after this fix

```
scan → persist (event store) → quality grading → GC signal detection
```