### PR TITLE
fix: wire SignalThresholds from config in make_test_state

### DIFF
--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -42,7 +42,7 @@ pub async fn make_test_state_with_registry(
     let tasks = crate::task_runner::TaskStore::open(&dir.join("tasks.db")).await?;
     let events = Arc::new(harness_observe::EventStore::new(dir).await?);
     let signal_detector = harness_gc::SignalDetector::new(
-        harness_gc::signal_detector::SignalThresholds::default(),
+        server.config.gc.signal_thresholds.clone().into(),
         harness_core::ProjectId::new(),
     );
     let draft_store = harness_gc::DraftStore::new(dir)?;


### PR DESCRIPTION
## Summary

- Use `server.config.gc.signal_thresholds.clone().into()` instead of `harness_gc::signal_detector::SignalThresholds::default()` in `make_test_state_with_registry` so test helpers respect configured thresholds, consistent with `build_app_state`.

The `From<harness_core::config::SignalThresholdsConfig>` impl already existed in `signal_detector.rs` and `build_app_state` in `http.rs` was already wired correctly; this patch closes the remaining gap in the test helpers.

Closes #98

## Test plan
- [ ] `cargo check` passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [ ] `cargo test -p harness-server -p harness-gc` passes