### PR TITLE
fix: add env_remove for CLAUDECODE to CodexAgent

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -86,7 +86,9 @@ impl CodeAgent for CodexAgent {
 
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
-            .current_dir(&req.project_root);
+            .current_dir(&req.project_root)
+            .env_remove("CLAUDECODE")
+            .env_remove("CLAUDE_CODE_ENTRYPOINT");
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -137,6 +139,8 @@ impl CodeAgent for CodexAgent {
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
+            .env_remove("CLAUDECODE")
+            .env_remove("CLAUDE_CODE_ENTRYPOINT")
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .kill_on_drop(true);


### PR DESCRIPTION
Closes #186

CodexAgent execute() and execute_stream() were missing env_remove for CLAUDECODE and CLAUDE_CODE_ENTRYPOINT, unlike ClaudeCodeAgent which has them in both methods. This adds the same defense-in-depth to prevent nested CLI detection issues.