### PR TITLE
feat: add native OTLP OpenTelemetry export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,22 +138,50 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
- "base64",
+ "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -141,13 +191,30 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.28.0",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -158,16 +225,22 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -180,6 +253,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -357,6 +436,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -711,6 +799,25 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -720,8 +827,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -735,10 +842,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "harness-core",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -777,7 +884,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "uuid",
@@ -792,7 +899,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -809,7 +916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -822,11 +929,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "harness-core",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -841,7 +951,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -856,7 +966,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -867,7 +977,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "dashmap",
  "futures",
@@ -884,11 +994,11 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "uuid",
@@ -905,10 +1015,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -983,6 +1099,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -993,12 +1120,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1009,8 +1147,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1028,6 +1166,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1036,9 +1198,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1055,14 +1217,26 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1073,7 +1247,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1087,19 +1261,19 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.2",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1240,6 +1414,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1271,6 +1455,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1321,7 +1514,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1373,6 +1566,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1503,7 +1702,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1539,6 +1738,105 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest 0.11.27",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.11.27",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1584,6 +1882,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1668,6 +1986,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,7 +2088,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1756,7 +2097,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1778,20 +2119,56 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -1805,11 +2182,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1859,7 +2236,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1932,7 +2309,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2036,7 +2413,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -2117,6 +2494,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2163,7 +2550,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -2176,7 +2563,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -2185,7 +2572,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2238,8 +2625,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2269,7 +2656,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2282,8 +2669,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2308,7 +2695,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2334,7 +2721,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2382,6 +2769,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2402,13 +2795,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2436,11 +2850,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2500,9 +2934,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2611,7 +3055,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2626,6 +3070,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,7 +3125,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2647,14 +3138,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2761,12 +3252,12 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2778,12 +3269,12 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2849,6 +3340,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -3013,7 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3037,9 +3534,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3365,6 +3862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,7 +3899,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3422,8 +3929,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -3442,7 +3949,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ dashmap = "6"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+opentelemetry = { version = "0.22", features = ["trace", "metrics", "logs"] }
+opentelemetry_sdk = { version = "0.22", features = ["trace", "metrics", "logs", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.15", features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-client"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/config/default.toml
+++ b/config/default.toml
@@ -52,3 +52,8 @@ discovery_paths = []
 db_path = "~/.local/share/harness/harness.db"
 session_renewal_secs = 1800
 log_retention_days = 90
+
+[otel]
+environment = "development"
+exporter = "disabled"
+log_user_prompt = false

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -311,10 +311,11 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     engine.load(&project)?;
                     let violations = engine.scan(&project).await?;
                     // Persist rule scan results for observability/GC even when running via CLI.
-                    match harness_observe::EventStore::with_policies(
+                    match harness_observe::EventStore::with_policies_and_otel(
                         &config.server.data_dir,
                         config.observe.session_renewal_secs,
                         config.observe.log_retention_days,
+                        &config.otel,
                     ) {
                         Ok(store) => {
                             store.persist_rule_scan(&project, &violations);

--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -17,7 +17,12 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
             };
             let project = Project::from_path(project_root);
 
-            let event_store = EventStore::new(data_dir)?;
+            let event_store = EventStore::with_policies_and_otel(
+                data_dir,
+                config.observe.session_renewal_secs,
+                config.observe.log_retention_days,
+                &config.otel,
+            )?;
             let events = event_store.query(&EventFilters::default())?;
 
             let thresholds = map_thresholds(&config.gc.signal_thresholds);

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -9,6 +9,7 @@ pub struct HarnessConfig {
     pub gc: GcConfig,
     pub rules: RulesConfig,
     pub observe: ObserveConfig,
+    pub otel: OtelConfig,
 }
 
 impl Default for HarnessConfig {
@@ -19,6 +20,7 @@ impl Default for HarnessConfig {
             gc: GcConfig::default(),
             rules: RulesConfig::default(),
             observe: ObserveConfig::default(),
+            otel: OtelConfig::default(),
         }
     }
 }
@@ -280,6 +282,44 @@ impl Default for ObserveConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OtelConfig {
+    #[serde(default = "default_otel_environment")]
+    pub environment: String,
+    #[serde(default)]
+    pub exporter: OtelExporter,
+    #[serde(default)]
+    pub log_user_prompt: bool,
+}
+
+impl Default for OtelConfig {
+    fn default() -> Self {
+        Self {
+            environment: default_otel_environment(),
+            exporter: OtelExporter::default(),
+            log_user_prompt: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OtelExporter {
+    Disabled,
+    OtlpHttp,
+    OtlpGrpc,
+}
+
+impl Default for OtelExporter {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
+fn default_otel_environment() -> String {
+    "development".to_string()
+}
+
 fn dirs_data_dir() -> PathBuf {
     dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."))
 }
@@ -434,5 +474,66 @@ mod tests {
         "#;
         let config: AnthropicApiConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.max_tokens, default_anthropic_api_max_tokens());
+    }
+
+    #[test]
+    fn otel_config_defaults_to_disabled_exporter() {
+        let config = OtelConfig::default();
+        assert_eq!(config.exporter, OtelExporter::Disabled);
+        assert!(!config.log_user_prompt);
+        assert_eq!(config.environment, "development");
+    }
+
+    #[test]
+    fn harness_config_deserializes_otel_section() {
+        let toml_str = r#"
+            [server]
+            transport = "stdio"
+            http_addr = "127.0.0.1:9800"
+            data_dir = "."
+            project_root = "."
+
+            [agents]
+            default_agent = "claude"
+            [agents.claude]
+            cli_path = "claude"
+            default_model = "sonnet"
+            [agents.codex]
+            cli_path = "codex"
+            [agents.anthropic_api]
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+
+            [gc]
+            max_drafts_per_run = 5
+            budget_per_signal_usd = 0.5
+            total_budget_usd = 5.0
+            [gc.signal_thresholds]
+            repeated_warn_min = 10
+            chronic_block_min = 5
+            hot_file_edits_min = 20
+            slow_op_threshold_ms = 5000
+            slow_op_count_min = 10
+            escalation_ratio = 1.5
+            violation_min = 5
+
+            [rules]
+            discovery_paths = []
+
+            [observe]
+            db_path = "."
+            session_renewal_secs = 1800
+            log_retention_days = 90
+
+            [otel]
+            environment = "staging"
+            exporter = "otlp-http"
+            log_user_prompt = true
+        "#;
+
+        let config: HarnessConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.otel.environment, "staging");
+        assert_eq!(config.otel.exporter, OtelExporter::OtlpHttp);
+        assert!(config.otel.log_user_prompt);
     }
 }

--- a/crates/harness-observe/Cargo.toml
+++ b/crates/harness-observe/Cargo.toml
@@ -14,6 +14,9 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -1,9 +1,12 @@
-use harness_core::{Decision, Event, EventFilters, EventId, SessionId, Severity, Violation};
+use harness_core::{
+    Decision, Event, EventFilters, EventId, OtelConfig, SessionId, Severity, Violation,
+};
 use std::path::{Path, PathBuf};
 
 /// Event store backed by JSONL files (SQLite upgrade path available).
 pub struct EventStore {
     data_dir: PathBuf,
+    otel_pipeline: Option<crate::otel_export::OtelPipeline>,
 }
 
 impl EventStore {
@@ -11,15 +14,40 @@ impl EventStore {
         std::fs::create_dir_all(data_dir)?;
         Ok(Self {
             data_dir: data_dir.to_path_buf(),
+            otel_pipeline: None,
         })
     }
 
     pub fn with_policies(
         data_dir: &Path,
+        session_renewal_secs: u64,
+        log_retention_days: u32,
+    ) -> anyhow::Result<Self> {
+        Self::with_policies_and_otel(
+            data_dir,
+            session_renewal_secs,
+            log_retention_days,
+            &OtelConfig::default(),
+        )
+    }
+
+    pub fn with_policies_and_otel(
+        data_dir: &Path,
         _session_renewal_secs: u64,
         _log_retention_days: u32,
+        otel_config: &OtelConfig,
     ) -> anyhow::Result<Self> {
-        Self::new(data_dir)
+        let mut store = Self::new(data_dir)?;
+        store.otel_pipeline = match crate::otel_export::OtelPipeline::from_config(otel_config) {
+            Ok(pipeline) => pipeline,
+            Err(err) => {
+                tracing::warn!(
+                    "OpenTelemetry initialization failed; continuing without export: {err}"
+                );
+                None
+            }
+        };
+        Ok(store)
     }
 
     fn events_file(&self) -> PathBuf {
@@ -34,6 +62,9 @@ impl EventStore {
             .open(self.events_file())?;
         let line = serde_json::to_string(event)?;
         writeln!(file, "{line}")?;
+        if let Some(pipeline) = &self.otel_pipeline {
+            pipeline.record_event(event);
+        }
         Ok(event.id.clone())
     }
 

--- a/crates/harness-observe/src/lib.rs
+++ b/crates/harness-observe/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod event_store;
 pub mod health;
+mod otel_export;
 pub mod quality;
 pub mod stats;
 

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -1,0 +1,367 @@
+use harness_core::{Decision, Event, OtelConfig, OtelExporter};
+use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider as _, Severity};
+use opentelemetry::metrics::{Counter, Histogram, MeterProvider as _};
+use opentelemetry::trace::{Span, Tracer, TracerProvider as _};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::logs::LoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::Resource;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+const SERVICE_NAME: &str = "harness-observe";
+const DEFAULT_HTTP_ENDPOINT: &str = "http://127.0.0.1:4318";
+const DEFAULT_GRPC_ENDPOINT: &str = "http://127.0.0.1:4317";
+
+pub struct OtelPipeline {
+    log_user_prompt: bool,
+    seen_sessions: Mutex<HashSet<String>>,
+    tracer_provider: opentelemetry_sdk::trace::TracerProvider,
+    tracer: opentelemetry_sdk::trace::Tracer,
+    logger_provider: LoggerProvider,
+    logger: opentelemetry_sdk::logs::Logger,
+    meter_provider: SdkMeterProvider,
+    conversation_starts_total: Counter<u64>,
+    api_request_total: Counter<u64>,
+    tool_decision_total: Counter<u64>,
+    tool_execution_duration_ms: Histogram<u64>,
+}
+
+impl OtelPipeline {
+    pub fn from_config(config: &OtelConfig) -> anyhow::Result<Option<Self>> {
+        if config.exporter == OtelExporter::Disabled {
+            return Ok(None);
+        }
+
+        let resource = Resource::new(vec![
+            KeyValue::new("service.name", SERVICE_NAME),
+            KeyValue::new("deployment.environment", config.environment.clone()),
+        ]);
+
+        let tracer_provider = build_tracer_provider(config.exporter, resource.clone())?;
+        let tracer = tracer_provider.tracer(SERVICE_NAME);
+        let logger_provider = build_logger_provider(config.exporter, resource.clone())?;
+        let logger = logger_provider.logger(SERVICE_NAME);
+        let meter_provider = build_meter_provider(config.exporter, resource)?;
+        let meter = meter_provider.meter(SERVICE_NAME);
+        let conversation_starts_total = meter
+            .u64_counter("harness.conversation_starts.total")
+            .with_description("Number of distinct conversation starts by session.")
+            .init();
+        let api_request_total = meter
+            .u64_counter("harness.api_request.total")
+            .with_description("Number of API request-like events.")
+            .init();
+        let tool_decision_total = meter
+            .u64_counter("harness.tool_decision.total")
+            .with_description("Number of tool decision events.")
+            .init();
+        let tool_execution_duration_ms = meter
+            .u64_histogram("harness.tool_execution.duration_ms")
+            .with_description("Tool execution duration in milliseconds.")
+            .init();
+
+        Ok(Some(Self {
+            log_user_prompt: config.log_user_prompt,
+            seen_sessions: Mutex::new(HashSet::new()),
+            tracer_provider,
+            tracer,
+            logger_provider,
+            logger,
+            meter_provider,
+            conversation_starts_total,
+            api_request_total,
+            tool_decision_total,
+            tool_execution_duration_ms,
+        }))
+    }
+
+    pub fn record_event(&self, event: &Event) {
+        let attrs = self.base_attributes(event);
+        self.tool_decision_total.add(1, &attrs);
+        self.emit_trace("tool_decision", event, &attrs);
+        self.emit_log("tool_decision", event, &attrs);
+
+        if self.mark_conversation_started(event) {
+            self.conversation_starts_total.add(1, &attrs);
+            self.emit_trace("conversation_starts", event, &attrs);
+            self.emit_log("conversation_starts", event, &attrs);
+        }
+
+        if is_api_request_event(event) {
+            self.api_request_total.add(1, &attrs);
+            self.emit_trace("api_request", event, &attrs);
+            self.emit_log("api_request", event, &attrs);
+        }
+
+        if let Some(duration_ms) = event.duration_ms {
+            self.tool_execution_duration_ms.record(duration_ms, &attrs);
+            let mut execution_attrs = attrs.clone();
+            execution_attrs.push(KeyValue::new("duration_ms", duration_ms as i64));
+            self.emit_trace("tool_execution", event, &execution_attrs);
+            self.emit_log("tool_execution", event, &execution_attrs);
+        }
+    }
+
+    fn mark_conversation_started(&self, event: &Event) -> bool {
+        match self.seen_sessions.lock() {
+            Ok(mut sessions) => sessions.insert(event.session_id.as_str().to_string()),
+            Err(_) => false,
+        }
+    }
+
+    fn base_attributes(&self, event: &Event) -> Vec<KeyValue> {
+        let mut attrs = vec![
+            KeyValue::new("event.id", event.id.as_str().to_string()),
+            KeyValue::new("event.session_id", event.session_id.as_str().to_string()),
+            KeyValue::new("event.hook", event.hook.clone()),
+            KeyValue::new("event.tool", event.tool.clone()),
+            KeyValue::new("event.decision", decision_label(event.decision)),
+        ];
+
+        if self.log_user_prompt || !looks_like_user_prompt_payload(event) {
+            if let Some(reason) = &event.reason {
+                attrs.push(KeyValue::new("event.reason", reason.clone()));
+            }
+            if let Some(detail) = &event.detail {
+                attrs.push(KeyValue::new("event.detail", detail.clone()));
+            }
+        }
+
+        attrs
+    }
+
+    fn emit_trace(&self, name: &str, event: &Event, attrs: &[KeyValue]) {
+        let mut span = self.tracer.start(name.to_string());
+        span.set_attribute(KeyValue::new("event.timestamp", event.ts.to_rfc3339()));
+        for attr in attrs {
+            span.set_attribute(attr.clone());
+        }
+        span.end();
+    }
+
+    fn emit_log(&self, name: &str, event: &Event, attrs: &[KeyValue]) {
+        let timestamp = std::time::SystemTime::from(event.ts);
+        let severity = severity_for_decision(event.decision);
+        let mut builder = LogRecord::builder()
+            .with_name(name.to_string().into())
+            .with_body(AnyValue::from(name.to_string()))
+            .with_timestamp(timestamp)
+            .with_severity_text(severity.name())
+            .with_severity_number(severity);
+        for attr in attrs {
+            builder = builder.with_attribute(attr.key.clone(), attr.value.clone());
+        }
+        self.logger.emit(builder.build());
+    }
+}
+
+impl Drop for OtelPipeline {
+    fn drop(&mut self) {
+        for result in self.tracer_provider.force_flush() {
+            if let Err(err) = result {
+                tracing::warn!("failed to force flush tracer provider: {err}");
+            }
+        }
+        if let Err(err) = self.meter_provider.force_flush() {
+            tracing::warn!("failed to force flush meter provider: {err}");
+        }
+        if let Err(err) = self.meter_provider.shutdown() {
+            tracing::warn!("failed to shut down meter provider: {err}");
+        }
+        for result in self.logger_provider.force_flush() {
+            if let Err(err) = result {
+                tracing::warn!("failed to force flush logger provider: {err}");
+            }
+        }
+        for result in self.logger_provider.shutdown() {
+            if let Err(err) = result {
+                tracing::warn!("failed to shut down logger provider: {err}");
+            }
+        }
+    }
+}
+
+fn build_tracer_provider(
+    exporter: OtelExporter,
+    resource: Resource,
+) -> anyhow::Result<opentelemetry_sdk::trace::TracerProvider> {
+    let span_exporter = match exporter {
+        OtelExporter::OtlpHttp => opentelemetry_otlp::new_exporter()
+            .http()
+            .with_endpoint(resolve_endpoint(exporter))
+            .build_span_exporter()?,
+        OtelExporter::OtlpGrpc => opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(resolve_endpoint(exporter))
+            .build_span_exporter()?,
+        OtelExporter::Disabled => {
+            unreachable!("disabled exporter should not initialize tracer provider")
+        }
+    };
+
+    Ok(opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_config(opentelemetry_sdk::trace::config().with_resource(resource))
+        .with_batch_exporter(span_exporter, opentelemetry_sdk::runtime::Tokio)
+        .build())
+}
+
+fn build_logger_provider(
+    exporter: OtelExporter,
+    resource: Resource,
+) -> anyhow::Result<LoggerProvider> {
+    let log_exporter = match exporter {
+        OtelExporter::OtlpHttp => opentelemetry_otlp::new_exporter()
+            .http()
+            .with_endpoint(resolve_endpoint(exporter))
+            .build_log_exporter()?,
+        OtelExporter::OtlpGrpc => opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(resolve_endpoint(exporter))
+            .build_log_exporter()?,
+        OtelExporter::Disabled => {
+            unreachable!("disabled exporter should not initialize logger provider")
+        }
+    };
+
+    let batch_processor = opentelemetry_sdk::logs::BatchLogProcessor::builder(
+        log_exporter,
+        opentelemetry_sdk::runtime::Tokio,
+    )
+    .build();
+    Ok(opentelemetry_sdk::logs::LoggerProvider::builder()
+        .with_config(opentelemetry_sdk::logs::Config::default().with_resource(resource))
+        .with_log_processor(batch_processor)
+        .build())
+}
+
+fn build_meter_provider(
+    exporter: OtelExporter,
+    resource: Resource,
+) -> anyhow::Result<SdkMeterProvider> {
+    let metrics_pipeline = opentelemetry_otlp::new_pipeline()
+        .metrics(opentelemetry_sdk::runtime::Tokio)
+        .with_resource(resource);
+
+    let meter_provider = match exporter {
+        OtelExporter::OtlpHttp => metrics_pipeline
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .http()
+                    .with_endpoint(resolve_endpoint(exporter)),
+            )
+            .build()?,
+        OtelExporter::OtlpGrpc => metrics_pipeline
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(resolve_endpoint(exporter)),
+            )
+            .build()?,
+        OtelExporter::Disabled => {
+            unreachable!("disabled exporter should not initialize meter provider")
+        }
+    };
+
+    Ok(meter_provider)
+}
+
+fn resolve_endpoint(exporter: OtelExporter) -> String {
+    if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        if !endpoint.trim().is_empty() {
+            return endpoint;
+        }
+    }
+
+    match exporter {
+        OtelExporter::OtlpHttp => DEFAULT_HTTP_ENDPOINT.to_string(),
+        OtelExporter::OtlpGrpc => DEFAULT_GRPC_ENDPOINT.to_string(),
+        OtelExporter::Disabled => String::new(),
+    }
+}
+
+fn is_api_request_event(event: &Event) -> bool {
+    let hook = event.hook.to_ascii_lowercase();
+    let tool = event.tool.to_ascii_lowercase();
+    hook.contains("api")
+        || hook.contains("http")
+        || hook.contains("request")
+        || tool.contains("api")
+        || tool.contains("http")
+        || tool.contains("request")
+}
+
+fn looks_like_user_prompt_payload(event: &Event) -> bool {
+    let hook = event.hook.to_ascii_lowercase();
+    let tool = event.tool.to_ascii_lowercase();
+    hook.contains("conversation")
+        || hook.contains("prompt")
+        || tool.contains("conversation")
+        || tool.contains("prompt")
+}
+
+fn decision_label(decision: Decision) -> &'static str {
+    match decision {
+        Decision::Pass => "pass",
+        Decision::Warn => "warn",
+        Decision::Block => "block",
+        Decision::Gate => "gate",
+        Decision::Escalate => "escalate",
+        Decision::Complete => "complete",
+    }
+}
+
+fn severity_for_decision(decision: Decision) -> Severity {
+    match decision {
+        Decision::Pass | Decision::Complete => Severity::Info,
+        Decision::Warn => Severity::Warn,
+        Decision::Block | Decision::Gate | Decision::Escalate => Severity::Error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{Decision, Event, SessionId};
+
+    fn event_with(hook: &str, tool: &str) -> Event {
+        Event::new(SessionId::new(), hook, tool, Decision::Pass)
+    }
+
+    #[test]
+    fn api_request_classifier_matches_common_markers() {
+        assert!(is_api_request_event(&event_with("api_call", "tool")));
+        assert!(is_api_request_event(&event_with("hook", "http_client")));
+        assert!(!is_api_request_event(&event_with(
+            "rule_scan",
+            "RuleEngine"
+        )));
+    }
+
+    #[test]
+    fn user_prompt_payload_classifier_matches_prompt_markers() {
+        assert!(looks_like_user_prompt_payload(&event_with(
+            "conversation_start",
+            "task_runner"
+        )));
+        assert!(looks_like_user_prompt_payload(&event_with(
+            "hook",
+            "user_prompt_tool"
+        )));
+        assert!(!looks_like_user_prompt_payload(&event_with(
+            "rule_check",
+            "RuleEngine"
+        )));
+    }
+
+    #[test]
+    fn from_config_returns_none_when_disabled() -> anyhow::Result<()> {
+        let config = OtelConfig {
+            exporter: OtelExporter::Disabled,
+            ..OtelConfig::default()
+        };
+        assert!(OtelPipeline::from_config(&config)?.is_none());
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -101,10 +101,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         tracing::warn!("failed to load builtin rules: {e}");
     }
 
-    let events = Arc::new(harness_observe::EventStore::with_policies(
+    let events = Arc::new(harness_observe::EventStore::with_policies_and_otel(
         &dir,
         server.config.observe.session_renewal_secs,
         server.config.observe.log_retention_days,
+        &server.config.otel,
     )?);
 
     let signal_detector = harness_gc::SignalDetector::new(


### PR DESCRIPTION
## Summary
- add `[otel]` config with `environment`, `exporter`, and `log_user_prompt`
- add a native OTLP export pipeline in `harness-observe` for traces, metrics, and logs
- support both `otlp-http` and `otlp-grpc` exporter modes
- wire server and CLI `EventStore` initialization to pass OTEL config
- keep export asynchronous via SDK batch processors and flush providers on shutdown

## Exported signals
- `conversation_starts`
- `api_request`
- `tool_decision`
- `tool_execution` duration metrics

## Validation
- `cargo check`
- `cargo test -p harness-core`
- `cargo test -p harness-observe`
- `cargo test -p harness-server`
- `cargo test`

Closes #115
