### PR TITLE
fix: WAITING status no longer consumes review rounds

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1046,6 +1046,20 @@ pub(crate) async fn run_task(
         }
 
         let lgtm = prompts::is_lgtm(&output);
+        let waiting = prompts::is_waiting(&output);
+
+        // WAITING means review bot hasn't posted yet (e.g., quota exhausted).
+        // Don't consume a round — just sleep and retry without incrementing.
+        if waiting {
+            tracing::info!(
+                round,
+                "PR #{pr_num} review bot has not responded yet; sleeping without consuming round"
+            );
+            waiting_count += 1;
+            update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
+            sleep(Duration::from_secs(wait_secs)).await;
+            continue;
+        }
 
         mutate_and_persist(store, task_id, |s| {
             s.rounds.push(RoundResult {


### PR DESCRIPTION
## Summary
- When review bot hasn't responded (e.g., Gemini quota exhausted), agent outputs `WAITING`
- Previously treated as "fixed", consuming a round — tasks exhausted all rounds without ever being reviewed
- Now `WAITING` triggers sleep-and-retry without incrementing round counter

## Root Cause
`is_waiting()` existed in prompts.rs (line 534) but was never checked in the review loop (task_executor.rs line 1048). Only `is_lgtm()` was checked — everything else defaulted to "fixed".

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes  
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes