### PR TITLE
FUT-84: Add Starlark execpolicy engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,58 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "allocative"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.14.5",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -24,6 +70,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -83,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,7 +154,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -182,6 +246,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +363,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -278,7 +375,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -286,6 +383,21 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "colorchoice"
@@ -307,6 +419,15 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -374,6 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +508,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -404,6 +541,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +561,45 @@ dependencies = [
  "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -427,6 +614,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,7 +652,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -444,12 +662,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -462,10 +709,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -476,6 +738,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -506,10 +774,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
@@ -625,7 +910,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -655,6 +940,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -738,7 +1032,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -777,7 +1071,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "uuid",
@@ -792,7 +1086,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -809,7 +1103,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -826,7 +1120,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -841,7 +1135,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -856,8 +1150,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "shlex",
+ "starlark",
+ "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -884,7 +1181,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
@@ -905,7 +1202,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
@@ -915,6 +1212,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -947,6 +1248,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1239,6 +1546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1561,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1267,10 +1589,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1286,6 +1637,37 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1321,7 +1703,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1366,6 +1748,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1819,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1431,12 +1864,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1503,7 +1973,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1520,7 +1990,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1571,6 +2041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +2060,25 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1649,13 +2144,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1681,6 +2182,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -1747,7 +2258,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1756,7 +2267,50 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1767,8 +2321,14 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1859,7 +2419,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1906,6 +2466,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +2503,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,7 +2556,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1982,7 +2606,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2007,6 +2631,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2101,6 +2736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,7 +2826,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2203,7 +2844,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2226,7 +2867,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2239,7 +2880,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2269,7 +2910,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2283,7 +2924,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2308,7 +2949,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2334,7 +2975,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2345,6 +2986,114 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starlark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f53849859f05d9db705b221bd92eede93877fd426c1b4a3c3061403a5912a8f"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "bumpalo",
+ "cmp_any",
+ "debugserver-types",
+ "derivative",
+ "derive_more",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde",
+ "hashbrown 0.14.5",
+ "inventory",
+ "itertools 0.13.0",
+ "maplit",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "ref-cast",
+ "regex",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strsim 0.10.0",
+ "textwrap",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe58bc6c8b7980a1fe4c9f8f48200c3212db42ebfe21ae6a0336385ab53f082a"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92659970f120df0cc1c0bb220b33587b7a9a90e80d4eecc5c5af5debb950173d"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "serde",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe53b3690d776aafd7cb6b9fed62d94f83280e3b87d88e3719cc0024638461b3"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more",
+ "dupe",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "starlark_map",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "stringprep"
@@ -2359,6 +3108,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -2368,6 +3123,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2397,7 +3163,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2406,7 +3172,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2435,12 +3201,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2451,7 +3257,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2461,6 +3267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2513,7 +3328,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2647,7 +3462,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2692,7 +3507,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2766,7 +3581,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2783,7 +3598,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2821,6 +3636,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +3675,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2983,7 +3811,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3037,7 +3865,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3064,6 +3892,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,7 +3934,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3095,7 +3945,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3394,7 +4244,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3410,7 +4260,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3422,7 +4272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -3477,7 +4327,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3498,7 +4348,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3518,7 +4368,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3558,7 +4408,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 # File patterns
 glob = "0.3"
+shlex = "1.3"
+starlark = "0.13"
 
 # Error handling
 thiserror = "2"

--- a/config/default.toml
+++ b/config/default.toml
@@ -47,6 +47,7 @@ violation_min = 5
 
 [rules]
 discovery_paths = []
+exec_policy_paths = []
 
 [observe]
 db_path = "~/.local/share/harness/harness.db"

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -56,6 +56,13 @@ pub enum Command {
         cmd: RuleCommand,
     },
 
+    /// Starlark execpolicy commands
+    #[command(name = "execpolicy")]
+    ExecPolicy {
+        #[command(subcommand)]
+        cmd: ExecPolicyCommand,
+    },
+
     /// Skill system commands
     Skill {
         #[command(subcommand)]
@@ -109,6 +116,33 @@ pub enum RuleCommand {
         /// Project directory
         #[arg(default_value = ".")]
         project: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ExecPolicyCommand {
+    /// Check a command against Starlark policy rules
+    Check {
+        /// Paths to policy files (repeatable). Falls back to config.rules.exec_policy_paths.
+        #[arg(short = 'r', long = "rules", value_name = "PATH")]
+        rules: Vec<PathBuf>,
+        /// Optional requirements.toml path for organization-level enforcement.
+        #[arg(long, value_name = "PATH")]
+        requirements: Option<PathBuf>,
+        /// Resolve absolute executables against basename rules.
+        #[arg(long)]
+        resolve_host_executables: bool,
+        /// Pretty-print JSON output.
+        #[arg(long)]
+        pretty: bool,
+        /// Command tokens to evaluate.
+        #[arg(
+            value_name = "COMMAND",
+            required = true,
+            trailing_var_arg = true,
+            allow_hyphen_values = true
+        )]
+        command: Vec<String>,
     },
 }
 
@@ -179,6 +213,7 @@ fn configured_rule_engine(config: &harness_core::HarnessConfig) -> harness_rules
     engine.configure_sources(
         config.rules.discovery_paths.clone(),
         config.rules.builtin_path.clone(),
+        config.rules.requirements_path.clone(),
     );
     engine
 }
@@ -341,6 +376,48 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             }
         }
 
