### PR TITLE
feat: persist full agent output artifacts per task

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -831,6 +831,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         .route("/tasks", get(list_tasks))
         .route("/tasks/batch", post(task_routes::create_tasks_batch))
         .route("/tasks/{id}", get(get_task))
+        .route("/tasks/{id}/artifacts", get(get_task_artifacts))
         .route("/tasks/{id}/stream", get(stream_task_sse))
         .route(
             "/projects",
@@ -1175,6 +1176,29 @@ async fn get_task(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
         None => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /tasks/{id}/artifacts — all persisted artifacts for a task.
+async fn get_task_artifacts(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = task_runner::TaskId(id);
+    if state.core.tasks.get(&task_id).is_none() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "task not found"})),
+        )
+            .into_response();
+    }
+    match state.core.tasks.list_artifacts(&task_id).await {
+        Ok(artifacts) => Json(artifacts).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
         )
             .into_response(),
     }

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1,14 +1,19 @@
 use crate::db::{open_pool, Migration, Migrator};
 use crate::task_runner::{TaskId, TaskState, TaskStatus};
 use harness_core::TaskDbDecodeError;
+use serde::{Deserialize, Serialize};
 use sqlx::sqlite::SqlitePool;
 use std::path::Path;
+
+/// Maximum artifact content size in bytes before truncation.
+const ARTIFACT_MAX_BYTES: usize = 65_536;
 
 /// Versioned migrations for the tasks table.
 ///
 /// v1 – baseline schema (all columns including those added in later iterations)
 /// v2/v3/v4 – additive ALTER TABLE for databases that predate v1 tracking;
 ///   duplicate-column errors are silently ignored by the Migrator.
+/// v5 – add task_artifacts table for persisting agent output per task turn.
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -39,7 +44,29 @@ static TASK_MIGRATIONS: &[Migration] = &[
         description: "add parent_id column",
         sql: "ALTER TABLE tasks ADD COLUMN parent_id TEXT",
     },
+    Migration {
+        version: 5,
+        description: "create task_artifacts table",
+        sql: "CREATE TABLE IF NOT EXISTS task_artifacts (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id       TEXT NOT NULL,
+            turn          INTEGER NOT NULL DEFAULT 0,
+            artifact_type TEXT NOT NULL,
+            content       TEXT NOT NULL,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )",
+    },
 ];
