### PR TITLE
feat: sprint plan 2026-03-23

### DIFF
--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -113,10 +113,9 @@ impl IntakeOrchestrator {
 
     async fn poll_tick(&self, state: &Arc<AppState>) {
         // 1. Collect all new issues from all sources, grouped by repo.
-        let mut by_repo: std::collections::HashMap<
-            String,
-            Vec<(Arc<dyn IntakeSource>, IncomingIssue)>,
-        > = std::collections::HashMap::new();
+        type RepoIssues = Vec<(Arc<dyn IntakeSource>, IncomingIssue)>;
+        let mut by_repo: std::collections::HashMap<String, RepoIssues> =
+            std::collections::HashMap::new();
 
         for source in &self.sources {
             let issues = match source.poll().await {

--- a/plan/sprint-2026-03-23.json
+++ b/plan/sprint-2026-03-23.json
@@ -1,0 +1,15 @@
+SPRINT_PLAN_START
+{
+  "rounds": [
+    {
+      "issues": [453, 454, 452],
+      "reason": "all P1, non-overlapping files: handlers/rules.rs (#453), db-path files (#454), periodic_reviewer.rs (#452)"
+    },
+    {
+      "issues": [447],
+      "reason": "bug fix in periodic_reviewer.rs — must follow #452 which rewrites the same file"
+    }
+  ],
+  "skip": []
+}
+SPRINT_PLAN_END


### PR DESCRIPTION
## Sprint Plan 2026-03-23

### Round 1 (parallel — all P1)
| Issue | Files touched |
|-------|--------------|
| #453 RS-01: read lock held during async scan | `handlers/rules.rs` |
| #454 U-11: hardcoded DB paths | `task_db.rs`, `thread_db.rs`, `plan_db.rs`, `http.rs`, `dirs.rs`, etc. |
| #452 REVIEW-01: git/gh in periodic_reviewer | `periodic_reviewer.rs` |

No file overlap → safe to parallelize.

### Round 2 (sequential — after Round 1)
| Issue | Files touched | Reason |
|-------|--------------|--------|
| #447 Guard scan on worktree | `periodic_reviewer.rs` | Must follow #452 (same file) |

## Also included
- Fix `clippy::type_complexity` in `intake/mod.rs` (introduce `RepoIssues` type alias)