### PR TITLE
test: add prompt-forwarding coverage for gc_adopt_task_request (closes #78)

### DIFF
--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -249,6 +249,20 @@ mod tests {
 
         assert_eq!(req.project, Some(project_root));
     }
+
+    #[test]
+    fn gc_adopt_task_request_forwards_prompt() {
+        let gc_config = harness_core::GcConfig::default();
+        let prompt = "adopt draft abc123".to_string();
+
+        let req = gc_adopt_task_request(
+            prompt.clone(),
+            &gc_config,
+            std::path::PathBuf::from("/tmp/project"),
+        );
+
+        assert_eq!(req.prompt, Some(prompt));
+    }
 }
 
 pub async fn gc_reject(


### PR DESCRIPTION
## Summary

- Issue #78 required `gc_adopt_task_request` to accept and pass `project_root` as `Some(...)` instead of `None`
- The runtime fix was already merged in PR #80; integration tests were added in PR #343
- This PR fills the remaining unit-test gap: verifies the `prompt` argument is correctly forwarded into `CreateTaskRequest.prompt`

## Changes

- `crates/harness-server/src/handlers/gc.rs`: adds `gc_adopt_task_request_forwards_prompt` unit test

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p harness-server gc_adopt_task_request` — 5/5 pass