### PR TITLE
feat: add production guard scripts for built-in rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 exec-plan-*.md
-.harness/
+.harness/*
+!.harness/guards
 crates/*/.harness/
 **/.harness/drafts/

--- a/.harness/guards/rs-03-unwrap.sh
+++ b/.harness/guards/rs-03-unwrap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# RS-03: Detect .unwrap() calls in non-test Rust source files.
+# Output format: FILE:LINE:RS-03:MESSAGE
+set -euo pipefail
+
+project_root="${1:-}"
+if [[ -z "${project_root}" ]]; then
+  exit 0
+fi
+
+# Find .unwrap() in Rust files, excluding test files and the target directory.
+find "${project_root}" -name "*.rs" \
+  ! -path "*/target/*" \
+  ! -path "*/.git/*" \
+  ! -name "*_test.rs" \
+  ! -path "*/tests/*" \
+  -print0 2>/dev/null \
+| xargs -0 grep -n '\.unwrap()' 2>/dev/null \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:RS-03:unwrap() in non-test code risks panic in production"
+done || true

--- a/.harness/guards/sec-01-sql-concat.sh
+++ b/.harness/guards/sec-01-sql-concat.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SEC-01: Detect SQL string concatenation patterns that may lead to injection.
+# Output format: FILE:LINE:SEC-01:MESSAGE
+set -euo pipefail
+
+project_root="${1:-}"
+if [[ -z "${project_root}" ]]; then
+  exit 0
+fi
+
+# Detect SQL keyword strings followed by concatenation operators in common languages.
+# Patterns: "SELECT ..." + , "INSERT ..." + , f"SELECT...", format!("SELECT {
+grep -rn \
+  --include="*.py" \
+  --include="*.js" \
+  --include="*.ts" \
+  --include="*.go" \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E '"(SELECT|INSERT|UPDATE|DELETE|DROP)\s[^"]*"\s*(\+|\.)|f"(SELECT|INSERT|UPDATE|DELETE|DROP)\s[^"]*\{|`(SELECT|INSERT|UPDATE|DELETE|DROP)\s[^`]*\$\{' \
+  "${project_root}" 2>/dev/null \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-01:SQL string concatenation may lead to injection"
+done || true

--- a/.harness/guards/sec-02-hardcoded-secrets.sh
+++ b/.harness/guards/sec-02-hardcoded-secrets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SEC-02: Detect hardcoded API keys, tokens, and secrets.
+# Output format: FILE:LINE:SEC-02:MESSAGE
+set -euo pipefail
+
+project_root="${1:-}"
+if [[ -z "${project_root}" ]]; then
+  exit 0
+fi
+
+# Detect common secret/key assignment patterns with non-trivial string values.
+grep -rn \
+  --include="*.py" \
+  --include="*.rs" \
+  --include="*.go" \
+  --include="*.js" \
+  --include="*.ts" \
+  --include="*.yaml" \
+  --include="*.yml" \
+  --include="*.env" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E '(api_key|apikey|api_secret|secret_key|access_token|auth_token|password|passwd)\s*[=:]\s*"[^"$\{]{8,}"' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(test|example|placeholder|changeme|your_|<|>|\*{3}|xxx|TODO|FIXME)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-02:Hardcoded secret or API key detected"
+done || true

--- a/.harness/guards/u-11-divergent-paths.sh
+++ b/.harness/guards/u-11-divergent-paths.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# U-11: Detect divergent hardcoded default database/config paths across binaries.
+# Flags multiple distinct .db path strings in production Rust code, which
+# indicates that different binaries may be using different data files.
+# Output format: FILE:LINE:U-11:MESSAGE
+set -euo pipefail
+
+project_root="${1:-}"
+if [[ -z "${project_root}" ]]; then
+  exit 0
+fi
+
+# Collect all hardcoded .db path joins outside of test and target directories.
+find "${project_root}" -name "*.rs" \
+  ! -path "*/target/*" \
+  ! -path "*/.git/*" \
+  ! -name "*_test.rs" \
+  ! -path "*/tests/*" \
+  -print0 2>/dev/null \
+| xargs -0 grep -n '\.join("[^"]*\.db")' 2>/dev/null \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:U-11:Hardcoded .db path — ensure all binaries use a shared default_db_path() function"
+done || true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-rules/src/engine.rs
+++ b/crates/harness-rules/src/engine.rs
@@ -358,6 +358,61 @@ impl RuleEngine {
         Ok(1)
     }
 
