### PR TITLE
chore: bump version to 0.6.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.6.11 to 0.6.12 (patch)

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all tests pass