### PR TITLE
test: add persisted_skills_survive_restart test for SkillStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -887,4 +887,34 @@ mod tests {
         assert_eq!(loaded.usage_count, 42);
         assert!(loaded.last_used.is_some());
     }
+
+    #[test]
+    fn persisted_skills_survive_restart() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let persist_path = dir.path().to_path_buf();
+
+        // Session 1: create a skill (writes to disk via persist_dir).
+        {
+            let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+            store.create(
+                "my-skill".to_string(),
+                "# My Skill\nDoes stuff.".to_string(),
+            );
+            assert_eq!(store.list().len(), 1);
+        }
+
+        // Session 2: simulate restart — new SkillStore with same persist_dir.
+        // discover() must reload the skill written in session 1.
+        {
+            let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+            store.load_builtin();
+            store.discover().expect("discover should succeed");
+            let skill = store.get_by_name("my-skill");
+            assert!(
+                skill.is_some(),
+                "persisted skill should survive server restart"
+            );
+            assert_eq!(skill.unwrap().name, "my-skill");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `persisted_skills_survive_restart` unit test to `harness-skills/src/store.rs`
- Test creates a `SkillStore` with `with_persist_dir()`, writes a skill to disk, then instantiates a fresh `SkillStore` with the same persist dir and calls `discover()` — asserting the skill is reloaded
- Completes the unchecked test-plan item from issue #76 / PR #79: "Skills persisted to disk survive server restart"
- Bumps version to 0.6.4

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (all tests green)
- [x] `persisted_skills_survive_restart` test directly verifies the fix from #76