### PR TITLE
fix: non-blocking batch submission and description passthrough for issue tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -110,6 +110,93 @@ pub struct BatchCreateTaskRequest {
     pub turn_timeout_secs: Option<u64>,
 }
 
+/// Enqueues a task for background execution, returning its ID immediately.
+///
+/// Unlike `enqueue_task`, this function never blocks on concurrency permit
+/// acquisition. The task is registered with Pending status right away, and a
+/// background tokio task waits for a slot and then begins execution. This
+/// keeps the `/tasks/batch` HTTP handler responsive even when all concurrency
+/// slots are occupied.
+async fn enqueue_task_background(
+    state: Arc<AppState>,
+    req: task_runner::CreateTaskRequest,
+) -> Result<task_runner::TaskId, EnqueueTaskError> {
+    if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
+        return Err(EnqueueTaskError::BadRequest(
+            "at least one of prompt, issue, or pr must be provided".to_string(),
+        ));
+    }
+
+    // Resolve agent up-front (fast, no I/O) so we can return an error immediately
+    // if the agent name is invalid, before registering the task.
+    let agent =
+        if let Some(name) = &req.agent {
+            state.core.server.agent_registry.get(name).ok_or_else(|| {
+                EnqueueTaskError::BadRequest(format!("agent '{name}' not registered"))
+            })?
+        } else {
+            let classification = crate::complexity_router::classify(
+                req.prompt.as_deref().unwrap_or_default(),
+                req.issue,
+                req.pr,
+            );
+            state
+                .core
+                .server
+                .agent_registry
+                .dispatch(&classification)
+                .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?
+        };
+
+    let (reviewer, review_config) = resolve_reviewer(
+        &state.core.server.agent_registry,
+        &state.core.server.config.agents.review,
+        agent.name(),
+    );
+
+    // Register the task immediately so the caller gets an ID without blocking.
+    let task_id =
+        task_runner::register_pending_task(state.core.tasks.clone(), req.source.clone()).await;
+
+    // Spawn a background tokio task that waits for a concurrency slot then executes.
+    // The HTTP handler returns the task_id before this future completes.
+    {
+        let task_id2 = task_id.clone();
+        tokio::spawn(async move {
+            match state.concurrency.task_queue.acquire().await {
+                Ok(permit) => {
+                    task_runner::spawn_preregistered_task(
+                        task_id2,
+                        state.core.tasks.clone(),
+                        agent,
+                        reviewer,
+                        review_config,
+                        state.engines.skills.clone(),
+                        state.observability.events.clone(),
+                        state.interceptors.clone(),
+                        req,
+                        state.concurrency.workspace_mgr.clone(),
+                        permit,
+                        state.completion_callback.clone(),
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    // Queue is full; mark the pre-registered task as failed.
+                    task_runner::mutate_and_persist(&state.core.tasks, &task_id2, |s| {
+                        s.status = task_runner::TaskStatus::Failed;
+                        s.error = Some(format!("task queue full: {e}"));
+                    })
+                    .await;
+                    state.core.tasks.close_task_stream(&task_id2);
+                }
+            }
+        });
+    }
+
+    Ok(task_id)
+}
+
 pub(super) async fn create_tasks_batch(
     State(state): State<Arc<AppState>>,
     Json(req): Json<BatchCreateTaskRequest>,
@@ -158,11 +245,13 @@ pub(super) async fn create_tasks_batch(
         }
     }
 
