### PR TITLE
docs: document startup sequence for SkillStore.with_persist_dir (issue #79)

### DIFF
--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -77,6 +77,13 @@ impl SkillStore {
     /// Enable disk persistence: created skills are written to `{dir}/{name}.md`,
     /// deleted skills are removed, and the dir is added to discovery_paths so
     /// skills survive restarts.
+    ///
+    /// # Startup sequence
+    ///
+    /// After calling `with_persist_dir`, call `load_builtin()` then `discover()`
+    /// so previously persisted skills are reloaded from disk.  User-tier skills
+    /// loaded from `persist_dir` take priority over same-named builtin (System)
+    /// skills during the `deduplicate()` step inside `discover()`.
     pub fn with_persist_dir(mut self, dir: PathBuf) -> Self {
         self.discovery_paths.push(dir.clone());
         self.persist_dir = Some(dir);


### PR DESCRIPTION
## Summary

- Documents the required startup sequence for `SkillStore::with_persist_dir` in an inline doc comment
- Clarifies that `discover()` must be called after `with_persist_dir()` and `load_builtin()` so previously persisted (User-tier) skills are reloaded on restart and shadow same-named builtins

The runtime fix (`discover()` call in `build_app_state`) was merged in an earlier PR. This PR adds the API-level doc comment so future maintainers understand the contract without needing to trace the call sites.

Closes #79

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo check --workspace --all-targets` passes (no warnings)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p harness-skills` passes (38/38 tests)
- [x] Skills persisted to disk survive server restart (tested in `startup_tests::persisted_skills_survive_restart`)