### PR TITLE
fix(task_executor): use per-task CARGO_TARGET_DIR to eliminate build lock contention (#488)

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -44,6 +44,27 @@ pub(crate) use pr_detection::{
 #[cfg(test)]
 pub(crate) use pr_detection::PromptBuilder;
 
+/// RAII guard that removes a per-task Cargo target directory on drop.
+///
+/// Each invocation of `run_task` gets an isolated `CARGO_TARGET_DIR` under
+/// `$TMPDIR/harness-cargo-targets/<task_id>`.  When the guard is dropped
+/// (whether the task succeeds, fails, or times out) the directory is removed,
+/// preventing disk exhaustion from accumulated build artefacts.
+struct TempTargetDir(PathBuf);
+
+impl Drop for TempTargetDir {
+    fn drop(&mut self) {
+        if self.0.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&self.0) {
+                tracing::warn!(
+                    path = %self.0.display(),
+                    "failed to clean up per-task CARGO_TARGET_DIR: {e}"
+                );
+            }
+        }
+    }
+}
+
 pub(crate) async fn run_turn_lifecycle(
     server: Arc<crate::server::HarnessServer>,
     thread_db: Option<crate::thread_db::ThreadDb>,
@@ -369,12 +390,16 @@ pub(crate) async fn run_task(
     update_status(store, task_id, TaskStatus::Implementing, 1).await?;
     let impl_phase_start = Instant::now();
 
-    // Set CARGO_TARGET_DIR to a per-workspace path so parallel agents using isolated
-    // git worktrees each build to their own target directory, eliminating cargo file
-    // lock contention when 4+ agents run cargo check/test simultaneously.
+    // Use a per-task CARGO_TARGET_DIR so concurrent agents on the same project
+    // each build to an isolated directory, eliminating cargo file-lock contention
+    // (issue #488).  The guard removes the directory when run_task returns.
+    let task_target = std::env::temp_dir()
+        .join("harness-cargo-targets")
+        .join(task_id.to_string());
+    let _target_guard = TempTargetDir(task_target.clone());
     let cargo_env: HashMap<String, String> = [(
         "CARGO_TARGET_DIR".to_string(),
-        format!("{}/target", project.display()),
+        task_target.display().to_string(),
     )]
     .into();
 


### PR DESCRIPTION
## Summary

- Fixes #488: concurrent tasks on the same project shared `{project_root}/target` as `CARGO_TARGET_DIR`, causing cargo's `.cargo-lock` to block or fail parallel `cargo check` runs
- Replaces the shared path with `$TMPDIR/harness-cargo-targets/<task_id>` — each task gets its own isolated build directory
- Adds a `TempTargetDir` RAII guard that removes the per-task directory when `run_task` returns (success, error, or timeout), preventing disk exhaustion

## Root cause

`cargo_env` was set to `{project_root}/target` for every agent invocation. Parallel tasks (e.g. periodic review + user-initiated task on the same project) contended on cargo's file lock, leading to timeouts or build failures.

## Fix

```rust
let task_target = std::env::temp_dir()
    .join("harness-cargo-targets")
    .join(task_id.to_string());
let _target_guard = TempTargetDir(task_target.clone());
let cargo_env: HashMap<String, String> = [(
    "CARGO_TARGET_DIR".to_string(),
    task_target.display().to_string(),
)]
.into();
```

`TempTargetDir` implements `Drop` to call `fs::remove_dir_all` on the temp path, so cleanup is automatic at all exit points.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 1032 tests pass, 0 failed