### PR TITLE
fix: eliminate silent error discards across codebase

### DIFF
--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 use tokio::sync::{mpsc, Mutex};
+use tracing;
 
 /// Streaming Claude Code adapter (L1-L2).
 ///
@@ -104,7 +105,13 @@ impl AgentAdapter for ClaudeAdapter {
         let exit_status = {
             let mut guard = self.child.lock().await;
             if let Some(ref mut child) = *guard {
-                child.wait().await.ok()
+                child
+                    .wait()
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!("claude: failed to wait for child process: {e}");
+                    })
+                    .ok()
             } else {
                 None
             }
@@ -112,17 +119,23 @@ impl AgentAdapter for ClaudeAdapter {
 
         if let Some(status) = exit_status {
             if !status.success() {
-                let _ = tx
+                if let Err(e) = tx
                     .send(AgentEvent::Error {
                         message: format!("claude exited with {status}"),
                     })
-                    .await;
+                    .await
+                {
+                    tracing::debug!("claude: event channel closed before error could be sent: {e}");
+                }
             }
         }
 
-        let _ = tx
+        if let Err(e) = tx
             .send(AgentEvent::TurnCompleted { output: output_buf })
-            .await;
+            .await
+        {
+            tracing::debug!("claude: event channel closed before turn completed: {e}");
+        }
 
         // Clean up child handle
         let mut guard = self.child.lock().await;

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex};
+use tracing;
 
 /// Codex App Server adapter (L3-L4).
 ///
@@ -98,7 +99,9 @@ impl CodexAdapter {
         stdin.write_all(line.as_bytes()).await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to write to codex: {e}"))
         })?;
-        stdin.flush().await.ok();
+        stdin.flush().await.map_err(|e| {
+            harness_core::HarnessError::AgentExecution(format!("failed to flush codex stdin: {e}"))
+        })?;
         Ok(())
     }
 }
@@ -248,7 +251,9 @@ impl AgentAdapter for CodexAdapter {
         stdin.write_all(line.as_bytes()).await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to write to codex: {e}"))
         })?;
-        stdin.flush().await.ok();
+        stdin.flush().await.map_err(|e| {
+            harness_core::HarnessError::AgentExecution(format!("failed to flush codex stdin: {e}"))
+        })?;
         Ok(())
     }
 }

--- a/crates/harness-gc/src/checkpoint.rs
+++ b/crates/harness-gc/src/checkpoint.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use harness_core::Event;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use tracing;
 
 /// Persisted state for incremental GC scanning.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -17,8 +18,19 @@ impl GcCheckpoint {
 
     /// Load checkpoint from `path`. Returns `None` if the file is missing or corrupt.
     pub fn load(path: &Path) -> Option<Self> {
-        let data = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&data).ok()
+        let data = match std::fs::read_to_string(path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                tracing::warn!("gc: failed to read checkpoint at {}: {e}", path.display());
+                return None;
+            }
+        };
+        serde_json::from_str(&data)
+            .map_err(|e| {
+                tracing::warn!("gc: corrupt checkpoint at {}: {e}", path.display());
+            })
+            .ok()
     }
 
     /// Save checkpoint to `path`, creating parent directories as needed.

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -131,8 +131,11 @@ impl EventStore {
                 continue;
             }
             if let Ok(event) = serde_json::from_str::<Event>(line) {
-                let _ = self.insert_event(&event).await;
-                imported += 1;
+                if let Err(e) = self.insert_event(&event).await {
+                    tracing::warn!("event store: failed to insert migrated event: {e}");
+                } else {
+                    imported += 1;
+                }
             }
         }
         if imported > 0 {

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -8,6 +8,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+use tracing;
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterProjectRequest {
@@ -77,7 +78,13 @@ pub async fn list_projects(
             let with_counts: Vec<serde_json::Value> = projects
                 .into_iter()
                 .map(|p| {
-                    let mut v = serde_json::to_value(&p).unwrap_or_default();
+                    let mut v = match serde_json::to_value(&p) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::warn!("projects: failed to serialize project: {e}");
+                            serde_json::Value::default()
+                        }
+                    };
                     // task_count is best-effort; tasks do not store project_id
                     v["task_count"] = json!(0);
                     v

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -988,7 +988,13 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
     let stream = futures::stream::unfold(rx, |mut rx| async move {
         match rx.recv().await {
             Ok(item) => {
-                let data = serde_json::to_string(&item).unwrap_or_default();
+                let data = match serde_json::to_string(&item) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!("sse: failed to serialize event: {e}");
+                        String::new()
+                    }
+                };
                 Some((
                     Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
                     rx,

--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -3,6 +3,7 @@ use harness_core::{
     AgentId, Item, Thread, ThreadId, ThreadStatus, TokenUsage, Turn, TurnId, TurnStatus,
 };
 use tokio::task::JoinHandle;
+use tracing;
 
 pub struct ThreadManager {
     threads: DashMap<String, Thread>,
@@ -211,7 +212,9 @@ impl ThreadManager {
         turn_id: &TurnId,
         message: String,
     ) -> harness_core::Result<Option<TokenUsage>> {
-        let _ = self.add_item(thread_id, turn_id, Item::Error { code: -1, message });
+        if let Err(e) = self.add_item(thread_id, turn_id, Item::Error { code: -1, message }) {
+            tracing::warn!("thread manager: failed to add error item for turn {turn_id}: {e}");
+        }
         self.fail_turn(thread_id, turn_id)
     }
 


### PR DESCRIPTION
## Summary

Fixes #331

Replace `let _ =`, `.ok()`, and `.unwrap_or_default()` patterns that silently discard meaningful errors with explicit `tracing::warn!`/`debug!` logging or proper error propagation.

### P1 — data integrity
- **event_store.rs**: log failed DB writes during JSONL migration (previously `imported` counter was also wrong — incremented even on failure)
- **thread_manager.rs**: log failed `add_item` call when recording error items
- **claude_adapter.rs**: log `child.wait()` failure; log when event channel is closed before error/completion events can be sent
- **codex_adapter.rs**: propagate `stdin.flush()` failures via `?` in `send_notification` and `respond_approval`

### P2 — debuggability
- **http.rs**: log SSE serialization failures instead of silently sending empty string
- **projects.rs**: log project serialization failures instead of returning `{}`
- **checkpoint.rs**: distinguish "file not found" (silent `None`) from "file unreadable/corrupt" (warn + `None`)

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — all 343 tests pass
- [x] `cargo fmt --all` applied