### PR TITLE
feat: auto-trigger Gemini review on PR created by agent (#185)

### DIFF
--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -75,6 +75,9 @@ pub struct AgentReviewConfig {
     /// Command to trigger review bot re-review (e.g. "/gemini review", "/reviewbot run").
     #[serde(default = "default_review_bot_command")]
     pub review_bot_command: String,
+    /// Automatically post review_bot_command as a PR comment when a task completes with a PR.
+    #[serde(default = "default_review_bot_auto_trigger")]
+    pub review_bot_auto_trigger: bool,
 }
 
 impl Default for AgentReviewConfig {
@@ -84,12 +87,17 @@ impl Default for AgentReviewConfig {
             reviewer_agent: String::new(),
             max_rounds: default_max_agent_review_rounds(),
             review_bot_command: default_review_bot_command(),
+            review_bot_auto_trigger: default_review_bot_auto_trigger(),
         }
     }
 }
 
 fn default_review_bot_command() -> String {
     "/gemini review".to_string()
+}
+
+fn default_review_bot_auto_trigger() -> bool {
+    true
 }
 
 fn default_max_agent_review_rounds() -> u32 {

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -265,6 +265,24 @@ pub fn extract_pr_number(url: &str) -> Option<u64> {
     None
 }
 
+/// Parse a GitHub PR URL into `(owner, repo, pr_number)`.
+///
+/// Accepts URLs of the form `https://github.com/{owner}/{repo}/pull/{number}[/...]`.
+pub fn parse_github_pr_url(url: &str) -> Option<(String, String, u64)> {
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))?;
+    let parts: Vec<&str> = path.splitn(5, '/').collect();
+    if parts.len() >= 4 && parts[2] == "pull" {
+        let owner = parts[0].to_string();
+        let repo = parts[1].to_string();
+        let number_str = parts[3].split('#').next()?;
+        let number = number_str.parse::<u64>().ok()?;
+        return Some((owner, repo, number));
+    }
+    None
+}
+
 /// Check if agent output's last non-empty line is exactly "LGTM".
 pub fn is_lgtm(output: &str) -> bool {
     last_non_empty_line(output) == Some("LGTM")
@@ -530,5 +548,50 @@ mod tests {
     fn test_extract_review_issues_empty() {
         assert!(extract_review_issues("APPROVED").is_empty());
         assert!(extract_review_issues("ISSUE: ").is_empty());
+    }
+
+    #[test]
+    fn test_parse_github_pr_url_basic() {
+        assert_eq!(
+            parse_github_pr_url("https://github.com/owner/repo/pull/42"),
+            Some(("owner".to_string(), "repo".to_string(), 42))
+        );
+    }
+
+    #[test]
+    fn test_parse_github_pr_url_with_path_suffix() {
+        assert_eq!(
+            parse_github_pr_url("https://github.com/owner/repo/pull/42/files"),
+            Some(("owner".to_string(), "repo".to_string(), 42))
+        );
+    }
+
+    #[test]
+    fn test_parse_github_pr_url_with_fragment() {
+        assert_eq!(
+            parse_github_pr_url("https://github.com/owner/repo/pull/42#discussion_r123"),
+            Some(("owner".to_string(), "repo".to_string(), 42))
+        );
+    }
+
+    #[test]
+    fn test_parse_github_pr_url_not_a_pr() {
+        assert_eq!(
+            parse_github_pr_url("https://github.com/owner/repo/issues/42"),
+            None
+        );
+        assert_eq!(
+            parse_github_pr_url("https://example.com/owner/repo/pull/42"),
+            None
+        );
+        assert_eq!(parse_github_pr_url("not a url"), None);
+    }
+
+    #[test]
+    fn test_parse_github_pr_url_invalid_number() {
+        assert_eq!(
+            parse_github_pr_url("https://github.com/owner/repo/pull/abc"),
+            None
+        );
     }
 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -277,7 +277,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             )) as Arc<dyn crate::intake::IntakeSource>
         });
 
