### PR TITLE
fix: make anthropic max_tokens config-driven

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -21,6 +21,7 @@ cli_path = "codex"
 [agents.anthropic_api]
 base_url = "https://api.anthropic.com"
 default_model = "claude-sonnet-4-20250514"
+max_tokens = 4096
 
 [agents.review]
 enabled = false

--- a/crates/harness-agents/src/anthropic_api.rs
+++ b/crates/harness-agents/src/anthropic_api.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use harness_core::{
-    AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
+    AgentRequest, AgentResponse, AnthropicApiConfig, Capability, CodeAgent, Item, StreamItem,
+    TokenUsage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -8,16 +9,39 @@ pub struct AnthropicApiAgent {
     pub api_key: String,
     pub base_url: String,
     pub default_model: String,
+    pub max_tokens: u32,
     client: reqwest::Client,
 }
 
 impl AnthropicApiAgent {
-    pub fn new(api_key: String, base_url: String, default_model: String) -> Self {
+    pub fn new(api_key: String, base_url: String, default_model: String, max_tokens: u32) -> Self {
         Self {
             api_key,
             base_url,
             default_model,
+            max_tokens,
             client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn from_config(api_key: String, config: &AnthropicApiConfig) -> Self {
+        Self::new(
+            api_key,
+            config.base_url.clone(),
+            config.default_model.clone(),
+            config.max_tokens,
+        )
+    }
+
+    fn build_request(&self, req: &AgentRequest) -> MessagesRequest {
+        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        MessagesRequest {
+            model: model.to_string(),
+            max_tokens: self.max_tokens,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: req.prompt.clone(),
+            }],
         }
     }
 }
@@ -64,16 +88,7 @@ impl CodeAgent for AnthropicApiAgent {
     }
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
-        let model = req.model.as_deref().unwrap_or(&self.default_model);
-
-        let body = MessagesRequest {
-            model: model.to_string(),
-            max_tokens: 4096,
-            messages: vec![Message {
-                role: "user".to_string(),
-                content: req.prompt.clone(),
-            }],
-        };
+        let body = self.build_request(&req);
 
         let resp = self
             .client
@@ -84,7 +99,9 @@ impl CodeAgent for AnthropicApiAgent {
             .json(&body)
             .send()
             .await
-            .map_err(|e| harness_core::HarnessError::AgentExecution(format!("API request failed: {e}")))?;
+            .map_err(|e| {
+                harness_core::HarnessError::AgentExecution(format!("API request failed: {e}"))
+            })?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -140,5 +157,68 @@ impl CodeAgent for AnthropicApiAgent {
             .await;
         let _ = tx.send(StreamItem::Done).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_request_uses_configured_max_tokens_and_default_model() {
+        let agent = AnthropicApiAgent::new(
+            "test-key".to_string(),
+            "https://example.com".to_string(),
+            "claude-default".to_string(),
+            2048,
+        );
+
+        let request = AgentRequest {
+            prompt: "hello".to_string(),
+            ..AgentRequest::default()
+        };
+        let body = agent.build_request(&request);
+
+        assert_eq!(body.model, "claude-default");
+        assert_eq!(body.max_tokens, 2048);
+        assert_eq!(body.messages.len(), 1);
+        assert_eq!(body.messages[0].role, "user");
+        assert_eq!(body.messages[0].content, "hello");
+    }
+
+    #[test]
+    fn build_request_prefers_model_override() {
+        let agent = AnthropicApiAgent::new(
+            "test-key".to_string(),
+            "https://example.com".to_string(),
+            "claude-default".to_string(),
+            1024,
+        );
+
+        let request = AgentRequest {
+            prompt: "hello".to_string(),
+            model: Some("claude-custom".to_string()),
+            ..AgentRequest::default()
+        };
+        let body = agent.build_request(&request);
+
+        assert_eq!(body.model, "claude-custom");
+        assert_eq!(body.max_tokens, 1024);
+    }
+
+    #[test]
+    fn from_config_wires_all_anthropic_settings() {
+        let config = AnthropicApiConfig {
+            base_url: "https://api.anthropic.com".to_string(),
+            default_model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: 3072,
+        };
+
+        let agent = AnthropicApiAgent::from_config("test-key".to_string(), &config);
+
+        assert_eq!(agent.api_key, "test-key");
+        assert_eq!(agent.base_url, config.base_url);
+        assert_eq!(agent.default_model, config.default_model);
+        assert_eq!(agent.max_tokens, 3072);
     }
 }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -136,6 +136,12 @@ impl Default for CodexAgentConfig {
 pub struct AnthropicApiConfig {
     pub base_url: String,
     pub default_model: String,
+    #[serde(default = "default_anthropic_api_max_tokens")]
+    pub max_tokens: u32,
+}
+
+fn default_anthropic_api_max_tokens() -> u32 {
+    4096
 }
 
 impl Default for AnthropicApiConfig {
@@ -143,6 +149,7 @@ impl Default for AnthropicApiConfig {
         Self {
             base_url: "https://api.anthropic.com".to_string(),
             default_model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: default_anthropic_api_max_tokens(),
         }
     }
 }
@@ -349,5 +356,30 @@ mod tests {
         assert!(config.review.enabled);
         assert_eq!(config.review.reviewer_agent, "codex");
         assert_eq!(config.review.max_rounds, 2);
+        assert_eq!(
+            config.anthropic_api.max_tokens,
+            default_anthropic_api_max_tokens()
+        );
+    }
+
+    #[test]
+    fn anthropic_api_config_deserializes_configured_max_tokens() {
+        let toml_str = r#"
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+            max_tokens = 8192
+        "#;
+        let config: AnthropicApiConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.max_tokens, 8192);
+    }
+
+    #[test]
+    fn anthropic_api_config_defaults_max_tokens_when_missing() {
+        let toml_str = r#"
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+        "#;
+        let config: AnthropicApiConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.max_tokens, default_anthropic_api_max_tokens());
     }
 }


### PR DESCRIPTION
## Summary\n- remove Anthropic request-path hardcoded `max_tokens: 4096`\n- add `agents.anthropic_api.max_tokens` to config model with explicit default behavior\n- add unit tests for configured/default max_tokens and agent request wiring\n\n## Validation\n- cargo test -p harness-core config::tests -- --nocapture\n- cargo test -p harness-agents anthropic_api -- --nocapture\n- cargo test -p harness-server\n\nRefs FUT-19