### PR TITLE
feat: sprint plan 2026-03-23 (#447 #452 #453 #454)

### DIFF
--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -113,10 +113,9 @@ impl IntakeOrchestrator {
 
     async fn poll_tick(&self, state: &Arc<AppState>) {
         // 1. Collect all new issues from all sources, grouped by repo.
-        let mut by_repo: std::collections::HashMap<
-            String,
-            Vec<(Arc<dyn IntakeSource>, IncomingIssue)>,
-        > = std::collections::HashMap::new();
+        type ByRepo =
+            std::collections::HashMap<String, Vec<(Arc<dyn IntakeSource>, IncomingIssue)>>;
+        let mut by_repo: ByRepo = std::collections::HashMap::new();
 
         for source in &self.sources {
             let issues = match source.poll().await {

--- a/docs/sprints/2026-03-23.md
+++ b/docs/sprints/2026-03-23.md
@@ -1,0 +1,37 @@
+# Sprint Plan — 2026-03-23
+
+## Issues
+
+| # | Title | Priority | Files Touched |
+|---|-------|----------|---------------|
+| #447 | Guard scan runs on worktree instead of source repo | P1 | `rule_enforcer.rs`, `engine/mod.rs`, `task_executor.rs` |
+| #452 | REVIEW-01: Direct git/gh invocations in periodic_reviewer | P1 | `periodic_reviewer.rs`, `prompts.rs` |
+| #453 | RS-01: Read lock held during async scan blocks writes | P1 | `rule_enforcer.rs`, `engine/mod.rs` |
+| #454 | U-11: Hardcoded DB paths in 15+ files | P1 | `http.rs`, `task_db.rs`, `thread_db.rs`, `db.rs`, `test_helpers.rs` |
+
+## Dependency Graph
+
+- **#447** and **#452** and **#454** can start immediately (no shared files between them).
+- **#453** must wait for **#447** — both touch `rule_enforcer.rs` and `engine/mod.rs`;
+  fixing the worktree path first gives a stable base for the async lock refactor.
+
+## Rationale
+
+### #447 → #453 dependency
+`rule_enforcer.rs:pre_execute` is the call site for both fixes:
+- #447 changes *where* `engine.scan()` is called (resolve worktree → source repo before passing `project_root`)
+- #453 changes *how* the read lock is held around `engine.scan().await` (drop lock before the async call)
+
+Applying them in sequence avoids a concurrent edit conflict on the same function and lets the #453 author work against already-correct scan semantics.
+
+SPRINT_PLAN_START
+{
+  "tasks": [
+    {"issue": 447, "depends_on": []},
+    {"issue": 452, "depends_on": []},
+    {"issue": 454, "depends_on": []},
+    {"issue": 453, "depends_on": [447]}
+  ],
+  "skip": []
+}
+SPRINT_PLAN_END


### PR DESCRIPTION
## Summary

- Dependency graph for 4 pending P1 issues
- #447 (worktree guard scan), #452 (git in periodic_reviewer), #454 (hardcoded DB paths) can start in parallel
- #453 (async read lock) depends on #447 — both touch `rule_enforcer.rs` and `engine/mod.rs`
- Fix pre-existing `clippy::type_complexity` in `intake/mod.rs`

## Sprint Plan

```
#447 ──────────────────────────────────► #453
#452 ──────────────────────────────────► (done)
#454 ──────────────────────────────────► (done)
```

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes