### PR TITLE
fix: call discover() after with_persist_dir() to reload persisted skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
  "uuid",
 ]
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -22,6 +22,11 @@ cli_path = "codex"
 base_url = "https://api.anthropic.com"
 default_model = "claude-sonnet-4-20250514"
 
+[agents.review]
+enabled = false
+reviewer_agent = ""
+max_rounds = 3
+
 [gc]
 max_drafts_per_run = 5
 budget_per_signal_usd = 0.50

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -238,6 +238,12 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     serve_config.agents.claude.default_model.clone(),
                 )),
             );
+            agent_registry.register(
+                "codex",
+                Arc::new(harness_agents::codex::CodexAgent::new(
+                    serve_config.agents.codex.cli_path.clone(),
+                )),
+            );
             let server = harness_server::server::HarnessServer::new(
                 serve_config.clone(),
                 thread_manager,

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "harness-core"
 version.workspace = true
 edition.workspace = true
+description = "Core domain model, configuration, prompts, and agent traits for Harness"
 
 [dependencies]
 serde = { workspace = true }
@@ -14,3 +15,4 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+toml = { workspace = true }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -63,6 +63,8 @@ pub struct AgentsConfig {
     pub claude: ClaudeAgentConfig,
     pub codex: CodexAgentConfig,
     pub anthropic_api: AnthropicApiConfig,
+    #[serde(default)]
+    pub review: AgentReviewConfig,
 }
 
 impl Default for AgentsConfig {
@@ -72,8 +74,34 @@ impl Default for AgentsConfig {
             claude: ClaudeAgentConfig::default(),
             codex: CodexAgentConfig::default(),
             anthropic_api: AnthropicApiConfig::default(),
+            review: AgentReviewConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentReviewConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Agent name to use as reviewer. Empty string = auto-select.
+    #[serde(default)]
+    pub reviewer_agent: String,
+    #[serde(default = "default_max_agent_review_rounds")]
+    pub max_rounds: u32,
+}
+
+impl Default for AgentReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            reviewer_agent: String::new(),
+            max_rounds: default_max_agent_review_rounds(),
+        }
+    }
+}
+
+fn default_max_agent_review_rounds() -> u32 {
+    3
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -261,5 +289,65 @@ mod dirs {
         {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_review_config_defaults() {
+        let config = AgentReviewConfig::default();
+        assert!(!config.enabled);
+        assert!(config.reviewer_agent.is_empty());
+        assert_eq!(config.max_rounds, 3);
+    }
+
+    #[test]
+    fn agent_review_config_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            reviewer_agent = "codex"
+            max_rounds = 5
+        "#;
+        let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.reviewer_agent, "codex");
+        assert_eq!(config.max_rounds, 5);
+    }
+
+    #[test]
+    fn agent_review_config_deserializes_with_defaults() {
+        let toml_str = r#"
+            enabled = true
+        "#;
+        let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert!(config.reviewer_agent.is_empty());
+        assert_eq!(config.max_rounds, 3);
+    }
+
+    #[test]
+    fn agents_config_includes_review() {
+        let toml_str = r#"
+            default_agent = "claude"
+            [claude]
+            cli_path = "claude"
+            default_model = "sonnet"
+            [codex]
+            cli_path = "codex"
+            [anthropic_api]
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+            [review]
+            enabled = true
+            reviewer_agent = "codex"
+            max_rounds = 2
+        "#;
+        let config: AgentsConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.review.enabled);
+        assert_eq!(config.review.reviewer_agent, "codex");
+        assert_eq!(config.review.max_rounds, 2);
     }
 }

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -128,6 +128,55 @@ pub fn review_prompt(issue: Option<u64>, pr: u64, round: u32, prev_fixed: bool) 
     )
 }
 
