### PR TITLE
fix: wire SignalThresholds from config in test helpers

### DIFF
--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -123,16 +123,13 @@ mod tests {
         cooldown_secs: u64,
     ) -> QualityTrigger {
         let events = Arc::new(EventStore::new(dir).await.expect("event store"));
+        let gc_config = harness_core::GcConfig::default();
         let signal_detector = SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            gc_config.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = DraftStore::new(dir).expect("draft store");
-        let gc_agent = Arc::new(GcAgent::new(
-            harness_core::GcConfig::default(),
-            signal_detector,
-            draft_store,
-        ));
+        let gc_agent = Arc::new(GcAgent::new(gc_config, signal_detector, draft_store));
         let agent_registry = Arc::new(harness_agents::AgentRegistry::new("test"));
         QualityTrigger::new(
             events,

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -204,12 +204,12 @@ mod tests {
         let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir).await?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;
         let gc_agent = Arc::new(harness_gc::GcAgent::new(
-            harness_core::GcConfig::default(),
+            server.config.gc.clone(),
             signal_detector,
             draft_store,
         ));
@@ -1439,12 +1439,12 @@ mod tests {
         let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir).await?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;
         let gc_agent = Arc::new(harness_gc::GcAgent::new(
-            harness_core::GcConfig::default(),
+            server.config.gc.clone(),
             signal_detector,
             draft_store,
         ));

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -98,12 +98,12 @@ mod tests {
         let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir).await?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;
         let gc_agent = Arc::new(harness_gc::GcAgent::new(
-            harness_core::GcConfig::default(),
+            server.config.gc.clone(),
             signal_detector,
             draft_store,
         ));

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -102,12 +102,12 @@ mod tests {
         let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir).await?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;
         let gc_agent = Arc::new(harness_gc::GcAgent::new(
-            harness_core::GcConfig::default(),
+            server.config.gc.clone(),
             signal_detector,
             draft_store,
         ));

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -42,12 +42,12 @@ pub async fn make_test_state_with_registry(
     let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
     let events = Arc::new(harness_observe::EventStore::new(dir).await?);
     let signal_detector = harness_gc::SignalDetector::new(
-        harness_gc::signal_detector::SignalThresholds::default(),
+        server.config.gc.signal_thresholds.clone().into(),
         harness_core::ProjectId::new(),
     );
     let draft_store = harness_gc::DraftStore::new(dir)?;
     let gc_agent = Arc::new(harness_gc::GcAgent::new(
-        harness_core::GcConfig::default(),
+        server.config.gc.clone(),
         signal_detector,
         draft_store,
     ));

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -245,12 +245,12 @@ mod tests {
         let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
         let events = Arc::new(harness_observe::EventStore::new(dir).await?);
         let signal_detector = harness_gc::SignalDetector::new(
-            harness_gc::signal_detector::SignalThresholds::default(),
+            server.config.gc.signal_thresholds.clone().into(),
             harness_core::ProjectId::new(),
         );
         let draft_store = harness_gc::DraftStore::new(dir)?;
         let gc_agent = Arc::new(harness_gc::GcAgent::new(
-            harness_core::GcConfig::default(),
+            server.config.gc.clone(),
             signal_detector,
             draft_store,
         ));


### PR DESCRIPTION
## Summary

- All test helpers that constructed `SignalDetector` were ignoring `HarnessConfig` and calling `SignalThresholds::default()` directly, meaning threshold config was silently dropped
- Fixed `test_helpers.rs`, `router.rs` (two helpers), `websocket.rs`, `stdio.rs`, `scheduler.rs` to use `server.config.gc.signal_thresholds.clone().into()` and `server.config.gc.clone()`
- Fixed `quality_trigger.rs` to derive thresholds from `GcConfig` instead of defaulting separately
- The production `build_app_state()` in `http.rs` was already correct; this PR closes the gap in the test layer

Closes #84

## Test plan
- [x] `cargo check --workspace --all-targets` passes with no warnings
- [x] `cargo test --workspace` passes (all tests green)
- [x] `cargo fmt --all` applied