### PR TITLE
feat: add GC draft expiration and cleanup

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -43,6 +43,7 @@ total_budget_usd = 5.0
 adopt_wait_secs = 120
 adopt_max_rounds = 3
 adopt_turn_timeout_secs = 600
+draft_ttl_hours = 72
 
 [gc.signal_thresholds]
 repeated_warn_min = 10

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -139,6 +139,9 @@ pub struct GcConfig {
     pub adopt_max_rounds: u32,
     #[serde(default = "default_gc_adopt_turn_timeout_secs")]
     pub adopt_turn_timeout_secs: u64,
+    /// Hours after which a pending draft is considered stale and removed. Default: 72.
+    #[serde(default = "default_gc_draft_ttl_hours")]
+    pub draft_ttl_hours: u64,
     pub signal_thresholds: SignalThresholdsConfig,
 }
 
@@ -151,6 +154,7 @@ impl Default for GcConfig {
             adopt_wait_secs: default_gc_adopt_wait_secs(),
             adopt_max_rounds: default_gc_adopt_max_rounds(),
             adopt_turn_timeout_secs: default_gc_adopt_turn_timeout_secs(),
+            draft_ttl_hours: default_gc_draft_ttl_hours(),
             signal_thresholds: SignalThresholdsConfig::default(),
         }
     }
@@ -166,6 +170,10 @@ fn default_gc_adopt_max_rounds() -> u32 {
 
 fn default_gc_adopt_turn_timeout_secs() -> u64 {
     600
+}
+
+fn default_gc_draft_ttl_hours() -> u64 {
+    72
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-gc/src/draft_store.rs
+++ b/crates/harness-gc/src/draft_store.rs
@@ -1,4 +1,5 @@
-use harness_core::{Draft, DraftId};
+use chrono::Utc;
+use harness_core::{Draft, DraftId, DraftStatus};
 use std::path::{Path, PathBuf};
 
 pub struct DraftStore {
@@ -56,7 +57,109 @@ impl DraftStore {
         Ok(())
     }
 
+    /// Expire all `Pending` drafts older than `ttl_hours` hours.
+    ///
+    /// Each expired draft is removed from disk. Returns the number of drafts expired.
+    pub fn expire_stale_drafts(&self, ttl_hours: u64) -> anyhow::Result<usize> {
+        let now = Utc::now();
+        let ttl = chrono::Duration::hours(ttl_hours as i64);
+        let mut expired = 0;
+
+        for mut draft in self.list()? {
+            if draft.status == DraftStatus::Pending && (now - draft.generated_at) > ttl {
+                draft.status = DraftStatus::Expired;
+                self.delete(&draft.id)?;
+                expired += 1;
+            }
+        }
+
+        Ok(expired)
+    }
+
     fn draft_path(&self, id: &DraftId) -> PathBuf {
         self.data_dir.join(format!("{}.json", id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::{
+        Artifact, ArtifactType, Draft, DraftId, DraftStatus, ProjectId, RemediationType, Signal,
+        SignalType,
+    };
+
+    fn make_draft(status: DraftStatus, generated_at: chrono::DateTime<Utc>) -> Draft {
+        let signal = Signal::new(
+            SignalType::RepeatedWarn,
+            ProjectId::new(),
+            serde_json::json!({}),
+            RemediationType::Guard,
+        );
+        Draft {
+            id: DraftId::new(),
+            status,
+            signal,
+            artifacts: vec![Artifact {
+                artifact_type: ArtifactType::Guard,
+                target_path: std::path::PathBuf::from("test.md"),
+                content: "content".into(),
+            }],
+            rationale: "test".into(),
+            validation: "test".into(),
+            generated_at,
+            agent_model: "test".into(),
+        }
+    }
+
+    #[test]
+    fn expire_stale_drafts_removes_old_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DraftStore::new(dir.path()).unwrap();
+
+        // Draft older than 72 hours
+        let old_draft = make_draft(
+            DraftStatus::Pending,
+            Utc::now() - chrono::Duration::hours(100),
+        );
+        store.save(&old_draft).unwrap();
+
+        let expired = store.expire_stale_drafts(72).unwrap();
+        assert_eq!(expired, 1);
+        assert!(store.get(&old_draft.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn expire_stale_drafts_keeps_recent_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DraftStore::new(dir.path()).unwrap();
+
+        // Draft only 1 hour old
+        let recent_draft = make_draft(
+            DraftStatus::Pending,
+            Utc::now() - chrono::Duration::hours(1),
+        );
+        store.save(&recent_draft).unwrap();
+
+        let expired = store.expire_stale_drafts(72).unwrap();
+        assert_eq!(expired, 0);
+        assert!(store.get(&recent_draft.id).unwrap().is_some());
+    }
+
+    #[test]
+    fn expire_stale_drafts_skips_non_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DraftStore::new(dir.path()).unwrap();
+
+        // Adopted draft older than TTL — should NOT be removed
+        let adopted = make_draft(
+            DraftStatus::Adopted,
+            Utc::now() - chrono::Duration::hours(100),
+        );
+        store.save(&adopted).unwrap();
+
+        let expired = store.expire_stale_drafts(72).unwrap();
+        assert_eq!(expired, 0);
+        assert!(store.get(&adopted.id).unwrap().is_some());
     }
 }

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -53,6 +53,10 @@ impl GcAgent {
         violations: &[harness_core::Violation],
         agent: &dyn CodeAgent,
     ) -> anyhow::Result<GcReport> {
+        // 0. Expire stale drafts before generating new ones
+        self.draft_store
+            .expire_stale_drafts(self.config.draft_ttl_hours)?;
+
         // Determine incremental cutoff from checkpoint (None → full scan).
         let since = self
             .checkpoint_path


### PR DESCRIPTION
## Summary

- Add `draft_ttl_hours` field to `GcConfig` (default: 72 hours) with `#[serde(default)]` so existing configs don't break
- Implement `DraftStore::expire_stale_drafts(ttl_hours)` — iterates all `Pending` drafts, removes those older than the TTL from disk, returns count expired
- Call expiration at the start of `GcAgent::run()` before signal detection, so stale drafts are cleaned up each cycle
- Add 3 unit tests in `draft_store.rs`: removes old pending drafts, keeps recent pending drafts, skips non-pending (adopted) drafts

## Test plan

- [ ] `cargo test -p harness-gc` passes all 3 new expiration tests
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [ ] Existing GC adopt/reject tests unaffected

Closes #249