### PR TITLE
feat: complete ExecPlan persistence read path with DB fallback

### DIFF
--- a/crates/harness-server/src/handlers/exec.rs
+++ b/crates/harness-server/src/handlers/exec.rs
@@ -35,12 +35,31 @@ pub async fn exec_plan_status(
     plan_id: ExecPlanId,
 ) -> RpcResponse {
     let plans = state.plans.read().await;
-    match plans.get(&plan_id) {
-        Some(plan) => match serde_json::to_value(plan) {
+    if let Some(plan) = plans.get(&plan_id) {
+        return match serde_json::to_value(plan) {
             Ok(v) => RpcResponse::success(id, v),
             Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
-        },
-        None => RpcResponse::error(id, NOT_FOUND, "plan not found"),
+        };
+    }
+    drop(plans);
+
+    // Fallback: query DB if plan not in memory.
+    if let Some(db) = &state.plan_db {
+        match db.get(&plan_id).await {
+            Ok(Some(plan)) => {
+                let resp = match serde_json::to_value(&plan) {
+                    Ok(v) => RpcResponse::success(id, v),
+                    Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                };
+                // Cache for subsequent lookups.
+                state.plans.write().await.insert(plan_id, plan);
+                resp
+            }
+            Ok(None) => RpcResponse::error(id, NOT_FOUND, "plan not found"),
+            Err(e) => RpcResponse::error(id, INTERNAL_ERROR, format!("db error: {e}")),
+        }
+    } else {
+        RpcResponse::error(id, NOT_FOUND, "plan not found")
     }
 }
 
@@ -51,6 +70,20 @@ pub async fn exec_plan_update(
     updates: serde_json::Value,
 ) -> RpcResponse {
     let mut plans = state.plans.write().await;
+
+    // If not in memory, try loading from DB first.
+    if !plans.contains_key(&plan_id) {
+        if let Some(db) = &state.plan_db {
+            match db.get(&plan_id).await {
+                Ok(Some(plan)) => {
+                    plans.insert(plan_id.clone(), plan);
+                }
+                Ok(None) => return RpcResponse::error(id, NOT_FOUND, "plan not found"),
+                Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, format!("db error: {e}")),
+            }
+        }
+    }
+
     match plans.get_mut(&plan_id) {
         Some(plan) => {
             let action = updates.get("action").and_then(|a| a.as_str()).unwrap_or("");

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -196,7 +196,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         rules: Arc::new(RwLock::new(rule_engine)),
         events,
         gc_agent,
-        plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        plans: {
+            let mut map = std::collections::HashMap::new();
+            match plan_db.list().await {
+                Ok(persisted) => {
+                    for plan in persisted {
+                        map.insert(plan.id.clone(), plan);
+                    }
+                }
+                Err(e) => tracing::warn!("failed to load persisted plans on startup: {e}"),
+            }
+            Arc::new(RwLock::new(map))
+        },
         thread_db: Some(thread_db),
         plan_db: Some(plan_db),
         interceptors: vec![Arc::new(crate::contract_validator::ContractValidator::new())],


### PR DESCRIPTION
## Summary

- Load persisted plans from DB into memory on startup in `build_app_state()`
- Add DB fallback in `exec_plan/status` when plan not found in memory cache
- Add DB fallback in `exec_plan/update` when plan not found in memory cache

Closes runtime-reality-check issue #5.

## Test plan

- [x] All 448 existing tests pass
- [x] `cargo check --workspace --all-targets` clean with `-Dwarnings`