### PR TITLE
feat: inject sibling task awareness into parallel agent prompts (closes #388)

### DIFF
--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -38,6 +38,39 @@ pub fn implement_from_issue(issue: u64, git: Option<&GitConfig>) -> String {
     )
 }
 
+/// Lightweight snapshot of a concurrently-running task used to build sibling-awareness
+/// context in agent prompts.
+pub struct SiblingTask {
+    /// GitHub issue number, if this task was created from an issue.
+    pub issue: Option<u64>,
+    /// Short description derived from the task prompt or issue number.
+    pub description: String,
+}
+
+/// Build a constraint block that tells an agent which issues are being handled
+/// concurrently by other agents on the same project.
+///
+/// Returns an empty string when `siblings` is empty so callers can append
+/// unconditionally without injecting noise into single-task prompts.
+pub fn sibling_task_context(siblings: &[SiblingTask]) -> String {
+    if siblings.is_empty() {
+        return String::new();
+    }
+    let mut block = String::from(
+        "\n\n\
+         ⚠️  The following issues are being handled by OTHER agents in parallel on this project.\n\
+         Do NOT modify files related to these issues — another agent is responsible:\n",
+    );
+    for sibling in siblings {
+        match sibling.issue {
+            Some(n) => block.push_str(&format!("- #{n}: {}\n", sibling.description)),
+            None => block.push_str(&format!("- {}\n", sibling.description)),
+        }
+    }
+    block.push_str("\nOnly modify files directly needed for YOUR assigned task.");
+    block
+}
+
 /// Build prompt: check an existing PR's CI and review status.
 pub fn check_existing_pr(pr: u64, review_bot_command: &str) -> String {
     let body = shell_single_quote(review_bot_command);
@@ -729,6 +762,41 @@ PR_URL=https://github.com/owner/repo/pull/269";
         ));
         assert!(!is_lgtm("somethingLGTM"));
         assert!(!is_lgtm("notLGTM\n"));
+    }
+
+    #[test]
+    fn sibling_task_context_empty_returns_empty_string() {
+        assert_eq!(sibling_task_context(&[]), "");
+    }
+
+    #[test]
+    fn sibling_task_context_with_issue_numbers() {
+        let siblings = vec![
+            SiblingTask {
+                issue: Some(77),
+                description: "fix Mistral unwrap".to_string(),
+            },
+            SiblingTask {
+                issue: Some(78),
+                description: "fix Vertex AI unwrap".to_string(),
+            },
+        ];
+        let ctx = sibling_task_context(&siblings);
+        assert!(ctx.contains("#77: fix Mistral unwrap"));
+        assert!(ctx.contains("#78: fix Vertex AI unwrap"));
+        assert!(ctx.contains("OTHER agents"));
+        assert!(ctx.contains("Only modify files directly needed for YOUR assigned task."));
+    }
+
+    #[test]
+    fn sibling_task_context_without_issue_number_omits_hash() {
+        let siblings = vec![SiblingTask {
+            issue: None,
+            description: "refactor auth module".to_string(),
+        }];
+        let ctx = sibling_task_context(&siblings);
+        assert!(ctx.contains("- refactor auth module"));
+        assert!(!ctx.contains('#'));
     }
 
     #[test]

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -183,6 +183,9 @@ impl TaskRow {
             external_id,
             parent_id: parent_id.map(TaskId),
             subtask_ids: Vec::new(),
+            project_root: None,
+            issue_number: None,
+            brief_description: None,
         })
     }
 }
@@ -257,6 +260,9 @@ mod tests {
             external_id: None,
             parent_id: None,
             subtask_ids: vec![],
+            project_root: None,
+            issue_number: None,
+            brief_description: None,
         }
     }
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -310,6 +310,15 @@ pub(crate) async fn run_task(
         prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default(), git)
     };
 
+    // Inject sibling-task awareness so the agent does not over-scope its changes
+    // when other agents are working on the same project concurrently.
+    let siblings = store.list_active_in_project(&project, task_id);
+    let first_prompt = if siblings.is_empty() {
+        first_prompt
+    } else {
+        format!("{first_prompt}{}", prompts::sibling_task_context(&siblings))
+    };
+
     // Inject language-detected validation instructions into the prompt when no
     // explicit validation config is set. This delegates validation to the agent
     // instead of running external commands that may not be installed.

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -93,6 +93,15 @@ pub struct TaskState {
     /// Populated at runtime; not persisted (use `TaskStore::list_children` after restart).
     #[serde(default)]
     pub subtask_ids: Vec<TaskId>,
+    /// Canonical project root for sibling-task awareness; runtime-only, not persisted.
+    #[serde(skip)]
+    pub project_root: Option<PathBuf>,
+    /// GitHub issue number for sibling-task context; runtime-only, not persisted.
+    #[serde(skip)]
+    pub issue_number: Option<u64>,
+    /// Brief description (first 80 chars of prompt) for sibling-task context; runtime-only.
+    #[serde(skip)]
+    pub brief_description: Option<String>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -122,6 +131,9 @@ impl TaskState {
             external_id: None,
             parent_id: None,
             subtask_ids: Vec::new(),
+            project_root: None,
+            issue_number: None,
+            brief_description: None,
         }
     }
 
@@ -365,6 +377,53 @@ impl TaskStore {
                 None
             }
         }
