### PR TITLE
feat: task cancellation API and dashboard Cancel button

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1087,6 +1087,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         .route("/tasks", get(list_tasks))
         .route("/tasks/batch", post(task_routes::create_tasks_batch))
         .route("/tasks/{id}", get(get_task))
+        .route("/tasks/{id}/cancel", post(task_routes::cancel_task))
         .route("/tasks/{id}/artifacts", get(get_task_artifacts))
         .route("/tasks/{id}/stream", get(stream_task_sse))
         .route(

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -495,6 +495,59 @@ pub(super) async fn create_task(
     }
 }
 
+/// POST /tasks/{id}/cancel — abort a running task.
+///
+/// Sets task status to `Cancelled` then aborts the Tokio future (which kills
+/// the child CLI process via `kill_on_drop(true)`).  Returns 409 if the task
+/// is already in a terminal state.
+pub(super) async fn cancel_task(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    use task_runner::TaskStatus;
+
+    let task_id = harness_core::types::TaskId(id);
+
+    let task = match state.core.tasks.get(&task_id) {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "task not found" })),
+            );
+        }
+    };
+
+    if matches!(
+        task.status,
+        TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+    ) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "task already in terminal state" })),
+        );
+    }
+
+    // Persist Cancelled status before aborting the future so the watcher sees
+    // it and skips the record_task_failure path.
+    if let Err(e) = task_runner::mutate_and_persist(&state.core.tasks, &task_id, |s| {
+        s.status = TaskStatus::Cancelled;
+    })
+    .await
+    {
+        tracing::error!("cancel_task: failed to persist Cancelled for {task_id:?}: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "failed to persist cancellation" })),
+        );
+    }
+
+    // abort() is a no-op if the task already finished — safe to call unconditionally.
+    state.core.tasks.abort_task(&task_id);
+
+    (StatusCode::OK, Json(json!({ "status": "cancelled" })))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/harness-server/src/intake/feishu.rs
+++ b/crates/harness-server/src/intake/feishu.rs
@@ -149,6 +149,7 @@ impl IntakeSource for FeishuIntake {
                 "Task failed: {}",
                 result.error.as_deref().unwrap_or("unknown error")
             ),
+            TaskStatus::Cancelled => return Ok(()),
             _ => return Ok(()),
         };
 
@@ -161,7 +162,10 @@ impl IntakeSource for FeishuIntake {
             }
         }
 
-        if matches!(result.status, TaskStatus::Done | TaskStatus::Failed) {
+        if matches!(
+            result.status,
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+        ) {
             self.dispatched.remove(external_id);
             self.chat_ids.remove(external_id);
         }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -52,6 +52,7 @@ pub enum TaskStatus {
     Reviewing,
     Done,
     Failed,
+    Cancelled,
 }
 
 impl AsRef<str> for TaskStatus {
@@ -65,6 +66,7 @@ impl AsRef<str> for TaskStatus {
             TaskStatus::Reviewing => "reviewing",
             TaskStatus::Done => "done",
             TaskStatus::Failed => "failed",
+            TaskStatus::Cancelled => "cancelled",
         }
     }
 }
@@ -82,6 +84,7 @@ impl std::str::FromStr for TaskStatus {
             "reviewing" => Ok(TaskStatus::Reviewing),
             "done" => Ok(TaskStatus::Done),
             "failed" => Ok(TaskStatus::Failed),
+            "cancelled" => Ok(TaskStatus::Cancelled),
             _ => anyhow::bail!("unknown task status `{s}`"),
         }
     }
@@ -512,6 +515,8 @@ pub struct TaskStore {
     persist_locks: DashMap<TaskId, Arc<Mutex<()>>>,
     /// Per-task broadcast channels for real-time stream forwarding to SSE clients.
     stream_txs: DashMap<TaskId, broadcast::Sender<StreamItem>>,
+    /// Per-task abort handles for cooperative cancellation via Tokio task abort.
+    abort_handles: DashMap<TaskId, tokio::task::AbortHandle>,
     /// Global circuit breaker: when the CLI account-level limit is hit,
     /// all tasks pause until this instant passes.
     rate_limit_until: RwLock<Option<tokio::time::Instant>>,
@@ -539,6 +544,7 @@ impl TaskStore {
             db,
             persist_locks,
             stream_txs: DashMap::new(),
+            abort_handles: DashMap::new(),
             rate_limit_until: RwLock::new(None),
         });
         Ok(store)
