### PR TITLE
feat: inject Golden Principles constitution into agent prompts

### DIFF
--- a/config/constitution.md
+++ b/config/constitution.md
@@ -1,0 +1,16 @@
+# Harness Constitution — Immutable Architectural Principles
+
+## GP-01: Auditable Artifacts
+All operations must produce auditable artifacts (PR, draft, log). Memory-only state changes are not allowed.
+
+## GP-02: Diagnose Before Fix
+Always diagnose before fixing. GC must generate signal report before generating fix drafts.
+
+## GP-03: Deterministic Enforcement
+Rule checks must be deterministic. Same input produces same output. Never rely on LLM judgment for compliance.
+
+## GP-04: Observable Operations
+Every Turn input/output/tool-call must be recorded to EventStore.
+
+## GP-05: Single Source of Truth
+Config and runtime state must be consistent. Single configuration source.

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -47,6 +47,10 @@ pub struct ServerConfig {
     /// Default: 100.
     #[serde(default = "default_signal_rate_limit_per_minute")]
     pub signal_rate_limit_per_minute: u32,
+    /// When true, the Harness Constitution (GP-01 through GP-05) is prepended
+    /// to every agent prompt. Default: true.
+    #[serde(default = "default_true")]
+    pub constitution_enabled: bool,
 }
 
 impl Default for ServerConfig {
@@ -65,6 +69,7 @@ impl Default for ServerConfig {
             allowed_project_roots: Vec::new(),
             max_webhook_body_bytes: default_max_webhook_body_bytes(),
             signal_rate_limit_per_minute: default_signal_rate_limit_per_minute(),
+            constitution_enabled: default_true(),
         }
     }
 }
@@ -99,4 +104,8 @@ fn default_max_webhook_body_bytes() -> usize {
 
 fn default_signal_rate_limit_per_minute() -> u32 {
     100
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -464,6 +464,11 @@ pub(crate) async fn run_task(
         }
     };
 
+    // Prepend constitution principles so every agent turn starts from shared
+    // architectural ground truth. Skipped when constitution_enabled is false.
+    let first_prompt =
+        inject_constitution_if_enabled(first_prompt, server_config.server.constitution_enabled);
+
     // Inject skill content directly into the prompt text.
     // Since harness uses single-turn `claude -p`, context items are not visible
     // to the agent — we must embed skill content in the prompt string itself.
@@ -983,6 +988,16 @@ async fn run_agent_review(
     Ok(())
 }
 
+/// Prepend the Harness Constitution to the prompt when the flag is enabled.
+pub(crate) fn inject_constitution_if_enabled(prompt: String, enabled: bool) -> String {
+    const CONSTITUTION: &str = include_str!("../../../config/constitution.md");
+    if enabled {
+        format!("{CONSTITUTION}\n\n---\n\n{prompt}")
+    } else {
+        prompt
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1154,5 +1169,28 @@ mod tests {
     fn implementation_turn_uses_full_profile_no_restriction() {
         // Full profile returns None — no --allowedTools flag is passed to the agent.
         assert!(CapabilityProfile::Full.tools().is_none());
+    }
+
+    #[test]
+    fn constitution_injected_when_enabled() {
+        let result = inject_constitution_if_enabled("task prompt".to_string(), true);
+        assert!(result.contains("GP-01"), "GP-01 must appear in prompt");
+        assert!(result.contains("GP-05"), "GP-05 must appear in prompt");
+        assert!(
+            result.contains("task prompt"),
+            "original prompt must be preserved"
+        );
+        assert!(result.contains("---"), "separator must be present");
+        // Constitution must come before the task prompt.
+        assert!(
+            result.find("---\n\n") < result.find("task prompt"),
+            "constitution must precede the task prompt"
+        );
+    }
+
+    #[test]
+    fn constitution_absent_when_disabled() {
+        let result = inject_constitution_if_enabled("task prompt".to_string(), false);
+        assert_eq!(result, "task prompt");
     }
 }


### PR DESCRIPTION
Adds `config/constitution.md` with 5 immutable architectural principles (GP-01 through GP-05), injected into every agent prompt. Configurable via `constitution_enabled` flag (default: true).