### PR TITLE
fix: resolve test isolation failures in rule_check and skill restart tests

### DIFF
--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -164,6 +164,8 @@ mod tests {
 
     #[tokio::test]
     async fn rule_check_returns_warning_when_no_guards_registered() -> anyhow::Result<()> {
+        // Hold HOME_LOCK so a concurrent persisted_skills_survive_restart cannot
+        // change HOME between tempdir_in_home() and validate_project_root().
         let _lock = HOME_LOCK.lock().await;
         let dir = tempdir_in_home("rule-check-no-guard-")?;
         let state = make_test_state(dir.path()).await?;
@@ -203,6 +205,7 @@ mod tests {
 
     #[tokio::test]
     async fn rule_check_with_guard_returns_violations() -> anyhow::Result<()> {
+        // Hold HOME_LOCK for the same reason as rule_check_returns_warning_when_no_guards_registered.
         let _lock = HOME_LOCK.lock().await;
         let dir = tempdir_in_home("rule-check-violations-")?;
         let state = make_test_state(dir.path()).await?;


### PR DESCRIPTION
## Summary

Fixes three intermittently failing tests that were rooted in two defects:

- **HOME env race condition**: `persisted_skills_survive_restart` temporarily redirects the process-global `HOME` env var but had no synchronisation with `rule_check_returns_warning_when_no_guards_registered`, `rule_check_with_guard_returns_violations`, and `rule_check_returns_warning_for_empty_scan_input`. A concurrent mutation of `HOME` between `tempdir_in_home()` and `validate_project_root()` caused the HOME-prefix check to reject a legitimately created temp directory.

- **Wrong assertion**: `persisted_skills_survive_restart` asserted `SkillLocation::System` for skills reloaded from `persist_dir`, but `load_from_dir()` intentionally assigns `SkillLocation::User` so user-created skills can override same-named builtins at higher priority.

## Changes

- `test_helpers.rs`: expose `pub static HOME_LOCK` so all tests can synchronise on the same mutex
- `http.rs`: drop the local `HOME_LOCK` and import the shared one; fix the `SkillLocation::System` → `SkillLocation::User` assertion
- `handlers/rules.rs`: have all three `rule_check_*` tests acquire `HOME_LOCK` for their duration

## Test plan

- [x] `cargo check --workspace --all-targets` (RUSTFLAGS="-Dwarnings") passes
- [x] `cargo test --workspace` — 376 tests pass, 0 failed
- [x] `cargo fmt --all` — no changes

Relates to issue #77 (thread persistence design).