### PR TITLE
test(harness-core): add integration tests for TaskId

### DIFF
--- a/crates/harness-core/tests/task_id.rs
+++ b/crates/harness-core/tests/task_id.rs
@@ -1,0 +1,30 @@
+use harness_core::TaskId;
+
+#[test]
+fn task_id_new_is_unique() {
+    let a = TaskId::new();
+    let b = TaskId::new();
+    assert_ne!(a, b);
+}
+
+#[test]
+fn task_id_serde_roundtrip() {
+    let id = TaskId::new();
+    let json = serde_json::to_string(&id).unwrap();
+    let back: TaskId = serde_json::from_str(&json).unwrap();
+    assert_eq!(id, back);
+}
+
+#[test]
+fn task_id_from_str_roundtrip() {
+    let id = TaskId::new();
+    let s = id.as_str().to_owned();
+    let back = TaskId::from_str(&s);
+    assert_eq!(id, back);
+}
+
+#[test]
+fn task_id_display() {
+    let id = TaskId::from_str("test-task-123");
+    assert_eq!(id.to_string(), "test-task-123");
+}


### PR DESCRIPTION
## Summary

- Adds integration tests in `crates/harness-core/tests/task_id.rs` verifying the `TaskId` type introduced in #208
- Tests cover: uniqueness (`new()` generates distinct IDs), serde roundtrip, `from_str` roundtrip, and `Display` formatting
- Tests live in a separate integration test file to stay within the 800-line limit for `types.rs` (VibeGuard U-16)

## Test plan

- [x] `cargo test -p harness-core --test task_id` — all 4 tests pass
- [x] `cargo fmt --all` — no formatting issues
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #208