### PR TITLE
feat: expand guard script library to cover high-severity rule types (#274)

### DIFF
--- a/.harness/guards/rs-01-nested-locks.sh
+++ b/.harness/guards/rs-01-nested-locks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# RS-01: Detect nested RwLock/Mutex acquisition patterns that risk deadlock.
+# Heuristic: two lock acquisition calls within 5 source lines of each other.
+# Output format: FILE:LINE:RS-01:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+find "${project_root}" -name "*.rs" \
+  ! -path "*/target/*" \
+  ! -path "*/.git/*" \
+  ! -name "*_test.rs" \
+  ! -path "*/tests/*" \
+  -print0 2>/dev/null \
+| xargs -0 awk '
+  /\.(lock|read|write)\(\)/ {
+    if (last_lock_line > 0 && (NR - last_lock_line) <= 5) {
+      print FILENAME ":" last_lock_line ":RS-01:Nested lock acquisition — risk of deadlock"
+    }
+    last_lock_line = NR
+  }
+' 2>/dev/null >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/rs-02-toctou.sh
+++ b/.harness/guards/rs-02-toctou.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+# RS-02: Detect TOCTOU — get() followed by insert() without Entry API.
+# Using .get() then .insert() on a map releases the lock between calls,
+# creating a race condition. Prefer .entry(key).or_insert(val) instead.
+# Output format: FILE:LINE:RS-02:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+# Detect .get( followed by .insert( within 10 lines in the same file.
+find "${project_root}" -name "*.rs" \
+  ! -path "*/target/*" \
+  ! -path "*/.git/*" \
+  ! -name "*_test.rs" \
+  ! -path "*/tests/*" \
+  -print0 2>/dev/null \
+| xargs -0 awk '
+  /\.get\(/ {
+    last_get_line = NR
+  }
+  /\.insert\(/ {
+    if (last_get_line > 0 && (NR - last_get_line) <= 10) {
+      print FILENAME ":" last_get_line ":RS-02:TOCTOU — use Entry API (.entry().or_insert()) instead of get()+insert()"
+      last_get_line = 0
+    }
+  }
+' 2>/dev/null >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/rs-10-silent-result.sh
+++ b/.harness/guards/rs-10-silent-result.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# RS-10: Detect silent discard of meaningful Result values.
+# Patterns: let _ = <expr>, .ok() on non-option, .unwrap_or_default()
+# swallowing errors without logging.
+# Output format: FILE:LINE:RS-10:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+grep -rn \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'let\s+_\s*=' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(//|#\[|let _ = Ok|let _ = Err|= \()' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:RS-10:Silent Result discard — use 'if let Err(e) = ...' and log the error"
+done >> "${tmpfile}"
+
+grep -rn \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E '\.(ok|unwrap_or_default)\(\)\s*;' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(//|test)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:RS-10:Silent Result discard via .ok() or .unwrap_or_default() — log errors explicitly"
+done >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/rs-12-dual-system.sh
+++ b/.harness/guards/rs-12-dual-system.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+# RS-12: Detect dual systems for the same responsibility.
+# Heuristic: look for parallel type hierarchies (e.g., Task*/Todo*, Manager*/Handler*)
+# where two naming conventions coexist for the same domain concept.
+# Output format: FILE:LINE:RS-12:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+# Detect structs/enums named with Task* and Todo* in the same codebase.
+has_task=$(grep -rl \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'struct\s+Task[A-Z]|enum\s+Task[A-Z]' \
+  "${project_root}" 2>/dev/null | head -1)
+
+has_todo=$(grep -rl \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'struct\s+Todo[A-Z]|enum\s+Todo[A-Z]' \
+  "${project_root}" 2>/dev/null | head -1)
+
+if [ -n "${has_task}" ] && [ -n "${has_todo}" ]; then
+  grep -rn \
+    --include="*.rs" \
+    --exclude-dir=".git" \
+    --exclude-dir="target" \
+    -E 'struct\s+Task[A-Z]|enum\s+Task[A-Z]' \
+    "${project_root}" 2>/dev/null \
+  | while IFS=: read -r file line rest; do
+    echo "${file}:${line}:RS-12:Dual system detected — Task* and Todo* types coexist; consolidate to a single domain model"
+  done >> "${tmpfile}"
+fi
+
+# Detect Manager*/Handler* coexisting for the same concept.
+has_manager=$(grep -rl \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'struct\s+[A-Z][a-zA-Z]+Manager\b' \
+  "${project_root}" 2>/dev/null | head -1)
+
+has_handler=$(grep -rl \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'struct\s+[A-Z][a-zA-Z]+Handler\b' \
+  "${project_root}" 2>/dev/null | head -1)
+
+if [ -n "${has_manager}" ] && [ -n "${has_handler}" ]; then
+  grep -rn \
+    --include="*.rs" \
+    --exclude-dir=".git" \
+    --exclude-dir="target" \
+    -E 'struct\s+[A-Z][a-zA-Z]+Manager\b' \
+    "${project_root}" 2>/dev/null \
+  | while IFS=: read -r file line rest; do
+    echo "${file}:${line}:RS-12:Dual system detected — *Manager and *Handler types coexist; unify under one abstraction"
+  done >> "${tmpfile}"
+fi
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/sec-03-xss.sh
+++ b/.harness/guards/sec-03-xss.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+# SEC-03: Detect XSS via innerHTML assignment with unsanitized user input.
+# Direct innerHTML assignment without DOMPurify or framework escaping is
+# an XSS vulnerability.
+# Output format: FILE:LINE:SEC-03:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+grep -rn \
+  --include="*.js" \
+  --include="*.ts" \
+  --include="*.jsx" \
+  --include="*.tsx" \
+  --include="*.html" \
+  --include="*.vue" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  --exclude-dir="node_modules" \
+  -E '\.innerHTML\s*=' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(DOMPurify|sanitize|escapeHtml|//\s*safe|test|spec)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-03:XSS risk — innerHTML assignment without sanitization; use DOMPurify or textContent"
+done >> "${tmpfile}"
+
+grep -rn \
+  --include="*.js" \
+  --include="*.ts" \
+  --include="*.jsx" \
+  --include="*.tsx" \
+  --exclude-dir=".git" \
+  --exclude-dir="node_modules" \
+  -E 'dangerouslySetInnerHTML\s*=\s*\{\s*\{[^}]*\}' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(sanitize|DOMPurify|test|spec)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-03:XSS risk — dangerouslySetInnerHTML without sanitization"
+done >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/sec-04-unauth-api.sh
+++ b/.harness/guards/sec-04-unauth-api.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# SEC-04: Detect API endpoints that lack authentication/authorization checks.
+# Heuristic: route handler functions without middleware or guard annotations.
+# Output format: FILE:LINE:SEC-04:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+# Python/Flask/FastAPI: route decorators without login_required or dependency
+grep -rn \
+  --include="*.py" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E '@(app|router|blueprint)\.(get|post|put|delete|patch)\(' \
+  "${project_root}" 2>/dev/null \
+| while IFS=: read -r file line rest; do
+  # Check if the next few lines contain auth references
+  auth_check=$(awk "NR>=${line} && NR<=$((line + 5))" "${file}" 2>/dev/null \
+    | grep -c -E '(login_required|current_user|Depends|authenticate|authorize|jwt|token|permission)' || true)
+  if [ "${auth_check}" = "0" ]; then
+    echo "${file}:${line}:SEC-04:API endpoint may lack authentication — add auth middleware or guard"
+  fi
+done >> "${tmpfile}"
+
+# JavaScript/TypeScript Express: router.get/post without auth middleware
+grep -rn \
+  --include="*.js" \
+  --include="*.ts" \
+  --exclude-dir=".git" \
+  --exclude-dir="node_modules" \
+  -E 'router\.(get|post|put|delete|patch)\(' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(authenticate|authorize|requireAuth|isAuthenticated|verifyToken|checkJwt|passport|guard|middleware)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-04:API route may lack authentication middleware"
+done >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/.harness/guards/sec-07-path-traversal.sh
+++ b/.harness/guards/sec-07-path-traversal.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# SEC-07: Detect path traversal vulnerabilities from unvalidated user-supplied paths.
+# User-controlled input used in file operations without canonicalization or
+# prefix validation allows reading/writing arbitrary files.
+# Output format: FILE:LINE:SEC-07:MESSAGE
+# Exit 0 on pass, exit 1 if violations found.
+
+project_root="${1:-}"
+if [ -z "${project_root}" ]; then
+  exit 0
+fi
+
+tmpfile=$(mktemp)
+
+# Python: open() or Path() with user-controlled variable without sanitization
+grep -rn \
+  --include="*.py" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'open\((request\.|params\[|args\[|data\[|form\[)' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(safe_join|realpath|resolve|abspath|test|spec)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-07:Path traversal risk — validate and canonicalize paths from user input before file operations"
+done >> "${tmpfile}"
+
+# Rust: path constructed from user input without canonicalize()
+grep -rn \
+  --include="*.rs" \
+  --exclude-dir=".git" \
+  --exclude-dir="target" \
+  -E 'PathBuf::from\(|Path::new\(' \
+  "${project_root}" 2>/dev/null \
+| while IFS=: read -r file line rest; do
+  # Check surrounding 5 lines for canonicalize or starts_with validation
+  safe=$(awk "NR>=$((line > 5 ? line - 5 : 1)) && NR<=$((line + 5))" "${file}" 2>/dev/null \
+    | grep -c -E '(canonicalize|starts_with|strip_prefix|contains\("\.\."\))' || true)
+  if [ "${safe}" = "0" ]; then
+    # Only flag if there's evidence of user input (query, param, header, body, arg)
+    user_input=$(awk "NR>=$((line > 3 ? line - 3 : 1)) && NR<=$((line + 3))" "${file}" 2>/dev/null \
+      | grep -c -E '(query|param|header|body|arg|request|user|input)' || true)
+    if [ "${user_input}" -gt 0 ]; then
+      echo "${file}:${line}:SEC-07:Path traversal risk — canonicalize path and verify it starts within allowed base dir"
+    fi
+  fi
+done >> "${tmpfile}"
+
+# JavaScript/TypeScript: path.join with user-controlled input
+grep -rn \
+  --include="*.js" \
+  --include="*.ts" \
+  --exclude-dir=".git" \
+  --exclude-dir="node_modules" \
+  -E 'path\.(join|resolve)\(.*req\.' \
+  "${project_root}" 2>/dev/null \
+| grep -v -E '(normalize|resolve.*__dirname|test|spec)' \
+| while IFS=: read -r file line rest; do
+  echo "${file}:${line}:SEC-07:Path traversal risk — validate that resolved path stays within allowed directory"
+done >> "${tmpfile}"
+
+if [ -s "${tmpfile}" ]; then
+  cat "${tmpfile}"
+  rm -f "${tmpfile}"
+  exit 1
+fi
+
+rm -f "${tmpfile}"
+exit 0

--- a/crates/harness-rules/tests/guard_scripts_test.rs
+++ b/crates/harness-rules/tests/guard_scripts_test.rs
@@ -1,0 +1,347 @@
+/// Integration tests: run each new guard script against synthetic fixtures and
+/// verify that violations are detected (positive case) and clean code passes
+/// (negative case).
+///
+/// Guards are located at `.harness/guards/` relative to the workspace root.
+/// Fixtures are written to a tempdir for each test.
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points to crates/harness-rules; go up two levels.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("failed to locate workspace root from CARGO_MANIFEST_DIR")
+        .to_path_buf()
+}
+
+fn guard_path(name: &str) -> PathBuf {
+    workspace_root().join(".harness").join("guards").join(name)
+}
+
+/// Run a guard script with `project_root` as the argument.
+/// Returns (stdout, exit_code).
+fn run_guard(script: &Path, project_root: &Path) -> (String, i32) {
+    let output = Command::new("bash")
+        .arg(script)
+        .arg(project_root)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run guard {:?}: {}", script, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let code = output.status.code().unwrap_or(-1);
+    (stdout, code)
+}
+
+/// Assert a guard finds at least one violation (stdout non-empty, exit 1).
+fn assert_violation(script: &Path, project_root: &Path, rule_id: &str) {
+    let (stdout, code) = run_guard(script, project_root);
+    assert!(
+        stdout.contains(rule_id),
+        "guard {:?} expected to find {} violation but stdout was:\n{}",
+        script.file_name().unwrap(),
+        rule_id,
+        stdout,
+    );
+    assert_eq!(
+        code,
+        1,
+        "guard {:?} should exit 1 when violations found, got {}",
+        script.file_name().unwrap(),
+        code
+    );
+}
+
+/// Assert a guard finds no violations (stdout empty, exit 0).
+fn assert_clean(script: &Path, project_root: &Path) {
+    let (stdout, code) = run_guard(script, project_root);
+    assert!(
+        stdout.trim().is_empty(),
+        "guard {:?} expected no violations but got:\n{}",
+        script.file_name().unwrap(),
+        stdout,
+    );
+    assert_eq!(
+        code,
+        0,
+        "guard {:?} should exit 0 on clean code, got {}",
+        script.file_name().unwrap(),
+        code
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RS-01: nested lock acquisition
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rs01_detects_nested_lock_acquisition() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("lib.rs"),
+        r#"
+fn bad(a: &RwLock<u32>, b: &RwLock<u32>) {
+    let _x = a.read().unwrap();
+    let _y = b.write().unwrap(); // nested — risk of deadlock
+}
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("rs-01-nested-locks.sh"), dir.path(), "RS-01");
+}
+
+#[test]
+fn rs01_passes_single_lock_acquisition() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("lib.rs"),
+        r#"
+fn good(a: &RwLock<u32>) -> u32 {
+    *a.read().unwrap()
+}
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("rs-01-nested-locks.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// RS-02: TOCTOU get() + insert()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rs02_detects_toctou_get_then_insert() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("cache.rs"),
+        r#"
+fn populate(map: &mut HashMap<u32, String>, key: u32) {
+    if map.get(&key).is_none() {
+        map.insert(key, "value".to_string()); // TOCTOU
+    }
+}
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("rs-02-toctou.sh"), dir.path(), "RS-02");
+}
+
+#[test]
+fn rs02_passes_entry_api() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("cache.rs"),
+        r#"
+fn populate(map: &mut HashMap<u32, String>, key: u32) {
+    map.entry(key).or_insert_with(|| "value".to_string());
+}
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("rs-02-toctou.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// RS-10: silent Result discard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rs10_detects_let_underscore_discard() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("db.rs"),
+        r#"
+fn run(conn: &Conn) {
+    let _ = conn.execute("UPDATE items SET done = 1");
+}
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("rs-10-silent-result.sh"), dir.path(), "RS-10");
+}
+
+#[test]
+fn rs10_passes_explicit_error_handling() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("db.rs"),
+        r#"
+fn run(conn: &Conn) -> Result<()> {
+    conn.execute("UPDATE items SET done = 1")?;
+    Ok(())
+}
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("rs-10-silent-result.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// RS-12: dual system for same responsibility
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rs12_detects_task_and_todo_coexistence() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("task.rs"),
+        r#"
+pub struct TaskItem { pub id: u32 }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        src.join("todo.rs"),
+        r#"
+pub struct TodoItem { pub id: u32 }
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("rs-12-dual-system.sh"), dir.path(), "RS-12");
+}
+
+#[test]
+fn rs12_passes_single_domain_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("task.rs"),
+        r#"
+pub struct TaskItem { pub id: u32 }
+pub struct TaskList { pub items: Vec<TaskItem> }
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("rs-12-dual-system.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// SEC-03: XSS via innerHTML
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sec03_detects_innerhtml_assignment() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("app.js"),
+        r#"
+function render(data) {
+    element.innerHTML = data.userContent; // XSS risk
+}
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("sec-03-xss.sh"), dir.path(), "SEC-03");
+}
+
+#[test]
+fn sec03_passes_sanitized_innerhtml() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("app.js"),
+        r#"
+function render(data) {
+    element.innerHTML = DOMPurify.sanitize(data.userContent);
+}
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("sec-03-xss.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// SEC-04: unauthenticated API endpoints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sec04_detects_unauthenticated_route() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("routes.js"),
+        r#"
+router.get('/admin/users', (req, res) => {
+    res.json(db.getUsers());
+});
+"#,
+    )
+    .unwrap();
+    assert_violation(&guard_path("sec-04-unauth-api.sh"), dir.path(), "SEC-04");
+}
+
+#[test]
+fn sec04_passes_authenticated_route() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("routes.js"),
+        r#"
+router.get('/admin/users', authenticate, (req, res) => {
+    res.json(db.getUsers());
+});
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("sec-04-unauth-api.sh"), dir.path());
+}
+
+// ---------------------------------------------------------------------------
+// SEC-07: path traversal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sec07_detects_path_traversal_in_js() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("server.js"),
+        r#"
+app.get('/file', (req, res) => {
+    const filePath = path.join(__dirname, req.query.name);
+    res.sendFile(filePath);
+});
+"#,
+    )
+    .unwrap();
+    assert_violation(
+        &guard_path("sec-07-path-traversal.sh"),
+        dir.path(),
+        "SEC-07",
+    );
+}
+
+#[test]
+fn sec07_passes_validated_path() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("server.js"),
+        r#"
+app.get('/file', (req, res) => {
+    const filePath = path.resolve(__dirname, 'static', req.query.name);
+    if (!filePath.startsWith(path.resolve(__dirname, 'static'))) {
+        return res.status(403).send('Forbidden');
+    }
+    res.sendFile(filePath);
+});
+"#,
+    )
+    .unwrap();
+    assert_clean(&guard_path("sec-07-path-traversal.sh"), dir.path());
+}


### PR DESCRIPTION
## Summary

- Add 7 new POSIX sh guard scripts covering high-severity rules: RS-01 (nested lock acquisition), RS-02 (TOCTOU get/insert), RS-10 (silent Result discard), RS-12 (dual system for same responsibility), SEC-03 (XSS via innerHTML), SEC-04 (unauthenticated API endpoints), SEC-07 (path traversal)
- Each guard accepts a project root path, outputs `FILE:LINE:RULE_ID:MESSAGE` violations to stdout, exits 0 on pass and 1 on violation
- All guards are auto-registered by the existing `auto_register_project_guards()` mechanism — no engine code changes needed
- Add integration test suite (`crates/harness-rules/tests/guard_scripts_test.rs`) with 14 tests: positive (violation detected) and negative (clean code passes) cases for each guard

## Test plan

- [x] `cargo check --workspace` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace` passes (all 14 new integration tests green)
- [x] `cargo fmt --all` applied

Closes #274