### PR TITLE
fix: remove mutate_and_persist_with, inline into mutate_and_persist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -725,27 +725,10 @@ pub(crate) async fn mutate_and_persist(
     id: &TaskId,
     f: impl FnOnce(&mut TaskState),
 ) {
-    let _ = mutate_and_persist_with(store, id, |state| {
-        f(state);
-    })
-    .await;
-}
-
-/// Mutate a task, compute a return value from the same in-lock snapshot, then persist.
-pub(crate) async fn mutate_and_persist_with<R>(
-    store: &TaskStore,
-    id: &TaskId,
-    f: impl FnOnce(&mut TaskState) -> R,
-) -> Option<R> {
-    let result = if let Some(mut entry) = store.cache.get_mut(id) {
-        let result = f(entry.value_mut());
-        Some(result)
-    } else {
-        None
-    };
-
+    if let Some(mut entry) = store.cache.get_mut(id) {
+        f(entry.value_mut());
+    }
     store.persist(id).await;
-    result
 }
 
 #[cfg(test)]
@@ -1068,8 +1051,7 @@ mod tests {
     }
 
     /// Verify that a local u32 counter correctly tracks waiting rounds without any store query.
-    /// This replaces the old mutate_and_persist_with counting pattern: task execution is
-    /// sequential within a single tokio task, so a plain local counter suffices.
+    /// Task execution is sequential within a single tokio task, so a plain local counter suffices.
     #[test]
     fn local_waiting_counter_increments_on_each_waiting_response() {
         let max_rounds = 5u32;


### PR DESCRIPTION
## Summary

`task_runner.rs` had a generic `mutate_and_persist_with` helper introduced in #67 to atomically snapshot `waiting_count`. Since `task_executor.rs` now uses a plain local `u32` counter (task execution is sequential within a single tokio task), the generic return-value variant is no longer needed.

- Remove `mutate_and_persist_with` function
- Inline its logic directly into `mutate_and_persist`
- Update test doc comment to drop stale reference to the old pattern
- Bump version to 0.6.5

Fixes #94

## Test plan

- `cargo check` passes (no warnings)
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- `cargo test -p harness-server` passes (383 tests)
- `local_waiting_counter_increments_on_each_waiting_response` test continues to verify the local counter logic