### PR TITLE
feat: OS-level sandbox via Seatbelt + Landlock strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "harness-core",
+ "harness-sandbox",
  "reqwest",
  "serde",
  "serde_json",
@@ -859,6 +860,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "harness-sandbox"
+version = "0.1.0"
+dependencies = [
+ "harness-core",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/harness-protocol",
     "crates/harness-server",
     "crates/harness-agents",
+    "crates/harness-sandbox",
     "crates/harness-gc",
     "crates/harness-rules",
     "crates/harness-skills",
@@ -25,6 +26,7 @@ harness-core = { path = "crates/harness-core" }
 harness-protocol = { path = "crates/harness-protocol" }
 harness-server = { path = "crates/harness-server" }
 harness-agents = { path = "crates/harness-agents" }
+harness-sandbox = { path = "crates/harness-sandbox" }
 harness-gc = { path = "crates/harness-gc" }
 harness-rules = { path = "crates/harness-rules" }
 harness-skills = { path = "crates/harness-skills" }

--- a/config/default.toml
+++ b/config/default.toml
@@ -10,6 +10,7 @@ notification_lag_log_every = 1
 
 [agents]
 default_agent = "claude"
+sandbox_mode = "workspace-write"
 
 [agents.claude]
 cli_path = "claude"

--- a/crates/harness-agents/Cargo.toml
+++ b/crates/harness-agents/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }
+harness-sandbox = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -1,21 +1,26 @@
 use crate::streaming::send_stream_item;
 use async_trait::async_trait;
+use harness_core::SandboxMode;
 use harness_core::{
     AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
 };
+use harness_sandbox::{wrap_command, SandboxSpec};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use tokio::process::Command;
 
 pub struct ClaudeCodeAgent {
     pub cli_path: PathBuf,
     pub default_model: String,
+    pub sandbox_mode: SandboxMode,
 }
 
 impl ClaudeCodeAgent {
-    pub fn new(cli_path: PathBuf, default_model: String) -> Self {
+    pub fn new(cli_path: PathBuf, default_model: String, sandbox_mode: SandboxMode) -> Self {
         Self {
             cli_path,
             default_model,
+            sandbox_mode,
         }
     }
 }
@@ -32,26 +37,40 @@ impl CodeAgent for ClaudeCodeAgent {
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
         let model = req.model.as_deref().unwrap_or(&self.default_model);
-        let mut cmd = Command::new(&self.cli_path);
-        cmd.arg("-p")
-            .arg("--dangerously-skip-permissions")
-            .arg("--output-format")
-            .arg("text")
-            .arg("--model")
-            .arg(model)
-            .arg("--verbose")
-            .current_dir(&req.project_root)
-            .env_remove("CLAUDECODE");
+        let mut base_args = vec![
+            OsString::from("-p"),
+            OsString::from("--dangerously-skip-permissions"),
+            OsString::from("--output-format"),
+            OsString::from("text"),
+            OsString::from("--model"),
+            OsString::from(model),
+            OsString::from("--verbose"),
+        ];
 
         if !req.allowed_tools.is_empty() {
-            cmd.arg("--allowedTools").arg(req.allowed_tools.join(","));
+            base_args.push(OsString::from("--allowedTools"));
+            base_args.push(OsString::from(req.allowed_tools.join(",")));
         }
 
         if let Some(budget) = req.max_budget_usd {
-            cmd.arg("--max-budget-usd").arg(budget.to_string());
+            base_args.push(OsString::from("--max-budget-usd"));
+            base_args.push(OsString::from(budget.to_string()));
         }
 
-        cmd.arg(&req.prompt);
+        base_args.push(OsString::from(req.prompt.clone()));
+
+        let sandbox_spec = SandboxSpec::new(self.sandbox_mode, &req.project_root);
+        let wrapped_command =
+            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
+                harness_core::HarnessError::AgentExecution(format!(
+                    "sandbox setup failed for claude: {error}"
+                ))
+            })?;
+
+        let mut cmd = Command::new(&wrapped_command.program);
+        cmd.args(&wrapped_command.args)
+            .current_dir(&req.project_root)
+            .env_remove("CLAUDECODE");
 
         let output = cmd.output().await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to run claude: {e}"))
