### PR TITLE
feat: implement periodic review subsystem

### DIFF
--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -11,8 +11,8 @@ pub use agents::{
 };
 pub use intake::{FeishuIntakeConfig, GitHubIntakeConfig, IntakeConfig};
 pub use misc::{
-    ConcurrencyConfig, GcConfig, ObserveConfig, OtelConfig, OtelExporter, RulesConfig,
-    SignalThresholdsConfig, ValidationConfig, WorkspaceConfig,
+    ConcurrencyConfig, GcConfig, ObserveConfig, OtelConfig, OtelExporter, ReviewConfig,
+    RulesConfig, SignalThresholdsConfig, ValidationConfig, WorkspaceConfig,
 };
 pub use project::{load_project_config, GitConfig, ProjectConfig};
 pub use server::{ServerConfig, Transport};
@@ -35,6 +35,8 @@ pub struct HarnessConfig {
     pub concurrency: ConcurrencyConfig,
     #[serde(default)]
     pub intake: IntakeConfig,
+    #[serde(default)]
+    pub review: ReviewConfig,
 }
 
 #[cfg(test)]
@@ -381,6 +383,49 @@ mod tests {
         assert!(!config.agents.review.enabled);
         assert_eq!(config.otel.exporter, OtelExporter::Disabled);
         assert_eq!(config.gc.max_drafts_per_run, 5);
+        assert!(!config.review.enabled);
+        assert_eq!(config.review.interval_hours, 24);
+        assert_eq!(config.review.timeout_secs, 900);
+        assert!(config.review.agent.is_none());
+    }
+
+    #[test]
+    fn review_config_defaults() {
+        let config = ReviewConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.interval_hours, 24);
+        assert_eq!(config.timeout_secs, 900);
+        assert!(config.agent.is_none());
+    }
+
+    #[test]
+    fn review_config_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            interval_hours = 48
+            agent = "claude"
+            timeout_secs = 1200
+        "#;
+        let config: ReviewConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.interval_hours, 48);
+        assert_eq!(config.agent.as_deref(), Some("claude"));
+        assert_eq!(config.timeout_secs, 1200);
+    }
+
+    #[test]
+    fn review_config_deserializes_with_defaults() {
+        let config: ReviewConfig = toml::from_str("enabled = true").unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.interval_hours, 24);
+        assert!(config.agent.is_none());
+        assert_eq!(config.timeout_secs, 900);
+    }
+
+    #[test]
+    fn harness_config_includes_review() {
+        let config = HarnessConfig::default();
+        assert!(!config.review.enabled);
     }
 
     #[test]

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -257,3 +257,42 @@ pub enum OtelExporter {
 fn default_otel_environment() -> String {
     "development".to_string()
 }
+
+/// Periodic codebase review configuration.
+///
+/// When enabled, the scheduler spawns an agent review job at the configured interval.
+/// The review is skipped if no new commits have landed since the last review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewConfig {
+    /// Whether periodic review is enabled. Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Interval between review runs in hours. Default: 24.
+    #[serde(default = "default_review_interval_hours")]
+    pub interval_hours: u64,
+    /// Agent to use for the review. Default: None (use the default agent).
+    #[serde(default)]
+    pub agent: Option<String>,
+    /// Per-turn timeout in seconds for the review agent. Default: 900.
+    #[serde(default = "default_review_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_review_interval_hours() -> u64 {
+    24
+}
+
+fn default_review_timeout_secs() -> u64 {
+    900
+}
+
+impl Default for ReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_hours: default_review_interval_hours(),
+            agent: None,
+            timeout_secs: default_review_timeout_secs(),
+        }
+    }
+}

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -221,6 +221,82 @@ pub fn agent_review_fix_prompt(pr: u64, issues: &[String], round: u32) -> String
     )
 }
 
