### PR TITLE
FUT-67: Add semantic error codes for key handler failures

### DIFF
--- a/crates/harness-protocol/src/codec.rs
+++ b/crates/harness-protocol/src/codec.rs
@@ -113,6 +113,10 @@ mod tests {
         assert!(crate::METHOD_NOT_FOUND < 0);
         assert!(crate::INVALID_PARAMS < 0);
         assert!(crate::INTERNAL_ERROR < 0);
+        assert!(crate::NOT_FOUND < 0);
+        assert!(crate::VALIDATION < 0);
+        assert!(crate::AGENT_UNAVAILABLE < 0);
+        assert!(crate::SERIALIZATION < 0);
     }
 
     #[test]

--- a/crates/harness-protocol/src/methods.rs
+++ b/crates/harness-protocol/src/methods.rs
@@ -221,3 +221,9 @@ pub const INVALID_REQUEST: i32 = -32600;
 pub const METHOD_NOT_FOUND: i32 = -32601;
 pub const INVALID_PARAMS: i32 = -32602;
 pub const INTERNAL_ERROR: i32 = -32603;
+
+// Application semantic error codes (JSON-RPC server error range)
+pub const NOT_FOUND: i32 = -32001;
+pub const VALIDATION: i32 = -32002;
+pub const AGENT_UNAVAILABLE: i32 = -32003;
+pub const SERIALIZATION: i32 = -32004;

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -1,6 +1,16 @@
 use crate::http::AppState;
 use harness_core::DraftId;
