### PR TITLE
fix: add regression coverage for anthropic stream send errors

### DIFF
--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -19,3 +19,38 @@ pub(crate) async fn send_stream_item(
         ))
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::HarnessError;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn send_stream_item_reports_closed_channel_with_context() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let error = send_stream_item(&tx, StreamItem::Done, "anthropic-api", "done")
+            .await
+            .expect_err("closed channel should return an error");
+
+        match error {
+            HarnessError::AgentExecution(message) => {
+                assert!(message.contains("anthropic-api stream send failed while sending done"));
+            }
+            other => panic!("expected HarnessError::AgentExecution, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_stream_item_succeeds_when_channel_open() {
+        let (tx, mut rx) = mpsc::channel(1);
+        send_stream_item(&tx, StreamItem::Done, "anthropic-api", "done")
+            .await
+            .expect("open channel should send successfully");
+
+        let received = rx.recv().await;
+        assert!(matches!(received, Some(StreamItem::Done)));
+    }
+}


### PR DESCRIPTION
## Summary
- verify `anthropic_api::execute_stream` already routes all sends through `streaming::send_stream_item`
- add regression tests in `crates/harness-agents/src/streaming.rs` for closed-channel failure context and open-channel success
- keep runtime behavior unchanged while guarding against silent mpsc send regressions

## Validation
- cargo test -p harness-agents send_stream_item -- --nocapture
- cargo check
- cargo test

Refs FUT-66