+        Command::ExecPolicy { cmd } => match cmd {
+            ExecPolicyCommand::Check {
+                rules,
+                requirements,
+                resolve_host_executables,
+                pretty,
+                command,
+            } => {
+                let mut engine = configured_rule_engine(&config);
+                let policy_paths = if rules.is_empty() {
+                    config.rules.exec_policy_paths.clone()
+                } else {
+                    rules
+                };
+                if policy_paths.is_empty() {
+                    anyhow::bail!(
+                        "no execpolicy rules supplied; pass --rules or set rules.exec_policy_paths"
+                    );
+                }
+
+                engine.load_exec_policy_files(&policy_paths)?;
+                if let Some(path) = requirements {
+                    engine.load_requirements_toml(&path)?;
+                } else {
+                    engine.load_configured_requirements()?;
+                }
+
+                let result = engine.check_command_policy(
+                    &command,
+                    &harness_rules::exec_policy::MatchOptions {
+                        resolve_host_executables,
+                    },
+                );
+                let rendered = if pretty {
+                    serde_json::to_string_pretty(&result)?
+                } else {
+                    serde_json::to_string(&result)?
+                };
+                println!("{rendered}");
+            }
+        },
+
         Command::Skill { cmd } => match cmd {
             SkillCommand::List { query } => {
                 let store = harness_skills::SkillStore::new();
@@ -451,5 +528,39 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(chain.contains("cwd lookup blocked"));
+    }
+
+    #[test]
+    fn cli_parses_execpolicy_check_subcommand() {
+        let cli = Cli::try_parse_from([
+            "harness",
+            "execpolicy",
+            "check",
+            "--rules",
+            "policy.star",
+            "--pretty",
+            "git",
+            "status",
+        ])
+        .expect("execpolicy command should parse");
+
+        match cli.command {
+            Command::ExecPolicy { cmd } => match cmd {
+                ExecPolicyCommand::Check {
+                    rules,
+                    requirements,
+                    resolve_host_executables,
+                    pretty,
+                    command,
+                } => {
+                    assert_eq!(rules, vec![PathBuf::from("policy.star")]);
+                    assert_eq!(requirements, None);
+                    assert!(!resolve_host_executables);
+                    assert!(pretty);
+                    assert_eq!(command, vec!["git".to_string(), "status".to_string()]);
+                }
+            },
+            _ => panic!("unexpected command variant parsed"),
+        }
     }
 }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -250,8 +250,14 @@ impl Default for SignalThresholds {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RulesConfig {
+    #[serde(default)]
     pub discovery_paths: Vec<PathBuf>,
+    #[serde(default)]
     pub builtin_path: Option<PathBuf>,
+    #[serde(default)]
+    pub exec_policy_paths: Vec<PathBuf>,
+    #[serde(default = "default_rules_requirements_path")]
+    pub requirements_path: Option<PathBuf>,
 }
 
 impl Default for RulesConfig {
@@ -259,8 +265,14 @@ impl Default for RulesConfig {
         Self {
             discovery_paths: vec![],
             builtin_path: None,
+            exec_policy_paths: vec![],
+            requirements_path: default_rules_requirements_path(),
         }
     }
+}
+
+fn default_rules_requirements_path() -> Option<PathBuf> {
+    Some(PathBuf::from("/etc/harness/requirements.toml"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-rules/Cargo.toml
+++ b/crates/harness-rules/Cargo.toml
@@ -14,3 +14,6 @@ tracing = { workspace = true }
 glob = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 chrono = { workspace = true }
+shlex = { workspace = true }
+starlark = { workspace = true }
+toml = { workspace = true }

--- a/crates/harness-rules/src/engine.rs
+++ b/crates/harness-rules/src/engine.rs
@@ -1,6 +1,7 @@
-use harness_core::{
-    Category, GuardId, Language, RuleId, Severity, Violation,
+use crate::exec_policy::{
+    ExecPolicy, ExecPolicyCheckOutput, ExecPolicyParser, MatchOptions, RequirementsToml,
 };
+use harness_core::{Category, GuardId, Language, RuleId, Severity, Violation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -28,8 +29,10 @@ pub struct RuleEngine {
     rules: Vec<Rule>,
     rule_ids: HashSet<RuleId>,
     guards: Vec<Guard>,
+    exec_policy: ExecPolicy,
     discovery_paths: Vec<PathBuf>,
     builtin_path: Option<PathBuf>,
+    requirements_path: Option<PathBuf>,
 }
 
 impl RuleEngine {
@@ -38,8 +41,10 @@ impl RuleEngine {
             rules: Vec::new(),
             rule_ids: HashSet::new(),
             guards: Vec::new(),
+            exec_policy: ExecPolicy::empty(),
             discovery_paths: Vec::new(),
             builtin_path: None,
+            requirements_path: None,
         }
     }
 
@@ -47,9 +52,11 @@ impl RuleEngine {
         &mut self,
         discovery_paths: Vec<PathBuf>,
         builtin_path: Option<PathBuf>,
+        requirements_path: Option<PathBuf>,
     ) {
         self.discovery_paths = discovery_paths;
         self.builtin_path = builtin_path;
+        self.requirements_path = requirements_path;
     }
 
     /// Load rules using the 4-layer discovery chain: repo → user → admin → system.
@@ -100,7 +107,11 @@ impl RuleEngine {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().map(|e| e == "md" || e == "toml").unwrap_or(false) {
+            if path
+                .extension()
+                .map(|e| e == "md" || e == "toml")
+                .unwrap_or(false)
+            {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     self.parse_rule_file(&path, &content)?;
                 }
@@ -125,17 +136,41 @@ impl RuleEngine {
                 self.parse_rule_file(&path, &content)?;
                 return Ok(());
             }
-            anyhow::bail!("configured rules.builtin_path does not exist: {}", path.display());
+            anyhow::bail!(
+                "configured rules.builtin_path does not exist: {}",
+                path.display()
+            );
         }
 
         let builtin = [
-            ("golden-principles.md", include_str!("../../../rules/golden-principles.md")),
-            ("common/coding-style.md", include_str!("../../../rules/common/coding-style.md")),
-            ("common/security.md", include_str!("../../../rules/common/security.md")),
-            ("go/quality.md", include_str!("../../../rules/go/quality.md")),
-            ("python/quality.md", include_str!("../../../rules/python/quality.md")),
-            ("rust/quality.md", include_str!("../../../rules/rust/quality.md")),
-            ("typescript/quality.md", include_str!("../../../rules/typescript/quality.md")),
+            (
+                "golden-principles.md",
+                include_str!("../../../rules/golden-principles.md"),
+            ),
+            (
+                "common/coding-style.md",
+                include_str!("../../../rules/common/coding-style.md"),
+            ),
+            (
+                "common/security.md",
+                include_str!("../../../rules/common/security.md"),
+            ),
+            (
+                "go/quality.md",
+                include_str!("../../../rules/go/quality.md"),
+            ),
+            (
+                "python/quality.md",
+                include_str!("../../../rules/python/quality.md"),
+            ),
+            (
+                "rust/quality.md",
+                include_str!("../../../rules/rust/quality.md"),
+            ),
+            (
+                "typescript/quality.md",
+                include_str!("../../../rules/typescript/quality.md"),
+            ),
         ];
         for (name, content) in builtin {
             self.parse_rule_file(Path::new(name), content)?;
@@ -176,7 +211,13 @@ impl RuleEngine {
             let first_line = section.lines().next().unwrap_or("");
             if let Some((id_part, title)) = first_line.split_once(':') {
                 let id = id_part.trim_start_matches('#').trim().to_string();
-                if id.is_empty() || !id.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false) {
+                if id.is_empty()
+                    || !id
+                        .chars()
+                        .next()
+                        .map(|c| c.is_ascii_uppercase())
+                        .unwrap_or(false)
+                {
                     continue;
                 }
                 let severity = if section.contains("严重") || section.contains("critical") {
@@ -191,7 +232,11 @@ impl RuleEngine {
 
                 let category = if id.starts_with("SEC") {
                     Category::Security
-                } else if id.starts_with("RS") || id.starts_with("GO") || id.starts_with("TS") || id.starts_with("PY") {
+                } else if id.starts_with("RS")
+                    || id.starts_with("GO")
+                    || id.starts_with("TS")
+                    || id.starts_with("PY")
+                {
                     Category::Stability
                 } else {
                     Category::Style
@@ -255,7 +300,11 @@ impl RuleEngine {
     }
 
     /// Scan specific files.
-    pub async fn scan_files(&self, project_root: &Path, files: &[PathBuf]) -> anyhow::Result<Vec<Violation>> {
+    pub async fn scan_files(
+        &self,
+        project_root: &Path,
+        files: &[PathBuf],
+    ) -> anyhow::Result<Vec<Violation>> {
         let mut violations = Vec::new();
         for guard in &self.guards {
             for file in files {
@@ -319,6 +368,56 @@ impl RuleEngine {
 
     pub fn guards(&self) -> &[Guard] {
         &self.guards
+    }
+
+    pub fn exec_policy(&self) -> &ExecPolicy {
+        &self.exec_policy
+    }
+
+    pub fn load_exec_policy_files(&mut self, policy_paths: &[PathBuf]) -> anyhow::Result<()> {
+        if policy_paths.is_empty() {
+            return Ok(());
+        }
+        let mut parser = ExecPolicyParser::new();
+        for path in policy_paths {
+            let content = std::fs::read_to_string(path).map_err(|error| {
+                anyhow::anyhow!("failed to read execpolicy file {}: {error}", path.display())
+            })?;
+            let identifier = path.to_string_lossy().to_string();
+            parser.parse(&identifier, &content).map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to parse execpolicy file {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+        self.exec_policy = self.exec_policy.merge_overlay(&parser.build());
+        Ok(())
+    }
+
+    pub fn load_requirements_toml(&mut self, path: &Path) -> anyhow::Result<()> {
+        let requirements = RequirementsToml::from_path(path)?;
+        let requirements_policy = requirements.to_policy()?;
+        self.exec_policy = self.exec_policy.merge_overlay(&requirements_policy);
+        Ok(())
+    }
+
+    pub fn load_configured_requirements(&mut self) -> anyhow::Result<()> {
+        let Some(path) = self.requirements_path.clone() else {
+            return Ok(());
+        };
+        if !path.exists() {
+            return Ok(());
+        }
+        self.load_requirements_toml(&path)
+    }
+
+    pub fn check_command_policy(
+        &self,
+        command: &[String],
+        options: &MatchOptions,
+    ) -> ExecPolicyCheckOutput {
+        self.exec_policy.check_command(command, options)
     }
 }
 
@@ -400,8 +499,14 @@ mod tests {
     fn load_builtin_parses_gp_and_sec_ids() -> anyhow::Result<()> {
         let mut engine = RuleEngine::new();
         engine.load_builtin()?;
-        assert!(engine.rules().iter().any(|r| r.id.as_str() == "GP-01"), "GP-01 rule missing");
-        assert!(engine.rules().iter().any(|r| r.id.as_str() == "SEC-01"), "SEC-01 rule missing");
+        assert!(
+            engine.rules().iter().any(|r| r.id.as_str() == "GP-01"),
+            "GP-01 rule missing"
+        );
+        assert!(
+            engine.rules().iter().any(|r| r.id.as_str() == "SEC-01"),
+            "SEC-01 rule missing"
+        );
         Ok(())
     }
 

--- a/crates/harness-rules/src/exec_policy.rs
+++ b/crates/harness-rules/src/exec_policy.rs
@@ -1,0 +1,886 @@
+use anyhow::anyhow;
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use starlark::any::ProvidesStaticType;
+use starlark::environment::GlobalsBuilder;
+use starlark::environment::Module;
+use starlark::eval::Evaluator;
+use starlark::starlark_module;
+use starlark::syntax::AstModule;
+use starlark::syntax::Dialect;
+use starlark::values::list::ListRef;
+use starlark::values::list::UnpackList;
+use starlark::values::none::NoneType;
+use starlark::values::Value;
+use std::cell::{RefCell, RefMut};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecDecision {
+    Allow,
+    Prompt,
+    Forbidden,
+}
+
+impl ExecDecision {
+    fn parse(raw: &str) -> anyhow::Result<Self> {
+        match raw {
+            "allow" => Ok(Self::Allow),
+            "prompt" => Ok(Self::Prompt),
+            "forbidden" => Ok(Self::Forbidden),
+            other => Err(anyhow!(
+                "invalid decision `{other}`; expected allow|prompt|forbidden"
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PatternToken {
+    Single(String),
+    Alts(Vec<String>),
+}
+
+impl PatternToken {
+    fn matches(&self, token: &str) -> bool {
+        match self {
+            Self::Single(expected) => expected == token,
+            Self::Alts(alternatives) => alternatives.iter().any(|alt| alt == token),
+        }
+    }
+
+    fn alternatives(&self) -> &[String] {
+        match self {
+            Self::Single(expected) => std::slice::from_ref(expected),
+            Self::Alts(alternatives) => alternatives,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrefixPattern {
+    pub first: Arc<str>,
+    pub rest: Arc<[PatternToken]>,
+}
+
+impl PrefixPattern {
+    fn matches_prefix(&self, command: &[String]) -> Option<Vec<String>> {
+        let pattern_len = self.rest.len() + 1;
+        if command.len() < pattern_len || command[0] != self.first.as_ref() {
+            return None;
+        }
+
+        for (pattern_token, command_token) in self.rest.iter().zip(&command[1..pattern_len]) {
+            if !pattern_token.matches(command_token) {
+                return None;
+            }
+        }
+
+        Some(command[..pattern_len].to_vec())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrefixRule {
+    pub pattern: PrefixPattern,
+    pub decision: ExecDecision,
+    pub justification: Option<String>,
+}
+
+impl PrefixRule {
+    fn matches(&self, command: &[String]) -> Option<RuleMatch> {
+        self.pattern
+            .matches_prefix(command)
+            .map(|matched_prefix| RuleMatch::PrefixRuleMatch {
+                matched_prefix,
+                decision: self.decision,
+                resolved_program: None,
+                justification: self.justification.clone(),
+            })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RuleMatch {
+    PrefixRuleMatch {
+        #[serde(rename = "matchedPrefix")]
+        matched_prefix: Vec<String>,
+        decision: ExecDecision,
+        #[serde(rename = "resolvedProgram", skip_serializing_if = "Option::is_none")]
+        resolved_program: Option<PathBuf>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        justification: Option<String>,
+    },
+}
+
+impl RuleMatch {
+    fn decision(&self) -> ExecDecision {
+        match self {
+            Self::PrefixRuleMatch { decision, .. } => *decision,
+        }
+    }
+
+    fn with_resolved_program(self, program: &Path) -> Self {
+        match self {
+            Self::PrefixRuleMatch {
+                matched_prefix,
+                decision,
+                justification,
+                ..
+            } => Self::PrefixRuleMatch {
+                matched_prefix,
+                decision,
+                resolved_program: Some(program.to_path_buf()),
+                justification,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct MatchOptions {
+    pub resolve_host_executables: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExecPolicy {
+    rules_by_program: HashMap<String, Vec<PrefixRule>>,
+    host_executables_by_name: HashMap<String, Arc<[PathBuf]>>,
+}
+
+impl ExecPolicy {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn merge_overlay(&self, overlay: &ExecPolicy) -> ExecPolicy {
+        let mut combined = self.clone();
+        for (program, rules) in &overlay.rules_by_program {
+            combined
+                .rules_by_program
+                .entry(program.clone())
+                .or_default()
+                .extend(rules.iter().cloned());
+        }
+        combined
+            .host_executables_by_name
+            .extend(overlay.host_executables_by_name.clone());
+        combined
+    }
+
+    pub fn add_rule(&mut self, rule: PrefixRule) {
+        self.rules_by_program
+            .entry(rule.pattern.first.as_ref().to_string())
+            .or_default()
+            .push(rule);
+    }
+
+    pub fn set_host_executable_paths(&mut self, name: String, paths: Vec<PathBuf>) {
+        self.host_executables_by_name.insert(name, paths.into());
+    }
+
+    pub fn check_command(
+        &self,
+        command: &[String],
+        options: &MatchOptions,
+    ) -> ExecPolicyCheckOutput {
+        let matched_rules = self.matches_for_command_with_options(command, options);
+        ExecPolicyCheckOutput::from_matches(matched_rules)
+    }
+
+    pub fn matches_for_command_with_options(
+        &self,
+        command: &[String],
+        options: &MatchOptions,
+    ) -> Vec<RuleMatch> {
+        let exact_matches = self.match_exact_rules(command);
+        if !exact_matches.is_empty() {
+            return exact_matches;
+        }
+
+        if options.resolve_host_executables {
+            return self.match_host_executable_rules(command);
+        }
+
+        Vec::new()
+    }
+
+    fn match_exact_rules(&self, command: &[String]) -> Vec<RuleMatch> {
+        let Some(program) = command.first() else {
+            return Vec::new();
+        };
+
+        self.rules_by_program
+            .get(program)
+            .map(|rules| {
+                rules
+                    .iter()
+                    .filter_map(|rule| rule.matches(command))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn match_host_executable_rules(&self, command: &[String]) -> Vec<RuleMatch> {
+        let Some(program) = command.first() else {
+            return Vec::new();
+        };
+
+        let program_path = Path::new(program);
+        if !program_path.is_absolute() {
+            return Vec::new();
+        }
+
+        let Some(name) = executable_name(program_path) else {
+            return Vec::new();
+        };
+
+        let Some(rules) = self.rules_by_program.get(name) else {
+            return Vec::new();
+        };
+
+        if let Some(paths) = self.host_executables_by_name.get(name) {
+            let raw_program_path = PathBuf::from(program);
+            if !paths.iter().any(|path| path == &raw_program_path) {
+                return Vec::new();
+            }
+        }
+
+        let basename_command = std::iter::once(name.to_string())
+            .chain(command.iter().skip(1).cloned())
+            .collect::<Vec<_>>();
+        let resolved_path = PathBuf::from(program);
+        rules
+            .iter()
+            .filter_map(|rule| rule.matches(&basename_command))
+            .map(|rule_match| rule_match.with_resolved_program(&resolved_path))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecPolicyCheckOutput {
+    #[serde(rename = "matchedRules")]
+    pub matched_rules: Vec<RuleMatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<ExecDecision>,
+}
+
+impl ExecPolicyCheckOutput {
+    fn from_matches(matched_rules: Vec<RuleMatch>) -> Self {
+        let decision = matched_rules.iter().map(RuleMatch::decision).max();
+        Self {
+            matched_rules,
+            decision,
+        }
+    }
+}
+
+pub struct ExecPolicyParser {
+    builder: RefCell<PolicyBuilder>,
+}
+
+impl Default for ExecPolicyParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExecPolicyParser {
+    pub fn new() -> Self {
+        Self {
+            builder: RefCell::new(PolicyBuilder::new()),
+        }
+    }
+
+    pub fn parse(&mut self, identifier: &str, policy_contents: &str) -> anyhow::Result<()> {
+        let pending_count = self.builder.borrow().pending_example_validations.len();
+        let mut dialect = Dialect::Extended.clone();
+        dialect.enable_f_strings = true;
+        let ast = AstModule::parse(identifier, policy_contents.to_string(), &dialect)
+            .map_err(|error| anyhow!("starlark parse failed for {identifier}: {error}"))?;
+        let globals = GlobalsBuilder::standard().with(policy_builtins).build();
+        let module = Module::new();
+        {
+            let mut eval = Evaluator::new(&module);
+            eval.extra = Some(&self.builder);
+            eval.eval_module(ast, &globals)
+                .map_err(|error| anyhow!("starlark evaluation failed for {identifier}: {error}"))?;
+        }
+        self.builder
+            .borrow()
+            .validate_pending_examples_from(pending_count)?;
+        Ok(())
+    }
+
+    pub fn build(self) -> ExecPolicy {
+        self.builder.into_inner().build()
+    }
+}
+
+#[derive(Debug, ProvidesStaticType)]
+struct PolicyBuilder {
+    policy: ExecPolicy,
+    pending_example_validations: Vec<PendingExampleValidation>,
+}
+
+impl PolicyBuilder {
+    fn new() -> Self {
+        Self {
+            policy: ExecPolicy::empty(),
+            pending_example_validations: Vec::new(),
+        }
+    }
+
+    fn add_rule(&mut self, rule: PrefixRule) {
+        self.policy.add_rule(rule);
+    }
+
+    fn add_host_executable(&mut self, name: String, paths: Vec<PathBuf>) {
+        self.policy.set_host_executable_paths(name, paths);
+    }
+
+    fn add_pending_example_validation(
+        &mut self,
+        rules: Vec<PrefixRule>,
+        matches: Vec<Vec<String>>,
+        not_matches: Vec<Vec<String>>,
+    ) {
+        self.pending_example_validations
+            .push(PendingExampleValidation {
+                rules,
+                matches,
+                not_matches,
+            });
+    }
+
+    fn validate_pending_examples_from(&self, start: usize) -> anyhow::Result<()> {
+        for validation in &self.pending_example_validations[start..] {
+            let mut policy = ExecPolicy::empty();
+            for rule in &validation.rules {
+                policy.add_rule(rule.clone());
+            }
+            policy.host_executables_by_name = self.policy.host_executables_by_name.clone();
+            let options = MatchOptions {
+                resolve_host_executables: true,
+            };
+
+            for example in &validation.matches {
+                if policy
+                    .matches_for_command_with_options(example, &options)
+                    .is_empty()
+                {
+                    let rendered = shlex::try_join(example.iter().map(String::as_str))
+                        .unwrap_or_else(|_| "invalid example".to_string());
+                    return Err(anyhow!("example did not match rule: {rendered}"));
+                }
+            }
+
+            for example in &validation.not_matches {
+                if !policy
+                    .matches_for_command_with_options(example, &options)
+                    .is_empty()
+                {
+                    let rendered = shlex::try_join(example.iter().map(String::as_str))
+                        .unwrap_or_else(|_| "invalid example".to_string());
+                    return Err(anyhow!(
+                        "negative example unexpectedly matched rule: {rendered}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn build(self) -> ExecPolicy {
+        self.policy
+    }
+}
+
+#[derive(Debug)]
+struct PendingExampleValidation {
+    rules: Vec<PrefixRule>,
+    matches: Vec<Vec<String>>,
+    not_matches: Vec<Vec<String>>,
+}
+
+fn policy_builder<'v, 'a>(eval: &Evaluator<'v, 'a, '_>) -> RefMut<'a, PolicyBuilder> {
+    #[expect(clippy::expect_used)]
+    eval.extra
+        .as_ref()
+        .expect("policy builder requires Evaluator.extra to be populated")
+        .downcast_ref::<RefCell<PolicyBuilder>>()
+        .expect("Evaluator.extra must contain a PolicyBuilder")
+        .borrow_mut()
+}
+
+fn parse_pattern<'v>(pattern: UnpackList<Value<'v>>) -> anyhow::Result<Vec<PatternToken>> {
+    let tokens: Vec<PatternToken> = pattern
+        .items
+        .into_iter()
+        .map(parse_pattern_token)
+        .collect::<anyhow::Result<_>>()?;
+    if tokens.is_empty() {
+        return Err(anyhow!("pattern cannot be empty"));
+    }
+    Ok(tokens)
+}
+
+fn parse_pattern_token<'v>(value: Value<'v>) -> anyhow::Result<PatternToken> {
+    if let Some(raw) = value.unpack_str() {
+        if raw.trim().is_empty() {
+            return Err(anyhow!("pattern token cannot be empty"));
+        }
+        return Ok(PatternToken::Single(raw.to_string()));
+    }
+
+    let Some(list) = ListRef::from_value(value) else {
+        return Err(anyhow!(
+            "pattern element must be a string or list of strings (got {})",
+            value.get_type()
+        ));
+    };
+
+    let alternatives: Vec<String> = list
+        .content()
+        .iter()
+        .map(|item| {
+            let Some(token) = item.unpack_str() else {
+                return Err(anyhow!(
+                    "pattern alternatives must be strings (got {})",
+                    item.get_type()
+                ));
+            };
+            if token.trim().is_empty() {
+                return Err(anyhow!("pattern alternatives cannot contain empty tokens"));
+            }
+            Ok(token.to_string())
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    match alternatives.as_slice() {
+        [] => Err(anyhow!("pattern alternatives cannot be empty")),
+        [single] => Ok(PatternToken::Single(single.clone())),
+        _ => Ok(PatternToken::Alts(alternatives)),
+    }
+}
+
+fn parse_examples<'v>(examples: UnpackList<Value<'v>>) -> anyhow::Result<Vec<Vec<String>>> {
+    examples.items.into_iter().map(parse_example).collect()
+}
+
+fn parse_example<'v>(value: Value<'v>) -> anyhow::Result<Vec<String>> {
+    if let Some(raw) = value.unpack_str() {
+        let Some(tokens) = shlex::split(raw) else {
+            return Err(anyhow!("example string has invalid shell syntax"));
+        };
+        if tokens.is_empty() {
+            return Err(anyhow!("example string cannot be empty"));
+        }
+        return Ok(tokens);
+    }
+
+    let Some(list) = ListRef::from_value(value) else {
+        return Err(anyhow!(
+            "example must be a string or list of strings (got {})",
+            value.get_type()
+        ));
+    };
+
+    let tokens: Vec<String> = list
+        .content()
+        .iter()
+        .map(|item| {
+            item.unpack_str()
+                .ok_or_else(|| anyhow!("example list entries must be strings"))
+                .map(str::to_string)
+        })
+        .collect::<anyhow::Result<_>>()?;
+    if tokens.is_empty() {
+        return Err(anyhow!("example list cannot be empty"));
+    }
+    Ok(tokens)
+}
+
+fn validate_host_executable_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        return Err(anyhow!("host_executable name cannot be empty"));
+    }
+    let path = Path::new(name);
+    if path.components().count() != 1
+        || path.file_name().and_then(|token| token.to_str()) != Some(name)
+    {
+        return Err(anyhow!(
+            "host_executable name must be a bare executable name: {name}"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_literal_absolute_path(raw: &str) -> anyhow::Result<PathBuf> {
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err(anyhow!("host_executable paths must be absolute: {raw}"));
+    }
+    Ok(path)
+}
+
+fn executable_name(path: &Path) -> Option<&str> {
+    path.file_name().and_then(|name| name.to_str())
+}
+
+#[starlark_module]
+fn policy_builtins(builder: &mut GlobalsBuilder) {
+    fn prefix_rule<'v>(
+        pattern: UnpackList<Value<'v>>,
+        decision: Option<&'v str>,
+        r#match: Option<UnpackList<Value<'v>>>,
+        not_match: Option<UnpackList<Value<'v>>>,
+        justification: Option<&'v str>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<NoneType> {
+        let decision = decision
+            .map(ExecDecision::parse)
+            .transpose()?
+            .unwrap_or(ExecDecision::Allow);
+        let justification = match justification {
+            Some(raw) if raw.trim().is_empty() => {
+                return Err(anyhow!("justification cannot be empty"));
+            }
+            Some(raw) => Some(raw.to_string()),
+            None => None,
+        };
+
+        let pattern_tokens = parse_pattern(pattern)?;
+        let matches = r#match.map(parse_examples).transpose()?.unwrap_or_default();
+        let not_matches = not_match
+            .map(parse_examples)
+            .transpose()?
+            .unwrap_or_default();
+
+        let mut policy_builder = policy_builder(eval);
+        let (first_token, remaining_tokens) = pattern_tokens
+            .split_first()
+            .ok_or_else(|| anyhow!("pattern cannot be empty"))?;
+
+        let rest: Arc<[PatternToken]> = remaining_tokens.to_vec().into();
+        let rules: Vec<PrefixRule> = first_token
+            .alternatives()
+            .iter()
+            .map(|head| PrefixRule {
+                pattern: PrefixPattern {
+                    first: Arc::from(head.as_str()),
+                    rest: rest.clone(),
+                },
+                decision,
+                justification: justification.clone(),
+            })
+            .collect();
+
+        for rule in rules.iter().cloned() {
+            policy_builder.add_rule(rule);
+        }
+        policy_builder.add_pending_example_validation(rules, matches, not_matches);
+        Ok(NoneType)
+    }
+
+    fn host_executable<'v>(
+        name: &'v str,
+        paths: UnpackList<Value<'v>>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<NoneType> {
+        validate_host_executable_name(name)?;
+        let mut parsed_paths = Vec::new();
+        for item in paths.items {
+            let raw = item
+                .unpack_str()
+                .ok_or_else(|| anyhow!("host_executable paths must be strings"))?;
+            let path = parse_literal_absolute_path(raw)?;
+            if executable_name(&path) != Some(name) {
+                return Err(anyhow!(
+                    "host_executable path `{raw}` must have basename `{name}`"
+                ));
+            }
+            if !parsed_paths.iter().any(|existing| existing == &path) {
+                parsed_paths.push(path);
+            }
+        }
+        policy_builder(eval).add_host_executable(name.to_string(), parsed_paths);
+        Ok(NoneType)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequirementsToml {
+    pub rules: RequirementsRuleSetToml,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequirementsRuleSetToml {
+    #[serde(default)]
+    pub prefix_rules: Vec<RequirementsPrefixRuleToml>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequirementsPrefixRuleToml {
+    pub pattern: Vec<RequirementsPatternTokenToml>,
+    pub decision: Option<RequirementsDecisionToml>,
+    pub justification: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequirementsPatternTokenToml {
+    pub token: Option<String>,
+    pub any_of: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RequirementsDecisionToml {
+    Allow,
+    Prompt,
+    Forbidden,
+}
+
+impl RequirementsDecisionToml {
+    fn as_decision(self) -> ExecDecision {
+        match self {
+            Self::Allow => ExecDecision::Allow,
+            Self::Prompt => ExecDecision::Prompt,
+            Self::Forbidden => ExecDecision::Forbidden,
+        }
+    }
+}
+
+impl RequirementsToml {
+    pub fn from_path(path: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read requirements file {}", path.display()))?;
+        toml::from_str::<Self>(&content)
+            .with_context(|| format!("failed to parse requirements file {}", path.display()))
+    }
+
+    pub fn to_policy(&self) -> anyhow::Result<ExecPolicy> {
+        if self.rules.prefix_rules.is_empty() {
+            return Err(anyhow!("rules.prefix_rules cannot be empty"));
+        }
+
+        let mut policy = ExecPolicy::empty();
+        for (rule_index, rule) in self.rules.prefix_rules.iter().enumerate() {
+            if let Some(justification) = &rule.justification {
+                if justification.trim().is_empty() {
+                    return Err(anyhow!(
+                        "rules.prefix_rules[{rule_index}].justification cannot be empty"
+                    ));
+                }
+            }
+            if rule.pattern.is_empty() {
+                return Err(anyhow!(
+                    "rules.prefix_rules[{rule_index}].pattern cannot be empty"
+                ));
+            }
+
+            let decision = match rule.decision {
+                Some(RequirementsDecisionToml::Allow) => {
+                    return Err(anyhow!(
+                        "rules.prefix_rules[{rule_index}] decision `allow` is not permitted in requirements.toml"
+                    ));
+                }
+                Some(decision) => decision.as_decision(),
+                None => {
+                    return Err(anyhow!(
+                        "rules.prefix_rules[{rule_index}] is missing `decision`"
+                    ));
+                }
+            };
+
+            let pattern_tokens = rule
+                .pattern
+                .iter()
+                .enumerate()
+                .map(|(token_index, token)| {
+                    parse_requirements_pattern_token(rule_index, token_index, token)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            let (first_token, remaining_tokens) =
+                pattern_tokens.split_first().ok_or_else(|| {
+                    anyhow!("rules.prefix_rules[{rule_index}].pattern cannot be empty")
+                })?;
+            let rest: Arc<[PatternToken]> = remaining_tokens.to_vec().into();
+
+            for head in first_token.alternatives() {
+                policy.add_rule(PrefixRule {
+                    pattern: PrefixPattern {
+                        first: Arc::from(head.as_str()),
+                        rest: rest.clone(),
+                    },
+                    decision,
+                    justification: rule.justification.clone(),
+                });
+            }
+        }
+        Ok(policy)
+    }
+}
+
+fn parse_requirements_pattern_token(
+    rule_index: usize,
+    token_index: usize,
+    token: &RequirementsPatternTokenToml,
+) -> anyhow::Result<PatternToken> {
+    match (&token.token, &token.any_of) {
+        (Some(single), None) => {
+            if single.trim().is_empty() {
+                return Err(anyhow!(
+                    "rules.prefix_rules[{rule_index}].pattern[{token_index}].token cannot be empty"
+                ));
+            }
+            Ok(PatternToken::Single(single.clone()))
+        }
+        (None, Some(alternatives)) => {
+            if alternatives.is_empty() {
+                return Err(anyhow!(
+                    "rules.prefix_rules[{rule_index}].pattern[{token_index}].any_of cannot be empty"
+                ));
+            }
+            if alternatives.iter().any(|alternative| alternative.trim().is_empty()) {
+                return Err(anyhow!(
+                    "rules.prefix_rules[{rule_index}].pattern[{token_index}].any_of cannot include empty tokens"
+                ));
+            }
+            Ok(PatternToken::Alts(alternatives.clone()))
+        }
+        (Some(_), Some(_)) => Err(anyhow!(
+            "rules.prefix_rules[{rule_index}].pattern[{token_index}] must set either token or any_of, not both"
+        )),
+        (None, None) => Err(anyhow!(
+            "rules.prefix_rules[{rule_index}].pattern[{token_index}] must set token or any_of"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_supports_prefix_rule_and_matches_command() -> anyhow::Result<()> {
+        let mut parser = ExecPolicyParser::new();
+        parser.parse(
+            "inline",
+            r#"
+prefix_rule(
+  pattern = ["git", ["push", "pull"]],
+  decision = "prompt",
+  justification = "needs approval",
+  match = ["git push"],
+  not_match = ["git status"],
+)
+"#,
+        )?;
+        let policy = parser.build();
+        let result = policy.check_command(
+            &["git".to_string(), "push".to_string()],
+            &MatchOptions::default(),
+        );
+        assert_eq!(result.decision, Some(ExecDecision::Prompt));
+        assert_eq!(result.matched_rules.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn parser_validates_negative_examples() {
+        let mut parser = ExecPolicyParser::new();
+        let result = parser.parse(
+            "inline",
+            r#"
+prefix_rule(
+  pattern = ["git", "push"],
+  decision = "prompt",
+  not_match = ["git push"],
+)
+"#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn host_executable_resolution_respects_declared_paths() -> anyhow::Result<()> {
+        let mut parser = ExecPolicyParser::new();
+        parser.parse(
+            "inline",
+            r#"
+prefix_rule(pattern = ["git", "status"], decision = "allow")
+host_executable(name = "git", paths = ["/usr/bin/git"])
+"#,
+        )?;
+        let policy = parser.build();
+
+        let matched = policy.check_command(
+            &[
+                "/usr/bin/git".to_string(),
+                "status".to_string(),
+                "--short".to_string(),
+            ],
+            &MatchOptions {
+                resolve_host_executables: true,
+            },
+        );
+        assert_eq!(matched.decision, Some(ExecDecision::Allow));
+        assert_eq!(matched.matched_rules.len(), 1);
+
+        let unmatched = policy.check_command(
+            &[
+                "/opt/homebrew/bin/git".to_string(),
+                "status".to_string(),
+                "--short".to_string(),
+            ],
+            &MatchOptions {
+                resolve_host_executables: true,
+            },
+        );
+        assert!(unmatched.matched_rules.is_empty());
+        assert_eq!(unmatched.decision, None);
+        Ok(())
+    }
+
+    #[test]
+    fn requirements_toml_converts_to_policy() -> anyhow::Result<()> {
+        let requirements: RequirementsToml = toml::from_str(
+            r#"
+[rules]
+[[rules.prefix_rules]]
+pattern = [{ token = "rm" }, { token = "-rf" }]
+decision = "forbidden"
+justification = "destructive"
+"#,
+        )?;
+        let policy = requirements.to_policy()?;
+        let result = policy.check_command(
+            &["rm".to_string(), "-rf".to_string(), "/tmp".to_string()],
+            &MatchOptions::default(),
+        );
+        assert_eq!(result.decision, Some(ExecDecision::Forbidden));
+        Ok(())
+    }
+
+    #[test]
+    fn requirements_disallow_allow_decision() -> anyhow::Result<()> {
+        let requirements: RequirementsToml = toml::from_str(
+            r#"
+[rules]
+[[rules.prefix_rules]]
+pattern = [{ token = "echo" }]
+decision = "allow"
+"#,
+        )?;
+        assert!(requirements.to_policy().is_err());
+        Ok(())
+    }
+}

--- a/crates/harness-rules/src/lib.rs
+++ b/crates/harness-rules/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod engine;
+pub mod exec_policy;
 pub mod scanner;
 
 pub use engine::RuleEngine;

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -96,6 +96,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     rule_engine.configure_sources(
         server.config.rules.discovery_paths.clone(),
         server.config.rules.builtin_path.clone(),
+        server.config.rules.requirements_path.clone(),
     );
     if let Err(e) = rule_engine.load_builtin() {
         tracing::warn!("failed to load builtin rules: {e}");
@@ -172,7 +173,10 @@ fn resolve_reviewer(
     registry: &harness_agents::AgentRegistry,
     config: &harness_core::AgentReviewConfig,
     implementor_name: &str,
-) -> (Option<Arc<dyn harness_core::CodeAgent>>, harness_core::AgentReviewConfig) {
+) -> (
+    Option<Arc<dyn harness_core::CodeAgent>>,
+    harness_core::AgentReviewConfig,
+) {
     if !config.enabled {
         return (None, config.clone());
     }
@@ -294,8 +298,11 @@ async fn create_task(
         }
     };
 
-    let (reviewer, review_config) =
-        resolve_reviewer(&state.server.agent_registry, &state.server.config.agents.review, agent.name());
+    let (reviewer, review_config) = resolve_reviewer(
+        &state.server.agent_registry,
+        &state.server.config.agents.review,
+        agent.name(),
+    );
 
     let task_id = task_runner::spawn_task(
         state.tasks.clone(),


### PR DESCRIPTION
## Summary
- add a Starlark-based execpolicy engine with `prefix_rule()` and `host_executable()` support
- add `harness execpolicy check` for offline command-policy evaluation
- add `requirements.toml` ingestion for org-level enforcement and wire config fields

## Validation
- cargo check
- cargo test
- cargo run -p harness-cli -- execpolicy check --rules .tmp.policy.star git status
- cargo run -p harness-cli -- execpolicy check --rules .tmp.policy.star --requirements .tmp.requirements.toml rm -rf /tmp/safe-check

Closes #114