-use harness_protocol::{RpcResponse, INTERNAL_ERROR};
+use harness_protocol::{RpcResponse, AGENT_UNAVAILABLE, INTERNAL_ERROR, NOT_FOUND, SERIALIZATION};
+
+fn gc_harness_error_response(id: Option<serde_json::Value>, error: anyhow::Error) -> RpcResponse {
+    let code = match error.downcast_ref::<harness_core::HarnessError>() {
+        Some(harness_core::HarnessError::DraftNotFound(_)) => NOT_FOUND,
+        Some(harness_core::HarnessError::AgentNotFound(_)) => AGENT_UNAVAILABLE,
+        Some(harness_core::HarnessError::Json(_)) => SERIALIZATION,
+        _ => INTERNAL_ERROR,
+    };
+    RpcResponse::error(id, code, error.to_string())
+}
 
 fn gc_adopt_task_request(
     prompt: String,
@@ -33,7 +43,7 @@ pub async fn gc_run(state: &AppState, id: Option<serde_json::Value>) -> RpcRespo
     let project = harness_core::Project::from_path(project_root);
     let agent = match state.server.agent_registry.default_agent() {
         Some(a) => a,
-        None => return RpcResponse::error(id, INTERNAL_ERROR, "no agent registered"),
+        None => return RpcResponse::error(id, AGENT_UNAVAILABLE, "no agent registered"),
     };
     match state
         .gc_agent
@@ -42,7 +52,7 @@ pub async fn gc_run(state: &AppState, id: Option<serde_json::Value>) -> RpcRespo
     {
         Ok(report) => match serde_json::to_value(&report) {
             Ok(v) => RpcResponse::success(id, v),
-            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            Err(e) => RpcResponse::error(id, SERIALIZATION, e.to_string()),
         },
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     }
@@ -59,7 +69,7 @@ pub async fn gc_drafts(state: &AppState, id: Option<serde_json::Value>) -> RpcRe
     match state.gc_agent.drafts() {
         Ok(drafts) => match serde_json::to_value(&drafts) {
             Ok(v) => RpcResponse::success(id, v),
-            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+            Err(e) => RpcResponse::error(id, SERIALIZATION, e.to_string()),
         },
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     }
@@ -73,7 +83,7 @@ pub async fn gc_adopt(
     let draft = match state.gc_agent.draft_store().get(&draft_id) {
         Ok(Some(d)) => d,
         Ok(None) => {
-            return RpcResponse::error(id, INTERNAL_ERROR, format!("draft {} not found", draft_id));
+            return RpcResponse::error(id, NOT_FOUND, format!("draft {} not found", draft_id));
         }
         Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     };
@@ -100,7 +110,11 @@ pub async fn gc_adopt(
                          commit, push, and open a PR. \
                          Print PR_URL=<url> on the last line."
                 );
-                let req = gc_adopt_task_request(prompt, &state.server.config.gc, state.project_root.clone());
+                let req = gc_adopt_task_request(
+                    prompt,
+                    &state.server.config.gc,
+                    state.project_root.clone(),
+                );
                 let tid = crate::task_runner::spawn_task(
                     state.tasks.clone(),
                     agent,
@@ -121,7 +135,7 @@ pub async fn gc_adopt(
                 serde_json::json!({ "adopted": true, "task_id": task_id }),
             )
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => gc_harness_error_response(id, e),
     }
 }
 
@@ -136,7 +150,11 @@ mod tests {
         gc_config.adopt_max_rounds = 9;
         gc_config.adopt_turn_timeout_secs = 11;
 
-        let req = gc_adopt_task_request("prompt".to_string(), &gc_config, std::path::PathBuf::from("/tmp/project"));
+        let req = gc_adopt_task_request(
+            "prompt".to_string(),
+            &gc_config,
+            std::path::PathBuf::from("/tmp/project"),
+        );
 
         assert_eq!(req.wait_secs, 7);
         assert_eq!(req.max_rounds, 9);
@@ -147,7 +165,11 @@ mod tests {
     fn gc_adopt_task_request_uses_gc_config_defaults() {
         let gc_config = harness_core::GcConfig::default();
 
-        let req = gc_adopt_task_request("prompt".to_string(), &gc_config, std::path::PathBuf::from("/tmp/project"));
+        let req = gc_adopt_task_request(
+            "prompt".to_string(),
+            &gc_config,
+            std::path::PathBuf::from("/tmp/project"),
+        );
 
         assert_eq!(req.wait_secs, 120);
         assert_eq!(req.max_rounds, 3);
@@ -173,6 +195,6 @@ pub async fn gc_reject(
 ) -> RpcResponse {
     match state.gc_agent.reject(&draft_id, reason.as_deref()) {
         Ok(()) => RpcResponse::success(id, serde_json::json!({ "rejected": true })),
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => gc_harness_error_response(id, e),
     }
 }

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -1,7 +1,21 @@
 use crate::http::AppState;
 use harness_core::{ThreadId, ThreadStatus, TurnStatus};
-use harness_protocol::{Notification, RpcResponse, INTERNAL_ERROR};
+use harness_protocol::{
+    Notification, RpcResponse, INTERNAL_ERROR, NOT_FOUND, SERIALIZATION, VALIDATION,
+};
 use std::path::PathBuf;
+
+fn thread_error_response(
+    id: Option<serde_json::Value>,
+    error: harness_core::HarnessError,
+) -> RpcResponse {
+    let code = match &error {
+        harness_core::HarnessError::ThreadNotFound(_)
+        | harness_core::HarnessError::TurnNotFound(_) => NOT_FOUND,
+        _ => INTERNAL_ERROR,
+    };
+    RpcResponse::error(id, code, error.to_string())
+}
 
 /// Persist an existing thread to the optional ThreadDb after a mutation.
 pub(crate) async fn persist_thread(state: &AppState, thread_id: &ThreadId) {
@@ -57,7 +71,7 @@ pub async fn thread_start(
 ) -> RpcResponse {
     let cwd = match crate::handlers::validate_project_root(&cwd) {
         Ok(p) => p,
-        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+        Err(e) => return RpcResponse::error(id, VALIDATION, e),
     };
     let thread_id = state.server.thread_manager.start_thread(cwd);
     persist_thread_insert(state, &thread_id).await;
@@ -84,7 +98,7 @@ fn thread_list_response<T: serde::Serialize>(
         Ok(value) => RpcResponse::success(id, value),
         Err(e) => RpcResponse::error(
             id,
-            INTERNAL_ERROR,
+            SERIALIZATION,
             format!("failed to serialize thread list: {e}"),
         ),
     }
@@ -113,8 +127,7 @@ pub async fn turn_start(
     input: String,
 ) -> RpcResponse {
     let input = harness_core::prompts::wrap_external_data(&input);
-    let agent_id =
-        harness_core::AgentId::from_str(&state.server.config.agents.default_agent);
+    let agent_id = harness_core::AgentId::from_str(&state.server.config.agents.default_agent);
     match state
         .server
         .thread_manager
@@ -131,7 +144,7 @@ pub async fn turn_start(
             );
             RpcResponse::success(id, serde_json::json!({ "turn_id": turn_id }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => thread_error_response(id, e),
     }
 }
 
@@ -159,10 +172,10 @@ pub async fn turn_cancel(
                     );
                     RpcResponse::success(id, serde_json::json!({ "cancelled": true }))
                 }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                Err(e) => thread_error_response(id, e),
             }
         }
-        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+        None => RpcResponse::error(id, NOT_FOUND, "turn not found in any thread"),
     }
 }
 
@@ -177,16 +190,16 @@ pub async fn turn_status(
                 if let Some(turn) = thread.turns.iter().find(|t| t.id == turn_id) {
                     match serde_json::to_value(turn) {
                         Ok(v) => RpcResponse::success(id, v),
-                        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                        Err(e) => RpcResponse::error(id, SERIALIZATION, e.to_string()),
                     }
                 } else {
-                    RpcResponse::error(id, INTERNAL_ERROR, "turn not found")
+                    RpcResponse::error(id, NOT_FOUND, "turn not found")
                 }
             } else {
-                RpcResponse::error(id, INTERNAL_ERROR, "thread not found")
+                RpcResponse::error(id, NOT_FOUND, "thread not found")
             }
         }
-        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+        None => RpcResponse::error(id, NOT_FOUND, "turn not found in any thread"),
     }
 }
 