@@ -114,7 +133,11 @@ mod tests {
 
     #[tokio::test]
     async fn execute_stream_returns_error_when_channel_closed() {
-        let agent = ClaudeCodeAgent::new(PathBuf::from("/usr/bin/true"), "test-model".to_string());
+        let agent = ClaudeCodeAgent::new(
+            PathBuf::from("/usr/bin/true"),
+            "test-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        );
         let request = AgentRequest::default();
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         drop(rx);

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -1,18 +1,25 @@
 use crate::streaming::send_stream_item;
 use async_trait::async_trait;
+use harness_core::SandboxMode;
 use harness_core::{
     AgentRequest, AgentResponse, Capability, CodeAgent, Item, StreamItem, TokenUsage,
 };
+use harness_sandbox::{wrap_command, SandboxSpec};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use tokio::process::Command;
 
 pub struct CodexAgent {
     pub cli_path: PathBuf,
+    pub sandbox_mode: SandboxMode,
 }
 
 impl CodexAgent {
-    pub fn new(cli_path: PathBuf) -> Self {
-        Self { cli_path }
+    pub fn new(cli_path: PathBuf, sandbox_mode: SandboxMode) -> Self {
+        Self {
+            cli_path,
+            sandbox_mode,
+        }
     }
 }
 
@@ -27,14 +34,26 @@ impl CodeAgent for CodexAgent {
     }
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
-        let mut cmd = Command::new(&self.cli_path);
-        cmd.arg("exec")
-            .arg("--skip-git-repo-check")
-            .arg("-a")
-            .arg("read-only")
-            .arg("-C")
-            .arg(&req.project_root)
-            .arg(&req.prompt);
+        let base_args = vec![
+            OsString::from("exec"),
+            OsString::from("--skip-git-repo-check"),
+            OsString::from("-a"),
+            OsString::from(codex_sandbox_mode(self.sandbox_mode)),
+            OsString::from("-C"),
+            req.project_root.as_os_str().to_os_string(),
+            OsString::from(req.prompt.clone()),
+        ];
+
+        let sandbox_spec = SandboxSpec::new(self.sandbox_mode, &req.project_root);
+        let wrapped_command =
+            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
+                harness_core::HarnessError::AgentExecution(format!(
+                    "sandbox setup failed for codex: {error}"
+                ))
+            })?;
+
+        let mut cmd = Command::new(&wrapped_command.program);
+        cmd.args(&wrapped_command.args);
 
         let output = cmd.output().await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to run codex: {e}"))
@@ -82,13 +101,24 @@ impl CodeAgent for CodexAgent {
     }
 }
 
+fn codex_sandbox_mode(mode: SandboxMode) -> &'static str {
+    match mode {
+        SandboxMode::ReadOnly => "read-only",
+        SandboxMode::WorkspaceWrite => "workspace-write",
+        SandboxMode::DangerFullAccess => "danger-full-access",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
     async fn execute_stream_returns_error_when_channel_closed() {
-        let agent = CodexAgent::new(PathBuf::from("/usr/bin/true"));
+        let agent = CodexAgent::new(
+            PathBuf::from("/usr/bin/true"),
+            SandboxMode::DangerFullAccess,
+        );
         let request = AgentRequest::default();
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         drop(rx);

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -489,11 +489,15 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
         Arc::new(ClaudeCodeAgent::new(
             config.agents.claude.cli_path.clone(),
             config.agents.claude.default_model.clone(),
+            config.agents.sandbox_mode,
         )),
     );
     agent_registry.register(
         "codex",
-        Arc::new(CodexAgent::new(config.agents.codex.cli_path.clone())),
+        Arc::new(CodexAgent::new(
+            config.agents.codex.cli_path.clone(),
+            config.agents.sandbox_mode,
+        )),
     );
 
     let executor = Arc::new(RegistryExecutor::new(Arc::new(agent_registry)));

--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -7,6 +7,7 @@ fn create_agent(config: &HarnessConfig) -> ClaudeCodeAgent {
     ClaudeCodeAgent::new(
         config.agents.claude.cli_path.clone(),
         config.agents.claude.default_model.clone(),
+        config.agents.sandbox_mode,
     )
 }
 

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -239,12 +239,14 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 Arc::new(harness_agents::claude::ClaudeCodeAgent::new(
                     serve_config.agents.claude.cli_path.clone(),
                     serve_config.agents.claude.default_model.clone(),
+                    serve_config.agents.sandbox_mode,
                 )),
             );
             agent_registry.register(
                 "codex",
                 Arc::new(harness_agents::codex::CodexAgent::new(
                     serve_config.agents.codex.cli_path.clone(),
+                    serve_config.agents.sandbox_mode,
                 )),
             );
             let server = harness_server::server::HarnessServer::new(
@@ -280,6 +282,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let agent = harness_agents::claude::ClaudeCodeAgent::new(
                 config.agents.claude.cli_path.clone(),
                 config.agents.claude.default_model.clone(),
+                config.agents.sandbox_mode,
             );
 
             let req = harness_core::AgentRequest {

--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -29,6 +29,7 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
             let claude = harness_agents::claude::ClaudeCodeAgent::new(
                 config.agents.claude.cli_path.clone(),
                 config.agents.claude.default_model.clone(),
+                config.agents.sandbox_mode,
             );
 
             let report = gc_agent.run(&project, &events, &[], &claude).await?;
@@ -62,7 +63,10 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
                 println!("No pending drafts");
             } else {
                 for draft in &pending {
-                    println!("{} [{:?}] {}", draft.id, draft.signal.signal_type, draft.rationale);
+                    println!(
+                        "{} [{:?}] {}",
+                        draft.id, draft.signal.signal_type, draft.rationale
+                    );
                 }
             }
         }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -75,6 +75,32 @@ impl Default for ApprovalPolicy {
     }
 }
 
