### PR TITLE
feat: add trusted_proxies config and X-Forwarded-For validation

### DIFF
--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -20,6 +20,10 @@ pub struct ServerConfig {
     /// Interval in seconds between WebSocket heartbeat pings. Must be >= 1.
     #[serde(default = "default_ws_heartbeat_interval_secs")]
     pub ws_heartbeat_interval_secs: u64,
+    /// List of trusted proxy IP addresses. X-Forwarded-For is only used when the
+    /// request originates from one of these IPs.
+    #[serde(default)]
+    pub trusted_proxies: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -33,6 +37,7 @@ impl Default for ServerConfig {
             notification_broadcast_capacity: default_notification_broadcast_capacity(),
             notification_lag_log_every: default_notification_lag_log_every(),
             ws_heartbeat_interval_secs: default_ws_heartbeat_interval_secs(),
+            trusted_proxies: Vec::new(),
         }
     }
 }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -34,6 +34,7 @@ pub mod task_queue;
 pub mod task_runner;
 pub mod thread_db;
 pub mod thread_manager;
+pub mod trusted_proxy;
 pub mod webhook;
 pub mod websocket;
 pub mod workspace;

--- a/crates/harness-server/src/trusted_proxy.rs
+++ b/crates/harness-server/src/trusted_proxy.rs
@@ -1,0 +1,113 @@
+use axum::http::HeaderMap;
+use std::net::IpAddr;
+
+/// Extracts the real client IP from request headers, respecting trusted proxy configuration.
+///
+/// If `peer_addr` is in `trusted_proxies`, the leftmost IP from the `X-Forwarded-For` header
+/// is used as the client IP. Otherwise, `peer_addr` is returned as-is.
+///
+/// Returns `None` when `peer_addr` is `None`.
+pub fn extract_client_ip(
+    headers: &HeaderMap,
+    peer_addr: Option<IpAddr>,
+    trusted_proxies: &[String],
+) -> Option<IpAddr> {
+    let peer = peer_addr?;
+    if is_trusted_proxy(peer, trusted_proxies) {
+        if let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+            if let Some(first) = xff.split(',').next().map(str::trim) {
+                if let Ok(ip) = first.parse::<IpAddr>() {
+                    return Some(ip);
+                }
+            }
+        }
+    }
+    Some(peer)
+}
+
+fn is_trusted_proxy(addr: IpAddr, trusted_proxies: &[String]) -> bool {
+    trusted_proxies.iter().any(|proxy| {
+        proxy
+            .parse::<IpAddr>()
+            .map(|ip| ip == addr)
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+    use std::net::IpAddr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn untrusted_proxy_ignores_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        let peer = ip("192.168.1.1");
+        let result = extract_client_ip(&headers, Some(peer), &[]);
+        assert_eq!(result, Some(peer));
+    }
+
+    #[test]
+    fn trusted_proxy_uses_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        let peer = ip("10.0.0.1");
+        let proxies = vec!["10.0.0.1".to_string()];
+        let result = extract_client_ip(&headers, Some(peer), &proxies);
+        assert_eq!(result, Some(ip("1.2.3.4")));
+    }
+
+    #[test]
+    fn trusted_proxy_uses_first_xff_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4, 5.6.7.8".parse().unwrap());
+        let peer = ip("10.0.0.1");
+        let proxies = vec!["10.0.0.1".to_string()];
+        let result = extract_client_ip(&headers, Some(peer), &proxies);
+        assert_eq!(result, Some(ip("1.2.3.4")));
+    }
+
+    #[test]
+    fn trusted_proxy_no_xff_falls_back_to_peer() {
+        let headers = HeaderMap::new();
+        let peer = ip("10.0.0.1");
+        let proxies = vec!["10.0.0.1".to_string()];
+        let result = extract_client_ip(&headers, Some(peer), &proxies);
+        assert_eq!(result, Some(peer));
+    }
+
+    #[test]
+    fn trusted_proxy_invalid_xff_falls_back_to_peer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "not-an-ip".parse().unwrap());
+        let peer = ip("10.0.0.1");
+        let proxies = vec!["10.0.0.1".to_string()];
+        let result = extract_client_ip(&headers, Some(peer), &proxies);
+        assert_eq!(result, Some(peer));
+    }
+
+    #[test]
+    fn no_peer_returns_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        let proxies = vec!["10.0.0.1".to_string()];
+        let result = extract_client_ip(&headers, None, &proxies);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn untrusted_peer_is_not_in_proxy_list() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        let peer = ip("172.16.0.5");
+        let proxies = vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()];
+        let result = extract_client_ip(&headers, Some(peer), &proxies);
+        assert_eq!(result, Some(peer));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `trusted_proxies: Vec<String>` field to `ServerConfig` (harness-core) with `#[serde(default)]` so existing configs are unaffected
- Adds `harness_server::trusted_proxy::extract_client_ip` — only trusts `X-Forwarded-For` when the direct peer address matches a configured trusted proxy IP; falls back to the real peer address otherwise
- Registers the new module in `harness-server/src/lib.rs`

## Test plan

- [x] 7 unit tests in `trusted_proxy::tests` covering: trusted proxy uses XFF, uses only first IP from multi-hop XFF, falls back when no XFF, falls back on invalid XFF, ignores XFF from untrusted peer, handles missing peer address, rejects peer not in proxy list
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test -p harness-server trusted_proxy` — 7/7 pass

Closes #60