### PR TITLE
feat: add periodic review subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
+ "toml",
  "tower 0.5.3",
  "tower-http",
  "tracing",

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -11,8 +11,8 @@ pub use agents::{
 };
 pub use intake::{FeishuIntakeConfig, GitHubIntakeConfig, IntakeConfig};
 pub use misc::{
-    ConcurrencyConfig, GcConfig, ObserveConfig, OtelConfig, OtelExporter, RulesConfig,
-    SignalThresholdsConfig, ValidationConfig, WorkspaceConfig,
+    ConcurrencyConfig, GcConfig, ObserveConfig, OtelConfig, OtelExporter, ReviewConfig,
+    RulesConfig, SignalThresholdsConfig, ValidationConfig, WorkspaceConfig,
 };
 pub use project::{load_project_config, GitConfig, ProjectConfig};
 pub use server::{ServerConfig, Transport};
@@ -35,6 +35,8 @@ pub struct HarnessConfig {
     pub concurrency: ConcurrencyConfig,
     #[serde(default)]
     pub intake: IntakeConfig,
+    #[serde(default)]
+    pub review: ReviewConfig,
 }
 
 #[cfg(test)]

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -257,3 +257,42 @@ pub enum OtelExporter {
 fn default_otel_environment() -> String {
     "development".to_string()
 }
+
+/// Periodic codebase review configuration.
+///
+/// When enabled, a scheduled agent reviews the full codebase for structural issues
+/// once per `interval_hours`, skipping cycles with no new commits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewConfig {
+    /// Enable the periodic review loop. Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Hours between review runs. Default: 24.
+    #[serde(default = "default_review_interval_hours")]
+    pub interval_hours: u64,
+    /// Agent name to use for the review. Default: None (use default agent).
+    #[serde(default)]
+    pub agent: Option<String>,
+    /// Per-turn timeout in seconds for the review agent. Default: 900.
+    #[serde(default = "default_review_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_review_interval_hours() -> u64 {
+    24
+}
+
+fn default_review_timeout_secs() -> u64 {
+    900
+}
+
+impl Default for ReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_hours: default_review_interval_hours(),
+            agent: None,
+            timeout_secs: default_review_timeout_secs(),
+        }
+    }
+}

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -221,6 +221,85 @@ pub fn agent_review_fix_prompt(pr: u64, issues: &[String], round: u32) -> String
     )
 }
 