+/// OS-level sandbox mode for agent subprocess execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl Default for SandboxMode {
+    fn default() -> Self {
+        Self::WorkspaceWrite
+    }
+}
+
+impl std::fmt::Display for SandboxMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            SandboxMode::ReadOnly => "read-only",
+            SandboxMode::WorkspaceWrite => "workspace-write",
+            SandboxMode::DangerFullAccess => "danger-full-access",
+        };
+        write!(f, "{value}")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentsConfig {
     pub default_agent: String,
@@ -85,6 +111,8 @@ pub struct AgentsConfig {
     pub review: AgentReviewConfig,
     #[serde(default)]
     pub approval_policy: ApprovalPolicy,
+    #[serde(default)]
+    pub sandbox_mode: SandboxMode,
 }
 
 impl Default for AgentsConfig {
@@ -96,6 +124,7 @@ impl Default for AgentsConfig {
             anthropic_api: AnthropicApiConfig::default(),
             review: AgentReviewConfig::default(),
             approval_policy: ApprovalPolicy::default(),
+            sandbox_mode: SandboxMode::default(),
         }
     }
 }
@@ -389,6 +418,7 @@ mod tests {
             config.anthropic_api.max_tokens,
             default_anthropic_api_max_tokens()
         );
+        assert_eq!(config.sandbox_mode, SandboxMode::WorkspaceWrite);
     }
 
     #[test]
@@ -409,6 +439,12 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_mode_defaults_to_workspace_write() {
+        let config = AgentsConfig::default();
+        assert_eq!(config.sandbox_mode, SandboxMode::WorkspaceWrite);
+    }
+
+    #[test]
     fn approval_policy_deserializes_from_toml() {
         let toml_str = r#"
             default_agent = "claude"
@@ -424,6 +460,24 @@ mod tests {
         "#;
         let config: AgentsConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.approval_policy, ApprovalPolicy::FullAuto);
+    }
+
+    #[test]
+    fn sandbox_mode_deserializes_from_toml() {
+        let toml_str = r#"
+            default_agent = "claude"
+            sandbox_mode = "danger-full-access"
+            [claude]
+            cli_path = "claude"
+            default_model = "sonnet"
+            [codex]
+            cli_path = "codex"
+            [anthropic_api]
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+        "#;
+        let config: AgentsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.sandbox_mode, SandboxMode::DangerFullAccess);
     }
 
     #[test]

