### PR TITLE
FUT-53: Remove Gemini hardcoding in review flow and wire config

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -21,6 +21,11 @@ cli_path = "codex"
 [agents.anthropic_api]
 base_url = "https://api.anthropic.com"
 default_model = "claude-sonnet-4-20250514"
+max_tokens = 4096
+
+[review]
+reviewer_name = "Gemini"
+recheck_command = "/gemini review"
 
 [gc]
 max_drafts_per_run = 5

--- a/crates/harness-agents/src/anthropic_api.rs
+++ b/crates/harness-agents/src/anthropic_api.rs
@@ -8,16 +8,40 @@ pub struct AnthropicApiAgent {
     pub api_key: String,
     pub base_url: String,
     pub default_model: String,
+    pub max_tokens: u32,
     client: reqwest::Client,
 }
 
 impl AnthropicApiAgent {
     pub fn new(api_key: String, base_url: String, default_model: String) -> Self {
+        let default_max_tokens = harness_core::AnthropicApiConfig::default().max_tokens;
+        Self::new_with_max_tokens(api_key, base_url, default_model, default_max_tokens)
+    }
+
+    pub fn new_with_max_tokens(
+        api_key: String,
+        base_url: String,
+        default_model: String,
+        max_tokens: u32,
+    ) -> Self {
         Self {
             api_key,
             base_url,
             default_model,
+            max_tokens,
             client: reqwest::Client::new(),
+        }
+    }
+
+    fn build_messages_request(&self, req: &AgentRequest) -> MessagesRequest {
+        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        MessagesRequest {
+            model: model.to_string(),
+            max_tokens: self.max_tokens,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: req.prompt.clone(),
+            }],
         }
     }
 }
@@ -64,16 +88,7 @@ impl CodeAgent for AnthropicApiAgent {
     }
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
-        let model = req.model.as_deref().unwrap_or(&self.default_model);
-
-        let body = MessagesRequest {
-            model: model.to_string(),
-            max_tokens: 4096,
-            messages: vec![Message {
-                role: "user".to_string(),
-                content: req.prompt.clone(),
-            }],
-        };
+        let body = self.build_messages_request(&req);
 
         let resp = self
             .client
