### PR TITLE
FUT-81: implement hardened CI/CD harness GitHub Action

### DIFF
--- a/.github/actions/harness-action/action.yml
+++ b/.github/actions/harness-action/action.yml
@@ -1,0 +1,172 @@
+name: Harness Action
+description: Install Harness CLI, run `harness exec`, and expose final message output.
+
+inputs:
+  prompt:
+    description: Prompt passed to `harness exec`
+    required: true
+  sandbox-mode:
+    description: Sandbox mode hint (read-only, workspace-write, danger-full-access)
+    required: false
+    default: workspace-write
+  model:
+    description: Optional model override
+    required: false
+    default: ""
+  output-file:
+    description: File path for final harness output
+    required: false
+    default: .harness/final-message.txt
+  drop-sudo:
+    description: Reject sudo/root execution by default
+    required: false
+    default: "true"
+  unprivileged-user:
+    description: Required local user when privilege checks are enabled
+    required: false
+    default: runner
+  allow-users:
+    description: Comma-separated allow list for human GitHub actors
+    required: false
+    default: ""
+  allow-bots:
+    description: Comma-separated allow list for bot GitHub actors
+    required: false
+    default: ""
+
+outputs:
+  final-message:
+    description: Final message emitted by `harness exec`
+    value: ${{ steps.export.outputs.final-message }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install Harness CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        workspace_root="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+        cargo install --locked --path "${workspace_root}/crates/harness-cli" --force
+
+    - name: Run harness exec
+      shell: bash
+      env:
+        INPUT_PROMPT: ${{ inputs.prompt }}
+        INPUT_SANDBOX_MODE: ${{ inputs.sandbox-mode }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
+        INPUT_DROP_SUDO: ${{ inputs.drop-sudo }}
+        INPUT_UNPRIVILEGED_USER: ${{ inputs.unprivileged-user }}
+        INPUT_ALLOW_USERS: ${{ inputs.allow-users }}
+        INPUT_ALLOW_BOTS: ${{ inputs.allow-bots }}
+      run: |
+        set -euo pipefail
+        workspace_root="$(realpath -m "${GITHUB_WORKSPACE}")"
+
+        if [[ -z "${INPUT_OUTPUT_FILE}" ]]; then
+          echo "::error::output-file input must not be empty."
+          exit 1
+        fi
+
+        if [[ "${INPUT_OUTPUT_FILE}" = /* ]]; then
+          resolved_output="$(realpath -m "${INPUT_OUTPUT_FILE}")"
+        else
+          resolved_output="$(realpath -m "${workspace_root}/${INPUT_OUTPUT_FILE}")"
+        fi
+
+        case "${resolved_output}" in
+          "${workspace_root}"/*) ;;
+          *)
+            echo "::error::output-file must stay within GITHUB_WORKSPACE (${workspace_root})."
+            exit 1
+            ;;
+        esac
+
+        relative_output="${resolved_output#${workspace_root}/}"
+        if [[ -z "${relative_output}" || "${relative_output}" == "${resolved_output}" ]]; then
+          echo "::error::output-file must resolve to a file path under GITHUB_WORKSPACE."
+          exit 1
+        fi
+
+        exec_args=(
+          exec
+          "${INPUT_PROMPT}"
+          --project "${GITHUB_WORKSPACE}"
+          --sandbox-mode "${INPUT_SANDBOX_MODE}"
+          --output-file "${relative_output}"
+          --actor "${GITHUB_ACTOR}"
+          --unprivileged-user "${INPUT_UNPRIVILEGED_USER}"
+        )
+
+        if [[ -n "${INPUT_MODEL}" ]]; then
+          exec_args+=(--model "${INPUT_MODEL}")
+        fi
+
+        if [[ -n "${INPUT_ALLOW_USERS}" ]]; then
+          exec_args+=(--allow-users "${INPUT_ALLOW_USERS}")
+        fi
+
+        if [[ -n "${INPUT_ALLOW_BOTS}" ]]; then
+          exec_args+=(--allow-bots "${INPUT_ALLOW_BOTS}")
+        fi
+
+        if [[ "${INPUT_DROP_SUDO}" == "false" ]]; then
+          exec_args+=(--drop-sudo=false)
+        fi
+
+        if [[ "${INPUT_DROP_SUDO}" == "true" && "${EUID}" -eq 0 ]]; then
+          if [[ -z "${INPUT_UNPRIVILEGED_USER}" ]]; then
+            echo "::error::drop-sudo is enabled, but no unprivileged-user was provided."
+            exit 1
+          fi
+          if ! command -v sudo >/dev/null 2>&1; then
+            echo "::error::drop-sudo is enabled but sudo is unavailable on this runner."
+            exit 1
+          fi
+          if ! id "${INPUT_UNPRIVILEGED_USER}" >/dev/null 2>&1; then
+            echo "::error::unprivileged-user '${INPUT_UNPRIVILEGED_USER}' does not exist."
+            exit 1
+          fi
+          sudo -u "${INPUT_UNPRIVILEGED_USER}" --preserve-env=GITHUB_ACTOR,HOME,PATH harness "${exec_args[@]}"
+        else
+          harness "${exec_args[@]}"
+        fi
+
+    - name: Export final message
+      id: export
+      shell: bash
+      env:
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        workspace_root="$(realpath -m "${GITHUB_WORKSPACE}")"
+
+        if [[ "${INPUT_OUTPUT_FILE}" = /* ]]; then
+          resolved_output="$(realpath -m "${INPUT_OUTPUT_FILE}")"
+        else
+          resolved_output="$(realpath -m "${workspace_root}/${INPUT_OUTPUT_FILE}")"
+        fi
+
+        case "${resolved_output}" in
+          "${workspace_root}"/*) ;;
+          *)
+            echo "::error::output-file must stay within GITHUB_WORKSPACE (${workspace_root})."
+            exit 1
+            ;;
+        esac
+
+        if [[ ! -f "${resolved_output}" ]]; then
+          echo "::error::Expected harness output file '${resolved_output}' was not generated."
+          exit 1
+        fi
+
+        delimiter="HARNESS_OUTPUT_$(openssl rand -hex 8)"
+        {
+          echo "final-message<<${delimiter}"
+          cat "${resolved_output}"
+          echo "${delimiter}"
+        } >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/harness-pr.yml
+++ b/.github/workflows/harness-pr.yml
@@ -1,0 +1,55 @@
+name: Harness PR Pipeline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  harness-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Skip when disabled or draft
+        if: ${{ !(vars.HARNESS_ACTION_ENABLED == 'true' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false) }}
+        run: echo "Harness action is disabled, PR is draft, or PR is from a fork; skipping run."
+
+      - name: Run harness action
+        id: harness
+        if: ${{ vars.HARNESS_ACTION_ENABLED == 'true' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false }}
+        uses: ./.github/actions/harness-action
+        with:
+          prompt: >-
+            Review this pull request and return a concise summary of key changes,
+            risks, and any required follow-up checks.
+          sandbox-mode: workspace-write
+          output-file: .harness/pr-final-message.txt
+          allow-users: ${{ github.actor }}
+          allow-bots: "dependabot[bot],renovate[bot]"
+
+      - name: Comment harness result on PR
+        if: ${{ vars.HARNESS_ACTION_ENABLED == 'true' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false }}
+        uses: actions/github-script@v7
+        env:
+          FINAL_MESSAGE: ${{ steps.harness.outputs.final-message }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = (process.env.FINAL_MESSAGE || "").trim();
+            if (!body) {
+              core.setFailed("harness-action output `final-message` is empty.");
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Harness CI/CD Result\n\n${body}`,
+            });

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "harness-rules",
  "harness-server",
  "harness-skills",
+ "libc",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -26,3 +26,4 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
+libc = "0.2"

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
-use clap::{Args, Parser, Subcommand};
-use std::path::PathBuf;
+use clap::{ArgAction, Args, Parser, Subcommand};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Parser)]
@@ -42,6 +42,30 @@ pub enum Command {
         /// Agent to use
         #[arg(long, default_value = "claude")]
         agent: String,
+        /// Optional model override
+        #[arg(long)]
+        model: Option<String>,
+        /// Sandbox mode hint injected into the exec prompt
+        #[arg(long, default_value = "workspace-write")]
+        sandbox_mode: String,
+        /// Optional output file for final response
+        #[arg(long)]
+        output_file: Option<PathBuf>,
+        /// Refuse execution from sudo/root context by default
+        #[arg(long, default_value_t = true, action = ArgAction::Set)]
+        drop_sudo: bool,
+        /// Require this local OS user for execution
+        #[arg(long)]
+        unprivileged_user: Option<String>,
+        /// Allowed human GitHub actors (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        allow_users: Vec<String>,
+        /// Allowed bot GitHub actors (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        allow_bots: Vec<String>,
+        /// GitHub actor identity used with allow lists
+        #[arg(long)]
+        actor: Option<String>,
     },
 
     /// GC Agent commands
@@ -212,6 +236,226 @@ where
     project_root
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExecSandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl ExecSandboxMode {
+    fn parse(input: &str) -> anyhow::Result<Self> {
+        match input {
+            "read-only" => Ok(Self::ReadOnly),
+            "workspace-write" => Ok(Self::WorkspaceWrite),
+            "danger-full-access" => Ok(Self::DangerFullAccess),
+            other => anyhow::bail!(
+                "unsupported sandbox mode `{other}`; expected one of: read-only, workspace-write, danger-full-access"
+            ),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::WorkspaceWrite => "workspace-write",
+            Self::DangerFullAccess => "danger-full-access",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GitHubActorKind {
+    User,
+    Bot,
+}
+
+fn classify_github_actor(actor: &str) -> GitHubActorKind {
+    if actor.ends_with("[bot]") {
+        GitHubActorKind::Bot
+    } else {
+        GitHubActorKind::User
+    }
+}
+
+fn normalize_allow_list(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn allow_list_matches(list: &[String], actor: &str) -> bool {
+    list.iter().any(|entry| entry == "*" || entry == actor)
+}
+
+fn resolve_exec_actor(actor: Option<String>) -> Option<String> {
+    actor
+        .or_else(|| std::env::var("GITHUB_ACTOR").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn enforce_exec_actor_filters(
+    actor: Option<String>,
+    allow_users: &[String],
+    allow_bots: &[String],
+) -> anyhow::Result<()> {
+    if allow_users.is_empty() && allow_bots.is_empty() {
+        return Ok(());
+    }
+
+    let actor = resolve_exec_actor(actor).ok_or_else(|| {
+        anyhow::anyhow!(
+            "allow lists are configured but no actor identity was provided; pass --actor or set GITHUB_ACTOR"
+        )
+    })?;
+
+    let allowed = match classify_github_actor(&actor) {
+        GitHubActorKind::User => allow_list_matches(allow_users, &actor),
+        GitHubActorKind::Bot => allow_list_matches(allow_bots, &actor),
+    };
+
+    if !allowed {
+        anyhow::bail!("actor `{actor}` is not allowed to run `harness exec`");
+    }
+
+    Ok(())
+}
+
+fn current_username() -> Option<String> {
+    std::env::var("USER")
+        .ok()
+        .or_else(|| std::env::var("LOGNAME").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn effective_uid_is_root() -> bool {
+    #[cfg(unix)]
+    {
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+fn detect_sudo_environment() -> bool {
+    std::env::var_os("SUDO_UID").is_some() || std::env::var_os("SUDO_USER").is_some()
+}
+
+fn enforce_exec_privilege_policy_with<IsRootFn, HasSudoEnvFn>(
+    drop_sudo: bool,
+    unprivileged_user: Option<&str>,
+    is_root_fn: IsRootFn,
+    has_sudo_env_fn: HasSudoEnvFn,
+) -> anyhow::Result<()>
+where
+    IsRootFn: FnOnce() -> bool,
+    HasSudoEnvFn: FnOnce() -> bool,
+{
+    let is_root_user = is_root_fn();
+    let has_sudo_env = has_sudo_env_fn();
+
+    if drop_sudo && (is_root_user || has_sudo_env) {
+        anyhow::bail!(
+            "refusing to run `harness exec` with elevated privileges; rerun without sudo or pass --drop-sudo=false"
+        );
+    }
+
+    if let Some(expected_user) = unprivileged_user {
+        let expected_user = expected_user.trim();
+        if !expected_user.is_empty() {
+            let current_user = current_username().ok_or_else(|| {
+                anyhow::anyhow!("unable to determine current OS user for --unprivileged-user check")
+            })?;
+            if current_user != expected_user {
+                anyhow::bail!(
+                    "`harness exec` must run as `{expected_user}`, current user is `{current_user}`"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn enforce_exec_privilege_policy(
+    drop_sudo: bool,
+    unprivileged_user: Option<&str>,
+) -> anyhow::Result<()> {
+    enforce_exec_privilege_policy_with(
+        drop_sudo,
+        unprivileged_user,
+        effective_uid_is_root,
+        detect_sudo_environment,
+    )
+}
+
+fn normalize_exec_output_path(path: &Path) -> anyhow::Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+    let mut saw_normal_component = false;
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::Normal(segment) => {
+                saw_normal_component = true;
+                normalized.push(segment);
+            }
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    anyhow::bail!("`--output-file` cannot escape the project root");
+                }
+            }
+        }
+    }
+
+    if !saw_normal_component {
+        anyhow::bail!("`--output-file` must reference a file path within project root");
+    }
+
+    Ok(normalized)
+}
+
+fn resolve_exec_output_path(project_root: &Path, output_file: &Path) -> anyhow::Result<PathBuf> {
+    let canonical_project_root = project_root.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize project root {} for --output-file validation",
+            project_root.display()
+        )
+    })?;
+
+    let candidate = if output_file.is_absolute() {
+        normalize_exec_output_path(output_file)?
+    } else {
+        normalize_exec_output_path(&canonical_project_root.join(output_file))?
+    };
+
+    if !candidate.starts_with(&canonical_project_root) {
+        anyhow::bail!(
+            "`--output-file` must stay within project root `{}`",
+            canonical_project_root.display()
+        );
+    }
+
+    Ok(candidate)
+}
+
+fn apply_sandbox_hint(prompt: String, sandbox_mode: ExecSandboxMode) -> String {
+    format!(
+        "Sandbox mode requirement for this run: `{}`.\n\n{}",
+        sandbox_mode.as_str(),
+        prompt
+    )
+}
+
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     // Load config
     let config = if let Some(config_path) = &cli.config {
@@ -274,21 +518,68 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Exec {
             prompt,
             project,
-            agent: _agent_name,
+            agent,
+            model,
+            sandbox_mode,
+            output_file,
+            drop_sudo,
+            unprivileged_user,
+            allow_users,
+            allow_bots,
+            actor,
         } => {
             let project_root = resolve_exec_project_root(project)?;
-            let agent = harness_agents::claude::ClaudeCodeAgent::new(
-                config.agents.claude.cli_path.clone(),
-                config.agents.claude.default_model.clone(),
-            );
+            let sandbox_mode = ExecSandboxMode::parse(&sandbox_mode)?;
+            let allow_users = normalize_allow_list(allow_users);
+            let allow_bots = normalize_allow_list(allow_bots);
+            let output_path = output_file
+                .as_deref()
+                .map(|path| resolve_exec_output_path(&project_root, path))
+                .transpose()?;
+
+            enforce_exec_actor_filters(actor, &allow_users, &allow_bots)?;
+            enforce_exec_privilege_policy(drop_sudo, unprivileged_user.as_deref())?;
 
             let req = harness_core::AgentRequest {
-                prompt,
-                project_root,
+                prompt: apply_sandbox_hint(prompt, sandbox_mode),
+                project_root: project_root.clone(),
+                model,
                 ..Default::default()
             };
 
-            let resp = harness_core::CodeAgent::execute(&agent, req).await?;
+            let selected_agent: Arc<dyn harness_core::CodeAgent> = match agent.as_str() {
+                "claude" => Arc::new(harness_agents::claude::ClaudeCodeAgent::new(
+                    config.agents.claude.cli_path.clone(),
+                    config.agents.claude.default_model.clone(),
+                )),
+                "codex" => Arc::new(harness_agents::codex::CodexAgent::new(
+                    config.agents.codex.cli_path.clone(),
+                )),
+                other => anyhow::bail!(
+                    "unknown exec agent `{other}`; supported values are: claude, codex"
+                ),
+            };
+
+            let resp = selected_agent.execute(req).await?;
+            if let Some(output_path) = output_path {
+                if let Some(parent) = output_path.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        std::fs::create_dir_all(parent).with_context(|| {
+                            format!(
+                                "failed to create parent directory for output file {}",
+                                output_path.display()
+                            )
+                        })?;
+                    }
+                }
+                std::fs::write(&output_path, &resp.output).with_context(|| {
+                    format!(
+                        "failed to write `harness exec` output to {}",
+                        output_path.display()
+                    )
+                })?;
+            }
+
             println!("{}", resp.output);
             if !resp.stderr.is_empty() {
                 eprintln!("[harness] agent stderr:\n{}", resp.stderr);
@@ -451,5 +742,123 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(chain.contains("cwd lookup blocked"));
+    }
+
+    #[test]
+    fn sandbox_mode_parse_accepts_supported_values() {
+        assert_eq!(
+            ExecSandboxMode::parse("read-only").expect("read-only should parse"),
+            ExecSandboxMode::ReadOnly
+        );
+        assert_eq!(
+            ExecSandboxMode::parse("workspace-write").expect("workspace-write should parse"),
+            ExecSandboxMode::WorkspaceWrite
+        );
+        assert_eq!(
+            ExecSandboxMode::parse("danger-full-access").expect("danger-full-access should parse"),
+            ExecSandboxMode::DangerFullAccess
+        );
+    }
+
+    #[test]
+    fn sandbox_mode_parse_rejects_unknown_value() {
+        let error = ExecSandboxMode::parse("unsafe").expect_err("unsupported mode should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported sandbox mode `unsafe`"));
+    }
+
+    #[test]
+    fn normalize_allow_list_trims_and_drops_empty_entries() {
+        let values = vec![
+            "alice".to_string(),
+            "  bob  ".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+        ];
+        assert_eq!(normalize_allow_list(values), vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn exec_actor_filters_allow_matching_user_or_bot() {
+        let users = vec!["alice".to_string()];
+        let bots = vec!["dependabot[bot]".to_string()];
+
+        enforce_exec_actor_filters(Some("alice".to_string()), &users, &bots)
+            .expect("listed human user should pass");
+        enforce_exec_actor_filters(Some("dependabot[bot]".to_string()), &users, &bots)
+            .expect("listed bot should pass");
+    }
+
+    #[test]
+    fn exec_actor_filters_block_unlisted_actor() {
+        let users = vec!["alice".to_string()];
+        let bots = vec!["dependabot[bot]".to_string()];
+        let error = enforce_exec_actor_filters(Some("mallory".to_string()), &users, &bots)
+            .expect_err("unlisted actor should be rejected when allow lists are configured");
+
+        assert!(error
+            .to_string()
+            .contains("actor `mallory` is not allowed to run `harness exec`"));
+    }
+
+    #[test]
+    fn apply_sandbox_hint_prefixes_prompt() {
+        let prompt = "review this PR".to_string();
+        let hinted = apply_sandbox_hint(prompt.clone(), ExecSandboxMode::WorkspaceWrite);
+        assert!(hinted.contains("Sandbox mode requirement for this run: `workspace-write`."));
+        assert!(hinted.ends_with(&prompt));
+    }
+
+    #[test]
+    fn resolve_exec_output_path_accepts_nested_relative_path() {
+        let root = std::env::temp_dir().join("harness-cli-output-path-accept");
+        std::fs::create_dir_all(&root).expect("temp test root should be creatable");
+
+        let output = resolve_exec_output_path(&root, Path::new(".harness/final.txt"))
+            .expect("relative output file should resolve inside project root");
+
+        assert!(output.starts_with(root.canonicalize().expect("root should canonicalize")));
+        assert!(output.ends_with(Path::new(".harness/final.txt")));
+    }
+
+    #[test]
+    fn resolve_exec_output_path_rejects_parent_escape() {
+        let root = std::env::temp_dir().join("harness-cli-output-path-reject");
+        std::fs::create_dir_all(&root).expect("temp test root should be creatable");
+
+        let error = resolve_exec_output_path(&root, Path::new("../escape.txt"))
+            .expect_err("path traversal outside project root should fail");
+
+        assert!(error
+            .to_string()
+            .contains("`--output-file` must stay within project root"));
+    }
+
+    #[test]
+    fn enforce_exec_privilege_policy_blocks_root_when_drop_sudo_enabled() {
+        let error = enforce_exec_privilege_policy_with(true, None, || true, || false)
+            .expect_err("drop-sudo should reject execution when real UID indicates root");
+
+        assert!(error
+            .to_string()
+            .contains("refusing to run `harness exec` with elevated privileges"));
+    }
+
+    #[test]
+    fn enforce_exec_privilege_policy_allows_root_when_drop_sudo_disabled() {
+        enforce_exec_privilege_policy_with(false, None, || true, || false)
+            .expect("drop-sudo=false should allow root execution when explicitly requested");
+    }
+
+    #[test]
+    fn enforce_exec_privilege_policy_blocks_sudo_environment() {
+        let error = enforce_exec_privilege_policy_with(true, None, || false, || true).expect_err(
+            "drop-sudo should reject execution when sudo environment markers are present",
+        );
+
+        assert!(error
+            .to_string()
+            .contains("refusing to run `harness exec` with elevated privileges"));
     }
 }


### PR DESCRIPTION
## Summary
- add `.github/actions/harness-action/action.yml` and PR workflow for CI/CD execution
- expand `harness exec` with CI integration flags and security policy enforcement
- harden output file handling (workspace-bound path validation), randomize `GITHUB_OUTPUT` delimiter, and switch root detection to real UID

## Validation
- cargo check
- cargo test -p harness-cli commands::tests
- cargo run -p harness-cli -- exec --help | rg "sandbox-mode|output-file|drop-sudo|unprivileged-user|allow-users|allow-bots|--model|--actor|--agent"
- test -f .github/actions/harness-action/action.yml && test -f .github/workflows/harness-pr.yml