--- a/crates/harness-sandbox/Cargo.toml
+++ b/crates/harness-sandbox/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "harness-sandbox"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+harness-core = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/harness-sandbox/src/lib.rs
+++ b/crates/harness-sandbox/src/lib.rs
@@ -1,0 +1,313 @@
+use harness_core::SandboxMode;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const PROTECTED_RELATIVE_PATHS: [&str; 2] = [".git", ".harness"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxEngine {
+    None,
+    Seatbelt,
+    Landlock,
+    Bubblewrap,
+}
+
+#[derive(Debug, Clone)]
+pub struct SandboxSpec {
+    pub mode: SandboxMode,
+    pub project_root: PathBuf,
+}
+
+impl SandboxSpec {
+    pub fn new(mode: SandboxMode, project_root: impl Into<PathBuf>) -> Self {
+        Self {
+            mode,
+            project_root: project_root.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WrappedCommand {
+    pub program: PathBuf,
+    pub args: Vec<OsString>,
+    pub engine: SandboxEngine,
+}
+
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    #[error("sandbox mode `{mode}` is unsupported on `{platform}`")]
+    UnsupportedPlatform {
+        mode: SandboxMode,
+        platform: &'static str,
+    },
+    #[error("sandbox tool not found: {0}")]
+    MissingTool(&'static str),
+}
+
+pub fn wrap_command(
+    program: &Path,
+    args: &[OsString],
+    spec: &SandboxSpec,
+) -> Result<WrappedCommand, SandboxError> {
+    if spec.mode == SandboxMode::DangerFullAccess {
+        return Ok(WrappedCommand {
+            program: program.to_path_buf(),
+            args: args.to_vec(),
+            engine: SandboxEngine::None,
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return wrap_macos_command(program, args, spec);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return wrap_linux_command(program, args, spec);
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Err(SandboxError::UnsupportedPlatform {
+            mode: spec.mode,
+            platform: std::env::consts::OS,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn wrap_macos_command(
+    program: &Path,
+    args: &[OsString],
+    spec: &SandboxSpec,
+) -> Result<WrappedCommand, SandboxError> {
+    let sandbox_exec =
+        find_tool("sandbox-exec").ok_or(SandboxError::MissingTool("sandbox-exec"))?;
+    let policy = seatbelt_policy(spec.mode, &spec.project_root);
+
+    let mut wrapped_args = vec![OsString::from("-p"), OsString::from(policy)];
+    wrapped_args.push(program.as_os_str().to_os_string());
+    wrapped_args.extend(args.iter().cloned());
+
+    Ok(WrappedCommand {
+        program: sandbox_exec,
+        args: wrapped_args,
+        engine: SandboxEngine::Seatbelt,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn wrap_linux_command(
+    program: &Path,
+    args: &[OsString],
+    spec: &SandboxSpec,
+) -> Result<WrappedCommand, SandboxError> {
+    if let Some(landlock_runner) = find_tool("harness-landlock") {
+        return Ok(WrappedCommand {
+            program: landlock_runner,
+            args: linux_landlock_args(program, args, spec),
+            engine: SandboxEngine::Landlock,
+        });
+    }
+
+    let bwrap = find_tool("bwrap").ok_or(SandboxError::MissingTool("harness-landlock or bwrap"))?;
+    Ok(WrappedCommand {
+        program: bwrap,
+        args: linux_bwrap_args(program, args, spec),
+        engine: SandboxEngine::Bubblewrap,
+    })
+}
+
+#[allow(dead_code)]
+fn seatbelt_policy(mode: SandboxMode, project_root: &Path) -> String {
+    let mut lines = vec![
+        "(version 1)".to_string(),
+        "(deny default)".to_string(),
+        "(allow process-exec)".to_string(),
+        "(allow process-fork)".to_string(),
+        "(allow signal (target self))".to_string(),
+        "(allow file-read*)".to_string(),
+        "(allow file-write* (subpath \"/private/tmp\") (subpath \"/tmp\") (subpath \"/var/tmp\"))"
+            .to_string(),
+    ];
+
+    match mode {
+        SandboxMode::ReadOnly => {}
+        SandboxMode::WorkspaceWrite => {
+            lines.push(format!(
+                "(allow file-write* (subpath \"{}\"))",
+                seatbelt_escape_path(project_root)
+            ));
+            for protected_path in protected_paths(project_root) {
+                lines.push(format!(
+                    "(deny file-write* (subpath \"{}\"))",
+                    seatbelt_escape_path(&protected_path)
+                ));
+            }
+        }
+        SandboxMode::DangerFullAccess => {}
+    }
+
+    lines.join("\n")
+}
+
+#[allow(dead_code)]
+fn linux_landlock_args(program: &Path, args: &[OsString], spec: &SandboxSpec) -> Vec<OsString> {
+    let mut wrapped_args = vec![
+        OsString::from("--mode"),
+        OsString::from(sandbox_mode_cli(spec.mode)),
+        OsString::from("--workspace"),
+        spec.project_root.as_os_str().to_os_string(),
+        OsString::from("--network"),
+    ];
+
+    if spec.mode == SandboxMode::WorkspaceWrite {
+        wrapped_args.push(OsString::from("deny"));
+    } else {
+        wrapped_args.push(OsString::from("allow"));
+    }
+
+    for protected_path in protected_paths(&spec.project_root) {
+        wrapped_args.push(OsString::from("--readonly-path"));
+        wrapped_args.push(protected_path.into_os_string());
+    }
+
+    wrapped_args.push(OsString::from("--"));
+    wrapped_args.push(program.as_os_str().to_os_string());
+    wrapped_args.extend(args.iter().cloned());
+    wrapped_args
+}
+
+#[allow(dead_code)]
+fn linux_bwrap_args(program: &Path, args: &[OsString], spec: &SandboxSpec) -> Vec<OsString> {
+    let mut wrapped_args = vec![
+        OsString::from("--die-with-parent"),
+        OsString::from("--new-session"),
+        OsString::from("--ro-bind"),
+        OsString::from("/"),
+        OsString::from("/"),
+        OsString::from("--proc"),
+        OsString::from("/proc"),
+        OsString::from("--dev"),
+        OsString::from("/dev"),
+        OsString::from("--tmpfs"),
+        OsString::from("/tmp"),
+    ];
+
+    match spec.mode {
+        SandboxMode::ReadOnly => {
+            wrapped_args.push(OsString::from("--ro-bind"));
+            wrapped_args.push(spec.project_root.as_os_str().to_os_string());
+            wrapped_args.push(spec.project_root.as_os_str().to_os_string());
+        }
+        SandboxMode::WorkspaceWrite => {
+            wrapped_args.push(OsString::from("--bind"));
+            wrapped_args.push(spec.project_root.as_os_str().to_os_string());
+            wrapped_args.push(spec.project_root.as_os_str().to_os_string());
+            for protected_path in protected_paths(&spec.project_root) {
+                if protected_path.exists() {
+                    wrapped_args.push(OsString::from("--ro-bind"));
+                    wrapped_args.push(protected_path.as_os_str().to_os_string());
+                    wrapped_args.push(protected_path.as_os_str().to_os_string());
+                }
+            }
+            wrapped_args.push(OsString::from("--unshare-net"));
+        }
+        SandboxMode::DangerFullAccess => {}
+    }
+
+    wrapped_args.push(OsString::from("--chdir"));
+    wrapped_args.push(spec.project_root.as_os_str().to_os_string());
+    wrapped_args.push(OsString::from("--"));
+    wrapped_args.push(program.as_os_str().to_os_string());
+    wrapped_args.extend(args.iter().cloned());
+    wrapped_args
+}
+
+fn protected_paths(project_root: &Path) -> Vec<PathBuf> {
+    PROTECTED_RELATIVE_PATHS
+        .into_iter()
+        .map(|relative| project_root.join(relative))
+        .collect()
+}
+
+fn seatbelt_escape_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('\"', "\\\"")
+}
+
+fn find_tool(name: &str) -> Option<PathBuf> {
+    let candidate = Path::new(name);
+    if candidate.is_absolute() && candidate.exists() {
+        return Some(candidate.to_path_buf());
+    }
+
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .map(|directory| directory.join(name))
+        .find(|path| path.is_file())
+}
+
+fn sandbox_mode_cli(mode: SandboxMode) -> &'static str {
+    match mode {
+        SandboxMode::ReadOnly => "read-only",
+        SandboxMode::WorkspaceWrite => "workspace-write",
+        SandboxMode::DangerFullAccess => "danger-full-access",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_write_seatbelt_policy_protects_git_and_harness() {
+        let project_root = PathBuf::from("/tmp/project");
+        let policy = seatbelt_policy(SandboxMode::WorkspaceWrite, &project_root);
+        assert!(policy.contains("(allow file-write* (subpath \"/tmp/project\"))"));
+        assert!(policy.contains("(deny file-write* (subpath \"/tmp/project/.git\"))"));
+        assert!(policy.contains("(deny file-write* (subpath \"/tmp/project/.harness\"))"));
+    }
+
+    #[test]
+    fn workspace_write_bwrap_args_disable_network_and_preserve_command() {
+        let project_root = PathBuf::from("/tmp/project");
+        let spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, &project_root);
+        let command_args = vec![OsString::from("--flag"), OsString::from("value")];
+        let args = linux_bwrap_args(Path::new("/usr/bin/claude"), &command_args, &spec);
+        assert!(args.contains(&OsString::from("--unshare-net")));
+        assert!(args.ends_with(&[
+            OsString::from("--"),
+            OsString::from("/usr/bin/claude"),
+            OsString::from("--flag"),
+            OsString::from("value"),
+        ]));
+    }
+
+    #[test]
+    fn landlock_args_include_mode_network_and_protected_paths() {
+        let project_root = PathBuf::from("/tmp/project");
+        let spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, &project_root);
+        let args = linux_landlock_args(Path::new("/usr/bin/codex"), &[], &spec);
+        assert!(args.contains(&OsString::from("--mode")));
+        assert!(args.contains(&OsString::from("workspace-write")));
+        assert!(args.contains(&OsString::from("--network")));
+        assert!(args.contains(&OsString::from("deny")));
+        assert!(args.contains(&OsString::from("/tmp/project/.git")));
+        assert!(args.contains(&OsString::from("/tmp/project/.harness")));
+    }
+
+    #[test]
+    fn danger_mode_passthrough_keeps_program_and_args() {
+        let spec = SandboxSpec::new(SandboxMode::DangerFullAccess, "/tmp/project");
+        let original_args = vec![OsString::from("arg1"), OsString::from("arg2")];
+        let wrapped = wrap_command(Path::new("/usr/bin/env"), &original_args, &spec).unwrap();
+        assert_eq!(wrapped.engine, SandboxEngine::None);
+        assert_eq!(wrapped.program, PathBuf::from("/usr/bin/env"));
+        assert_eq!(wrapped.args, original_args);
+    }
+}

--- a/docs/codex-app-server-reference.md
+++ b/docs/codex-app-server-reference.md
@@ -239,7 +239,7 @@ Three modes: `apikey` (OpenAI API key), `chatgpt` (OAuth), `chatgptAuthTokens` (
 | Agent | Built-in gpt-5.3-codex | Pluggable: Claude Code, Codex CLI, Anthropic API |
 | Thread | Full persistence + resume + fork | In-memory (planned: SQLite) |
 | Protocol | Complete JSON-RPC 2.0 | Partial implementation |
-| Sandbox | Seatbelt/Landlock native | None (delegates to agent) |
+| Sandbox | Seatbelt/Landlock native | Seatbelt (macOS), Landlock/bwrap strategy (Linux) for CLI agent subprocesses |
 | Value | Single-agent deep integration | Multi-agent orchestration + rules + GC |
 
 ## Sources


### PR DESCRIPTION
## Summary
- add new `harness-sandbox` crate for OS-level sandbox command wrapping
- add configurable `agents.sandbox_mode` (`read-only` / `workspace-write` / `danger-full-access`), defaulting to `workspace-write`
- wrap Claude/Codex subprocess launches through sandbox policy selection (Seatbelt on macOS, Landlock helper then bwrap fallback on Linux)
- enforce protected path policy construction for `.git` and `.harness`, with deterministic tool-missing errors

## Validation
- cargo test -p harness-sandbox
- cargo test -p harness-core config::tests
- cargo test -p harness-agents
- cargo check

Closes #105