+/// Build prompt: periodic codebase review with an 11-item checklist.
+///
+/// `repo_structure` is the output of a directory listing (e.g., `find . -type f -name '*.rs'`).
+/// `diff_stat` is the output of `git diff --stat` since the last review.
+/// `recent_commits` is the output of `git log --oneline` since the last review.
+pub fn periodic_review_prompt(
+    repo_structure: &str,
+    diff_stat: &str,
+    recent_commits: &str,
+) -> String {
+    let safe_structure = wrap_external_data(repo_structure);
+    let safe_diff_stat = wrap_external_data(diff_stat);
+    let safe_commits = wrap_external_data(recent_commits);
+    format!(
+        "You are conducting a periodic codebase health review. \
+         Examine the entire codebase for the 11 categories of issues below. \
+         Produce a structured markdown report with severity-ranked findings.\n\n\
+         ## Context\n\n\
+         Repository structure:\n{safe_structure}\n\n\
+         Changes since last review (diff stat):\n{safe_diff_stat}\n\n\
+         Recent commits:\n{safe_commits}\n\n\
+         ## Review Checklist\n\n\
+         Check for ALL of the following (mark each item even if no issues found):\n\n\
+         ### CRITICAL\n\
+         1. **Duplicate Type Definitions** — Structs or enums with the same name in multiple \
+         crates. Config structs duplicated across crate boundaries.\n\
+         7. **Declaration-Execution Gap** — Components built but never wired into the actual \
+         execution path. Modules registered in lib.rs but never called from startup/runtime code. \
+         (Note: config structs using Default::default() instead of loaded values belong to #11, \
+         not here.)\n\n\
+         ### HIGH\n\
+         2. **Oversized Files** — Any .rs file exceeding 400 lines. Report exact line count \
+         and suggest split points.\n\
+         3. **God Objects** — Structs with more than 10 public fields. Modules mixing unrelated concerns.\n\
+         8. **Dead Code** — pub functions with zero call sites outside their own module. \
+         Structs or enums defined but never instantiated. Entire modules exported via pub mod \
+         but never imported. (Exclude #[cfg(test)] code.)\n\
+         10. **Project Rule Violations** — Verify CLAUDE.md rules: ZERO Command::new(\"gh\") or \
+         Command::new(\"git\") calls (all git/GitHub interaction must be in agent prompts only); \
+         all user-facing strings and comments in English; no hardcoded ports/URLs/credentials; \
+         cargo fmt compliance.\n\n\
+         ### MEDIUM\n\
+         4. **Public API Leakage** — lib.rs files exporting more than 5 pub mod entries. \
+         Internal implementation details exposed as public.\n\
+         5. **Repeated Patterns** — Same function signature pattern appearing 3+ times across \
+         files. Boilerplate that should be abstracted.\n\
+         9. **Error Handling Inconsistency** — Mixing anyhow::Result and custom error types \
+         without clear boundary rules. Silently discarding meaningful errors with let _ or .ok(). \
+         .unwrap() in non-test async code.\n\
+         11. **Config-Default Divergence** — Config struct has fields with serde defaults, but \
+         consuming code constructs via Default::default() instead of loading from file.\n\n\
+         ### LOW\n\
+         6. **Dependency Issues** — Crates depending on more than 5 workspace siblings. \
+         Circular or unnecessary dependencies.\n\n\
+         ## Output Format\n\n\
+         For each finding:\n\
+         ```\n\
+         ## [SEVERITY] Category: Short Title\n\n\
+         **File:** path/to/file.rs:LINE\n\
+         **Details:** What the issue is and why it matters\n\
+         **Action:** Specific fix recommendation\n\
+         ```\n\n\
+         End with a summary table:\n\
+         ```\n\
+         | Severity | Count |\n\
+         |----------|-------|\n\
+         | CRITICAL | N     |\n\
+         | HIGH     | N     |\n\
+         | MEDIUM   | N     |\n\
+         | LOW      | N     |\n\
+         ```\n\n\
+         If a category has no findings, include a one-line note: \
+         `## [SEVERITY] Category: No issues found.`"
+    )
+}
+
 /// Check if agent output indicates approval (last non-empty line is "APPROVED").
 pub fn is_approved(output: &str) -> bool {
     last_non_empty_line(output) == Some("APPROVED")

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod http;
 pub mod intake;
 pub mod notify;
 pub mod parallel_dispatch;
+pub mod periodic_reviewer;
 pub mod plan_db;
 pub mod post_validator;
 pub mod router;

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1,0 +1,220 @@
+use crate::http::task_routes;
+use crate::http::AppState;
+use crate::task_runner::CreateTaskRequest;
+use harness_core::{Decision, Event, EventFilters, ReviewConfig, SessionId};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Spawn the periodic review loop as a background task.
+///
+/// If review is disabled in config the loop returns immediately without
+/// spawning anything; no resources are consumed.
+pub fn start(state: Arc<AppState>, config: ReviewConfig) {
+    if !config.enabled {
+        tracing::debug!("scheduler: periodic review disabled, review_loop not started");
+        return;
+    }
+
+    tokio::spawn(async move {
+        review_loop(state, config).await;
+    });
+}
+
+async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
+    let interval = Duration::from_secs(config.interval_hours * 3600);
+    loop {
+        sleep(interval).await;
+        if let Err(err) = run_review_tick(&state, &config).await {
+            tracing::error!("scheduler: periodic review tick failed: {err}");
+        }
+    }
+}
+
+async fn run_review_tick(state: &Arc<AppState>, config: &ReviewConfig) -> anyhow::Result<()> {
+    let project_root = &state.core.project_root;
+
+    // Query EventStore for the most recent "periodic_review" event timestamp.
+    let events = state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("periodic_review".to_string()),
+            ..EventFilters::default()
+        })
+        .map_err(|e| anyhow::anyhow!("failed to query periodic_review events: {e}"))?;
+
+    let last_review_ts = events.iter().map(|e| e.ts).max();
+
+    // If there was a prior review, skip this cycle when no new commits have landed.
+    // On first boot (no prior event) we always run.
+    if let Some(ts) = last_review_ts {
+        let since = ts.to_rfc3339();
+        let output = tokio::process::Command::new("git")
+            .args(["log", "--oneline", &format!("--since={since}"), "-1"])
+            .current_dir(project_root)
+            .output()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to run git log: {e}"))?;
+
+        if String::from_utf8_lossy(&output.stdout).trim().is_empty() {
+            tracing::debug!(
+                since = %since,
+                "scheduler: periodic review skipped — no new commits"
+            );
+            return Ok(());
+        }
+    }
+
+    // Gather context strings for the review prompt.
+    let since_arg = last_review_ts
+        .map(|ts| ts.to_rfc3339())
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+    let repo_structure = gather_repo_structure(project_root).await;
+    let diff_stat = gather_diff_stat(project_root, &since_arg).await;
+    let recent_commits = gather_recent_commits(project_root, &since_arg).await;
+
+    let prompt =
+        harness_core::prompts::periodic_review_prompt(&repo_structure, &diff_stat, &recent_commits);
+
+    let req = CreateTaskRequest {
+        prompt: Some(prompt),
+        agent: config.agent.clone(),
+        turn_timeout_secs: config.timeout_secs,
+        source: Some("periodic_review".to_string()),
+        ..CreateTaskRequest::default()
+    };
+
+    match task_routes::enqueue_task(state, req).await {
+        Ok(task_id) => {
+            tracing::info!(
+                task_id = %task_id,
+                "scheduler: periodic review task enqueued"
+            );
+        }
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to enqueue periodic review task: {err}"
+            ));
+        }
+    }
+
+    // Log a "periodic_review" event so the next cycle can check the timestamp.
+    let event = Event::new(
+        SessionId::new(),
+        "periodic_review",
+        "scheduler",
+        Decision::Pass,
+    );
+    if let Err(err) = state.observability.events.log(&event) {
+        tracing::warn!("scheduler: failed to log periodic_review event: {err}");
+    }
+
+    Ok(())
+}
+
+async fn gather_repo_structure(project_root: &std::path::Path) -> String {
+    let output = tokio::process::Command::new("git")
+        .args(["ls-files", "--", "*.rs"])
+        .current_dir(project_root)
+        .output()
+        .await;
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+async fn gather_diff_stat(project_root: &std::path::Path, since: &str) -> String {
+    // Find the first new commit after `since` to diff from its parent.
+    let rev_output = tokio::process::Command::new("git")
+        .args([
+            "log",
+            "--format=%H",
+            &format!("--since={since}"),
+            "--reverse",
+            "-1",
+        ])
+        .current_dir(project_root)
+        .output()
+        .await;
+
+    let first_new_commit = match rev_output {
+        Ok(o) => {
+            let hash = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if hash.is_empty() {
+                return String::new();
+            }
+            hash
+        }
+        Err(_) => return String::new(),
+    };
+
+    let output = tokio::process::Command::new("git")
+        .args(["diff", "--stat", &format!("{first_new_commit}^"), "HEAD"])
+        .current_dir(project_root)
+        .output()
+        .await;
+
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+async fn gather_recent_commits(project_root: &std::path::Path, since: &str) -> String {
+    let output = tokio::process::Command::new("git")
+        .args(["log", "--oneline", &format!("--since={since}")])
+        .current_dir(project_root)
+        .output()
+        .await;
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_config_defaults_disabled() {
+        let config = ReviewConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.interval_hours, 24);
+        assert_eq!(config.timeout_secs, 900);
+        assert!(config.agent.is_none());
+    }
+
+    #[test]
+    fn review_config_custom_values() {
+        let config = ReviewConfig {
+            enabled: true,
+            interval_hours: 12,
+            agent: Some("claude".to_string()),
+            timeout_secs: 600,
+        };
+        assert!(config.enabled);
+        assert_eq!(config.interval_hours, 12);
+        assert_eq!(config.agent.as_deref(), Some("claude"));
+        assert_eq!(config.timeout_secs, 600);
+    }
+
+    #[test]
+    fn create_task_request_source_field() {
+        let req = CreateTaskRequest {
+            prompt: Some("review".to_string()),
+            source: Some("periodic_review".to_string()),
+            ..CreateTaskRequest::default()
+        };
+        assert_eq!(req.source.as_deref(), Some("periodic_review"));
+    }
+
+    #[test]
+    fn create_task_request_source_defaults_to_none() {
+        let req = CreateTaskRequest::default();
+        assert!(req.source.is_none());
+    }
+}

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -29,7 +29,7 @@ impl Scheduler {
             }
         });
 
