### PR TITLE
[P2] #111 TypeScript/Python SDK

### DIFF
--- a/docs/harness-sdk.md
+++ b/docs/harness-sdk.md
@@ -1,0 +1,54 @@
+# Harness SDKs (TypeScript + Python)
+
+Harness now includes first-party SDK scaffolds for programmatic JSON-RPC usage.
+
+## Scope
+
+- TypeScript SDK with `startThread()`, `resumeThread()`, `thread.run(prompt)`, and `thread.runStream(prompt)`.
+- Python SDK with `start_thread()`, `resume_thread()`, `thread.run(prompt)`, and `thread.run_stream(prompt)`.
+- Event streaming via incremental run events (`turn/started`, `turn/status`, `turn/completed`, `turn/timeout`).
+
+## Package Locations
+
+- TypeScript: `sdk/typescript`
+- Python: `sdk/python`
+
+## Quick Usage
+
+### TypeScript
+
+```ts
+import { Harness } from "harness-sdk";
+
+const harness = new Harness({ baseUrl: "http://127.0.0.1:8080" });
+const thread = await harness.startThread();
+const result = await thread.run("Analyze this repository");
+```
+
+### Python
+
+```python
+from harness_sdk import Harness
+
+harness = Harness(base_url="http://127.0.0.1:8080")
+thread = harness.start_thread()
+result = thread.run("Analyze this repository")
+```
+
+## Publish Notes
+
+### npm
+
+```bash
+cd sdk/typescript
+npm run build
+npm publish --access public
+```
+
+### PyPI
+
+```bash
+cd sdk/python
+python -m build
+twine upload dist/*
+```

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,39 @@
+# Harness Python SDK
+
+Python client for the Harness JSON-RPC app server.
+
+## Install
+
+```bash
+pip install harness-sdk
+```
+
+## Usage
+
+```python
+from harness_sdk import Harness
+
+harness = Harness(base_url="http://127.0.0.1:8080")
+thread = harness.start_thread()
+
+result = thread.run(
+    "Summarize the repository",
+    on_event=lambda event: print(event["method"], event["params"]),
+)
+
+print(result.status, result.output)
+```
+
+### Stream events explicitly
+
+```python
+for event in thread.run_stream("Diagnose failing tests"):
+    print(event["method"], event["params"])
+```
+
+## Publish to PyPI
+
+```bash
+python -m build
+twine upload dist/*
+```

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "harness-sdk"
+version = "0.1.0"
+description = "Python SDK for Harness JSON-RPC app server"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Future Frontiers" }]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "License :: OSI Approved :: MIT License",
+  "Topic :: Software Development :: Libraries",
+]
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/sdk/python/src/harness_sdk/__init__.py
+++ b/sdk/python/src/harness_sdk/__init__.py
@@ -1,0 +1,3 @@
+from .client import Harness, HarnessRpcError, HarnessThread, RunResult
+
+__all__ = ["Harness", "HarnessThread", "RunResult", "HarnessRpcError"]

