### PR TITLE
test(webhook): add missing coverage for issues event and HTTP integration

### DIFF
--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -823,6 +823,111 @@ async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let secret = "secret";
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let before_count = state.core.tasks.count();
+    let app = webhook_app(state.clone());
+
+    let payload = serde_json::json!({
+        "action": "opened",
+        "issue": {
+            "number": 77,
+            "body": "@harness please implement this feature"
+        }
+    });
+    let payload_body = payload.to_string();
+    let signature = webhook_signature(secret, payload_body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", signature)
+                .header("content-type", "application/json")
+                .body(Body::from(payload_body))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(state.core.tasks.count(), before_count + 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn webhook_pull_request_review_changes_requested_creates_task() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let secret = "secret";
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let before_count = state.core.tasks.count();
+    let app = webhook_app(state.clone());
+
+    let payload = serde_json::json!({
+        "action": "submitted",
+        "review": {
+            "state": "changes_requested",
+            "body": "Please fix the error handling.",
+            "html_url": "https://github.com/org/repo/pull/10#pullrequestreview-1"
+        },
+        "pull_request": {
+            "number": 10,
+            "html_url": "https://github.com/org/repo/pull/10"
+        },
+        "repository": { "full_name": "org/repo" }
+    });
+    let payload_body = payload.to_string();
+    let signature = webhook_signature(secret, payload_body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("x-github-event", "pull_request_review")
+                .header("x-hub-signature-256", signature)
+                .header("content-type", "application/json")
+                .body(Body::from(payload_body))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(state.core.tasks.count(), before_count + 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn webhook_ping_event_returns_accepted_without_creating_task() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let secret = "secret";
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let before_count = state.core.tasks.count();
+    let app = webhook_app(state.clone());
+
+    let payload = serde_json::json!({ "zen": "Design for failure." });
+    let payload_body = payload.to_string();
+    let signature = webhook_signature(secret, payload_body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("x-github-event", "ping")
+                .header("x-hub-signature-256", signature)
+                .header("content-type", "application/json")
+                .body(Body::from(payload_body))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(state.core.tasks.count(), before_count);
+    Ok(())
+}
+
 /// Agent stub that records invocations via an atomic flag.
 /// Records in both `execute` and `execute_stream` since the task executor
 /// calls `execute_stream` (via `run_agent_streaming`).

--- a/crates/harness-server/src/webhook.rs
+++ b/crates/harness-server/src/webhook.rs
@@ -364,6 +364,71 @@ mod tests {
     }
 
     #[test]
+    fn parse_issues_opened_with_harness_mention_creates_issue_task() {
+        let payload = serde_json::json!({
+            "action": "opened",
+            "issue": {
+                "number": 77,
+                "body": "@harness please implement this feature"
+            }
+        });
+
+        let (request, reason) =
+            parse_github_webhook_task_request("issues", payload.to_string().as_bytes()).unwrap();
+        let request = request.expect("request should exist");
+        assert_eq!(reason, "issue mention");
+        assert_eq!(request.issue, Some(77));
+        assert_eq!(request.pr, None);
+        assert_eq!(request.prompt, None);
+    }
+
+    #[test]
+    fn parse_issues_reopened_with_harness_mention_creates_issue_task() {
+        let payload = serde_json::json!({
+            "action": "reopened",
+            "issue": {
+                "number": 88,
+                "body": "This is still broken, @harness fix it"
+            }
+        });
+
+        let (request, reason) =
+            parse_github_webhook_task_request("issues", payload.to_string().as_bytes()).unwrap();
+        let request = request.expect("request should exist");
+        assert_eq!(reason, "issue mention");
+        assert_eq!(request.issue, Some(88));
+    }
+
+    #[test]
+    fn parse_issues_opened_without_harness_mention_is_ignored() {
+        let payload = serde_json::json!({
+            "action": "opened",
+            "issue": {
+                "number": 99,
+                "body": "This issue has no harness mention"
+            }
+        });
+
+        let (request, reason) =
+            parse_github_webhook_task_request("issues", payload.to_string().as_bytes()).unwrap();
+        assert!(request.is_none());
+        assert_eq!(reason, "no @harness command in issue body");
+    }
+
+    #[test]
+    fn parse_issues_opened_with_no_body_is_ignored() {
+        let payload = serde_json::json!({
+            "action": "opened",
+            "issue": { "number": 100 }
+        });
+
+        let (request, reason) =
+            parse_github_webhook_task_request("issues", payload.to_string().as_bytes()).unwrap();
+        assert!(request.is_none());
+        assert_eq!(reason, "no @harness command in issue body");
+    }
+
+    #[test]
     fn parse_issues_edited_action_is_ignored() {
         let payload = serde_json::json!({
             "action": "edited",


### PR DESCRIPTION
## Summary

Closes #134 (test coverage gap follow-up)

- Add 4 unit tests in `webhook.rs` for the `issues` event happy/sad paths:
  - `parse_issues_opened_with_harness_mention_creates_issue_task`
  - `parse_issues_reopened_with_harness_mention_creates_issue_task`
  - `parse_issues_opened_without_harness_mention_is_ignored`
  - `parse_issues_opened_with_no_body_is_ignored`
- Add 3 HTTP-level integration tests in `http/tests.rs`:
  - `webhook_issues_opened_with_mention_creates_issue_task`
  - `webhook_pull_request_review_changes_requested_creates_task`
  - `webhook_ping_event_returns_accepted_without_creating_task`
- Total webhook test count: 35 → 42 (+7)

## Test plan

- [x] `cargo test -p harness-server webhook -- --nocapture` → 42 passed
- [x] `cargo test -p harness-server parse_issue_comment -- --nocapture` → 3 passed
- [x] `cargo test -p harness-server parse_harness -- --nocapture` → 5 passed
- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`