### PR TITLE
feat: inject Golden Principles constitution into agent prompts

### DIFF
--- a/config/constitution.md
+++ b/config/constitution.md
@@ -1,0 +1,16 @@
+# Harness Constitution — Immutable Architectural Principles
+
+## GP-01: Auditable Artifacts
+All operations must produce auditable artifacts (PR, draft, log). Memory-only state changes are not allowed.
+
+## GP-02: Diagnose Before Fix
+Always diagnose before fixing. GC must generate signal report before generating fix drafts.
+
+## GP-03: Deterministic Enforcement
+Rule checks must be deterministic. Same input produces same output. Never rely on LLM judgment for compliance.
+
+## GP-04: Observable Operations
+Every Turn input/output/tool-call must be recorded to EventStore.
+
+## GP-05: Single Source of Truth
+Config and runtime state must be consistent. Single configuration source.

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -47,6 +47,10 @@ pub struct ServerConfig {
     /// Default: 100.
     #[serde(default = "default_signal_rate_limit_per_minute")]
     pub signal_rate_limit_per_minute: u32,
+    /// When true, the Harness Constitution is prepended to every agent prompt.
+    /// Default: true.
+    #[serde(default = "default_true")]
+    pub constitution_enabled: bool,
 }
 
 impl Default for ServerConfig {
@@ -65,6 +69,7 @@ impl Default for ServerConfig {
             allowed_project_roots: Vec::new(),
             max_webhook_body_bytes: default_max_webhook_body_bytes(),
             signal_rate_limit_per_minute: default_signal_rate_limit_per_minute(),
+            constitution_enabled: default_true(),
         }
     }
 }
@@ -99,4 +104,8 @@ fn default_max_webhook_body_bytes() -> usize {
 
 fn default_signal_rate_limit_per_minute() -> u32 {
     100
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -464,6 +464,15 @@ pub(crate) async fn run_task(
         }
     };
 
+    // Prepend the Harness Constitution when enabled. Embedded at compile time so
+    // no runtime file I/O is needed.
+    const CONSTITUTION: &str = include_str!("../../../config/constitution.md");
+    let first_prompt = if server_config.server.constitution_enabled {
+        format!("{CONSTITUTION}\n\n---\n\n{first_prompt}")
+    } else {
+        first_prompt
+    };
+
     // Inject skill content directly into the prompt text.
     // Since harness uses single-turn `claude -p`, context items are not visible
     // to the agent — we must embed skill content in the prompt string itself.
@@ -1154,5 +1163,26 @@ mod tests {
     fn implementation_turn_uses_full_profile_no_restriction() {
         // Full profile returns None — no --allowedTools flag is passed to the agent.
         assert!(CapabilityProfile::Full.tools().is_none());
+    }
+
+    #[test]
+    fn constitution_prepended_when_enabled() {
+        const CONSTITUTION: &str = include_str!("../../../config/constitution.md");
+        let base = "Do the task.".to_string();
+        let result = format!("{CONSTITUTION}\n\n---\n\n{base}");
+        assert!(result.starts_with("# Harness Constitution"));
+        assert!(result.contains("GP-01"));
+        assert!(result.contains("GP-05"));
+        assert!(result.contains("Do the task."));
+    }
+
+    #[test]
+    fn constitution_absent_when_disabled() {
+        const CONSTITUTION: &str = include_str!("../../../config/constitution.md");
+        let base = "Do the task.".to_string();
+        // When disabled, prompt is returned as-is.
+        let result = base.clone();
+        assert!(!result.contains(CONSTITUTION));
+        assert_eq!(result, base);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `config/constitution.md` with 5 immutable architectural principles (GP-01 through GP-05)
- Embeds the constitution at compile time via `include_str!` and prepends it to every agent prompt
- Adds `constitution_enabled: bool` flag to `ServerConfig` (default `true`) to allow opt-out

## Test plan
- [ ] `cargo test -p harness-server constitution` — two new unit tests pass
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean