### PR TITLE
refactor(agents): extend ScopedEnvVar to multi-key, remove bare unsafe set_var in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -199,20 +199,31 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    /// RAII guard that sets one or more env vars under the shared env lock and
+    /// restores them on drop (including on panic).  All keys are set atomically
+    /// while holding the lock, eliminating re-entrant lock attempts.
     struct ScopedEnvVar {
-        key: String,
-        original: Option<String>,
+        entries: Vec<(String, Option<String>)>,
         _guard: MutexGuard<'static, ()>,
     }
 
     impl ScopedEnvVar {
         fn set(key: &str, value: &str) -> Self {
+            Self::set_pairs(&[(key, value)])
+        }
+
+        fn set_pairs(pairs: &[(&str, &str)]) -> Self {
             let guard = env_lock().lock().expect("env lock should not be poisoned");
-            let original = std::env::var(key).ok();
-            unsafe { std::env::set_var(key, value) };
+            let entries = pairs
+                .iter()
+                .map(|(key, value)| {
+                    let original = std::env::var(key).ok();
+                    unsafe { std::env::set_var(key, value) };
+                    (key.to_string(), original)
+                })
+                .collect();
             Self {
-                key: key.to_string(),
-                original,
+                entries,
                 _guard: guard,
             }
         }
@@ -220,10 +231,12 @@ mod tests {
 
     impl Drop for ScopedEnvVar {
         fn drop(&mut self) {
-            if let Some(value) = &self.original {
-                unsafe { std::env::set_var(&self.key, value) };
-            } else {
-                unsafe { std::env::remove_var(&self.key) };
+            for (key, original) in &self.entries {
+                if let Some(value) = original {
+                    unsafe { std::env::set_var(key, value) };
+                } else {
+                    unsafe { std::env::remove_var(key) };
+                }
             }
         }
     }
@@ -565,10 +578,10 @@ printf 'third\n'
 
     #[tokio::test]
     async fn execute_removes_claude_code_env_vars() -> anyhow::Result<()> {
-        // Use a single ScopedEnvVar to hold the env lock; set both vars while
-        // the lock is already held to avoid a re-entrant deadlock.
-        let _guard = ScopedEnvVar::set("CLAUDECODE", "1");
-        unsafe { std::env::set_var("CLAUDE_CODE_ENTRYPOINT", "claude-code") };
+        let _guard = ScopedEnvVar::set_pairs(&[
+            ("CLAUDECODE", "1"),
+            ("CLAUDE_CODE_ENTRYPOINT", "claude-code"),
+        ]);
 
         let dir = tempdir()?;
         let agent_capture = dir.path().join("agent-env.txt");
@@ -594,8 +607,6 @@ printf 'third\n'
         };
 
         agent.execute(request).await?;
-
-        unsafe { std::env::remove_var("CLAUDE_CODE_ENTRYPOINT") };
 
         let agent_env = fs::read_to_string(agent_capture)?;
         assert!(


### PR DESCRIPTION
## Summary

Follow-up to #166 (consolidate test home helpers, remove unsafe set_var).

The `codex` test module had a bare `unsafe { std::env::set_var("CLAUDE_CODE_ENTRYPOINT", ...) }` / `unsafe { std::env::remove_var(...) }` pair that bypassed RAII cleanup. If `agent.execute()` returned early via `?`, `CLAUDE_CODE_ENTRYPOINT` would leak into subsequent tests.

**Root cause**: `ScopedEnvVar::set()` acquires the env lock internally, so calling it a second time within the same test would cause a re-entrant deadlock. The workaround was to use bare `unsafe set_var` while the first guard held the lock — but without a Drop impl to restore `CLAUDE_CODE_ENTRYPOINT`.

**Fix**: Extend `ScopedEnvVar` with a `set_pairs()` constructor that sets multiple key-value pairs atomically under a single lock acquisition. The `Drop` impl now restores all entries, eliminating both the bare unsafe calls and the env-var leak on test failure.

Changes:
- `ScopedEnvVar` now holds `Vec<(String, Option<String>)>` instead of a single key
- Add `set_pairs(&[(&str, &str)])` constructor
- `set(key, value)` delegates to `set_pairs` (no API break for existing callers)
- `execute_removes_claude_code_env_vars` test: replace bare `unsafe set_var` + manual `remove_var` with a single `set_pairs` call

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 70 harness-agents tests pass