### PR TITLE
feat: AdapterRegistry for streaming agent dispatch

### DIFF
--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -6,4 +6,4 @@ pub mod anthropic_api;
 pub mod registry;
 mod streaming;
 
-pub use registry::AgentRegistry;
+pub use registry::{AdapterRegistry, AgentRegistry};

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -1,4 +1,4 @@
-use harness_core::{CodeAgent, HarnessError, TaskClassification, TaskComplexity};
+use harness_core::{AgentAdapter, CodeAgent, HarnessError, TaskClassification, TaskComplexity};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -42,5 +42,128 @@ impl AgentRegistry {
 
     pub fn list(&self) -> Vec<&str> {
         self.agents.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+/// Registry for streaming `AgentAdapter` implementations.
+///
+/// Coexists with `AgentRegistry` — when an adapter is available for a given
+/// agent name, the task executor prefers it over the legacy `CodeAgent` path.
+pub struct AdapterRegistry {
+    adapters: HashMap<String, Arc<dyn AgentAdapter>>,
+    default_adapter: String,
+}
+
+impl AdapterRegistry {
+    pub fn new(default_adapter: impl Into<String>) -> Self {
+        Self {
+            adapters: HashMap::new(),
+            default_adapter: default_adapter.into(),
+        }
+    }
+
+    pub fn register(&mut self, name: impl Into<String>, adapter: Arc<dyn AgentAdapter>) {
+        self.adapters.insert(name.into(), adapter);
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
+        self.adapters.get(name).cloned()
+    }
+
+    pub fn default_adapter(&self) -> Option<Arc<dyn AgentAdapter>> {
+        self.get(&self.default_adapter)
+    }
+
+    pub fn list(&self) -> Vec<&str> {
+        self.adapters.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{AgentEvent, TurnRequest};
+
+    struct MockAdapter;
+
+    #[async_trait::async_trait]
+    impl AgentAdapter for MockAdapter {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn start_turn(
+            &self,
+            _req: TurnRequest,
+            tx: tokio::sync::mpsc::Sender<AgentEvent>,
+        ) -> harness_core::Result<()> {
+            let _ = tx.send(AgentEvent::TurnStarted).await;
+            let _ = tx
+                .send(AgentEvent::TurnCompleted {
+                    output: "mock done".into(),
+                })
+                .await;
+            Ok(())
+        }
+
+        async fn interrupt(&self) -> harness_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn adapter_registry_register_and_get() {
+        let mut registry = AdapterRegistry::new("mock");
+        registry.register("mock", Arc::new(MockAdapter));
+        assert!(registry.get("mock").is_some());
+        assert!(registry.get("missing").is_none());
+    }
+
+    #[test]
+    fn adapter_registry_default() {
+        let mut registry = AdapterRegistry::new("mock");
+        registry.register("mock", Arc::new(MockAdapter));
+        let adapter = registry.default_adapter().unwrap();
+        assert_eq!(adapter.name(), "mock");
+    }
+
+    #[test]
+    fn adapter_registry_default_returns_none_when_unregistered() {
+        let registry = AdapterRegistry::new("missing");
+        assert!(registry.default_adapter().is_none());
+    }
+
+    #[test]
+    fn adapter_registry_list() {
+        let mut registry = AdapterRegistry::new("a");
+        registry.register("a", Arc::new(MockAdapter));
+        registry.register("b", Arc::new(MockAdapter));
+        let mut names = registry.list();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn mock_adapter_produces_events() {
+        let adapter = MockAdapter;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let req = TurnRequest {
+            prompt: "test".into(),
+            project_root: std::path::PathBuf::from("."),
+            model: None,
+            allowed_tools: vec![],
+            context: vec![],
+            timeout_secs: None,
+        };
+        adapter.start_turn(req, tx).await.unwrap();
+
+        let first = rx.recv().await.unwrap();
+        assert!(matches!(first, AgentEvent::TurnStarted));
+
+        let second = rx.recv().await.unwrap();
+        match second {
+            AgentEvent::TurnCompleted { output } => assert_eq!(output, "mock done"),
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
     }
 }

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -80,7 +80,7 @@ pub enum TaskComplexity {
 // === Streaming Agent Adapter (new, coexists with CodeAgent) ===
 
 /// Events emitted by an agent adapter during a turn.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentEvent {
     TurnStarted,
@@ -94,7 +94,7 @@ pub enum AgentEvent {
 }
 
 /// Decision for an approval request from the agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "decision", rename_all = "snake_case")]
 pub enum ApprovalDecision {
     Accept,
@@ -179,10 +179,10 @@ mod tests {
             },
         ];
 
-        for event in &events {
-            let json = serde_json::to_string(event).unwrap();
+        for event in events {
+            let json = serde_json::to_string(&event).unwrap();
             let parsed: AgentEvent = serde_json::from_str(&json).unwrap();
-            assert_eq!(json, serde_json::to_string(&parsed).unwrap());
+            assert_eq!(event, parsed);
         }
     }
 
@@ -199,16 +199,18 @@ mod tests {
 
     #[test]
     fn approval_decision_serde_round_trip() {
-        let accept = ApprovalDecision::Accept;
-        let json = serde_json::to_string(&accept).unwrap();
-        assert!(json.contains("\"decision\":\"accept\""));
+        let decisions = vec![
+            ApprovalDecision::Accept,
+            ApprovalDecision::Reject {
+                reason: "dangerous".into(),
+            },
+        ];
 
-        let reject = ApprovalDecision::Reject {
-            reason: "dangerous".into(),
-        };
-        let json = serde_json::to_string(&reject).unwrap();
-        let parsed: ApprovalDecision = serde_json::from_str(&json).unwrap();
-        assert_eq!(json, serde_json::to_string(&parsed).unwrap());
+        for decision in decisions {
+            let json = serde_json::to_string(&decision).unwrap();
+            let parsed: ApprovalDecision = serde_json::from_str(&json).unwrap();
+            assert_eq!(decision, parsed);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `AdapterRegistry` for streaming `AgentAdapter` lookup (coexists with `AgentRegistry`)
- Derive `PartialEq` on `AgentEvent` and `ApprovalDecision` (Gemini review from #118)
- Improve serde round-trip tests with direct value comparison
- 5 new registry tests, 248 workspace tests passing

## Test plan
- [x] `cargo test -p harness-agents` — 30 tests pass
- [x] `cargo test --workspace` — 248 tests pass