### PR TITLE
docs: document ThreadManager as in-memory-only cache (issue #77)

### DIFF
--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -14,14 +14,19 @@ use tokio::task::JoinHandle;
 /// - **Startup hydration**: performed in `http.rs` during app initialisation,
 ///   which loads persisted threads from `thread_db` into this cache via
 ///   `threads_cache()`.
-/// - **Mutation persistence**: every mutation to this cache is followed by a
-///   write-through to `thread_db`. There are two call sites responsible:
+/// - **Mutation persistence**: when `thread_db` is configured, mutations to
+///   this cache are followed by a write-through. All persistence helpers
+///   short-circuit when `thread_db` is `None`, so durability is optional.
+///   There are three call sites responsible:
 ///   1. `handlers/thread.rs` — `persist_thread` / `persist_thread_insert`
 ///      are called after each direct handler mutation: thread create/fork
 ///      (`thread_start`, `thread_fork`), turn start (`turn_start`), turn
 ///      cancel (`turn_cancel`), turn steer (`turn_steer`), thread resume
 ///      (`thread_resume`), and thread compact (`thread_compact`).
-///   2. `task_executor` — `persist_runtime_thread` is called (a) after each
+///   2. `handlers/thread.rs` — `thread_delete` removes the entry from this
+///      cache and, when `thread_db` is present, calls `db.delete(...)` to
+///      remove it from the backing store as well.
+///   3. `task_executor` — `persist_runtime_thread` is called (a) after each
 ///      stream item is applied to the cache (`task_executor/helpers.rs`
 ///      `process_stream_item`), and (b) at turn completion or failure
 ///      (`task_executor.rs` and `task_executor/helpers.rs`


### PR DESCRIPTION
## Summary

- Add struct-level doc comment to `ThreadManager` documenting it as a pure in-memory cache
- Explicitly states that thread persistence is handled exclusively by `CoreServices.thread_db`
- Makes the architectural contract from issue #77 visible in the code

Issue #77 removed the dead `db: Option<ThreadDb>` field and persist methods from `ThreadManager` (via PR #100). This PR adds documentation to make the resulting design intent permanently visible to future contributors.

## Acceptance criteria from #77

- [x] ThreadManager has no `db` field or persist methods
- [x] All thread persistence uses `state.thread_db` (`state.core.thread_db`)
- [x] No dead code warnings
- [x] `cargo check` and `cargo test` pass

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test -p harness-server` — all tests pass
- [x] `cargo fmt --all` — no formatting changes