### PR TITLE
fix: clean up Codex approval policy defaults

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -17,6 +17,7 @@ default_model = "sonnet"
 
 [agents.codex]
 cli_path = "codex"
+approval_policy = "suggest" # suggest | auto-edit | full-auto
 
 [agents.anthropic_api]
 base_url = "https://api.anthropic.com"

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -1,18 +1,46 @@
 use crate::streaming::send_stream_item;
 use async_trait::async_trait;
 use harness_core::{
-    AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
+    AgentRequest, AgentResponse, Capability, CodeAgent, CodexApprovalPolicy, Item, StreamItem,
+    TokenUsage,
 };
+use std::ffi::OsString;
 use std::path::PathBuf;
 use tokio::process::Command;
 
 pub struct CodexAgent {
     pub cli_path: PathBuf,
+    pub approval_policy: CodexApprovalPolicy,
 }
 
 impl CodexAgent {
-    pub fn new(cli_path: PathBuf) -> Self {
-        Self { cli_path }
+    pub fn new(cli_path: PathBuf, approval_policy: CodexApprovalPolicy) -> Self {
+        Self {
+            cli_path,
+            approval_policy,
+        }
+    }
+
+    fn command_args(&self, req: &AgentRequest) -> Vec<OsString> {
+        let mut args: Vec<OsString> = vec!["exec".into(), "--skip-git-repo-check".into()];
+
+        match self.approval_policy {
+            CodexApprovalPolicy::Suggest => {
+                args.push("--sandbox".into());
+                args.push("read-only".into());
+            }
+            CodexApprovalPolicy::AutoEdit => {
+                args.push("--full-auto".into());
+            }
+            CodexApprovalPolicy::FullAuto => {
+                args.push("--dangerously-bypass-approvals-and-sandbox".into());
+            }
+        }
+
+        args.push("-C".into());
+        args.push(req.project_root.as_os_str().to_os_string());
+        args.push(req.prompt.clone().into());
+        args
     }
 }
 
@@ -28,13 +56,7 @@ impl CodeAgent for CodexAgent {
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
         let mut cmd = Command::new(&self.cli_path);
-        cmd.arg("exec")
-            .arg("--skip-git-repo-check")
-            .arg("-a")
-            .arg("read-only")
-            .arg("-C")
-            .arg(&req.project_root)
-            .arg(&req.prompt);
+        cmd.args(self.command_args(&req));
 
         let output = cmd.output().await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to run codex: {e}"))
@@ -85,10 +107,11 @@ impl CodeAgent for CodexAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::CodexApprovalPolicy;
 
     #[tokio::test]
     async fn execute_stream_returns_error_when_channel_closed() {
-        let agent = CodexAgent::new(PathBuf::from("/usr/bin/true"));
+        let agent = CodexAgent::new(PathBuf::from("/usr/bin/true"), CodexApprovalPolicy::Suggest);
         let request = AgentRequest::default();
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         drop(rx);
@@ -103,5 +126,58 @@ mod tests {
             message.contains("stream send failed"),
             "expected send failure in error message, got: {message}"
         );
+    }
+
+    #[test]
+    fn suggest_policy_uses_read_only_sandbox() {
+        let agent = CodexAgent::new(PathBuf::from("codex"), CodexApprovalPolicy::Suggest);
+        let request = AgentRequest::default();
+        let args: Vec<String> = agent
+            .command_args(&request)
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert!(args.windows(2).any(|window| {
+            matches!(
+                window,
+                [flag, value] if flag == "--sandbox" && value == "read-only"
+            )
+        }));
+        assert!(!args.iter().any(|arg| arg == "--full-auto"));
+        assert!(!args
+            .iter()
+            .any(|arg| arg == "--dangerously-bypass-approvals-and-sandbox"));
+    }
+
+    #[test]
+    fn auto_edit_policy_uses_full_auto_mode() {
+        let agent = CodexAgent::new(PathBuf::from("codex"), CodexApprovalPolicy::AutoEdit);
+        let request = AgentRequest::default();
+        let args: Vec<String> = agent
+            .command_args(&request)
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert!(args.iter().any(|arg| arg == "--full-auto"));
+        assert!(!args.iter().any(|arg| arg == "--sandbox"));
+    }
+
+    #[test]
+    fn full_auto_policy_bypasses_approvals_and_sandbox() {
+        let agent = CodexAgent::new(PathBuf::from("codex"), CodexApprovalPolicy::FullAuto);
+        let request = AgentRequest::default();
+        let args: Vec<String> = agent
+            .command_args(&request)
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert!(args
+            .iter()
+            .any(|arg| arg == "--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!args.iter().any(|arg| arg == "--sandbox"));
+        assert!(!args.iter().any(|arg| arg == "--full-auto"));
     }
 }

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -242,6 +242,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 "codex",
                 Arc::new(harness_agents::codex::CodexAgent::new(
                     serve_config.agents.codex.cli_path.clone(),
+                    serve_config.agents.codex.approval_policy,
                 )),
             );
             let server = harness_server::server::HarnessServer::new(

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -130,12 +130,29 @@ impl Default for ClaudeAgentConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodexAgentConfig {
     pub cli_path: PathBuf,
+    #[serde(default)]
+    pub approval_policy: CodexApprovalPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodexApprovalPolicy {
+    Suggest,
+    AutoEdit,
+    FullAuto,
+}
+
+impl Default for CodexApprovalPolicy {
+    fn default() -> Self {
+        Self::Suggest
+    }
 }
 
 impl Default for CodexAgentConfig {
     fn default() -> Self {
         Self {
             cli_path: PathBuf::from("codex"),
+            approval_policy: CodexApprovalPolicy::default(),
         }
     }
 }
@@ -389,5 +406,21 @@ mod tests {
         "#;
         let config: AnthropicApiConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.max_tokens, default_anthropic_api_max_tokens());
+    }
+
+    #[test]
+    fn codex_agent_config_defaults_to_suggest_policy() {
+        let config = CodexAgentConfig::default();
+        assert_eq!(config.approval_policy, CodexApprovalPolicy::Suggest);
+    }
+
+    #[test]
+    fn codex_agent_config_deserializes_approval_policy() {
+        let toml_str = r#"
+            cli_path = "codex"
+            approval_policy = "full-auto"
+        "#;
+        let config: CodexAgentConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.approval_policy, CodexApprovalPolicy::FullAuto);
     }
 }


### PR DESCRIPTION
## Summary
- add explicit Codex approval policy config (`suggest`, `auto-edit`, `full-auto`)
- map policy modes to valid `codex exec` flags in runtime invocation
- remove invalid `-a read-only` argument path and align defaults in `config/default.toml`

## Validation
- reproduced baseline failure: `codex exec --skip-git-repo-check -a read-only ...` -> `unexpected argument '-a'`
- attempted `cargo test -p harness-core codex_agent_config -- --nocapture` (failed: `No space left on device`)
- attempted broader Rust validation (blocked by same disk-space condition)

## Blocker
- local filesystem capacity prevented full compile/test validation (`No space left on device`, os error 28)
