### PR TITLE
fix: cross-platform shell — .gitattributes, PYTHONUTF8, shell:bash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for scripts and Python files to prevent
+# CRLF issues on Windows that break bash script execution.
+*.sh text eol=lf
+*.py text eol=lf

--- a/.github/workflows/ci-disabled-modules.yml
+++ b/.github/workflows/ci-disabled-modules.yml
@@ -8,6 +8,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check-all-features:
     name: Compile-check disabled modules (--all-features)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   pr-body:
     name: PR Description

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "sdk-v*"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   verify-typescript:
     name: Verify TypeScript SDK

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# hooks/run-hook.sh — cross-platform hook runner
+#
+# Usage: hooks/run-hook.sh <script> [args...]
+#
+# Sets Python UTF-8 encoding env vars before delegating to the hook script
+# so that guard scripts invoking Python work correctly on Windows (CP-1252)
+# and other non-UTF-8 default locales.
+set -euo pipefail
+
+export PYTHONUTF8=1
+export PYTHONIOENCODING=utf-8
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <script> [args...]" >&2
+    exit 1
+fi
+
+exec bash "$@"


### PR DESCRIPTION
## Summary

- Add `.gitattributes` forcing LF line endings for `*.sh` and `*.py` — prevents CRLF from breaking bash scripts on Windows
- Add `hooks/run-hook.sh` wrapper that exports `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` before delegating to the hook script — fixes `UnicodeEncodeError` on systems with CP-1252 default encoding
- Add `defaults: run: shell: bash` to all CI workflows (`ci.yml`, `ci-disabled-modules.yml`, `pr-check.yml`, `publish-sdk.yml`) — prevents PowerShell glob expansion from breaking test file paths on Windows runners