### PR TITLE
feat: hook circuit breaker to prevent infinite loops

### DIFF
--- a/crates/harness-server/src/circuit_breaker.rs
+++ b/crates/harness-server/src/circuit_breaker.rs
@@ -1,0 +1,223 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Minimum consecutive blocks before the circuit opens.
+const FAILURE_THRESHOLD: u32 = 3;
+/// How long the circuit stays open (auto-pass) before transitioning to half-open.
+pub const COOLDOWN: Duration = Duration::from_secs(300);
+
+#[derive(Debug)]
+enum State {
+    /// Normal operation — enforcement runs on every call.
+    Closed { consecutive_failures: u32 },
+    /// Circuit tripped — calls auto-pass until cooldown expires.
+    Open { opened_at: Instant },
+    /// Cooldown expired — allow one probe call to test recovery.
+    HalfOpen,
+}
+
+struct Entry {
+    state: State,
+}
+
+impl Entry {
+    fn new() -> Self {
+        Self {
+            state: State::Closed {
+                consecutive_failures: 0,
+            },
+        }
+    }
+}
+
+/// Martin Fowler–style circuit breaker for hook enforcement.
+///
+/// Tracks consecutive block counts per key (typically a session ID or hook
+/// name). After [`FAILURE_THRESHOLD`] consecutive blocks the circuit opens and
+/// all subsequent calls auto-pass for [`COOLDOWN`] seconds, preventing infinite
+/// loops caused by unresolvable violations (GitHub issue #3573, #10205).
+///
+/// This replaces the role of Claude Code's `stop_hook_active` field: when the
+/// circuit is open the enforcer behaves as if `stop_hook_active = true` — it
+/// does not emit a blocking signal, breaking the loop.
+///
+/// State machine:
+/// ```text
+/// CLOSED ──(≥3 blocks)──► OPEN ──(5 min elapsed)──► HALF-OPEN
+///   ▲                                                     │
+///   └─────────────(pass)─────────────────────────────────┘
+///                         OPEN ◄──(block)────────── HALF-OPEN
+/// ```
+pub struct CircuitBreaker {
+    entries: Mutex<HashMap<String, Entry>>,
+}
+
+impl CircuitBreaker {
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `true` if enforcement should proceed.
+    /// Returns `false` if the circuit is open and still in cooldown (auto-pass).
+    pub fn allow(&self, key: &str) -> bool {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(key.to_string()).or_insert_with(Entry::new);
+        match &entry.state {
+            State::Closed { .. } => true,
+            State::Open { opened_at } => {
+                if opened_at.elapsed() >= COOLDOWN {
+                    tracing::info!(
+                        key,
+                        "hook_circuit_breaker: cooldown elapsed, transitioning to half-open"
+                    );
+                    entry.state = State::HalfOpen;
+                    true
+                } else {
+                    false
+                }
+            }
+            State::HalfOpen => true,
+        }
+    }
+
+    /// Record a block outcome (violations found). Opens the circuit after
+    /// [`FAILURE_THRESHOLD`] consecutive blocks.
+    pub fn record_block(&self, key: &str) {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(key.to_string()).or_insert_with(Entry::new);
+        match &entry.state {
+            State::Closed {
+                consecutive_failures,
+            } => {
+                let next = consecutive_failures + 1;
+                if next >= FAILURE_THRESHOLD {
+                    tracing::warn!(
+                        key,
+                        consecutive = next,
+                        "hook_circuit_breaker: opening circuit after {} consecutive blocks",
+                        next
+                    );
+                    entry.state = State::Open {
+                        opened_at: Instant::now(),
+                    };
+                } else {
+                    entry.state = State::Closed {
+                        consecutive_failures: next,
+                    };
+                }
+            }
+            State::HalfOpen => {
+                tracing::warn!(
+                    key,
+                    "hook_circuit_breaker: probe failed, re-opening circuit"
+                );
+                entry.state = State::Open {
+                    opened_at: Instant::now(),
+                };
+            }
+            State::Open { .. } => {}
+        }
+    }
+
+    /// Record a pass outcome (no violations). Resets the failure counter and
+    /// closes the circuit if it was half-open.
+    pub fn record_pass(&self, key: &str) {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(key.to_string()).or_insert_with(Entry::new);
+        if matches!(entry.state, State::HalfOpen) {
+            tracing::info!(key, "hook_circuit_breaker: probe passed, closing circuit");
+        }
+        entry.state = State::Closed {
+            consecutive_failures: 0,
+        };
+    }
+
+    /// Returns `true` when the circuit for `key` is currently open (auto-passing).
+    #[cfg(test)]
+    pub fn is_open(&self, key: &str) -> bool {
+        let map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        matches!(map.get(key).map(|e| &e.state), Some(State::Open { .. }))
+    }
+
+    /// Returns the consecutive failure count for `key` when the circuit is closed.
+    #[cfg(test)]
+    pub fn consecutive_failures(&self, key: &str) -> u32 {
+        let map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        match map.get(key).map(|e| &e.state) {
+            Some(State::Closed {
+                consecutive_failures,
+            }) => *consecutive_failures,
+            _ => 0,
+        }
+    }
+}
+
+impl Default for CircuitBreaker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circuit_starts_closed_and_allows() {
+        let cb = CircuitBreaker::new();
+        assert!(cb.allow("sess-1"));
+    }
+
+    #[test]
+    fn opens_after_failure_threshold() {
+        let cb = CircuitBreaker::new();
+        let key = "sess-open";
+        for _ in 0..FAILURE_THRESHOLD {
+            assert!(cb.allow(key));
+            cb.record_block(key);
+        }
+        assert!(
+            cb.is_open(key),
+            "circuit must be open after threshold blocks"
+        );
+        assert!(!cb.allow(key), "open circuit must deny enforcement");
+    }
+
+    #[test]
+    fn pass_resets_consecutive_counter() {
+        let cb = CircuitBreaker::new();
+        let key = "sess-reset";
+        cb.record_block(key);
+        cb.record_block(key);
+        assert_eq!(cb.consecutive_failures(key), 2);
+        cb.record_pass(key);
+        assert_eq!(cb.consecutive_failures(key), 0);
+        assert!(!cb.is_open(key));
+    }
+
+    #[test]
+    fn below_threshold_stays_closed() {
+        let cb = CircuitBreaker::new();
+        let key = "sess-below";
+        for _ in 0..(FAILURE_THRESHOLD - 1) {
+            cb.record_block(key);
+        }
+        assert!(!cb.is_open(key));
+        assert!(cb.allow(key));
+    }
+
+    #[test]
+    fn open_circuit_auto_passes() {
+        let cb = CircuitBreaker::new();
+        let key = "sess-autopass";
+        for _ in 0..FAILURE_THRESHOLD {
+            cb.record_block(key);
+        }
+        // Circuit is open — allow() returns false (caller skips enforcement,
+        // which means auto-pass for the agent).
+        assert!(!cb.allow(key));
+    }
+}

