### PR TITLE
feat: add CI workflow for SDK publishing to npm and PyPI

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,79 @@
+name: Publish SDKs
+
+on:
+  push:
+    tags:
+      - "sdk-v*"
+
+jobs:
+  verify-typescript:
+    name: Verify TypeScript SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  verify-python:
+    name: Verify Python SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build twine
+      - run: python -m build
+      - run: twine check dist/*
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: verify-typescript
+    environment: npm-publish
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: verify-python
+    environment: pypi-publish
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-sdk.yml` triggered on `sdk-v*` tags
- Verifies TypeScript SDK builds cleanly (`npm run build`, `npm test`)
- Verifies Python SDK builds cleanly (`python -m build`, `twine check`)
- Publishes to npm using `NPM_TOKEN` secret via `npm-publish` environment
- Publishes to PyPI using OIDC trusted publishing via `pypi-publish` environment

## Test plan

- [ ] Push a `sdk-v*` tag to verify the workflow triggers
- [ ] Confirm `verify-typescript` job passes (`npm ci && npm run build && npm test`)
- [ ] Confirm `verify-python` job passes (`pip install build twine && python -m build && twine check dist/*`)
- [ ] Confirm `publish-npm` and `publish-pypi` jobs are gated behind environment approval and registry secrets

Closes #255