### PR TITLE
feat: add version command to display current version

### DIFF
--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -482,13 +482,15 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let content = std::fs::read_to_string(&cargo_toml_path)?;
             let parsed: toml::Value = toml::from_str(&content)?;
 
-            if let Some(version) = parsed.get("workspace")
+            if let Some(version) = parsed
+                .get("workspace")
                 .and_then(|w| w.get("package"))
                 .and_then(|p| p.get("version"))
                 .and_then(|v| v.as_str())
             {
                 println!("Current version: {}", version);
-            } else if let Some(version) = parsed.get("package")
+            } else if let Some(version) = parsed
+                .get("package")
                 .and_then(|p| p.get("version"))
                 .and_then(|v| v.as_str())
             {


### PR DESCRIPTION
Add a new `version` subcommand to the CLI that reads Cargo.toml and displays the current workspace version.

## Changes
- Added `Version` variant to the `Command` enum
- Implemented version reading logic that supports both workspace and package-level version fields
- Bumped version to 0.5.3

## Testing
- `cargo check` passed
- `cargo test` passed

Resolves #285