### PR TITLE
feat: ProjectRegistry with SQLite persistence and REST API

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod health;
 pub mod learn;
 pub mod observe;
 pub mod preflight;
+pub mod projects;
 pub mod rules;
 pub mod skills;
 pub mod thread;

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -1,0 +1,141 @@
+use crate::http::AppState;
+use crate::project_registry::{validate_project_root, Project};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterProjectRequest {
+    pub id: String,
+    pub root: std::path::PathBuf,
+    #[serde(default)]
+    pub max_concurrent: Option<u32>,
+    #[serde(default)]
+    pub default_agent: Option<String>,
+}
+
+pub async fn register_project(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RegisterProjectRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(registry) = state.core.project_registry.as_ref() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "project registry not initialized"})),
+        );
+    };
+
+    let root = match req.root.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid root path: {e}")})),
+            )
+        }
+    };
+
+    if let Err(msg) = validate_project_root(&root) {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": msg})));
+    }
+
+    let project = Project {
+        id: req.id,
+        root,
+        max_concurrent: req.max_concurrent,
+        default_agent: req.default_agent,
+        active: true,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    match registry.register(project.clone()).await {
+        Ok(()) => (StatusCode::CREATED, Json(json!(project))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+pub async fn list_projects(
+    State(state): State<Arc<AppState>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(registry) = state.core.project_registry.as_ref() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "project registry not initialized"})),
+        );
+    };
+
+    match registry.list().await {
+        Ok(projects) => {
+            let with_counts: Vec<serde_json::Value> = projects
+                .into_iter()
+                .map(|p| {
+                    let mut v = serde_json::to_value(&p).unwrap_or_default();
+                    // task_count is best-effort; tasks do not store project_id
+                    v["task_count"] = json!(0);
+                    v
+                })
+                .collect();
+            (StatusCode::OK, Json(json!(with_counts)))
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+pub async fn get_project(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(registry) = state.core.project_registry.as_ref() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "project registry not initialized"})),
+        );
+    };
+
+    match registry.get(&id).await {
+        Ok(Some(project)) => (StatusCode::OK, Json(json!(project))),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("project '{id}' not found")})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+pub async fn delete_project(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(registry) = state.core.project_registry.as_ref() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "project registry not initialized"})),
+        );
+    };
+
+    match registry.remove(&id).await {
+        Ok(true) => (StatusCode::OK, Json(json!({"deleted": id}))),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("project '{id}' not found")})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -131,6 +131,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -66,6 +66,7 @@ pub struct CoreServices {
     pub plan_db: Option<crate::plan_db::PlanDb>,
     pub plans:
         Arc<RwLock<std::collections::HashMap<harness_core::ExecPlanId, harness_exec::ExecPlan>>>,
+    pub project_registry: Option<std::sync::Arc<crate::project_registry::ProjectRegistry>>,
 }
 
 /// Engine services: skills, rules, and garbage collection.
@@ -252,6 +253,26 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     let thread_db_path = dir.join("threads.db");
     let thread_db = crate::thread_db::ThreadDb::open(&thread_db_path).await?;
     let plan_db = crate::plan_db::PlanDb::open(&dir.join("plans.db")).await?;
+
+    let project_registry =
+        crate::project_registry::ProjectRegistry::open(&dir.join("projects.db")).await?;
+    // Auto-register the default project from --project-root on startup.
+    let default_project = crate::project_registry::Project {
+        id: "default".to_string(),
+        root: project_root.clone(),
+        max_concurrent: None,
+        default_agent: None,
+        active: true,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    if let Err(e) = project_registry.register(default_project).await {
+        tracing::warn!("failed to auto-register default project: {e}");
+    } else {
+        tracing::info!(
+            project_root = %project_root.display(),
+            "project registry: default project registered"
+        );
+    }
     let plans_md_dir = dir.join("plans");
     match plan_db.migrate_from_markdown_dir(&plans_md_dir).await {
         Ok(0) => {}
@@ -384,6 +405,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                 Arc::new(RwLock::new(map))
             },
             plan_db: Some(plan_db),
+            project_registry: Some(project_registry),
         },
         engines: EngineServices {
             skills: Arc::new(RwLock::new(skill_store)),
@@ -670,6 +692,16 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         .route("/tasks", get(list_tasks))
         .route("/tasks/{id}", get(get_task))
         .route("/tasks/{id}/stream", get(stream_task_sse))
+        .route(
+            "/projects",
+            post(crate::handlers::projects::register_project)
+                .get(crate::handlers::projects::list_projects),
+        )
+        .route(
+            "/projects/{id}",
+            get(crate::handlers::projects::get_project)
+                .delete(crate::handlers::projects::delete_project),
+        )
         .route("/api/intake", get(intake_status))
         .route(
             "/webhook",

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -29,6 +29,26 @@ pub(crate) async fn enqueue_task(
         ));
     }
 
