### PR TITLE
fix: document ThreadManager no-db design and bump version (closes #97)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -7,7 +7,13 @@ use tracing;
 
 /// In-memory thread registry and turn lifecycle manager.
 ///
-/// `ThreadManager` is a pure in-memory cache. It owns no persistence layer.
+/// `ThreadManager` is a pure in-memory cache with no persistence layer.
+/// It owns only two DashMaps: one for thread state and one for running-turn
+/// task handles.  It intentionally has no `db` field and no async persistence
+/// methods (`open`, `persist`, `persist_insert`, `persist_delete`); those were
+/// removed in issue #97 because they duplicated the write-through logic that
+/// handlers and the task executor perform via `AppState.core.thread_db`.
+///
 /// Thread persistence is handled exclusively by `CoreServices.thread_db`
 /// (`AppState.core.thread_db`).
 ///


### PR DESCRIPTION
## Summary

- The `db: Option<ThreadDb>` field and dead persistence methods (`open`, `persist`, `persist_insert`, `persist_delete`) were already removed from `ThreadManager` per issue #97.
- This PR adds an explicit tombstone doc comment to `ThreadManager` naming those removed items and the rationale (issue #97), making the no-persistence design intent clear and reducing the chance of regression.
- Bumps workspace version 0.6.4 → 0.6.5 (patch).

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check -p harness-server` — clean
- [x] `cargo test -p harness-server --lib -- thread_manager` — 24/24 pass
- [x] `cargo fmt --all` — no changes

Closes #97