+/// Build prompt: reviewer agent evaluates a PR diff.
+///
+/// The reviewer reads the diff and outputs either `APPROVED` on the last line
+/// or lists issues prefixed with `ISSUE:`.
+pub fn agent_review_prompt(pr: u64, round: u32) -> String {
+    format!(
+        "You are an independent code reviewer. Review PR #{pr} (agent review round {round}).\n\n\
+         Steps:\n\
+         1. Run `gh pr diff {pr}` to read the full diff\n\
+         2. Check for correctness, safety, and style issues\n\
+         3. If everything looks good, print APPROVED on the last line\n\
+         4. Otherwise, list each issue on its own line prefixed with \"ISSUE: \"\n\n\
+         Constraints:\n\
+         - Focus on correctness and safety, not cosmetic preferences\n\
+         - NEVER downgrade dependency versions\n\
+         - Be specific: reference file names and line numbers"
+    )
+}
+
+/// Build prompt: implementor fixes issues found by the reviewer agent.
+pub fn agent_review_fix_prompt(pr: u64, issues: &[String], round: u32) -> String {
+    let issue_list: String = issues
+        .iter()
+        .enumerate()
+        .map(|(i, issue)| format!("{}. {issue}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "The independent reviewer found the following issues in PR #{pr} \
+         (agent review round {round}):\n\n{issue_list}\n\n\
+         Fix each issue, run cargo check and cargo test, then commit and push.\n\
+         On the last line of your output, print PR_URL=<PR URL>"
+    )
+}
+
+/// Check if agent output indicates approval (last non-empty line is "APPROVED").
+pub fn is_approved(output: &str) -> bool {
+    last_non_empty_line(output) == Some("APPROVED")
+}
+
+/// Extract `ISSUE:` prefixed lines from agent review output.
+pub fn extract_review_issues(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("ISSUE:").map(|s| s.trim().to_string()))
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// Parse `PR_URL=<url>` from agent output (searches from last line).
 pub fn parse_pr_url(output: &str) -> Option<String> {
     for line in output.lines().rev() {
@@ -323,5 +372,48 @@ mod tests {
         assert!(!is_lgtm("I think it looks LGTM but needs one more fix\nFIXED"));
         assert!(!is_lgtm("somethingLGTM"));
         assert!(!is_lgtm("notLGTM\n"));
+    }
+
+    #[test]
+    fn test_agent_review_prompt() {
+        let p = agent_review_prompt(42, 1);
+        assert!(p.contains("PR #42"));
+        assert!(p.contains("round 1"));
+        assert!(p.contains("APPROVED"));
+        assert!(p.contains("ISSUE:"));
+    }
+
+    #[test]
+    fn test_agent_review_fix_prompt() {
+        let issues = vec!["Missing error handling".to_string(), "Unbounded loop".to_string()];
+        let p = agent_review_fix_prompt(42, &issues, 2);
+        assert!(p.contains("PR #42"));
+        assert!(p.contains("round 2"));
+        assert!(p.contains("Missing error handling"));
+        assert!(p.contains("Unbounded loop"));
+        assert!(p.contains("PR_URL="));
+    }
+
+    #[test]
+    fn test_is_approved() {
+        assert!(is_approved("looks good\nAPPROVED"));
+        assert!(is_approved("APPROVED\n"));
+        assert!(is_approved("APPROVED"));
+        assert!(!is_approved("APPROVED but with caveats"));
+        assert!(!is_approved("ISSUE: something\nAPPROVED not really"));
+        assert!(!is_approved("LGTM"));
+    }
+
+    #[test]
+    fn test_extract_review_issues() {
+        let output = "Looking at the diff...\nISSUE: Missing error handling\nThis is fine\nISSUE: Unbounded loop\nAPPROVED";
+        let issues = extract_review_issues(output);
+        assert_eq!(issues, vec!["Missing error handling", "Unbounded loop"]);
+    }
+
+    #[test]
+    fn test_extract_review_issues_empty() {
+        assert!(extract_review_issues("APPROVED").is_empty());
+        assert!(extract_review_issues("ISSUE: ").is_empty());
     }
 }

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -85,7 +85,7 @@ pub async fn run_cross_review(
     let challenger = match challenger {
         None => {
             // Graceful degradation: treat all ISSUE lines as consensus.
-            let consensus_issues = extract_issues(&primary_review);
+            let consensus_issues = harness_core::prompts::extract_review_issues(&primary_review);
             let verdict = verdict_for(&consensus_issues);
             return Ok(CrossReviewResult {
                 primary_review,
@@ -101,7 +101,8 @@ pub async fn run_cross_review(
 
     let mut challenger_review = String::new();
     let mut rounds_done = 1u32;
-    let mut consensus_issues: Vec<String> = extract_issues(&primary_review);
+    let mut consensus_issues: Vec<String> =
+        harness_core::prompts::extract_review_issues(&primary_review);
     let safe_primary = harness_core::prompts::wrap_external_data(&primary_review);
 
     for _ in 0..max_rounds.saturating_sub(1) {
@@ -178,14 +179,6 @@ fn verdict_for(issues: &[String]) -> String {
     } else {
         "NOT_CONVERGED".to_string()
     }
-}
-
-fn extract_issues(output: &str) -> Vec<String> {
-    output
-        .lines()
-        .filter_map(|l| l.trim().strip_prefix("ISSUE:").map(|s| s.trim().to_string()))
-        .filter(|s| !s.is_empty())
-        .collect()
 }
 
 fn extract_tagged(output: &str, tag: &str) -> Vec<String> {

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -103,6 +103,8 @@ pub async fn gc_adopt(
                 let tid = crate::task_runner::spawn_task(
                     state.tasks.clone(),
                     agent,
+                    None,
+                    harness_core::AgentReviewConfig::default(),
                     state.skills.clone(),
                     state.events.clone(),
                     state.interceptors.clone(),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -155,6 +155,51 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     })
 }
 
+/// Resolve the reviewer agent for independent agent review.
+///
+/// 1. If `config.reviewer_agent` is set and differs from implementor, use it.
+/// 2. Otherwise, auto-select the first registered agent that isn't the implementor.
+/// 3. If none found, return None (agent review will be skipped).
+fn resolve_reviewer(
+    registry: &harness_agents::AgentRegistry,
+    config: &harness_core::AgentReviewConfig,
+    implementor_name: &str,
+) -> (Option<Arc<dyn harness_core::CodeAgent>>, harness_core::AgentReviewConfig) {
+    if !config.enabled {
+        return (None, config.clone());
+    }
+
+    // Explicit reviewer
+    if !config.reviewer_agent.is_empty() {
+        if config.reviewer_agent == implementor_name {
+            tracing::warn!(
+                "agents.review.reviewer_agent == implementor '{}', skipping agent review",
+                implementor_name
+            );
+            return (None, config.clone());
+        }
+        if let Some(agent) = registry.get(&config.reviewer_agent) {
+            return (Some(agent), config.clone());
+        }
+        tracing::warn!(
+            "agents.review.reviewer_agent '{}' not registered, skipping agent review",
+            config.reviewer_agent
+        );
+        return (None, config.clone());
+    }
+
+    // Auto-select: first agent != implementor
+    for name in registry.list() {
+        if name != implementor_name {
+            if let Some(agent) = registry.get(name) {
+                return (Some(agent), config.clone());
+            }
+        }
+    }
+
+    (None, config.clone())
+}
+
 pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Result<()> {
     tracing::info!("harness: HTTP server listening on {addr}");
 
@@ -228,9 +273,14 @@ async fn create_task(
         }
     };
 
+    let (reviewer, review_config) =
+        resolve_reviewer(&state.server.agent_registry, &state.server.config.agents.review, agent.name());
+
     let task_id = task_runner::spawn_task(
         state.tasks.clone(),
         agent,
+        reviewer,
+        review_config,
         state.skills.clone(),
         state.events.clone(),
         state.interceptors.clone(),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -133,15 +133,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             .insert(thread.id.as_str().to_string(), thread);
     }
 
+    let mut skill_store = harness_skills::SkillStore::new().with_persist_dir(dir.join("skills"));
+    skill_store.load_builtin();
+    if let Err(e) = skill_store.discover() {
+        tracing::warn!("Failed to reload persisted skills on startup: {}", e);
+    }
+
     Ok(AppState {
         server,
         project_root,
         tasks,
-        skills: Arc::new(RwLock::new({
-            let mut store = harness_skills::SkillStore::new().with_persist_dir(dir.join("skills"));
-            store.load_builtin();
-            store
-        })),
+        skills: Arc::new(RwLock::new(skill_store)),
         rules: Arc::new(RwLock::new(rule_engine)),
         events,
         gc_agent,

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -148,6 +148,7 @@ fn status_to_str(s: &TaskStatus) -> &'static str {
     match s {
         TaskStatus::Pending => "pending",
         TaskStatus::Implementing => "implementing",
+        TaskStatus::AgentReview => "agent_review",
         TaskStatus::Waiting => "waiting",
         TaskStatus::Reviewing => "reviewing",
         TaskStatus::Done => "done",
@@ -159,6 +160,7 @@ fn str_to_status(s: &str) -> TaskStatus {
     match s {
         "pending" => TaskStatus::Pending,
         "implementing" => TaskStatus::Implementing,
+        "agent_review" => TaskStatus::AgentReview,
         "waiting" => TaskStatus::Waiting,
         "reviewing" => TaskStatus::Reviewing,
         "done" => TaskStatus::Done,

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -92,6 +92,8 @@ pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
     agent: &dyn CodeAgent,
+    reviewer: Option<&dyn CodeAgent>,
+    review_config: &harness_core::AgentReviewConfig,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Arc<Vec<Arc<dyn TurnInterceptor>>>,
@@ -186,6 +188,28 @@ pub(crate) async fn run_task(
             return Ok(());
         }
     };
+
+    // Agent review phase: independent reviewer evaluates PR diff before GitHub review
+    if review_config.enabled {
+        if let Some(reviewer) = reviewer {
+            run_agent_review(
+                store,
+                task_id,
+                agent,
+                reviewer,
+                review_config,
+                &skill_items,
+                &project,
+                &interceptors,
+                turn_timeout,
+                pr_num,
+                &events,
+            )
+            .await?;
+        } else {
+            tracing::info!("agent review enabled but no reviewer available, skipping");
+        }
+    }
 
     // Review loop: Turn 2..N
     let last_review_round = req.max_rounds.saturating_add(1);
@@ -297,6 +321,143 @@ pub(crate) async fn run_task(
         ));
     })
     .await;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_agent_review(
+    store: &TaskStore,
+    task_id: &TaskId,
+    agent: &dyn CodeAgent,
+    reviewer: &dyn CodeAgent,
+    review_config: &harness_core::AgentReviewConfig,
+    skill_items: &[ContextItem],
+    project: &Path,
+    interceptors: &[Arc<dyn TurnInterceptor>],
+    turn_timeout: Duration,
+    pr_num: u64,
+    events: &harness_observe::EventStore,
+) -> anyhow::Result<()> {
+    let max_rounds = review_config.max_rounds;
+    for agent_round in 1..=max_rounds {
+        update_status(store, task_id, TaskStatus::AgentReview, agent_round).await;
+
+        // Reviewer evaluates the PR diff
+        let review_req = AgentRequest {
+            prompt: prompts::agent_review_prompt(pr_num, agent_round),
+            project_root: project.to_path_buf(),
+            context: skill_items.to_vec(),
+            ..Default::default()
+        };
+        let review_req = run_pre_execute(interceptors, review_req).await?;
+
+        let resp = tokio::time::timeout(turn_timeout, reviewer.execute(review_req.clone())).await;
+        let resp = match resp {
+            Ok(Ok(r)) => {
+                run_post_execute(interceptors, &review_req, &r).await;
+                r
+            }
+            Ok(Err(e)) => {
+                run_on_error(interceptors, &review_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Agent review round {agent_round} timed out after {}s",
+                    turn_timeout.as_secs()
+                );
+                run_on_error(interceptors, &review_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        };
+
+        let approved = prompts::is_approved(&resp.output);
+        let issues = prompts::extract_review_issues(&resp.output);
+
+        mutate_and_persist(store, task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: 0, // agent review rounds use turn 0
+                action: "agent_review".into(),
+                result: if approved {
+                    "approved".into()
+                } else {
+                    format!("{} issues", issues.len())
+                },
+            });
+        })
+        .await;
+
+        // Log agent_review event
+        let mut ev = harness_core::Event::new(
+            harness_core::SessionId::new(),
+            "agent_review",
+            "task_runner",
+            if approved {
+                harness_core::Decision::Complete
+            } else {
+                harness_core::Decision::Warn
+            },
+        );
+        ev.detail = Some(format!("pr={pr_num}"));
+        ev.reason = Some(if approved {
+            format!("round {agent_round}: approved")
+        } else {
+            format!("round {agent_round}: {} issues", issues.len())
+        });
+        if let Err(e) = events.log(&ev) {
+            tracing::warn!("failed to log agent_review event: {e}");
+        }
+
+        if approved || issues.is_empty() {
+            tracing::info!("agent review approved at round {agent_round}");
+            break;
+        }
+
+        if agent_round == max_rounds {
+            tracing::info!(
+                "agent review exhausted {max_rounds} rounds, proceeding to GitHub review"
+            );
+            break;
+        }
+
+        // Implementor fixes the issues
+        let fix_req = AgentRequest {
+            prompt: prompts::agent_review_fix_prompt(pr_num, &issues, agent_round),
+            project_root: project.to_path_buf(),
+            context: skill_items.to_vec(),
+            ..Default::default()
+        };
+        let fix_req = run_pre_execute(interceptors, fix_req).await?;
+
+        let fix_resp = tokio::time::timeout(turn_timeout, agent.execute(fix_req.clone())).await;
+        match fix_resp {
+            Ok(Ok(r)) => {
+                run_post_execute(interceptors, &fix_req, &r).await;
+            }
+            Ok(Err(e)) => {
+                run_on_error(interceptors, &fix_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Agent review fix round {agent_round} timed out after {}s",
+                    turn_timeout.as_secs()
+                );
+                run_on_error(interceptors, &fix_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        }
+
+        mutate_and_persist(store, task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: 0,
+                action: "agent_review_fix".into(),
+                result: "fixed".into(),
+            });
+        })
+        .await;
+    }
+
     Ok(())
 }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -20,6 +20,7 @@ impl TaskId {
 pub enum TaskStatus {
     Pending,
     Implementing,
+    AgentReview,
     Waiting,
     Reviewing,
     Done,
@@ -246,6 +247,8 @@ impl TaskStore {
 pub async fn spawn_task(
     store: Arc<TaskStore>,
     agent: Arc<dyn CodeAgent>,
+    reviewer: Option<Arc<dyn CodeAgent>>,
+    review_config: harness_core::AgentReviewConfig,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -254,6 +257,8 @@ pub async fn spawn_task(
     spawn_task_with_worktree_detector(
         store,
         agent,
+        reviewer,
+        review_config,
         skills,
         events,
         interceptors,
@@ -266,6 +271,8 @@ pub async fn spawn_task(
 async fn spawn_task_with_worktree_detector<F>(
     store: Arc<TaskStore>,
     agent: Arc<dyn CodeAgent>,
+    reviewer: Option<Arc<dyn CodeAgent>>,
+    review_config: harness_core::AgentReviewConfig,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -296,6 +303,8 @@ where
             &store,
             &id,
             agent.as_ref(),
+            reviewer.as_deref(),
+            &review_config,
             skills,
             events,
             interceptors,
@@ -478,7 +487,7 @@ mod tests {
         };
 
         let events = Arc::new(harness_observe::EventStore::new(dir.path())?);
-        spawn_task(store, agent_clone, skills, events, vec![], req).await;
+        spawn_task(store, agent_clone, None, Default::default(), skills, events, vec![], req).await;
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -536,7 +545,7 @@ mod tests {
             turn_timeout_secs: 30,
         };
 
-        let task_id = spawn_task(store.clone(), agent, skills, events, interceptors, req).await;
+        let task_id = spawn_task(store.clone(), agent, None, Default::default(), skills, events, interceptors, req).await;
 
         // Allow async task to complete.
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -646,6 +655,8 @@ mod tests {
         let task_id = spawn_task_with_worktree_detector(
             store.clone(),
             agent,
+            None,
+            Default::default(),
             skills,
             events.clone(),
             vec![],

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -1,0 +1,50 @@
+use crate::{http::AppState, server::HarnessServer, thread_manager::ThreadManager};
+use harness_agents::AgentRegistry;
+use harness_core::HarnessConfig;
+use std::sync::{atomic::AtomicU64, Arc};
+use tokio::sync::{broadcast, RwLock};
+
+pub async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
+    make_test_state_with_registry(dir, AgentRegistry::new("test")).await
+}
+
+pub async fn make_test_state_with_registry(
+    dir: &std::path::Path,
+    agent_registry: AgentRegistry,
+) -> anyhow::Result<AppState> {
+    let server = Arc::new(HarnessServer::new(
+        HarnessConfig::default(),
+        ThreadManager::new(),
+        agent_registry,
+    ));
+    let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
+    let events = Arc::new(harness_observe::EventStore::new(dir)?);
+    let signal_detector = harness_gc::SignalDetector::new(
+        harness_gc::signal_detector::SignalThresholds::default(),
+        harness_core::ProjectId::new(),
+    );
+    let draft_store = harness_gc::DraftStore::new(dir)?;
+    let gc_agent = Arc::new(harness_gc::GcAgent::new(
+        harness_gc::gc_agent::GcConfig::default(),
+        signal_detector,
+        draft_store,
+    ));
+    let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+    let (notification_tx, _) = broadcast::channel(64);
+    Ok(AppState {
+        server,
+        project_root: dir.to_path_buf(),
+        tasks,
+        skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),
+        rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
+        events,
+        gc_agent,
+        plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        thread_db: Some(thread_db),
+        interceptors: vec![],
+        notification_tx,
+        notification_lagged_total: Arc::new(AtomicU64::new(0)),
+        notification_lag_log_every: 1,
+        notify_tx: None,
+    })
+}


### PR DESCRIPTION
Closes #76

## Summary
- Extract `SkillStore` initialization out of the `AppState` struct literal
- Call `store.discover()` after `load_builtin()` so persisted skills are reloaded on startup
- Log a warning (non-fatal) if `discover()` fails

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test` passes (87 tests)
- [ ] Skills persisted to disk survive server restart