--- a/sdk/python/src/harness_sdk/client.py
+++ b/sdk/python/src/harness_sdk/client.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generator, List, Optional
+
+Event = Dict[str, Any]
+RpcHandler = Callable[[str, Dict[str, Any]], Any]
+EventHandler = Callable[[Event], None]
+
+
+class HarnessRpcError(RuntimeError):
+    def __init__(self, code: int, message: str, data: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
+@dataclass
+class RunResult:
+    thread_id: str
+    turn_id: str
+    status: str
+    output: str
+    turn: Optional[Dict[str, Any]]
+    events: List[Event]
+    timed_out: bool
+
+
+class Harness:
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8080",
+        cwd: Optional[str] = None,
+        request_timeout_seconds: float = 15.0,
+        rpc_handler: Optional[RpcHandler] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.cwd = cwd or os.getcwd()
+        self.request_timeout_seconds = request_timeout_seconds
+        self._rpc_handler = rpc_handler
+        self._next_id = 1
+
+    def start_thread(self, cwd: Optional[str] = None) -> "HarnessThread":
+        result = self._rpc("thread/start", {"cwd": cwd or self.cwd})
+        return HarnessThread(self, str(result["thread_id"]))
+
+    def resume_thread(self, thread_id: str) -> "HarnessThread":
+        self._rpc("thread/resume", {"thread_id": thread_id})
+        return HarnessThread(self, thread_id)
+
+    def thread(self, thread_id: str) -> "HarnessThread":
+        return HarnessThread(self, thread_id)
+
+    def start_turn(self, thread_id: str, prompt: str) -> Dict[str, Any]:
+        return self._rpc("turn/start", {"thread_id": thread_id, "input": prompt})
+
+    def turn_status(self, turn_id: str) -> Dict[str, Any]:
+        return self._rpc("turn/status", {"turn_id": turn_id})
+
+    def _rpc(self, method: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        if self._rpc_handler:
+            return self._rpc_handler(method, params or {})
+
+        request_id = self._next_id
+        self._next_id += 1
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}/rpc",
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self.request_timeout_seconds
+            ) as response:
+                response_body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as error:
+            response_body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP {error.code}: {response_body}") from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"Failed to reach Harness server: {error}") from error
+
+        try:
+            parsed = json.loads(response_body)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                f"Failed to parse RPC response for '{method}': {error}"
+            ) from error
+
+        if parsed.get("error"):
+            rpc_error = parsed["error"]
+            raise HarnessRpcError(
+                code=int(rpc_error.get("code", -32000)),
+                message=str(rpc_error.get("message", "unknown error")),
+                data=rpc_error.get("data"),
+            )
+
+        if "result" not in parsed:
+            raise RuntimeError(f"Missing RPC result for '{method}'")
+        return parsed["result"]
+
+
+class HarnessThread:
+    def __init__(self, client: Harness, thread_id: str) -> None:
+        self._client = client
+        self.id = thread_id
+
+    def run(
+        self,
+        prompt: str,
+        timeout_seconds: float = 30.0,
+        poll_interval_seconds: float = 0.5,
+        on_event: Optional[EventHandler] = None,
+    ) -> RunResult:
+        events: List[Event] = []
+        turn_id = ""
+        latest_turn: Optional[Dict[str, Any]] = None
+
+        for event in self.run_stream(
+            prompt,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+            on_event=on_event,
+        ):
+            events.append(event)
+            if event["method"] == "turn/started":
+                turn_id = str(event["params"]["turn_id"])
+            if event["method"] == "turn/status":
+                latest_turn = event["params"]["turn"]
+
+        if not latest_turn and turn_id:
+            latest_turn = self._client.turn_status(turn_id)
+
+        return RunResult(
+            thread_id=self.id,
+            turn_id=turn_id,
+            status=str((latest_turn or {}).get("status", "running")),
+            output=_extract_output(latest_turn),
+            turn=latest_turn,
+            events=events,
+            timed_out=any(event["method"] == "turn/timeout" for event in events),
+        )
+
+    def run_stream(
+        self,
+        prompt: str,
+        timeout_seconds: float = 30.0,
+        poll_interval_seconds: float = 0.5,
+        on_event: Optional[EventHandler] = None,
+    ) -> Generator[Event, None, None]:
+        poll_interval = max(0.01, float(poll_interval_seconds))
+        timeout = max(0.01, float(timeout_seconds))
+
+        started = self._client.start_turn(self.id, prompt)
+        turn_id = str(started["turn_id"])
+        started_at = time.monotonic()
+        previous_signature = ""
+
+        start_event = _new_event(
+            "turn/started",
+            {"thread_id": self.id, "turn_id": turn_id, "source": "rpc"},
+        )
+        _notify(on_event, start_event)
+        yield start_event
+
+        while True:
+            turn = self._client.turn_status(turn_id)
+            signature = _turn_signature(turn)
+
+            if signature != previous_signature:
+                previous_signature = signature
+                status_event = _new_event(
+                    "turn/status",
+                    {"thread_id": self.id, "turn_id": turn_id, "turn": turn},
+                )
+                _notify(on_event, status_event)
+                yield status_event
+
+            status = str(turn.get("status", "running"))
+            if _is_terminal_status(status):
+                completed_event = _new_event(
+                    "turn/completed",
+                    {
+                        "thread_id": self.id,
+                        "turn_id": turn_id,
+                        "status": status,
+                        "token_usage": turn.get("token_usage"),
+                    },
+                )
+                _notify(on_event, completed_event)
+                yield completed_event
+                return
+
+            if time.monotonic() - started_at >= timeout:
+                timeout_event = _new_event(
+                    "turn/timeout",
+                    {
+                        "thread_id": self.id,
+                        "turn_id": turn_id,
+                        "timeout_seconds": timeout,
+                    },
+                )
+                _notify(on_event, timeout_event)
+                yield timeout_event
+                return
+
+            time.sleep(poll_interval)
+
+
+def _notify(on_event: Optional[EventHandler], event: Event) -> None:
+    if on_event:
+        on_event(event)
+
+
+def _new_event(method: str, params: Dict[str, Any]) -> Event:
+    return {
+        "method": method,
+        "params": params,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def _turn_signature(turn: Dict[str, Any]) -> str:
+    status = str(turn.get("status", "running"))
+    items = turn.get("items")
+    item_count = len(items) if isinstance(items, list) else 0
+    completed_at = str(turn.get("completed_at") or "")
+    return f"{status}|{item_count}|{completed_at}"
+
+
+def _is_terminal_status(status: str) -> bool:
+    return status in {"completed", "cancelled", "failed"}
+
+
+def _extract_output(turn: Optional[Dict[str, Any]]) -> str:
+    if not turn:
+        return ""
+
+    items = turn.get("items")
+    if not isinstance(items, list):
+        return ""
+
+    messages: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+
+        if item.get("type") == "user_message":
+            continue
+
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            messages.append(content.strip())
+            continue
+
+        stdout = item.get("stdout")
+        if isinstance(stdout, str) and stdout.strip():
+            messages.append(stdout.strip())
+            continue
+
+        message = item.get("message")
+        if isinstance(message, str) and message.strip():
+            messages.append(message.strip())
+
+    return "\n\n".join(messages)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,118 @@
+import unittest
+from typing import Any, Dict, List, Tuple
+
+from harness_sdk import Harness, HarnessRpcError
+
+
+class MockRpc:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+        self.status_polls = 0
+
+    def start_thread_and_run_complete(self, method: str, params: Dict[str, Any]) -> Any:
+        self.calls.append((method, params))
+        if method == "thread/start":
+            return {"thread_id": "thread-1"}
+        if method == "turn/start":
+            return {"turn_id": "turn-1"}
+        if method == "turn/status":
+            self.status_polls += 1
+            if self.status_polls == 1:
+                return {
+                    "id": "turn-1",
+                    "thread_id": "thread-1",
+                    "status": "running",
+                    "items": [{"type": "user_message", "content": "hello"}],
+                }
+            return {
+                "id": "turn-1",
+                "thread_id": "thread-1",
+                "status": "completed",
+                "items": [
+                    {"type": "user_message", "content": "hello"},
+                    {"type": "agent_reasoning", "content": "done"},
+                ],
+            }
+        if method == "thread/resume":
+            return {"resumed": True}
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+    def run_timeout(self, method: str, params: Dict[str, Any]) -> Any:
+        self.calls.append((method, params))
+        if method == "thread/start":
+            return {"thread_id": "thread-2"}
+        if method == "turn/start":
+            return {"turn_id": "turn-2"}
+        if method == "turn/status":
+            return {
+                "id": "turn-2",
+                "thread_id": "thread-2",
+                "status": "running",
+                "items": [{"type": "user_message", "content": "still running"}],
+            }
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+    def rpc_error(self, method: str, params: Dict[str, Any]) -> Any:
+        self.calls.append((method, params))
+        raise HarnessRpcError(-32001, "thread not found")
+
+
+class HarnessSdkTests(unittest.TestCase):
+    def test_start_thread_uses_thread_start_rpc(self) -> None:
+        mock = MockRpc()
+        harness = Harness(rpc_handler=mock.start_thread_and_run_complete, cwd="/repo")
+
+        thread = harness.start_thread()
+
+        self.assertEqual(thread.id, "thread-1")
+        self.assertEqual(mock.calls[0][0], "thread/start")
+        self.assertEqual(mock.calls[0][1]["cwd"], "/repo")
+
+    def test_run_collects_events_and_output(self) -> None:
+        mock = MockRpc()
+        harness = Harness(rpc_handler=mock.start_thread_and_run_complete)
+        thread = harness.start_thread(cwd="/repo")
+        emitted: List[Dict[str, Any]] = []
+
+        result = thread.run(
+            "Summarize repository",
+            timeout_seconds=1.0,
+            poll_interval_seconds=0.01,
+            on_event=lambda event: emitted.append(event),
+        )
+
+        self.assertEqual(result.thread_id, "thread-1")
+        self.assertEqual(result.turn_id, "turn-1")
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.output, "done")
+        self.assertFalse(result.timed_out)
+        self.assertTrue(any(event["method"] == "turn/completed" for event in result.events))
+        self.assertGreaterEqual(len(emitted), 3)
+
+    def test_run_returns_timeout_when_turn_never_completes(self) -> None:
+        mock = MockRpc()
+        harness = Harness(rpc_handler=mock.run_timeout)
+        thread = harness.start_thread()
+
+        result = thread.run(
+            "Keep going",
+            timeout_seconds=0.05,
+            poll_interval_seconds=0.01,
+        )
+
+        self.assertEqual(result.thread_id, "thread-2")
+        self.assertEqual(result.turn_id, "turn-2")
+        self.assertEqual(result.status, "running")
+        self.assertTrue(result.timed_out)
+        self.assertTrue(any(event["method"] == "turn/timeout" for event in result.events))
+
+    def test_resume_thread_surfaces_rpc_errors(self) -> None:
+        mock = MockRpc()
+        harness = Harness(rpc_handler=mock.rpc_error)
+
+        with self.assertRaises(HarnessRpcError):
+            harness.resume_thread("missing-thread")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,41 @@
+# Harness TypeScript SDK
+
+TypeScript client for the Harness JSON-RPC app server.
+
+## Install
+
+```bash
+npm install harness-sdk
+```
+
+## Usage
+
+```ts
+import { Harness } from "harness-sdk";
+
+const harness = new Harness({ baseUrl: "http://127.0.0.1:8080" });
+const thread = await harness.startThread();
+
+const result = await thread.run("Summarize the repository", {
+  onEvent: (event) => {
+    console.log(event.method, event.params);
+  },
+});
+
+console.log(result.status, result.output);
+```
+
+### Stream events explicitly
+
+```ts
+for await (const event of thread.runStream("Diagnose failing tests")) {
+  console.log(event.method, event.params);
+}
+```
+
+## Publish to npm
+
+```bash
+npm run build
+npm publish --access public
+```

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "harness-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for Harness JSON-RPC app server",
+  "license": "MIT",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx --test tests/harness.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.57",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,423 @@
+type RpcId = number;
+
+interface RpcErrorPayload {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+interface RpcEnvelope<T> {
+  jsonrpc: string;
+  id?: RpcId | null;
+  result?: T;
+  error?: RpcErrorPayload;
+}
+
+interface RpcRequestEnvelope {
+  jsonrpc: "2.0";
+  id: RpcId;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}
+
+type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<FetchResponseLike>;
+
+export interface HarnessOptions {
+  baseUrl?: string;
+  cwd?: string;
+  fetch?: FetchLike;
+  requestTimeoutMs?: number;
+  defaultPollIntervalMs?: number;
+  defaultRunTimeoutMs?: number;
+}
+
+export interface StartThreadOptions {
+  cwd?: string;
+}
+
+export interface TokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+export interface TurnItem {
+  type: string;
+  content?: string;
+  stdout?: string;
+  stderr?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface TurnSnapshot {
+  id: string;
+  thread_id: string;
+  status: string;
+  items: TurnItem[];
+  token_usage?: TokenUsage;
+  completed_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ThreadEvent {
+  method: string;
+  params: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface RunOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onEvent?: (event: ThreadEvent) => void | Promise<void>;
+}
+
+export interface RunResult {
+  threadId: string;
+  turnId: string;
+  status: string;
+  output: string;
+  turn?: TurnSnapshot;
+  events: ThreadEvent[];
+  timedOut: boolean;
+}
+
+export class HarnessRpcError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+
+  constructor(payload: RpcErrorPayload) {
+    super(payload.message);
+    this.name = "HarnessRpcError";
+    this.code = payload.code;
+    this.data = payload.data;
+  }
+}
+
+class RpcTransport {
+  private readonly endpoint: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly requestTimeoutMs: number;
+  private nextRequestId: RpcId;
+
+  constructor(options: HarnessOptions) {
+    this.endpoint = `${normalizeBaseUrl(options.baseUrl)}/rpc`;
+    this.fetchImpl = resolveFetch(options.fetch);
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 15_000;
+    this.nextRequestId = 1;
+  }
+
+  async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const payload: RpcRequestEnvelope = {
+      jsonrpc: "2.0",
+      id: this.nextRequestId++,
+      method,
+      params,
+    };
+
+    const responseText = await withTimeout(
+      this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      }).then(async (response) => {
+        const body = await response.text();
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${body}`);
+        }
+        return body;
+      }),
+      this.requestTimeoutMs,
+      `RPC request timeout after ${this.requestTimeoutMs}ms for method '${method}'`,
+    );
+
+    let parsed: RpcEnvelope<T>;
+    try {
+      parsed = JSON.parse(responseText) as RpcEnvelope<T>;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse RPC response for '${method}': ${(error as Error).message}`,
+      );
+    }
+
+    if (parsed.error) {
+      throw new HarnessRpcError(parsed.error);
+    }
+
+    if (typeof parsed.result === "undefined") {
+      throw new Error(`Missing RPC result for '${method}'`);
+    }
+
+    return parsed.result;
+  }
+}
+
+export class Harness {
+  private readonly transport: RpcTransport;
+  private readonly defaultCwd: string;
+  readonly defaultPollIntervalMs: number;
+  readonly defaultRunTimeoutMs: number;
+
+  constructor(options: HarnessOptions = {}) {
+    this.transport = new RpcTransport(options);
+    this.defaultCwd = options.cwd ?? process.cwd();
+    this.defaultPollIntervalMs = options.defaultPollIntervalMs ?? 500;
+    this.defaultRunTimeoutMs = options.defaultRunTimeoutMs ?? 30_000;
+  }
+
+  async startThread(options: StartThreadOptions = {}): Promise<HarnessThread> {
+    const result = await this.transport.request<{ thread_id: string }>("thread/start", {
+      cwd: options.cwd ?? this.defaultCwd,
+    });
+    return new HarnessThread(this, result.thread_id);
+  }
+
+  async resumeThread(threadId: string): Promise<HarnessThread> {
+    await this.transport.request<{ resumed: boolean }>("thread/resume", {
+      thread_id: threadId,
+    });
+    return new HarnessThread(this, threadId);
+  }
+
+  thread(threadId: string): HarnessThread {
+    return new HarnessThread(this, threadId);
+  }
+
+  async startTurn(threadId: string, prompt: string): Promise<{ turn_id: string }> {
+    return this.transport.request<{ turn_id: string }>("turn/start", {
+      thread_id: threadId,
+      input: prompt,
+    });
+  }
+
+  async turnStatus(turnId: string): Promise<TurnSnapshot> {
+    return this.transport.request<TurnSnapshot>("turn/status", { turn_id: turnId });
+  }
+}
+
+export class HarnessThread {
+  readonly id: string;
+  private readonly client: Harness;
+
+  constructor(client: Harness, threadId: string) {
+    this.client = client;
+    this.id = threadId;
+  }
+
+  async run(prompt: string, options: RunOptions = {}): Promise<RunResult> {
+    const events: ThreadEvent[] = [];
+    let turnId = "";
+    let latestTurn: TurnSnapshot | undefined;
+
+    for await (const event of this.runStream(prompt, options)) {
+      events.push(event);
+
+      if (event.method === "turn/started") {
+        turnId = String(event.params.turn_id ?? "");
+      }
+
+      if (event.method === "turn/status") {
+        latestTurn = event.params.turn as TurnSnapshot;
+      }
+    }
+
+    if (!latestTurn && turnId) {
+      latestTurn = await this.client.turnStatus(turnId);
+    }
+
+    return {
+      threadId: this.id,
+      turnId,
+      status: latestTurn?.status ?? "running",
+      output: extractOutput(latestTurn),
+      turn: latestTurn,
+      events,
+      timedOut: events.some((event) => event.method === "turn/timeout"),
+    };
+  }
+
+  async *runStream(
+    prompt: string,
+    options: RunOptions = {},
+  ): AsyncGenerator<ThreadEvent, void, void> {
+    const pollIntervalMs = Math.max(
+      10,
+      options.pollIntervalMs ?? this.client.defaultPollIntervalMs,
+    );
+    const timeoutMs = Math.max(1, options.timeoutMs ?? this.client.defaultRunTimeoutMs);
+    const startedAt = Date.now();
+    let previousSignature = "";
+
+    const started = await this.client.startTurn(this.id, prompt);
+    const turnId = started.turn_id;
+
+    yield* emitEvent(
+      {
+        method: "turn/started",
+        params: {
+          thread_id: this.id,
+          turn_id: turnId,
+          source: "rpc",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      options.onEvent,
+    );
+
+    while (true) {
+      const turn = await this.client.turnStatus(turnId);
+      const signature = turnSignature(turn);
+
+      if (signature !== previousSignature) {
+        previousSignature = signature;
+        yield* emitEvent(
+          {
+            method: "turn/status",
+            params: {
+              thread_id: this.id,
+              turn_id: turnId,
+              turn,
+            },
+            timestamp: new Date().toISOString(),
+          },
+          options.onEvent,
+        );
+      }
+
+      if (isTerminalStatus(turn.status)) {
+        yield* emitEvent(
+          {
+            method: "turn/completed",
+            params: {
+              thread_id: this.id,
+              turn_id: turnId,
+              status: turn.status,
+              token_usage: turn.token_usage ?? null,
+            },
+            timestamp: new Date().toISOString(),
+          },
+          options.onEvent,
+        );
+        return;
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        yield* emitEvent(
+          {
+            method: "turn/timeout",
+            params: {
+              thread_id: this.id,
+              turn_id: turnId,
+              timeout_ms: timeoutMs,
+            },
+            timestamp: new Date().toISOString(),
+          },
+          options.onEvent,
+        );
+        return;
+      }
+
+      await sleep(pollIntervalMs);
+    }
+  }
+}
+
+function normalizeBaseUrl(value: string | undefined): string {
+  return (value ?? "http://127.0.0.1:8080").replace(/\/+$/, "");
+}
+
+function resolveFetch(customFetch: FetchLike | undefined): FetchLike {
+  if (customFetch) {
+    return customFetch;
+  }
+
+  const globalFetch = (globalThis as { fetch?: FetchLike }).fetch;
+  if (!globalFetch) {
+    throw new Error("No fetch implementation available. Pass `fetch` in HarnessOptions.");
+  }
+  return globalFetch;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === "completed" || status === "cancelled" || status === "failed";
+}
+
+function turnSignature(turn: TurnSnapshot): string {
+  const itemCount = Array.isArray(turn.items) ? turn.items.length : 0;
+  return `${turn.status}|${itemCount}|${turn.completed_at ?? ""}`;
+}
+
+function extractOutput(turn: TurnSnapshot | undefined): string {
+  if (!turn || !Array.isArray(turn.items)) {
+    return "";
+  }
+
+  const messages: string[] = [];
+  for (const item of turn.items) {
+    if (item.type === "user_message") {
+      continue;
+    }
+    if (typeof item.content === "string" && item.content.trim()) {
+      messages.push(item.content.trim());
+      continue;
+    }
+    if (typeof item.stdout === "string" && item.stdout.trim()) {
+      messages.push(item.stdout.trim());
+      continue;
+    }
+    if (typeof item.message === "string" && item.message.trim()) {
+      messages.push(item.message.trim());
+    }
+  }
+
+  return messages.join("\n\n");
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutHandle = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+async function* emitEvent(
+  event: ThreadEvent,
+  onEvent: ((event: ThreadEvent) => void | Promise<void>) | undefined,
+): AsyncGenerator<ThreadEvent, void, void> {
+  if (onEvent) {
+    await onEvent(event);
+  }
+  yield event;
+}

--- a/sdk/typescript/tests/harness.test.ts
+++ b/sdk/typescript/tests/harness.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Harness, HarnessRpcError, ThreadEvent } from "../src/index";
+
+interface RecordedCall {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+function createMockFetch(
+  handler: (method: string, params: Record<string, unknown>) => unknown,
+): {
+  calls: RecordedCall[];
+  fetch: (
+    _url: string,
+    init: {
+      method: string;
+      headers: Record<string, string>;
+      body: string;
+    },
+  ) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+} {
+  const calls: RecordedCall[] = [];
+
+  return {
+    calls,
+    fetch: async (_url, init) => {
+      const payload = JSON.parse(init.body) as {
+        method: string;
+        params: Record<string, unknown>;
+        id: number;
+      };
+
+      calls.push({ method: payload.method, params: payload.params });
+      const result = handler(payload.method, payload.params);
+      const envelope = {
+        jsonrpc: "2.0",
+        id: payload.id,
+        ...result,
+      };
+
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(envelope);
+        },
+      };
+    },
+  };
+}
+
+test("startThread sends thread/start and returns thread handle", async () => {
+  const mock = createMockFetch((method) => {
+    if (method === "thread/start") {
+      return { result: { thread_id: "thread-1" } };
+    }
+    return { result: {} };
+  });
+
+  const harness = new Harness({ fetch: mock.fetch, cwd: "/repo" });
+  const thread = await harness.startThread();
+
+  assert.equal(thread.id, "thread-1");
+  assert.equal(mock.calls.length, 1);
+  assert.equal(mock.calls[0]?.method, "thread/start");
+  assert.equal(mock.calls[0]?.params.cwd, "/repo");
+});
+
+test("run returns completed status and collected output", async () => {
+  let statusPollCount = 0;
+
+  const mock = createMockFetch((method) => {
+    if (method === "thread/start") {
+      return { result: { thread_id: "thread-2" } };
+    }
+    if (method === "turn/start") {
+      return { result: { turn_id: "turn-2" } };
+    }
+    if (method === "turn/status") {
+      statusPollCount += 1;
+      if (statusPollCount === 1) {
+        return {
+          result: {
+            id: "turn-2",
+            thread_id: "thread-2",
+            status: "running",
+            items: [{ type: "user_message", content: "hello" }],
+          },
+        };
+      }
+      return {
+        result: {
+          id: "turn-2",
+          thread_id: "thread-2",
+          status: "completed",
+          items: [
+            { type: "user_message", content: "hello" },
+            { type: "agent_reasoning", content: "done" },
+          ],
+          token_usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            total_tokens: 2,
+            cost_usd: 0,
+          },
+        },
+      };
+    }
+    return { result: {} };
+  });
+
+  const harness = new Harness({
+    fetch: mock.fetch,
+    defaultPollIntervalMs: 1,
+    defaultRunTimeoutMs: 500,
+  });
+  const thread = await harness.startThread({ cwd: "/repo" });
+  const emitted: ThreadEvent[] = [];
+  const result = await thread.run("Summarize", {
+    onEvent: async (event) => {
+      emitted.push(event);
+    },
+  });
+
+  assert.equal(result.threadId, "thread-2");
+  assert.equal(result.turnId, "turn-2");
+  assert.equal(result.status, "completed");
+  assert.equal(result.output, "done");
+  assert.equal(result.timedOut, false);
+  assert.ok(result.events.some((event) => event.method === "turn/completed"));
+  assert.ok(emitted.length >= 3);
+});
+
+test("run handles timeout when turn never reaches terminal status", async () => {
+  const mock = createMockFetch((method) => {
+    if (method === "thread/start") {
+      return { result: { thread_id: "thread-3" } };
+    }
+    if (method === "turn/start") {
+      return { result: { turn_id: "turn-3" } };
+    }
+    if (method === "turn/status") {
+      return {
+        result: {
+          id: "turn-3",
+          thread_id: "thread-3",
+          status: "running",
+          items: [{ type: "user_message", content: "hello" }],
+        },
+      };
+    }
+    return { result: {} };
+  });
+
+  const harness = new Harness({
+    fetch: mock.fetch,
+    defaultPollIntervalMs: 1,
+    defaultRunTimeoutMs: 5,
+  });
+
+  const thread = await harness.startThread({ cwd: "/repo" });
+  const result = await thread.run("Keep going");
+
+  assert.equal(result.threadId, "thread-3");
+  assert.equal(result.turnId, "turn-3");
+  assert.equal(result.status, "running");
+  assert.equal(result.timedOut, true);
+  assert.ok(result.events.some((event) => event.method === "turn/timeout"));
+});
+
+test("raises HarnessRpcError when server returns JSON-RPC error", async () => {
+  const mock = createMockFetch(() => ({
+    error: { code: -32001, message: "thread not found" },
+  }));
+
+  const harness = new Harness({ fetch: mock.fetch });
+  await assert.rejects(() => harness.resumeThread("missing-thread"), (error) => {
+    assert.ok(error instanceof HarnessRpcError);
+    assert.equal(error.code, -32001);
+    return true;
+  });
+});

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript SDK package with Codex-style `startThread()`, `resumeThread()`, `thread.run()`, and `thread.runStream()` APIs
- add an equivalent Python SDK package with `start_thread()`, `resume_thread()`, `thread.run()`, and `thread.run_stream()`
- add SDK-focused tests and publication guidance for npm/PyPI

## Validation
- npm --prefix sdk/typescript test
- PYTHONPATH=sdk/python/src python3 -m unittest discover -s sdk/python/tests
- cargo check
- cargo test

Resolves #111
