### PR TITLE
fix: WAITING responses no longer consume review rounds

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -997,8 +997,10 @@ pub(crate) async fn run_task(
 
     let review_phase_start = Instant::now();
 
-    // Review loop
-    for round in 1..=req.max_rounds {
+    // Review loop — use a manual counter so WAITING responses don't consume a round.
+    // A `for` loop would increment `round` on every `continue`, including WAITING paths.
+    let mut round = 1u32;
+    while round <= req.max_rounds {
         update_status(store, task_id, TaskStatus::Reviewing, round).await?;
 
         let check_req = AgentRequest {
@@ -1158,6 +1160,7 @@ pub(crate) async fn run_task(
             update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
             sleep(Duration::from_secs(wait_secs)).await;
         }
+        round += 1;
     }
 
     mutate_and_persist(store, task_id, |s| {


### PR DESCRIPTION
## Summary
- Replaces `for round in 1..=max_rounds` with a `while` loop and explicit `round += 1` at end of body
- Previously `continue` on WAITING paths still advanced the for-loop counter, silently consuming a review round on every bot-not-ready retry
- WAITING retries now correctly stay on the same round number

Closes #550