### PR TITLE
test: add regression tests for rule_scan anchor event in handler path

### DIFF
--- a/crates/harness-server/src/handlers/health.rs
+++ b/crates/harness-server/src/handlers/health.rs
@@ -123,6 +123,48 @@ mod tests {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn health_check_emits_rule_scan_anchor_event() -> anyhow::Result<()> {
+        // Regression test for issue #82: the handler path must write a
+        // `rule_scan` anchor event so that session-scoped violation counting
+        // in metrics_query works correctly.
+        let project_root = tempdir_in_home("health-scan-anchor-root-")?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(project_root.path(), data_dir.path()).await?;
+
+        let response = health_check(
+            &state,
+            Some(serde_json::json!(1)),
+            project_root.path().to_path_buf(),
+        )
+        .await;
+
+        assert!(
+            response.error.is_none(),
+            "health_check should succeed: {:?}",
+            response.error
+        );
+
+        let events = state
+            .observability
+            .events
+            .query(&harness_core::EventFilters {
+                hook: Some("rule_scan".to_string()),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(
+            events.len(),
+            1,
+            "health_check must emit exactly one rule_scan anchor event"
+        );
+        assert_eq!(
+            events[0].hook, "rule_scan",
+            "anchor event hook must be 'rule_scan'"
+        );
+        Ok(())
+    }
 }
 
 pub async fn stats_query(

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -222,6 +222,48 @@ mod tests {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn metrics_collect_emits_rule_scan_anchor_event() -> anyhow::Result<()> {
+        // Regression test for issue #82: the handler path must write a
+        // `rule_scan` anchor event so that session-scoped violation counting
+        // in metrics_query works correctly.
+        let project_root = tempdir_in_home("metrics-scan-anchor-root-")?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(project_root.path(), data_dir.path()).await?;
+
+        let response = metrics_collect(
+            &state,
+            Some(serde_json::json!(1)),
+            project_root.path().to_path_buf(),
+        )
+        .await;
+
+        assert!(
+            response.error.is_none(),
+            "metrics_collect should succeed: {:?}",
+            response.error
+        );
+
+        let events = state
+            .observability
+            .events
+            .query(&EventFilters {
+                hook: Some("rule_scan".to_string()),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(
+            events.len(),
+            1,
+            "metrics_collect must emit exactly one rule_scan anchor event"
+        );
+        assert_eq!(
+            events[0].hook, "rule_scan",
+            "anchor event hook must be 'rule_scan'"
+        );
+        Ok(())
+    }
 }
 
 pub async fn metrics_query(


### PR DESCRIPTION
## Summary

Adds success-path regression tests for `metrics_collect` and `health_check` handlers, verifying that each emits exactly one `rule_scan` anchor event after a successful scan.

Fixes #82

## Changes
- `handlers/observe.rs`: add `metrics_collect_emits_rule_scan_anchor_event` test
- `handlers/health.rs`: add `health_check_emits_rule_scan_anchor_event` test

## Test plan
- `cargo test rule_scan_anchor_event` — both new tests pass
- `cargo test` — full suite green
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — no warnings