### PR TITLE
FUT-69: Persist ExecPlan in SQLite

### DIFF
--- a/crates/harness-server/src/exec_plan_db.rs
+++ b/crates/harness-server/src/exec_plan_db.rs
@@ -1,0 +1,128 @@
+use harness_core::ExecPlanId;
+use harness_exec::ExecPlan;
+use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use std::path::Path;
+
+pub struct ExecPlanDb {
+    pool: SqlitePool,
+}
+
+impl ExecPlanDb {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        let url = format!("sqlite:{}?mode=rwc", path.display());
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect(&url)
+            .await?;
+        let db = Self { pool };
+        db.migrate().await?;
+        Ok(db)
+    }
+
+    async fn migrate(&self) -> anyhow::Result<()> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS exec_plans (
+                id TEXT PRIMARY KEY,
+                plan_json TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn upsert(&self, plan: &ExecPlan) -> anyhow::Result<()> {
+        let plan_json = serde_json::to_string(plan)?;
+        sqlx::query(
+            "INSERT INTO exec_plans (id, plan_json, created_at, updated_at)
+             VALUES (?, ?, datetime('now'), datetime('now'))
+             ON CONFLICT(id) DO UPDATE
+             SET plan_json = excluded.plan_json, updated_at = datetime('now')",
+        )
+        .bind(plan.id.as_str())
+        .bind(&plan_json)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get(&self, plan_id: &ExecPlanId) -> anyhow::Result<Option<ExecPlan>> {
+        let stored =
+            sqlx::query_scalar::<_, String>("SELECT plan_json FROM exec_plans WHERE id = ?")
+                .bind(plan_id.as_str())
+                .fetch_optional(&self.pool)
+                .await?;
+
+        stored
+            .map(|plan_json| {
+                serde_json::from_str::<ExecPlan>(&plan_json).map_err(anyhow::Error::from)
+            })
+            .transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[tokio::test]
+    async fn exec_plan_db_migrates_table_on_open() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("exec_plans.db");
+        let db = ExecPlanDb::open(&db_path).await?;
+
+        let table_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(1) FROM sqlite_master WHERE type='table' AND name='exec_plans'",
+        )
+        .fetch_one(&db.pool)
+        .await?;
+        assert_eq!(table_count, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_db_roundtrip_update() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("exec_plans.db");
+        let db = ExecPlanDb::open(&db_path).await?;
+
+        let mut plan = ExecPlan::from_spec("# Persist plan", Path::new("/tmp"))?;
+        db.upsert(&plan).await?;
+
+        let loaded = db.get(&plan.id).await?.expect("expected persisted plan");
+        assert_eq!(loaded.id, plan.id);
+        assert_eq!(loaded.status, harness_core::ExecPlanStatus::Draft);
+
+        plan.activate();
+        db.upsert(&plan).await?;
+        let updated = db.get(&plan.id).await?.expect("expected updated plan");
+        assert_eq!(updated.status, harness_core::ExecPlanStatus::Active);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_db_survives_reopen() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("exec_plans.db");
+
+        let persisted_plan_id = {
+            let db = ExecPlanDb::open(&db_path).await?;
+            let plan = ExecPlan::from_spec("# Restart recovery", Path::new("/tmp"))?;
+            let plan_id = plan.id.clone();
+            db.upsert(&plan).await?;
+            plan_id
+        };
+
+        let reopened_db = ExecPlanDb::open(&db_path).await?;
+        let recovered = reopened_db
+            .get(&persisted_plan_id)
+            .await?
+            .expect("expected plan after reopen");
+        assert_eq!(recovered.id, persisted_plan_id);
+        assert_eq!(recovered.purpose, "Restart recovery");
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/handlers/exec.rs
+++ b/crates/harness-server/src/handlers/exec.rs
@@ -16,8 +16,9 @@ pub async fn exec_plan_init(
     match harness_exec::ExecPlan::from_spec(&spec, &project_root) {
         Ok(plan) => {
             let plan_id = plan.id.clone();
-            let mut plans = state.plans.write().await;
-            plans.insert(plan_id.clone(), plan);
+            if let Err(e) = state.exec_plan_db.upsert(&plan).await {
+                return RpcResponse::error(id, INTERNAL_ERROR, e.to_string());
+            }
             RpcResponse::success(id, serde_json::json!({ "plan_id": plan_id }))
         }
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -29,13 +30,13 @@ pub async fn exec_plan_status(
     id: Option<serde_json::Value>,
     plan_id: ExecPlanId,
 ) -> RpcResponse {
-    let plans = state.plans.read().await;
-    match plans.get(&plan_id) {
-        Some(plan) => match serde_json::to_value(plan) {
+    match state.exec_plan_db.get(&plan_id).await {
+        Ok(Some(plan)) => match serde_json::to_value(&plan) {
             Ok(v) => RpcResponse::success(id, v),
             Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
         },
-        None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+        Ok(None) => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     }
 }
 
@@ -45,48 +46,42 @@ pub async fn exec_plan_update(
     plan_id: ExecPlanId,
     updates: serde_json::Value,
 ) -> RpcResponse {
-    let mut plans = state.plans.write().await;
-    match plans.get_mut(&plan_id) {
-        Some(plan) => {
-            let action = updates
-                .get("action")
-                .and_then(|a| a.as_str())
-                .unwrap_or("");
-            match action {
-                "activate" => plan.activate(),
-                "complete" => plan.complete(),
-                "abandon" => plan.abandon(),
-                "add_milestone" => {
-                    if let Some(desc) =
-                        updates.get("description").and_then(|d| d.as_str())
-                    {
-                        plan.add_milestone(desc.to_string());
-                    }
-                }
-                "log_decision" => {
-                    let decision = updates
-                        .get("decision")
-                        .and_then(|d| d.as_str())
-                        .unwrap_or("");
-                    let rationale = updates
-                        .get("rationale")
-                        .and_then(|r| r.as_str())
-                        .unwrap_or("");
-                    plan.log_decision(decision, rationale);
-                }
-                _ => {
-                    return RpcResponse::error(
-                        id,
-                        INTERNAL_ERROR,
-                        format!("unknown action: {action}"),
-                    )
-                }
-            }
-            match serde_json::to_value(&*plan) {
-                Ok(v) => RpcResponse::success(id, v),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    let mut plan = match state.exec_plan_db.get(&plan_id).await {
+        Ok(Some(plan)) => plan,
+        Ok(None) => return RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    };
+
+    let action = updates.get("action").and_then(|a| a.as_str()).unwrap_or("");
+    match action {
+        "activate" => plan.activate(),
+        "complete" => plan.complete(),
+        "abandon" => plan.abandon(),
+        "add_milestone" => {
+            if let Some(desc) = updates.get("description").and_then(|d| d.as_str()) {
+                plan.add_milestone(desc.to_string());
             }
         }
-        None => RpcResponse::error(id, INTERNAL_ERROR, "plan not found"),
+        "log_decision" => {
+            let decision = updates
+                .get("decision")
+                .and_then(|d| d.as_str())
+                .unwrap_or("");
+            let rationale = updates
+                .get("rationale")
+                .and_then(|r| r.as_str())
+                .unwrap_or("");
+            plan.log_decision(decision, rationale);
+        }
+        _ => return RpcResponse::error(id, INTERNAL_ERROR, format!("unknown action: {action}")),
+    }
+
+    if let Err(e) = state.exec_plan_db.upsert(&plan).await {
+        return RpcResponse::error(id, INTERNAL_ERROR, e.to_string());
+    }
+
+    match serde_json::to_value(&plan) {
+        Ok(v) => RpcResponse::success(id, v),
+        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     }
 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -21,8 +21,7 @@ pub struct AppState {
     pub rules: Arc<RwLock<harness_rules::engine::RuleEngine>>,
     pub events: Arc<harness_observe::EventStore>,
     pub gc_agent: Arc<harness_gc::GcAgent>,
-    pub plans:
-        Arc<RwLock<std::collections::HashMap<harness_core::ExecPlanId, harness_exec::ExecPlan>>>,
+    pub exec_plan_db: Arc<crate::exec_plan_db::ExecPlanDb>,
     pub thread_db: Option<crate::thread_db::ThreadDb>,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
     /// Broadcast channel for server-push notifications (WebSocket and stdio transports).
@@ -119,6 +118,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
 
     let thread_db_path = dir.join("threads.db");
     let thread_db = crate::thread_db::ThreadDb::open(&thread_db_path).await?;
+    let exec_plan_db =
+        Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
     let configured_capacity = server.config.server.notification_broadcast_capacity;
     let notification_broadcast_capacity = configured_capacity.max(1);
     let notification_lag_log_every = server.config.server.notification_lag_log_every;
@@ -149,7 +150,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         rules: Arc::new(RwLock::new(rule_engine)),
         events,
         gc_agent,
-        plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        exec_plan_db,
         thread_db: Some(thread_db),
         interceptors: vec![Arc::new(crate::contract_validator::ContractValidator::new())],
         notification_tx: broadcast::channel(notification_broadcast_capacity).0,
@@ -352,6 +353,8 @@ mod tests {
             draft_store,
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let exec_plan_db =
+            Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
         Ok(Arc::new(AppState {
             server,
             project_root: dir.to_path_buf(),
@@ -362,7 +365,7 @@ mod tests {
             )),
             events,
             gc_agent,
-            plans: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+            exec_plan_db,
             thread_db: Some(thread_db),
             interceptors: vec![],
             notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod server;
 pub mod thread_manager;
 pub mod thread_db;
+pub mod exec_plan_db;
 pub mod stdio;
 pub mod http;
 pub mod handlers;

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -214,6 +214,8 @@ mod tests {
             draft_store,
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let exec_plan_db =
+            Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
         let (notification_tx, _) = tokio::sync::broadcast::channel(64);
         Ok(AppState {
             server,
@@ -223,7 +225,7 @@ mod tests {
             rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
             events,
             gc_agent,
-            plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            exec_plan_db,
             thread_db: Some(thread_db),
             interceptors: vec![],
             notification_tx,

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -99,6 +99,8 @@ mod tests {
             draft_store,
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let exec_plan_db =
+            Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
         Ok(Arc::new(AppState {
             server,
             project_root: project_root.to_path_buf(),
@@ -107,7 +109,7 @@ mod tests {
             rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
             events,
             gc_agent,
-            plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            exec_plan_db,
             thread_db: Some(thread_db),
             interceptors: vec![],
             notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -111,6 +111,8 @@ mod tests {
             draft_store,
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let exec_plan_db =
+            Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
 
         Ok(AppState {
             server,
@@ -120,7 +122,7 @@ mod tests {
             rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
             events,
             gc_agent,
-            plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            exec_plan_db,
             thread_db: Some(thread_db),
             interceptors: vec![],
             notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -30,6 +30,8 @@ pub async fn make_test_state_with_registry(
         draft_store,
     ));
     let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+    let exec_plan_db =
+        Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
     let (notification_tx, _) = broadcast::channel(64);
     Ok(AppState {
         server,
@@ -39,7 +41,7 @@ pub async fn make_test_state_with_registry(
         rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
         events,
         gc_agent,
-        plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        exec_plan_db,
         thread_db: Some(thread_db),
         interceptors: vec![],
         notification_tx,

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -203,6 +203,8 @@ mod tests {
             draft_store,
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let exec_plan_db =
+            Arc::new(crate::exec_plan_db::ExecPlanDb::open(&dir.join("exec_plans.db")).await?);
         let (notification_tx, _) = broadcast::channel(notification_broadcast_capacity);
 
         Ok(AppState {
@@ -213,7 +215,7 @@ mod tests {
             rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
             events,
             gc_agent,
-            plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            exec_plan_db,
             thread_db: Some(thread_db),
             interceptors: vec![],
             notification_tx,


### PR DESCRIPTION
## Summary
- replace in-memory ExecPlan storage with a SQLite-backed `ExecPlanDb`
- persist ExecPlan init/update/status flows through SQLite while keeping RPC responses unchanged
- open `exec_plans.db` in all server/test AppState constructors
- add migration and restart-recovery tests for ExecPlan persistence

## Validation
- `RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p harness-server exec_plan_db --jobs 1`
- `RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p harness-server exec_plan_ --jobs 1`
- `RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo check -p harness-server --jobs 1`
- `RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p harness-server --jobs 1`