+    }
+
+    /// Wire runtime-only metadata for sibling-task awareness into the in-memory cache.
+    /// No-op when the task ID is not found (e.g. task was already removed).
+    pub(crate) fn set_runtime_metadata(
+        &self,
+        id: &TaskId,
+        project_root: PathBuf,
+        issue_number: Option<u64>,
+        brief_description: Option<String>,
+    ) {
+        if let Some(mut entry) = self.cache.get_mut(id) {
+            entry.project_root = Some(project_root);
+            entry.issue_number = issue_number;
+            entry.brief_description = brief_description;
+        }
+    }
+
+    /// Return sibling tasks that are actively running on the same project root,
+    /// excluding `exclude_id`. Active means `Pending` or `Implementing` status.
+    /// Used to inject sibling-task context into agent prompts so parallel agents
+    /// do not over-scope their changes.
+    pub fn list_active_in_project(
+        &self,
+        project: &std::path::Path,
+        exclude_id: &TaskId,
+    ) -> Vec<harness_core::prompts::SiblingTask> {
+        self.cache
+            .iter()
+            .filter(|e| {
+                let task = e.value();
+                &task.id != exclude_id
+                    && task.project_root.as_deref() == Some(project)
+                    && matches!(task.status, TaskStatus::Pending | TaskStatus::Implementing)
+            })
+            .map(|e| {
+                let task = e.value();
+                let description = task.brief_description.clone().unwrap_or_else(|| {
+                    task.issue_number
+                        .map_or_else(String::new, |n| format!("issue #{n}"))
+                });
+                harness_core::prompts::SiblingTask {
+                    issue: task.issue_number,
+                    description,
+                }
+            })
+            .collect()
     }
 
     /// Return all cached tasks whose `parent_id` matches the given ID.
@@ -636,6 +695,13 @@ where
                 }
             }
         }
+
+        // Wire runtime-only metadata before project_root is potentially moved.
+        let brief_description = req
+            .prompt
+            .as_deref()
+            .map(|p| p.chars().take(80).collect::<String>());
+        store.set_runtime_metadata(&id, project_root.clone(), req.issue, brief_description);
 
         // If workspace isolation is configured, create a per-task git worktree.
         let run_project = if let Some(ref wmgr) = workspace_mgr {
@@ -1363,6 +1429,84 @@ mod tests {
             phases[1],
             Some(ExecutionPhase::Validation),
             "review check turn must use Validation phase"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_active_in_project_excludes_self_and_terminal_tasks() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project = std::path::PathBuf::from("/projects/myrepo");
+
+        let self_id = TaskId("self".to_string());
+        let sibling_id = TaskId("sibling".to_string());
+        let done_id = TaskId("done".to_string());
+        let other_project_id = TaskId("other-project".to_string());
+
+        // Insert all tasks as Pending first.
+        for id in [&self_id, &sibling_id, &done_id, &other_project_id] {
+            let mut state = TaskState::new(id.clone());
+            state.status = TaskStatus::Pending;
+            store.cache.insert(id.clone(), state);
+        }
+
+        // Wire metadata: self and sibling share the same project, done and other do not.
+        store.set_runtime_metadata(
+            &self_id,
+            project.clone(),
+            Some(10),
+            Some("self task".into()),
+        );
+        store.set_runtime_metadata(
+            &sibling_id,
+            project.clone(),
+            Some(11),
+            Some("sibling task".into()),
+        );
+        store.set_runtime_metadata(
+            &done_id,
+            project.clone(),
+            Some(12),
+            Some("done task".into()),
+        );
+        store.set_runtime_metadata(
+            &other_project_id,
+            std::path::PathBuf::from("/projects/other"),
+            Some(13),
+            Some("other project task".into()),
+        );
+
+        // Mark done task as Done.
+        if let Some(mut e) = store.cache.get_mut(&done_id) {
+            e.status = TaskStatus::Done;
+        }
+
+        let siblings = store.list_active_in_project(&project, &self_id);
+
+        // Only the sibling (Pending, same project, not self) should appear.
+        assert_eq!(siblings.len(), 1, "expected exactly one sibling");
+        assert_eq!(siblings[0].issue, Some(11));
+        assert_eq!(siblings[0].description, "sibling task");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_active_in_project_empty_when_no_siblings() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project = std::path::PathBuf::from("/projects/solo");
+
+        let id = TaskId("solo".to_string());
+        let mut state = TaskState::new(id.clone());
+        state.status = TaskStatus::Implementing;
+        store.cache.insert(id.clone(), state);
+        store.set_runtime_metadata(&id, project.clone(), Some(99), Some("solo".into()));
+
+        let siblings = store.list_active_in_project(&project, &id);
+        assert!(
+            siblings.is_empty(),
+            "task with no siblings should return empty vec"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes the parallel agent over-scoping problem described in #388: when multiple agents work on the same project concurrently, each agent now receives a constraint block listing sibling tasks so it stays within its own scope.

- **`prompts.rs`**: Add `SiblingTask` struct and `sibling_task_context()` builder that produces a `⚠️ OTHER agents` constraint block
- **`task_runner.rs`**: Add three runtime-only fields to `TaskState` (`project_root`, `issue_number`, `brief_description`); add `set_runtime_metadata()` and `list_active_in_project()` to `TaskStore`
- **`task_executor.rs`**: Query active siblings before constructing the first prompt; append the constraint block when siblings exist
- **`task_db.rs`**: Initialize the new `#[serde(skip)]` fields in `TaskRow::try_into_task_state` — no schema migration required

## Test plan

- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] 3 new unit tests for `sibling_task_context` (empty, with issues, without issue number)
- [x] 2 new integration tests for `list_active_in_project` (excludes self/terminal tasks, empty when no siblings)
- [x] Full workspace test suite: 184 passed in harness-core, all crates green