### PR TITLE
feat: Feishu Bot intake pipeline (Task 2.3)

### DIFF
--- a/crates/harness-server/src/intake/feishu.rs
+++ b/crates/harness-server/src/intake/feishu.rs
@@ -170,7 +170,9 @@ impl IntakeSource for FeishuIntake {
 /// - Returns `{"challenge": ...}` for verification handshake.
 /// - For `im.message.receive_v1` events containing the trigger keyword,
 ///   creates a Harness task and replies in the originating chat.
+///
 /// Verify the token field in a Feishu webhook payload against the configured verification_token.
+///
 /// Returns true if no verification_token is configured (open mode) or if the token matches.
 fn verify_feishu_token(
     config: &harness_core::FeishuIntakeConfig,


### PR DESCRIPTION
## Summary

- Add `FeishuIntakeConfig` to `harness-core/src/config.rs` with `enabled/app_id/app_secret/verification_token/trigger_keyword/default_repo`; disabled by default, credentials fall back to `FEISHU_APP_ID`/`FEISHU_APP_SECRET` env vars
- Create `intake/feishu.rs`: `FeishuIntake` implements `IntakeSource` — `poll()` returns empty (webhook-driven), `mark_dispatched()` sends "task created" reply in chat via Feishu API, `on_task_complete()` sends result + PR link on Done/Failed
- Add `POST /webhook/feishu` route: handles verification challenge, parses `im.message.receive_v1`, checks `trigger_keyword`, dispatches task, replies asynchronously
- Register `FeishuIntake` in `build_orchestrator()` and initialise `AppState.feishu_intake` at startup

## Test plan

- [x] All 207 harness-server unit tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] 12 new unit tests: verification challenge, payload parsing, keyword detection, description extraction, IncomingIssue construction, poll returns empty, chat_id storage