@@ -208,10 +221,10 @@ pub async fn turn_steer(
                     persist_thread(state, &thread_id).await;
                     RpcResponse::success(id, serde_json::json!({ "steered": true }))
                 }
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                Err(e) => thread_error_response(id, e),
             }
         }
-        None => RpcResponse::error(id, INTERNAL_ERROR, "turn not found in any thread"),
+        None => RpcResponse::error(id, NOT_FOUND, "turn not found in any thread"),
     }
 }
 
@@ -225,7 +238,7 @@ pub async fn thread_resume(
             persist_thread(state, &thread_id).await;
             RpcResponse::success(id, serde_json::json!({ "resumed": true }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => thread_error_response(id, e),
     }
 }
 
@@ -244,7 +257,7 @@ pub async fn thread_fork(
             persist_thread_insert(state, &new_id).await;
             RpcResponse::success(id, serde_json::json!({ "thread_id": new_id }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => thread_error_response(id, e),
     }
 }
 
@@ -258,7 +271,7 @@ pub async fn thread_compact(
             persist_thread(state, &thread_id).await;
             RpcResponse::success(id, serde_json::json!({ "compacted": true }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => thread_error_response(id, e),
     }
 }
 
@@ -292,8 +305,10 @@ mod tests {
         let response = thread_list_response(Some(json!(1)), AlwaysFailSerialize);
 
         assert!(response.result.is_none());
-        let error = response.error.expect("expected serialization error response");
-        assert_eq!(error.code, INTERNAL_ERROR);
+        let error = response
+            .error
+            .expect("expected serialization error response");
+        assert_eq!(error.code, SERIALIZATION);
         assert!(error
             .message
             .contains("failed to serialize thread list: forced serialization failure"));

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -774,14 +774,10 @@ mod tests {
             .await
             .expect("expected response for request with id");
 
-        assert!(
-            resp.error.is_none(),
-            "expected success: {:?}",
-            resp.error
-        );
-        let result =
-            resp.result
-                .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        assert!(resp.error.is_none(), "expected success: {:?}", resp.error);
+        let result = resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?;
         let coverage = result["dimensions"]["coverage"]
             .as_f64()
             .ok_or_else(|| anyhow::anyhow!("missing coverage"))?;
@@ -799,8 +795,7 @@ mod tests {
         let linked_checks = events
             .iter()
             .filter(|event| {
-                event.hook == "rule_check"
-                    && event.session_id == latest_scan.session_id
+                event.hook == "rule_check" && event.session_id == latest_scan.session_id
             })
             .count();
         assert_eq!(linked_checks, violations.len());
@@ -845,6 +840,67 @@ mod tests {
             .await?
             .expect("thread should be in DB");
         assert_eq!(thread.project_root, canonical_proj);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn thread_start_invalid_root_returns_validation_error() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::ThreadStart {
+                cwd: dir.path().join("missing-project-root"),
+            },
+        };
+        let resp = handle_request(&state, req)
+            .await
+            .expect("expected response for request with id");
+
+        let error = resp.error.ok_or_else(|| anyhow::anyhow!("missing error"))?;
+        assert_eq!(error.code, harness_protocol::VALIDATION);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gc_run_without_default_agent_returns_agent_unavailable() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::GcRun { project_id: None },
+        };
+        let resp = handle_request(&state, req)
+            .await
+            .expect("expected response for request with id");
+
+        let error = resp.error.ok_or_else(|| anyhow::anyhow!("missing error"))?;
+        assert_eq!(error.code, harness_protocol::AGENT_UNAVAILABLE);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gc_adopt_missing_draft_returns_not_found() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_test_state(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::GcAdopt {
+                draft_id: harness_core::DraftId::new(),
+            },
+        };
+        let resp = handle_request(&state, req)
+            .await
+            .expect("expected response for request with id");
+
+        let error = resp.error.ok_or_else(|| anyhow::anyhow!("missing error"))?;
+        assert_eq!(error.code, harness_protocol::NOT_FOUND);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add semantic JSON-RPC server error code constants (NOT_FOUND, VALIDATION, AGENT_UNAVAILABLE, SERIALIZATION)
- map representative thread and gc handler failures away from uniform INTERNAL_ERROR
- add router-level regression tests for validation, agent availability, and not-found mappings

## Validation
- cargo check
- cargo test
