### PR TITLE
fix: atomically snapshot waiting_count retry updates

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1,6 +1,6 @@
 use crate::task_runner::{
-    mutate_and_persist, update_status, CreateTaskRequest, RoundResult, TaskId, TaskStatus,
-    TaskStore,
+    mutate_and_persist, mutate_and_persist_with, update_status, CreateTaskRequest, RoundResult,
+    TaskId, TaskStatus, TaskStore,
 };
 use harness_core::{
     interceptor::TurnInterceptor, prompts, AgentRequest, AgentResponse, CodeAgent, ContextItem,
@@ -20,8 +20,14 @@ async fn run_pre_execute(
     for interceptor in interceptors {
         let result = interceptor.pre_execute(&req).await;
         if let Decision::Block = result.decision {
-            let reason = result.reason.unwrap_or_else(|| interceptor.name().to_string());
-            return Err(anyhow::anyhow!("Blocked by interceptor '{}': {}", interceptor.name(), reason));
+            let reason = result
+                .reason
+                .unwrap_or_else(|| interceptor.name().to_string());
+            return Err(anyhow::anyhow!(
+                "Blocked by interceptor '{}': {}",
+                interceptor.name(),
+                reason
+            ));
         }
         if let Some(modified) = result.request {
             req = modified;
@@ -40,11 +46,7 @@ async fn run_post_execute(
     }
 }
 
-async fn run_on_error(
-    interceptors: &[Arc<dyn TurnInterceptor>],
-    req: &AgentRequest,
-    error: &str,
-) {
+async fn run_on_error(interceptors: &[Arc<dyn TurnInterceptor>], req: &AgentRequest, error: &str) {
     for interceptor in interceptors {
         interceptor.on_error(req, error).await;
     }
@@ -178,24 +180,19 @@ pub(crate) async fn run_task(
         };
 
         if prompts::is_waiting(&resp.output) {
-            mutate_and_persist(store, task_id, |s| {
+            let waiting_count = mutate_and_persist_with(store, task_id, |s| {
                 s.rounds.push(RoundResult {
                     turn: round,
                     action: "review".into(),
                     result: "waiting".into(),
                 });
+                s.rounds
+                    .iter()
+                    .filter(|r| r.result == "waiting" && r.turn == round)
+                    .count() as u32
             })
-            .await;
-
-            let waiting_count = store
-                .get(task_id)
-                .map(|s| {
-                    s.rounds
-                        .iter()
-                        .filter(|r| r.result == "waiting" && r.turn == round)
-                        .count() as u32
-                })
-                .unwrap_or(0);
+            .await
+            .unwrap_or(0);
 
             if waiting_count >= max_waiting_retries {
                 prev_fixed = true;
@@ -220,7 +217,11 @@ pub(crate) async fn run_task(
             SessionId::new(),
             "pr_review",
             "task_runner",
-            if lgtm { Decision::Complete } else { Decision::Warn },
+            if lgtm {
+                Decision::Complete
+            } else {
+                Decision::Warn
+            },
         );
         ev.detail = Some(format!("pr={pr_num}"));
         ev.reason = Some(if lgtm {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -4,7 +4,7 @@ use harness_core::CodeAgent;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TaskId(pub String);
@@ -110,7 +110,9 @@ fn detect_main_worktree() -> PathBuf {
                 .map(|p| PathBuf::from(p.trim()))
         })
         .unwrap_or_else(|| {
-            tracing::warn!("detect_main_worktree: could not detect git worktree root, falling back to '.'");
+            tracing::warn!(
+                "detect_main_worktree: could not detect git worktree root, falling back to '.'"
+            );
             PathBuf::from(".")
         })
 }
@@ -129,16 +131,23 @@ fn default_turn_timeout() -> u64 {
 pub struct TaskStore {
     pub(crate) cache: DashMap<TaskId, TaskState>,
     db: TaskDb,
+    persist_locks: DashMap<TaskId, Arc<Mutex<()>>>,
 }
 
 impl TaskStore {
     pub async fn open(db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
         let db = TaskDb::open(db_path).await?;
         let cache = DashMap::new();
+        let persist_locks = DashMap::new();
         for task in db.list().await? {
+            persist_locks.insert(task.id.clone(), Arc::new(Mutex::new(())));
             cache.insert(task.id.clone(), task);
         }
-        Ok(Arc::new(Self { cache, db }))
+        Ok(Arc::new(Self {
+            cache,
+            db,
+            persist_locks,
+        }))
     }
 
     pub fn get(&self, id: &TaskId) -> Option<TaskState> {
@@ -154,6 +163,9 @@ impl TaskStore {
     }
 
     pub(crate) async fn insert(&self, state: &TaskState) {
+        self.persist_locks
+            .entry(state.id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())));
         self.cache.insert(state.id.clone(), state.clone());
         if let Err(e) = self.db.insert(state).await {
             tracing::error!("task_db insert failed: {e}");
@@ -161,8 +173,16 @@ impl TaskStore {
     }
 
     pub(crate) async fn persist(&self, id: &TaskId) {
-        if let Some(state) = self.cache.get(id) {
-            if let Err(e) = self.db.update(state.value()).await {
+        let lock = self
+            .persist_locks
+            .entry(id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
+        let snapshot = self.cache.get(id).map(|state| state.value().clone());
+        if let Some(state) = snapshot {
+            if let Err(e) = self.db.update(&state).await {
                 tracing::error!("task_db update failed: {e}");
             }
         }
@@ -196,7 +216,14 @@ pub async fn spawn_task(
         let project = crate::handlers::validate_project_root(&raw_project)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         crate::task_executor::run_task(
-            &store, &id, agent.as_ref(), skills, events, interceptors, &req, project,
+            &store,
+            &id,
+            agent.as_ref(),
+            skills,
+            events,
+            interceptors,
+            &req,
+            project,
         )
         .await
     });
@@ -212,9 +239,7 @@ pub async fn spawn_task(
                 .await;
             }
             Err(join_err) => {
-                tracing::error!(
-                    "task {id_watcher:?} panicked or was cancelled: {join_err}"
-                );
+                tracing::error!("task {id_watcher:?} panicked or was cancelled: {join_err}");
                 mutate_and_persist(&store_watcher, &id_watcher, |s| {
                     s.status = TaskStatus::Failed;
                     s.error = Some(format!("task failed unexpectedly: {join_err}"));
@@ -246,10 +271,27 @@ pub(crate) async fn mutate_and_persist(
     id: &TaskId,
     f: impl FnOnce(&mut TaskState),
 ) {
-    if let Some(mut entry) = store.cache.get_mut(id) {
-        f(entry.value_mut());
-    }
+    let _ = mutate_and_persist_with(store, id, |state| {
+        f(state);
+    })
+    .await;
+}
+
+/// Mutate a task, compute a return value from the same in-lock snapshot, then persist.
+pub(crate) async fn mutate_and_persist_with<R>(
+    store: &TaskStore,
+    id: &TaskId,
+    f: impl FnOnce(&mut TaskState) -> R,
+) -> Option<R> {
+    let result = if let Some(mut entry) = store.cache.get_mut(id) {
+        let result = f(entry.value_mut());
+        Some(result)
+    } else {
+        None
+    };
+
     store.persist(id).await;
+    result
 }
 
 #[cfg(test)]
@@ -283,9 +325,7 @@ mod tests {
     }
 
     fn writable_home() -> std::path::PathBuf {
-        let home = std::path::PathBuf::from(
-            std::env::var("HOME").unwrap_or_else(|_| ".".into()),
-        );
+        let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()));
         if tempfile::Builder::new()
             .prefix("harness-home-probe-")
             .tempdir_in(&home)
@@ -312,10 +352,7 @@ mod tests {
             vec![]
         }
 
-        async fn execute(
-            &self,
-            req: AgentRequest,
-        ) -> harness_core::Result<AgentResponse> {
+        async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
             let mut guard = self.captured.lock().await;
             if guard.is_empty() {
                 *guard = req.context.clone();
@@ -350,8 +387,7 @@ mod tests {
         let dir = tempfile::Builder::new()
             .prefix("harness-test-")
             .tempdir_in(&home)?;
-        let store =
-            TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
 
         let mut skill_store = harness_skills::SkillStore::new();
         skill_store.create("test-skill".to_string(), "do something useful".to_string());
@@ -441,10 +477,78 @@ mod tests {
             state.status
         );
         assert!(
-            state.error.as_deref().unwrap_or("").contains("Blocked by interceptor"),
+            state
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Blocked by interceptor"),
             "error message should mention blocked: {:?}",
             state.error
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mutate_and_persist_with_counts_waiting_entries_in_single_snapshot(
+    ) -> anyhow::Result<()> {
+        let home = writable_home();
+        let dir = tempfile::Builder::new()
+            .prefix("harness-test-")
+            .tempdir_in(&home)?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let task_id = TaskId::new();
+        let task_state = TaskState::new(task_id.clone());
+        store.insert(&task_state).await;
+
+        let mut handles = Vec::new();
+        let round = 2u32;
+        let workers = 8u32;
+
+        for _ in 0..workers {
+            let store = store.clone();
+            let task_id = task_id.clone();
+            handles.push(tokio::spawn(async move {
+                mutate_and_persist_with(store.as_ref(), &task_id, |state| {
+                    state.rounds.push(RoundResult {
+                        turn: round,
+                        action: "review".into(),
+                        result: "waiting".into(),
+                    });
+                    state
+                        .rounds
+                        .iter()
+                        .filter(|result| result.turn == round && result.result == "waiting")
+                        .count() as u32
+                })
+                .await
+                .expect("task state should exist")
+            }));
+        }
+
+        let mut observed_counts = Vec::new();
+        for handle in handles {
+            observed_counts.push(handle.await?);
+        }
+        observed_counts.sort_unstable();
+
+        assert_eq!(observed_counts, (1..=workers).collect::<Vec<u32>>());
+
+        let state = store.get(&task_id).expect("task state should exist");
+        let waiting_entries = state
+            .rounds
+            .iter()
+            .filter(|result| result.turn == round && result.result == "waiting")
+            .count() as u32;
+        assert_eq!(waiting_entries, workers);
+
+        let persisted = store
+            .db
+            .get(&task_id.0)
+            .await?
+            .expect("persisted task state should exist");
+        assert_eq!(persisted.rounds.len(), state.rounds.len());
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- compute waiting_count inside a single mutate-and-persist snapshot to remove TOCTOU from waiting retry logic
- add mutate_and_persist_with helper so waiting result derivation happens under the same task-state mutation
- serialize per-task persist writes and clone cache snapshot before DB I/O to avoid lock contention during concurrent updates
- add concurrent unit test coverage for waiting retry counting

## Validation
- cargo test -p harness-server task_runner::tests::mutate_and_persist_with_counts_waiting_entries_in_single_snapshot
- cargo test -p harness-server
