### PR TITLE
FUT-68: validate artifact target_path in GC adopt before writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "harness-rules",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -24,7 +24,12 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
             let signal_detector = SignalDetector::new(thresholds, project.id.clone());
             let gc_config = map_gc_config(&config.gc);
             let draft_store = DraftStore::new(data_dir)?;
-            let gc_agent = GcAgent::new(gc_config, signal_detector, draft_store);
+            let gc_agent = GcAgent::new(
+                gc_config,
+                signal_detector,
+                draft_store,
+                project.root.clone(),
+            );
 
             let claude = harness_agents::claude::ClaudeCodeAgent::new(
                 config.agents.claude.cli_path.clone(),
@@ -87,10 +92,12 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
 
 fn make_agent_for_draft_ops(data_dir: &std::path::Path) -> anyhow::Result<GcAgent> {
     let draft_store = DraftStore::new(data_dir)?;
+    let project_root = std::env::current_dir()?;
     Ok(GcAgent::new(
         GcAgentConfig::default(),
         SignalDetector::new(GcThresholds::default(), ProjectId::new()),
         draft_store,
+        project_root,
     ))
 }
 

--- a/crates/harness-gc/Cargo.toml
+++ b/crates/harness-gc/Cargo.toml
@@ -16,3 +16,6 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -1,12 +1,14 @@
-use harness_core::{
-    AgentRequest, Artifact, ArtifactType, CodeAgent, Draft, DraftId, DraftStatus,
-    Project, Signal, SignalType, RemediationType,
-};
 use crate::draft_store::DraftStore;
 use crate::remediation::signal_priority;
 use crate::signal_detector::SignalDetector;
+use anyhow::Context;
 use chrono::Utc;
+use harness_core::{
+    AgentRequest, Artifact, ArtifactType, CodeAgent, Draft, DraftId, DraftStatus, Project,
+    RemediationType, Signal, SignalType,
+};
 use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GcConfig {
@@ -36,14 +38,21 @@ pub struct GcAgent {
     config: GcConfig,
     signal_detector: SignalDetector,
     draft_store: DraftStore,
+    project_root: PathBuf,
 }
 
 impl GcAgent {
-    pub fn new(config: GcConfig, signal_detector: SignalDetector, draft_store: DraftStore) -> Self {
+    pub fn new(
+        config: GcConfig,
+        signal_detector: SignalDetector,
+        draft_store: DraftStore,
+        project_root: PathBuf,
+    ) -> Self {
         Self {
             config,
             signal_detector,
             draft_store,
+            project_root,
         }
     }
 
@@ -105,7 +114,10 @@ impl GcAgent {
                     }
                 }
                 Err(e) => {
-                    errors.push(format!("agent failed for signal {:?}: {e}", signal.signal_type));
+                    errors.push(format!(
+                        "agent failed for signal {:?}: {e}",
+                        signal.signal_type
+                    ));
                 }
             }
         }
@@ -123,12 +135,35 @@ impl GcAgent {
             .draft_store
             .get(draft_id)?
             .ok_or_else(|| anyhow::anyhow!("draft not found"))?;
+        let canonical_project_root = self.project_root.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize project root '{}'",
+                self.project_root.display()
+            )
+        })?;
 
         for artifact in &draft.artifacts {
-            if let Some(parent) = artifact.target_path.parent() {
+            let validated_target_path = match validate_target_path_for_write(
+                &canonical_project_root,
+                &artifact.target_path,
+            ) {
+                Ok(path) => path,
+                Err(err) => {
+                    tracing::error!(
+                        draft_id = %draft_id,
+                        target_path = %artifact.target_path.display(),
+                        project_root = %canonical_project_root.display(),
+                        error = %err,
+                        "GC adopt rejected unsafe artifact target_path"
+                    );
+                    return Err(err);
+                }
+            };
+
+            if let Some(parent) = validated_target_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(&artifact.target_path, &artifact.content)?;
+            std::fs::write(&validated_target_path, &artifact.content)?;
         }
 
         draft.status = DraftStatus::Adopted;
@@ -154,6 +189,72 @@ impl GcAgent {
     pub fn draft_store(&self) -> &DraftStore {
         &self.draft_store
     }
+}
+
+fn validate_target_path_for_write(
+    project_root: &Path,
+    target_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    let absolute_target = if target_path.is_absolute() {
+        target_path.to_path_buf()
+    } else {
+        project_root.join(target_path)
+    };
+    let normalized_target = normalize_path(&absolute_target);
+    let resolved_target =
+        resolve_path_for_boundary_check(&normalized_target).with_context(|| {
+            format!(
+                "invalid artifact target_path '{}': failed to resolve path",
+                target_path.display()
+            )
+        })?;
+
+    if resolved_target == project_root || resolved_target.starts_with(project_root) {
+        return Ok(normalized_target);
+    }
+
+    anyhow::bail!(
+        "invalid artifact target_path '{}': resolved path '{}' is outside project root '{}'",
+        target_path.display(),
+        resolved_target.display(),
+        project_root.display()
+    );
+}
+
+fn resolve_path_for_boundary_check(path: &Path) -> anyhow::Result<PathBuf> {
+    let mut existing_ancestor = path;
+    while !existing_ancestor.exists() {
+        existing_ancestor = existing_ancestor.parent().ok_or_else(|| {
+            anyhow::anyhow!(
+                "invalid artifact target_path '{}': no existing ancestor",
+                path.display()
+            )
+        })?;
+    }
+
+    let canonical_ancestor = existing_ancestor.canonicalize()?;
+    let remaining_suffix = path
+        .strip_prefix(existing_ancestor)
+        .map_err(|_| anyhow::anyhow!("failed to compute suffix for '{}'", path.display()))?;
+    Ok(canonical_ancestor.join(remaining_suffix))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized.file_name().is_some() {
+                    normalized.pop();
+                }
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+    normalized
 }
 
 fn build_prompt(signal: &Signal, project: &Project) -> String {
@@ -202,10 +303,124 @@ fn parse_artifacts(output: &str, signal: &Signal) -> Vec<Artifact> {
     // For now, treat the entire output as a single artifact
     vec![Artifact {
         artifact_type,
-        target_path: std::path::PathBuf::from(format!(
-            ".harness/drafts/{}.md",
-            signal.id
-        )),
+        target_path: std::path::PathBuf::from(format!(".harness/drafts/{}.md", signal.id)),
         content: output.to_string(),
     }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{ProjectId, RemediationType};
+    use serde_json::json;
+
+    fn make_agent(project_root: &Path) -> anyhow::Result<GcAgent> {
+        let data_dir = project_root.join(".harness");
+        let draft_store = DraftStore::new(&data_dir)?;
+        let signal_detector = SignalDetector::new(Default::default(), ProjectId::new());
+        Ok(GcAgent::new(
+            GcConfig::default(),
+            signal_detector,
+            draft_store,
+            project_root.to_path_buf(),
+        ))
+    }
+
+    fn make_draft(target_path: PathBuf) -> Draft {
+        let signal = Signal::new(
+            SignalType::LinterViolations,
+            ProjectId::new(),
+            json!({ "source": "test" }),
+            RemediationType::Guard,
+        );
+
+        Draft {
+            id: DraftId::new(),
+            status: DraftStatus::Pending,
+            signal,
+            artifacts: vec![Artifact {
+                artifact_type: ArtifactType::Guard,
+                target_path,
+                content: "guard content".to_string(),
+            }],
+            rationale: "test draft".to_string(),
+            validation: "test validation".to_string(),
+            generated_at: Utc::now(),
+            agent_model: "test-model".to_string(),
+        }
+    }
+
+    #[test]
+    fn adopt_rejects_path_traversal_target_path() -> anyhow::Result<()> {
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let agent = make_agent(&project_root)?;
+        let draft = make_draft(PathBuf::from("../escaped.txt"));
+        let draft_id = draft.id.clone();
+        agent.draft_store().save(&draft)?;
+
+        let err = agent
+            .adopt(&draft_id)
+            .expect_err("path traversal should be rejected");
+        assert!(err.to_string().contains("outside project root"));
+        let escaped_path = project_root
+            .parent()
+            .expect("project root has parent")
+            .join("escaped.txt");
+        assert!(!escaped_path.exists(), "escaped path must not be written");
+        let persisted = agent
+            .draft_store()
+            .get(&draft_id)?
+            .expect("draft should remain saved");
+        assert_eq!(persisted.status, DraftStatus::Pending);
+        Ok(())
+    }
+
+    #[test]
+    fn adopt_rejects_absolute_outside_root_target_path() -> anyhow::Result<()> {
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let outside_path = sandbox.path().join("outside").join("escape.txt");
+        let agent = make_agent(&project_root)?;
+        let draft = make_draft(outside_path.clone());
+        let draft_id = draft.id.clone();
+        agent.draft_store().save(&draft)?;
+
+        let err = agent
+            .adopt(&draft_id)
+            .expect_err("absolute outside-root path should be rejected");
+        assert!(err.to_string().contains("outside project root"));
+        assert!(!outside_path.exists(), "outside path must not be written");
+        let persisted = agent
+            .draft_store()
+            .get(&draft_id)?
+            .expect("draft should remain saved");
+        assert_eq!(persisted.status, DraftStatus::Pending);
+        Ok(())
+    }
+
+    #[test]
+    fn adopt_writes_artifact_within_project_root() -> anyhow::Result<()> {
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let agent = make_agent(&project_root)?;
+        let draft = make_draft(PathBuf::from("rules/new-guard.md"));
+        let draft_id = draft.id.clone();
+        agent.draft_store().save(&draft)?;
+
+        agent.adopt(&draft_id)?;
+
+        let written_path = project_root.join("rules/new-guard.md");
+        let written = std::fs::read_to_string(&written_path)?;
+        assert_eq!(written, "guard content");
+        let persisted = agent
+            .draft_store()
+            .get(&draft_id)?
+            .expect("draft should remain saved");
+        assert_eq!(persisted.status, DraftStatus::Adopted);
+        Ok(())
+    }
 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -115,6 +115,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         harness_gc::gc_agent::GcConfig::default(),
         signal_detector,
         draft_store,
+        project_root.clone(),
     ));
 
     let thread_db_path = dir.join("threads.db");
@@ -350,6 +351,7 @@ mod tests {
             harness_gc::gc_agent::GcConfig::default(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         Ok(Arc::new(AppState {

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -212,6 +212,7 @@ mod tests {
             harness_gc::gc_agent::GcConfig::default(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let (notification_tx, _) = tokio::sync::broadcast::channel(64);

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -97,6 +97,7 @@ mod tests {
             harness_gc::gc_agent::GcConfig::default(),
             signal_detector,
             draft_store,
+            project_root.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         Ok(Arc::new(AppState {

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -109,6 +109,7 @@ mod tests {
             harness_gc::gc_agent::GcConfig::default(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
 

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -28,6 +28,7 @@ pub async fn make_test_state_with_registry(
         harness_gc::gc_agent::GcConfig::default(),
         signal_detector,
         draft_store,
+        dir.to_path_buf(),
     ));
     let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
     let (notification_tx, _) = broadcast::channel(64);

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -201,6 +201,7 @@ mod tests {
             harness_gc::gc_agent::GcConfig::default(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let (notification_tx, _) = broadcast::channel(notification_broadcast_capacity);


### PR DESCRIPTION
## Summary
- add GC adopt path-boundary validation so artifact writes must remain under project root
- log and return explicit errors when target_path resolves outside the root
- add regression tests for path traversal and absolute outside-root paths
- pass project root into GcAgent constructors across CLI/server callsites

## Validation
- cargo test -p harness-gc
- cargo test -p harness-cli -p harness-server --no-run