+/// Build the periodic codebase review prompt with 11-item checklist.
+///
+/// `recent_commits` is the output of `git log --oneline` since the last review.
+/// The agent reviews the entire codebase and outputs findings sorted by severity,
+/// ending with a summary table.
+pub fn periodic_review_prompt(recent_commits: &str) -> String {
+    format!(
+        "You are performing a periodic codebase health review.\n\n\
+         Recent commits since last review:\n{recent_commits}\n\n\
+         Review the entire codebase for the following 11 categories of issues.\n\
+         For each finding, format your output as:\n\n\
+         ## [SEVERITY] Category: Short Title\n\n\
+         **File:** path/to/file.rs:LINE\n\
+         **Details:** What the issue is and why it matters\n\
+         **Action:** Specific fix recommendation\n\n\
+         ---\n\n\
+         ## Review Checklist\n\n\
+         ### CRITICAL\n\n\
+         **1. Duplicate Type Definitions**\n\
+         Structs or enums with the same name defined in multiple crates. \
+         Types that should be shared from a single source (e.g., `harness-core`). \
+         Config structs duplicated across crate boundaries.\n\n\
+         **7. Declaration-Execution Gap**\n\
+         Components built but never wired into the actual execution path. \
+         Modules registered in `lib.rs` but never imported or called. \
+         Functions or traits implemented but never invoked from startup/runtime code. \
+         Check `build_app_state()`, `main()`, and startup code to verify all \
+         declared components are actually connected. \
+         Note: Config structs using `Default::default()` instead of loaded values belong \
+         to item 11 (Config-Default Divergence), not here.\n\n\
+         ### HIGH\n\n\
+         **2. Oversized Files**\n\
+         Any `.rs` file exceeding 400 lines. Report exact line count and suggest split points.\n\n\
+         **3. God Objects**\n\
+         Structs with more than 10 public fields. Modules that mix unrelated concerns.\n\n\
+         **8. Dead Code**\n\
+         `pub` functions with zero call sites outside their own module. \
+         Structs or enums defined but never instantiated. \
+         Entire modules exported via `pub mod` but never imported by any other crate. \
+         Helper functions written speculatively but never used. \
+         Note: `#[cfg(test)]` code is excluded from this check.\n\n\
+         **10. Project Rule Violations**\n\
+         Verify that `CLAUDE.md` rules are respected throughout the codebase:\n\
+         - ZERO `Command::new(\"gh\")` or `Command::new(\"git\")` calls inside harness \
+         crates — all GitHub/git interaction must be in agent prompts only\n\
+         - All user-facing strings, comments, and docs in English\n\
+         - No hardcoded ports, URLs, or credentials\n\
+         - `cargo fmt` compliance\n\n\
+         ### MEDIUM\n\n\
+         **4. Public API Leakage**\n\
+         `lib.rs` files that export more than 5 `pub mod`. \
+         Internal implementation details exposed as public.\n\n\
+         **5. Repeated Patterns**\n\
+         Same function signature pattern appearing 3+ times across files. \
+         Boilerplate that should be abstracted (e.g., error wrapping, validation, CRUD).\n\n\
+         **9. Error Handling Inconsistency**\n\
+         Mixing `anyhow::Result` and custom error types without clear boundary rules. \
+         `let _ = result` or `.ok()` silently discarding meaningful errors. \
+         `.unwrap()` in non-test async code where `?` should be used.\n\n\
+         **11. Config-Default Divergence**\n\
+         Config struct has fields with serde defaults, but consuming code constructs via \
+         `Default::default()` instead of loading from file. \
+         For each Config struct, trace whether `load_config()` result is \
+         actually propagated to the code that uses it.\n\n\
+         ### LOW\n\n\
+         **6. Dependency Issues**\n\
+         Crates depending on more than 5 workspace siblings. \
+         Circular or unnecessary dependencies.\n\n\
+         ---\n\n\
+         After listing all findings, end with a summary table:\n\n\
+         | Severity | Count |\n\
+         |----------|-------|\n\
+         | CRITICAL | N     |\n\
+         | HIGH     | N     |\n\
+         | MEDIUM   | N     |\n\
+         | LOW      | N     |"
+    )
+}
+
 /// Check if agent output indicates approval (last non-empty line is "APPROVED").
 pub fn is_approved(output: &str) -> bool {
     last_non_empty_line(output) == Some("APPROVED")

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -36,3 +36,4 @@ reqwest = { workspace = true }
 tempfile = "3"
 http-body-util = "0.1"
 tokio-tungstenite = "0.26"
+toml = { workspace = true }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -557,7 +557,8 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
             .unwrap_or(0);
         harness_observe::quality::QualityGrader::grade(&events, violation_count).grade
     };