-        let health_state = state;
+        let health_state = state.clone();
         let health_interval = self.health_interval;
         tokio::spawn(async move {
             loop {
@@ -39,6 +39,9 @@ impl Scheduler {
                 }
             }
         });
+
+        let review_config = state.core.server.config.review.clone();
+        crate::periodic_reviewer::start(state, review_config);
     }
 
     async fn run_health_tick(state: &AppState) -> anyhow::Result<()> {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -155,6 +155,9 @@ pub struct CreateTaskRequest {
     /// Overrides the global `concurrency.stall_timeout_secs` for this task.
     #[serde(default = "default_stall_timeout")]
     pub stall_timeout_secs: u64,
+    /// Intake source name (e.g. "github", "feishu", "periodic_review"). None for manual tasks.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 impl Default for CreateTaskRequest {
@@ -172,6 +175,7 @@ impl Default for CreateTaskRequest {
             retry_base_backoff_ms: default_retry_base_backoff_ms(),
             retry_max_backoff_ms: default_retry_max_backoff_ms(),
             stall_timeout_secs: default_stall_timeout(),
+            source: None,
         }
     }
 }
@@ -384,7 +388,8 @@ where
     F: Fn() -> PathBuf + Send + Sync + 'static,
 {
     let task_id = TaskId::new();
-    let state = TaskState::new(task_id.clone());
+    let mut state = TaskState::new(task_id.clone());
+    state.source = req.source.clone();
     store.insert(&state).await;
 
     let id = task_id.clone();


### PR DESCRIPTION
## Summary

Implements the Periodic Review subsystem from `docs/periodic-review.md` (closes #244).

- **`ReviewConfig`** added to `harness-core` config: `enabled`, `interval_hours` (default 24), `agent`, `timeout_secs` (default 900). Wired into `HarnessConfig` under `[review]`.
- **`periodic_review_prompt()`** added to `prompts.rs`: 11-item structured checklist covering CRITICAL (duplicate types, declaration-execution gap), HIGH (oversized files, god objects, dead code, rule violations), MEDIUM (API leakage, repeated patterns, error handling, config-default divergence), and LOW (dependency issues).
- **`harness-server/src/periodic_reviewer.rs`** (new): `review_loop()` queries EventStore for the last `periodic_review` event timestamp, runs `git log --since` to skip if no new commits, gathers context (repo structure via `git ls-files`, diff stat, recent commits), and enqueues a `CreateTaskRequest` with `source="periodic_review"`. Logs a `periodic_review` event after each successful dispatch for next-cycle skip detection.
- **`Scheduler::start()`** wired to spawn `periodic_reviewer::start()` alongside gc_loop and health_loop.
- **`source` field** added to `CreateTaskRequest` (serde default `None`) and propagated to `TaskState` at spawn time.

## Test plan

- [ ] `cargo check --workspace --all-targets` passes clean (no warnings)
- [ ] `cargo test --workspace` — all 129+ tests pass including new `review_config_*` and `create_task_request_source_*` tests
- [ ] `cargo fmt --all -- --check` clean
- [ ] Config disabled by default — `ReviewConfig::default().enabled == false`, review_loop exits immediately
- [ ] `HarnessConfig` round-trip includes `review` section with correct defaults

Fixes #244