### PR TITLE
feat: integrate ReasoningBudget per-phase model selection

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -3,7 +3,9 @@ use crate::streaming::{
 };
 use async_trait::async_trait;
 use harness_core::SandboxMode;
-use harness_core::{AgentRequest, AgentResponse, Capability, CodeAgent, StreamItem, TokenUsage};
+use harness_core::{
+    AgentRequest, AgentResponse, Capability, CodeAgent, ReasoningBudget, StreamItem, TokenUsage,
+};
 use harness_sandbox::{wrap_command, SandboxSpec};
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -14,6 +16,9 @@ pub struct ClaudeCodeAgent {
     pub cli_path: PathBuf,
     pub default_model: String,
     pub sandbox_mode: SandboxMode,
+    /// Per-phase model selection. When set, model is chosen based on
+    /// `req.execution_phase`. Falls back to `req.model` or `default_model`.
+    pub reasoning_budget: Option<ReasoningBudget>,
 }
 
 impl ClaudeCodeAgent {
@@ -22,11 +27,25 @@ impl ClaudeCodeAgent {
             cli_path,
             default_model,
             sandbox_mode,
+            reasoning_budget: None,
         }
     }
 
+    /// Attach a ReasoningBudget for per-phase model selection.
+    pub fn with_reasoning_budget(mut self, budget: ReasoningBudget) -> Self {
+        self.reasoning_budget = Some(budget);
+        self
+    }
+
+    fn resolve_model<'a>(&'a self, req: &'a AgentRequest) -> &'a str {
+        if let (Some(budget), Some(phase)) = (&self.reasoning_budget, req.execution_phase) {
+            return budget.model_for_phase(phase);
+        }
+        req.model.as_deref().unwrap_or(&self.default_model)
+    }
+
     fn base_args(&self, req: &AgentRequest) -> Vec<OsString> {
-        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let model = self.resolve_model(req);
         let mut base_args = vec![
             OsString::from("-p"),
             OsString::from("--dangerously-skip-permissions"),
@@ -63,7 +82,7 @@ impl CodeAgent for ClaudeCodeAgent {
     }
 
     async fn execute(&self, req: AgentRequest) -> harness_core::Result<AgentResponse> {
-        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let model = self.resolve_model(&req).to_string();
         let base_args = self.base_args(&req);
 
         let sandbox_spec = SandboxSpec::new(self.sandbox_mode, &req.project_root);
@@ -155,10 +174,83 @@ impl CodeAgent for ClaudeCodeAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::Item;
+    use harness_core::{ExecutionPhase, Item, ReasoningBudget};
     use std::fs;
     use std::time::Duration;
     use tokio::time::timeout;
+
+    #[test]
+    fn resolve_model_uses_phase_when_budget_configured() {
+        let budget = ReasoningBudget::default();
+        let agent = ClaudeCodeAgent::new(
+            PathBuf::from("claude"),
+            "default-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        )
+        .with_reasoning_budget(budget);
+
+        let req_planning = AgentRequest {
+            execution_phase: Some(ExecutionPhase::Planning),
+            ..AgentRequest::default()
+        };
+        let req_execution = AgentRequest {
+            execution_phase: Some(ExecutionPhase::Execution),
+            ..AgentRequest::default()
+        };
+        let req_validation = AgentRequest {
+            execution_phase: Some(ExecutionPhase::Validation),
+            ..AgentRequest::default()
+        };
+        let req_no_phase = AgentRequest::default();
+
+        assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-20250514");
+        assert_eq!(
+            agent.resolve_model(&req_execution),
+            "claude-sonnet-4-20250514"
+        );
+        assert_eq!(
+            agent.resolve_model(&req_validation),
+            "claude-opus-4-20250514"
+        );
+        // No phase → falls back to default_model
+        assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
+    }
+
+    #[test]
+    fn resolve_model_falls_back_to_req_model_when_no_budget() {
+        let agent = ClaudeCodeAgent::new(
+            PathBuf::from("claude"),
+            "default-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        );
+
+        let req_with_model = AgentRequest {
+            model: Some("explicit-model".to_string()),
+            execution_phase: Some(ExecutionPhase::Planning),
+            ..AgentRequest::default()
+        };
+        let req_no_model = AgentRequest {
+            execution_phase: Some(ExecutionPhase::Planning),
+            ..AgentRequest::default()
+        };
+
+        // No budget → req.model takes precedence over phase
+        assert_eq!(agent.resolve_model(&req_with_model), "explicit-model");
+        // No budget, no req.model → default_model
+        assert_eq!(agent.resolve_model(&req_no_model), "default-model");
+    }
+
+    #[test]
+    fn with_reasoning_budget_sets_field() {
+        let budget = ReasoningBudget::default();
+        let agent = ClaudeCodeAgent::new(
+            PathBuf::from("claude"),
+            "default-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        )
+        .with_reasoning_budget(budget);
+        assert!(agent.reasoning_budget.is_some());
+    }
 
     fn write_executable_script(script_body: &str) -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().expect("create tempdir");

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -29,14 +29,15 @@ pub async fn run(
     }
     let thread_manager = harness_server::thread_manager::ThreadManager::new();
     let mut agent_registry = harness_agents::AgentRegistry::new(&serve_config.agents.default_agent);
-    agent_registry.register(
-        "claude",
-        Arc::new(harness_agents::claude::ClaudeCodeAgent::new(
-            serve_config.agents.claude.cli_path.clone(),
-            serve_config.agents.claude.default_model.clone(),
-            serve_config.agents.sandbox_mode,
-        )),
+    let mut claude_agent = harness_agents::claude::ClaudeCodeAgent::new(
+        serve_config.agents.claude.cli_path.clone(),
+        serve_config.agents.claude.default_model.clone(),
+        serve_config.agents.sandbox_mode,
     );
+    if let Some(budget) = serve_config.agents.claude.reasoning_budget.clone() {
+        claude_agent = claude_agent.with_reasoning_budget(budget);
+    }
+    agent_registry.register("claude", Arc::new(claude_agent));
     agent_registry.register(
         "codex",
         Arc::new(harness_agents::codex::CodexAgent::from_config(

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -24,6 +24,11 @@ pub struct AgentRequest {
     pub model: Option<String>,
     pub max_budget_usd: Option<f64>,
     pub context: Vec<ContextItem>,
+    /// Execution phase for per-phase model selection via ReasoningBudget.
+    /// When set and the agent has a ReasoningBudget configured, the phase
+    /// determines which model is used. Defaults to None (uses req.model or default_model).
+    #[serde(default)]
+    pub execution_phase: Option<ExecutionPhase>,
 }
 
 impl Default for AgentRequest {
@@ -35,6 +40,7 @@ impl Default for AgentRequest {
             model: None,
             max_budget_usd: None,
             context: Vec::new(),
+            execution_phase: None,
         }
     }
 }

--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -1,3 +1,4 @@
+use crate::types::ReasoningBudget;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -178,6 +179,10 @@ fn default_max_agent_review_rounds() -> u32 {
 pub struct ClaudeAgentConfig {
     pub cli_path: PathBuf,
     pub default_model: String,
+    /// Optional per-phase model selection. When set, the agent switches models
+    /// based on the `execution_phase` field of each `AgentRequest`.
+    #[serde(default)]
+    pub reasoning_budget: Option<ReasoningBudget>,
 }
 
 impl Default for ClaudeAgentConfig {
@@ -185,6 +190,7 @@ impl Default for ClaudeAgentConfig {
         Self {
             cli_path: PathBuf::from("claude"),
             default_model: "sonnet".to_string(),
+            reasoning_budget: None,
         }
     }
 }

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -499,6 +499,94 @@ pub enum BudgetTier {
     Medium,
 }
 
+/// Phase of task execution used to select the appropriate model via ReasoningBudget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionPhase {
+    /// Initial planning and analysis (uses high-reasoning model).
+    Planning,
+    /// Core implementation work (uses balanced model).
+    Execution,
+    /// Validation and review (uses high-reasoning model).
+    Validation,
+}
+
+/// Per-phase model selection configuration.
+///
+/// Maps each `ExecutionPhase` to a `BudgetTier`, then maps tiers to model identifiers.
+/// When configured on `ClaudeCodeAgent`, the model is selected by phase rather than
+/// the flat `default_model`. Falls back to `req.model` or `default_model` when no
+/// `execution_phase` is set on the `AgentRequest`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningBudget {
+    /// Tier used for the Planning phase (default: XHigh).
+    #[serde(default = "default_planning_tier")]
+    pub planning_tier: BudgetTier,
+    /// Tier used for the Execution phase (default: High).
+    #[serde(default = "default_execution_tier")]
+    pub execution_tier: BudgetTier,
+    /// Tier used for the Validation phase (default: XHigh).
+    #[serde(default = "default_validation_tier")]
+    pub validation_tier: BudgetTier,
+    /// Model identifier for XHigh tier (default: opus).
+    #[serde(default = "default_xhigh_model")]
+    pub xhigh_model: String,
+    /// Model identifier for High tier (default: sonnet).
+    #[serde(default = "default_high_model")]
+    pub high_model: String,
+    /// Model identifier for Medium tier (default: haiku).
+    #[serde(default = "default_medium_model")]
+    pub medium_model: String,
+}
+
+fn default_planning_tier() -> BudgetTier {
+    BudgetTier::XHigh
+}
+fn default_execution_tier() -> BudgetTier {
+    BudgetTier::High
+}
+fn default_validation_tier() -> BudgetTier {
+    BudgetTier::XHigh
+}
+fn default_xhigh_model() -> String {
+    "claude-opus-4-20250514".to_string()
+}
+fn default_high_model() -> String {
+    "claude-sonnet-4-20250514".to_string()
+}
+fn default_medium_model() -> String {
+    "claude-haiku-4-20250514".to_string()
+}
+
+impl Default for ReasoningBudget {
+    fn default() -> Self {
+        Self {
+            planning_tier: default_planning_tier(),
+            execution_tier: default_execution_tier(),
+            validation_tier: default_validation_tier(),
+            xhigh_model: default_xhigh_model(),
+            high_model: default_high_model(),
+            medium_model: default_medium_model(),
+        }
+    }
+}
+
+impl ReasoningBudget {
+    /// Returns the model identifier for the given execution phase.
+    pub fn model_for_phase(&self, phase: ExecutionPhase) -> &str {
+        let tier = match phase {
+            ExecutionPhase::Planning => self.planning_tier,
+            ExecutionPhase::Execution => self.execution_tier,
+            ExecutionPhase::Validation => self.validation_tier,
+        };
+        match tier {
+            BudgetTier::XHigh => &self.xhigh_model,
+            BudgetTier::High => &self.high_model,
+            BudgetTier::Medium => &self.medium_model,
+        }
+    }
+}
+
 // === Event Filters ===
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -601,6 +689,84 @@ mod tests {
             Item::UserMessage { content } => assert_eq!(content, "hello world"),
             _ => anyhow::bail!("wrong variant"),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn reasoning_budget_default_phase_mapping() {
+        let budget = ReasoningBudget::default();
+        // Planning and Validation use XHigh → opus
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Planning),
+            "claude-opus-4-20250514"
+        );
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Validation),
+            "claude-opus-4-20250514"
+        );
+        // Execution uses High → sonnet
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Execution),
+            "claude-sonnet-4-20250514"
+        );
+    }
+
+    #[test]
+    fn reasoning_budget_custom_models() {
+        let budget = ReasoningBudget {
+            planning_tier: BudgetTier::High,
+            execution_tier: BudgetTier::Medium,
+            validation_tier: BudgetTier::XHigh,
+            xhigh_model: "opus-custom".to_string(),
+            high_model: "sonnet-custom".to_string(),
+            medium_model: "haiku-custom".to_string(),
+        };
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Planning),
+            "sonnet-custom"
+        );
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Execution),
+            "haiku-custom"
+        );
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Validation),
+            "opus-custom"
+        );
+    }
+
+    #[test]
+    fn reasoning_budget_serde_roundtrip() -> anyhow::Result<()> {
+        let budget = ReasoningBudget::default();
+        let json = serde_json::to_string(&budget)?;
+        let back: ReasoningBudget = serde_json::from_str(&json)?;
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Planning),
+            back.model_for_phase(ExecutionPhase::Planning)
+        );
+        assert_eq!(
+            budget.model_for_phase(ExecutionPhase::Execution),
+            back.model_for_phase(ExecutionPhase::Execution)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn execution_phase_serde_snake_case() -> anyhow::Result<()> {
+        assert_eq!(
+            serde_json::to_string(&ExecutionPhase::Planning)?,
+            "\"planning\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ExecutionPhase::Execution)?,
+            "\"execution\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ExecutionPhase::Validation)?,
+            "\"validation\""
+        );
+        let back: ExecutionPhase = serde_json::from_str("\"validation\"")?;
+        assert_eq!(back, ExecutionPhase::Validation);
         Ok(())
     }
 }

