### PR TITLE
feat: auto-trigger GC based on QualityGrader score

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,3 +1,4 @@
+use crate::Grade;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -143,6 +144,12 @@ pub struct GcConfig {
     #[serde(default = "default_gc_draft_ttl_hours")]
     pub draft_ttl_hours: u64,
     pub signal_thresholds: SignalThresholdsConfig,
+    /// Grades that trigger an automatic GC run after task completion. Default: [D].
+    #[serde(default = "default_auto_gc_grades")]
+    pub auto_gc_grades: Vec<Grade>,
+    /// Minimum seconds between auto-triggered GC runs (cooldown). Default: 300.
+    #[serde(default = "default_auto_gc_cooldown_secs")]
+    pub auto_gc_cooldown_secs: u64,
 }
 
 impl Default for GcConfig {
@@ -156,6 +163,8 @@ impl Default for GcConfig {
             adopt_turn_timeout_secs: default_gc_adopt_turn_timeout_secs(),
             draft_ttl_hours: default_gc_draft_ttl_hours(),
             signal_thresholds: SignalThresholdsConfig::default(),
+            auto_gc_grades: default_auto_gc_grades(),
+            auto_gc_cooldown_secs: default_auto_gc_cooldown_secs(),
         }
     }
 }
@@ -174,6 +183,14 @@ fn default_gc_adopt_turn_timeout_secs() -> u64 {
 
 fn default_gc_draft_ttl_hours() -> u64 {
     72
+}
+
+fn default_auto_gc_grades() -> Vec<Grade> {
+    vec![Grade::D]
+}
+
+fn default_auto_gc_cooldown_secs() -> u64 {
+    300
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -1,5 +1,5 @@
 use harness_core::{
-    Decision, Event, EventFilters, EventId, OtelConfig, SessionId, Severity, Violation,
+    Decision, Event, EventFilters, EventId, Grade, OtelConfig, SessionId, Severity, Violation,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -173,6 +173,23 @@ impl EventStore {
             if let Err(e) = self.log(&event) {
                 tracing::warn!("failed to log rule violation event: {e}");
             }
+        }
+    }
+
+    /// Log a quality grade event for trend tracking.
+    ///
+    /// Uses the "quality_grade" hook with decision mapped from grade:
+    /// A/B → Pass, C → Warn, D → Block.
+    pub fn log_quality_grade(&self, grade: Grade, score: f64) {
+        let decision = match grade {
+            Grade::A | Grade::B => Decision::Pass,
+            Grade::C => Decision::Warn,
+            Grade::D => Decision::Block,
+        };
+        let mut event = Event::new(SessionId::new(), "quality_grade", "QualityGrader", decision);
+        event.detail = Some(format!("grade={grade:?} score={score:.1}"));
+        if let Err(e) = self.log(&event) {
+            tracing::warn!("failed to log quality_grade event: {e}");
         }
     }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -293,10 +293,23 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             )) as Arc<dyn crate::intake::IntakeSource>
         });
 