+    // Resolve project: if the supplied path does not exist as a directory,
+    // treat it as a project ID and look it up in the registry.
+    let mut req = req;
+    if let (Some(registry), Some(project_path)) =
+        (state.core.project_registry.as_ref(), req.project.clone())
+    {
+        if !project_path.is_dir() {
+            let id = project_path.to_string_lossy();
+            match registry.resolve_path(&id).await {
+                Ok(Some(root)) => req.project = Some(root),
+                Ok(None) => {
+                    return Err(EnqueueTaskError::BadRequest(format!(
+                        "project '{id}' not found in registry and is not a valid directory"
+                    )))
+                }
+                Err(e) => return Err(EnqueueTaskError::Internal(e.to_string())),
+            }
+        }
+    }
+
     // Acquire concurrency permit before spawning. Blocks if all slots are
     // occupied; rejects immediately if the waiting queue is full.
     let permit = state

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -89,6 +89,7 @@ async fn make_test_state_with(
             thread_db: Some(thread_db),
             plan_db: None,
             plans: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+            project_registry: None,
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(tokio::sync::RwLock::new(harness_skills::SkillStore::new())),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod parallel_dispatch;
 pub mod periodic_reviewer;
 pub mod plan_db;
 pub mod post_validator;
+pub mod project_registry;
 pub mod quality_trigger;
 pub mod router;
 pub mod rule_enforcer;

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,0 +1,226 @@
+use crate::db::{Db, DbEntity};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// A registered project with its root path and optional config overrides.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: String,
+    pub root: PathBuf,
+    #[serde(default)]
+    pub max_concurrent: Option<u32>,
+    #[serde(default)]
+    pub default_agent: Option<String>,
+    #[serde(default = "default_active")]
+    pub active: bool,
+    pub created_at: String,
+}
+
+fn default_active() -> bool {
+    true
+}
+
+impl DbEntity for Project {
+    fn table_name() -> &'static str {
+        "projects"
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn create_table_sql() -> &'static str {
+        "CREATE TABLE IF NOT EXISTS projects (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )"
+    }
+}
+
+/// Registry of projects backed by SQLite. Survives server restarts.
+pub struct ProjectRegistry {
+    db: Db<Project>,
+}
+
+impl ProjectRegistry {
+    pub async fn open(path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
+        let db = Db::open(path).await?;
+        Ok(Arc::new(Self { db }))
+    }
+
+    /// Register or update a project.
+    pub async fn register(&self, project: Project) -> anyhow::Result<()> {
+        self.db.upsert(&project).await
+    }
+
+    /// List all registered projects ordered by creation time (newest first).
+    pub async fn list(&self) -> anyhow::Result<Vec<Project>> {
+        self.db.list().await
+    }
+
+    /// Get a project by ID.
+    pub async fn get(&self, id: &str) -> anyhow::Result<Option<Project>> {
+        self.db.get(id).await
+    }
+
+    /// Remove a project by ID. Returns `true` if it existed.
+    pub async fn remove(&self, id: &str) -> anyhow::Result<bool> {
+        self.db.delete(id).await
+    }
+
+    /// Resolve a project ID to its root path. Returns `None` if not found.
+    pub async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
+        Ok(self.get(id).await?.map(|p| p.root))
+    }
+}
+
+/// Validate that a path is an existing directory and a git repository.
+pub fn validate_project_root(root: &std::path::Path) -> Result<(), String> {
+    if !root.is_dir() {
+        return Err(format!("root is not a directory: {}", root.display()));
+    }
+    // Check for .git directory or .git file (worktree case)
+    if !root.join(".git").exists() {
+        return Err(format!(
+            "root is not a git repository (no .git found): {}",
+            root.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_and_get_roundtrip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+
+        let project = Project {
+            id: "my-project".to_string(),
+            root: PathBuf::from("/tmp/my-project"),
+            max_concurrent: None,
+            default_agent: None,
+            active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        registry.register(project.clone()).await?;
+
+        let loaded = registry
+            .get("my-project")
+            .await?
+            .expect("project should exist");
+        assert_eq!(loaded.id, "my-project");
+        assert_eq!(loaded.root, PathBuf::from("/tmp/my-project"));
+        assert!(loaded.active);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_projects() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+
+        for i in 0..3u32 {
+            registry
+                .register(Project {
+                    id: format!("p{i}"),
+                    root: PathBuf::from(format!("/tmp/p{i}")),
+                    max_concurrent: None,
+                    default_agent: None,
+                    active: true,
+                    created_at: "2026-01-01T00:00:00Z".to_string(),
+                })
+                .await?;
+        }
+
+        let all = registry.list().await?;
+        assert_eq!(all.len(), 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remove_returns_true_when_found() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+
+        registry
+            .register(Project {
+                id: "to-delete".to_string(),
+                root: PathBuf::from("/tmp/x"),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        assert!(registry.remove("to-delete").await?);
+        assert!(registry.get("to-delete").await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remove_returns_false_when_missing() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        assert!(!registry.remove("nonexistent").await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_path_returns_root() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+
+        registry
+            .register(Project {
+                id: "harness".to_string(),
+                root: PathBuf::from("/home/user/harness"),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        let path = registry.resolve_path("harness").await?;
+        assert_eq!(path, Some(PathBuf::from("/home/user/harness")));
+        assert!(registry.resolve_path("unknown").await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn survives_reopen() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("projects.db");
+
+        {
+            let registry = ProjectRegistry::open(&db_path).await?;
+            registry
+                .register(Project {
+                    id: "persistent".to_string(),
+                    root: PathBuf::from("/tmp/persistent"),
+                    max_concurrent: Some(2),
+                    default_agent: Some("claude".to_string()),
+                    active: true,
+                    created_at: "2026-01-01T00:00:00Z".to_string(),
+                })
+                .await?;
+        }
+
+        let registry = ProjectRegistry::open(&db_path).await?;
+        let loaded = registry
+            .get("persistent")
+            .await?
+            .expect("should survive reopen");
+        assert_eq!(loaded.max_concurrent, Some(2));
+        assert_eq!(loaded.default_agent.as_deref(), Some("claude"));
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -235,6 +235,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),
@@ -1470,6 +1471,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: Some(plan_db),
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -116,6 +116,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -121,6 +121,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -266,6 +266,7 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
+                project_registry: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::SkillStore::new())),


### PR DESCRIPTION
## Summary

Closes #302.

- **`project_registry.rs`**: New `ProjectRegistry` struct backed by SQLite using the existing `Db<T>` generic store. Schema: id, root, max_concurrent, default_agent, active, created_at. Validates that project root is an existing directory and git repository on registration.
- **`handlers/projects.rs`**: REST handlers for CRUD — `POST /projects`, `GET /projects`, `GET /projects/{id}`, `DELETE /projects/{id}`.
- **`http.rs`**: Added `project_registry: Option<Arc<ProjectRegistry>>` to `CoreServices`. Auto-registers `--project-root` as `"default"` project on startup.
- **`task_routes.rs`**: `enqueue_task` resolves a project short-ID from the registry when the supplied `project` field is not an existing directory path.

## Test plan

- [x] `cargo test -p harness-server` — 323 tests pass (6 new `project_registry` tests)
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --all` — applied
- [ ] Manual: `POST /projects {"id":"harness","root":"/path/to/harness"}` registers project
- [ ] Manual: `POST /tasks {"prompt":"...","project":"harness"}` resolves to registered root
- [ ] Manual: server restart — projects survive (SQLite persistence)