### PR TITLE
fix: eliminate silent error discards across codebase

### DIFF
--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -104,7 +104,13 @@ impl AgentAdapter for ClaudeAdapter {
         let exit_status = {
             let mut guard = self.child.lock().await;
             if let Some(ref mut child) = *guard {
-                child.wait().await.ok()
+                match child.wait().await {
+                    Ok(status) => Some(status),
+                    Err(e) => {
+                        tracing::warn!("claude_adapter: failed to wait for child process: {e}");
+                        None
+                    }
+                }
             } else {
                 None
             }
@@ -112,17 +118,23 @@ impl AgentAdapter for ClaudeAdapter {
 
         if let Some(status) = exit_status {
             if !status.success() {
-                let _ = tx
+                if let Err(e) = tx
                     .send(AgentEvent::Error {
                         message: format!("claude exited with {status}"),
                     })
-                    .await;
+                    .await
+                {
+                    tracing::warn!("claude_adapter: failed to send Error event: {e}");
+                }
             }
         }
 
-        let _ = tx
+        if let Err(e) = tx
             .send(AgentEvent::TurnCompleted { output: output_buf })
-            .await;
+            .await
+        {
+            tracing::warn!("claude_adapter: failed to send TurnCompleted event: {e}");
+        }
 
         // Clean up child handle
         let mut guard = self.child.lock().await;

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -98,7 +98,9 @@ impl CodexAdapter {
         stdin.write_all(line.as_bytes()).await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to write to codex: {e}"))
         })?;
-        stdin.flush().await.ok();
+        if let Err(e) = stdin.flush().await {
+            tracing::warn!("codex_adapter: failed to flush stdin after notification: {e}");
+        }
         Ok(())
     }
 }
@@ -248,7 +250,9 @@ impl AgentAdapter for CodexAdapter {
         stdin.write_all(line.as_bytes()).await.map_err(|e| {
             harness_core::HarnessError::AgentExecution(format!("failed to write to codex: {e}"))
         })?;
-        stdin.flush().await.ok();
+        if let Err(e) = stdin.flush().await {
+            tracing::warn!("codex_adapter: failed to flush stdin after approval response: {e}");
+        }
         Ok(())
     }
 }

--- a/crates/harness-gc/src/checkpoint.rs
+++ b/crates/harness-gc/src/checkpoint.rs
@@ -17,8 +17,24 @@ impl GcCheckpoint {
 
     /// Load checkpoint from `path`. Returns `None` if the file is missing or corrupt.
     pub fn load(path: &Path) -> Option<Self> {
-        let data = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&data).ok()
+        let data = match std::fs::read_to_string(path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                tracing::warn!("gc: failed to read checkpoint at {}: {e}", path.display());
+                return None;
+            }
+        };
+        match serde_json::from_str(&data) {
+            Ok(cp) => Some(cp),
+            Err(e) => {
+                tracing::warn!(
+                    "gc: checkpoint at {} is corrupt, starting full scan: {e}",
+                    path.display()
+                );
+                None
+            }
+        }
     }
 
     /// Save checkpoint to `path`, creating parent directories as needed.

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -131,8 +131,11 @@ impl EventStore {
                 continue;
             }
             if let Ok(event) = serde_json::from_str::<Event>(line) {
-                let _ = self.insert_event(&event).await;
-                imported += 1;
+                if let Err(e) = self.insert_event(&event).await {
+                    tracing::warn!("event store: failed to migrate event to SQLite: {e}");
+                } else {
+                    imported += 1;
+                }
             }
         }
         if imported > 0 {

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -76,11 +76,18 @@ pub async fn list_projects(
         Ok(projects) => {
             let with_counts: Vec<serde_json::Value> = projects
                 .into_iter()
-                .map(|p| {
-                    let mut v = serde_json::to_value(&p).unwrap_or_default();
-                    // task_count is best-effort; tasks do not store project_id
-                    v["task_count"] = json!(0);
-                    v
+                .filter_map(|p| {
+                    match serde_json::to_value(&p) {
+                        Ok(mut v) => {
+                            // task_count is best-effort; tasks do not store project_id
+                            v["task_count"] = json!(0);
+                            Some(v)
+                        }
+                        Err(e) => {
+                            tracing::warn!("projects: failed to serialize project entry: {e}");
+                            None
+                        }
+                    }
                 })
                 .collect();
             (StatusCode::OK, Json(json!(with_counts)))

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -988,7 +988,18 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
     let stream = futures::stream::unfold(rx, |mut rx| async move {
         match rx.recv().await {
             Ok(item) => {
-                let data = serde_json::to_string(&item).unwrap_or_default();
+                let data = match serde_json::to_string(&item) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!("sse: failed to serialize event: {e}");
+                        return Some((
+                            Ok::<Event, std::convert::Infallible>(
+                                Event::default().event("error").data("serialize_error"),
+                            ),
+                            rx,
+                        ));
+                    }
+                };
                 Some((
                     Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
                     rx,

--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -211,7 +211,9 @@ impl ThreadManager {
         turn_id: &TurnId,
         message: String,
     ) -> harness_core::Result<Option<TokenUsage>> {
-        let _ = self.add_item(thread_id, turn_id, Item::Error { code: -1, message });
+        if let Err(e) = self.add_item(thread_id, turn_id, Item::Error { code: -1, message }) {
+            tracing::warn!("thread_manager: failed to record error item for turn {turn_id}: {e}");
+        }
         self.fail_turn(thread_id, turn_id)
     }
 


### PR DESCRIPTION
## Summary

Fixes #331 — replace `let _ =`, `.ok()`, and `.unwrap_or_default()` on meaningful `Result` values with explicit `if let Err(e)` blocks that emit `tracing::warn!`.

**P1 — data integrity:**
- `event_store`: log failed DB writes during JSONL migration; exclude failed rows from the imported count
- `thread_manager`: log when `add_item` fails in `mark_turn_failed_with_error`
- `claude_adapter`: log `child.wait()` failure; log dropped `Error`/`TurnCompleted` channel sends
- `codex_adapter`: log stdin flush failures after notification and after approval response

**P2 — degraded behavior:**
- `http.rs` SSE stream: emit a named `"error"` SSE event instead of sending an empty string on serialize failure
- `projects.rs`: `filter_map` to skip and log project entries that fail `to_value()` instead of returning `{}` placeholders
- `checkpoint.rs`: distinguish `NotFound` (silent `None`) from other I/O errors (`warn` + `None`); also `warn` on corrupt JSON

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — all 343 tests pass
- [x] No new `unwrap()`/`.ok()` patterns introduced in production code paths