--- a/crates/harness-server/src/hook_enforcer.rs
+++ b/crates/harness-server/src/hook_enforcer.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::circuit_breaker::CircuitBreaker;
+
 /// Post-tool-use hook enforcer.
 ///
 /// When `enabled`, this interceptor fires after each agent turn, detects files
@@ -16,14 +18,34 @@ use tokio::sync::RwLock;
 /// registered guards, logs a `hook_enforcement` event to the [`EventStore`],
 /// and returns any violations as feedback for the agent's next turn prompt.
 ///
+/// ## Infinite-loop protection (circuit breaker)
+///
+/// The enforcer embeds a [`CircuitBreaker`] that tracks consecutive block
+/// counts per session. After 3 consecutive blocks the circuit opens and all
+/// subsequent calls auto-pass for 5 minutes, preventing the analysis-paralysis
+/// loop described in GitHub issues #3573 and #10205.
+///
+/// This mirrors the role of Claude Code's `stop_hook_active` input field: once
+/// the circuit is open the enforcer stops emitting blocking signals, breaking
+/// the loop.
+///
+/// ## CI guard
+///
+/// When the `CI` environment variable is set the enforcer skips all
+/// enforcement unconditionally. Desktop-specific hooks must not run in CI
+/// environments (GitHub issue #3573).
+///
 /// The enforcer silently passes through when:
 /// - `enabled` is `false` (controlled by `rules.hook_enforcement` in config)
+/// - `CI` environment variable is set
 /// - no guards are registered
 /// - no files were modified during the turn
+/// - the circuit breaker is open (consecutive-block limit reached)
 pub struct HookEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
     events: Arc<EventStore>,
     enabled: bool,
+    breaker: CircuitBreaker,
 }
 
 impl HookEnforcer {
@@ -32,6 +54,7 @@ impl HookEnforcer {
             rules,
             events,
             enabled,
+            breaker: CircuitBreaker::new(),
         }
     }
 
@@ -71,6 +94,17 @@ impl HookEnforcer {
             }
         }
     }
+
+    /// Returns the circuit-breaker key for a session.
+    ///
+    /// Uses the session ID when available so each agent session has its own
+    /// failure counter. Falls back to a shared key when the session is unknown.
+    fn breaker_key(session_id: Option<&SessionId>) -> String {
+        match session_id {
+            Some(sid) => format!("session:{sid}"),
+            None => "global".to_string(),
+        }
+    }
 }
 
 #[async_trait]
