### PR TITLE
feat: rewrite builtin skill descriptions as trigger conditions

### DIFF
--- a/skills/build-fix.md
+++ b/skills/build-fix.md
@@ -1,4 +1,4 @@
-# Build Fix
+# Use when: a build or compilation fails — locate root cause and apply the minimal fix to get it green. Triggers on: build error, build failed, compilation error, compile error, cargo error, fix build
 
 <!-- trigger-patterns: build error, build failed, compilation error, compile error, cargo error, fix build -->
 

--- a/skills/check.md
+++ b/skills/check.md
@@ -1,4 +1,4 @@
-# Check
+# Use when: running all guard scripts to produce a project health report, before committing, or after significant changes. Triggers on: health report, project check, run guards, guard scripts, project health
 
 <!-- trigger-patterns: health report, project check, run guards, guard scripts, project health -->
 

--- a/skills/cross-review.md
+++ b/skills/cross-review.md
@@ -1,4 +1,4 @@
-# Cross Review
+# Use when: reviewing high-stakes changes such as security-sensitive code, public API changes, or data migrations that need adversarial dual-model scrutiny. Triggers on: cross review, adversarial review, dual model, high stakes, security sensitive
 
 <!-- trigger-patterns: cross review, adversarial review, dual model, high stakes, security sensitive -->
 

--- a/skills/exec-plan.md
+++ b/skills/exec-plan.md
@@ -1,4 +1,4 @@
-# Exec Plan
+# Use when: a SPEC is approved and you need a milestone-based execution plan for a long-running multi-session task. Triggers on: exec plan, execution plan, long running, multi-session, milestone plan
 
 <!-- trigger-patterns: exec plan, execution plan, long running, multi-session, milestone plan -->
 

--- a/skills/gc.md
+++ b/skills/gc.md
@@ -1,4 +1,4 @@
-# GC
+# Use when: disk usage is high or on a weekly cadence to archive old logs, clean worktrees, and scan for code smells. Triggers on: garbage collect, disk usage, clean worktrees, archive logs, code smells
 
 <!-- trigger-patterns: garbage collect, disk usage, clean worktrees, archive logs, code smells -->
 

--- a/skills/interview.md
+++ b/skills/interview.md
@@ -1,4 +1,4 @@
-# Interview
+# Use when: starting a large feature (6+ files) to deeply understand requirements, constraints, and risks before writing any code. Triggers on: interview, requirements, large feature, 6+ files, deeply understand
 
 <!-- trigger-patterns: interview, requirements, large feature, 6+ files, deeply understand -->
 

--- a/skills/learn.md
+++ b/skills/learn.md
@@ -1,4 +1,4 @@
-# Learn
+# Use when: after fixing a bug or completing a successful implementation to extract reusable rules or skills from the experience. Triggers on: extract rules, learn from, reusable rules, after fixing, after implementation
 
 <!-- trigger-patterns: extract rules, learn from, reusable rules, after fixing, after implementation -->
 

--- a/skills/preflight.md
+++ b/skills/preflight.md
@@ -1,4 +1,4 @@
-# Preflight
+# Use when: about to make medium-complexity changes (3-5 files) to identify constraints and risks before writing any code. Triggers on: preflight, before changes, 3-5 files, medium complexity, identify constraints
 
 <!-- trigger-patterns: preflight, before changes, 3-5 files, medium complexity, identify constraints -->
 

--- a/skills/review.md
+++ b/skills/review.md
@@ -1,4 +1,4 @@
-# Review
+# Use when: reviewing a pull request, checking code quality on a diff, or responding to review comments. Triggers on: code review, review pr, review the, review this, review diff
 
 <!-- trigger-patterns: code review, review pr, review the, review this, review diff -->
 

--- a/skills/stats.md
+++ b/skills/stats.md
@@ -1,4 +1,4 @@
-# Stats
+# Use when: viewing aggregated hook statistics, compliance trends, or identifying the most violated rules. Triggers on: hook stats, hook statistics, compliance trends, violated rules, aggregated stats
 
 <!-- trigger-patterns: hook stats, hook statistics, compliance trends, violated rules, aggregated stats -->
 


### PR DESCRIPTION
## Summary

- Rewrote the first-line heading of all 10 builtin skill markdown files to use trigger condition format
- Each description now answers "When should the agent use this skill?" with `Use when: <condition>. Triggers on: <keywords>` pattern
- No changes to skill names, content body, or trigger_patterns

## Skills updated

| Skill | Old | New |
|-------|-----|-----|
| interview | "Interview" | "Use when: starting a large feature (6+ files)..." |
| exec-plan | "Exec Plan" | "Use when: a SPEC is approved and you need a milestone-based execution plan..." |
| preflight | "Preflight" | "Use when: about to make medium-complexity changes (3-5 files)..." |
| check | "Check" | "Use when: running all guard scripts to produce a project health report..." |
| build-fix | "Build Fix" | "Use when: a build or compilation fails..." |
| review | "Review" | "Use when: reviewing a pull request, checking code quality..." |
| cross-review | "Cross Review" | "Use when: reviewing high-stakes changes such as security-sensitive code..." |
| learn | "Learn" | "Use when: after fixing a bug or completing a successful implementation..." |
| gc | "GC" | "Use when: disk usage is high or on a weekly cadence..." |
| stats | "Stats" | "Use when: viewing aggregated hook statistics, compliance trends..." |