### PR TITLE
fix: log mpsc send errors instead of silently ignoring them

### DIFF
--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -190,7 +190,9 @@ impl AgentAdapter for CodexAdapter {
             Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
             drop(state);
 
-            let _ = tx.send(AgentEvent::TurnStarted).await;
+            if let Err(e) = tx.send(AgentEvent::TurnStarted).await {
+                tracing::debug!("stream channel closed: {e}");
+            }
         }
 
         Ok(())

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -229,12 +229,17 @@ mod tests {
             _req: TurnRequest,
             tx: tokio::sync::mpsc::Sender<AgentEvent>,
         ) -> harness_core::Result<()> {
-            let _ = tx.send(AgentEvent::TurnStarted).await;
-            let _ = tx
+            if let Err(e) = tx.send(AgentEvent::TurnStarted).await {
+                tracing::debug!("stream channel closed: {e}");
+            }
+            if let Err(e) = tx
                 .send(AgentEvent::TurnCompleted {
                     output: "mock done".into(),
                 })
-                .await;
+                .await
+            {
+                tracing::debug!("stream channel closed: {e}");
+            }
             Ok(())
         }
 


### PR DESCRIPTION
## Summary

- Replace `let _ = tx.send(...).await` with `if let Err(e)` blocks in `codex_adapter.rs` and `registry.rs`
- Emit `tracing::debug!("stream channel closed: {e}")` when the receiver has dropped, making channel closure visible in debug logs
- Addresses the pattern described in issue #87 across all remaining `let _ = tx.send` sites in the codebase

## Test plan

- [x] `cargo check` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [x] `cargo test` passes
- [x] `cargo fmt --all` applied