### PR TITLE
feat: add harness-api crate as stable API facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness-api"
+version = "0.1.0"
+dependencies = [
+ "harness-core",
+ "harness-exec",
+ "harness-protocol",
+ "harness-sandbox",
+]
+
+[[package]]
 name = "harness-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/harness-core",
     "crates/harness-protocol",
+    "crates/harness-api",
     "crates/harness-server",
     "crates/harness-agents",
     "crates/harness-sandbox",
@@ -24,6 +25,7 @@ rust-version = "1.75"
 # Internal crates
 harness-core = { path = "crates/harness-core" }
 harness-protocol = { path = "crates/harness-protocol" }
+harness-api = { path = "crates/harness-api" }
 harness-server = { path = "crates/harness-server" }
 harness-agents = { path = "crates/harness-agents" }
 harness-sandbox = { path = "crates/harness-sandbox" }

--- a/crates/harness-api/Cargo.toml
+++ b/crates/harness-api/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "harness-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+harness-core = { workspace = true }
+harness-protocol = { workspace = true }
+harness-sandbox = { workspace = true }
+harness-exec = { workspace = true }

--- a/crates/harness-api/src/lib.rs
+++ b/crates/harness-api/src/lib.rs
@@ -1,0 +1,28 @@
+//! Stable public API surface for Harness.
+//!
+//! This crate provides a single import point for consumers of the Harness
+//! ecosystem. It re-exports stable interfaces from the underlying crates,
+//! shielding consumers from internal reorganization.
+//!
+//! # Modules
+//!
+//! - [`core`] — domain types, agent traits, ID types, error types
+//! - [`protocol`] — JSON-RPC wire types and codec (all RPC methods)
+//! - [`sandbox`] — sandboxing types and `wrap_command`
+//! - [`exec`] — execution plan types for spec-driven workflows
+
+pub mod core {
+    pub use harness_core::*;
+}
+
+pub mod protocol {
+    pub use harness_protocol::*;
+}
+
+pub mod sandbox {
+    pub use harness_sandbox::*;
+}
+
+pub mod exec {
+    pub use harness_exec::*;
+}


### PR DESCRIPTION
## Summary

- Adds `crates/harness-api` as a new façade crate
- Re-exports stable interfaces from `harness-core`, `harness-protocol`, `harness-sandbox`, and `harness-exec` under namespaced modules (`core`, `protocol`, `sandbox`, `exec`)
- Registers the crate in the workspace `members` and `[workspace.dependencies]`

Closes #202

## Test plan

- [x] `cargo check -p harness-api` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [x] `cargo test -p harness-api` passes