+    /// Register guard scripts found in `guards_dir` (all `*.sh` files).
+    ///
+    /// The guard ID is derived from the filename stem (uppercased, hyphens preserved).
+    /// Already-registered guards are skipped. Returns the count of newly registered guards.
+    pub fn auto_register_project_guards(&mut self, guards_dir: &Path) -> anyhow::Result<usize> {
+        if !guards_dir.is_dir() {
+            return Ok(0);
+        }
+
+        let mut registered = 0;
+        for entry in std::fs::read_dir(guards_dir)
+            .with_context(|| format!("failed to read guards directory: {}", guards_dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.extension().map(|e| e == "sh").unwrap_or(false) {
+                continue;
+            }
+
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_uppercase(),
+                None => continue,
+            };
+            let guard_id = GuardId::from_str(&stem);
+
+            if self.guards.iter().any(|g| g.id == guard_id) {
+                continue;
+            }
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(meta) = std::fs::metadata(&path) {
+                    let mut perms = meta.permissions();
+                    perms.set_mode(0o755);
+                    if let Err(e) = std::fs::set_permissions(&path, perms) {
+                        tracing::warn!(
+                            path = %path.display(),
+                            "failed to set executable bit on guard script: {e}"
+                        );
+                    }
+                }
+            }
+
+            self.register_guard(Guard {
+                id: guard_id,
+                script_path: path,
+                language: Language::Common,
+                rules: Vec::new(),
+            });
+            registered += 1;
+        }
+        Ok(registered)
+    }
+
     pub fn validate_scan_request(&self, files: Option<&[PathBuf]>) -> anyhow::Result<()> {
         if let Some(files) = files {
             if files.is_empty() {

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -192,6 +192,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rule_check_with_guard_returns_violations() -> anyhow::Result<()> {
+        let dir = tempdir_in_home("rule-check-violations-")?;
+        let state = make_test_state(dir.path()).await?;
+
+        // Write a guard script that always reports one violation.
+        let guard_script = dir.path().join("violation-guard.sh");
+        let violation_line = format!(
+            "#!/usr/bin/env bash\necho '{}:1:RS-03:unwrap in production code'\n",
+            dir.path().join("src/main.rs").display()
+        );
+        std::fs::write(&guard_script, violation_line)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&guard_script)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&guard_script, perms)?;
+        }
+
+        {
+            let mut rules = state.engines.rules.write().await;
+            rules.register_guard(Guard {
+                id: GuardId::from_str("RS-03-TEST"),
+                script_path: guard_script,
+                language: Language::Common,
+                rules: vec![],
+            });
+        }
+
+        let response = rule_check(
+            &state,
+            Some(serde_json::json!(1)),
+            dir.path().to_path_buf(),
+            None,
+        )
+        .await;
+
+        assert!(
+            response.error.is_none(),
+            "rule/check with guard should succeed: {:?}",
+            response.error
+        );
+        let violations: Vec<serde_json::Value> =
+            serde_json::from_value(response.result.expect("expected violations result"))?;
+        assert_eq!(violations.len(), 1, "expected exactly one violation");
+        let rule_id = violations[0]["rule_id"].as_str().unwrap_or("");
+        assert_eq!(rule_id, "RS-03", "expected RS-03 violation");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn rule_check_returns_warning_for_empty_scan_input() -> anyhow::Result<()> {
         let dir = tempdir_in_home("rule-check-empty-input-")?;
         let state = make_test_state(dir.path()).await?;

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -169,6 +169,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             tracing::warn!("failed to auto-register builtin guards: {e}");
         }
     }
+    match rule_engine.auto_register_project_guards(&project_root.join(".harness/guards")) {
+        Ok(registered) => {
+            tracing::info!(
+                registered_guard_count = registered,
+                total_guard_count = rule_engine.guards().len(),
+                "rules: project guard auto-registration completed"
+            );
+        }
+        Err(e) => {
+            tracing::warn!("failed to auto-register project guards: {e}");
+        }
+    }
     rule_engine
         .load_exec_policy_files(&server.config.rules.exec_policy_paths)
         .context("failed to load rules.exec_policy_paths")?;


### PR DESCRIPTION
Closes #246

## Summary

- Add 4 guard scripts in `.harness/guards/` covering high-value rules:
  - `sec-01-sql-concat.sh` — detects SQL string concatenation patterns (SQL injection risk)
  - `sec-02-hardcoded-secrets.sh` — detects hardcoded API keys, tokens, and passwords
  - `rs-03-unwrap.sh` — detects `.unwrap()` calls in non-test Rust source files
  - `u-11-divergent-paths.sh` — detects hardcoded `.db` path joins that may diverge across binaries
- Add `auto_register_project_guards(guards_dir)` to `RuleEngine` — scans a directory for `*.sh` files, sets executable bit, and registers each as a guard
- Call `auto_register_project_guards` from `build_app_state` using `<project_root>/.harness/guards/`
- Update `.gitignore` to track `.harness/guards/` (negation exception for `.harness/*`)
- Add integration test `rule_check_with_guard_returns_violations` — verifies `rule/check` returns a violation when a guard emits output

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — no warnings
- [x] `cargo test -p harness-rules -p harness-server` — 285+ tests pass
- [x] New integration test `rule_check_with_guard_returns_violations` passes