-    crate::scheduler::Scheduler::from_grade(initial_grade).start(state.clone());
+    crate::scheduler::Scheduler::from_grade(initial_grade, state.core.server.config.review.clone())
+        .start(state.clone());
     crate::intake::build_orchestrator(
         &state.core.server.config.intake,
         Some(&state.core.server.config.server.data_dir),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod http;
 pub mod intake;
 pub mod notify;
 pub mod parallel_dispatch;
+pub mod periodic_reviewer;
 pub mod plan_db;
 pub mod post_validator;
 pub mod router;

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1,0 +1,159 @@
+use crate::http::AppState;
+use harness_core::{Decision, Event, EventFilters, ReviewConfig, SessionId};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+const HOOK: &str = "periodic_review";
+
+/// Background loop that triggers a periodic codebase review agent task.
+///
+/// Sleeps for `config.interval_hours`, then checks whether any new commits have
+/// landed since the last review. If yes, enqueues a review task via the normal
+/// task pipeline. Skips the cycle silently if there are no new commits.
+pub async fn review_loop(config: ReviewConfig, state: Arc<AppState>) {
+    let interval = Duration::from_secs(config.interval_hours * 3600);
+    loop {
+        sleep(interval).await;
+        if let Err(e) = run_review_tick(&config, &state).await {
+            tracing::error!("periodic_reviewer: review tick failed: {e}");
+        }
+    }
+}
+
+async fn run_review_tick(config: &ReviewConfig, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let last_ts = last_review_timestamp(state)?;
+    let project_root = state.core.project_root.clone();
+
+    let commits = match last_ts {
+        Some(ts) => {
+            let since = ts.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+            let root = project_root.clone();
+            tokio::task::spawn_blocking(move || {
+                std::process::Command::new("git")
+                    .args([
+                        "-C",
+                        root.to_str().unwrap_or("."),
+                        "log",
+                        "--oneline",
+                        &format!("--since={since}"),
+                        "-1",
+                    ])
+                    .output()
+                    .ok()
+                    .and_then(|o| String::from_utf8(o.stdout).ok())
+                    .unwrap_or_default()
+            })
+            .await
+            .unwrap_or_default()
+        }
+        // First boot: no prior review recorded, always run.
+        None => "initial review".to_string(),
+    };
+
+    if commits.trim().is_empty() {
+        tracing::debug!("periodic_reviewer: no new commits since last review, skipping");
+        return Ok(());
+    }
+
+    tracing::info!(
+        commits = commits.trim(),
+        "periodic_reviewer: new commits detected, enqueueing review task"
+    );
+
+    let prompt = harness_core::prompts::periodic_review_prompt(commits.trim());
+    let req = crate::task_runner::CreateTaskRequest {
+        prompt: Some(prompt),
+        agent: config.agent.clone(),
+        project: Some(project_root),
+        turn_timeout_secs: config.timeout_secs,
+        ..Default::default()
+    };
+
+    match crate::http::task_routes::enqueue_task(state, req).await {
+        Ok(task_id) => {
+            crate::task_runner::mutate_and_persist(&state.core.tasks, &task_id, |s| {
+                s.source = Some(HOOK.to_string());
+            })
+            .await;
+
+            let mut event = Event::new(
+                SessionId::new(),
+                HOOK,
+                "periodic_reviewer",
+                Decision::Complete,
+            );
+            event.detail = Some(format!("task_id={}", task_id.0));
+            if let Err(e) = state.observability.events.log(&event) {
+                tracing::warn!("periodic_reviewer: failed to log review event: {e}");
+            }
+
+            tracing::info!(task_id = %task_id.0, "periodic_reviewer: review task enqueued");
+        }
+        Err(e) => {
+            tracing::error!("periodic_reviewer: failed to enqueue review task: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+fn last_review_timestamp(
+    state: &AppState,
+) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
+    let events = state.observability.events.query(&EventFilters {
+        hook: Some(HOOK.to_string()),
+        ..Default::default()
+    })?;
+    Ok(events.last().map(|e| e.ts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_config_defaults() {
+        let config = ReviewConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.interval_hours, 24);
+        assert!(config.agent.is_none());
+        assert_eq!(config.timeout_secs, 900);
+    }
+
+    #[test]
+    fn review_config_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            interval_hours = 48
+            agent = "claude"
+            timeout_secs = 1800
+        "#;
+        let config: ReviewConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.interval_hours, 48);
+        assert_eq!(config.agent.as_deref(), Some("claude"));
+        assert_eq!(config.timeout_secs, 1800);
+    }
+
+    #[test]
+    fn skip_logic_triggers_on_empty_commits() {
+        // Empty or whitespace-only output from git log means no new commits.
+        assert!("".trim().is_empty());
+        assert!("  \n  ".trim().is_empty());
+    }
+
+    #[test]
+    fn skip_logic_does_not_trigger_on_commit_output() {
+        let git_output = "a1b2c3d fix: some bug";
+        assert!(!git_output.trim().is_empty());
+    }
+
+    #[test]
+    fn first_boot_always_runs() {
+        // When no prior review event exists, last_ts is None and commits is
+        // set to the sentinel string, which is non-empty → review runs.
+        let sentinel = "initial review";
+        assert!(!sentinel.trim().is_empty());
+    }
+}

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -1,5 +1,5 @@
 use crate::http::AppState;
-use harness_core::{EventFilters, Grade};
+use harness_core::{EventFilters, Grade, ReviewConfig};
 use harness_observe::health::generate_health_report;
 use std::sync::Arc;
 use std::time::Duration;
@@ -8,13 +8,15 @@ use tokio::time::sleep;
 pub struct Scheduler {
     pub gc_interval: Duration,
     pub health_interval: Duration,
+    pub review: ReviewConfig,
 }
 
 impl Scheduler {
-    pub fn from_grade(grade: Grade) -> Self {
+    pub fn from_grade(grade: Grade, review: ReviewConfig) -> Self {
         Self {
             gc_interval: grade.recommended_gc_interval(),
             health_interval: Duration::from_secs(24 * 3600),
+            review,
         }
     }
 
@@ -29,7 +31,7 @@ impl Scheduler {
             }
         });
 
-        let health_state = state;
+        let health_state = state.clone();
         let health_interval = self.health_interval;
         tokio::spawn(async move {
             loop {
@@ -39,6 +41,14 @@ impl Scheduler {
                 }
             }
         });
+
+        if self.review.enabled {
+            let review_state = state;
+            let review_config = self.review;
+            tokio::spawn(async move {
+                crate::periodic_reviewer::review_loop(review_config, review_state).await;
+            });
+        }
     }
 
     async fn run_health_tick(state: &AppState) -> anyhow::Result<()> {
@@ -148,27 +158,27 @@ mod tests {
 
     #[test]
     fn from_grade_d_returns_1h_gc_interval() {
-        let s = Scheduler::from_grade(Grade::D);
+        let s = Scheduler::from_grade(Grade::D, ReviewConfig::default());
         assert_eq!(s.gc_interval, Duration::from_secs(3600));
         assert_eq!(s.health_interval, Duration::from_secs(24 * 3600));
     }
 
     #[test]
     fn from_grade_a_returns_7d_gc_interval() {
-        let s = Scheduler::from_grade(Grade::A);
+        let s = Scheduler::from_grade(Grade::A, ReviewConfig::default());
         assert_eq!(s.gc_interval, Duration::from_secs(7 * 24 * 3600));
         assert_eq!(s.health_interval, Duration::from_secs(24 * 3600));
     }
 
     #[test]
     fn from_grade_b_returns_3d_gc_interval() {
-        let s = Scheduler::from_grade(Grade::B);
+        let s = Scheduler::from_grade(Grade::B, ReviewConfig::default());
         assert_eq!(s.gc_interval, Duration::from_secs(3 * 24 * 3600));
     }
 
     #[test]
     fn from_grade_c_returns_1d_gc_interval() {
-        let s = Scheduler::from_grade(Grade::C);
+        let s = Scheduler::from_grade(Grade::C, ReviewConfig::default());
         assert_eq!(s.gc_interval, Duration::from_secs(24 * 3600));
     }
 


### PR DESCRIPTION
## Summary

- Add `ReviewConfig` struct to `harness-core` with `enabled`, `interval_hours`, `agent`, and `timeout_secs` fields
- Add `periodic_review_prompt()` to `harness-core/src/prompts.rs` with 11-item codebase review checklist
- Create `harness-server/src/periodic_reviewer.rs` with `review_loop()` that queries EventStore for last review timestamp, checks for new commits via `git log --since`, and enqueues a review task
- Wire `review_loop` into `Scheduler::start()` alongside existing `gc_loop` and `health_loop`
- Add unit tests for skip logic and config defaults

## Test plan

- [ ] `cargo check --workspace --all-targets` passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] Unit tests in `periodic_reviewer.rs` and `scheduler.rs` pass