### PR TITLE
feat: AgentAdapter trait + AgentEvent streaming types

### DIFF
--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -77,3 +77,138 @@ pub enum TaskComplexity {
     Critical,
 }
 
+// === Streaming Agent Adapter (new, coexists with CodeAgent) ===
+
+/// Events emitted by an agent adapter during a turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentEvent {
+    TurnStarted,
+    ItemStarted { item_type: String },
+    MessageDelta { text: String },
+    ToolCall { name: String, input: serde_json::Value },
+    ApprovalRequest { id: String, command: String },
+    ItemCompleted,
+    TurnCompleted { output: String },
+    Error { message: String },
+}
+
+/// Decision for an approval request from the agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum ApprovalDecision {
+    Accept,
+    Reject { reason: String },
+}
+
+/// Request to start a turn via an adapter.
+#[derive(Debug, Clone)]
+pub struct TurnRequest {
+    pub prompt: String,
+    pub project_root: PathBuf,
+    pub model: Option<String>,
+    pub allowed_tools: Vec<String>,
+    pub context: Vec<ContextItem>,
+    pub timeout_secs: Option<u64>,
+}
+
+/// Streaming agent adapter — coexists with legacy CodeAgent trait.
+///
+/// Implementations send `AgentEvent`s through the provided mpsc channel
+/// during execution. The caller consumes events to drive notifications,
+/// logging, and approval gates.
+#[async_trait]
+pub trait AgentAdapter: Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Start a turn. Send events to `tx` until complete or error.
+    async fn start_turn(
+        &self,
+        req: TurnRequest,
+        tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> crate::Result<()>;
+
+    /// Interrupt an in-progress turn.
+    async fn interrupt(&self) -> crate::Result<()>;
+
+    /// Append instructions to an active turn (steer).
+    /// Returns `Err` with `Unsupported` if the adapter doesn't support steering.
+    async fn steer(&self, _text: String) -> crate::Result<()> {
+        Err(crate::Error::Unsupported("steer not supported".into()))
+    }
+
+    /// Respond to an approval request from the agent.
+    /// Returns `Err` with `Unsupported` if the adapter doesn't support approval.
+    async fn respond_approval(
+        &self,
+        _id: String,
+        _decision: ApprovalDecision,
+    ) -> crate::Result<()> {
+        Err(crate::Error::Unsupported("approval not supported".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_event_serde_round_trip() {
+        let events = vec![
+            AgentEvent::TurnStarted,
+            AgentEvent::ItemStarted {
+                item_type: "message".into(),
+            },
+            AgentEvent::MessageDelta {
+                text: "hello".into(),
+            },
+            AgentEvent::ToolCall {
+                name: "bash".into(),
+                input: serde_json::json!({"cmd": "ls"}),
+            },
+            AgentEvent::ApprovalRequest {
+                id: "req-1".into(),
+                command: "rm -rf /tmp/test".into(),
+            },
+            AgentEvent::ItemCompleted,
+            AgentEvent::TurnCompleted {
+                output: "done".into(),
+            },
+            AgentEvent::Error {
+                message: "oops".into(),
+            },
+        ];
+
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let parsed: AgentEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(json, serde_json::to_string(&parsed).unwrap());
+        }
+    }
+
+    #[test]
+    fn agent_event_tagged_format() {
+        let event = AgentEvent::ToolCall {
+            name: "bash".into(),
+            input: serde_json::json!({"cmd": "ls"}),
+        };
+        let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "tool_call");
+        assert_eq!(json["name"], "bash");
+    }
+
+    #[test]
+    fn approval_decision_serde_round_trip() {
+        let accept = ApprovalDecision::Accept;
+        let json = serde_json::to_string(&accept).unwrap();
+        assert!(json.contains("\"decision\":\"accept\""));
+
+        let reject = ApprovalDecision::Reject {
+            reason: "dangerous".into(),
+        };
+        let json = serde_json::to_string(&reject).unwrap();
+        let parsed: ApprovalDecision = serde_json::from_str(&json).unwrap();
+        assert_eq!(json, serde_json::to_string(&parsed).unwrap());
+    }
+}
+

--- a/crates/harness-core/src/error.rs
+++ b/crates/harness-core/src/error.rs
@@ -50,8 +50,12 @@ pub enum HarnessError {
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+
     #[error("{0}")]
     Other(String),
 }
 
+pub type Error = HarnessError;
 pub type Result<T> = std::result::Result<T, HarnessError>;


### PR DESCRIPTION
## Summary
- Add `AgentAdapter` trait for streaming agent execution (coexists with legacy `CodeAgent`)
- Add `AgentEvent` enum (8 variants) for event-driven turn execution
- Add `ApprovalDecision`, `TurnRequest` types
- Add `HarnessError::Unsupported` variant for optional adapter capabilities
- 3 serde round-trip tests, 220 workspace tests passing

## Test plan
- [x] `cargo test -p harness-core` — 38 tests pass
- [x] `cargo test --workspace` — 220 tests pass