### PR TITLE
feat: add prepublishOnly tarball verification for TypeScript SDK

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -21,6 +21,8 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+      - name: Tarball smoke test
+        run: bash scripts/verify-package-contents.sh
 
   verify-python:
     name: Verify Python SDK

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -8,7 +8,8 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "exports": {
     ".": {
@@ -20,7 +21,8 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "test": "tsx --test tests/harness.test.ts"
+    "test": "tsx --test tests/harness.test.ts",
+    "prepublishOnly": "npm run build && bash scripts/verify-package-contents.sh"
   },
   "devDependencies": {
     "@types/node": "^20.17.57",

--- a/sdk/typescript/scripts/verify-package-contents.sh
+++ b/sdk/typescript/scripts/verify-package-contents.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# verify-package-contents.sh — pre-publish tarball smoke test
+# Packs the package into a temporary tarball and checks that all required
+# files are present before allowing `npm publish` to proceed.
+set -euo pipefail
+
+REQUIRED_FILES=(
+  "package/dist/index.js"
+  "package/dist/index.cjs"
+  "package/dist/index.d.ts"
+)
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Packing tarball for verification..."
+npm pack --pack-destination "$TMPDIR" --quiet
+
+TARBALL=$(ls "$TMPDIR"/*.tgz | head -1)
+if [ -z "$TARBALL" ]; then
+  echo "ERROR: npm pack produced no tarball" >&2
+  exit 1
+fi
+
+echo "Unpacking $TARBALL..."
+tar -xzf "$TARBALL" -C "$TMPDIR"
+
+MISSING=0
+for f in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$TMPDIR/$f" ]; then
+    echo "MISSING: $f" >&2
+    MISSING=1
+  else
+    echo "  OK: $f"
+  fi
+done
+
+if [ "$MISSING" -ne 0 ]; then
+  echo ""
+  echo "ERROR: npm publish aborted — required files are missing from the tarball." >&2
+  echo "Run 'npm run build' to regenerate dist/, then retry." >&2
+  exit 1
+fi
+
+echo ""
+echo "All required files present in tarball."


### PR DESCRIPTION
## Summary

- Add `scripts/verify-package-contents.sh` that packs a tarball and checks required dist files are present before publish
- Add `prepublishOnly` hook to `package.json` (runs `build` then verification)
- Add CI tarball smoke test step to `verify-typescript` job in `publish-sdk.yml`

## Test plan

- [ ] `npm run build && bash scripts/verify-package-contents.sh` passes when dist/ is populated
- [ ] Running `npm publish` without building first is blocked by `prepublishOnly`
- [ ] CI `verify-typescript` job fails if tarball is missing required files