### PR TITLE
feat: expose --agent input in harness composite action (closes #135)

### DIFF
--- a/.github/actions/harness-action/action.yml
+++ b/.github/actions/harness-action/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Comma-separated allow list for bot GitHub actors
     required: false
     default: ""
+  agent:
+    description: Agent backend to use (claude, codex, anthropic-api)
+    required: false
+    default: claude
 
 outputs:
   final-message:
@@ -104,6 +108,7 @@ runs:
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_SANDBOX_MODE: ${{ inputs.sandbox-mode }}
         INPUT_MODEL: ${{ inputs.model }}
+        INPUT_AGENT: ${{ inputs.agent }}
         INPUT_DROP_SUDO: ${{ inputs.drop-sudo }}
         INPUT_UNPRIVILEGED_USER: ${{ inputs.unprivileged-user }}
         INPUT_ALLOW_USERS: ${{ inputs.allow-users }}
@@ -121,6 +126,7 @@ runs:
           exec
           "${INPUT_PROMPT}"
           --project "${GITHUB_WORKSPACE}"
+          --agent "${INPUT_AGENT}"
           --sandbox-mode "${INPUT_SANDBOX_MODE}"
           --output-file "${RELATIVE_OUTPUT_FILE}"
           --actor "${GITHUB_ACTOR}"


### PR DESCRIPTION
## Summary

- Adds `agent` input to `.github/actions/harness-action/action.yml` so callers can select `claude`, `codex`, or `anthropic-api` without forking the action
- Wires `INPUT_AGENT` through to `harness exec --agent` in the composite action run step
- Default remains `claude` for full backward compatibility

## Context

Issue #135 (FUT-81) required the CI/CD harness GitHub Action to support all `harness exec` security/CI flags. The `--agent` flag was missing from the composite action inputs, leaving agent selection hardcoded to the default. This PR closes the gap.

## Validation

```
cargo check
cargo test -p harness-cli commands::tests
cargo run -p harness-cli -- exec --help | grep -E "sandbox-mode|output-file|drop-sudo|unprivileged-user|allow-users|allow-bots|--model|--actor|--agent"
```

All checks pass.

## Test plan

- [x] `cargo fmt --all` — no formatting changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p harness-cli commands::tests` — 29 tests pass
- [x] `harness exec --help` shows all required flags including `--agent`