### PR TITLE
feat: implement multi-agent parallel dispatch for task decomposition (#275)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -39,7 +39,7 @@ impl TaskDb {
 
         // Additive migrations for existing DBs that predate Task 3.1.
         // "duplicate column name" errors mean the column was already added — safe to ignore.
-        for col in &["source TEXT", "external_id TEXT"] {
+        for col in &["source TEXT", "external_id TEXT", "parent_id TEXT"] {
             let sql = format!("ALTER TABLE tasks ADD COLUMN {col}");
             if let Err(e) = sqlx::query(&sql).execute(&self.pool).await {
                 let msg = e.to_string().to_lowercase();
@@ -56,8 +56,8 @@ impl TaskDb {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let status = state.status.as_ref();
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error)
-             VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, parent_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -65,6 +65,7 @@ impl TaskDb {
         .bind(&state.pr_url)
         .bind(&rounds_json)
         .bind(&state.error)
+        .bind(state.parent_id.as_ref().map(|id| &id.0))
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -91,7 +92,7 @@ impl TaskDb {
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<TaskState>> {
         let row = sqlx::query_as::<_, TaskRow>(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id
              FROM tasks WHERE id = ?",
         )
         .bind(id)
@@ -102,9 +103,21 @@ impl TaskDb {
 
     pub async fn list(&self) -> anyhow::Result<Vec<TaskState>> {
         let rows = sqlx::query_as::<_, TaskRow>(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id
              FROM tasks ORDER BY created_at DESC",
         )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
+    /// Return all tasks whose `parent_id` matches the given parent task ID.
+    pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
+        let rows = sqlx::query_as::<_, TaskRow>(
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id
+             FROM tasks WHERE parent_id = ? ORDER BY created_at DESC",
+        )
+        .bind(parent_id)
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
@@ -121,6 +134,7 @@ struct TaskRow {
     error: Option<String>,
     source: Option<String>,
     external_id: Option<String>,
+    parent_id: Option<String>,
 }
 
 impl TaskRow {
@@ -134,6 +148,7 @@ impl TaskRow {
             error,
             source,
             external_id,
+            parent_id,
         } = self;
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
@@ -152,6 +167,8 @@ impl TaskRow {
             error,
             source,
             external_id,
+            parent_id: parent_id.map(TaskId),
+            subtask_ids: Vec::new(),
         })
     }
 }
@@ -172,6 +189,7 @@ mod tests {
             error: None,
             source: None,
             external_id: None,
+            parent_id: None,
         }
     }
 
@@ -223,6 +241,8 @@ mod tests {
             error: None,
             source: None,
             external_id: None,
+            parent_id: None,
+            subtask_ids: vec![],
         }
     }
 
@@ -366,6 +386,39 @@ mod tests {
             .await?
             .expect("task should survive reopen");
         assert!(matches!(loaded.status, TaskStatus::Done));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_children_returns_subtasks_by_parent_id() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let parent = make_task("parent-1", TaskStatus::Pending);
+        db.insert(&parent).await?;
+
+        let mut child1 = make_task("child-1", TaskStatus::Pending);
+        child1.parent_id = Some(TaskId("parent-1".to_string()));
+        db.insert(&child1).await?;
+
+        let mut child2 = make_task("child-2", TaskStatus::Done);
+        child2.parent_id = Some(TaskId("parent-1".to_string()));
+        db.insert(&child2).await?;
+
+        // Unrelated task.
+        db.insert(&make_task("unrelated", TaskStatus::Pending))
+            .await?;
+
+        let children = db.list_children("parent-1").await?;
+        assert_eq!(children.len(), 2);
+        assert!(children.iter().all(|c| c
+            .parent_id
+            .as_ref()
+            .map(|id| id.0 == "parent-1")
+            .unwrap_or(false)));
+
+        let no_children = db.list_children("nonexistent").await?;
+        assert!(no_children.is_empty());
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -82,6 +82,13 @@ pub struct TaskState {
     /// Source-specific identifier for the originating issue/message.
     /// Used by `CompletionCallback` to call `IntakeSource::on_task_complete`.
     pub external_id: Option<String>,
+    /// Parent task ID when this task is a subtask spawned via parallel dispatch.
+    /// Persisted so parent-child relationships survive server restart.
+    pub parent_id: Option<TaskId>,
+    /// IDs of subtasks spawned by this task during parallel dispatch.
+    /// Populated at runtime; not persisted (use `TaskStore::list_children` after restart).
+    #[serde(default)]
+    pub subtask_ids: Vec<TaskId>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -94,6 +101,8 @@ pub struct TaskSummary {
     pub error: Option<String>,
     /// Intake source name (e.g. "github", "feishu", "dashboard"). None for manual tasks.
     pub source: Option<String>,
+    /// Parent task ID when this is a subtask.
+    pub parent_id: Option<TaskId>,
 }
 
 impl TaskState {
@@ -107,6 +116,8 @@ impl TaskState {
             error: None,
             source: None,
             external_id: None,
+            parent_id: None,
+            subtask_ids: Vec::new(),
         }
     }
 
@@ -118,6 +129,7 @@ impl TaskState {
             pr_url: self.pr_url.clone(),
             error: self.error.clone(),
             source: self.source.clone(),
+            parent_id: self.parent_id.clone(),
         }
     }
 }
@@ -313,6 +325,17 @@ impl TaskStore {
         self.cache.iter().map(|e| e.value().clone()).collect()
     }
 
+    /// Return all cached tasks whose `parent_id` matches the given ID.
+    /// Reconstructs the child list from in-memory state; does not require
+    /// `subtask_ids` to be persisted on the parent.
+    pub fn list_children(&self, parent_id: &TaskId) -> Vec<TaskState> {
+        self.cache
+            .iter()
+            .filter(|e| e.value().parent_id.as_ref() == Some(parent_id))
+            .map(|e| e.value().clone())
+            .collect()
+    }
+
     pub(crate) async fn insert(&self, state: &TaskState) {
         self.persist_locks
             .entry(state.id.clone())
@@ -428,6 +451,15 @@ where
                     let project_config = harness_core::config::load_project_config(&project_root);
                     let remote = project_config.git.remote.clone();
                     let base_branch = project_config.git.base_branch.clone();
+
+                    // Register subtask IDs in the parent before dispatch.
+                    let sub_ids: Vec<TaskId> = (0..subtask_prompts.len())
+                        .map(|i| TaskId(format!("{}-p{i}", id.0)))
+                        .collect();
+                    mutate_and_persist(&store, &id, |s| {
+                        s.subtask_ids = sub_ids.clone();
+                    })
+                    .await;
 
                     let context_items = crate::task_executor::collect_context_items(
                         &skills,
@@ -594,6 +626,39 @@ mod tests {
         AgentRequest, AgentResponse, Capability, ContextItem, EventFilters, StreamItem, TokenUsage,
     };
     use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn list_children_returns_subtasks_for_parent() -> anyhow::Result<()> {
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let parent_id = TaskId("parent-task".to_string());
+        let parent = TaskState::new(parent_id.clone());
+        store.insert(&parent).await;
+
+        let mut child1 = TaskState::new(TaskId("child-1".to_string()));
+        child1.parent_id = Some(parent_id.clone());
+        store.insert(&child1).await;
+
+        let mut child2 = TaskState::new(TaskId("child-2".to_string()));
+        child2.parent_id = Some(parent_id.clone());
+        store.insert(&child2).await;
+
+        // Unrelated task.
+        store
+            .insert(&TaskState::new(TaskId("other".to_string())))
+            .await;
+
+        let children = store.list_children(&parent_id);
+        assert_eq!(children.len(), 2);
+        assert!(children
+            .iter()
+            .all(|c| c.parent_id.as_ref() == Some(&parent_id)));
+
+        let no_children = store.list_children(&TaskId("nonexistent".to_string()));
+        assert!(no_children.is_empty());
+        Ok(())
+    }
 
     #[test]
     fn test_task_state_new() {


### PR DESCRIPTION
## Summary

- Fix build errors: `parent_id`/`subtask_ids` fields missing from `TaskRow` and `TaskState` test helpers in `task_db.rs`
- Add `TaskDb::list_children(parent_id)` — SQL query returning all tasks with a matching `parent_id` column
- Add `TaskStore::list_children(parent_id)` — in-memory cache filter, reconstructs child list without requiring persisted `subtask_ids`
- Populate `subtask_ids` on the parent task before parallel dispatch executes, so callers can observe which subtasks are associated

## Test plan

- [x] `cargo check --workspace --all-targets` passes with `RUSTFLAGS="-Dwarnings"`
- [x] `cargo test --workspace` — all 675+ tests pass
- [x] New test `task_db::tests::list_children_returns_subtasks_by_parent_id` verifies DB-layer child queries
- [x] New test `task_runner::tests::list_children_returns_subtasks_for_parent` verifies in-memory store child lookup
- [x] `cargo fmt --all` applied

Closes #275