### PR TITLE
test(gc): add unit tests for SignalThresholds From<SignalThresholdsConfig> conversion

### DIFF
--- a/crates/harness-gc/src/signal_detector.rs
+++ b/crates/harness-gc/src/signal_detector.rs
@@ -543,4 +543,61 @@ mod tests {
             .iter()
             .any(|s| s.signal_type == SignalType::LinterViolations));
     }
+
+    #[test]
+    fn signal_thresholds_from_config_maps_all_fields() {
+        let config = harness_core::config::SignalThresholdsConfig {
+            repeated_warn_min: 3,
+            chronic_block_min: 2,
+            hot_file_edits_min: 7,
+            slow_op_threshold_ms: 1000,
+            slow_op_count_min: 4,
+            escalation_ratio: 2.5,
+            violation_min: 6,
+        };
+        let thresholds = SignalThresholds::from(config);
+        assert_eq!(thresholds.repeated_warn_min, 3);
+        assert_eq!(thresholds.chronic_block_min, 2);
+        assert_eq!(thresholds.hot_file_edits_min, 7);
+        assert_eq!(thresholds.slow_op_threshold_ms, 1000);
+        assert_eq!(thresholds.slow_op_count_min, 4);
+        assert_eq!(thresholds.escalation_ratio, 2.5);
+        assert_eq!(thresholds.violation_min, 6);
+    }
+
+    #[test]
+    fn detector_uses_custom_thresholds_from_config() {
+        // Build detector from a config with lower thresholds than default
+        let config = harness_core::config::SignalThresholdsConfig {
+            repeated_warn_min: 2,
+            chronic_block_min: 2,
+            hot_file_edits_min: 2,
+            slow_op_threshold_ms: 100,
+            slow_op_count_min: 2,
+            escalation_ratio: 1.5,
+            violation_min: 2,
+        };
+        let det = SignalDetector::new(config.into(), ProjectId::new());
+
+        // 2 warns should exceed the custom threshold of 2
+        let events: Vec<Event> = (0..2).map(|_| warn_event("test")).collect();
+        let signals = det.detect(&events);
+        assert!(
+            signals
+                .iter()
+                .any(|s| s.signal_type == SignalType::RepeatedWarn),
+            "expected RepeatedWarn signal with custom threshold of 2"
+        );
+
+        // With default thresholds (10), 2 warns would not trigger — confirming
+        // custom config is wired through, not the default.
+        let default_det = detector();
+        let signals_default = default_det.detect(&events);
+        assert!(
+            !signals_default
+                .iter()
+                .any(|s| s.signal_type == SignalType::RepeatedWarn),
+            "default detector should not fire RepeatedWarn for only 2 warns"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `signal_thresholds_from_config_maps_all_fields`: verifies that every field in `SignalThresholdsConfig` is faithfully copied by the `From` impl
- Adds `detector_uses_custom_thresholds_from_config`: proves that a `SignalDetector` built from a non-default config actually applies those custom thresholds, and that the same events do *not* trigger the default detector

The wiring itself (issue #84 / #98) was already merged. These tests provide explicit regression coverage for the `From` conversion and confirm that custom config values flow end-to-end into detection behavior.

## Test plan

- [x] `cargo test -p harness-gc` — all 35 tests pass including the 2 new ones
- [x] `cargo fmt --all` — no formatting changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #98