### PR TITLE
feat: add CI workflow for publishing TypeScript and Python SDKs

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,92 @@
+name: Publish SDKs
+
+on:
+  push:
+    tags:
+      - "sdk-v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, skip publish)"
+        required: false
+        default: "true"
+        type: boolean
+
+jobs:
+  build-typescript:
+    name: Build TypeScript SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: typescript-dist
+          path: sdk/typescript/dist/
+
+  build-python:
+    name: Build Python SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: sdk/python/dist/
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build-typescript
+    if: startsWith(github.ref, 'refs/tags/sdk-v') && github.event.inputs.dry_run != 'true'
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-python
+    if: startsWith(github.ref, 'refs/tags/sdk-v') && github.event.inputs.dry_run != 'true'
+    defaults:
+      run:
+        working-directory: sdk/python
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-sdk.yml` that builds and publishes both SDKs
- Build jobs verify `npm run build` (TypeScript) and `python -m build` (Python) on every trigger
- Publish jobs run only on `sdk-v*` tag pushes, using `NPM_TOKEN` for npm and OIDC trusted publishing for PyPI
- Supports `workflow_dispatch` with a `dry_run` flag to test builds without publishing

## Test plan

- [ ] Verify workflow YAML is valid (CI lint)
- [ ] Trigger `workflow_dispatch` with `dry_run=true` to confirm both SDK builds succeed
- [ ] Push a `sdk-v0.1.0` tag to verify publish jobs trigger (requires registry credentials in secrets)

Closes #255