### PR TITLE
feat: add exponential backoff to validation retry loop

### DIFF
--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -17,6 +17,7 @@ fn gc_adopt_task_request(
         max_rounds: gc_config.adopt_max_rounds,
         turn_timeout_secs: gc_config.adopt_turn_timeout_secs,
         max_budget_usd: Some(gc_config.budget_per_signal_usd),
+        ..Default::default()
     }
 }
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -149,6 +149,17 @@ pub(crate) async fn run_turn_lifecycle(
     }
 }
 
+/// Compute exponential backoff: `min(base_ms * 2^(attempt-1), max_ms)`.
+///
+/// - Attempt 1: `base_ms`
+/// - Attempt 2: `base_ms * 2`
+/// - Attempt 3: `base_ms * 4`
+/// - …capped at `max_ms`
+fn compute_backoff_ms(base_ms: u64, max_ms: u64, attempt: u32) -> u64 {
+    let shift = attempt.saturating_sub(1).min(63);
+    base_ms.saturating_mul(1u64 << shift).min(max_ms)
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
@@ -219,17 +230,24 @@ pub(crate) async fn run_task(
                 if let Some(err) = run_post_execute(&interceptors, &impl_req, &r).await {
                     if validation_attempt < max_validation_retries {
                         validation_attempt += 1;
+                        let backoff_ms = compute_backoff_ms(
+                            req.retry_base_backoff_ms,
+                            req.retry_max_backoff_ms,
+                            validation_attempt,
+                        );
                         tracing::warn!(
                             attempt = validation_attempt,
                             max = max_validation_retries,
+                            backoff_ms,
                             error = %err,
-                            "post-execution validation failed; retrying with error context"
+                            "post-execution validation failed; backing off before retry"
                         );
                         let truncated = truncate_validation_error(&err, 2000);
                         impl_req.prompt = format!(
                             "{}\n\nPost-execution validation failed (attempt {}/{}):\n{}",
                             first_req.prompt, validation_attempt, max_validation_retries, truncated
                         );
+                        sleep(Duration::from_millis(backoff_ms)).await;
                         continue;
                     } else {
                         tracing::error!(
@@ -603,6 +621,28 @@ async fn run_agent_review(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exponential_backoff_three_consecutive_retries() {
+        let base_ms: u64 = 10_000;
+        let max_ms: u64 = 300_000;
+
+        // Attempt 1: base_ms * 2^0 = 10_000 ms (10 s)
+        assert_eq!(compute_backoff_ms(base_ms, max_ms, 1), 10_000);
+        // Attempt 2: base_ms * 2^1 = 20_000 ms (20 s)
+        assert_eq!(compute_backoff_ms(base_ms, max_ms, 2), 20_000);
+        // Attempt 3: base_ms * 2^2 = 40_000 ms (40 s)
+        assert_eq!(compute_backoff_ms(base_ms, max_ms, 3), 40_000);
+    }
+
+    #[test]
+    fn exponential_backoff_capped_at_max() {
+        let base_ms: u64 = 10_000;
+        let max_ms: u64 = 300_000;
+
+        // Attempt 6: 10_000 * 2^5 = 320_000 — should be capped at 300_000
+        assert_eq!(compute_backoff_ms(base_ms, max_ms, 6), 300_000);
+    }
 
     #[test]
     fn parse_harness_review_command() {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -144,6 +144,13 @@ pub struct CreateTaskRequest {
     /// Maximum spend budget for the agent in USD; None means unlimited.
     #[serde(default)]
     pub max_budget_usd: Option<f64>,
+    /// Base delay in milliseconds for the first validation retry; subsequent retries double the
+    /// delay up to `retry_max_backoff_ms`. Default: 10 000 ms (10 s).
+    #[serde(default = "default_retry_base_backoff_ms")]
+    pub retry_base_backoff_ms: u64,
+    /// Maximum backoff cap in milliseconds for validation retries. Default: 300 000 ms (5 min).
+    #[serde(default = "default_retry_max_backoff_ms")]
+    pub retry_max_backoff_ms: u64,
 }
 
 impl Default for CreateTaskRequest {
@@ -158,6 +165,8 @@ impl Default for CreateTaskRequest {
             max_rounds: default_max_rounds(),
             turn_timeout_secs: default_turn_timeout(),
             max_budget_usd: None,
+            retry_base_backoff_ms: default_retry_base_backoff_ms(),
+            retry_max_backoff_ms: default_retry_max_backoff_ms(),
         }
     }
 }
@@ -189,6 +198,12 @@ fn default_wait() -> u64 {
 }
 fn default_max_rounds() -> u32 {
     5
+}
+fn default_retry_base_backoff_ms() -> u64 {
+    10_000
+}
+fn default_retry_max_backoff_ms() -> u64 {
+    300_000
 }
 fn default_turn_timeout() -> u64 {
     // 1 hour: parallel subtasks and complex agent turns on large codebases
@@ -652,6 +667,7 @@ mod tests {
             max_rounds: 0,
             turn_timeout_secs: 30,
             max_budget_usd: None,
+            ..Default::default()
         };
 
         let events = Arc::new(harness_observe::EventStore::new(dir.path())?);
@@ -725,6 +741,7 @@ mod tests {
             max_rounds: 0,
             turn_timeout_secs: 30,
             max_budget_usd: None,
+            ..Default::default()
         };
 
         let queue = crate::task_queue::TaskQueue::unbounded();
@@ -847,6 +864,7 @@ mod tests {
             max_rounds: 0,
             turn_timeout_secs: 30,
             max_budget_usd: None,
+            ..Default::default()
         };
 
         let queue = crate::task_queue::TaskQueue::unbounded();


### PR DESCRIPTION
## Summary

- Add `retry_base_backoff_ms` (default 10s) and `retry_max_backoff_ms` (default 5min) config fields to `CreateTaskRequest`
- Apply `min(base_ms * 2^(attempt-1), max_ms)` backoff sleep before each validation retry in `task_executor.rs`
- Log attempt number and backoff duration on each retry
- Add `compute_backoff_ms` helper with unit tests verifying durations for 3 consecutive retries and cap behavior
- Fix existing test struct initializations to include new fields via `..Default::default()`

Closes #184

## Test plan

- [x] `cargo check --workspace --all-targets` passes with `RUSTFLAGS="-Dwarnings"`
- [x] `cargo test --workspace` passes
- [x] `test exponential_backoff_three_consecutive_retries`: attempt 1→10s, attempt 2→20s, attempt 3→40s
- [x] `test exponential_backoff_capped_at_max`: attempt 6 (320s) capped to 300s