### PR TITLE
fix(sec): deny access when allowed_project_root canonicalization fails (SEC-07)

### DIFF
--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -47,9 +47,12 @@ pub async fn register_project(
 
     let allowed = &state.core.server.config.server.allowed_project_roots;
     if !allowed.is_empty() {
-        let permitted = allowed.iter().any(|base| {
-            let canonical_base = base.canonicalize().unwrap_or_else(|_| base.clone());
-            root.starts_with(&canonical_base)
+        let permitted = allowed.iter().any(|base| match base.canonicalize() {
+            Ok(canonical_base) => root.starts_with(&canonical_base),
+            Err(e) => {
+                tracing::error!("failed to canonicalize allowed root {:?}: {}", base, e);
+                false
+            }
         });
         if !permitted {
             return (


### PR DESCRIPTION
## Summary

- Fixes SEC-07 symlink traversal vulnerability in `handlers/projects.rs`
- When `base.canonicalize()` fails, the old code silently fell back to the raw (non-canonical) path, enabling path traversal attacks via `starts_with` on unresolved paths
- The fix returns `false` (deny) and logs an error when any allowed root cannot be canonicalized — closing the unsafe fallback entirely

Closes #486

## Test plan
- [ ] `cargo fmt --all` — passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — passes (no warnings)
- [ ] `cargo test --workspace` — passes
- [ ] Manual: allowed root with valid path still permits matching project roots
- [ ] Manual: if an allowed root path is missing/inaccessible, registration is denied with FORBIDDEN