### PR TITLE
[P1] 修复 main CI 失败：Format + Security Audit 权限问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2.0.0

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -1,6 +1,5 @@
 //! Prompt templates and output parsers shared across CLI and HTTP entries.
 
-
 /// Build prompt: continue work on an existing PR for a GitHub issue.
 ///
 /// Used when a prior task already created a PR for this issue. Instead of


### PR DESCRIPTION
## Summary
- remove the extra leading blank line in crates/harness-core/src/prompts.rs so cargo fmt --all -- --check passes
- add minimal permissions to CI Security Audit job in .github/workflows/ci.yml:
  - contents: read
  - checks: write
- keep other jobs unchanged (check/test/clippy/format commands remain the same)

## Validation
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings

Closes FUT-97