@@ -86,16 +120,36 @@ impl TurnInterceptor for HookEnforcer {
     /// Scan `event.affected_files` with all registered guards, log a
     /// `hook_enforcement` event to the [`EventStore`], and return violation
     /// feedback when violations are found.
+    ///
+    /// Auto-passes (returns clean) when the CI environment variable is set or
+    /// when the per-session circuit breaker has opened due to repeated blocks.
     async fn post_tool_use(&self, event: &ToolUseEvent, project_root: &Path) -> PostToolUseResult {
         if !self.enabled {
             return PostToolUseResult::clean();
         }
+
+        // CI guard: skip all enforcement in CI environments (#3573).
+        if std::env::var("CI").is_ok() {
+            return PostToolUseResult::clean();
+        }
+
         if event.affected_files.is_empty() {
             return PostToolUseResult::clean();
         }
 
         let engine = self.rules.read().await;
         if engine.guards().is_empty() {
+            return PostToolUseResult::clean();
+        }
+
+        // Circuit breaker: auto-pass when the consecutive-block limit has been
+        // reached (stop_hook_active equivalent — prevents infinite loops).
+        let key = Self::breaker_key(event.session_id.as_ref());
+        if !self.breaker.allow(&key) {
+            tracing::warn!(
+                session = %key,
+                "hook_enforcer: circuit open, auto-passing to break enforcement loop"
+            );
             return PostToolUseResult::clean();
         }
 
@@ -134,8 +188,11 @@ impl TurnInterceptor for HookEnforcer {
         }
 
         if violations.is_empty() {
+            self.breaker.record_pass(&key);
             return PostToolUseResult::clean();
         }
+
+        self.breaker.record_block(&key);
 
         let feedback = violations
             .iter()
@@ -313,6 +370,70 @@ mod tests {
         let rules = Arc::new(RwLock::new(RuleEngine::new()));
         let enforcer = HookEnforcer::new(rules, events, false);
         assert_eq!(enforcer.name(), "hook_enforcer");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn circuit_breaker_opens_after_repeated_blocks() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let events = make_event_store(dir.path()).await;
+        let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project)?;
+
+        let sid = SessionId::new();
+        let enforcer = HookEnforcer::new(rules, events, true);
+        let event = ToolUseEvent {
+            tool_name: "write_file".to_string(),
+            affected_files: vec![PathBuf::from("src/main.rs")],
+            session_id: Some(sid.clone()),
+        };
+
+        // First two blocks: violations returned, circuit still closed.
+        for _ in 0..2 {
+            let result = enforcer.post_tool_use(&event, &project).await;
+            assert!(
+                result.violation_feedback.is_some(),
+                "should return violations before circuit opens"
+            );
+        }
+
+        // Third block: circuit opens.
+        let _ = enforcer.post_tool_use(&event, &project).await;
+
+        // Fourth call: circuit is open — auto-pass (no violation feedback).
+        let result = enforcer.post_tool_use(&event, &project).await;
+        assert!(
+            result.violation_feedback.is_none(),
+            "open circuit must auto-pass to break the enforcement loop"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ci_env_skips_enforcement() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let events = make_event_store(dir.path()).await;
+        let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project)?;
+
+        let enforcer = HookEnforcer::new(rules, events, true);
+        let event = ToolUseEvent {
+            tool_name: "write_file".to_string(),
+            affected_files: vec![PathBuf::from("src/main.rs")],
+            session_id: None,
+        };
+
+        // SAFETY: test process only; env mutation isolated by unique var name.
+        unsafe { std::env::set_var("CI", "true") };
+        let result = enforcer.post_tool_use(&event, &project).await;
+        unsafe { std::env::remove_var("CI") };
+
+        assert!(
+            result.violation_feedback.is_none(),
+            "CI environment must bypass hook enforcement"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::unnecessary_to_owned
 )]
 
+pub mod circuit_breaker;
 pub mod complexity_router;
 pub mod contract_validator;
 pub mod dashboard;


### PR DESCRIPTION
## Summary

- Add `circuit_breaker.rs`: Martin Fowler–style state machine (CLOSED→OPEN→HALF-OPEN) that tracks consecutive block counts per session
- After ≥3 consecutive blocks the circuit opens and auto-passes for 5 minutes, breaking the enforcement loop (issues #3573, #10205)
- Add CI guard in `HookEnforcer::post_tool_use`: skip all enforcement when `$CI` is set (prevents CI environment failures)
- 8 tests: all original tests preserved + 2 new tests (`circuit_breaker_opens_after_repeated_blocks`, `ci_env_skips_enforcement`)

## Test plan

- [x] `cargo test --package harness-server hook_enforcer` — 8/8 pass
- [x] `cargo fmt --all` — no changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean