### PR TITLE
fix(lang_detect): use check-only format commands for Python and C# (#173)

### DIFF
--- a/crates/harness-core/src/lang_detect.rs
+++ b/crates/harness-core/src/lang_detect.rs
@@ -171,7 +171,10 @@ pub fn default_pre_commit_commands(lang: Language, project_root: &Path) -> Vec<S
             }
             cmds
         }
-        Language::Python => vec!["ruff format .".to_string(), "ruff check .".to_string()],
+        Language::Python => vec![
+            "ruff format --check .".to_string(),
+            "ruff check .".to_string(),
+        ],
         Language::Java => {
             if is_gradle_project(project_root) {
                 vec!["./gradlew check".to_string()]
@@ -179,7 +182,10 @@ pub fn default_pre_commit_commands(lang: Language, project_root: &Path) -> Vec<S
                 vec!["mvn compile -B".to_string()]
             }
         }
-        Language::CSharp => vec!["dotnet format".to_string(), "dotnet build".to_string()],
+        Language::CSharp => vec![
+            "dotnet format --verify-no-changes".to_string(),
+            "dotnet build".to_string(),
+        ],
         Language::Ruby => {
             if has_rubocop_config(project_root) {
                 vec!["bundle exec rubocop".to_string()]
@@ -474,7 +480,7 @@ mod tests {
     fn python_pre_commit_includes_ruff_format_and_check() {
         let dir = tmpdir();
         let cmds = default_pre_commit_commands(Language::Python, dir.path());
-        assert!(cmds.iter().any(|c| c == "ruff format ."));
+        assert!(cmds.iter().any(|c| c == "ruff format --check ."));
         assert!(cmds.iter().any(|c| c == "ruff check ."));
     }
 
@@ -517,7 +523,10 @@ mod tests {
     fn csharp_pre_commit_commands() {
         let dir = tmpdir();
         let cmds = default_pre_commit_commands(Language::CSharp, dir.path());
-        assert_eq!(cmds, vec!["dotnet format", "dotnet build"]);
+        assert_eq!(
+            cmds,
+            vec!["dotnet format --verify-no-changes", "dotnet build"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Python**: change `ruff format .` → `ruff format --check .` in `default_pre_commit_commands`
- **C#**: change `dotnet format` → `dotnet format --verify-no-changes` in `default_pre_commit_commands`
- Update corresponding unit tests to match

## Motivation

Check-only format commands (`--check` / `--verify-no-changes`) fail when
the agent produces unformatted code, injecting the error into the next
turn prompt so the agent can explicitly fix the issue. Auto-fix commands
(`ruff format .`, `dotnet format`) silently modify files and exit 0,
so the agent never receives feedback about formatting errors.

This aligns Python and C# with the spec described in #173 and makes the
validator's feedback loop effective for formatting checks.

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass (41 lang_detect tests, 0 failures)