### PR TITLE
fix(gc): validate artifact target_path within project root before writing

### DIFF
--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -30,7 +30,12 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
             let signal_detector = SignalDetector::new(thresholds, project.id.clone());
             let gc_config = map_gc_config(&config.gc);
             let draft_store = DraftStore::new(data_dir)?;
-            let gc_agent = GcAgent::new(gc_config, signal_detector, draft_store);
+            let gc_agent = GcAgent::new(
+                gc_config,
+                signal_detector,
+                draft_store,
+                project.root.clone(),
+            );
 
             let claude = harness_agents::claude::ClaudeCodeAgent::new(
                 config.agents.claude.cli_path.clone(),
@@ -79,14 +84,16 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
 
         GcCommand::Adopt { draft_id } => {
             let id = DraftId::from_str(&draft_id);
-            let gc_agent = make_agent_for_draft_ops(data_dir)?;
+            let project_root = config.server.project_root.clone();
+            let gc_agent = make_agent_for_draft_ops(data_dir, &project_root)?;
             gc_agent.adopt(&id)?;
             println!("Adopted draft: {draft_id}");
         }
 
         GcCommand::Reject { draft_id, reason } => {
             let id = DraftId::from_str(&draft_id);
-            let gc_agent = make_agent_for_draft_ops(data_dir)?;
+            let project_root = config.server.project_root.clone();
+            let gc_agent = make_agent_for_draft_ops(data_dir, &project_root)?;
             gc_agent.reject(&id, reason.as_deref())?;
             println!("Rejected draft: {draft_id}");
         }
@@ -95,12 +102,16 @@ pub async fn run_gc(cmd: GcCommand, config: &harness_core::HarnessConfig) -> any
     Ok(())
 }
 