-    let completion_callback = build_completion_callback(&feishu_intake, &github_intake);
+    let completion_callback = build_completion_callback(
+        &feishu_intake,
+        &github_intake,
+        server.config.agents.review.clone(),
+    );
 
     Ok(AppState {
         core: CoreServices {
@@ -331,6 +335,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
 fn build_completion_callback(
     feishu_intake: &Option<Arc<crate::intake::feishu::FeishuIntake>>,
     github_intake: &Option<Arc<dyn crate::intake::IntakeSource>>,
+    review_config: harness_core::AgentReviewConfig,
 ) -> Option<task_runner::CompletionCallback> {
     let mut sources: std::collections::HashMap<String, Arc<dyn crate::intake::IntakeSource>> =
         std::collections::HashMap::new();
@@ -341,13 +346,57 @@ fn build_completion_callback(
         let fi_source: Arc<dyn crate::intake::IntakeSource> = fi.clone();
         sources.insert(fi_source.name().to_string(), fi_source);
     }
-    if sources.is_empty() {
+    if sources.is_empty() && !review_config.review_bot_auto_trigger {
         return None;
     }
     let sources = Arc::new(sources);
     Some(Arc::new(move |task: task_runner::TaskState| {
         let sources = sources.clone();
+        let review_config = review_config.clone();
         Box::pin(async move {
+            // Auto-trigger review bot comment when task completes with a PR URL.
+            if review_config.review_bot_auto_trigger {
+                if let task_runner::TaskStatus::Done = &task.status {
+                    if let Some(pr_url) = task.pr_url.as_deref() {
+                        if let Some((owner, repo, pr_num)) =
+                            harness_core::prompts::parse_github_pr_url(pr_url)
+                        {
+                            match std::env::var("GITHUB_TOKEN") {
+                                Ok(token) if !token.is_empty() => {
+                                    if let Err(e) = post_review_bot_comment(
+                                        &owner,
+                                        &repo,
+                                        pr_num,
+                                        &review_config.review_bot_command,
+                                        &token,
+                                    )
+                                    .await
+                                    {
+                                        tracing::warn!(
+                                            pr_url,
+                                            "review_bot_auto_trigger: failed to post comment: {e}"
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            pr_url,
+                                            comment = review_config.review_bot_command,
+                                            "review bot comment posted"
+                                        );
+                                    }
+                                }
+                                _ => {
+                                    tracing::warn!(
+                                        pr_url,
+                                        "review_bot_auto_trigger: GITHUB_TOKEN not set or empty; skipping"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Intake source notification.
             let Some(source_name) = task.source.as_deref() else {
                 return;
             };
@@ -400,6 +449,33 @@ fn build_completion_callback(
             }
         })
     }))
+}
+
+/// Post a comment to a GitHub PR via the Issues API.
+async fn post_review_bot_comment(
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    body: &str,
+    github_token: &str,
+) -> anyhow::Result<()> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {github_token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "harness-bot")
+        .json(&serde_json::json!({ "body": body }))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("GitHub API returned {status}: {text}");
+    }
+    Ok(())
 }
 
 /// Resolve the reviewer agent for independent agent review.


### PR DESCRIPTION
## Summary

- Adds `review_bot_auto_trigger: bool` (default `true`) to `AgentReviewConfig` in `config/agents.rs`
- Adds `parse_github_pr_url(url) -> Option<(String, String, u64)>` to `prompts.rs` to extract `(owner, repo, pr_number)` from a GitHub PR URL
- Adds `post_review_bot_comment()` in `http.rs` that POSTs the configured `review_bot_command` (default `/gemini review`) to the GitHub Issues API using `GITHUB_TOKEN`
- Updates `build_completion_callback` to accept `AgentReviewConfig` and auto-post the review comment when a task completes with a `pr_url`; failures are logged but do not affect task completion

## Test plan

- [ ] `cargo test --workspace` passes (all 603 tests pass, 0 failed)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes cleanly
- [ ] New unit tests for `parse_github_pr_url`: basic URL, path suffix, URL fragment, non-PR URL, invalid number
- [ ] `review_bot_auto_trigger` defaults to `true`; set to `false` to disable
- [ ] When `GITHUB_TOKEN` is unset, a warning is logged and task completion is unaffected

Closes #185