### PR TITLE
refactor: extract PromptBuilder to eliminate repeated prompt-building logic

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -22,6 +22,9 @@ pub(crate) use pr_detection::{
     build_fix_ci_prompt, build_pr_approved_prompt, build_pr_rework_prompt,
     find_existing_pr_for_issue, parse_harness_mention_command, HarnessMentionCommand,
 };
+// PromptBuilder is used internally by pr_detection and re-exported for tests.
+#[cfg(test)]
+pub(crate) use pr_detection::PromptBuilder;
 
 pub(crate) async fn run_turn_lifecycle(
     server: Arc<crate::server::HarnessServer>,
@@ -643,6 +646,54 @@ mod tests {
     fn parse_harness_first_mention_per_line_is_used() {
         let cmd = parse_harness_mention_command("@harness review then @harness fix ci");
         assert_eq!(cmd, Some(HarnessMentionCommand::Review));
+    }
+
+    #[test]
+    fn prompt_builder_no_sections_adds_trailing_newline() {
+        let result = PromptBuilder::new("Title line.").build();
+        assert_eq!(result, "Title line.\n");
+    }
+
+    #[test]
+    fn prompt_builder_optional_url_absent_is_skipped() {
+        let result = PromptBuilder::new("Title.")
+            .add_optional_url("Link", None)
+            .build();
+        assert_eq!(result, "Title.\n");
+    }
+
+    #[test]
+    fn prompt_builder_optional_url_present_appears_in_output() {
+        let result = PromptBuilder::new("Title.")
+            .add_optional_url("Link", Some("https://example.com"))
+            .build();
+        assert!(result.contains("- Link: "));
+        assert!(result.contains("https://example.com"));
+        assert!(result.ends_with('\n'));
+    }
+
+    #[test]
+    fn prompt_builder_add_section_wraps_external_data() {
+        let result = PromptBuilder::new("Title.")
+            .add_section("Payload", "content here")
+            .build();
+        assert!(result.contains("Payload:\n"));
+        assert!(result.contains("<external_data>"));
+        assert!(result.contains("content here"));
+    }
+
+    #[test]
+    fn prompt_builder_multiple_urls_all_appear() {
+        let result = PromptBuilder::new("Title.")
+            .add_optional_url("First", Some("url1"))
+            .add_optional_url("Second", None)
+            .add_optional_url("Third", Some("url3"))
+            .build();
+        assert!(result.contains("- First: "));
+        assert!(result.contains("url1"));
+        assert!(!result.contains("Second"));
+        assert!(result.contains("- Third: "));
+        assert!(result.contains("url3"));
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/pr_detection.rs
+++ b/crates/harness-server/src/task_executor/pr_detection.rs
@@ -44,6 +44,54 @@ pub(crate) fn parse_harness_mention_command(body: &str) -> Option<HarnessMention
     None
 }
 
+pub(crate) struct PromptBuilder {
+    title: String,
+    sections: Vec<(String, String)>,
+}
+
+impl PromptBuilder {
+    pub(crate) fn new(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            sections: Vec::new(),
+        }
+    }
+
+    /// Add a named section with `content` wrapped in external_data tags.
+    pub(crate) fn add_section(mut self, name: &str, content: &str) -> Self {
+        self.sections
+            .push((name.to_string(), prompts::wrap_external_data(content)));
+        self
+    }
+
+    /// Add an optional URL metadata line. No-op if `url` is `None`.
+    pub(crate) fn add_optional_url(mut self, label: &str, url: Option<&str>) -> Self {
+        if let Some(u) = url {
+            let safe = prompts::wrap_external_data(u);
+            self.sections
+                .push((String::new(), format!("- {label}: {safe}")));
+        }
+        self
+    }
+
+    /// Assemble the prompt: title, then each section, with a trailing newline.
+    pub(crate) fn build(self) -> String {
+        let mut out = self.title;
+        for (name, content) in &self.sections {
+            out.push('\n');
+            if name.is_empty() {
+                out.push_str(content);
+            } else {
+                out.push_str(name);
+                out.push_str(":\n");
+                out.push_str(content);
+            }
+        }
+        out.push('\n');
+        out
+    }
+}
+
 pub(crate) fn build_fix_ci_prompt(
     repository: &str,
     pr_number: u64,
@@ -51,25 +99,17 @@ pub(crate) fn build_fix_ci_prompt(
     comment_url: Option<&str>,
     pr_url: Option<&str>,
 ) -> String {
-    let wrapped_comment = prompts::wrap_external_data(comment_body);
-    let safe_comment_url = comment_url.map(prompts::wrap_external_data);
-    let comment_url_line = safe_comment_url
-        .as_deref()
-        .map(|url| format!("- Trigger comment: {url}\n"))
-        .unwrap_or_default();
-    let safe_pr_url = pr_url.map(prompts::wrap_external_data);
-    let pr_url_line = safe_pr_url
-        .as_deref()
-        .map(|url| format!("- PR URL: {url}\n"))
-        .unwrap_or_default();
     let canonical_pr_url = format!("https://github.com/{repository}/pull/{pr_number}");
+    let preamble = PromptBuilder::new(format!(
+        "CI failure repair requested for PR #{pr_number} in `{repository}`."
+    ))
+    .add_optional_url("Trigger comment", comment_url)
+    .add_optional_url("PR URL", pr_url)
+    .add_section("Command payload", comment_body)
+    .build();
 
     format!(
-        "CI failure repair requested for PR #{pr_number} in `{repository}`.\n\
-         {comment_url_line}\
-         {pr_url_line}\
-         Command payload:\n\
-         {wrapped_comment}\n\n\
+        "{preamble}\n\
          Required workflow:\n\
          1. Inspect failing checks for PR #{pr_number} (`gh pr checks {pr_number}`)\n\
          2. Investigate CI failure details from logs and failing tests\n\
@@ -88,26 +128,17 @@ pub(crate) fn build_pr_rework_prompt(
     review_url: Option<&str>,
     pr_url: Option<&str>,
 ) -> String {
-    let wrapped_body = prompts::wrap_external_data(review_body);
-    let safe_review_url = review_url.map(prompts::wrap_external_data);
-    let review_url_line = safe_review_url
-        .as_deref()
-        .map(|url| format!("- Review URL: {url}\n"))
-        .unwrap_or_default();
-    let safe_pr_url = pr_url.map(prompts::wrap_external_data);
-    let pr_url_line = safe_pr_url
-        .as_deref()
-        .map(|url| format!("- PR URL: {url}\n"))
-        .unwrap_or_default();
     let canonical_pr_url = format!("https://github.com/{repository}/pull/{pr_number}");
+    let preamble = PromptBuilder::new(format!(
+        "PR review feedback received on PR #{pr_number} in `{repository}`.\nReview state: {review_state}"
+    ))
+    .add_optional_url("Review URL", review_url)
+    .add_optional_url("PR URL", pr_url)
+    .add_section("Review feedback", review_body)
+    .build();
 
     format!(
-        "PR review feedback received on PR #{pr_number} in `{repository}`.\n\
-         Review state: {review_state}\n\
-         {review_url_line}\
-         {pr_url_line}\
-         Review feedback:\n\
-         {wrapped_body}\n\n\
+        "{preamble}\n\
          Required workflow:\n\
          1. Read the review feedback above carefully.\n\
          2. Address all requested changes.\n\
@@ -122,16 +153,15 @@ pub(crate) fn build_pr_approved_prompt(
     pr_number: u64,
     review_url: Option<&str>,
 ) -> String {
-    let safe_review_url = review_url.map(prompts::wrap_external_data);
-    let review_url_line = safe_review_url
-        .as_deref()
-        .map(|url| format!("- Review URL: {url}\n"))
-        .unwrap_or_default();
     let canonical_pr_url = format!("https://github.com/{repository}/pull/{pr_number}");
+    let preamble = PromptBuilder::new(format!(
+        "PR #{pr_number} in `{repository}` has been approved by a reviewer."
+    ))
+    .add_optional_url("Review URL", review_url)
+    .build();
 
     format!(
-        "PR #{pr_number} in `{repository}` has been approved by a reviewer.\n\
-         {review_url_line}\n\
+        "{preamble}\n\
          Action required:\n\
          Post a comment on the PR indicating it is ready to merge:\n\
          gh pr comment {pr_number} --repo {repository} --body \"Approved — ready to merge.\"\n\n\


### PR DESCRIPTION
## Summary

- Extract `PromptBuilder` struct to `task_executor.rs` with `add_section()` and `add_optional_url()` builder methods
- Refactor `build_fix_ci_prompt`, `build_pr_rework_prompt`, and `build_pr_approved_prompt` to use it, removing ~40 lines of repeated boilerplate
- Add 5 unit tests for `PromptBuilder`

Closes #197