--- a/crates/harness-server/src/contract_validator.rs
+++ b/crates/harness-server/src/contract_validator.rs
@@ -126,6 +126,7 @@ mod tests {
             model: None,
             max_budget_usd: None,
             context: vec![],
+            execution_phase: None,
         }
     }
 

--- a/crates/harness-server/src/handlers/preflight.rs
+++ b/crates/harness-server/src/handlers/preflight.rs
@@ -92,6 +92,7 @@ pub async fn run_preflight(
         model: None,
         max_budget_usd: None,
         context: vec![],
+        execution_phase: None,
     };
 
     let resp = agent.execute(req).await?;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -6,7 +6,7 @@ use crate::task_runner::{
 };
 use harness_core::{
     config::load_project_config, prompts, AgentRequest, AgentResponse, CodeAgent, ContextItem,
-    Event, SessionId, ThreadId, TurnId, TurnStatus,
+    Event, ExecutionPhase, SessionId, ThreadId, TurnId, TurnStatus,
 };
 use harness_protocol::{Notification, RpcNotification};
 use std::path::{Path, PathBuf};
@@ -233,6 +233,7 @@ pub(crate) async fn run_task(
         project_root: project.clone(),
         context: context_items.clone(),
         max_budget_usd: req.max_budget_usd,
+        execution_phase: Some(ExecutionPhase::Planning),
         ..Default::default()
     };
 
