### PR TITLE
fix: capture HOME once at startup to eliminate TOCTOU in path validation (RS-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -25,7 +25,7 @@ pub async fn cross_review(
     target: String,
     max_rounds: Option<u32>,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     let primary = match state.core.server.agent_registry.default_agent() {
         Some(a) => a,

--- a/crates/harness-server/src/handlers/exec.rs
+++ b/crates/harness-server/src/handlers/exec.rs
@@ -9,7 +9,7 @@ pub async fn exec_plan_init(
     spec: String,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
     match harness_exec::ExecPlan::from_spec(&spec, &project_root) {
         Ok(plan) => {
             let plan_id = plan.id.clone();

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -173,6 +173,7 @@ pub async fn gc_adopt(
                     state.concurrency.workspace_mgr.clone(),
                     permit,
                     None,
+                    state.core.home_dir.clone(),
                 )
                 .await;
                 Some(tid.0)

--- a/crates/harness-server/src/handlers/health.rs
+++ b/crates/harness-server/src/handlers/health.rs
@@ -9,7 +9,7 @@ pub async fn health_check(
     id: Option<serde_json::Value>,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     // Query historical events before persisting the current scan to avoid the
     // just-persisted rule_check events inflating the quality stability score.

--- a/crates/harness-server/src/handlers/learn.rs
+++ b/crates/harness-server/src/handlers/learn.rs
@@ -9,7 +9,7 @@ pub async fn learn_rules(
     id: Option<serde_json::Value>,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     let draft_contents = match collect_adopted_draft_contents(state) {
         Ok(d) => d,
@@ -61,7 +61,7 @@ pub async fn learn_skills(
     id: Option<serde_json::Value>,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     let draft_contents = match collect_adopted_draft_contents(state) {
         Ok(d) => d,

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -15,14 +15,17 @@ pub mod thread;
 /// Validate a project root path, returning early with an `INTERNAL_ERROR`
 /// response on failure.
 ///
+/// `$home` must be a `&std::path::Path` capturing the HOME directory at
+/// server startup — do **not** pass `std::env::var("HOME")` here.
+///
 /// # Example
 /// ```ignore
-/// let project_root = validate_root!(&project_root, id);
+/// let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 /// ```
 #[macro_export]
 macro_rules! validate_root {
-    ($path:expr, $id:expr) => {
-        match $crate::handlers::validate_project_root($path) {
+    ($path:expr, $id:expr, $home:expr) => {
+        match $crate::handlers::validate_project_root($path, $home) {
             Ok(p) => p,
             Err(e) => {
                 return harness_protocol::RpcResponse::error(
@@ -54,12 +57,17 @@ pub(crate) fn validate_file_in_root(
     Ok(canonical)
 }
 
-/// Validate that a project root is an existing directory within `$HOME`.
+/// Validate that a project root is an existing directory within `home`.
+///
+/// `home` must be the HOME directory captured **once at server startup**,
+/// not read from the environment on each call — callers are responsible for
+/// passing a stable value (e.g. `&state.core.home_dir`).
+///
 /// Returns the canonicalized path on success.
-pub(crate) fn validate_project_root(path: &std::path::Path) -> Result<std::path::PathBuf, String> {
-    let home = std::env::var("HOME")
-        .map(std::path::PathBuf::from)
-        .map_err(|_| "HOME environment variable not set".to_string())?;
+pub(crate) fn validate_project_root(
+    path: &std::path::Path,
+    home: &std::path::Path,
+) -> Result<std::path::PathBuf, String> {
     let canonical = path
         .canonicalize()
         .map_err(|e| format!("invalid project root '{}': {e}", path.display()))?;
@@ -69,7 +77,7 @@ pub(crate) fn validate_project_root(path: &std::path::Path) -> Result<std::path:
             canonical.display()
         ));
     }
-    if !canonical.starts_with(&home) {
+    if !canonical.starts_with(home) {
         return Err(format!(
             "project root must be within HOME: {}",
             canonical.display()

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -41,7 +41,7 @@ pub async fn metrics_collect(
     id: Option<serde_json::Value>,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     // scan -> persist -> query -> grade
     let violations = {

--- a/crates/harness-server/src/handlers/preflight.rs
+++ b/crates/harness-server/src/handlers/preflight.rs
@@ -212,7 +212,7 @@ pub async fn preflight(
     project_root: PathBuf,
     task_description: String,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
 
     let agent = match state.core.server.agent_registry.default_agent() {
         Some(a) => a,

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -7,7 +7,7 @@ pub async fn rule_load(
     id: Option<serde_json::Value>,
     project_root: PathBuf,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
     let mut rules = state.engines.rules.write().await;
     match rules.load(&project_root) {
         Ok(()) => {
@@ -24,7 +24,7 @@ pub async fn rule_check(
     project_root: PathBuf,
     files: Option<Vec<PathBuf>>,
 ) -> RpcResponse {
-    let project_root = validate_root!(&project_root, id);
+    let project_root = validate_root!(&project_root, id, &state.core.home_dir);
     let file_count = files.as_ref().map_or(0, |paths| paths.len());
     let result = {
         let rules = state.engines.rules.read().await;

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -55,7 +55,7 @@ pub async fn thread_start(
     id: Option<serde_json::Value>,
     cwd: PathBuf,
 ) -> RpcResponse {
-    let cwd = validate_root!(&cwd, id);
+    let cwd = validate_root!(&cwd, id, &state.core.home_dir);
     let thread_id = state.core.server.thread_manager.start_thread(cwd);
     persist_thread_insert(state, &thread_id).await;
     crate::notify::emit(

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -61,6 +61,9 @@ pub(crate) mod task_routes;
 pub struct CoreServices {
     pub server: Arc<HarnessServer>,
     pub project_root: std::path::PathBuf,
+    /// HOME directory captured once at server startup.
+    /// Used by `validate_project_root` to avoid per-request env reads (TOCTOU).
+    pub home_dir: std::path::PathBuf,
     pub tasks: Arc<task_runner::TaskStore>,
     pub thread_db: Option<crate::thread_db::ThreadDb>,
     pub plan_db: Option<crate::plan_db::PlanDb>,
@@ -197,6 +200,11 @@ fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
 pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppState> {
     let dir = expand_tilde(&server.config.server.data_dir);
     let project_root = resolve_project_root(&server.config.server.project_root)?;
+    // Capture HOME once at startup so validate_project_root never races with
+    // concurrent env-var mutations (TOCTOU — see RS-01).
+    let home_dir = std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .context("HOME environment variable not set")?;
     std::fs::create_dir_all(&dir)?;
     tracing::debug!(
         data_dir = %dir.display(),
@@ -523,6 +531,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         completion_callback.clone(),
         Some(project_registry.clone()),
         server.config.server.allowed_project_roots.clone(),
+        home_dir.clone(),
     );
 
     let signal_rate_limit = server.config.server.signal_rate_limit_per_minute;
@@ -530,6 +539,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         core: CoreServices {
             server,
             project_root,
+            home_dir,
             tasks,
             thread_db: Some(thread_db),
             plan_db: Some(plan_db),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -122,6 +122,7 @@ pub(crate) async fn enqueue_task(
         state.concurrency.workspace_mgr.clone(),
         permit,
         state.intake.completion_callback.clone(),
+        state.core.home_dir.clone(),
     )
     .await;
 
@@ -314,6 +315,7 @@ async fn enqueue_task_background(
                         permit,
                         state.intake.completion_callback.clone(),
                         group_permit,
+                        state.core.home_dir.clone(),
                     )
                     .await;
                 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -99,11 +99,17 @@ async fn make_test_state_with(
         None,
         None,
         vec![],
+        std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dir.to_path_buf()),
     );
     Ok(Arc::new(AppState {
         core: crate::http::CoreServices {
             server,
             project_root: dir.to_path_buf(),
+            home_dir: std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.to_path_buf()),
             tasks,
             thread_db: Some(thread_db),
             plan_db: None,

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -53,11 +53,17 @@ async fn make_test_state_with_config_and_registry(
         None,
         None,
         vec![],
+        std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dir.to_path_buf()),
     );
     Ok(AppState {
         core: crate::http::CoreServices {
             server,
             project_root: dir.to_path_buf(),
+            home_dir: std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.to_path_buf()),
             tasks,
             thread_db: Some(thread_db),
             plan_db: None,
@@ -1342,11 +1348,17 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         None,
         None,
         vec![],
+        std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dir.to_path_buf()),
     );
     Ok(AppState {
         core: crate::http::CoreServices {
             server,
             project_root: dir.to_path_buf(),
+            home_dir: std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.to_path_buf()),
             tasks,
             thread_db: Some(thread_db),
             plan_db: Some(plan_db),

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -71,6 +71,8 @@ pub struct DefaultExecutionService {
     completion_callback: Option<CompletionCallback>,
     project_registry: Option<Arc<ProjectRegistry>>,
     allowed_project_roots: Vec<PathBuf>,
+    /// HOME directory captured at startup; passed to `validate_project_root` (RS-01).
+    home_dir: PathBuf,
 }
 
 impl DefaultExecutionService {
@@ -87,6 +89,7 @@ impl DefaultExecutionService {
         completion_callback: Option<CompletionCallback>,
         project_registry: Option<Arc<ProjectRegistry>>,
         allowed_project_roots: Vec<PathBuf>,
+        home_dir: PathBuf,
     ) -> Arc<Self> {
         Arc::new(Self {
             tasks,
@@ -100,6 +103,7 @@ impl DefaultExecutionService {
             completion_callback,
             project_registry,
             allowed_project_roots,
+            home_dir,
         })
     }
 
@@ -218,6 +222,7 @@ impl ExecutionService for DefaultExecutionService {
             self.workspace_mgr.clone(),
             permit,
             self.completion_callback.clone(),
+            self.home_dir.clone(),
         )
         .await;
 
@@ -262,6 +267,7 @@ impl ExecutionService for DefaultExecutionService {
         let workspace_mgr = self.workspace_mgr.clone();
         let task_queue = self.task_queue.clone();
         let completion_callback = self.completion_callback.clone();
+        let home_dir = self.home_dir.clone();
         let task_id2 = task_id.clone();
         tokio::spawn(async move {
             match task_queue.acquire(&project_id).await {
@@ -280,6 +286,7 @@ impl ExecutionService for DefaultExecutionService {
                         permit,
                         completion_callback,
                         None,
+                        home_dir,
                     )
                     .await;
                 }
@@ -483,6 +490,9 @@ mod tests {
     ) -> Arc<DefaultExecutionService> {
         let config = Arc::new(HarnessConfig::default());
         let agent_registry = Arc::new(AgentRegistry::new("test"));
+        let home_dir = std::env::var("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp"));
         DefaultExecutionService::new(
             store,
             agent_registry,
@@ -495,6 +505,7 @@ mod tests {
             None,
             registry,
             vec![],
+            home_dir,
         )
     }
 
@@ -504,6 +515,9 @@ mod tests {
     ) -> Arc<DefaultExecutionService> {
         let config = Arc::new(HarnessConfig::default());
         let agent_registry = Arc::new(AgentRegistry::new("test"));
+        let home_dir = std::env::var("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp"));
         DefaultExecutionService::new(
             store,
             agent_registry,
@@ -516,6 +530,7 @@ mod tests {
             None,
             None,
             allowed,
+            home_dir,
         )
     }
 }

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -166,12 +166,18 @@ mod tests {
             None,
             None,
             vec![],
+            std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.to_path_buf()),
         );
 
         Ok(AppState {
             core: crate::http::CoreServices {
                 server,
                 project_root: dir.to_path_buf(),
+                home_dir: std::env::var("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| dir.to_path_buf()),
                 tasks,
                 thread_db: Some(thread_db),
                 plan_db: None,

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -517,6 +517,7 @@ pub async fn spawn_task(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    home_dir: std::path::PathBuf,
 ) -> TaskId {
     spawn_task_with_worktree_detector(
         store,
@@ -533,6 +534,7 @@ pub async fn spawn_task(
         completion_callback,
         None,
         None,
+        home_dir,
     )
     .await
 }
@@ -568,6 +570,7 @@ pub async fn spawn_preregistered_task(
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
     group_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    home_dir: std::path::PathBuf,
 ) {
     spawn_task_with_worktree_detector(
         store,
@@ -584,6 +587,7 @@ pub async fn spawn_preregistered_task(
         completion_callback,
         Some(task_id),
         group_permit,
+        home_dir,
     )
     .await;
 }
@@ -603,6 +607,7 @@ async fn spawn_task_with_worktree_detector<F>(
     completion_callback: Option<CompletionCallback>,
     preregistered_id: Option<TaskId>,
     group_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    home_dir: std::path::PathBuf,
 ) -> TaskId
 where
     F: Fn() -> PathBuf + Send + Sync + 'static,
@@ -637,7 +642,7 @@ where
         let detect_worktree = detect_worktree.clone();
         let raw_project =
             resolve_project_root_with(req.project.clone(), move || detect_worktree()).await?;
-        let project_root = crate::handlers::validate_project_root(&raw_project)
+        let project_root = crate::handlers::validate_project_root(&raw_project, &home_dir)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         // Populate transient sibling-awareness fields in the in-memory cache.
@@ -1141,6 +1146,9 @@ mod tests {
         let events = Arc::new(harness_observe::EventStore::new(dir.path()).await?);
         let queue = crate::task_queue::TaskQueue::unbounded();
         let permit = queue.acquire("test").await?;
+        let home_dir = std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dir.path().to_path_buf());
         spawn_task(
             store,
             agent_clone,
@@ -1153,6 +1161,7 @@ mod tests {
             None,
             permit,
             None,
+            home_dir,
         )
         .await;
 
@@ -1215,6 +1224,9 @@ mod tests {
 
         let queue = crate::task_queue::TaskQueue::unbounded();
         let permit = queue.acquire("test").await?;
+        let home_dir = std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dir.path().to_path_buf());
         let task_id = spawn_task(
             store.clone(),
             agent,
@@ -1227,6 +1239,7 @@ mod tests {
             None,
             permit,
             None,
+            home_dir,
         )
         .await;
 
@@ -1319,6 +1332,9 @@ mod tests {
             None,
             None,
             None,
+            std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.path().to_path_buf()),
         )
         .await;
 
@@ -1468,6 +1484,9 @@ mod tests {
             None,
             permit,
             None,
+            std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.path().to_path_buf()),
         )
         .await;
 
@@ -1525,6 +1544,9 @@ mod tests {
             None,
             permit,
             None,
+            std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.path().to_path_buf()),
         )
         .await;
 

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -119,6 +119,9 @@ async fn make_state_inner(
         project_root.to_path_buf(),
     );
     let task_svc = crate::services::DefaultTaskService::new(tasks.clone());
+    let home_dir = std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().expect("resolve cwd"));
     let execution_svc = crate::services::DefaultExecutionService::new(
         tasks.clone(),
         server.agent_registry.clone(),
@@ -131,12 +134,13 @@ async fn make_state_inner(
         None,
         None,
         vec![],
+        home_dir.clone(),
     );
-
     Ok(AppState {
         core: crate::http::CoreServices {
             server,
             project_root: project_root.to_path_buf(),
+            home_dir,
             tasks,
             thread_db: Some(thread_db),
             plan_db: None,

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -276,11 +276,17 @@ mod tests {
             None,
             None,
             vec![],
+            std::env::var("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dir.to_path_buf()),
         );
         Ok(AppState {
             core: crate::http::CoreServices {
                 server,
                 project_root: dir.to_path_buf(),
+                home_dir: std::env::var("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| dir.to_path_buf()),
                 tasks,
                 thread_db: Some(thread_db),
                 plan_db: None,


### PR DESCRIPTION
## Summary

- Fixes RS-01 TOCTOU vulnerability where `validate_project_root()` re-read `HOME` from the environment on every call, creating a race condition in concurrent test environments
- `HOME` is now captured once at server startup and stored in `CoreServices.home_dir`
- Passed explicitly through the call chain: `CoreServices` → handlers → `spawn_task` family → `validate_project_root(path, home)`
- `DefaultExecutionService` stores `home_dir: PathBuf` to carry the captured value into async-spawned tasks

## Changes

- `handlers/mod.rs`: `validate_project_root(path, home)` — accepts explicit `home: &Path` instead of reading env
- `handlers/mod.rs`: `validate_root!` macro updated to 3-arg form `($path, $id, $home)`
- `http.rs`: `CoreServices` gains `home_dir: PathBuf` field; captured once in `build_app_state`
- `services/execution.rs`: `DefaultExecutionService` gains `home_dir: PathBuf`; `new()` accepts it as last param
- `task_runner.rs`: `spawn_task`, `spawn_preregistered_task`, `spawn_task_with_worktree_detector` all accept `home_dir: PathBuf`
- All 8 handler files: `validate_root!` calls updated to pass `&state.core.home_dir`
- All test helpers: read HOME from env at construction time

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — 477+ tests passing, 0 failed
- [x] Version bumped to 0.6.12 (PATCH — bug fix)

Closes #489