### PR TITLE
test(dispatch): add Critical and Medium complexity coverage for #168

### DIFF
--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -195,6 +195,54 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_critical_task_prefers_claude() {
+        let mut registry = registry_with_default();
+        registry.register(
+            "claude",
+            Arc::new(StubAgent {
+                agent_name: "claude",
+            }),
+        );
+
+        let agent = registry
+            .dispatch(&classification(TaskComplexity::Critical))
+            .unwrap();
+        assert_eq!(agent.name(), "claude");
+    }
+
+    #[test]
+    fn dispatch_critical_task_falls_back_to_anthropic_api_when_no_claude() {
+        let mut registry = registry_with_default();
+        registry.register(
+            "anthropic-api",
+            Arc::new(StubAgent {
+                agent_name: "anthropic-api",
+            }),
+        );
+
+        let agent = registry
+            .dispatch(&classification(TaskComplexity::Critical))
+            .unwrap();
+        assert_eq!(agent.name(), "anthropic-api");
+    }
+
+    #[test]
+    fn dispatch_medium_task_uses_default_agent() {
+        let mut registry = registry_with_default();
+        registry.register(
+            "claude",
+            Arc::new(StubAgent {
+                agent_name: "claude",
+            }),
+        );
+
+        let agent = registry
+            .dispatch(&classification(TaskComplexity::Medium))
+            .unwrap();
+        assert_eq!(agent.name(), "default-agent");
+    }
+
+    #[test]
     fn dispatch_returns_error_when_no_agents_registered() {
         let registry = AgentRegistry::new("missing");
         let result = registry.dispatch(&classification(TaskComplexity::Simple));


### PR DESCRIPTION
## Summary

Follow-up to #168 (multi-agent dispatch + anthropic-api adapter). The original PR added 5 tests covering `Complex` and `Simple` complexity routing, but left `Critical` and `Medium` variants without dedicated coverage.

- Add `dispatch_critical_task_prefers_claude` — verifies `Critical` maps to the same high-priority branch as `Complex`
- Add `dispatch_critical_task_falls_back_to_anthropic_api_when_no_claude` — verifies `Critical` fallback path
- Add `dispatch_medium_task_uses_default_agent` — verifies `Medium` falls through to the default agent

All four `TaskComplexity` variants (Simple, Medium, Complex, Critical) are now explicitly tested.

## Test plan

- [x] `cargo test -p harness-agents` — all 73 tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass