### PR TITLE
fix: rework OpenTelemetry export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,11 +138,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -131,7 +180,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -144,10 +193,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.28.0",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -721,7 +790,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -738,7 +807,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -777,7 +846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "uuid",
@@ -792,7 +861,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -809,7 +878,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -822,11 +891,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "harness-core",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -841,7 +913,7 @@ dependencies = [
  "harness-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -856,7 +928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -867,7 +939,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "dashmap",
  "futures",
@@ -884,11 +956,11 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "uuid",
@@ -905,10 +977,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1066,6 +1144,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,7 +1189,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1240,6 +1331,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1271,6 +1372,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1373,6 +1483,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1542,6 +1658,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1781,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1665,6 +1882,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1785,6 +2025,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1809,7 +2050,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2036,7 +2277,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -2117,6 +2358,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2176,7 +2427,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -2185,7 +2436,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2269,7 +2520,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2308,7 +2559,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2334,7 +2585,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2436,11 +2687,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2500,7 +2771,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2611,7 +2882,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2624,6 +2895,56 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -2654,7 +2975,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2766,7 +3087,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2783,7 +3104,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -3013,7 +3334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3039,7 +3360,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3392,7 +3713,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3423,7 +3744,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -3442,7 +3763,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ dashmap = "6"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+opentelemetry = { version = "0.27", features = ["trace", "metrics", "logs"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace", "metrics", "logs", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-client"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/config/default.toml
+++ b/config/default.toml
@@ -52,3 +52,9 @@ discovery_paths = []
 db_path = "~/.local/share/harness/harness.db"
 session_renewal_secs = 1800
 log_retention_days = 90
+
+[otel]
+environment = "development"
+exporter = "disabled"
+# endpoint = "http://127.0.0.1:4318"
+log_user_prompt = false

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -311,10 +311,11 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                     engine.load(&project)?;
                     let violations = engine.scan(&project).await?;
                     // Persist rule scan results for observability/GC even when running via CLI.
-                    match harness_observe::EventStore::with_policies(
+                    match harness_observe::EventStore::with_policies_and_otel(
                         &config.server.data_dir,
                         config.observe.session_renewal_secs,
                         config.observe.log_retention_days,
+                        &config.otel,
                     ) {
                         Ok(store) => {
                             store.persist_rule_scan(&project, &violations);

--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -17,7 +17,12 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
             };
             let project = Project::from_path(project_root);
 
-            let event_store = EventStore::new(data_dir)?;
+            let event_store = EventStore::with_policies_and_otel(
+                data_dir,
+                config.observe.session_renewal_secs,
+                config.observe.log_retention_days,
+                &config.otel,
+            )?;
             let events = event_store.query(&EventFilters::default())?;
 
             let thresholds = map_thresholds(&config.gc.signal_thresholds);

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -9,6 +9,7 @@ pub struct HarnessConfig {
     pub gc: GcConfig,
     pub rules: RulesConfig,
     pub observe: ObserveConfig,
+    pub otel: OtelConfig,
 }
 
 impl Default for HarnessConfig {
@@ -19,6 +20,7 @@ impl Default for HarnessConfig {
             gc: GcConfig::default(),
             rules: RulesConfig::default(),
             observe: ObserveConfig::default(),
+            otel: OtelConfig::default(),
         }
     }
 }
@@ -280,6 +282,47 @@ impl Default for ObserveConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OtelConfig {
+    #[serde(default = "default_otel_environment")]
+    pub environment: String,
+    #[serde(default)]
+    pub exporter: OtelExporter,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub log_user_prompt: bool,
+}
+
+impl Default for OtelConfig {
+    fn default() -> Self {
+        Self {
+            environment: default_otel_environment(),
+            exporter: OtelExporter::default(),
+            endpoint: None,
+            log_user_prompt: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OtelExporter {
+    Disabled,
+    OtlpHttp,
+    OtlpGrpc,
+}
+
+impl Default for OtelExporter {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
+fn default_otel_environment() -> String {
+    "development".to_string()
+}
+
 fn dirs_data_dir() -> PathBuf {
     dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."))
 }
@@ -434,5 +477,72 @@ mod tests {
         "#;
         let config: AnthropicApiConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.max_tokens, default_anthropic_api_max_tokens());
+    }
+
+    #[test]
+    fn otel_config_defaults_to_disabled_exporter() {
+        let config = OtelConfig::default();
+        assert_eq!(config.exporter, OtelExporter::Disabled);
+        assert!(config.endpoint.is_none());
+        assert!(!config.log_user_prompt);
+        assert_eq!(config.environment, "development");
+    }
+
+    #[test]
+    fn harness_config_deserializes_otel_section() {
+        let toml_str = r#"
+            [server]
+            transport = "stdio"
+            http_addr = "127.0.0.1:9800"
+            data_dir = "."
+            project_root = "."
+
+            [agents]
+            default_agent = "claude"
+            [agents.claude]
+            cli_path = "claude"
+            default_model = "sonnet"
+            [agents.codex]
+            cli_path = "codex"
+            [agents.anthropic_api]
+            base_url = "https://api.anthropic.com"
+            default_model = "claude-sonnet-4-20250514"
+
+            [gc]
+            max_drafts_per_run = 5
+            budget_per_signal_usd = 0.5
+            total_budget_usd = 5.0
+            [gc.signal_thresholds]
+            repeated_warn_min = 10
+            chronic_block_min = 5
+            hot_file_edits_min = 20
+            slow_op_threshold_ms = 5000
+            slow_op_count_min = 10
+            escalation_ratio = 1.5
+            violation_min = 5
+
+            [rules]
+            discovery_paths = []
+
+            [observe]
+            db_path = "."
+            session_renewal_secs = 1800
+            log_retention_days = 90
+
+            [otel]
+            environment = "staging"
+            exporter = "otlp-http"
+            endpoint = "http://collector:4318"
+            log_user_prompt = true
+        "#;
+
+        let config: HarnessConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.otel.environment, "staging");
+        assert_eq!(config.otel.exporter, OtelExporter::OtlpHttp);
+        assert_eq!(
+            config.otel.endpoint.as_deref(),
+            Some("http://collector:4318")
+        );
+        assert!(config.otel.log_user_prompt);
     }
 }

--- a/crates/harness-observe/Cargo.toml
+++ b/crates/harness-observe/Cargo.toml
@@ -14,6 +14,9 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -1,9 +1,12 @@
-use harness_core::{Decision, Event, EventFilters, EventId, SessionId, Severity, Violation};
+use harness_core::{
+    Decision, Event, EventFilters, EventId, OtelConfig, SessionId, Severity, Violation,
+};
 use std::path::{Path, PathBuf};
 
 /// Event store backed by JSONL files (SQLite upgrade path available).
 pub struct EventStore {
     data_dir: PathBuf,
+    otel_pipeline: Option<crate::otel_export::OtelPipeline>,
 }
 
 impl EventStore {
@@ -11,15 +14,32 @@ impl EventStore {
         std::fs::create_dir_all(data_dir)?;
         Ok(Self {
             data_dir: data_dir.to_path_buf(),
+            otel_pipeline: None,
         })
     }
 
-    pub fn with_policies(
+    pub fn with_policies_and_otel(
         data_dir: &Path,
-        _session_renewal_secs: u64,
-        _log_retention_days: u32,
+        session_renewal_secs: u64,
+        log_retention_days: u32,
+        otel_config: &OtelConfig,
     ) -> anyhow::Result<Self> {
-        Self::new(data_dir)
+        let mut store = Self::new(data_dir)?;
+        tracing::debug!(
+            session_renewal_secs,
+            log_retention_days,
+            "event store policy values accepted"
+        );
+        store.otel_pipeline = match crate::otel_export::OtelPipeline::from_config(otel_config) {
+            Ok(pipeline) => pipeline,
+            Err(err) => {
+                tracing::warn!(
+                    "OpenTelemetry initialization failed; continuing without export: {err}"
+                );
+                None
+            }
+        };
+        Ok(store)
     }
 
     fn events_file(&self) -> PathBuf {
@@ -34,6 +54,9 @@ impl EventStore {
             .open(self.events_file())?;
         let line = serde_json::to_string(event)?;
         writeln!(file, "{line}")?;
+        if let Some(pipeline) = &self.otel_pipeline {
+            pipeline.record_event(event);
+        }
         Ok(event.id.clone())
     }
 
@@ -161,7 +184,7 @@ impl EventStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::{Decision, Event, EventFilters, RuleId, SessionId};
+    use harness_core::{Decision, Event, EventFilters, OtelExporter, RuleId, SessionId};
     use std::path::Path;
 
     fn make_event(hook: &str, decision: Decision) -> Event {
@@ -365,6 +388,32 @@ mod tests {
         })?;
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].detail.as_deref(), Some("/tmp/my-project"));
+        Ok(())
+    }
+
+    #[test]
+    fn log_with_unreachable_otel_endpoint_still_persists_event() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config = OtelConfig {
+            exporter: OtelExporter::OtlpHttp,
+            endpoint: Some("http://127.0.0.1:1".to_string()),
+            ..OtelConfig::default()
+        };
+        let store = EventStore::with_policies_and_otel(dir.path(), 1800, 90, &config)?;
+        assert!(store.otel_pipeline.is_none());
+        let event = Event::new(
+            SessionId::new(),
+            "api_request",
+            "http_client",
+            Decision::Pass,
+        );
+        store.log(&event)?;
+        let events = store.query(&EventFilters {
+            session_id: Some(event.session_id.clone()),
+            ..Default::default()
+        })?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, event.id);
         Ok(())
     }
 }

--- a/crates/harness-observe/src/lib.rs
+++ b/crates/harness-observe/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod event_store;
 pub mod health;
+mod otel_export;
 pub mod quality;
 pub mod stats;
 

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -1,0 +1,517 @@
+use harness_core::{Decision, Event, OtelConfig, OtelExporter};
+use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider as _, Severity};
+use opentelemetry::metrics::{Counter, Histogram, MeterProvider as _};
+use opentelemetry::trace::{Span, Tracer, TracerProvider as _};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::logs::LoggerProvider;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use std::collections::{HashSet, VecDeque};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Mutex;
+use std::time::Duration;
+
+const SERVICE_NAME: &str = "harness-observe";
+const DEFAULT_HTTP_ENDPOINT: &str = "http://127.0.0.1:4318";
+const DEFAULT_GRPC_ENDPOINT: &str = "http://127.0.0.1:4317";
+const MAX_TRACKED_CONVERSATION_SESSIONS: usize = 10_000;
+
+struct SessionStartDeduper {
+    seen: HashSet<String>,
+    order: VecDeque<String>,
+    capacity: usize,
+}
+
+impl SessionStartDeduper {
+    fn new(capacity: usize) -> Self {
+        Self {
+            seen: HashSet::new(),
+            order: VecDeque::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    fn insert(&mut self, session_id: &str) -> bool {
+        if self.seen.contains(session_id) {
+            return false;
+        }
+
+        let session_id = session_id.to_string();
+        self.seen.insert(session_id.clone());
+        self.order.push_back(session_id);
+
+        while self.order.len() > self.capacity {
+            if let Some(expired) = self.order.pop_front() {
+                self.seen.remove(expired.as_str());
+            }
+        }
+
+        true
+    }
+}
+
+pub struct OtelPipeline {
+    log_user_prompt: bool,
+    seen_sessions: Mutex<SessionStartDeduper>,
+    tracer_provider: opentelemetry_sdk::trace::TracerProvider,
+    tracer: opentelemetry_sdk::trace::Tracer,
+    logger_provider: LoggerProvider,
+    logger: opentelemetry_sdk::logs::Logger,
+    meter_provider: SdkMeterProvider,
+    conversation_starts_total: Counter<u64>,
+    api_request_total: Counter<u64>,
+    tool_decision_total: Counter<u64>,
+    tool_execution_duration_ms: Histogram<u64>,
+}
+
+impl OtelPipeline {
+    pub fn from_config(config: &OtelConfig) -> anyhow::Result<Option<Self>> {
+        if config.exporter == OtelExporter::Disabled {
+            return Ok(None);
+        }
+
+        let endpoint = resolve_endpoint(config.exporter, config.endpoint.as_deref());
+        ensure_endpoint_reachable(config.exporter, endpoint.as_str())?;
+
+        let resource = Resource::new(vec![
+            KeyValue::new("service.name", SERVICE_NAME),
+            KeyValue::new("deployment.environment", config.environment.clone()),
+        ]);
+
+        let tracer_provider =
+            build_tracer_provider(config.exporter, endpoint.as_str(), resource.clone())?;
+        let tracer = tracer_provider.tracer(SERVICE_NAME);
+        let logger_provider =
+            build_logger_provider(config.exporter, endpoint.as_str(), resource.clone())?;
+        let logger = logger_provider.logger(SERVICE_NAME);
+        let meter_provider = build_meter_provider(config.exporter, endpoint.as_str(), resource)?;
+        let meter = meter_provider.meter(SERVICE_NAME);
+        let conversation_starts_total = meter
+            .u64_counter("harness.conversation_starts.total")
+            .with_description("Number of distinct conversation starts by session.")
+            .build();
+        let api_request_total = meter
+            .u64_counter("harness.api_request.total")
+            .with_description("Number of API request-like events.")
+            .build();
+        let tool_decision_total = meter
+            .u64_counter("harness.tool_decision.total")
+            .with_description("Number of tool decision events.")
+            .build();
+        let tool_execution_duration_ms = meter
+            .u64_histogram("harness.tool_execution.duration_ms")
+            .with_description("Tool execution duration in milliseconds.")
+            .build();
+
+        Ok(Some(Self {
+            log_user_prompt: config.log_user_prompt,
+            seen_sessions: Mutex::new(SessionStartDeduper::new(MAX_TRACKED_CONVERSATION_SESSIONS)),
+            tracer_provider,
+            tracer,
+            logger_provider,
+            logger,
+            meter_provider,
+            conversation_starts_total,
+            api_request_total,
+            tool_decision_total,
+            tool_execution_duration_ms,
+        }))
+    }
+
+    pub fn record_event(&self, event: &Event) {
+        let attrs = self.base_attributes(event);
+        self.tool_decision_total.add(1, &attrs);
+        self.emit_trace("tool_decision", event, &attrs);
+        self.emit_log("tool_decision", event, &attrs);
+
+        if self.mark_conversation_started(event) {
+            self.conversation_starts_total.add(1, &attrs);
+            self.emit_trace("conversation_starts", event, &attrs);
+            self.emit_log("conversation_starts", event, &attrs);
+        }
+
+        if is_api_request_event(event) {
+            self.api_request_total.add(1, &attrs);
+            self.emit_trace("api_request", event, &attrs);
+            self.emit_log("api_request", event, &attrs);
+        }
+
+        if let Some(duration_ms) = event.duration_ms {
+            self.tool_execution_duration_ms.record(duration_ms, &attrs);
+            let mut execution_attrs = attrs.clone();
+            execution_attrs.push(KeyValue::new("duration_ms", duration_ms as i64));
+            self.emit_trace("tool_execution", event, &execution_attrs);
+            self.emit_log("tool_execution", event, &execution_attrs);
+        }
+    }
+
+    fn mark_conversation_started(&self, event: &Event) -> bool {
+        match self.seen_sessions.lock() {
+            Ok(mut sessions) => sessions.insert(event.session_id.as_str()),
+            Err(poisoned) => {
+                tracing::error!("SessionStartDeduper mutex poisoned; recovering state");
+                poisoned.into_inner().insert(event.session_id.as_str())
+            }
+        }
+    }
+
+    fn base_attributes(&self, event: &Event) -> Vec<KeyValue> {
+        let mut attrs = vec![
+            KeyValue::new("event.id", event.id.as_str().to_string()),
+            KeyValue::new("event.session_id", event.session_id.as_str().to_string()),
+            KeyValue::new("event.hook", event.hook.clone()),
+            KeyValue::new("event.tool", event.tool.clone()),
+            KeyValue::new("event.decision", decision_label(event.decision)),
+        ];
+
+        if self.log_user_prompt || !looks_like_user_prompt_payload(event) {
+            if let Some(reason) = &event.reason {
+                attrs.push(KeyValue::new("event.reason", reason.clone()));
+            }
+            if let Some(detail) = &event.detail {
+                attrs.push(KeyValue::new("event.detail", detail.clone()));
+            }
+        }
+
+        attrs
+    }
+
+    fn emit_trace(&self, name: &str, event: &Event, attrs: &[KeyValue]) {
+        let mut span = self.tracer.start(name.to_string());
+        span.set_attribute(KeyValue::new("event.timestamp", event.ts.to_rfc3339()));
+        for attr in attrs {
+            span.set_attribute(attr.clone());
+        }
+        span.end();
+    }
+
+    fn emit_log(&self, name: &'static str, event: &Event, attrs: &[KeyValue]) {
+        let timestamp = std::time::SystemTime::from(event.ts);
+        let severity = severity_for_decision(event.decision);
+        let mut record = self.logger.create_log_record();
+        record.set_event_name(name);
+        record.set_body(AnyValue::from(name.to_string()));
+        record.set_timestamp(timestamp);
+        record.set_observed_timestamp(timestamp);
+        record.set_severity_text(severity.name());
+        record.set_severity_number(severity);
+        for attr in attrs {
+            record.add_attribute(attr.key.clone(), attr.value.to_string());
+        }
+        self.logger.emit(record);
+    }
+}
+
+impl Drop for OtelPipeline {
+    fn drop(&mut self) {
+        for result in self.tracer_provider.force_flush() {
+            if let Err(err) = result {
+                report_pipeline_error("failed to force flush tracer provider", err);
+            }
+        }
+        if let Err(err) = self.tracer_provider.shutdown() {
+            report_pipeline_error("failed to shut down tracer provider", err);
+        }
+        if let Err(err) = self.meter_provider.force_flush() {
+            report_pipeline_error("failed to force flush meter provider", err);
+        }
+        if let Err(err) = self.meter_provider.shutdown() {
+            report_pipeline_error("failed to shut down meter provider", err);
+        }
+        for result in self.logger_provider.force_flush() {
+            if let Err(err) = result {
+                report_pipeline_error("failed to force flush logger provider", err);
+            }
+        }
+        if let Err(err) = self.logger_provider.shutdown() {
+            report_pipeline_error("failed to shut down logger provider", err);
+        }
+    }
+}
+
+fn build_tracer_provider(
+    exporter: OtelExporter,
+    endpoint: &str,
+    resource: Resource,
+) -> anyhow::Result<opentelemetry_sdk::trace::TracerProvider> {
+    let span_exporter = match exporter {
+        OtelExporter::OtlpHttp => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::OtlpGrpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::Disabled => {
+            anyhow::bail!("disabled exporter cannot initialize tracer provider")
+        }
+    };
+
+    Ok(opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(span_exporter, opentelemetry_sdk::runtime::Tokio)
+        .build())
+}
+
+fn build_logger_provider(
+    exporter: OtelExporter,
+    endpoint: &str,
+    resource: Resource,
+) -> anyhow::Result<LoggerProvider> {
+    let log_exporter = match exporter {
+        OtelExporter::OtlpHttp => opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::OtlpGrpc => opentelemetry_otlp::LogExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::Disabled => {
+            anyhow::bail!("disabled exporter cannot initialize logger provider")
+        }
+    };
+
+    Ok(opentelemetry_sdk::logs::LoggerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(log_exporter, opentelemetry_sdk::runtime::Tokio)
+        .build())
+}
+
+fn build_meter_provider(
+    exporter: OtelExporter,
+    endpoint: &str,
+    resource: Resource,
+) -> anyhow::Result<SdkMeterProvider> {
+    let metric_exporter = match exporter {
+        OtelExporter::OtlpHttp => opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::OtlpGrpc => opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint.to_string())
+            .build()?,
+        OtelExporter::Disabled => {
+            anyhow::bail!("disabled exporter cannot initialize meter provider")
+        }
+    };
+
+    let reader =
+        PeriodicReader::builder(metric_exporter, opentelemetry_sdk::runtime::Tokio).build();
+    Ok(SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build())
+}
+
+fn resolve_endpoint(exporter: OtelExporter, config_endpoint: Option<&str>) -> String {
+    if let Some(endpoint) = config_endpoint
+        .map(str::trim)
+        .filter(|endpoint| !endpoint.is_empty())
+    {
+        return endpoint.to_string();
+    }
+
+    if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        if !endpoint.trim().is_empty() {
+            return endpoint;
+        }
+    }
+
+    match exporter {
+        OtelExporter::OtlpHttp => DEFAULT_HTTP_ENDPOINT.to_string(),
+        OtelExporter::OtlpGrpc => DEFAULT_GRPC_ENDPOINT.to_string(),
+        OtelExporter::Disabled => String::new(),
+    }
+}
+
+fn ensure_endpoint_reachable(exporter: OtelExporter, endpoint: &str) -> anyhow::Result<()> {
+    let (host, port) = endpoint_host_and_port(exporter, endpoint)?;
+    let mut attempted = false;
+    let mut connection_errors: Vec<String> = Vec::new();
+
+    for addr in (host.as_str(), port).to_socket_addrs()? {
+        attempted = true;
+        match TcpStream::connect_timeout(&addr, Duration::from_secs(1)) {
+            Ok(stream) => {
+                drop(stream);
+                return Ok(());
+            }
+            Err(err) => connection_errors.push(format!("{addr}: {err}")),
+        }
+    }
+
+    if !attempted {
+        anyhow::bail!("OTLP endpoint `{endpoint}` did not resolve to any socket address");
+    }
+
+    anyhow::bail!(
+        "OTLP endpoint `{endpoint}` is unreachable ({})",
+        connection_errors.join("; ")
+    )
+}
+
+fn endpoint_host_and_port(exporter: OtelExporter, endpoint: &str) -> anyhow::Result<(String, u16)> {
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("OTLP endpoint cannot be empty");
+    }
+
+    let without_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed);
+    let authority = without_scheme.split('/').next().unwrap_or_default();
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+
+    if authority.is_empty() {
+        anyhow::bail!("OTLP endpoint `{endpoint}` is missing authority");
+    }
+
+    if authority.starts_with('[') {
+        let close = authority.find(']').ok_or_else(|| {
+            anyhow::anyhow!("OTLP endpoint `{endpoint}` has invalid IPv6 authority")
+        })?;
+        let host = authority[1..close].to_string();
+        let tail = &authority[(close + 1)..];
+        let port = if let Some(port_str) = tail.strip_prefix(':') {
+            port_str
+                .parse::<u16>()
+                .map_err(|err| anyhow::anyhow!("invalid OTLP endpoint port `{port_str}`: {err}"))?
+        } else {
+            default_endpoint_port(exporter)
+        };
+        return Ok((host, port));
+    }
+
+    if let Some((host, port_str)) = authority.rsplit_once(':') {
+        if !host.contains(':') {
+            let port = port_str
+                .parse::<u16>()
+                .map_err(|err| anyhow::anyhow!("invalid OTLP endpoint port `{port_str}`: {err}"))?;
+            return Ok((host.to_string(), port));
+        }
+    }
+
+    Ok((authority.to_string(), default_endpoint_port(exporter)))
+}
+
+fn default_endpoint_port(exporter: OtelExporter) -> u16 {
+    match exporter {
+        OtelExporter::OtlpHttp => 4318,
+        OtelExporter::OtlpGrpc => 4317,
+        OtelExporter::Disabled => 0,
+    }
+}
+
+fn is_api_request_event(event: &Event) -> bool {
+    [event.hook.as_str(), event.tool.as_str()]
+        .iter()
+        .any(|value| {
+            has_token(value, "api") || has_token(value, "http") || has_token(value, "request")
+        })
+}
+
+fn has_token(value: &str, needle: &str) -> bool {
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|token| token.eq_ignore_ascii_case(needle))
+}
+
+fn looks_like_user_prompt_payload(event: &Event) -> bool {
+    let hook = event.hook.to_ascii_lowercase();
+    let tool = event.tool.to_ascii_lowercase();
+    hook.contains("conversation")
+        || hook.contains("prompt")
+        || tool.contains("conversation")
+        || tool.contains("prompt")
+}
+
+fn decision_label(decision: Decision) -> &'static str {
+    match decision {
+        Decision::Pass => "pass",
+        Decision::Warn => "warn",
+        Decision::Block => "block",
+        Decision::Gate => "gate",
+        Decision::Escalate => "escalate",
+        Decision::Complete => "complete",
+    }
+}
+
+fn severity_for_decision(decision: Decision) -> Severity {
+    match decision {
+        Decision::Pass | Decision::Complete => Severity::Info,
+        Decision::Warn => Severity::Warn,
+        Decision::Block | Decision::Gate | Decision::Escalate => Severity::Error,
+    }
+}
+
+fn report_pipeline_error(message: &str, err: impl std::fmt::Display) {
+    tracing::warn!("{message}: {err}");
+    eprintln!("harness-observe: {message}: {err}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{Decision, Event, SessionId};
+
+    fn event_with(hook: &str, tool: &str) -> Event {
+        Event::new(SessionId::new(), hook, tool, Decision::Pass)
+    }
+
+    #[test]
+    fn api_request_classifier_matches_common_markers() {
+        assert!(is_api_request_event(&event_with("api_call", "tool")));
+        assert!(is_api_request_event(&event_with("hook", "http_client")));
+        assert!(is_api_request_event(&event_with("request_started", "tool")));
+        assert!(!is_api_request_event(&event_with(
+            "rule_scan",
+            "RuleEngine"
+        )));
+        assert!(!is_api_request_event(&event_with("therapist", "editor")));
+    }
+
+    #[test]
+    fn user_prompt_payload_classifier_matches_prompt_markers() {
+        assert!(looks_like_user_prompt_payload(&event_with(
+            "conversation_start",
+            "task_runner"
+        )));
+        assert!(looks_like_user_prompt_payload(&event_with(
+            "hook",
+            "user_prompt_tool"
+        )));
+        assert!(!looks_like_user_prompt_payload(&event_with(
+            "rule_check",
+            "RuleEngine"
+        )));
+    }
+
+    #[test]
+    fn from_config_returns_none_when_disabled() -> anyhow::Result<()> {
+        let config = OtelConfig {
+            exporter: OtelExporter::Disabled,
+            ..OtelConfig::default()
+        };
+        assert!(OtelPipeline::from_config(&config)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn from_config_reports_error_when_endpoint_unreachable() {
+        let config = OtelConfig {
+            exporter: OtelExporter::OtlpHttp,
+            endpoint: Some("http://127.0.0.1:1".to_string()),
+            ..OtelConfig::default()
+        };
+        let result = OtelPipeline::from_config(&config);
+        assert!(result.is_err());
+    }
+}

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -101,10 +101,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         tracing::warn!("failed to load builtin rules: {e}");
     }
 
-    let events = Arc::new(harness_observe::EventStore::with_policies(
+    let events = Arc::new(harness_observe::EventStore::with_policies_and_otel(
         &dir,
         server.config.observe.session_renewal_secs,
         server.config.observe.log_retention_days,
+        &server.config.otel,
     )?);
 
     let signal_detector = harness_gc::SignalDetector::new(


### PR DESCRIPTION
## Summary
- re-apply the OpenTelemetry export implementation from the prior rework on a fresh branch
- fail fast when OTLP endpoint is unreachable by validating endpoint reachability during pipeline init
- keep runtime stable by falling back to local event persistence when OTEL init fails, and recover poisoned session deduper state
- add regression coverage for unreachable endpoint init failure + persistence fallback behavior

## Validation
- cargo check
- cargo test -p harness-observe
- cargo test -p harness-core
- cargo test -p harness-server
- cargo test