+
+/// A single persisted artifact captured from agent output during task execution.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TaskArtifact {
+    pub task_id: String,
+    pub turn: i64,
+    pub artifact_type: String,
+    pub content: String,
+    pub created_at: String,
+}
 
 pub struct TaskDb {
     pool: SqlitePool,
@@ -149,6 +176,57 @@ impl TaskDb {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
+    /// Persist a single artifact captured from agent output.
+    ///
+    /// Content larger than [`ARTIFACT_MAX_BYTES`] is truncated to avoid
+    /// unbounded database growth without requiring an external compression
+    /// dependency.
+    pub async fn insert_artifact(
+        &self,
+        task_id: &str,
+        turn: u32,
+        artifact_type: &str,
+        content: &str,
+    ) -> anyhow::Result<()> {
+        let stored = if content.len() > ARTIFACT_MAX_BYTES {
+            let mut boundary = ARTIFACT_MAX_BYTES;
+            while boundary > 0 && !content.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            format!(
+                "{}\n[truncated: {} bytes total]",
+                &content[..boundary],
+                content.len()
+            )
+        } else {
+            content.to_string()
+        };
+
+        sqlx::query(
+            "INSERT INTO task_artifacts (task_id, turn, artifact_type, content)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(task_id)
+        .bind(turn as i64)
+        .bind(artifact_type)
+        .bind(&stored)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return all artifacts for a task ordered by insertion time.
+    pub async fn list_artifacts(&self, task_id: &str) -> anyhow::Result<Vec<TaskArtifact>> {
+        let rows = sqlx::query_as::<_, TaskArtifact>(
+            "SELECT task_id, turn, artifact_type, content, created_at
+             FROM task_artifacts WHERE task_id = ? ORDER BY id ASC",
+        )
+        .bind(task_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
     }
 }
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -192,14 +192,75 @@ fn compute_backoff_ms(base_ms: u64, max_ms: u64, attempt: u32) -> u64 {
     base_ms.saturating_mul(1u64 << shift).min(max_ms)
 }
 
+/// Persist a completed stream item as a task artifact when it carries content
+/// worth retaining across context loss (shell commands, file edits, tool calls).
+async fn persist_artifact(
+    store: &TaskStore,
+    task_id: &TaskId,
+    turn: u32,
+    item: &harness_core::Item,
+) {
+    let (artifact_type, content) = match item {
+        harness_core::Item::ShellCommand {
+            command,
+            exit_code,
+            stdout,
+            stderr,
+        } => {
+            let c = serde_json::json!({
+                "command": command,
+                "exit_code": exit_code,
+                "stdout": stdout,
+                "stderr": stderr,
+            })
+            .to_string();
+            ("shell_command", c)
+        }
+        harness_core::Item::FileEdit {
+            path,
+            before,
+            after,
+        } => {
+            let c = serde_json::json!({
+                "path": path,
+                "before": before,
+                "after": after,
+            })
+            .to_string();
+            ("file_edit", c)
+        }
+        harness_core::Item::ToolCall {
+            name,
+            input,
+            output,
+        } => {
+            let c = serde_json::json!({
+                "name": name,
+                "input": input,
+                "output": output,
+            })
+            .to_string();
+            ("tool_call", c)
+        }
+        _ => return,
+    };
+    store
+        .insert_artifact(task_id, turn, artifact_type, &content)
+        .await;
+}
+
 /// Execute an agent request via [`CodeAgent::execute_stream`], broadcasting
 /// each [`StreamItem`] to the per-task channel in real time, and reconstruct
 /// an [`AgentResponse`] from the collected stream events.
+///
+/// `turn` is stored with each captured artifact so callers can distinguish
+/// implementation turn (1) from later review or retry turns.
 async fn run_agent_streaming(
     agent: &dyn CodeAgent,
     req: AgentRequest,
     task_id: &TaskId,
     store: &TaskStore,
+    turn: u32,
 ) -> harness_core::Result<AgentResponse> {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamItem>(128);
     let mut exec = std::pin::pin!(agent.execute_stream(req, tx));
@@ -226,6 +287,9 @@ async fn run_agent_streaming(
                             } => {
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
+                            }
+                            StreamItem::ItemCompleted { item: completed_item } => {
+                                persist_artifact(store, task_id, turn, completed_item).await;
                             }
                             StreamItem::TokenUsage { usage } => {
                                 token_usage = usage.clone();
@@ -400,7 +464,7 @@ pub(crate) async fn run_task(
     let resp = loop {
         let raw = tokio::time::timeout(
             turn_timeout,
-            run_agent_streaming(agent, impl_req.clone(), task_id, store),
+            run_agent_streaming(agent, impl_req.clone(), task_id, store, 1),
         )
         .await;
         match raw {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -454,6 +454,31 @@ impl TaskStore {
         self.stream_txs.remove(id);
     }
 
+    /// Persist an artifact captured from agent output during task execution.
+    pub(crate) async fn insert_artifact(
+        &self,
+        task_id: &TaskId,
+        turn: u32,
+        artifact_type: &str,
+        content: &str,
+    ) {
+        if let Err(e) = self
+            .db
+            .insert_artifact(&task_id.0, turn, artifact_type, content)
+            .await
+        {
+            tracing::warn!(task_id = %task_id.0, artifact_type, "failed to insert task artifact: {e}");
+        }
+    }
+
+    /// Return all artifacts for a task ordered by insertion time.
+    pub async fn list_artifacts(
+        &self,
+        task_id: &TaskId,
+    ) -> anyhow::Result<Vec<crate::task_db::TaskArtifact>> {
+        self.db.list_artifacts(&task_id.0).await
+    }
+
     pub(crate) async fn insert(&self, state: &TaskState) {
         self.persist_locks
             .entry(state.id.clone())


### PR DESCRIPTION
## Summary

- Adds a `task_artifacts` table to `TaskDb` (migration v5) with columns: `task_id`, `turn`, `artifact_type`, `content`, `created_at`
- Captures `ShellCommand`, `FileEdit`, and `ToolCall` items from agent streaming turns via a new `persist_artifact` helper in `task_executor.rs`
- Content exceeding 65 536 bytes is truncated to keep the database bounded without requiring an external compression dependency
- Exposes `GET /tasks/{id}/artifacts` endpoint returning the full artifact list for a task

## Changes

- `task_db.rs`: migration v5, `TaskArtifact` struct, `insert_artifact` / `list_artifacts` on `TaskDb`
- `task_runner.rs`: `insert_artifact` / `list_artifacts` delegation methods on `TaskStore`
- `task_executor.rs`: `persist_artifact` helper + `turn` parameter on `run_agent_streaming`; captures completed `ShellCommand`, `FileEdit`, `ToolCall` items
- `http.rs`: `GET /tasks/{id}/artifacts` route and handler

## Test plan

- [ ] All existing tests pass (`cargo test --workspace`)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [ ] Manual: start server, run a task, `GET /tasks/{id}/artifacts` returns captured shell/file/tool events

Fixes #459