-    // Enqueue each task; collect results (task_id or error per entry).
+    // Register each task without blocking on concurrency permit acquisition.
+    // Each task gets an ID immediately; a background tokio task handles permit
+    // waiting and execution. The HTTP handler returns as soon as all tasks are registered.
     let mut results = Vec::with_capacity(task_requests.len());
     for task_req in task_requests {
-        let entry = match enqueue_task(&state, task_req).await {
-            Ok(task_id) => json!({ "task_id": task_id.0, "status": "running" }),
+        let entry = match enqueue_task_background(state.clone(), task_req).await {
+            Ok(task_id) => json!({ "task_id": task_id.0, "status": "queued" }),
             Err(EnqueueTaskError::BadRequest(error)) => json!({ "error": error }),
             Err(EnqueueTaskError::Internal(error)) => json!({ "error": error }),
         };

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -278,7 +278,7 @@ pub(crate) async fn run_task(
     let git = Some(&project_config.git);
 
     let first_prompt = if let Some(issue) = req.issue {
-        match find_existing_pr_for_issue(&project, issue).await {
+        let base = match find_existing_pr_for_issue(&project, issue).await {
             Ok(Some((pr_num, branch))) => {
                 tracing::info!(
                     "reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}"
@@ -290,6 +290,17 @@ pub(crate) async fn run_task(
                 tracing::warn!("failed to check for existing PR for issue #{issue}: {e}");
                 prompts::implement_from_issue(issue, git)
             }
+        };
+        // If the caller also supplied a description alongside the issue number, include it
+        // as additional context. Without this, batch tasks that set both `description` and
+        // `issue` would silently discard the description.
+        if let Some(hint) = req.prompt.as_deref().filter(|s| !s.is_empty()) {
+            format!(
+                "{base}\n\nAdditional context from caller:\n{}",
+                prompts::wrap_external_data(hint)
+            )
+        } else {
+            base
         }
     } else if let Some(pr) = req.pr {
         prompts::check_existing_pr(pr, &review_config.review_bot_command)

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -428,8 +428,56 @@ pub async fn spawn_task(
         workspace_mgr,
         permit,
         completion_callback,
+        None,
     )
     .await
+}
+
+/// Register a task with Pending status and return its ID immediately, without waiting
+/// for a concurrency permit. Pair with `spawn_preregistered_task` (called from a
+/// background tokio task after `task_queue.acquire()`) to begin execution.
+pub async fn register_pending_task(store: Arc<TaskStore>, source: Option<String>) -> TaskId {
+    let task_id = TaskId::new();
+    let mut state = TaskState::new(task_id.clone());
+    state.source = source;
+    store.insert(&state).await;
+    // Register stream channel now so SSE clients can subscribe before execution begins.
+    store.register_task_stream(&task_id);
+    task_id
+}
+
+/// Begin execution for a task pre-registered via `register_pending_task`.
+/// The caller must have already acquired a concurrency permit; it is held for the task's lifetime.
+pub async fn spawn_preregistered_task(
+    task_id: TaskId,
+    store: Arc<TaskStore>,
+    agent: Arc<dyn CodeAgent>,
+    reviewer: Option<Arc<dyn CodeAgent>>,
+    review_config: harness_core::AgentReviewConfig,
+    skills: Arc<RwLock<harness_skills::SkillStore>>,
+    events: Arc<harness_observe::EventStore>,
+    interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    req: CreateTaskRequest,
+    workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
+    permit: crate::task_queue::TaskPermit,
+    completion_callback: Option<CompletionCallback>,
+) {
+    spawn_task_with_worktree_detector(
+        store,
+        agent,
+        reviewer,
+        review_config,
+        skills,
+        events,
+        interceptors,
+        req,
+        detect_main_worktree,
+        workspace_mgr,
+        permit,
+        completion_callback,
+        Some(task_id),
+    )
+    .await;
 }
 
 async fn spawn_task_with_worktree_detector<F>(
@@ -445,16 +493,24 @@ async fn spawn_task_with_worktree_detector<F>(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    preregistered_id: Option<TaskId>,
 ) -> TaskId
 where
     F: Fn() -> PathBuf + Send + Sync + 'static,
 {
-    let task_id = TaskId::new();
-    let mut state = TaskState::new(task_id.clone());
-    state.source = req.source.clone();
-    store.insert(&state).await;
-    // Register stream channel before spawning so SSE clients can subscribe immediately.
-    store.register_task_stream(&task_id);
+    let task_id = if let Some(id) = preregistered_id {
+        // Task was pre-registered (e.g. by register_pending_task for batch submission);
+        // store.insert and register_task_stream were already called.
+        id
+    } else {
+        let task_id = TaskId::new();
+        let mut state = TaskState::new(task_id.clone());
+        state.source = req.source.clone();
+        store.insert(&state).await;
+        // Register stream channel before spawning so SSE clients can subscribe immediately.
+        store.register_task_stream(&task_id);
+        task_id
+    };
 
     let id = task_id.clone();
     let store_watcher = store.clone();
@@ -1080,6 +1136,7 @@ mod tests {
             },
             None,
             permit,
+            None,
             None,
         )
         .await;


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on PR #311:

- **Issue 1 (serial blocking)**: `POST /tasks/batch` was calling `enqueue_task()` serially in a loop, blocking on semaphore permit acquisition for each item. When all `max_concurrent_tasks` slots were occupied, the HTTP handler would hang until a running task finished. Fix: `enqueue_task_background()` registers each task immediately (returning a TaskId) and spawns a background tokio task to wait for a permit and run. The HTTP handler returns as soon as all tasks are registered.

- **Issue 2 (silent description discard)**: `task_executor.rs` ignored `req.prompt` whenever `req.issue` was set, so batch tasks using the detailed format with both `description` and `issue` would silently drop the caller-supplied description. Fix: when both are present, description is appended as "Additional context from caller" to the issue-based prompt.

## New functions

- `task_runner::register_pending_task()` — allocates task ID and inserts Pending record instantly (no I/O)
- `task_runner::spawn_preregistered_task()` — accepts a pre-registered task ID, acquires permit, executes task

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test` — all tests pass