+    let quality_trigger = {
+        let gc_cfg = &server.config.gc;
+        Arc::new(crate::quality_trigger::QualityTrigger::new(
+            events.clone(),
+            gc_agent.clone(),
+            server.agent_registry.clone(),
+            project_root.clone(),
+            gc_cfg.auto_gc_grades.clone(),
+            gc_cfg.auto_gc_cooldown_secs,
+        ))
+    };
+
     let completion_callback = build_completion_callback(
         &feishu_intake,
         &github_intake,
         server.config.agents.review.clone(),
+        Some(quality_trigger),
     );
 
     Ok(AppState {
@@ -353,6 +366,7 @@ fn build_completion_callback(
     feishu_intake: &Option<Arc<crate::intake::feishu::FeishuIntake>>,
     github_intake: &Option<Arc<dyn crate::intake::IntakeSource>>,
     review_config: harness_core::AgentReviewConfig,
+    quality_trigger: Option<Arc<crate::quality_trigger::QualityTrigger>>,
 ) -> Option<task_runner::CompletionCallback> {
     let mut sources: std::collections::HashMap<String, Arc<dyn crate::intake::IntakeSource>> =
         std::collections::HashMap::new();
@@ -363,14 +377,20 @@ fn build_completion_callback(
         let fi_source: Arc<dyn crate::intake::IntakeSource> = fi.clone();
         sources.insert(fi_source.name().to_string(), fi_source);
     }
-    if sources.is_empty() && !review_config.review_bot_auto_trigger {
+    if sources.is_empty() && !review_config.review_bot_auto_trigger && quality_trigger.is_none() {
         return None;
     }
     let sources = Arc::new(sources);
     Some(Arc::new(move |task: task_runner::TaskState| {
         let sources = sources.clone();
         let review_config = review_config.clone();
+        let quality_trigger = quality_trigger.clone();
         Box::pin(async move {
+            // Grade recent events and auto-trigger GC if quality is poor.
+            if let Some(qt) = quality_trigger {
+                qt.check_and_maybe_trigger().await;
+            }
+
             // Auto-trigger review bot comment when task completes with a PR URL.
             if review_config.review_bot_auto_trigger {
                 if let task_runner::TaskStatus::Done = &task.status {

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -21,6 +21,7 @@ pub mod parallel_dispatch;
 pub mod periodic_reviewer;
 pub mod plan_db;
 pub mod post_validator;
+pub mod quality_trigger;
 pub mod router;
 pub mod rule_enforcer;
 pub mod scheduler;

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -1,0 +1,252 @@
+use harness_core::{EventFilters, Grade, Project};
+use harness_gc::GcAgent;
+use harness_observe::{EventStore, QualityGrader};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Evaluates project quality after each task completion and triggers GC when
+/// the grade falls below a configured threshold.
+pub struct QualityTrigger {
+    events: Arc<EventStore>,
+    gc_agent: Arc<GcAgent>,
+    agent_registry: Arc<harness_agents::AgentRegistry>,
+    project_root: PathBuf,
+    auto_gc_grades: Vec<Grade>,
+    cooldown_secs: u64,
+    last_triggered: Arc<AtomicU64>,
+}
+
+impl QualityTrigger {
+    pub fn new(
+        events: Arc<EventStore>,
+        gc_agent: Arc<GcAgent>,
+        agent_registry: Arc<harness_agents::AgentRegistry>,
+        project_root: PathBuf,
+        auto_gc_grades: Vec<Grade>,
+        cooldown_secs: u64,
+    ) -> Self {
+        Self {
+            events,
+            gc_agent,
+            agent_registry,
+            project_root,
+            auto_gc_grades,
+            cooldown_secs,
+            last_triggered: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Returns true if the given grade should trigger an auto-GC run.
+    pub fn grade_triggers_gc(&self, grade: Grade) -> bool {
+        self.auto_gc_grades.contains(&grade)
+    }
+
+    /// Returns true if the cooldown period has elapsed since the last trigger.
+    fn cooldown_elapsed(&self) -> bool {
+        let last = self.last_triggered.load(Ordering::Relaxed);
+        unix_now().saturating_sub(last) >= self.cooldown_secs
+    }
+
+    /// Grade recent events, log the result, and auto-trigger GC if warranted.
+    pub async fn check_and_maybe_trigger(&self) {
+        let events = match self.events.query(&EventFilters::default()) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("quality_trigger: failed to query events: {e}");
+                return;
+            }
+        };
+
+        let report = QualityGrader::grade(&events, 0);
+        self.events.log_quality_grade(report.grade, report.score);
+
+        tracing::info!(
+            grade = ?report.grade,
+            score = report.score,
+            "quality_trigger: post-task quality check"
+        );
+
+        if !self.grade_triggers_gc(report.grade) {
+            return;
+        }
+
+        if !self.cooldown_elapsed() {
+            tracing::debug!(
+                grade = ?report.grade,
+                cooldown_secs = self.cooldown_secs,
+                "quality_trigger: grade triggers GC but cooldown not elapsed, skipping"
+            );
+            return;
+        }
+
+        tracing::info!(
+            grade = ?report.grade,
+            "quality_trigger: grade triggers auto-GC run"
+        );
+        self.last_triggered.store(unix_now(), Ordering::Relaxed);
+
+        let Some(agent) = self.agent_registry.default_agent() else {
+            tracing::warn!("quality_trigger: no agent registered, skipping auto-GC");
+            return;
+        };
+        let project = Project::from_path(self.project_root.clone());
+        if let Err(e) = self
+            .gc_agent
+            .run(&project, &events, &[], agent.as_ref())
+            .await
+        {
+            tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{Decision, Event, Grade, SessionId};
+    use harness_gc::{DraftStore, GcAgent, SignalDetector};
+    use std::path::Path;
+
+    fn make_trigger(dir: &Path, auto_gc_grades: Vec<Grade>, cooldown_secs: u64) -> QualityTrigger {
+        let events = Arc::new(EventStore::new(dir).expect("event store"));
+        let signal_detector = SignalDetector::new(
+            harness_gc::signal_detector::SignalThresholds::default(),
+            harness_core::ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(dir).expect("draft store");
+        let gc_agent = Arc::new(GcAgent::new(
+            harness_core::GcConfig::default(),
+            signal_detector,
+            draft_store,
+        ));
+        let agent_registry = Arc::new(harness_agents::AgentRegistry::new("test"));
+        QualityTrigger::new(
+            events,
+            gc_agent,
+            agent_registry,
+            dir.to_path_buf(),
+            auto_gc_grades,
+            cooldown_secs,
+        )
+    }
+
+    // --- grade_triggers_gc mapping tests ---
+
+    #[test]
+    fn grade_d_triggers_gc_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        assert!(trigger.grade_triggers_gc(Grade::D));
+    }
+
+    #[test]
+    fn grade_a_does_not_trigger_gc_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        assert!(!trigger.grade_triggers_gc(Grade::A));
+    }
+
+    #[test]
+    fn grade_b_does_not_trigger_gc_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        assert!(!trigger.grade_triggers_gc(Grade::B));
+    }
+
+    #[test]
+    fn grade_c_does_not_trigger_gc_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        assert!(!trigger.grade_triggers_gc(Grade::C));
+    }
+
+    #[test]
+    fn configuring_c_and_d_both_trigger() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::C, Grade::D], 300);
+        assert!(trigger.grade_triggers_gc(Grade::C));
+        assert!(trigger.grade_triggers_gc(Grade::D));
+        assert!(!trigger.grade_triggers_gc(Grade::A));
+        assert!(!trigger.grade_triggers_gc(Grade::B));
+    }
+
+    #[test]
+    fn empty_auto_gc_grades_never_triggers() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![], 300);
+        assert!(!trigger.grade_triggers_gc(Grade::A));
+        assert!(!trigger.grade_triggers_gc(Grade::B));
+        assert!(!trigger.grade_triggers_gc(Grade::C));
+        assert!(!trigger.grade_triggers_gc(Grade::D));
+    }
+
+    // --- cooldown tests ---
+
+    #[test]
+    fn cooldown_elapsed_when_never_triggered() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        assert!(trigger.cooldown_elapsed());
+    }
+
+    #[test]
+    fn cooldown_not_elapsed_immediately_after_trigger() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+        trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
+        assert!(!trigger.cooldown_elapsed());
+    }
+
+    #[test]
+    fn zero_cooldown_always_elapsed() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 0);
+        trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
+        assert!(trigger.cooldown_elapsed());
+    }
+
+    // --- log_quality_grade integration test ---
+
+    #[test]
+    fn check_logs_quality_grade_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300);
+
+        // Seed a passing event so grade comes back as A (score ~ 100)
+        trigger
+            .events
+            .log(&Event::new(
+                SessionId::new(),
+                "pre_tool_use",
+                "Edit",
+                Decision::Pass,
+            ))
+            .unwrap();
+
+        // Run synchronously (no agent needed for just the grading path)
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(trigger.check_and_maybe_trigger());
+
+        let events = trigger
+            .events
+            .query(&harness_core::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(events.len(), 1, "expected exactly one quality_grade event");
+        assert!(events[0]
+            .detail
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("grade="));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #245

- **`GcConfig` thresholds**: adds `auto_gc_grades` (default `[D]`) and `auto_gc_cooldown_secs` (default 300s) so operators can configure which grades trigger GC and at what frequency
- **`EventStore::log_quality_grade()`**: persists a `quality_grade` event (decision mapped A/B→Pass, C→Warn, D→Block) after every task, enabling grade trend tracking in the event log
- **`QualityTrigger`**: new module that runs after each task completion — grades all events via `QualityGrader::grade()`, logs the grade, and calls `gc_agent.run()` when the grade is in `auto_gc_grades` and the cooldown has elapsed
- **Wired into `build_completion_callback`**: `QualityTrigger` is created in `build_app_state` (capturing `events`, `gc_agent`, `agent_registry`, `project_root`) and attached to the existing completion callback pipeline

## Test plan

- [x] 10 unit tests in `quality_trigger.rs`:
  - Grade-to-trigger mapping: D triggers, A/B/C do not (with default config)
  - Configurable grades: C+D both trigger when configured
  - Empty `auto_gc_grades` never triggers
  - Cooldown: not elapsed immediately after trigger; zero cooldown always elapsed
  - `check_and_maybe_trigger` logs exactly one `quality_grade` event
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace` — all tests pass