@@ -629,6 +635,29 @@ impl TaskStore {
     /// Remove the task's stream channel after execution completes.
     pub(crate) fn close_task_stream(&self, id: &TaskId) {
         self.stream_txs.remove(id);
+    }
+
+    /// Store the abort handle for a running task so it can be cancelled later.
+    pub(crate) fn store_abort_handle(&self, id: &TaskId, handle: tokio::task::AbortHandle) {
+        self.abort_handles.insert(id.clone(), handle);
+    }
+
+    /// Remove and discard the abort handle when the task finishes normally.
+    pub(crate) fn remove_abort_handle(&self, id: &TaskId) {
+        self.abort_handles.remove(id);
+    }
+
+    /// Abort the running task's Tokio future, if one is registered.
+    /// The `kill_on_drop(true)` flag on child processes ensures the CLI subprocess
+    /// is also killed when the future is dropped after abort.
+    /// Returns `true` if an abort handle was found and triggered.
+    pub fn abort_task(&self, id: &TaskId) -> bool {
+        if let Some(handle) = self.abort_handles.get(id) {
+            handle.abort();
+            true
+        } else {
+            false
+        }
     }
 
     /// Activate the global rate-limit circuit breaker. All tasks will pause
@@ -1031,6 +1060,10 @@ where
     let id_watcher = id.clone();
     let interceptors = Arc::new(interceptors);
     let detect_worktree = Arc::new(detect_worktree);
+    // Clones used to store the abort handle after the main future is spawned
+    // (store and id are moved into the spawn closure).
+    let store_for_abort = store.clone();
+    let id_for_abort = id.clone();
 
     let handle = tokio::spawn(async move {
         // Hold both permits for the task's lifetime so that the group serialisation
@@ -1295,6 +1328,11 @@ where
         task_result
     });
 
+    // Store abort handle before the watcher consumes the JoinHandle, so the
+    // cancel endpoint can abort the task's Tokio future (which also kills the
+    // child process via kill_on_drop(true)).
+    store_for_abort.store_abort_handle(&id_for_abort, handle.abort_handle());
+
     tokio::spawn(async move {
         match handle.await {
             Ok(Ok(())) => {}
@@ -1302,12 +1340,18 @@ where
                 record_task_failure(&store_watcher, &events_watcher, &id_watcher, e.to_string())
                     .await;
             }
+            Err(join_err) if join_err.is_cancelled() => {
+                // abort() was called by the cancel endpoint; status already set to
+                // Cancelled before abort() was called — do not overwrite with Failed.
+                tracing::info!("task {id_watcher:?} cancelled via abort");
+            }
             Err(join_err) => {
-                tracing::error!("task {id_watcher:?} panicked or was cancelled: {join_err}");
+                tracing::error!("task {id_watcher:?} panicked: {join_err}");
                 let reason = format!("task failed unexpectedly: {join_err}");
                 record_task_failure(&store_watcher, &events_watcher, &id_watcher, reason).await;
             }
         }
+        store_watcher.remove_abort_handle(&id_watcher);
         // Close the stream channel so SSE clients receive EOF.
         store_watcher.close_task_stream(&id_watcher);
         if let Some(cb) = completion_callback {

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -322,6 +322,10 @@ function showDetail(task) {
   if (task.source) body += `<span class="source-badge source-badge-${escapeHtml(task.source)}">${escapeHtml(task.source)}</span>`;
   if (task.repo) body += `<span class="repo-badge">${escapeHtml(task.repo)}</span>`;
   if (task.phase && task.phase !== "implement") body += `<span class="phase-badge">${escapeHtml(task.phase)}</span>`;
+  const ACTIVE_STATUSES = ["pending", "awaiting_deps", "implementing", "agent_review", "waiting", "reviewing"];
+  if (ACTIVE_STATUSES.includes(status)) {
+    body += `<button class="cancel-btn" data-task-id="${escapeHtml(task.id || "")}">Cancel</button>`;
+  }
   body += `</div>`;
 
   body += `<table class="detail-table">`;
@@ -362,6 +366,27 @@ function showDetail(task) {
   }
 
   document.getElementById("detail-body").innerHTML = body;
+
+  const cancelBtn = document.querySelector(".cancel-btn[data-task-id]");
+  if (cancelBtn) {
+    cancelBtn.addEventListener("click", async () => {
+      const taskId = cancelBtn.dataset.taskId;
+      if (!confirm(`Cancel task ${taskId}?`)) return;
+      try {
+        const resp = await fetch(`/tasks/${encodeURIComponent(taskId)}/cancel`, { method: "POST" });
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          alert(`Cancel failed: ${body.error || resp.status}`);
+          return;
+        }
+        closeDetail();
+        fetchTasks();
+      } catch (e) {
+        alert(`Cancel failed: ${e}`);
+      }
+    });
+  }
+
   panel.classList.add("detail-panel-open");
   document.body.style.overflow = "hidden";
 }


### PR DESCRIPTION
## Summary

- Adds `TaskStatus::Cancelled` variant with full DB round-trip support
- `POST /tasks/{id}/cancel` sets status to `Cancelled`, then aborts the Tokio future — the `kill_on_drop(true)` flag on all CLI child processes ensures the agent process is killed immediately
- Dashboard Cancel button appears for active-status tasks with a confirm dialog; refreshes the task list after cancellation
- Watcher correctly skips `record_task_failure` when abort is intentional (`JoinError::is_cancelled()`)

Closes #579