### PR TITLE
docs: add [agents.anthropic_api] with max_tokens to README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ default_model = "sonnet"
 [agents.codex]
 cli_path = "codex"
 
+[agents.anthropic_api]
+base_url = "https://api.anthropic.com"
+default_model = "claude-sonnet-4-20250514"
+max_tokens = 4096
+
 [agents.review]
 enabled = true
 reviewer_agent = "codex"   # independent reviewer != implementor


### PR DESCRIPTION
## Summary

- Adds the missing `[agents.anthropic_api]` section to the inline TOML configuration example in README.md
- Shows `base_url`, `default_model`, and `max_tokens = 4096` (the configurable default from `AnthropicApiConfig`)
- The implementation making `max_tokens` configurable was done in #116; this PR ensures the README documents how to use it

## Test plan

- [ ] `cargo check --workspace --all-targets` passes (no warnings, no errors)
- [ ] `cargo test --workspace` passes (all tests green)
- [ ] README config example now shows how to set `max_tokens` under `[agents.anthropic_api]`

Closes #85