@@ -390,6 +391,7 @@ pub(crate) async fn run_task(
             prompt: prompts::check_existing_pr(pr_num, &review_config.review_bot_command),
             project_root: project.clone(),
             context: context_items.clone(),
+            execution_phase: Some(ExecutionPhase::Validation),
             ..Default::default()
         };
         let check_req = run_pre_execute(&interceptors, check_req).await?;
@@ -510,6 +512,7 @@ async fn run_agent_review(
             prompt: prompts::agent_review_prompt(pr_num, agent_round),
             project_root: project.to_path_buf(),
             context: context_items.to_vec(),
+            execution_phase: Some(ExecutionPhase::Validation),
             ..Default::default()
         };
         let review_req = run_pre_execute(interceptors, review_req).await?;
@@ -602,6 +605,7 @@ async fn run_agent_review(
             prompt: prompts::agent_review_fix_prompt(pr_num, &issues, agent_round),
             project_root: project.to_path_buf(),
             context: context_items.to_vec(),
+            execution_phase: Some(ExecutionPhase::Execution),
             ..Default::default()
         };
         let fix_req = run_pre_execute(interceptors, fix_req).await?;


### PR DESCRIPTION
## Summary

Closes #272

- Added `ExecutionPhase` enum (`Planning`, `Execution`, `Validation`) and `ReasoningBudget` struct to `harness-core/types.rs`
- Added `execution_phase: Option<ExecutionPhase>` to `AgentRequest` (backward-compatible, defaults to `None`)
- Added `reasoning_budget: Option<ReasoningBudget>` to `ClaudeAgentConfig` (TOML-configurable)
- `ClaudeCodeAgent` gains a `reasoning_budget` field and `resolve_model()` helper: when a budget is set and `execution_phase` is present, selects the phase-appropriate model; otherwise falls back to `req.model` or `default_model`
- `serve.rs` wires the config-provided budget into the agent at startup
- `task_executor.rs` sets `Planning` on the initial implementation turn, `Validation` on review/check turns, and `Execution` on agent-review fix turns

## Phase → Model mapping (defaults)

| Phase | Tier | Model |
|---|---|---|
| Planning | XHigh | `claude-opus-4-20250514` |
| Execution | High | `claude-sonnet-4-20250514` |
| Validation | XHigh | `claude-opus-4-20250514` |

## Test plan

- [x] `cargo check --workspace --all-targets` (RUSTFLAGS="-Dwarnings") — clean
- [x] `cargo test --workspace` — all pass
- [x] `cargo fmt --all` — applied
- [x] Unit tests for `ReasoningBudget::model_for_phase`, `ExecutionPhase` serde, `ClaudeCodeAgent::resolve_model` with/without budget, fallback behavior