### PR TITLE
fix: write canonical project back to req in batch path (closes #364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -240,8 +240,14 @@ async fn enqueue_task_background(
     }
 
     let project_id = canonical_project.to_string_lossy().into_owned();
+    req.project = Some(canonical_project);
 
     let server_config = std::sync::Arc::new(state.core.server.config.clone());
+
+    tracing::info!(
+        project = %req.project.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "None".to_string()),
+        "enqueue_task_background: resolved project for batch task"
+    );
 
     // Register the task immediately so the caller gets an ID without blocking.
     let task_id =


### PR DESCRIPTION
## Summary
- `enqueue_task_background()` was missing `req.project = Some(canonical_project)` after resolving the canonical project path
- In `enqueue_task()` (single task path), this line exists at line 92 — but the batch path omitted it
- When `project` is `None` or a registry ID, `req.project` stayed unresolved, causing `spawn_task_with_worktree_detector` to fall back to `detect_main_worktree()` → CWD → harness repo
- Result: all litellm-rs batch tasks silently executed in the harness repo
- Added tracing to log resolved project for each batch task

## Root cause
```
// enqueue_task (single) — line 92:
req.project = Some(canonical_project);  // ✅ present

// enqueue_task_background (batch) — was missing:
// req.project = Some(canonical_project);  // ❌ missing → now fixed
```

## Test plan
- [x] `cargo check --workspace --all-targets` with `-Dwarnings`
- [x] All 12 task_routes unit tests pass
- [ ] Submit batch task with `project: "litellm-rs"` and verify workspace is created from litellm-rs repo