### PR TITLE
feat: improve server log signal-to-noise ratio

### DIFF
--- a/crates/harness-server/src/rule_enforcer.rs
+++ b/crates/harness-server/src/rule_enforcer.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
+use dashmap::DashMap;
 use harness_core::{
     interceptor::{InterceptResult, TurnInterceptor},
     AgentRequest, Severity,
 };
 use harness_rules::engine::RuleEngine;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -15,11 +17,16 @@ use tokio::sync::RwLock;
 /// When no guards are registered the enforcer passes through silently.
 pub struct RuleEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
+    /// Per-workspace violation count from the previous scan, used to compute deltas.
+    prev_counts: DashMap<PathBuf, usize>,
 }
 
 impl RuleEnforcer {
     pub fn new(rules: Arc<RwLock<RuleEngine>>) -> Self {
-        Self { rules }
+        Self {
+            rules,
+            prev_counts: DashMap::new(),
+        }
     }
 }
 
@@ -65,11 +72,37 @@ impl TurnInterceptor for RuleEnforcer {
             return InterceptResult::pass();
         }
 
-        tracing::info!(
-            violation_count = violations.len(),
-            project_root = %req.project_root.display(),
-            "rule_enforcer: scan completed"
-        );
+        let total = violations.len();
+        let prev = self
+            .prev_counts
+            .get(&req.project_root)
+            .map(|v| *v)
+            .unwrap_or(0);
+        let new_violations = total.saturating_sub(prev);
+        let fixed_violations = prev.saturating_sub(total);
+        self.prev_counts.insert(req.project_root.clone(), total);
+
+        // Only log at INFO when the count changes; repeat-same scans go to DEBUG.
+        let delta_zero = new_violations == 0 && fixed_violations == 0 && prev > 0;
+        if delta_zero {
+            tracing::debug!(
+                violation_count = total,
+                violations_total = total,
+                violations_new = new_violations,
+                violations_fixed = fixed_violations,
+                project_root = %req.project_root.display(),
+                "rule_enforcer: scan completed"
+            );
+        } else {
+            tracing::info!(
+                violation_count = total,
+                violations_total = total,
+                violations_new = new_violations,
+                violations_fixed = fixed_violations,
+                project_root = %req.project_root.display(),
+                "rule_enforcer: scan completed"
+            );
+        }
 
         let critical: Vec<_> = violations
             .iter()

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -360,7 +360,9 @@ pub(crate) async fn run_task(
     project: PathBuf,
     server_config: &harness_core::HarnessConfig,
 ) -> anyhow::Result<()> {
+    let task_start = Instant::now();
     update_status(store, task_id, TaskStatus::Implementing, 1).await?;
+    let impl_phase_start = Instant::now();
 
     let project_config = load_project_config(&project);
     let resolved = harness_core::config::resolve_config(server_config, &project_config);
@@ -580,7 +582,30 @@ pub(crate) async fn run_task(
         }
     };
 
-    let AgentResponse { output, stderr, .. } = resp;
+    let AgentResponse {
+        output,
+        stderr,
+        token_usage: impl_token_usage,
+        ..
+    } = resp;
+
+    tracing::info!(
+        task_id = %task_id,
+        phase = "implementing",
+        elapsed_secs = impl_phase_start.elapsed().as_secs(),
+        "phase_completed"
+    );
+    {
+        let preview: String = output.chars().take(200).collect();
+        tracing::info!(
+            task_id = %task_id,
+            output_chars = output.len(),
+            preview = %preview,
+            input_tokens = impl_token_usage.input_tokens,
+            output_tokens = impl_token_usage.output_tokens,
+            "agent_output_summary"
+        );
+    }
 
     if !stderr.is_empty() {
         tracing::warn!(stderr = %stderr, "agent stderr during implementation");
@@ -608,6 +633,14 @@ pub(crate) async fn run_task(
             });
         })
         .await?;
+        tracing::info!(
+            task_id = %task_id,
+            status = "done",
+            turns = 1,
+            pr_url = tracing::field::Empty,
+            total_elapsed_secs = task_start.elapsed().as_secs(),
+            "task_completed"
+        );
         return Ok(());
     }
 
@@ -648,6 +681,14 @@ pub(crate) async fn run_task(
             s.turn = 2;
         })
         .await?;
+        tracing::info!(
+            task_id = %task_id,
+            status = "done",
+            turns = 2,
+            pr_url = tracing::field::Empty,
+            total_elapsed_secs = task_start.elapsed().as_secs(),
+            "task_completed"
+        );
         return Ok(());
     };
 
@@ -684,6 +725,8 @@ pub(crate) async fn run_task(
     let wait_secs = req.wait_secs;
     tracing::info!("waiting {wait_secs}s for review bot on PR #{pr_num}");
     sleep(Duration::from_secs(wait_secs)).await;
+
+    let review_phase_start = Instant::now();
 
     // Review loop
     for round in 1..=req.max_rounds {
@@ -772,6 +815,20 @@ pub(crate) async fn run_task(
                 s.turn = round.saturating_add(1);
             })
             .await?;
+            tracing::info!(
+                task_id = %task_id,
+                phase = "reviewing",
+                elapsed_secs = review_phase_start.elapsed().as_secs(),
+                "phase_completed"
+            );
+            tracing::info!(
+                task_id = %task_id,
+                status = "done",
+                turns = round.saturating_add(1),
+                pr_url = pr_url.as_deref().unwrap_or(""),
+                total_elapsed_secs = task_start.elapsed().as_secs(),
+                "task_completed"
+            );
             return Ok(());
         }
 
@@ -792,6 +849,20 @@ pub(crate) async fn run_task(
         ));
     })
     .await?;
+    tracing::info!(
+        task_id = %task_id,
+        phase = "reviewing",
+        elapsed_secs = review_phase_start.elapsed().as_secs(),
+        "phase_completed"
+    );
+    tracing::info!(
+        task_id = %task_id,
+        status = "failed",
+        turns = req.max_rounds.saturating_add(1),
+        pr_url = pr_url.as_deref().unwrap_or(""),
+        total_elapsed_secs = task_start.elapsed().as_secs(),
+        "task_completed"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- **Delta-only violation reporting**: `rule_enforcer` now tracks per-workspace violation counts across scans. Unchanged counts log at `DEBUG`; only new/fixed deltas surface at `INFO`. Adds `violations_total`, `violations_new`, `violations_fixed` structured fields.
- **Agent output summary**: After each implementation turn, logs `agent_output_summary` with first 200 chars of output and token counts (`input_tokens`, `output_tokens`).
- **Phase elapsed time**: Logs `phase_completed` with `phase` and `elapsed_secs` at implementing→reviewing→done/failed transitions.
- **Task completion summary**: Logs `task_completed` with `id`, `status`, `turns`, `pr_url`, and `total_elapsed_secs` at every Done/Failed exit point in `run_task`.

## Constraints respected

- No existing log fields removed — only new structured fields added alongside existing ones
- `violation_count` field preserved for backward compatibility; new delta fields are additive