### PR TITLE
test(task_executor): add regression test for U-23 hard-fail on Full profile

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1328,6 +1328,22 @@ mod tests {
     }
 
     #[test]
+    fn full_profile_hard_fails_in_restricted_tools() {
+        // Passing Full (which returns None) to restricted_tools must return Err, not
+        // silently degrade to ReadOnly. This guards against U-23 regressions.
+        let result = restricted_tools(CapabilityProfile::Full);
+        assert!(
+            result.is_err(),
+            "Full profile must produce an error, not silent fallback"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("misconfiguration"),
+            "error message should mention misconfiguration"
+        );
+    }
+
+    #[test]
     fn constitution_present_when_enabled() {
         let result = prepend_constitution("Do the task.".to_string(), true);
         assert!(result.contains("GP-01"));


### PR DESCRIPTION
## Summary

- The fix for #487 (PR #494) changed `restricted_tools` to return `Result` and hard-fail when `CapabilityProfile::Full` is passed (which returns `None` from `tools()`), satisfying U-23.
- However, no test directly exercised the error path — only the `ReadOnly` and `Standard` success paths were tested.
- This PR adds `full_profile_hard_fails_in_restricted_tools` to verify that `restricted_tools(CapabilityProfile::Full)` returns `Err` containing "misconfiguration", guarding against future regressions.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 478 tests pass in harness-server, including the new test `task_executor::tests::full_profile_hard_fails_in_restricted_tools`

Closes #487