### PR TITLE
test: verify startup grade uses session-scoped violation count (#82)

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1293,7 +1293,7 @@ mod startup_tests {
             message: "critical issue".to_string(),
             severity: Severity::Critical,
         };
-        state
+        let old_session_id = state
             .observability
             .events
             .persist_rule_scan(&project_root, &[old_violation])
@@ -1312,7 +1312,30 @@ mod startup_tests {
             .events
             .query(&EventFilters::default())
             .await
-            .unwrap_or_default();
+            .expect("event store query must succeed");
+
+        // Guard: verify both scan sessions were actually persisted before
+        // testing the counting logic.  Without this, a silent write failure
+        // would leave `events` empty and the final assert_eq!(…, 0) would pass
+        // vacuously, giving a false green.
+        //
+        // Expected layout:
+        //   - 2 × rule_scan  (one per persist_rule_scan call)
+        //   - 1 × rule_check (the single violation in the first scan)
+        assert_eq!(
+            events.len(),
+            3,
+            "expected 2 rule_scan anchor events and 1 rule_check violation event, got {}",
+            events.len()
+        );
+        let old_check_count = events
+            .iter()
+            .filter(|e| e.hook == "rule_check" && e.session_id == old_session_id)
+            .count();
+        assert_eq!(
+            old_check_count, 1,
+            "first scan must have persisted exactly 1 violation event"
+        );
 
         let violation_count = events
             .iter()


### PR DESCRIPTION
## Summary

Adds a regression test to `startup_tests` in `http.rs` that verifies the session-scoped violation counting logic used in `serve()` during server startup.

Fixes #82

## Problem

Issue #82 identified that the old `persist_violations` path never wrote a `rule_scan` anchor event, which meant `serve()`'s startup grade calculation would silently fall back to 0 violations regardless of actual state. That core fix was landed in PR #99.

PR #346 added a regression test for `metrics_query` (`metrics_query_sees_violations_written_via_handler_entry`), but the identical session-scoped counting invariant used at startup in `serve()` had no corresponding test.

## Changes

- Add `startup_grade_uses_latest_rule_scan_session_for_violation_count` to `startup_tests` in `crates/harness-server/src/http.rs`
- Update imports in `startup_tests` to include `EventFilters`, `RuleId`, `Severity`, `Violation`

## Test plan

- [x] New test passes: `cargo test -p harness-server startup_grade_uses_latest_rule_scan_session`
- [x] Full suite passes: `cargo test --workspace`
- [x] CI-equivalent check passes: `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- [x] `cargo fmt --all` applied