### PR TITLE
test: extend notification delivery tests to cover turn lifecycle

### DIFF
--- a/crates/harness-server/tests/notification_delivery.rs
+++ b/crates/harness-server/tests/notification_delivery.rs
@@ -1,7 +1,11 @@
 mod common;
 
+use async_trait::async_trait;
 use harness_agents::AgentRegistry;
-use harness_core::{HarnessConfig, ThreadId, ThreadStatus};
+use harness_core::{
+    AgentRequest, AgentResponse, Capability, CodeAgent, HarnessConfig, HarnessError, Item,
+    StreamItem, ThreadId, ThreadStatus, TokenUsage, TurnStatus,
+};
 use harness_protocol::Notification;
 use harness_server::{
     handlers::thread::{thread_start, turn_start},
@@ -11,6 +15,96 @@ use harness_server::{
     thread_manager::ThreadManager,
 };
 use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tokio::time::{timeout, Duration};
+
+// ---------------------------------------------------------------------------
+// MockAgent — minimal in-process agent used by turn lifecycle tests
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+enum MockMode {
+    Complete,
+    Fail,
+}
+
+#[derive(Clone)]
+struct MockAgent {
+    mode: MockMode,
+}
+
+impl MockAgent {
+    fn complete() -> Arc<Self> {
+        Arc::new(Self {
+            mode: MockMode::Complete,
+        })
+    }
+
+    fn fail() -> Arc<Self> {
+        Arc::new(Self {
+            mode: MockMode::Fail,
+        })
+    }
+}
+
+#[async_trait]
+impl CodeAgent for MockAgent {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::Read]
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::Result<AgentResponse> {
+        Ok(AgentResponse {
+            output: "ok".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: Sender<StreamItem>,
+    ) -> harness_core::Result<()> {
+        match self.mode {
+            MockMode::Complete => {
+                tx.send(StreamItem::ItemCompleted {
+                    item: Item::AgentReasoning {
+                        content: "done".to_string(),
+                    },
+                })
+                .await
+                .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+                tx.send(StreamItem::TokenUsage {
+                    usage: TokenUsage {
+                        input_tokens: 5,
+                        output_tokens: 5,
+                        total_tokens: 10,
+                        cost_usd: 0.0,
+                    },
+                })
+                .await
+                .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+                tx.send(StreamItem::Done)
+                    .await
+                    .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+                Ok(())
+            }
+            MockMode::Fail => Err(HarnessError::AgentExecution("mock failure".to_string())),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State builders
+// ---------------------------------------------------------------------------
 
 async fn make_state(root: &std::path::Path) -> anyhow::Result<harness_server::http::AppState> {
     let project_root = root.join("project");
@@ -26,6 +120,53 @@ async fn make_state(root: &std::path::Path) -> anyhow::Result<harness_server::ht
         AgentRegistry::new("test"),
     ));
     build_app_state(server).await
+}
+
+async fn make_state_with_mock(
+    root: &std::path::Path,
+    agent: Arc<MockAgent>,
+) -> anyhow::Result<harness_server::http::AppState> {
+    let project_root = root.join("project");
+    std::fs::create_dir_all(&project_root)?;
+
+    let mut config = HarnessConfig::default();
+    config.server.data_dir = root.join("server-data");
+    config.server.project_root = project_root;
+    config.agents.default_agent = "mock".to_string();
+
+    let mut registry = AgentRegistry::new("mock");
+    registry.register("mock", agent);
+
+    let server = Arc::new(HarnessServer::new(config, ThreadManager::new(), registry));
+    build_app_state(server).await
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Drain the notify channel until the predicate matches, or timeout elapses.
+async fn wait_for_notification(
+    rx: &mut notify::NotifyReceiver,
+    predicate: impl Fn(&Notification) -> bool,
+    timeout_ms: u64,
+) -> anyhow::Result<Notification> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            anyhow::bail!("timeout: expected notification not received");
+        }
+        match timeout(remaining, rx.recv()).await {
+            Ok(Some(rpc)) => {
+                if predicate(&rpc.notification) {
+                    return Ok(rpc.notification);
+                }
+            }
+            Ok(None) => anyhow::bail!("notification channel closed unexpectedly"),
+            Err(_) => anyhow::bail!("timeout: expected notification not received"),
+        }
+    }
 }
 
 fn parse_str_field(value: &serde_json::Value, field: &str) -> anyhow::Result<String> {
@@ -117,6 +258,114 @@ async fn turn_start_delivers_turn_started_notification() -> anyhow::Result<()> {
             "expected turn/started notification, got: {:?}",
             notif.notification
         );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_completed_delivers_turn_completed_notification() -> anyhow::Result<()> {
+    let sandbox = common::tempdir_in_home("harness-notif-")?;
+    let mut state = make_state_with_mock(sandbox.path(), MockAgent::complete()).await?;
+
+    let (notify_tx, mut notify_rx) = notify::channel(32);
+    state.notifications.notify_tx = Some(notify_tx);
+
+    let cwd = sandbox.path().join("project");
+
+    let thread_resp = thread_start(&state, Some(serde_json::json!(1)), cwd).await;
+    assert!(
+        thread_resp.error.is_none(),
+        "thread_start failed: {:?}",
+        thread_resp.error
+    );
+    let thread_id_str = parse_str_field(thread_resp.result.as_ref().unwrap(), "thread_id")?;
+    let thread_id = ThreadId::from_str(&thread_id_str);
+
+    let turn_resp = turn_start(
+        &state,
+        Some(serde_json::json!(2)),
+        thread_id,
+        "hello".to_string(),
+    )
+    .await;
+    assert!(
+        turn_resp.error.is_none(),
+        "turn_start failed: {:?}",
+        turn_resp.error
+    );
+    let turn_id_str = parse_str_field(turn_resp.result.as_ref().unwrap(), "turn_id")?;
+
+    let notif = wait_for_notification(
+        &mut notify_rx,
+        |n| matches!(n, Notification::TurnCompleted { .. }),
+        3_000,
+    )
+    .await?;
+
+    if let Notification::TurnCompleted {
+        turn_id,
+        status,
+        token_usage,
+    } = notif
+    {
+        assert_eq!(turn_id.as_str(), turn_id_str);
+        assert_eq!(status, TurnStatus::Completed);
+        assert_eq!(token_usage.total_tokens, 10);
+    } else {
+        panic!("expected turn/completed notification, got: {:?}", notif);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_failed_delivers_turn_completed_notification_with_failed_status() -> anyhow::Result<()>
+{
+    let sandbox = common::tempdir_in_home("harness-notif-")?;
+    let mut state = make_state_with_mock(sandbox.path(), MockAgent::fail()).await?;
+
+    let (notify_tx, mut notify_rx) = notify::channel(32);
+    state.notifications.notify_tx = Some(notify_tx);
+
+    let cwd = sandbox.path().join("project");
+
+    let thread_resp = thread_start(&state, Some(serde_json::json!(1)), cwd).await;
+    assert!(
+        thread_resp.error.is_none(),
+        "thread_start failed: {:?}",
+        thread_resp.error
+    );
+    let thread_id_str = parse_str_field(thread_resp.result.as_ref().unwrap(), "thread_id")?;
+    let thread_id = ThreadId::from_str(&thread_id_str);
+
+    let turn_resp = turn_start(
+        &state,
+        Some(serde_json::json!(2)),
+        thread_id,
+        "fail please".to_string(),
+    )
+    .await;
+    assert!(
+        turn_resp.error.is_none(),
+        "turn_start failed: {:?}",
+        turn_resp.error
+    );
+    let turn_id_str = parse_str_field(turn_resp.result.as_ref().unwrap(), "turn_id")?;
+
+    let notif = wait_for_notification(
+        &mut notify_rx,
+        |n| matches!(n, Notification::TurnCompleted { .. }),
+        3_000,
+    )
+    .await?;
+
+    if let Notification::TurnCompleted {
+        turn_id, status, ..
+    } = notif
+    {
+        assert_eq!(turn_id.as_str(), turn_id_str);
+        assert_eq!(status, TurnStatus::Failed);
+    } else {
+        panic!("expected turn/completed notification, got: {:?}", notif);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Builds on the `thread_start`/`turn_start` notification coverage added in issue #167 by adding integration tests that verify `TurnCompleted` notifications are delivered through the notify channel when a turn finishes or fails.

- **`turn_completed_delivers_turn_completed_notification`** — wires notify channel, calls `thread_start` then `turn_start` with a `MockAgent` that completes immediately, asserts `turn/completed` notification received with correct `turn_id`, `Completed` status, and expected `token_usage`.
- **`turn_failed_delivers_turn_completed_notification_with_failed_status`** — same setup with a failing `MockAgent`, asserts `turn/completed` notification received with `Failed` status.
- Adds `MockAgent`, `make_state_with_mock`, and `wait_for_notification` helpers to support asynchronous notification polling in tests.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 4 notification delivery tests pass)