### PR TITLE
feat: ExecPlan persistence — rename table to exec_plans and add handler integration tests

### DIFF
--- a/crates/harness-server/src/plan_db.rs
+++ b/crates/harness-server/src/plan_db.rs
@@ -3,7 +3,7 @@ use harness_core::ExecPlanId;
 use harness_exec::ExecPlan;
 use std::path::Path;
 
-const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS plans (
+const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS exec_plans (
     id         TEXT PRIMARY KEY,
     data       TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -12,7 +12,7 @@ const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS plans (
 
 impl DbEntity for ExecPlan {
     fn table_name() -> &'static str {
-        "plans"
+        "exec_plans"
     }
 
     fn id(&self) -> &str {

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -1414,4 +1414,320 @@ mod tests {
         );
         Ok(())
     }
+
+    // --- ExecPlan persistence tests ---
+
+    async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<AppState> {
+        let server = Arc::new(HarnessServer::new(
+            HarnessConfig::default(),
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        ));
+        let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
+        let events = Arc::new(harness_observe::EventStore::new(dir)?);
+        let signal_detector = harness_gc::SignalDetector::new(
+            harness_gc::signal_detector::SignalThresholds::default(),
+            harness_core::ProjectId::new(),
+        );
+        let draft_store = harness_gc::DraftStore::new(dir)?;
+        let gc_agent = Arc::new(harness_gc::GcAgent::new(
+            harness_core::GcConfig::default(),
+            signal_detector,
+            draft_store,
+        ));
+        let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
+        let plan_db = crate::plan_db::PlanDb::open(&dir.join("exec_plans.db")).await?;
+        let (notification_tx, _) = tokio::sync::broadcast::channel(64);
+        Ok(AppState {
+            core: crate::http::CoreServices {
+                server,
+                project_root: dir.to_path_buf(),
+                tasks,
+                thread_db: Some(thread_db),
+                plan_db: Some(plan_db),
+                plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            },
+            engines: crate::http::EngineServices {
+                skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),
+                rules: Arc::new(RwLock::new(harness_rules::engine::RuleEngine::new())),
+                gc_agent,
+            },
+            observability: crate::http::ObservabilityServices { events },
+            concurrency: crate::http::ConcurrencyServices {
+                task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
+                workspace_mgr: None,
+            },
+            notifications: crate::http::NotificationServices {
+                notification_tx,
+                notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                notification_lag_log_every: 1,
+                notify_tx: None,
+                initialized: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            },
+            interceptors: vec![],
+            feishu_intake: None,
+            github_intake: None,
+            completion_callback: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn exec_plan_init_persists_to_db() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let proj_dir = crate::test_helpers::tempdir_in_home("harness-exec-test-")?;
+        let state = make_test_state_with_plan_db(dir.path()).await?;
+
+        let req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::ExecPlanInit {
+                spec: "# Persist to DB\n\nTest plan.".to_string(),
+                project_root: proj_dir.path().to_path_buf(),
+            },
+        };
+        let resp = handle_request(&state, req)
+            .await
+            .expect("expected response");
+        assert!(
+            resp.error.is_none(),
+            "init should succeed: {:?}",
+            resp.error
+        );
+
+        let plan_id_str = resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?["plan_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("plan_id not a string"))?
+            .to_string();
+
+        let plan_id = harness_core::ExecPlanId(plan_id_str);
+        let db = state.core.plan_db.as_ref().unwrap();
+        let stored = db
+            .get(&plan_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("plan should be in DB"))?;
+        assert_eq!(stored.purpose, "Persist to DB");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_status_reads_plan_from_memory() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let proj_dir = crate::test_helpers::tempdir_in_home("harness-exec-test-")?;
+        let state = make_test_state_with_plan_db(dir.path()).await?;
+
+        let init_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::ExecPlanInit {
+                spec: "# Status Test".to_string(),
+                project_root: proj_dir.path().to_path_buf(),
+            },
+        };
+        let init_resp = handle_request(&state, init_req)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+        assert!(
+            init_resp.error.is_none(),
+            "init should succeed: {:?}",
+            init_resp.error
+        );
+        let plan_id_str = init_resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?["plan_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("plan_id not a string"))?
+            .to_string();
+
+        let status_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: Method::ExecPlanStatus {
+                plan_id: harness_core::ExecPlanId(plan_id_str),
+            },
+        };
+        let status_resp = handle_request(&state, status_req)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+        assert!(
+            status_resp.error.is_none(),
+            "status should succeed: {:?}",
+            status_resp.error
+        );
+        let result = status_resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        assert_eq!(result["purpose"], "Status Test");
+        assert_eq!(result["status"], "draft");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_update_persists_status_change() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let proj_dir = crate::test_helpers::tempdir_in_home("harness-exec-test-")?;
+        let state = make_test_state_with_plan_db(dir.path()).await?;
+
+        let init_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::ExecPlanInit {
+                spec: "# Update Test".to_string(),
+                project_root: proj_dir.path().to_path_buf(),
+            },
+        };
+        let init_resp = handle_request(&state, init_req)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+        assert!(
+            init_resp.error.is_none(),
+            "init should succeed: {:?}",
+            init_resp.error
+        );
+        let plan_id_str = init_resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?["plan_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("plan_id not a string"))?
+            .to_string();
+        let plan_id = harness_core::ExecPlanId(plan_id_str);
+
+        let update_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: Method::ExecPlanUpdate {
+                plan_id: plan_id.clone(),
+                updates: serde_json::json!({ "action": "activate" }),
+            },
+        };
+        let update_resp = handle_request(&state, update_req)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+        assert!(
+            update_resp.error.is_none(),
+            "update should succeed: {:?}",
+            update_resp.error
+        );
+
+        let db = state
+            .core
+            .plan_db
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("plan_db should be set"))?;
+        let stored = db
+            .get(&plan_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("plan should be in DB"))?;
+        assert_eq!(stored.status, harness_core::ExecPlanStatus::Active);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_survives_simulated_restart() -> anyhow::Result<()> {
+        let data_dir = tempfile::tempdir()?;
+        let proj_dir = crate::test_helpers::tempdir_in_home("harness-exec-test-")?;
+        let plan_db_path = data_dir.path().join("exec_plans.db");
+        let plan_id_str: String;
+
+        // Session 1: create and activate a plan.
+        {
+            let state = make_test_state_with_plan_db(data_dir.path()).await?;
+            let init_req = RpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: Some(serde_json::json!(1)),
+                method: Method::ExecPlanInit {
+                    spec: "# Restart Test".to_string(),
+                    project_root: proj_dir.path().to_path_buf(),
+                },
+            };
+            let init_resp = handle_request(&state, init_req)
+                .await
+                .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+            assert!(
+                init_resp.error.is_none(),
+                "init should succeed: {:?}",
+                init_resp.error
+            );
+            plan_id_str = init_resp
+                .result
+                .ok_or_else(|| anyhow::anyhow!("missing result"))?["plan_id"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("plan_id not a string"))?
+                .to_string();
+
+            let update_req = RpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: Some(serde_json::json!(2)),
+                method: Method::ExecPlanUpdate {
+                    plan_id: harness_core::ExecPlanId(plan_id_str.clone()),
+                    updates: serde_json::json!({ "action": "activate" }),
+                },
+            };
+            let update_resp = handle_request(&state, update_req)
+                .await
+                .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+            assert!(
+                update_resp.error.is_none(),
+                "activate should succeed: {:?}",
+                update_resp.error
+            );
+        } // state is dropped here — simulates server shutdown
+
+        // Session 2: fresh DB open — simulates restart.
+        {
+            let plan_db = crate::plan_db::PlanDb::open(&plan_db_path).await?;
+            let persisted = plan_db.list().await?;
+            let mut map = std::collections::HashMap::new();
+            for plan in persisted {
+                map.insert(plan.id.clone(), plan);
+            }
+
+            let pid = harness_core::ExecPlanId(plan_id_str.clone());
+            let recovered = map
+                .get(&pid)
+                .ok_or_else(|| anyhow::anyhow!("plan should survive restart"))?;
+            assert_eq!(recovered.purpose, "Restart Test");
+            assert_eq!(recovered.status, harness_core::ExecPlanStatus::Active);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exec_plan_status_fallback_to_db_when_not_in_memory() -> anyhow::Result<()> {
+        let data_dir = tempfile::tempdir()?;
+        let proj_dir = crate::test_helpers::tempdir_in_home("harness-exec-test-")?;
+        let plan_db_path = data_dir.path().join("exec_plans.db");
+
+        // Insert a plan directly into the DB without going through the in-memory HashMap.
+        let plan = harness_exec::ExecPlan::from_spec("# Direct DB Insert", proj_dir.path())?;
+        let plan_id = plan.id.clone();
+        {
+            let db = crate::plan_db::PlanDb::open(&plan_db_path).await?;
+            db.upsert(&plan).await?;
+        }
+
+        // Create state with the DB but empty HashMap (simulates post-restart before warmup).
+        let state = make_test_state_with_plan_db(data_dir.path()).await?;
+
+        // ExecPlanStatus must fall back to DB when plan is absent from HashMap.
+        let status_req = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: Method::ExecPlanStatus { plan_id },
+        };
+        let resp = handle_request(&state, status_req)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("expected response"))?;
+        assert!(
+            resp.error.is_none(),
+            "status should fall back to DB: {:?}",
+            resp.error
+        );
+        let result = resp
+            .result
+            .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+        assert_eq!(result["purpose"], "Direct DB Insert");
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Closes #221

- Rename the SQLite table from `plans` to `exec_plans` to match the acceptance criteria in #221
- Add five integration tests that exercise ExecPlan persistence through the full RPC handler layer (previously all test helpers used `plan_db: None`)

## Changes

### `crates/harness-server/src/plan_db.rs`
- `CREATE_TABLE_SQL`: `plans` → `exec_plans`
- `DbEntity::table_name()`: `"plans"` → `"exec_plans"`

### `crates/harness-server/src/router.rs`
New test helper `make_test_state_with_plan_db` and five new tests:

| Test | Verifies |
|------|---------|
| `exec_plan_init_persists_to_db` | Plan written to SQLite on `ExecPlanInit` |
| `exec_plan_status_reads_plan_from_memory` | `ExecPlanStatus` returns cached plan with correct fields |
| `exec_plan_update_persists_status_change` | `activate` action written to DB via `ExecPlanUpdate` |
| `exec_plan_survives_simulated_restart` | Plan + status survive DB close/reopen (server restart) |
| `exec_plan_status_fallback_to_db_when_not_in_memory` | `ExecPlanStatus` falls back to DB when plan absent from HashMap |

## Test plan

- [x] `cargo check --workspace --all-targets` (no warnings)
- [x] `cargo fmt --all` applied
- [x] All new tests pass (`router::tests::exec_plan_*`)
- [x] Full test suite passes (pre-existing `harness-core` config test failures are unrelated to this PR)