### PR TITLE
feat: add Golden Principles constitution system

### DIFF
--- a/config/constitution.md
+++ b/config/constitution.md
@@ -1,0 +1,37 @@
+# Golden Principles Constitution
+
+These principles govern every agent turn executed by harness. They are
+non-negotiable invariants — follow them in every task.
+
+## GP-01: Auditable Artifacts
+
+Every operation must produce a durable, inspectable artifact: a PR, a draft,
+or an event log entry. Changes that exist only in memory or in transient agent
+output are not acceptable. If an operation cannot produce an artifact, it must
+be refused or deferred until it can.
+
+## GP-02: Diagnose Before Fix
+
+Always diagnose first. Before proposing or applying any fix, generate a signal
+report that identifies the root cause. GC runs must produce a signal report
+before drafting fixes. Blind edits without a diagnostic step violate this
+principle.
+
+## GP-03: Deterministic Enforcement
+
+Rule checks must be deterministic: given the same input, produce the same
+output. Do not use probabilistic or context-sensitive heuristics for
+enforcement decisions. Checks that depend on external state (network, time,
+random) must be isolated from enforcement logic.
+
+## GP-04: Observable Operations
+
+Every turn's input and output, and every tool call within a turn, must be
+recorded to the EventStore. Silent operations — turns that consume tokens
+without emitting events — are prohibited. Observability is not optional.
+
+## GP-05: Single Source of Truth
+
+Configuration and runtime state must be consistent. There is exactly one
+authoritative source for any piece of state. Duplicate stores, shadow configs,
+or in-memory overrides that diverge from persisted state are prohibited.

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -47,6 +47,10 @@ pub struct ServerConfig {
     /// Default: 100.
     #[serde(default = "default_signal_rate_limit_per_minute")]
     pub signal_rate_limit_per_minute: u32,
+    /// Prepend the Golden Principles constitution to every agent prompt.
+    /// Default: true.
+    #[serde(default = "default_constitution_enabled")]
+    pub constitution_enabled: bool,
 }
 
 impl Default for ServerConfig {
@@ -65,6 +69,7 @@ impl Default for ServerConfig {
             allowed_project_roots: Vec::new(),
             max_webhook_body_bytes: default_max_webhook_body_bytes(),
             signal_rate_limit_per_minute: default_signal_rate_limit_per_minute(),
+            constitution_enabled: true,
         }
     }
 }
@@ -99,4 +104,8 @@ fn default_max_webhook_body_bytes() -> usize {
 
 fn default_signal_rate_limit_per_minute() -> u32 {
     100
+}
+
+fn default_constitution_enabled() -> bool {
+    true
 }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -349,6 +349,15 @@ async fn run_agent_streaming(
     }
 }
 
+fn prepend_constitution(prompt: String, enabled: bool) -> String {
+    const CONSTITUTION: &str = include_str!("../../../config/constitution.md");
+    if enabled {
+        format!("{CONSTITUTION}\n\n{prompt}")
+    } else {
+        prompt
+    }
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
@@ -465,6 +474,10 @@ pub(crate) async fn run_task(
             format!("{first_prompt}\n\n{ctx}")
         }
     };
+
+    // Prepend the Golden Principles constitution when enabled.
+    let first_prompt =
+        prepend_constitution(first_prompt, server_config.server.constitution_enabled);
 
     // Inject skill content directly into the prompt text.
     // Since harness uses single-turn `claude -p`, context items are not visible
@@ -1225,5 +1238,23 @@ mod tests {
     fn implementation_turn_uses_full_profile_no_restriction() {
         // Full profile returns None — no --allowedTools flag is passed to the agent.
         assert!(CapabilityProfile::Full.tools().is_none());
+    }
+
+    #[test]
+    fn constitution_present_when_enabled() {
+        let result = prepend_constitution("Do the task.".to_string(), true);
+        assert!(result.contains("GP-01"));
+        assert!(result.contains("GP-02"));
+        assert!(result.contains("GP-03"));
+        assert!(result.contains("GP-04"));
+        assert!(result.contains("GP-05"));
+        assert!(result.ends_with("Do the task."));
+    }
+
+    #[test]
+    fn constitution_absent_when_disabled() {
+        let result = prepend_constitution("Do the task.".to_string(), false);
+        assert_eq!(result, "Do the task.");
+        assert!(!result.contains("GP-01"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `config/constitution.md` with five GP invariants (GP-01 through GP-05): Auditable Artifacts, Diagnose Before Fix, Deterministic Enforcement, Observable Operations, Single Source of Truth
- Add `constitution_enabled: bool` (default `true`) to `ServerConfig` with serde support
- Prepend constitution to every agent prompt in `run_task()` before skill injection when enabled
- Add two unit tests: `constitution_present_when_enabled` and `constitution_absent_when_disabled`

## Test plan

- [ ] `cargo test -p harness-server constitution` — 2 tests pass
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean