### PR TITLE
fix: restricted_tools hard-fails on misconfigured capability profiles (#487)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -13,23 +13,17 @@ use harness_core::{
 use harness_protocol::{Notification, RpcNotification};
 use std::collections::HashMap;
 
-/// Extract tool list from a capability profile, falling back to ReadOnly if
-/// the profile unexpectedly returns `None` (which means Full/unrestricted).
-/// This prevents silent privilege escalation: a misconfigured restricted profile
-/// never degrades to Full access.
-fn restricted_tools(profile: CapabilityProfile) -> Vec<String> {
-    match profile.tools() {
-        Some(tools) => tools,
-        None => {
-            tracing::warn!(
-                ?profile,
-                "restricted profile returned None (Full); falling back to ReadOnly"
-            );
-            CapabilityProfile::ReadOnly
-                .tools()
-                .unwrap_or_else(|| vec!["Read".to_string(), "Grep".to_string(), "Glob".to_string()])
-        }
-    }
+/// Extract tool list from a capability profile, returning an error if the
+/// profile unexpectedly returns `None` (which means Full/unrestricted).
+/// A misconfigured profile causes a hard failure rather than silent degradation,
+/// per U-23 (no silent capability downgrade).
+fn restricted_tools(profile: CapabilityProfile) -> anyhow::Result<Vec<String>> {
+    profile.tools().ok_or_else(|| {
+        anyhow::anyhow!(
+            "capability profile {:?} returned None from tools() — misconfiguration",
+            profile
+        )
+    })
 }
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -504,7 +498,7 @@ pub(crate) async fn run_task(
     let (initial_allowed_tools, capability_prompt_note) =
         if req.source.as_deref() == Some("periodic_review") {
             (
-                restricted_tools(CapabilityProfile::Standard),
+                restricted_tools(CapabilityProfile::Standard)?,
                 CapabilityProfile::Standard.prompt_note(),
             )
         } else {
@@ -818,7 +812,7 @@ pub(crate) async fn run_task(
             project_root: project.clone(),
             context: context_items.clone(),
             execution_phase: Some(ExecutionPhase::Validation),
-            allowed_tools: restricted_tools(CapabilityProfile::ReadOnly),
+            allowed_tools: restricted_tools(CapabilityProfile::ReadOnly)?,
             env_vars: cargo_env.clone(),
             ..Default::default()
         };
@@ -995,7 +989,7 @@ async fn run_agent_review(
             project_root: project.to_path_buf(),
             context: context_items.to_vec(),
             execution_phase: Some(ExecutionPhase::Validation),
-            allowed_tools: restricted_tools(CapabilityProfile::ReadOnly),
+            allowed_tools: restricted_tools(CapabilityProfile::ReadOnly)?,
             env_vars: cargo_env.clone(),
             ..Default::default()
         };
@@ -1307,7 +1301,7 @@ mod tests {
 
     #[test]
     fn review_check_turn_uses_readonly_profile() {
-        let tools = restricted_tools(CapabilityProfile::ReadOnly);
+        let tools = restricted_tools(CapabilityProfile::ReadOnly).unwrap();
         assert!(tools.contains(&"Read".to_string()));
         assert!(tools.contains(&"Grep".to_string()));
         assert!(tools.contains(&"Glob".to_string()));
@@ -1318,7 +1312,7 @@ mod tests {
 
     #[test]
     fn periodic_review_turn_uses_standard_profile_with_bash() {
-        let tools = restricted_tools(CapabilityProfile::Standard);
+        let tools = restricted_tools(CapabilityProfile::Standard).unwrap();
         assert!(tools.contains(&"Bash".to_string()));
         assert!(tools.contains(&"Read".to_string()));
         assert!(tools.contains(&"Write".to_string()));


### PR DESCRIPTION
## Summary

- Fixes U-23 violation in `task_executor.rs`: `restricted_tools()` previously silently degraded to `ReadOnly` when a `CapabilityProfile` returned `None` from `tools()`, masking misconfigurations
- Changed `restricted_tools` return type from `Vec<String>` to `anyhow::Result<Vec<String>>` — a misconfigured profile now causes a hard `Err` that refuses task startup
- Propagated the error at all three production call sites using `?`
- Updated the two test call sites to `.unwrap()` (valid in `#[test]` context, exempt from RS-03)

## Test plan

- [ ] `cargo fmt --all` — passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — passes (0 warnings)
- [ ] `cargo test --workspace` — all tests pass (existing `review_check_turn_uses_readonly_profile` and `periodic_review_turn_uses_standard_profile_with_bash` tests updated and green)

Closes #487