### PR TITLE
fix: scope rule enforcement to projects with .harness/guards directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/rule_enforcer.rs
+++ b/crates/harness-server/src/rule_enforcer.rs
@@ -37,6 +37,18 @@ impl TurnInterceptor for RuleEnforcer {
             return InterceptResult::pass();
         }
 
+        // Only enforce rules on projects that have opted in by providing their
+        // own `.harness/guards` directory.  Guards loaded at startup are scoped
+        // to the projects they belong to; scanning unrelated projects produces
+        // false positives (e.g. SEC-02 on test constants in external repos).
+        if !req.project_root.join(".harness").join("guards").is_dir() {
+            tracing::debug!(
+                project_root = %req.project_root.display(),
+                "rule_enforcer: project has no .harness/guards, skipping enforcement"
+            );
+            return InterceptResult::pass();
+        }
+
         let violations = match engine.scan(&req.project_root).await {
             Ok(v) => v,
             Err(e) => {
@@ -154,7 +166,7 @@ mod tests {
     async fn blocks_on_critical_violation() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let project = dir.path().join("project");
-        std::fs::create_dir_all(&project)?;
+        std::fs::create_dir_all(project.join(".harness").join("guards"))?;
 
         let rules = engine_with_guard(dir.path(), "SEC-01", "critical")?;
         {
@@ -191,7 +203,7 @@ mod tests {
     async fn warns_on_high_violation() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let project = dir.path().join("project");
-        std::fs::create_dir_all(&project)?;
+        std::fs::create_dir_all(project.join(".harness").join("guards"))?;
 
         let rules = engine_with_guard(dir.path(), "SEC-04", "high")?;
         {


### PR DESCRIPTION
## Summary
- Rule enforcer now only scans projects that have opted in via `.harness/guards` directory
- Prevents false positives (e.g. SEC-02 on test constants) when scanning external repos like litellm-rs
- Test fixtures updated to create `.harness/guards` in temp project directories
- Version bump to 0.6.6

## Test plan
- [x] `cargo check --workspace --all-targets` with `-Dwarnings` passes
- [x] All 6 rule_enforcer unit tests pass
- [x] Projects without `.harness/guards` skip enforcement silently