### PR TITLE
refactor: rename SignalThresholds to SignalThresholdsConfig

### DIFF
--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -108,7 +108,7 @@ fn count_by_status(drafts: &[Draft], status: DraftStatus) -> usize {
     drafts.iter().filter(|d| d.status == status).count()
 }
 
-fn map_thresholds(t: &harness_core::SignalThresholds) -> GcThresholds {
+fn map_thresholds(t: &harness_core::SignalThresholdsConfig) -> GcThresholds {
     GcThresholds {
         repeated_warn_min: t.repeated_warn_min,
         chronic_block_min: t.chronic_block_min,

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -12,7 +12,7 @@ pub use agents::{
 pub use intake::{FeishuIntakeConfig, GitHubIntakeConfig, IntakeConfig};
 pub use misc::{
     ConcurrencyConfig, GcConfig, ObserveConfig, OtelConfig, OtelExporter, RulesConfig,
-    SignalThresholds, ValidationConfig, WorkspaceConfig,
+    SignalThresholdsConfig, ValidationConfig, WorkspaceConfig,
 };
 pub use project::{load_project_config, GitConfig, ProjectConfig};
 pub use server::{ServerConfig, Transport};
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn signal_thresholds_defaults_are_consistent() {
-        let thresholds = SignalThresholds::default();
+        let thresholds = SignalThresholdsConfig::default();
         assert_eq!(thresholds.repeated_warn_min, 10);
         assert_eq!(thresholds.chronic_block_min, 5);
         assert_eq!(thresholds.hot_file_edits_min, 20);

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -131,7 +131,7 @@ pub struct GcConfig {
     pub adopt_max_rounds: u32,
     #[serde(default = "default_gc_adopt_turn_timeout_secs")]
     pub adopt_turn_timeout_secs: u64,
-    pub signal_thresholds: SignalThresholds,
+    pub signal_thresholds: SignalThresholdsConfig,
 }
 
 impl Default for GcConfig {
@@ -143,7 +143,7 @@ impl Default for GcConfig {
             adopt_wait_secs: default_gc_adopt_wait_secs(),
             adopt_max_rounds: default_gc_adopt_max_rounds(),
             adopt_turn_timeout_secs: default_gc_adopt_turn_timeout_secs(),
-            signal_thresholds: SignalThresholds::default(),
+            signal_thresholds: SignalThresholdsConfig::default(),
         }
     }
 }
@@ -161,7 +161,7 @@ fn default_gc_adopt_turn_timeout_secs() -> u64 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalThresholds {
+pub struct SignalThresholdsConfig {
     pub repeated_warn_min: usize,
     pub chronic_block_min: usize,
     pub hot_file_edits_min: usize,
@@ -171,7 +171,7 @@ pub struct SignalThresholds {
     pub violation_min: usize,
 }
 
-impl Default for SignalThresholds {
+impl Default for SignalThresholdsConfig {
     fn default() -> Self {
         Self {
             repeated_warn_min: 10,

--- a/crates/harness-gc/src/signal_detector.rs
+++ b/crates/harness-gc/src/signal_detector.rs
@@ -27,8 +27,8 @@ impl Default for SignalThresholds {
     }
 }
 
-impl From<harness_core::config::SignalThresholds> for SignalThresholds {
-    fn from(t: harness_core::config::SignalThresholds) -> Self {
+impl From<harness_core::config::SignalThresholdsConfig> for SignalThresholds {
+    fn from(t: harness_core::config::SignalThresholdsConfig) -> Self {
         Self {
             repeated_warn_min: t.repeated_warn_min,
             chronic_block_min: t.chronic_block_min,


### PR DESCRIPTION
Renames `SignalThresholds` → `SignalThresholdsConfig` in `harness-core/src/config.rs`, the only config struct that was missing the `{Domain}Config` suffix.

Updated downstream references in `harness-gc` and `harness-cli`.

Closes #199