### PR TITLE
fix: unify violation logging — replace persist_violations with persist_rule_scan

### DIFF
--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -24,7 +24,7 @@ pub async fn gc_run(state: &AppState, id: Option<serde_json::Value>) -> RpcRespo
         let rules = state.rules.read().await;
         rules.scan(&project_root).await.unwrap_or_default()
     };
-    crate::handlers::persist_violations(&state.events, &project_root, &violations);
+    state.events.persist_rule_scan(&project_root, &violations);
 
     let events = match state.events.query(&harness_core::EventFilters::default()) {
         Ok(e) => e,

--- a/crates/harness-server/src/handlers/health.rs
+++ b/crates/harness-server/src/handlers/health.rs
@@ -25,7 +25,7 @@ pub async fn health_check(
         let rules = state.rules.read().await;
         rules.scan(&project_root).await.unwrap_or_default()
     };
-    crate::handlers::persist_violations(&state.events, &project_root, &violations);
+    state.events.persist_rule_scan(&project_root, &violations);
 
     let report = generate_health_report(&events, &violations);
     match serde_json::to_value(&report) {

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -10,15 +10,6 @@ pub mod rules;
 pub mod skills;
 pub mod thread;
 
-/// Persist rule scan results to the event store with a `rule_scan` anchor.
-pub(crate) fn persist_violations(
-    events: &harness_observe::EventStore,
-    project_root: &std::path::Path,
-    violations: &[harness_core::Violation],
-) {
-    events.persist_rule_scan(project_root, violations);
-}
-
 /// Validate that `file` is an existing path within `project_root` (already canonicalized).
 /// Returns the canonicalized file path on success.
 pub(crate) fn validate_file_in_root(

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -45,7 +45,7 @@ pub async fn metrics_collect(
         let rules = state.rules.read().await;
         rules.scan(&project_root).await.unwrap_or_default()
     };
-    crate::handlers::persist_violations(&state.events, &project_root, &violations);
+    state.events.persist_rule_scan(&project_root, &violations);
 
     let evts = match state.events.query(&harness_core::EventFilters::default()) {
         Ok(e) => e,

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -50,7 +50,7 @@ pub async fn rule_check(
     };
     match result {
         Ok(violations) => {
-            crate::handlers::persist_violations(&state.events, &project_root, &violations);
+            state.events.persist_rule_scan(&project_root, &violations);
             match serde_json::to_value(&violations) {
                 Ok(v) => RpcResponse::success(id, v),
                 Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -734,7 +734,7 @@ mod tests {
                 severity: harness_core::Severity::Low,
             },
         ];
-        crate::handlers::persist_violations(&state.events, &project_root, &violations);
+        state.events.persist_rule_scan(&project_root, &violations);
 
         let req = RpcRequest {
             jsonrpc: "2.0".to_string(),


### PR DESCRIPTION
## Summary
- Remove `persist_violations` wrapper in `handlers/mod.rs`
- Replace all 5 call sites with direct `EventStore::persist_rule_scan` calls

Closes #82