### PR TITLE
fix: wire SignalThresholds from config instead of using default

### DIFF
--- a/crates/harness-gc/src/signal_detector.rs
+++ b/crates/harness-gc/src/signal_detector.rs
@@ -29,6 +29,20 @@ impl Default for SignalThresholds {
     }
 }
 
+impl From<harness_core::config::SignalThresholds> for SignalThresholds {
+    fn from(t: harness_core::config::SignalThresholds) -> Self {
+        Self {
+            repeated_warn_min: t.repeated_warn_min,
+            chronic_block_min: t.chronic_block_min,
+            hot_file_edits_min: t.hot_file_edits_min,
+            slow_op_threshold_ms: t.slow_op_threshold_ms,
+            slow_op_count_min: t.slow_op_count_min,
+            escalation_ratio: t.escalation_ratio,
+            violation_min: t.violation_min,
+        }
+    }
+}
+
 pub struct SignalDetector {
     thresholds: SignalThresholds,
     project_id: ProjectId,

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -105,7 +105,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     )?);
 
     let signal_detector = harness_gc::SignalDetector::new(
-        harness_gc::signal_detector::SignalThresholds::default(),
+        server.config.gc.signal_thresholds.clone().into(),
         harness_core::ProjectId::new(),
     );
     let draft_store = harness_gc::DraftStore::new(&dir)?;
@@ -339,7 +339,7 @@ mod tests {
         let tasks = task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir)?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -20,7 +20,7 @@ pub async fn make_test_state_with_registry(
     let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
     let events = Arc::new(harness_observe::EventStore::new(dir)?);
     let signal_detector = harness_gc::SignalDetector::new(
-        harness_gc::signal_detector::SignalThresholds::default(),
+        server.config.gc.signal_thresholds.clone().into(),
         harness_core::ProjectId::new(),
     );
     let draft_store = harness_gc::DraftStore::new(dir)?;


### PR DESCRIPTION
## Summary
- Add `From<harness_core::config::SignalThresholds>` impl for `harness_gc::signal_detector::SignalThresholds`
- Pass `server.config.gc.signal_thresholds.into()` to `SignalDetector::new()` instead of `Default::default()`
- Apply same fix to test helpers

Closes #84