@@ -84,7 +99,9 @@ impl CodeAgent for AnthropicApiAgent {
             .json(&body)
             .send()
             .await
-            .map_err(|e| harness_core::HarnessError::AgentExecution(format!("API request failed: {e}")))?;
+            .map_err(|e| {
+                harness_core::HarnessError::AgentExecution(format!("API request failed: {e}"))
+            })?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -140,5 +157,45 @@ impl CodeAgent for AnthropicApiAgent {
             .await;
         let _ = tx.send(StreamItem::Done).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_messages_request_uses_configured_max_tokens() {
+        let agent = AnthropicApiAgent::new_with_max_tokens(
+            "key".into(),
+            "https://api.anthropic.com".into(),
+            "claude-sonnet".into(),
+            2048,
+        );
+        let req = AgentRequest {
+            prompt: "hello".into(),
+            ..Default::default()
+        };
+
+        let body = agent.build_messages_request(&req);
+        assert_eq!(body.max_tokens, 2048);
+    }
+
+    #[test]
+    fn build_messages_request_uses_request_model_override() {
+        let agent = AnthropicApiAgent::new_with_max_tokens(
+            "key".into(),
+            "https://api.anthropic.com".into(),
+            "default-model".into(),
+            4096,
+        );
+        let req = AgentRequest {
+            prompt: "hello".into(),
+            model: Some("override-model".into()),
+            ..Default::default()
+        };
+
+        let body = agent.build_messages_request(&req);
+        assert_eq!(body.model, "override-model");
     }
 }

--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -1,5 +1,5 @@
 use harness_agents::claude::ClaudeCodeAgent;
-use harness_core::{prompts, AgentRequest, CodeAgent, HarnessConfig};
+use harness_core::{prompts, AgentRequest, CodeAgent, HarnessConfig, ReviewConfig};
 use std::path::PathBuf;
 use tokio::time::{sleep, Duration};
 
@@ -40,6 +40,7 @@ pub async fn fix(
     run_review_loop(
         &agent,
         &project,
+        &config.review,
         Some(issue),
         pr_number,
         Some(&pr_url),
@@ -60,12 +61,23 @@ pub async fn loop_pr(
 
     println!("[harness] Starting review loop for PR #{pr}");
 
-    run_review_loop(&agent, &project, None, pr, None, wait, max_rounds).await
+    run_review_loop(
+        &agent,
+        &project,
+        &config.review,
+        None,
+        pr,
+        None,
+        wait,
+        max_rounds,
+    )
+    .await
 }
 
 async fn run_review_loop(
     agent: &impl CodeAgent,
     project: &PathBuf,
+    review: &ReviewConfig,
     issue: Option<u64>,
     pr: u64,
     pr_url: Option<&str>,
@@ -87,7 +99,7 @@ async fn run_review_loop(
         println!("[harness] Review round {round}/{max_rounds}, PR #{pr}");
 
         let req = AgentRequest {
-            prompt: prompts::review_prompt(issue, pr, round, prev_fixed),
+            prompt: prompts::review_prompt(issue, pr, round, prev_fixed, review),
             project_root: project.clone(),
             ..Default::default()
         };
@@ -96,7 +108,10 @@ async fn run_review_loop(
         println!("{}", resp.output);
 
         if prompts::is_waiting(&resp.output) {
-            println!("[harness] Gemini hasn't re-reviewed yet, retrying...");
+            println!(
+                "[harness] {} hasn't re-reviewed yet, retrying...",
+                review.reviewer_name
+            );
             continue;
         }
 

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -238,6 +238,23 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     serve_config.agents.claude.default_model.clone(),
                 )),
             );
+            if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
+                agent_registry.register(
+                    "anthropic-api",
+                    Arc::new(
+                        harness_agents::anthropic_api::AnthropicApiAgent::new_with_max_tokens(
+                            api_key,
+                            serve_config.agents.anthropic_api.base_url.clone(),
+                            serve_config.agents.anthropic_api.default_model.clone(),
+                            serve_config.agents.anthropic_api.max_tokens,
+                        ),
+                    ),
+                );
+            } else {
+                tracing::info!(
+                    "ANTHROPIC_API_KEY is not set; skipping anthropic-api agent registration"
+                );
+            }
             let server = harness_server::server::HarnessServer::new(
                 serve_config.clone(),
                 thread_manager,

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 pub struct HarnessConfig {
     pub server: ServerConfig,
     pub agents: AgentsConfig,
+    #[serde(default)]
+    pub review: ReviewConfig,
     pub gc: GcConfig,
     pub rules: RulesConfig,
     pub observe: ObserveConfig,
@@ -16,6 +18,7 @@ impl Default for HarnessConfig {
         Self {
             server: ServerConfig::default(),
             agents: AgentsConfig::default(),
+            review: ReviewConfig::default(),
             gc: GcConfig::default(),
             rules: RulesConfig::default(),
             observe: ObserveConfig::default(),
@@ -108,6 +111,8 @@ impl Default for CodexAgentConfig {
 pub struct AnthropicApiConfig {
     pub base_url: String,
     pub default_model: String,
+    #[serde(default = "default_anthropic_api_max_tokens")]
+    pub max_tokens: u32,
 }
 
 impl Default for AnthropicApiConfig {
@@ -115,8 +120,38 @@ impl Default for AnthropicApiConfig {
         Self {
             base_url: "https://api.anthropic.com".to_string(),
             default_model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: default_anthropic_api_max_tokens(),
         }
     }
+}
+
+fn default_anthropic_api_max_tokens() -> u32 {
+    4096
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewConfig {
+    #[serde(default = "default_reviewer_name")]
+    pub reviewer_name: String,
+    #[serde(default = "default_recheck_command")]
+    pub recheck_command: String,
+}
+
+impl Default for ReviewConfig {
+    fn default() -> Self {
+        Self {
+            reviewer_name: default_reviewer_name(),
+            recheck_command: default_recheck_command(),
+        }
+    }
+}
+
+fn default_reviewer_name() -> String {
+    "Gemini".to_string()
+}
+
+fn default_recheck_command() -> String {
+    "/gemini review".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -261,5 +296,77 @@ mod dirs {
         {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn review_config_defaults_match_gemini_compatibility() {
+        let review = ReviewConfig::default();
+        assert_eq!(review.reviewer_name, "Gemini");
+        assert_eq!(review.recheck_command, "/gemini review");
+    }
+
+    #[test]
+    fn deserialize_without_new_review_fields_keeps_defaults() {
+        let raw = json!({
+            "server": {
+                "transport": "stdio",
+                "http_addr": "127.0.0.1:9800",
+                "data_dir": ".",
+                "project_root": ".",
+                "notification_broadcast_capacity": 256,
+                "notification_lag_log_every": 1
+            },
+            "agents": {
+                "default_agent": "claude",
+                "claude": {
+                    "cli_path": "claude",
+                    "default_model": "sonnet"
+                },
+                "codex": {
+                    "cli_path": "codex"
+                },
+                "anthropic_api": {
+                    "base_url": "https://api.anthropic.com",
+                    "default_model": "claude-sonnet-4-20250514"
+                }
+            },
+            "gc": {
+                "max_drafts_per_run": 5,
+                "budget_per_signal_usd": 0.5,
+                "total_budget_usd": 5.0,
+                "adopt_wait_secs": 120,
+                "adopt_max_rounds": 3,
+                "adopt_turn_timeout_secs": 600,
+                "signal_thresholds": {
+                    "repeated_warn_min": 10,
+                    "chronic_block_min": 5,
+                    "hot_file_edits_min": 20,
+                    "slow_op_threshold_ms": 5000,
+                    "slow_op_count_min": 10,
+                    "escalation_ratio": 1.5,
+                    "violation_min": 5
+                }
+            },
+            "rules": {
+                "discovery_paths": [],
+                "builtin_path": null
+            },
+            "observe": {
+                "db_path": "./harness.db",
+                "session_renewal_secs": 1800,
+                "log_retention_days": 90
+            }
+        });
+
+        let parsed: HarnessConfig = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.review.reviewer_name, "Gemini");
+        assert_eq!(parsed.review.recheck_command, "/gemini review");
+        assert_eq!(parsed.agents.anthropic_api.max_tokens, 4096);
     }
 }

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -1,4 +1,5 @@
 /// Prompt templates and output parsers shared across CLI and HTTP entries.
+use crate::ReviewConfig;
 
 /// Build prompt: continue work on an existing PR for a GitHub issue.
 ///
@@ -33,16 +34,19 @@ pub fn implement_from_issue(issue: u64) -> String {
 }
 
 /// Build prompt: check an existing PR's CI and review status.
-pub fn check_existing_pr(pr: u64) -> String {
+pub fn check_existing_pr(pr: u64, review: &ReviewConfig) -> String {
     format!(
         "Check PR #{pr}:\n\
          1. `gh pr checks {pr}` — check CI status\n\
          2. `gh api repos/{{owner}}/{{repo}}/pulls/{pr}/comments` — read inline review comments\n\
          3. If CI passes and there are no unresolved review comments, print LGTM on the last line\n\
          4. Otherwise fix each comment, commit, push, \
-         then run `gh pr comment {pr} --body '/gemini review'` to trigger re-review, \
+         then run `gh pr comment {pr} --body '{recheck_command}'` to trigger {reviewer_name} re-review, \
          and print FIXED on the last line\n\n\
          Always print PR_URL=https://github.com/{{owner}}/{{repo}}/pull/{pr} on a separate line of your output."
+        ,
+        recheck_command = review.recheck_command,
+        reviewer_name = review.reviewer_name
     )
 }
 
@@ -70,9 +74,15 @@ pub fn implement_from_prompt(prompt: &str) -> String {
 /// - Round 3+: only fix critical/high; skip medium style/design suggestions
 ///
 /// When `prev_fixed` is true (previous round pushed code), the agent must first
-/// verify that Gemini has submitted a **new** review covering the latest commit
+/// verify that the configured reviewer has submitted a **new** review covering the latest commit
 /// before declaring LGTM. If no new review exists yet, agent outputs WAITING.
-pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, prev_fixed: bool) -> String {
+pub fn review_prompt(
+    issue: Option<u64>,
+    pr: u64,
+    round: u32,
+    prev_fixed: bool,
+    review: &ReviewConfig,
+) -> String {
     let context = match issue {
         Some(n) => format!("You previously created PR #{pr} for issue #{n}.\n"),
         None => format!("Review PR #{pr}.\n"),
@@ -86,24 +96,27 @@ pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, prev_fixed: bool) 
     };
 
     let push_action = format!(
-        "commit, push, then run `gh pr comment {pr} --body '/gemini review'` \
-         to trigger re-review on the new code"
+        "commit, push, then run `gh pr comment {pr} --body '{recheck_command}'` \
+         to trigger {reviewer_name} re-review on the new code",
+        recheck_command = review.recheck_command,
+        reviewer_name = review.reviewer_name
     );
 
     let freshness_check = if prev_fixed {
         format!(
             "\n\nIMPORTANT — New review verification:\n\
              The previous round pushed a fix commit. Before evaluating review status, \
-             you MUST verify that Gemini has submitted a NEW review covering the latest commit:\n\
+             you MUST verify that {reviewer_name} has submitted a NEW review covering the latest commit:\n\
              1. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/reviews --jq '.[-1].submitted_at'` \
              to get the timestamp of the most recent review\n\
              2. Run `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{pr}/commits --jq '.[-1].commit.committer.date'` \
              to get the timestamp of the latest commit\n\
              3. If the latest review was submitted BEFORE the latest commit, \
-             Gemini has not yet re-reviewed the new code. \
+             {reviewer_name} has not yet re-reviewed the new code. \
              In this case, print WAITING on the last line and stop.\n\
              4. Only proceed with the review evaluation below if the latest review \
-             was submitted AFTER the latest commit."
+             was submitted AFTER the latest commit.",
+            reviewer_name = review.reviewer_name
         )
     } else {
         String::new()
@@ -160,7 +173,7 @@ pub fn is_lgtm(output: &str) -> bool {
 }
 
 /// Check if agent output's last non-empty line is exactly "WAITING".
-/// This means Gemini has not yet re-reviewed after the latest fix commit.
+/// This means the reviewer has not yet re-reviewed after the latest fix commit.
 pub fn is_waiting(output: &str) -> bool {
     last_non_empty_line(output) == Some("WAITING")
 }
@@ -176,6 +189,10 @@ fn last_non_empty_line(output: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn default_review() -> ReviewConfig {
+        ReviewConfig::default()
+    }
 
     #[test]
     fn test_continue_existing_pr() {
@@ -196,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_check_existing_pr() {
-        let p = check_existing_pr(10);
+        let p = check_existing_pr(10, &default_review());
         assert!(p.contains("PR #10"));
         assert!(p.contains("LGTM"));
         assert!(p.contains("PR_URL="));
@@ -211,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_review_prompt_with_issue() {
-        let p = review_prompt(Some(5), 10, 2, false);
+        let p = review_prompt(Some(5), 10, 2, false, &default_review());
         assert!(p.contains("issue #5"));
         assert!(p.contains("PR #10"));
         assert!(p.contains("medium")); // round 2 includes medium
@@ -219,39 +236,53 @@ mod tests {
 
     #[test]
     fn test_review_prompt_without_issue() {
-        let p = review_prompt(None, 10, 2, false);
+        let p = review_prompt(None, 10, 2, false, &default_review());
         assert!(p.contains("PR #10"));
         assert!(!p.contains("issue #")); // no issue reference when None
     }
 
     #[test]
     fn test_review_prompt_late_round_skips_medium() {
-        let p = review_prompt(None, 10, 3, false);
+        let p = review_prompt(None, 10, 3, false, &default_review());
         assert!(p.contains("Skip medium"));
     }
 
     #[test]
-    fn test_review_prompt_always_triggers_gemini_review() {
-        let p = review_prompt(None, 10, 2, false);
+    fn test_review_prompt_always_triggers_default_recheck_command() {
+        let p = review_prompt(None, 10, 2, false, &default_review());
         assert!(p.contains("/gemini review"));
-        let p = review_prompt(None, 10, 4, true);
+        let p = review_prompt(None, 10, 4, true, &default_review());
         assert!(p.contains("/gemini review"));
     }
 
     #[test]
     fn test_review_prompt_prev_fixed_requires_freshness_check() {
-        let p = review_prompt(None, 10, 3, true);
+        let p = review_prompt(None, 10, 3, true, &default_review());
         assert!(p.contains("WAITING"));
         assert!(p.contains("latest review was submitted BEFORE the latest commit"));
         // Without prev_fixed, no freshness check
-        let p = review_prompt(None, 10, 3, false);
+        let p = review_prompt(None, 10, 3, false, &default_review());
         assert!(!p.contains("WAITING"));
     }
 
     #[test]
     fn test_review_prompt_constraints() {
-        let p = review_prompt(None, 10, 2, false);
+        let p = review_prompt(None, 10, 2, false, &default_review());
         assert!(p.contains("NEVER downgrade dependency"));
+    }
+
+    #[test]
+    fn test_review_prompt_uses_configured_reviewer_and_recheck() {
+        let review = ReviewConfig {
+            reviewer_name: "CodeRabbit".into(),
+            recheck_command: "/coderabbit review".into(),
+        };
+        let p = review_prompt(None, 10, 2, false, &review);
+        assert!(p.contains("CodeRabbit"));
+        assert!(p.contains("/coderabbit review"));
+        let check = check_existing_pr(10, &review);
+        assert!(check.contains("CodeRabbit"));
+        assert!(check.contains("/coderabbit review"));
     }
 
     #[test]
@@ -286,7 +317,10 @@ mod tests {
 
     #[test]
     fn test_extract_pr_number_invalid() {
-        assert_eq!(extract_pr_number("https://github.com/owner/repo/pull/"), None);
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/"),
+            None
+        );
     }
 
     #[test]
@@ -320,7 +354,9 @@ mod tests {
     fn test_is_lgtm_false_positive() {
         // "LGTM" embedded in another word or non-final line should NOT match
         assert!(!is_lgtm("LGTM but actually not done"));
-        assert!(!is_lgtm("I think it looks LGTM but needs one more fix\nFIXED"));
+        assert!(!is_lgtm(
+            "I think it looks LGTM but needs one more fix\nFIXED"
+        ));
         assert!(!is_lgtm("somethingLGTM"));
         assert!(!is_lgtm("notLGTM\n"));
     }

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -106,6 +106,7 @@ pub async fn gc_adopt(
                     state.skills.clone(),
                     state.events.clone(),
                     state.interceptors.clone(),
+                    state.server.config.review.clone(),
                     req,
                 )
                 .await;

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -234,6 +234,7 @@ async fn create_task(
         state.skills.clone(),
         state.events.clone(),
         state.interceptors.clone(),
+        state.server.config.review.clone(),
         req,
     )
     .await;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -4,7 +4,7 @@ use crate::task_runner::{
 };
 use harness_core::{
     interceptor::TurnInterceptor, prompts, AgentRequest, AgentResponse, CodeAgent, ContextItem,
-    Decision, Event, SessionId,
+    Decision, Event, ReviewConfig, SessionId,
 };
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -69,7 +69,14 @@ async fn find_existing_pr_for_issue(
 ) -> anyhow::Result<Option<(u64, String)>> {
     let output = Command::new("gh")
         .current_dir(project)
-        .args(["pr", "list", "--search", &format!("#{issue}"), "--state", "open"])
+        .args([
+            "pr",
+            "list",
+            "--search",
+            &format!("#{issue}"),
+            "--state",
+            "open",
+        ])
         .args(["--json", "number,headRefName", "--limit", "1"])
         .output()
         .await
@@ -85,7 +92,10 @@ async fn find_existing_pr_for_issue(
     let items: Vec<GhPrListItem> = serde_json::from_slice(&output.stdout)
         .map_err(|e| anyhow::anyhow!("invalid JSON from `gh pr list`: {e}"))?;
 
-    Ok(items.into_iter().next().map(|item| (item.number, item.head_ref_name)))
+    Ok(items
+        .into_iter()
+        .next()
+        .map(|item| (item.number, item.head_ref_name)))
 }
 
 pub(crate) async fn run_task(
@@ -96,6 +106,7 @@ pub(crate) async fn run_task(
     events: Arc<harness_observe::EventStore>,
     interceptors: Arc<Vec<Arc<dyn TurnInterceptor>>>,
     req: &CreateTaskRequest,
+    review: &ReviewConfig,
     project: PathBuf,
 ) -> anyhow::Result<()> {
     update_status(store, task_id, TaskStatus::Implementing, 1).await;
@@ -103,7 +114,9 @@ pub(crate) async fn run_task(
     let first_prompt = if let Some(issue) = req.issue {
         match find_existing_pr_for_issue(&project, issue).await {
             Ok(Some((pr_num, branch))) => {
-                tracing::info!("reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}");
+                tracing::info!(
+                    "reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}"
+                );
                 prompts::continue_existing_pr(issue, pr_num, &branch)
             }
             Ok(None) => prompts::implement_from_issue(issue),
@@ -113,7 +126,7 @@ pub(crate) async fn run_task(
             }
         }
     } else if let Some(pr) = req.pr {
-        prompts::check_existing_pr(pr)
+        prompts::check_existing_pr(pr, review)
     } else {
         prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default())
     };
@@ -200,7 +213,7 @@ pub(crate) async fn run_task(
         update_status(store, task_id, TaskStatus::Reviewing, round).await;
 
         let review_req = AgentRequest {
-            prompt: prompts::review_prompt(req.issue, pr_num, round, prev_fixed),
+            prompt: prompts::review_prompt(req.issue, pr_num, round, prev_fixed, review),
             project_root: project.clone(),
             context: skill_items.clone(),
             ..Default::default()

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1,6 +1,6 @@
 use crate::task_db::TaskDb;
 use dashmap::DashMap;
-use harness_core::{CodeAgent, Decision, Event, SessionId};
+use harness_core::{CodeAgent, Decision, Event, ReviewConfig, SessionId};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -249,6 +249,7 @@ pub async fn spawn_task(
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    review: ReviewConfig,
     req: CreateTaskRequest,
 ) -> TaskId {
     spawn_task_with_worktree_detector(
@@ -257,6 +258,7 @@ pub async fn spawn_task(
         skills,
         events,
         interceptors,
+        review,
         req,
         detect_main_worktree,
     )
@@ -269,6 +271,7 @@ async fn spawn_task_with_worktree_detector<F>(
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    review: ReviewConfig,
     req: CreateTaskRequest,
     detect_worktree: F,
 ) -> TaskId
@@ -285,9 +288,11 @@ where
     let id_watcher = id.clone();
     let interceptors = Arc::new(interceptors);
     let detect_worktree = Arc::new(detect_worktree);
+    let review = Arc::new(review);
 
     let handle = tokio::spawn(async move {
         let detect_worktree = detect_worktree.clone();
+        let review = review.clone();
         let raw_project =
             resolve_project_root_with(req.project.clone(), move || detect_worktree()).await?;
         let project = crate::handlers::validate_project_root(&raw_project)
@@ -300,6 +305,7 @@ where
             events,
             interceptors,
             &req,
+            review.as_ref(),
             project,
         )
         .await
@@ -478,7 +484,16 @@ mod tests {
         };
 
         let events = Arc::new(harness_observe::EventStore::new(dir.path())?);
-        spawn_task(store, agent_clone, skills, events, vec![], req).await;
+        spawn_task(
+            store,
+            agent_clone,
+            skills,
+            events,
+            vec![],
+            ReviewConfig::default(),
+            req,
+        )
+        .await;
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -536,7 +551,16 @@ mod tests {
             turn_timeout_secs: 30,
         };
 
-        let task_id = spawn_task(store.clone(), agent, skills, events, interceptors, req).await;
+        let task_id = spawn_task(
+            store.clone(),
+            agent,
+            skills,
+            events,
+            interceptors,
+            ReviewConfig::default(),
+            req,
+        )
+        .await;
 
         // Allow async task to complete.
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -649,6 +673,7 @@ mod tests {
             skills,
             events.clone(),
             vec![],
+            ReviewConfig::default(),
             req,
             || -> PathBuf {
                 panic!("forced detect_main_worktree panic");


### PR DESCRIPTION
## Summary
- add configurable `review.reviewer_name` and `review.recheck_command` with Gemini-compatible defaults
- thread review config through server + CLI task execution prompts so runtime text is no longer Gemini-hardcoded
- wire Anthropic API `max_tokens` to config and add focused tests for prompt/config compatibility

## Validation
- cargo check
- cargo test -p harness-core
- cargo test -p harness-agents
- cargo test -p harness-cli
- cargo test -p harness-server

Linear: https://linear.app/future-frontiers/issue/FUT-53/remove-gemini-hardcoding-in-review-flow-and-wire-review-config
