### PR TITLE
feat: add auto_pr config to GcConfig (#289)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -150,6 +150,10 @@ pub struct GcConfig {
     /// Minimum seconds between auto-triggered GC runs (cooldown). Default: 300.
     #[serde(default = "default_auto_gc_cooldown_secs")]
     pub auto_gc_cooldown_secs: u64,
+    /// When true, `gc adopt` automatically creates a branch, commits the fix, pushes,
+    /// and opens a PR via the agent prompt flow. Default: true.
+    #[serde(default = "default_gc_auto_pr")]
+    pub auto_pr: bool,
 }
 
 impl Default for GcConfig {
@@ -165,6 +169,7 @@ impl Default for GcConfig {
             signal_thresholds: SignalThresholdsConfig::default(),
             auto_gc_grades: default_auto_gc_grades(),
             auto_gc_cooldown_secs: default_auto_gc_cooldown_secs(),
+            auto_pr: default_gc_auto_pr(),
         }
     }
 }
@@ -191,6 +196,10 @@ fn default_auto_gc_grades() -> Vec<Grade> {
 
 fn default_auto_gc_cooldown_secs() -> u64 {
     300
+}
+
+fn default_gc_auto_pr() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -123,7 +123,7 @@ pub async fn gc_adopt(
 
     match state.engines.gc_agent.adopt(&draft_id) {
         Ok(()) => {
-            if artifact_paths.is_empty() {
+            if artifact_paths.is_empty() || !state.core.server.config.gc.auto_pr {
                 return RpcResponse::success(
                     id,
                     serde_json::json!({ "adopted": true, "task_id": null }),

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -73,6 +73,13 @@ impl CodeAgent for MockPrAgent {
 // ---------------------------------------------------------------------------
 
 async fn make_state(root: &Path) -> anyhow::Result<harness_server::http::AppState> {
+    make_state_with_auto_pr(root, true).await
+}
+
+async fn make_state_with_auto_pr(
+    root: &Path,
+    auto_pr: bool,
+) -> anyhow::Result<harness_server::http::AppState> {
     let project_root = root.join("project");
     std::fs::create_dir_all(&project_root)?;
 
@@ -80,6 +87,7 @@ async fn make_state(root: &Path) -> anyhow::Result<harness_server::http::AppStat
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
     config.agents.default_agent = "mock-pr".to_string();
+    config.gc.auto_pr = auto_pr;
 
     let mut registry = AgentRegistry::new("mock-pr");
     registry.register("mock-pr", Arc::new(MockPrAgent));
@@ -188,6 +196,62 @@ async fn gc_adopt_unknown_draft_returns_not_found() -> anyhow::Result<()> {
 
     assert!(resp.error.is_some(), "expected error for unknown draft");
     assert_eq!(resp.error.unwrap().code, harness_protocol::NOT_FOUND);
+
+    Ok(())
+}
+
+/// gc_adopt with auto_pr=false skips task dispatch and returns null task_id.
+#[tokio::test]
+async fn gc_adopt_auto_pr_false_skips_task_dispatch() -> anyhow::Result<()> {
+    let sandbox = common::tempdir_in_home("gc-adopt-no-auto-pr-")?;
+    let state = make_state_with_auto_pr(sandbox.path(), false).await?;
+
+    let artifact_rel = std::path::PathBuf::from(".harness/drafts/test-guard.sh");
+    let draft = make_draft(&artifact_rel, "#!/usr/bin/env bash\necho 'guard'");
+    state.engines.gc_agent.draft_store().save(&draft)?;
+
+    let draft_id = draft.id.clone();
+    let resp = gc_adopt(&state, Some(serde_json::json!(1)), draft_id).await;
+
+    assert!(
+        resp.error.is_none(),
+        "expected success, got error: {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("missing result");
+    assert_eq!(result["adopted"], true);
+    assert!(
+        result["task_id"].is_null(),
+        "task_id should be null when auto_pr=false"
+    );
+
+    Ok(())
+}
+
+/// gc_adopt with auto_pr=true (default) dispatches a task when artifacts exist.
+#[tokio::test]
+async fn gc_adopt_auto_pr_true_dispatches_task() -> anyhow::Result<()> {
+    let sandbox = common::tempdir_in_home("gc-adopt-auto-pr-true-")?;
+    let state = make_state_with_auto_pr(sandbox.path(), true).await?;
+
+    let artifact_rel = std::path::PathBuf::from(".harness/drafts/test-guard.sh");
+    let draft = make_draft(&artifact_rel, "#!/usr/bin/env bash\necho 'guard'");
+    state.engines.gc_agent.draft_store().save(&draft)?;
+
+    let draft_id = draft.id.clone();
+    let resp = gc_adopt(&state, Some(serde_json::json!(1)), draft_id).await;
+
+    assert!(
+        resp.error.is_none(),
+        "expected success, got error: {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("missing result");
+    assert_eq!(result["adopted"], true);
+    assert!(
+        !result["task_id"].is_null(),
+        "task_id should be set when auto_pr=true and agent is registered"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds `auto_pr: bool` field to `GcConfig` (default: `true`) so users can disable automatic PR creation on `gc adopt` via config
- In `gc_adopt` handler, skip agent task dispatch when `auto_pr = false` — artifacts are still written to disk, only the branch/commit/push/PR step is skipped
- PR creation continues to use the existing prompt-based `ClaudeCodeAgent` flow (no `Command::new("gh")`)
- Two new integration tests: `auto_pr=false` returns null `task_id`, `auto_pr=true` dispatches the task

## Files changed

- `crates/harness-core/src/config/misc.rs` — `auto_pr` field + default fn
- `crates/harness-server/src/handlers/gc.rs` — guard on `auto_pr` before spawning task
- `crates/harness-server/tests/gc_adopt_pipeline.rs` — new tests + `make_state_with_auto_pr` helper

## Test plan

- [x] `cargo check --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` passes
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all` applied

Closes #289