### PR TITLE
fix: surface mpsc send errors in claude/codex streams

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -1,3 +1,4 @@
+use crate::streaming::send_stream_item;
 use async_trait::async_trait;
 use harness_core::{
     AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
@@ -26,11 +27,7 @@ impl CodeAgent for ClaudeCodeAgent {
     }
 
     fn capabilities(&self) -> Vec<Capability> {
-        vec![
-            Capability::Read,
-            Capability::Write,
-            Capability::Execute,
-        ]
+        vec![Capability::Read, Capability::Write, Capability::Execute]
     }
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
@@ -38,8 +35,10 @@ impl CodeAgent for ClaudeCodeAgent {
         let mut cmd = Command::new(&self.cli_path);
         cmd.arg("-p")
             .arg("--dangerously-skip-permissions")
-            .arg("--output-format").arg("text")
-            .arg("--model").arg(model)
+            .arg("--output-format")
+            .arg("text")
+            .arg("--model")
+            .arg(model)
             .arg("--verbose")
             .current_dir(&req.project_root)
             .env_remove("CLAUDECODE");
@@ -84,19 +83,51 @@ impl CodeAgent for ClaudeCodeAgent {
         tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::Result<()> {
         let resp = self.execute(req).await?;
-        let _ = tx
-            .send(StreamItem::ItemCompleted {
+        send_stream_item(
+            &tx,
+            StreamItem::ItemCompleted {
                 item: Item::AgentReasoning {
                     content: resp.output.clone(),
                 },
-            })
-            .await;
-        let _ = tx
-            .send(StreamItem::TokenUsage {
+            },
+            self.name(),
+            "item_completed",
+        )
+        .await?;
+        send_stream_item(
+            &tx,
+            StreamItem::TokenUsage {
                 usage: resp.token_usage,
-            })
-            .await;
-        let _ = tx.send(StreamItem::Done).await;
+            },
+            self.name(),
+            "token_usage",
+        )
+        .await?;
+        send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn execute_stream_returns_error_when_channel_closed() {
+        let agent = ClaudeCodeAgent::new(PathBuf::from("/usr/bin/true"), "test-model".to_string());
+        let request = AgentRequest::default();
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        drop(rx);
+
+        let err = agent
+            .execute_stream(request, tx)
+            .await
+            .expect_err("execute_stream should fail when receiver is dropped");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("stream send failed"),
+            "expected send failure in error message, got: {message}"
+        );
     }
 }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -1,3 +1,4 @@
+use crate::streaming::send_stream_item;
 use async_trait::async_trait;
 use harness_core::{
     AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
@@ -29,8 +30,10 @@ impl CodeAgent for CodexAgent {
         let mut cmd = Command::new(&self.cli_path);
         cmd.arg("exec")
             .arg("--skip-git-repo-check")
-            .arg("-a").arg("read-only")
-            .arg("-C").arg(&req.project_root)
+            .arg("-a")
+            .arg("read-only")
+            .arg("-C")
+            .arg(&req.project_root)
             .arg(&req.prompt);
 
         let output = cmd.output().await.map_err(|e| {
@@ -63,14 +66,42 @@ impl CodeAgent for CodexAgent {
         tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::Result<()> {
         let resp = self.execute(req).await?;
-        let _ = tx
-            .send(StreamItem::ItemCompleted {
+        send_stream_item(
+            &tx,
+            StreamItem::ItemCompleted {
                 item: Item::AgentReasoning {
                     content: resp.output.clone(),
                 },
-            })
-            .await;
-        let _ = tx.send(StreamItem::Done).await;
+            },
+            self.name(),
+            "item_completed",
+        )
+        .await?;
+        send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn execute_stream_returns_error_when_channel_closed() {
+        let agent = CodexAgent::new(PathBuf::from("/usr/bin/true"));
+        let request = AgentRequest::default();
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        drop(rx);
+
+        let err = agent
+            .execute_stream(request, tx)
+            .await
+            .expect_err("execute_stream should fail when receiver is dropped");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("stream send failed"),
+            "expected send failure in error message, got: {message}"
+        );
     }
 }

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -2,5 +2,6 @@ pub mod claude;
 pub mod codex;
 pub mod anthropic_api;
 pub mod registry;
+mod streaming;
 
 pub use registry::AgentRegistry;

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -1,0 +1,21 @@
+use harness_core::{HarnessError, StreamItem};
+use tokio::sync::mpsc::Sender;
+
+pub(crate) async fn send_stream_item(
+    tx: &Sender<StreamItem>,
+    item: StreamItem,
+    agent_name: &str,
+    item_label: &'static str,
+) -> harness_core::Result<()> {
+    tx.send(item).await.map_err(|err| {
+        tracing::error!(
+            agent = agent_name,
+            stream_item = item_label,
+            error = %err,
+            "failed to send stream item"
+        );
+        HarnessError::AgentExecution(format!(
+            "{agent_name} stream send failed while sending {item_label}: {err}"
+        ))
+    })
+}


### PR DESCRIPTION
## Summary
- add shared stream-send helper that logs and returns an error when mpsc send fails
- update claude and codex execute_stream paths to propagate send failures
- add closed-channel unit tests for both agents

## Validation
- cargo test -p harness-agents execute_stream_returns_error_when_channel_closed
- cargo test -p harness-server