### PR TITLE
fix: warn when preflight skill is absent instead of silent fallback

### DIFF
--- a/crates/harness-server/src/handlers/preflight.rs
+++ b/crates/harness-server/src/handlers/preflight.rs
@@ -51,12 +51,15 @@ pub async fn run_preflight(
 ) -> anyhow::Result<PreflightResult> {
     let skill_content = {
         let store = skills.read().await;
-        store
-            .list()
-            .iter()
-            .find(|s| s.name == "preflight")
-            .map(|s| s.content.clone())
-            .unwrap_or_default()
+        match store.list().iter().find(|s| s.name == "preflight") {
+            Some(s) => s.content.clone(),
+            None => {
+                tracing::warn!(
+                    "preflight skill not found in store; proceeding with empty skill content"
+                );
+                String::new()
+            }
+        }
     };
 
     let rules_summary = {


### PR DESCRIPTION
## Summary

Replaces the silent `.unwrap_or_default()` on the preflight skill content
lookup with an explicit `match` that emits `tracing::warn!` when no
`"preflight"` skill is registered in the store.

This is the remaining call site from issue #88 — the other three
(`observe.rs`, `gc.rs`, `health.rs`) were already addressed in PR #122.

Fixes #88

## Changes

- `crates/harness-server/src/handlers/preflight.rs`: replace
  `.find(...).map(...).unwrap_or_default()` with a `match` that logs a
  warning via `tracing::warn!` when the preflight skill is absent before
  falling back to an empty string.

## Test plan

- `cargo check --workspace --all-targets` (with `-Dwarnings`) passes
- `cargo test -p harness-server` passes; existing tests already exercise
  the absent-skill path via an empty `SkillStore`