-fn make_agent_for_draft_ops(data_dir: &std::path::Path) -> anyhow::Result<GcAgent> {
+fn make_agent_for_draft_ops(
+    data_dir: &std::path::Path,
+    project_root: &std::path::Path,
+) -> anyhow::Result<GcAgent> {
     let draft_store = DraftStore::new(data_dir)?;
     Ok(GcAgent::new(
         GcConfig::default(),
         SignalDetector::new(GcThresholds::default(), ProjectId::new()),
         draft_store,
+        project_root.to_path_buf(),
     ))
 }
 

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -2,13 +2,14 @@ use crate::checkpoint::{filter_events_since, GcCheckpoint};
 use crate::draft_store::DraftStore;
 use crate::remediation::signal_priority;
 use crate::signal_detector::SignalDetector;
+use anyhow::Context;
 use chrono::Utc;
 use harness_core::{
     AgentRequest, Artifact, ArtifactType, CodeAgent, Draft, DraftId, DraftStatus, GcConfig,
     Project, RemediationType, Signal, SignalType,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GcReport {
@@ -21,16 +22,24 @@ pub struct GcAgent {
     config: GcConfig,
     signal_detector: SignalDetector,
     draft_store: DraftStore,
+    /// Canonical project root used to validate artifact target paths in `adopt`.
+    project_root: PathBuf,
     /// Path to the checkpoint file; `None` disables checkpoint-based scanning.
     checkpoint_path: Option<PathBuf>,
 }
 
 impl GcAgent {
-    pub fn new(config: GcConfig, signal_detector: SignalDetector, draft_store: DraftStore) -> Self {
+    pub fn new(
+        config: GcConfig,
+        signal_detector: SignalDetector,
+        draft_store: DraftStore,
+        project_root: PathBuf,
+    ) -> Self {
         Self {
             config,
             signal_detector,
             draft_store,
+            project_root,
             checkpoint_path: None,
         }
     }
@@ -143,38 +152,33 @@ impl GcAgent {
 
     /// Adopt a draft: write artifacts to disk.
     ///
-    /// All artifact target_paths are validated to be relative (no absolute
-    /// paths or `..` traversal) before any writes occur.
+    /// All artifact target_paths are canonicalized and validated to reside
+    /// within the project root before any writes occur.
     pub fn adopt(&self, draft_id: &DraftId) -> anyhow::Result<()> {
         let mut draft = self
             .draft_store
             .get(draft_id)?
             .ok_or_else(|| anyhow::anyhow!("draft not found"))?;
 
-        // Validate all paths before writing any files
-        for artifact in &draft.artifacts {
-            let path = &artifact.target_path;
-            if path.is_absolute() {
-                anyhow::bail!(
-                    "artifact target_path must be relative, got: {}",
-                    path.display()
-                );
-            }
-            for component in path.components() {
-                if matches!(component, std::path::Component::ParentDir) {
-                    anyhow::bail!(
-                        "artifact target_path must not contain '..': {}",
-                        path.display()
-                    );
-                }
-            }
-        }
+        let canonical_root = self.project_root.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize project root '{}'",
+                self.project_root.display()
+            )
+        })?;
 
-        for artifact in &draft.artifacts {
-            if let Some(parent) = artifact.target_path.parent() {
+        // Validate and resolve all paths before writing any files
+        let resolved: Vec<PathBuf> = draft
+            .artifacts
+            .iter()
+            .map(|a| validate_target_path(&canonical_root, &a.target_path))
+            .collect::<anyhow::Result<_>>()?;
+
+        for (artifact, target) in draft.artifacts.iter().zip(resolved.iter()) {
+            if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(&artifact.target_path, &artifact.content)?;
+            std::fs::write(target, &artifact.content)?;
         }
 
         draft.status = DraftStatus::Adopted;
@@ -200,6 +204,69 @@ impl GcAgent {
     pub fn draft_store(&self) -> &DraftStore {
         &self.draft_store
     }
+}
+
+/// Validate and resolve an artifact target path to an absolute path within `project_root`.
+///
+/// Steps:
+/// 1. Make the path absolute by joining it with `project_root` (if relative).
+/// 2. Lexically normalize `.` and `..` components.
+/// 3. Resolve the nearest existing ancestor via `canonicalize` to detect symlink escapes.
+/// 4. Verify the resolved path starts with `project_root`.
+fn validate_target_path(project_root: &Path, target_path: &Path) -> anyhow::Result<PathBuf> {
+    let absolute = if target_path.is_absolute() {
+        target_path.to_path_buf()
+    } else {
+        project_root.join(target_path)
+    };
+    let normalized = normalize_path(&absolute);
+    let resolved = resolve_for_boundary_check(&normalized)?;
+
+    if resolved == project_root || resolved.starts_with(project_root) {
+        return Ok(normalized);
+    }
+
+    anyhow::bail!(
+        "resolved path '{}' is outside project root '{}'",
+        resolved.display(),
+        project_root.display()
+    );
+}
+
+/// Lexically normalize a path: collapse `.` and `..` without hitting the filesystem.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(p) => out.push(p.as_os_str()),
+            Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if out.file_name().is_some() {
+                    out.pop();
+                }
+            }
+            Component::Normal(seg) => out.push(seg),
+        }
+    }
+    out
+}
+
+/// Walk up from `path` to find the nearest existing ancestor, canonicalize it,
+/// then re-attach the remaining suffix. This allows boundary checks on paths
+/// that do not yet exist on disk.
+fn resolve_for_boundary_check(path: &Path) -> anyhow::Result<PathBuf> {
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        ancestor = ancestor.parent().ok_or_else(|| {
+            anyhow::anyhow!("no existing ancestor found for '{}'", path.display())
+        })?;
+    }
+    let canonical = ancestor.canonicalize()?;
+    let suffix = path
+        .strip_prefix(ancestor)
+        .map_err(|_| anyhow::anyhow!("failed to compute suffix for '{}'", path.display()))?;
+    Ok(canonical.join(suffix))
 }
 
 fn build_prompt(signal: &Signal, project: &Project) -> String {
@@ -375,7 +442,12 @@ mod tests {
             ProjectId::new(),
         );
         let draft_store = DraftStore::new(dir).unwrap();
-        GcAgent::new(GcConfig::default(), signal_detector, draft_store)
+        GcAgent::new(
+            GcConfig::default(),
+            signal_detector,
+            draft_store,
+            dir.to_path_buf(),
+        )
     }
 
     fn test_signal() -> Signal {
@@ -401,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn adopt_rejects_absolute_target_path() {
+    fn adopt_rejects_absolute_path_outside_project_root() {
         let dir = tempfile::tempdir().unwrap();
         let gc = make_test_gc_agent(dir.path());
 
@@ -414,15 +486,27 @@ mod tests {
 
         let err = gc.adopt(&draft.id).unwrap_err();
         assert!(
-            err.to_string().contains("must be relative"),
+            err.to_string().contains("outside project root"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
     fn adopt_rejects_parent_dir_traversal() {
-        let dir = tempfile::tempdir().unwrap();
-        let gc = make_test_gc_agent(dir.path());
+        let sandbox = tempfile::tempdir().unwrap();
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let signal_detector = SignalDetector::new(
+            crate::signal_detector::SignalThresholds::default(),
+            ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(&project_root).unwrap();
+        let gc = GcAgent::new(
+            GcConfig::default(),
+            signal_detector,
+            draft_store,
+            project_root.clone(),
+        );
 
         let draft = test_draft(vec![Artifact {
             artifact_type: ArtifactType::Skill,
@@ -433,9 +517,12 @@ mod tests {
 
         let err = gc.adopt(&draft.id).unwrap_err();
         assert!(
-            err.to_string().contains("must not contain '..'"),
+            err.to_string().contains("outside project root"),
             "unexpected error: {err}"
         );
+        // Verify no file was written outside the project root
+        let escaped = sandbox.path().join("etc/shadow");
+        assert!(!escaped.exists());
     }
 
     #[test]
@@ -445,12 +532,13 @@ mod tests {
 
         let draft = test_draft(vec![Artifact {
             artifact_type: ArtifactType::Guard,
-            target_path: std::path::PathBuf::from(".harness/drafts/test.md"),
+            target_path: std::path::PathBuf::from("subdir/test.md"),
             content: "valid content".into(),
         }]);
         gc.draft_store.save(&draft).unwrap();
 
         gc.adopt(&draft.id).unwrap();
+        assert!(dir.path().join("subdir/test.md").exists());
     }
 
     // --- parse_artifacts tests ---

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -120,6 +120,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let (notification_tx, _) = broadcast::channel(64);

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -265,6 +265,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         server.config.gc.clone(),
         signal_detector,
         draft_store,
+        project_root.clone(),
     ));
 
     let thread_db_path = dir.join("threads.db");

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -79,6 +79,7 @@ async fn make_test_state_with(
         server.config.gc.clone(),
         signal_detector,
         draft_store,
+        dir.to_path_buf(),
     ));
     let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
     Ok(Arc::new(AppState {

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -129,7 +129,12 @@ mod tests {
             harness_core::ProjectId::new(),
         );
         let draft_store = DraftStore::new(dir).expect("draft store");
-        let gc_agent = Arc::new(GcAgent::new(gc_config, signal_detector, draft_store));
+        let gc_agent = Arc::new(GcAgent::new(
+            gc_config,
+            signal_detector,
+            draft_store,
+            dir.to_path_buf(),
+        ));
         let agent_registry = Arc::new(harness_agents::AgentRegistry::new("test"));
         QualityTrigger::new(
             events,

--- a/crates/harness-server/src/router.rs
+++ b/crates/harness-server/src/router.rs
@@ -212,6 +212,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let (notification_tx, _) = tokio::sync::broadcast::channel(64);
@@ -1451,6 +1452,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let plan_db = crate::plan_db::PlanDb::open(&dir.join("exec_plans.db")).await?;

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -106,6 +106,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            project_root.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         Ok(Arc::new(AppState {

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -110,6 +110,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
 

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -85,6 +85,7 @@ pub async fn make_test_state_with_registry(
         server.config.gc.clone(),
         signal_detector,
         draft_store,
+        dir.to_path_buf(),
     ));
     let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
     let (notification_tx, _) = tokio::sync::broadcast::channel(64);

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -253,6 +253,7 @@ mod tests {
             server.config.gc.clone(),
             signal_detector,
             draft_store,
+            dir.to_path_buf(),
         ));
         let thread_db = crate::thread_db::ThreadDb::open(&dir.join("threads.db")).await?;
         let (notification_tx, _) = broadcast::channel(notification_broadcast_capacity);


### PR DESCRIPTION
## Summary

Closes #92.

`GcAgent` lacked boundary validation on artifact target paths in `adopt`. A malicious or corrupted draft could write files anywhere on the filesystem. This PR adds full canonicalize + project-root boundary enforcement.

## Changes

- Add `project_root: PathBuf` field to `GcAgent`; update `new()` signature (4th arg)
- Replace naive relative/`..` checks in `adopt` with `validate_target_path`:
  1. Relative paths are joined to `project_root`
  2. Lexical normalization resolves `.` / `..` without hitting the filesystem
  3. Nearest existing ancestor is `canonicalize`d to detect symlink escapes
  4. Resolved path must `start_with` the canonical project root
- Add three helpers: `validate_target_path`, `normalize_path`, `resolve_for_boundary_check`
- Update all `GcAgent::new` call-sites (11 files) to pass `project_root`
- Update tests: `adopt_rejects_absolute_path_outside_project_root`, `adopt_rejects_parent_dir_traversal`, `adopt_accepts_valid_relative_path`

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` — all tests pass