### PR TITLE
feat: filter agent stderr — show errors at warn, suppress noise at debug

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -1,4 +1,6 @@
-use crate::streaming::{send_stream_item, stream_child_output};
+use crate::streaming::{
+    filter_agent_stderr, log_captured_stderr, send_stream_item, stream_child_output,
+};
 use async_trait::async_trait;
 use harness_core::SandboxMode;
 use harness_core::{AgentRequest, AgentResponse, Capability, CodeAgent, StreamItem, TokenUsage};
@@ -84,6 +86,7 @@ impl CodeAgent for ClaudeCodeAgent {
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        log_captured_stderr(&stderr, self.name());
 
         if !output.status.success() {
             return Err(harness_core::HarnessError::AgentExecution(format!(
@@ -122,12 +125,19 @@ impl CodeAgent for ClaudeCodeAgent {
             .env_remove("CLAUDECODE")
             .env_remove("CLAUDE_CODE_ENTRYPOINT")
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
 
         let mut child = cmd.spawn().map_err(|error| {
             harness_core::HarnessError::AgentExecution(format!("failed to run claude: {error}"))
         })?;
+
+        if let Some(stderr) = child.stderr.take() {
+            let agent = self.name().to_string();
+            tokio::spawn(async move {
+                filter_agent_stderr(stderr, &agent).await;
+            });
+        }
 
         stream_child_output(&mut child, &tx, self.name()).await?;
         send_stream_item(

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -1,5 +1,7 @@
 use crate::cloud_setup;
-use crate::streaming::{send_stream_item, stream_child_output};
+use crate::streaming::{
+    filter_agent_stderr, log_captured_stderr, send_stream_item, stream_child_output,
+};
 use async_trait::async_trait;
 use harness_core::SandboxMode;
 use harness_core::{
@@ -102,6 +104,7 @@ impl CodeAgent for CodexAgent {
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        log_captured_stderr(&stderr, self.name());
 
         if !output.status.success() {
             return Err(harness_core::HarnessError::AgentExecution(format!(
@@ -142,7 +145,7 @@ impl CodeAgent for CodexAgent {
             .env_remove("CLAUDECODE")
             .env_remove("CLAUDE_CODE_ENTRYPOINT")
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
 
         if self.cloud.enabled {
@@ -154,6 +157,13 @@ impl CodeAgent for CodexAgent {
         let mut child = cmd.spawn().map_err(|error| {
             harness_core::HarnessError::AgentExecution(format!("failed to run codex: {error}"))
         })?;
+
+        if let Some(stderr) = child.stderr.take() {
+            let agent = self.name().to_string();
+            tokio::spawn(async move {
+                filter_agent_stderr(stderr, &agent).await;
+            });
+        }
 
         stream_child_output(&mut child, &tx, self.name()).await?;
         send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -1,6 +1,54 @@
 use harness_core::{HarnessError, Item, StreamItem};
-use tokio::io::{AsyncReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::sync::mpsc::Sender;
+
+const STDERR_ERROR_KEYWORDS: &[&str] = &[
+    "error",
+    "warn",
+    "warning",
+    "failed",
+    "fatal",
+    "panic",
+    "exception",
+];
+const MAX_STDERR_LINE_LEN: usize = 1000;
+
+/// Read agent stderr line-by-line. Lines matching error keywords are logged
+/// at warn level; all others at debug level (invisible by default).
+pub(crate) async fn filter_agent_stderr(stderr: tokio::process::ChildStderr, agent_name: &str) {
+    let reader = BufReader::new(stderr);
+    let mut lines = reader.lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let trimmed = &line[..line.len().min(MAX_STDERR_LINE_LEN)];
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let lower = trimmed.to_lowercase();
+        if STDERR_ERROR_KEYWORDS.iter().any(|kw| lower.contains(kw)) {
+            tracing::warn!(agent = agent_name, "{trimmed}");
+        } else {
+            tracing::debug!(agent = agent_name, "{trimmed}");
+        }
+    }
+}
+
+/// Log stderr captured from a non-streaming `output()` call.
+pub(crate) fn log_captured_stderr(stderr: &str, agent_name: &str) {
+    for line in stderr.lines() {
+        let trimmed = &line[..line.len().min(MAX_STDERR_LINE_LEN)];
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lower = trimmed.to_lowercase();
+        if STDERR_ERROR_KEYWORDS.iter().any(|kw| lower.contains(kw)) {
+            tracing::warn!(agent = agent_name, "{trimmed}");
+        } else {
+            tracing::debug!(agent = agent_name, "{trimmed}");
+        }
+    }
+}
 
 pub(crate) async fn send_stream_item(
     tx: &Sender<StreamItem>,
@@ -78,4 +126,43 @@ pub(crate) async fn stream_child_output(
     .await?;
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::process::Command;
+
+    /// Spawn a child whose stderr contains mixed lines, run filter_agent_stderr,
+    /// and verify it completes without panicking (behavioral smoke test).
+    #[tokio::test]
+    async fn filter_agent_stderr_drains_without_panic() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(
+                "echo 'Compiling foo v0.1' >&2; \
+                 echo 'error[E0308]: mismatched types' >&2; \
+                 echo 'warning: unused import' >&2; \
+                 echo 'test result: ok. 5 passed' >&2",
+            )
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+
+        let stderr = child.stderr.take().expect("stderr piped");
+        filter_agent_stderr(stderr, "test-agent").await;
+        child.wait().await.expect("child wait");
+    }
+
+    #[test]
+    fn log_captured_stderr_does_not_panic_on_empty() {
+        log_captured_stderr("", "agent");
+    }
+
+    #[test]
+    fn log_captured_stderr_truncates_long_lines() {
+        let long_line = "x".repeat(2000);
+        // Should not panic
+        log_captured_stderr(&long_line, "agent");
+    }
 }

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -7,6 +7,13 @@ mod commands;
 mod gc;
 
 fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "harness=info,warn".into()),
+        )
+        .init();
+
     let cli = commands::Cli::parse();
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
## Summary

- Replaces `.stderr(Stdio::inherit())` with `.stderr(Stdio::piped())` in both `claude.rs` and `codex.rs` `execute_stream`; spawns a background task draining each line through a keyword filter
- Lines matching `error/warn/warning/failed/fatal/panic/exception` → `tracing::warn!`; all others → `tracing::debug!` (silent by default)
- `execute()` (non-streaming) applies the same filter via `log_captured_stderr()` after `cmd.output()` returns
- Adds `tracing_subscriber` init with `EnvFilter` to `harness-cli/src/main.rs`; operator controls verbosity via `RUST_LOG`

Closes #215