### PR TITLE
test(plan_db): add update_in_txn test coverage for issue #95

### DIFF
--- a/crates/harness-server/src/plan_db.rs
+++ b/crates/harness-server/src/plan_db.rs
@@ -252,4 +252,38 @@ mod tests {
         assert_eq!(count, 0);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn update_in_txn_persists_mutation() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = PlanDb::open(&dir.path().join("plans.db")).await?;
+
+        let plan = ExecPlan::from_spec("# Update test", &dir.path().to_path_buf())?;
+        db.upsert(&plan).await?;
+
+        let updated = db
+            .update_in_txn(&plan.id, |p| p.activate())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("plan should exist after upsert"))?;
+        assert_eq!(updated.status, ExecPlanStatus::Active);
+
+        // Reload from DB to confirm the change was persisted, not just returned in-memory.
+        let reloaded = db
+            .get(&plan.id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("plan should still exist after update"))?;
+        assert_eq!(reloaded.status, ExecPlanStatus::Active);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_in_txn_returns_none_for_missing_plan() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = PlanDb::open(&dir.path().join("plans.db")).await?;
+        let result = db
+            .update_in_txn(&ExecPlanId::new(), |p| p.activate())
+            .await?;
+        assert!(result.is_none());
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `update_in_txn_persists_mutation`: verifies that read-modify-write mutations via `update_in_txn` are durable — reloads the plan from SQLite after the call to confirm the change survived a round-trip
- Adds `update_in_txn_returns_none_for_missing_plan`: verifies the method returns `None` rather than an error when the plan ID does not exist

The `update_in_txn` method (which holds an exclusive mutex to prevent lost-update races) was the only public method on `PlanDb` without test coverage following the implementation in #95.

## Test plan

- [x] `cargo check --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — clean
- [x] `cargo test --lib -p harness-server -- plan_db` — 10/10 pass (8 pre-existing + 2 new)