### PR TITLE
fix: wire per-project config overrides to runtime enforcement

### DIFF
--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -38,7 +38,7 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
                 config.agents.sandbox_mode,
             );
 
-            let report = gc_agent.run(&project, &events, &[], &claude).await?;
+            let report = gc_agent.run(&project, &events, &[], &claude, None).await?;
             println!("Signals detected: {}", report.signals.len());
             println!("Drafts generated: {}", report.drafts_generated);
             for e in &report.errors {

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -52,6 +52,7 @@ impl GcAgent {
         events: &[harness_core::Event],
         violations: &[harness_core::Violation],
         agent: &dyn CodeAgent,
+        max_drafts_override: Option<usize>,
     ) -> anyhow::Result<GcReport> {
         // 0. Expire stale drafts before generating new ones
         self.draft_store
@@ -81,7 +82,8 @@ impl GcAgent {
         let mut drafts_generated = 0;
         let mut errors = Vec::new();
 
-        for signal in signals.iter().take(self.config.max_drafts_per_run) {
+        let max_drafts = max_drafts_override.unwrap_or(self.config.max_drafts_per_run);
+        for signal in signals.iter().take(max_drafts) {
             let prompt = build_prompt(signal, project);
 
             let result = agent

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -75,7 +75,7 @@ pub async fn gc_run(state: &AppState, id: Option<serde_json::Value>) -> RpcRespo
     match state
         .engines
         .gc_agent
-        .run(&project, &events, &violations, agent.as_ref())
+        .run(&project, &events, &violations, agent.as_ref(), None)
         .await
     {
         Ok(report) => match serde_json::to_value(&report) {
@@ -156,7 +156,7 @@ pub async fn gc_adopt(
                 let tid = crate::task_runner::spawn_task(
                     state.core.tasks.clone(),
                     agent,
-                    None,
+                    state.core.server.agent_registry.clone(),
                     std::sync::Arc::new(state.core.server.config.clone()),
                     state.engines.skills.clone(),
                     state.observability.events.clone(),
@@ -165,6 +165,7 @@ pub async fn gc_adopt(
                     state.concurrency.workspace_mgr.clone(),
                     permit,
                     None,
+                    state.concurrency.project_semaphores.clone(),
                 )
                 .await;
                 Some(tid.0)

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -145,6 +145,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx,

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -82,10 +82,13 @@ pub struct ObservabilityServices {
     pub signal_rate_limiter: Arc<SignalRateLimiter>,
 }
 
-/// Concurrency services: task queue and workspace isolation.
+/// Concurrency services: task queue, workspace isolation, and per-project semaphores.
 pub struct ConcurrencyServices {
     pub task_queue: Arc<crate::task_queue::TaskQueue>,
     pub workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
+    /// Per-project concurrency semaphores. Created lazily when a project config
+    /// specifies a `max_concurrent_tasks` lower than the global limit.
+    pub project_semaphores: Arc<dashmap::DashMap<std::path::PathBuf, Arc<tokio::sync::Semaphore>>>,
 }
 
 /// Notification services: broadcast channels and lag tracking.
@@ -245,7 +248,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     );
     let draft_store = harness_gc::DraftStore::new(&dir)?;
     let gc_agent = Arc::new(harness_gc::GcAgent::new(
-        harness_core::GcConfig::default(),
+        server.config.gc.clone(),
         signal_detector,
         draft_store,
     ));
@@ -419,6 +422,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         concurrency: ConcurrencyServices {
             task_queue,
             workspace_mgr,
+            project_semaphores: Arc::new(dashmap::DashMap::new()),
         },
         notifications: NotificationServices {
             notification_tx: broadcast::channel(notification_broadcast_capacity).0,
@@ -484,14 +488,15 @@ fn build_completion_callback(
                         {
                             match std::env::var("GITHUB_TOKEN") {
                                 Ok(token) if !token.is_empty() => {
-                                    if let Err(e) = post_review_bot_comment(
-                                        &owner,
-                                        &repo,
-                                        pr_num,
-                                        &review_config.review_bot_command,
-                                        &token,
-                                    )
-                                    .await
+                                    // Use the task's effective (project-resolved) bot command if
+                                    // available; fall back to the global server-level command.
+                                    let cmd = task
+                                        .review_bot_command
+                                        .as_deref()
+                                        .unwrap_or(&review_config.review_bot_command);
+                                    if let Err(e) =
+                                        post_review_bot_comment(&owner, &repo, pr_num, cmd, &token)
+                                            .await
                                     {
                                         tracing::warn!(
                                             pr_url,
@@ -500,7 +505,7 @@ fn build_completion_callback(
                                     } else {
                                         tracing::info!(
                                             pr_url,
-                                            comment = review_config.review_bot_command,
+                                            comment = cmd,
                                             "review bot comment posted"
                                         );
                                     }
@@ -597,54 +602,6 @@ async fn post_review_bot_comment(
         anyhow::bail!("GitHub API returned {status}: {text}");
     }
     Ok(())
-}
-
-/// Resolve the reviewer agent for independent agent review.
-///
-/// 1. If `config.reviewer_agent` is set and differs from implementor, use it.
-/// 2. Otherwise, auto-select the first registered agent that isn't the implementor.
-/// 3. If none found, return None (agent review will be skipped).
-fn resolve_reviewer(
-    registry: &harness_agents::AgentRegistry,
-    config: &harness_core::AgentReviewConfig,
-    implementor_name: &str,
-) -> (
-    Option<Arc<dyn harness_core::CodeAgent>>,
-    harness_core::AgentReviewConfig,
-) {
-    if !config.enabled {
-        return (None, config.clone());
-    }
-
-    // Explicit reviewer
-    if !config.reviewer_agent.is_empty() {
-        if config.reviewer_agent == implementor_name {
-            tracing::warn!(
-                "agents.review.reviewer_agent == implementor '{}', skipping agent review",
-                implementor_name
-            );
-            return (None, config.clone());
-        }
-        if let Some(agent) = registry.get(&config.reviewer_agent) {
-            return (Some(agent), config.clone());
-        }
-        tracing::warn!(
-            "agents.review.reviewer_agent '{}' not registered, skipping agent review",
-            config.reviewer_agent
-        );
-        return (None, config.clone());
-    }
-
-    // Auto-select: first agent != implementor
-    for name in registry.list() {
-        if name != implementor_name {
-            if let Some(agent) = registry.get(name) {
-                return (Some(agent), config.clone());
-            }
-        }
-    }
-
-    (None, config.clone())
 }
 
 pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Result<()> {

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -1,4 +1,4 @@
-use super::{resolve_reviewer, AppState};
+use super::AppState;
 use crate::task_runner;
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Deserialize;
@@ -91,16 +91,10 @@ pub(crate) async fn enqueue_task(
                 .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?
         };
 
-    let (reviewer, _review_config) = resolve_reviewer(
-        &state.core.server.agent_registry,
-        &state.core.server.config.agents.review,
-        agent.name(),
-    );
-
     let task_id = task_runner::spawn_task(
         state.core.tasks.clone(),
         agent,
-        reviewer,
+        state.core.server.agent_registry.clone(),
         Arc::new(state.core.server.config.clone()),
         state.engines.skills.clone(),
         state.observability.events.clone(),
@@ -109,6 +103,7 @@ pub(crate) async fn enqueue_task(
         state.concurrency.workspace_mgr.clone(),
         permit,
         state.completion_callback.clone(),
+        state.concurrency.project_semaphores.clone(),
     )
     .await;
 
@@ -152,7 +147,7 @@ pub struct BatchCreateTaskRequest {
 /// slots are occupied.
 async fn enqueue_task_background(
     state: Arc<AppState>,
-    req: task_runner::CreateTaskRequest,
+    mut req: task_runner::CreateTaskRequest,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
     if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
         return Err(EnqueueTaskError::BadRequest(
@@ -181,11 +176,11 @@ async fn enqueue_task_background(
                 .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?
         };
 
-    let (reviewer, review_config) = resolve_reviewer(
-        &state.core.server.agent_registry,
-        &state.core.server.config.agents.review,
-        agent.name(),
-    );
+    let canonical_project = task_runner::resolve_canonical_project(req.project.clone())
+        .await
+        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
+    let project_id = canonical_project.to_string_lossy().into_owned();
+    req.project = Some(canonical_project);
 
     // Register the task immediately so the caller gets an ID without blocking.
     let task_id =
@@ -196,14 +191,14 @@ async fn enqueue_task_background(
     {
         let task_id2 = task_id.clone();
         tokio::spawn(async move {
-            match state.concurrency.task_queue.acquire().await {
+            match state.concurrency.task_queue.acquire(&project_id).await {
                 Ok(permit) => {
                     task_runner::spawn_preregistered_task(
                         task_id2,
                         state.core.tasks.clone(),
                         agent,
-                        reviewer,
-                        review_config,
+                        state.core.server.agent_registry.clone(),
+                        Arc::new(state.core.server.config.clone()),
                         state.engines.skills.clone(),
                         state.observability.events.clone(),
                         state.interceptors.clone(),
@@ -211,6 +206,7 @@ async fn enqueue_task_background(
                         state.concurrency.workspace_mgr.clone(),
                         permit,
                         state.completion_callback.clone(),
+                        state.concurrency.project_semaphores.clone(),
                     )
                     .await;
                 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -105,6 +105,7 @@ async fn make_test_state_with(
         concurrency: crate::http::ConcurrencyServices {
             task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             workspace_mgr: None,
+            project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
         },
         notifications: crate::http::NotificationServices {
             notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -100,9 +100,12 @@ impl QualityTrigger {
             return;
         };
         let project = Project::from_path(self.project_root.clone());
+        let max_drafts_override = harness_core::config::load_project_config(&self.project_root)
+            .gc
+            .and_then(|g| g.max_drafts_per_run);
         if let Err(e) = self
             .gc_agent
-            .run(&project, &events, &[], agent.as_ref())
+            .run(&project, &events, &[], agent.as_ref(), max_drafts_override)
             .await
         {
             tracing::warn!("quality_trigger: gc_agent.run failed: {e}");

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -249,6 +249,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx,
@@ -1485,6 +1486,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx,

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -130,6 +130,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -135,6 +135,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx: tokio::sync::broadcast::channel(32).0,

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -169,6 +169,7 @@ impl TaskRow {
             external_id,
             parent_id: parent_id.map(TaskId),
             subtask_ids: Vec::new(),
+            review_bot_command: None,
         })
     }
 }
@@ -243,6 +244,7 @@ mod tests {
             external_id: None,
             parent_id: None,
             subtask_ids: vec![],
+            review_bot_command: None,
         }
     }
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -260,11 +260,55 @@ async fn run_agent_streaming(
     }
 }
 
+/// Resolve the reviewer agent using the effective (post-project-override) review config.
+///
+/// Called after `resolve_config` so that project-level `[review] enabled = true`
+/// can activate review even when the server default is disabled.
+pub(crate) fn resolve_reviewer(
+    registry: &harness_agents::AgentRegistry,
+    config: &harness_core::AgentReviewConfig,
+    implementor_name: &str,
+) -> Option<std::sync::Arc<dyn CodeAgent>> {
+    if !config.enabled {
+        return None;
+    }
+
+    // Explicit reviewer
+    if !config.reviewer_agent.is_empty() {
+        if config.reviewer_agent == implementor_name {
+            tracing::warn!(
+                "agents.review.reviewer_agent == implementor '{}', skipping agent review",
+                implementor_name
+            );
+            return None;
+        }
+        if let Some(agent) = registry.get(&config.reviewer_agent) {
+            return Some(agent);
+        }
+        tracing::warn!(
+            "agents.review.reviewer_agent '{}' not registered, skipping agent review",
+            config.reviewer_agent
+        );
+        return None;
+    }
+
+    // Auto-select: first registered agent that isn't the implementor
+    for name in registry.list() {
+        if name != implementor_name {
+            if let Some(agent) = registry.get(name) {
+                return Some(agent);
+            }
+        }
+    }
+
+    None
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
     agent: &dyn CodeAgent,
-    reviewer: Option<&dyn CodeAgent>,
+    registry: &harness_agents::AgentRegistry,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Arc<Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
@@ -278,6 +322,18 @@ pub(crate) async fn run_task(
     let resolved = harness_core::config::resolve_config(server_config, &project_config);
     let review_config = &resolved.review;
     let git = Some(&project_config.git);
+
+    // Fix 1: resolve reviewer after project config is loaded, so project-level
+    // `[review] enabled = true` can override a globally-disabled review.
+    let reviewer_arc = resolve_reviewer(registry, review_config, agent.name());
+    let reviewer = reviewer_arc.as_deref();
+
+    // Fix 2: store the effective bot command in TaskState so the completion
+    // callback uses the project-specific command, not the global one.
+    mutate_and_persist(store, task_id, |s| {
+        s.review_bot_command = Some(review_config.review_bot_command.clone());
+    })
+    .await;
 
     let first_prompt = if let Some(issue) = req.issue {
         let base = match find_existing_pr_for_issue(&project, issue).await {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -93,6 +93,10 @@ pub struct TaskState {
     /// Populated at runtime; not persisted (use `TaskStore::list_children` after restart).
     #[serde(default)]
     pub subtask_ids: Vec<TaskId>,
+    /// Effective review-bot command for this task (resolved from project + server config).
+    /// Used by the completion callback to post the correct trigger comment per project.
+    #[serde(default)]
+    pub review_bot_command: Option<String>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -122,6 +126,7 @@ impl TaskState {
             external_id: None,
             parent_id: None,
             subtask_ids: Vec::new(),
+            review_bot_command: None,
         }
     }
 
@@ -421,10 +426,13 @@ impl TaskStore {
     }
 }
 
+/// Shared map of per-project concurrency semaphores, keyed by canonical project root.
+pub type ProjectSemaphores = Arc<DashMap<PathBuf, Arc<tokio::sync::Semaphore>>>;
+
 pub async fn spawn_task(
     store: Arc<TaskStore>,
     agent: Arc<dyn CodeAgent>,
-    reviewer: Option<Arc<dyn CodeAgent>>,
+    registry: Arc<harness_agents::AgentRegistry>,
     server_config: std::sync::Arc<harness_core::HarnessConfig>,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
@@ -433,11 +441,12 @@ pub async fn spawn_task(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    project_semaphores: ProjectSemaphores,
 ) -> TaskId {
     spawn_task_with_worktree_detector(
         store,
         agent,
-        reviewer,
+        registry,
         server_config,
         skills,
         events,
@@ -448,6 +457,7 @@ pub async fn spawn_task(
         permit,
         completion_callback,
         None,
+        project_semaphores,
     )
     .await
 }
@@ -471,8 +481,8 @@ pub async fn spawn_preregistered_task(
     task_id: TaskId,
     store: Arc<TaskStore>,
     agent: Arc<dyn CodeAgent>,
-    reviewer: Option<Arc<dyn CodeAgent>>,
-    review_config: harness_core::AgentReviewConfig,
+    registry: Arc<harness_agents::AgentRegistry>,
+    server_config: std::sync::Arc<harness_core::HarnessConfig>,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
     interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -480,12 +490,13 @@ pub async fn spawn_preregistered_task(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    project_semaphores: ProjectSemaphores,
 ) {
     spawn_task_with_worktree_detector(
         store,
         agent,
-        reviewer,
-        review_config,
+        registry,
+        server_config,
         skills,
         events,
         interceptors,
@@ -495,6 +506,7 @@ pub async fn spawn_preregistered_task(
         permit,
         completion_callback,
         Some(task_id),
+        project_semaphores,
     )
     .await;
 }
@@ -502,7 +514,7 @@ pub async fn spawn_preregistered_task(
 async fn spawn_task_with_worktree_detector<F>(
     store: Arc<TaskStore>,
     agent: Arc<dyn CodeAgent>,
-    reviewer: Option<Arc<dyn CodeAgent>>,
+    registry: Arc<harness_agents::AgentRegistry>,
     server_config: std::sync::Arc<harness_core::HarnessConfig>,
     skills: Arc<RwLock<harness_skills::SkillStore>>,
     events: Arc<harness_observe::EventStore>,
@@ -513,6 +525,7 @@ async fn spawn_task_with_worktree_detector<F>(
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
     preregistered_id: Option<TaskId>,
+    project_semaphores: ProjectSemaphores,
 ) -> TaskId
 where
     F: Fn() -> PathBuf + Send + Sync + 'static,
@@ -625,6 +638,44 @@ where
             }
         }
 
+        // Fix 3 + Fix 4: load project config once here to apply overrides before
+        // workspace creation consumes `project_root`.
+        let proj_cfg = harness_core::config::load_project_config(&project_root);
+        let resolved_early = harness_core::config::resolve_config(&server_config, &proj_cfg);
+
+        // Fix 3: apply project-level default-agent override when no explicit agent requested.
+        let agent = if req.agent.is_none()
+            && resolved_early.default_agent != server_config.agents.default_agent
+        {
+            registry.get(&resolved_early.default_agent).unwrap_or(agent)
+        } else {
+            agent
+        };
+
+        // Fix 4: enforce per-project concurrency limit when it is stricter than the global one.
+        // A per-project semaphore is created lazily on first use.
+        let _project_permit: Option<tokio::sync::OwnedSemaphorePermit> =
+            if resolved_early.concurrency.max_concurrent_tasks
+                < server_config.concurrency.max_concurrent_tasks
+            {
+                use dashmap::mapref::entry::Entry;
+                let sem = match project_semaphores.entry(project_root.clone()) {
+                    Entry::Occupied(e) => e.get().clone(),
+                    Entry::Vacant(e) => e
+                        .insert(std::sync::Arc::new(tokio::sync::Semaphore::new(
+                            resolved_early.concurrency.max_concurrent_tasks,
+                        )))
+                        .clone(),
+                };
+                Some(
+                    sem.acquire_owned()
+                        .await
+                        .map_err(|e| anyhow::anyhow!("project semaphore closed: {e}"))?,
+                )
+            } else {
+                None
+            };
+
         // If workspace isolation is configured, create a per-task git worktree.
         let run_project = if let Some(ref wmgr) = workspace_mgr {
             let project_config = harness_core::config::load_project_config(&project_root);
@@ -643,7 +694,7 @@ where
             &store,
             &id,
             agent.as_ref(),
-            reviewer.as_deref(),
+            &*registry,
             skills,
             events,
             interceptors,
@@ -948,7 +999,7 @@ mod tests {
         spawn_task(
             store,
             agent_clone,
-            None,
+            Arc::new(harness_agents::AgentRegistry::new("test")),
             Default::default(),
             skills,
             events,
@@ -957,6 +1008,7 @@ mod tests {
             None,
             permit,
             None,
+            Arc::new(DashMap::new()),
         )
         .await;
 
@@ -1021,7 +1073,7 @@ mod tests {
         let task_id = spawn_task(
             store.clone(),
             agent,
-            None,
+            Arc::new(harness_agents::AgentRegistry::new("test")),
             Default::default(),
             skills,
             events,
@@ -1030,6 +1082,7 @@ mod tests {
             None,
             permit,
             None,
+            Arc::new(DashMap::new()),
         )
         .await;
 
@@ -1144,7 +1197,7 @@ mod tests {
         let task_id = spawn_task_with_worktree_detector(
             store.clone(),
             agent,
-            None,
+            Arc::new(harness_agents::AgentRegistry::new("test")),
             Default::default(),
             skills,
             events.clone(),
@@ -1157,6 +1210,7 @@ mod tests {
             permit,
             None,
             None,
+            Arc::new(DashMap::new()),
         )
         .await;
 

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -280,6 +280,7 @@ mod tests {
             concurrency: crate::http::ConcurrencyServices {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
+                project_semaphores: std::sync::Arc::new(dashmap::DashMap::new()),
             },
             notifications: crate::http::NotificationServices {
                 notification_tx,


### PR DESCRIPTION
## Summary

Fixes four dead-knob issues found in code review of PR #309 (per-project configuration override system):

- **Fix 1 — Reviewer resolution uses resolved config**: `resolve_reviewer` moved from `http.rs` into `task_executor.rs` and called *after* `resolve_config()` inside `run_task`, so project-level `[review] enabled = true` can now activate review even when globally disabled.
- **Fix 2 — Completion callback uses per-task bot command**: Added `review_bot_command: Option<String>` to `TaskState`; `run_task` stores the effective (resolved) command on the task; the completion callback reads `task.review_bot_command` with fallback to global config, eliminating the mismatch between executor and callback.
- **Fix 3 — `[agent] default` override is actually applied**: `spawn_task_with_worktree_detector` now loads the project config and applies `default_agent` before workspace creation, so per-project agent selection takes effect.
- **Fix 4 — Per-project concurrency and GC limits are enforced**: `GcAgent` initialized with `server.config.gc` (not `GcConfig::default()`); `GcAgent::run()` accepts `max_drafts_override`; `quality_trigger` and `gc/run` handler pass per-project `max_drafts_per_run`; `ConcurrencyServices` gains a `DashMap<PathBuf, Semaphore>` for per-project task concurrency enforcement.

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes with zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all` applied