### PR TITLE
test: cover review_bot_command and review_bot_auto_trigger in AgentReviewConfig

### DIFF
--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -76,6 +76,8 @@ mod tests {
         assert!(!config.enabled);
         assert!(config.reviewer_agent.is_empty());
         assert_eq!(config.max_rounds, 3);
+        assert_eq!(config.review_bot_command, "/gemini review");
+        assert!(config.review_bot_auto_trigger);
     }
 
     #[test]
@@ -89,6 +91,8 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.reviewer_agent, "codex");
         assert_eq!(config.max_rounds, 5);
+        assert_eq!(config.review_bot_command, "/gemini review");
+        assert!(config.review_bot_auto_trigger);
     }
 
     #[test]
@@ -100,6 +104,21 @@ mod tests {
         assert!(config.enabled);
         assert!(config.reviewer_agent.is_empty());
         assert_eq!(config.max_rounds, 3);
+        assert_eq!(config.review_bot_command, "/gemini review");
+        assert!(config.review_bot_auto_trigger);
+    }
+
+    #[test]
+    fn agent_review_config_deserializes_bot_settings() {
+        let toml_str = r#"
+            enabled = true
+            review_bot_command = "/reviewbot run"
+            review_bot_auto_trigger = false
+        "#;
+        let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.review_bot_command, "/reviewbot run");
+        assert!(!config.review_bot_auto_trigger);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `AgentReviewConfig` struct introduced in issue #97 has two fields —
`review_bot_command` and `review_bot_auto_trigger` — whose default values
and TOML deserialization paths had no test coverage.

This PR closes that gap:
- Adds `review_bot_command` / `review_bot_auto_trigger` assertions to the
  three existing `agent_review_config_*` tests.
- Adds `agent_review_config_deserializes_bot_settings` to verify non-default
  values deserialize correctly from TOML.

Closes #97

## Changes
- `crates/harness-core/src/config.rs`: 4 test additions/updates

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p harness-core --lib` — 182 passed, 0 failed