### PR TITLE
feat: add runtime host lifecycle and persistence

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -253,6 +253,19 @@ mod tests {
             .collect()
     }
 
+    async fn wait_for_path(path: &std::path::Path, timeout_duration: Duration) -> bool {
+        timeout(timeout_duration, async {
+            loop {
+                if path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
     #[test]
     fn base_args_full_profile_uses_dangerously_skip_permissions() {
         let agent = ClaudeCodeAgent::new(
@@ -627,12 +640,14 @@ printf 'second\n'
     #[tokio::test]
     async fn execute_stream_timeout_drop_does_not_leave_hanging_process() {
         let dir = tempfile::tempdir().expect("create tempdir");
+        let started_marker = dir.path().join("timeout-started.txt");
         let marker = dir.path().join("timeout-marker.txt");
         let script = dir.path().join("mock-claude-timeout.sh");
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nset -eu\nsleep 5\necho reached > \"{}\"\n",
+                "#!/bin/sh\nset -eu\necho started > \"{}\"\nsleep 5\necho reached > \"{}\"\n",
+                started_marker.display(),
                 marker.display()
             ),
         )
@@ -658,18 +673,27 @@ printf 'second\n'
             ..AgentRequest::default()
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let handle = tokio::spawn(async move { agent.execute_stream(request, tx).await });
 
-        let timed = timeout(
-            Duration::from_millis(500),
-            agent.execute_stream(request, tx),
-        )
-        .await;
-        assert!(timed.is_err(), "expected timeout on long-running stream");
+        if !wait_for_path(&started_marker, Duration::from_secs(10)).await {
+            let outcome = timeout(Duration::from_secs(1), handle).await;
+            panic!("stream process did not stay alive long enough to observe startup: {outcome:?}");
+        }
+
+        handle.abort();
+        let join_err = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("aborted execute_stream task should resolve")
+            .expect_err("aborted execute_stream task should not return successfully");
+        assert!(
+            join_err.is_cancelled(),
+            "expected cancelled join error after abort, got: {join_err}"
+        );
 
         tokio::time::sleep(Duration::from_millis(200)).await;
         assert!(
             !marker.exists(),
-            "process should be killed when stream future is dropped on timeout"
+            "process should be killed when stream future is dropped"
         );
     }
 }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -286,6 +286,19 @@ mod tests {
         (dir, path)
     }
 
+    async fn wait_for_path(path: &std::path::Path, timeout_duration: Duration) -> bool {
+        timeout(timeout_duration, async {
+            loop {
+                if path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
     #[tokio::test]
     async fn execute_stream_returns_error_when_channel_closed() {
         let agent = CodexAgent::new(
@@ -430,12 +443,14 @@ printf 'third\n'
     #[tokio::test]
     async fn execute_stream_timeout_drop_does_not_leave_hanging_process() {
         let dir = tempfile::tempdir().expect("create tempdir");
+        let started_marker = dir.path().join("timeout-started.txt");
         let marker = dir.path().join("timeout-marker.txt");
         let script = dir.path().join("mock-codex-timeout.sh");
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nset -eu\nsleep 5\necho reached > \"{}\"\n",
+                "#!/bin/sh\nset -eu\necho started > \"{}\"\nsleep 5\necho reached > \"{}\"\n",
+                started_marker.display(),
                 marker.display()
             ),
         )
@@ -457,18 +472,27 @@ printf 'third\n'
             ..AgentRequest::default()
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let handle = tokio::spawn(async move { agent.execute_stream(request, tx).await });
 
-        let timed = timeout(
-            Duration::from_millis(500),
-            agent.execute_stream(request, tx),
-        )
-        .await;
-        assert!(timed.is_err(), "expected timeout on long-running stream");
+        if !wait_for_path(&started_marker, Duration::from_secs(10)).await {
+            let outcome = timeout(Duration::from_secs(1), handle).await;
+            panic!("stream process did not stay alive long enough to observe startup: {outcome:?}");
+        }
+
+        handle.abort();
+        let join_err = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("aborted execute_stream task should resolve")
+            .expect_err("aborted execute_stream task should not return successfully");
+        assert!(
+            join_err.is_cancelled(),
+            "expected cancelled join error after abort, got: {join_err}"
+        );
 
         tokio::time::sleep(Duration::from_millis(200)).await;
         assert!(
             !marker.exists(),
-            "process should be killed when stream future is dropped on timeout"
+            "process should be killed when stream future is dropped"
         );
     }
 

--- a/crates/harness-server/src/dashboard.rs
+++ b/crates/harness-server/src/dashboard.rs
@@ -86,6 +86,10 @@ pub async fn index(State(state): State<Arc<crate::http::AppState>>) -> impl Into
 <div id="tab-channels" class="tab-panel">
   <div id="pipeline-row" class="pipeline-row"></div>
   <div id="channel-grid" class="channel-grid"></div>
+  <div class="runtime-hosts-section">
+    <h3 class="section-subtitle">Runtime Hosts</h3>
+    <div id="runtime-host-grid" class="channel-grid"></div>
+  </div>
 </div>
 
 <div id="tab-submit" class="tab-panel">

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -97,8 +97,35 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         },
     };
 
+    let runtime_hosts: Vec<Value> = state
+        .runtime_hosts
+        .list_hosts()
+        .into_iter()
+        .map(|host| {
+            let watched_projects = state
+                .runtime_project_cache
+                .get_host_cache(&host.id)
+                .map(|snapshot| snapshot.project_count)
+                .unwrap_or(0);
+            json!({
+                "id": host.id,
+                "display_name": host.display_name,
+                "capabilities": host.capabilities,
+                "online": host.online,
+                "last_heartbeat_at": host.last_heartbeat_at,
+                "watched_projects": watched_projects,
+            })
+        })
+        .collect();
+    let runtime_hosts_total = runtime_hosts.len() as u64;
+    let runtime_hosts_online = runtime_hosts
+        .iter()
+        .filter(|host| host["online"].as_bool().unwrap_or(false))
+        .count() as u64;
+
     let body = json!({
         "projects": projects,
+        "runtime_hosts": runtime_hosts,
         "global": {
             "running": tq.running_count(),
             "queued": tq.queued_count(),
@@ -108,6 +135,8 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
             "failed": global_failed,
             "latest_pr": latest_pr,
             "grade": grade,
+            "runtime_hosts_total": runtime_hosts_total,
+            "runtime_hosts_online": runtime_hosts_online,
         }
     });
 
@@ -165,6 +194,12 @@ mod tests {
         assert!(global.get("uptime_secs").is_some());
         assert!(global.get("done").is_some());
         assert!(global.get("failed").is_some());
+        assert!(global.get("runtime_hosts_total").is_some());
+        assert!(global.get("runtime_hosts_online").is_some());
+        assert!(body
+            .get("runtime_hosts")
+            .and_then(|v| v.as_array())
+            .is_some());
 
         Ok(())
     }

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -9,9 +9,17 @@ pub mod observe;
 pub mod preflight;
 pub mod projects;
 pub mod rules;
+pub mod runtime_hosts;
+pub mod runtime_project_cache;
 pub mod skills;
 pub mod thread;
 pub mod token_usage;
+
+#[cfg(test)]
+mod runtime_project_cache_api_tests;
+
+#[cfg(test)]
+mod runtime_hosts_api_tests;
 
 /// Validate a project root path, returning early with an `INTERNAL_ERROR`
 /// response on failure.

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -116,6 +116,12 @@ pub async fn claim_task_for_runtime_host(
         );
     }
 
+    let project_filter = req
+        .project
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
     let mut tasks: Vec<ClaimCandidate> = state
         .core
         .tasks
@@ -127,6 +133,10 @@ pub async fn claim_task_for_runtime_host(
             status: task.status,
             created_at: task.created_at,
             project: task.project_root.map(|p| p.to_string_lossy().into_owned()),
+        })
+        .filter(|candidate| match project_filter {
+            Some(filter) => candidate.project.as_deref() == Some(filter),
+            None => true,
         })
         .collect();
     tasks.sort_by(|a, b| {

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -109,7 +109,14 @@ pub async fn claim_task_for_runtime_host(
     Path(host_id): Path<String>,
     Json(req): Json<ClaimTaskRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let tasks = state
+    if !state.runtime_hosts.hosts.contains_key(&host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
+        );
+    }
+
+    let mut tasks: Vec<ClaimCandidate> = state
         .core
         .tasks
         .list_all()
@@ -122,6 +129,11 @@ pub async fn claim_task_for_runtime_host(
             project: task.project_root.map(|p| p.to_string_lossy().into_owned()),
         })
         .collect();
+    tasks.sort_by(|a, b| {
+        a.created_at
+            .cmp(&b.created_at)
+            .then_with(|| a.task_id.as_str().cmp(b.task_id.as_str()))
+    });
 
     let lease_secs = match req.lease_secs {
         Some(value) => match i64::try_from(value) {
@@ -135,44 +147,59 @@ pub async fn claim_task_for_runtime_host(
         },
         None => None,
     };
-    match state
-        .runtime_hosts
-        .claim_task(&host_id, tasks, lease_secs, req.project.as_deref())
-    {
-        Ok(Some(claim)) => {
-            if let Err((_, Json(error_body))) = persist_runtime_state(&state).await {
-                tracing::error!(
-                    host_id = %host_id,
-                    task_id = %claim.task_id,
-                    error = %error_body["error"].as_str().unwrap_or("unknown persistence error"),
-                    "runtime claim persisted in memory but runtime state persistence failed"
+
+    for candidate in tasks {
+        let live_claim = state
+            .core
+            .tasks
+            .with_task_if_pending(&candidate.task_id, || {
+                state
+                    .runtime_hosts
+                    .claim_task_id(&host_id, &candidate.task_id, lease_secs)
+            });
+        let Some(claim_result) = live_claim else {
+            continue;
+        };
+        match claim_result {
+            Ok(Some(claim)) => {
+                if let Err((_, Json(error_body))) = persist_runtime_state(&state).await {
+                    tracing::error!(
+                        host_id = %host_id,
+                        task_id = %claim.task_id,
+                        error = %error_body["error"].as_str().unwrap_or("unknown persistence error"),
+                        "runtime claim persisted in memory but runtime state persistence failed"
+                    );
+                }
+                return (
+                    StatusCode::OK,
+                    Json(json!({
+                        "claimed": true,
+                        "task_id": claim.task_id,
+                        "lease_expires_at": claim.lease_expires_at
+                    })),
                 );
             }
-            (
-                StatusCode::OK,
-                Json(json!({
-                    "claimed": true,
-                    "task_id": claim.task_id,
-                    "lease_expires_at": claim.lease_expires_at
-                })),
-            )
+            Ok(None) => continue,
+            Err(e) => return claim_task_error_response(e),
         }
-        Ok(None) => {
-            if let Err(response) = persist_runtime_state(&state).await {
-                return response;
-            }
-            (StatusCode::OK, Json(json!({ "claimed": false })))
-        }
-        Err(e) => match e {
-            ClaimTaskError::HostNotRegistered(_) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({ "error": e.to_string() })),
-            ),
-            ClaimTaskError::LeaseTtlOutOfRange(_) => (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": e.to_string() })),
-            ),
-        },
+    }
+
+    if let Err(response) = persist_runtime_state(&state).await {
+        return response;
+    }
+    (StatusCode::OK, Json(json!({ "claimed": false })))
+}
+
+fn claim_task_error_response(e: ClaimTaskError) -> (StatusCode, Json<serde_json::Value>) {
+    match e {
+        ClaimTaskError::HostNotRegistered(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": e.to_string() })),
+        ),
+        ClaimTaskError::LeaseTtlOutOfRange(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        ),
     }
 }
 

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -119,8 +119,13 @@ pub async fn claim_task_for_runtime_host(
         .claim_task(&host_id, tasks, lease_secs, req.project.as_deref())
     {
         Ok(Some(claim)) => {
-            if let Err(response) = persist_runtime_state(&state).await {
-                return response;
+            if let Err((_, Json(error_body))) = persist_runtime_state(&state).await {
+                tracing::error!(
+                    host_id = %host_id,
+                    task_id = %claim.task_id,
+                    error = %error_body["error"].as_str().unwrap_or("unknown persistence error"),
+                    "runtime claim persisted in memory but runtime state persistence failed"
+                );
             }
             (
                 StatusCode::OK,

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -57,12 +57,7 @@ pub async fn heartbeat_runtime_host(
     Path(host_id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     match state.runtime_hosts.heartbeat(&host_id) {
-        Ok(host) => {
-            if let Err(response) = persist_runtime_state(&state).await {
-                return response;
-            }
-            (StatusCode::OK, Json(json!({ "host": host })))
-        }
+        Ok(host) => (StatusCode::OK, Json(json!({ "host": host }))),
         Err(e) => (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": e.to_string() })),
@@ -98,6 +93,7 @@ pub async fn claim_task_for_runtime_host(
         .tasks
         .list_all()
         .into_iter()
+        .filter(|task| task.status.as_ref() == "pending")
         .map(|task| ClaimCandidate {
             task_id: task.id,
             status: task.status,
@@ -106,7 +102,18 @@ pub async fn claim_task_for_runtime_host(
         })
         .collect();
 
-    let lease_secs = req.lease_secs.map(|s| s as i64);
+    let lease_secs = match req.lease_secs {
+        Some(value) => match i64::try_from(value) {
+            Ok(v) => Some(v),
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": "lease_secs must be <= i64::MAX" })),
+                )
+            }
+        },
+        None => None,
+    };
     match state
         .runtime_hosts
         .claim_task(&host_id, tasks, lease_secs, req.project.as_deref())

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -57,7 +57,21 @@ pub async fn heartbeat_runtime_host(
     Path(host_id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     match state.runtime_hosts.heartbeat(&host_id) {
-        Ok(host) => (StatusCode::OK, Json(json!({ "host": host }))),
+        Ok(host) => {
+            // Heartbeat is intentionally not persisted (transient data, self-healing
+            // after restart).  However if a prior mutation left the dirty flag, piggyback
+            // on this frequent call to converge durable state.
+            if state.is_runtime_state_dirty() {
+                if let Err(e) = state.persist_runtime_state().await {
+                    tracing::warn!(
+                        host_id = %host_id,
+                        error = %e,
+                        "opportunistic dirty-state flush on heartbeat failed; will retry next heartbeat"
+                    );
+                }
+            }
+            (StatusCode::OK, Json(json!({ "host": host })))
+        }
         Err(e) => (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": e.to_string() })),
@@ -76,6 +90,13 @@ pub async fn deregister_runtime_host(
         }
         (StatusCode::OK, Json(json!({ "deregistered": true })))
     } else {
+        // Host already gone from memory (idempotent retry).  If a prior
+        // deregister mutated memory but failed to persist, converge now.
+        if state.is_runtime_state_dirty() {
+            if let Err(response) = persist_runtime_state(&state).await {
+                return response;
+            }
+        }
         (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "runtime host not found" })),

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -1,0 +1,151 @@
+use crate::http::AppState;
+use crate::runtime_hosts::ClaimCandidate;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRuntimeHostRequest {
+    pub host_id: String,
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaimTaskRequest {
+    pub lease_secs: Option<u64>,
+    pub project: Option<String>,
+}
+
+pub async fn list_runtime_hosts(
+    State(state): State<Arc<AppState>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let hosts = state.runtime_hosts.list_hosts();
+    (StatusCode::OK, Json(json!({ "hosts": hosts })))
+}
+
+pub async fn register_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RegisterRuntimeHostRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let host_id = req.host_id.trim();
+    if host_id.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "host_id must not be empty" })),
+        );
+    }
+    let host = state.runtime_hosts.register(
+        host_id.to_string(),
+        req.display_name.map(|v| v.trim().to_string()),
+        req.capabilities,
+    );
+    if let Err(response) = persist_runtime_state(&state).await {
+        return response;
+    }
+    (StatusCode::OK, Json(json!({ "host": host })))
+}
+
+pub async fn heartbeat_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match state.runtime_hosts.heartbeat(&host_id) {
+        Ok(host) => {
+            if let Err(response) = persist_runtime_state(&state).await {
+                return response;
+            }
+            (StatusCode::OK, Json(json!({ "host": host })))
+        }
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+pub async fn deregister_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if state.runtime_hosts.deregister(&host_id) {
+        state.runtime_project_cache.clear_host(&host_id);
+        if let Err(response) = persist_runtime_state(&state).await {
+            return response;
+        }
+        (StatusCode::OK, Json(json!({ "deregistered": true })))
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "runtime host not found" })),
+        )
+    }
+}
+
+pub async fn claim_task_for_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+    Json(req): Json<ClaimTaskRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let tasks = state
+        .core
+        .tasks
+        .list_all()
+        .into_iter()
+        .map(|task| ClaimCandidate {
+            task_id: task.id,
+            status: task.status,
+            created_at: task.created_at,
+            project: task.project_root.map(|p| p.to_string_lossy().into_owned()),
+        })
+        .collect();
+
+    let lease_secs = req.lease_secs.map(|s| s as i64);
+    match state
+        .runtime_hosts
+        .claim_task(&host_id, tasks, lease_secs, req.project.as_deref())
+    {
+        Ok(Some(claim)) => {
+            if let Err(response) = persist_runtime_state(&state).await {
+                return response;
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "claimed": true,
+                    "task_id": claim.task_id,
+                    "lease_expires_at": claim.lease_expires_at
+                })),
+            )
+        }
+        Ok(None) => {
+            if let Err(response) = persist_runtime_state(&state).await {
+                return response;
+            }
+            (StatusCode::OK, Json(json!({ "claimed": false })))
+        }
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+async fn persist_runtime_state(
+    state: &Arc<AppState>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if let Err(e) = state.persist_runtime_state().await {
+        tracing::error!("failed to persist runtime state after runtime host mutation: {e}");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("failed to persist runtime state: {e}") })),
+        ));
+    }
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -1,5 +1,5 @@
 use crate::http::AppState;
-use crate::runtime_hosts::ClaimCandidate;
+use crate::runtime_hosts::{ClaimCandidate, ClaimTaskError};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -142,10 +142,16 @@ pub async fn claim_task_for_runtime_host(
             }
             (StatusCode::OK, Json(json!({ "claimed": false })))
         }
-        Err(e) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": e.to_string() })),
-        ),
+        Err(e) => match e {
+            ClaimTaskError::HostNotRegistered(_) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": e.to_string() })),
+            ),
+            ClaimTaskError::LeaseTtlOutOfRange(_) => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": e.to_string() })),
+            ),
+        },
     }
 }
 

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -212,3 +212,69 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
     assert_eq!(json["error"], "lease_secs must be <= i64::MAX");
     Ok(())
 }
+
+#[tokio::test]
+async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let task = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        issue: None,
+        repo: None,
+        description: Some("pending task".to_string()),
+        created_at: Some("2026-04-02T00:00:00Z".to_string()),
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+    };
+    state.core.tasks.insert(&task).await;
+    let app = runtime_hosts_app(state);
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "host_id": "host-a" }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), axum::http::StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "lease_secs": i64::MAX as u64 }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+    let json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(response.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert!(json["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("too large to compute a valid expiration timestamp"));
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -149,3 +149,66 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
     assert_eq!(second_json["claimed"], false);
     Ok(())
 }
+
+#[tokio::test]
+async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let task = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        issue: None,
+        repo: None,
+        description: Some("pending task".to_string()),
+        created_at: Some("2026-04-02T00:00:00Z".to_string()),
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+    };
+    state.core.tasks.insert(&task).await;
+    let app = runtime_hosts_app(state);
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "host_id": "host-a" }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), axum::http::StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "lease_secs": u64::MAX }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+    let json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(response.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(json["error"], "lease_secs must be <= i64::MAX");
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -1,0 +1,151 @@
+use super::runtime_hosts;
+use axum::{
+    body::Body,
+    http::Request,
+    routing::{get, post},
+    Router,
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn runtime_hosts_app(state: Arc<crate::http::AppState>) -> Router {
+    Router::new()
+        .route("/api/runtime-hosts", get(runtime_hosts::list_runtime_hosts))
+        .route(
+            "/api/runtime-hosts/register",
+            post(runtime_hosts::register_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{id}/heartbeat",
+            post(runtime_hosts::heartbeat_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{id}/tasks/claim",
+            post(runtime_hosts::claim_task_for_runtime_host),
+        )
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn register_then_list_runtime_hosts() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let app = runtime_hosts_app(state);
+
+    let body = serde_json::json!({
+        "host_id": "host-a",
+        "display_name": "Host A",
+        "capabilities": ["claude", "codex"]
+    });
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(register.status(), axum::http::StatusCode::OK);
+
+    let list = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/runtime-hosts")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(list.status(), axum::http::StatusCode::OK);
+    let data = http_body_util::BodyExt::collect(list.into_body())
+        .await?
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&data)?;
+    assert_eq!(json["hosts"][0]["id"], "host-a");
+    assert_eq!(json["hosts"][0]["online"], true);
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let task = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        issue: None,
+        repo: None,
+        description: Some("pending task".to_string()),
+        created_at: Some("2026-04-02T00:00:00Z".to_string()),
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+    let app = runtime_hosts_app(state);
+
+    for host in ["host-a", "host-b"] {
+        let body = serde_json::json!({ "host_id": host });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/runtime-hosts/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))?,
+            )
+            .await?;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "lease_secs": 30 }).to_string(),
+                ))?,
+        )
+        .await?;
+    let first_json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(first.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(first_json["claimed"], true);
+    assert_eq!(first_json["task_id"], task_id.to_string());
+
+    let second = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-b/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "lease_secs": 30 }).to_string(),
+                ))?,
+        )
+        .await?;
+    let second_json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(second.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(second_json["claimed"], false);
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -151,6 +151,103 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+
+    let project_a = dir.path().join("project-a");
+    let project_b = dir.path().join("project-b");
+
+    let task_a = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(project_a),
+        issue: None,
+        repo: None,
+        description: Some("pending task a".to_string()),
+        created_at: Some("2026-04-02T00:00:00Z".to_string()),
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+    };
+    let task_b = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(project_b.clone()),
+        issue: None,
+        repo: None,
+        description: Some("pending task b".to_string()),
+        created_at: Some("2026-04-02T00:00:01Z".to_string()),
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+    };
+    let task_b_id = task_b.id.clone();
+
+    state.core.tasks.insert(&task_a).await;
+    state.core.tasks.insert(&task_b).await;
+
+    let app = runtime_hosts_app(state);
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "host_id": "host-a" }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), axum::http::StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "lease_secs": 30,
+                        "project": project_b.to_string_lossy(),
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(response.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(json["claimed"], true);
+    assert_eq!(json["task_id"], task_b_id.to_string());
+    Ok(())
+}
+
+#[tokio::test]
 async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -115,9 +115,7 @@ async fn resolve_project_token(
 }
 
 fn validate_allowed_root(state: &AppState, root: &std::path::Path) -> Result<(), String> {
-    if let Err(msg) = validate_project_root(root) {
-        return Err(msg);
-    }
+    validate_project_root(root)?;
     let allowed = &state.core.server.config.server.allowed_project_roots;
     if !allowed.is_empty() && !allowed.iter().any(|base| root.starts_with(base)) {
         return Err("project root is not under an allowed base directory".to_string());

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -1,0 +1,139 @@
+use crate::http::AppState;
+use crate::project_registry::validate_project_root;
+use crate::runtime_project_cache::WatchedProjectInput;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub struct SyncWatchedProjectsRequest {
+    #[serde(default)]
+    pub projects: Vec<SyncProjectItem>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SyncProjectItem {
+    pub project: String,
+}
+
+pub async fn list_runtime_host_projects(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !host_exists(&state, &host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "runtime host not found"})),
+        );
+    }
+    let snapshot = state
+        .runtime_project_cache
+        .get_host_cache(&host_id)
+        .unwrap_or_else(|| state.runtime_project_cache.empty_snapshot(&host_id));
+    (StatusCode::OK, Json(json!(snapshot)))
+}
+
+pub async fn sync_runtime_host_projects(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+    Json(req): Json<SyncWatchedProjectsRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !host_exists(&state, &host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "runtime host not found"})),
+        );
+    }
+
+    let mut inputs: Vec<WatchedProjectInput> = Vec::with_capacity(req.projects.len());
+    for item in req.projects {
+        let token = item.project.trim();
+        if token.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "project token must not be empty"})),
+            );
+        }
+        let (project_id, root) = match resolve_project_token(&state, token).await {
+            Ok(v) => v,
+            Err(msg) => return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))),
+        };
+        if let Err(msg) = validate_allowed_root(&state, &root) {
+            return (StatusCode::FORBIDDEN, Json(json!({"error": msg})));
+        }
+        inputs.push(WatchedProjectInput {
+            project_id,
+            root: root.to_string_lossy().into_owned(),
+        });
+    }
+
+    let snapshot = state
+        .runtime_project_cache
+        .sync_host_projects(&host_id, inputs);
+    if let Err(response) = persist_runtime_state(&state).await {
+        return response;
+    }
+    (StatusCode::OK, Json(json!(snapshot)))
+}
+
+fn host_exists(state: &AppState, host_id: &str) -> bool {
+    state
+        .runtime_hosts
+        .list_hosts()
+        .into_iter()
+        .any(|host| host.id == host_id)
+}
+
+async fn resolve_project_token(
+    state: &AppState,
+    token: &str,
+) -> Result<(Option<String>, PathBuf), String> {
+    let as_path = PathBuf::from(token);
+    if as_path.is_dir() {
+        return as_path
+            .canonicalize()
+            .map(|root| (None, root))
+            .map_err(|e| format!("invalid project path '{token}': {e}"));
+    }
+
+    match state.project_svc.resolve_path(token).await {
+        Ok(Some(root)) => root
+            .canonicalize()
+            .map(|canon| (Some(token.to_string()), canon))
+            .map_err(|e| format!("project '{token}' root is not accessible: {e}")),
+        Ok(None) => Err(format!(
+            "project '{token}' not found in registry and is not a valid directory"
+        )),
+        Err(e) => Err(format!("failed to resolve project '{token}': {e}")),
+    }
+}
+
+fn validate_allowed_root(state: &AppState, root: &std::path::Path) -> Result<(), String> {
+    if let Err(msg) = validate_project_root(root) {
+        return Err(msg);
+    }
+    let allowed = &state.core.server.config.server.allowed_project_roots;
+    if !allowed.is_empty() && !allowed.iter().any(|base| root.starts_with(base)) {
+        return Err("project root is not under an allowed base directory".to_string());
+    }
+    Ok(())
+}
+
+async fn persist_runtime_state(
+    state: &Arc<AppState>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if let Err(e) = state.persist_runtime_state().await {
+        tracing::error!("failed to persist runtime state after project cache sync: {e}");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("failed to persist runtime state: {e}") })),
+        ));
+    }
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -1,5 +1,5 @@
 use crate::http::AppState;
-use crate::project_registry::validate_project_root;
+use crate::project_registry::{check_allowed_roots, validate_project_root};
 use crate::runtime_project_cache::WatchedProjectInput;
 use axum::{
     extract::{Path, State},
@@ -120,11 +120,7 @@ async fn resolve_project_token(
 
 fn validate_allowed_root(state: &AppState, root: &std::path::Path) -> Result<(), String> {
     validate_project_root(root)?;
-    let allowed = &state.core.server.config.server.allowed_project_roots;
-    if !allowed.is_empty() && !allowed.iter().any(|base| root.starts_with(base)) {
-        return Err("project root is not under an allowed base directory".to_string());
-    }
-    Ok(())
+    check_allowed_roots(root, &state.core.server.config.server.allowed_project_roots)
 }
 
 async fn persist_runtime_state(

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -73,6 +73,14 @@ pub async fn sync_runtime_host_projects(
         });
     }
 
+    // Keep a read guard while writing cache to prevent concurrent deregister()
+    // from deleting the host between validation and cache sync.
+    let Some(_host_guard) = state.runtime_hosts.hosts.get(&host_id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "runtime host not found"})),
+        );
+    };
     let snapshot = state
         .runtime_project_cache
         .sync_host_projects(&host_id, inputs);
@@ -83,11 +91,7 @@ pub async fn sync_runtime_host_projects(
 }
 
 fn host_exists(state: &AppState, host_id: &str) -> bool {
-    state
-        .runtime_hosts
-        .list_hosts()
-        .into_iter()
-        .any(|host| host.id == host_id)
+    state.runtime_hosts.hosts.contains_key(host_id)
 }
 
 async fn resolve_project_token(

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -15,6 +15,10 @@ fn runtime_project_cache_app(state: Arc<crate::http::AppState>) -> Router {
             post(runtime_hosts::register_runtime_host),
         )
         .route(
+            "/api/runtime-hosts/{host_id}/deregister",
+            post(runtime_hosts::deregister_runtime_host),
+        )
+        .route(
             "/api/runtime-hosts/{host_id}/projects",
             get(runtime_project_cache::list_runtime_host_projects),
         )
@@ -162,5 +166,82 @@ async fn sync_by_project_id_resolves_registry_root() -> anyhow::Result<()> {
             .to_bytes(),
     )?;
     assert_eq!(json["projects"][0]["project_id"], "demo");
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_after_deregister_does_not_recreate_cache() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+
+    let state = Arc::new(crate::test_helpers::make_test_state(data_dir.path()).await?);
+    let app = runtime_project_cache_app(state.clone());
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+
+    let initial_sync = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "projects": [{"project": project_dir.path().to_string_lossy()}]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(initial_sync.status(), StatusCode::OK);
+
+    let deregister = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/deregister")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(deregister.status(), StatusCode::OK);
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+
+    let stale_sync = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "projects": [{"project": project_dir.path().to_string_lossy()}]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(stale_sync.status(), StatusCode::NOT_FOUND);
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
     Ok(())
 }

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -1,0 +1,166 @@
+use super::{runtime_hosts, runtime_project_cache};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn runtime_project_cache_app(state: Arc<crate::http::AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/runtime-hosts/register",
+            post(runtime_hosts::register_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/projects",
+            get(runtime_project_cache::list_runtime_host_projects),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/projects/sync",
+            post(runtime_project_cache::sync_runtime_host_projects),
+        )
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn sync_and_list_watched_projects_by_path() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+
+    let state = Arc::new(crate::test_helpers::make_test_state(data_dir.path()).await?);
+    let app = runtime_project_cache_app(state);
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+
+    let sync = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "projects": [{"project": project_dir.path().to_string_lossy()}]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(sync.status(), StatusCode::OK);
+
+    let list = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/runtime-hosts/host-a/projects")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(list.status(), StatusCode::OK);
+    let body = http_body_util::BodyExt::collect(list.into_body())
+        .await?
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(json["project_count"], 1);
+    assert_eq!(
+        json["projects"][0]["root"],
+        project_dir
+            .path()
+            .canonicalize()?
+            .to_string_lossy()
+            .to_string()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_unknown_host_returns_not_found() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let app = runtime_project_cache_app(Arc::new(
+        crate::test_helpers::make_test_state(dir.path()).await?,
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/ghost/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "projects": [{"project": "."}] }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_by_project_id_resolves_registry_root() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+    let state = Arc::new(crate::test_helpers::make_test_state(data_dir.path()).await?);
+    state
+        .project_svc
+        .register(crate::project_registry::Project {
+            id: "demo".to_string(),
+            root: project_dir.path().to_path_buf(),
+            max_concurrent: None,
+            default_agent: None,
+            active: true,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+        .await?;
+
+    let app = runtime_project_cache_app(state);
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+
+    let sync = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "projects": [{"project": "demo"}] }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(sync.status(), StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(sync.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(json["projects"][0]["project_id"], "demo");
+    Ok(())
+}

--- a/crates/harness-server/src/hook_enforcer.rs
+++ b/crates/harness-server/src/hook_enforcer.rs
@@ -212,7 +212,45 @@ mod tests {
     use super::*;
     use harness_core::{types::EventFilters, types::GuardId, types::Language};
     use harness_rules::engine::{Guard, RuleEngine};
+    use std::ffi::OsString;
     use tempfile::tempdir;
+    use tokio::sync::Mutex;
+
+    static CI_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct CiEnvGuard {
+        previous: Option<OsString>,
+    }
+
+    impl Drop for CiEnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => {
+                    // SAFETY: tests run in a single process; caller serializes with CI_ENV_LOCK.
+                    unsafe { std::env::set_var("CI", value) };
+                }
+                None => {
+                    // SAFETY: tests run in a single process; caller serializes with CI_ENV_LOCK.
+                    unsafe { std::env::remove_var("CI") };
+                }
+            }
+        }
+    }
+
+    fn with_ci_env(value: Option<&str>) -> CiEnvGuard {
+        let previous = std::env::var_os("CI");
+        match value {
+            Some(v) => {
+                // SAFETY: tests run in a single process; caller serializes with CI_ENV_LOCK.
+                unsafe { std::env::set_var("CI", v) };
+            }
+            None => {
+                // SAFETY: tests run in a single process; caller serializes with CI_ENV_LOCK.
+                unsafe { std::env::remove_var("CI") };
+            }
+        }
+        CiEnvGuard { previous }
+    }
 
     async fn make_event_store(dir: &Path) -> Arc<EventStore> {
         Arc::new(EventStore::new(dir).await.unwrap())
@@ -250,6 +288,8 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_returns_violations_when_guard_fires() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -277,6 +317,8 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_disabled_passes_through() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -299,6 +341,8 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_empty_files_returns_clean() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -316,6 +360,8 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_logs_event_to_store() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let event_store = Arc::new(EventStore::new(dir.path()).await?);
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -346,6 +392,8 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_no_guards_passes_through() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = Arc::new(RwLock::new(RuleEngine::new()));
@@ -376,6 +424,8 @@ mod tests {
 
     #[tokio::test]
     async fn circuit_breaker_opens_after_repeated_blocks() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(None);
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -413,6 +463,8 @@ mod tests {
 
     #[tokio::test]
     async fn ci_env_skips_enforcement() -> anyhow::Result<()> {
+        let _env_lock = CI_ENV_LOCK.lock().await;
+        let _ci_guard = with_ci_env(Some("true"));
         let dir = tempdir()?;
         let events = make_event_store(dir.path()).await;
         let rules = make_engine_with_guard(dir.path(), "U-16", "medium");
@@ -426,10 +478,7 @@ mod tests {
             session_id: None,
         };
 
-        // SAFETY: test process only; env mutation isolated by unique var name.
-        unsafe { std::env::set_var("CI", "true") };
         let result = enforcer.post_tool_use(&event, &project).await;
-        unsafe { std::env::remove_var("CI") };
 
         assert!(
             result.violation_feedback.is_none(),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -19,7 +19,7 @@ use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
 
 pub(crate) mod auth;
 pub(crate) mod rate_limit;
@@ -103,6 +103,8 @@ pub struct AppState {
     pub concurrency: ConcurrencyServices,
     pub runtime_hosts: Arc<crate::runtime_hosts::RuntimeHostManager>,
     pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
+    /// Serializes runtime snapshot writes to avoid out-of-order persistence.
+    pub runtime_state_persist_lock: Mutex<()>,
     pub notifications: NotificationServices,
     pub intake: IntakeServices,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -139,6 +141,7 @@ impl AppState {
     }
 
     pub async fn persist_runtime_state(&self) -> anyhow::Result<()> {
+        let _guard = self.runtime_state_persist_lock.lock().await;
         let Some(store) = self.core.runtime_state_store.as_ref() else {
             return Ok(());
         };
@@ -679,6 +682,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         },
         runtime_hosts,
         runtime_project_cache,
+        runtime_state_persist_lock: Mutex::new(()),
         notifications: NotificationServices {
             notification_tx: broadcast::channel(notification_broadcast_capacity).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -105,6 +105,11 @@ pub struct AppState {
     pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
     /// Serializes runtime snapshot writes to avoid out-of-order persistence.
     pub runtime_state_persist_lock: Mutex<()>,
+    /// Set when a runtime-state persist fails; the next successful
+    /// `persist_runtime_state` call clears it.  Handlers that find no
+    /// in-memory mutation (e.g. idempotent deregister retry) still trigger a
+    /// persist when this flag is set, converging durable state.
+    pub runtime_state_dirty: AtomicBool,
     pub notifications: NotificationServices,
     pub intake: IntakeServices,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -147,7 +152,24 @@ impl AppState {
         };
         let (hosts, leases) = self.runtime_hosts.snapshot_state();
         let project_caches = self.runtime_project_cache.snapshot_state();
-        store.persist_snapshot(hosts, leases, project_caches).await
+        match store.persist_snapshot(hosts, leases, project_caches).await {
+            Ok(()) => {
+                self.runtime_state_dirty.store(false, Ordering::Release);
+                Ok(())
+            }
+            Err(e) => {
+                self.runtime_state_dirty.store(true, Ordering::Release);
+                Err(e)
+            }
+        }
+    }
+
+    /// Returns `true` when a previous persist failed and durable state may be
+    /// stale.  Handlers that skip their own mutation (e.g. idempotent
+    /// deregister retry returning NOT_FOUND) should check this and re-persist
+    /// to converge.
+    pub fn is_runtime_state_dirty(&self) -> bool {
+        self.runtime_state_dirty.load(Ordering::Acquire)
     }
 }
 fn resolve_project_root(configured_root: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
@@ -683,6 +705,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         runtime_hosts,
         runtime_project_cache,
         runtime_state_persist_lock: Mutex::new(()),
+            runtime_state_dirty: AtomicBool::new(false),
         notifications: NotificationServices {
             notification_tx: broadcast::channel(notification_broadcast_capacity).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -39,6 +39,7 @@ pub struct CoreServices {
     /// Write-through: every mutation must also persist via `plan_db`.
     pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
     pub project_registry: Option<std::sync::Arc<crate::project_registry::ProjectRegistry>>,
+    pub runtime_state_store: Option<Arc<crate::runtime_state_store::RuntimeStateStore>>,
 }
 
 /// Engine services: skills, rules, and garbage collection.
@@ -100,6 +101,8 @@ pub struct AppState {
     pub engines: EngineServices,
     pub observability: ObservabilityServices,
     pub concurrency: ConcurrencyServices,
+    pub runtime_hosts: Arc<crate::runtime_hosts::RuntimeHostManager>,
+    pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
     pub notifications: NotificationServices,
     pub intake: IntakeServices,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
@@ -133,6 +136,15 @@ impl AppState {
             );
         }
         dropped_total
+    }
+
+    pub async fn persist_runtime_state(&self) -> anyhow::Result<()> {
+        let Some(store) = self.core.runtime_state_store.as_ref() else {
+            return Ok(());
+        };
+        let (hosts, leases) = self.runtime_hosts.snapshot_state();
+        let project_caches = self.runtime_project_cache.snapshot_state();
+        store.persist_snapshot(hosts, leases, project_caches).await
     }
 }
 fn resolve_project_root(configured_root: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
@@ -583,6 +595,43 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         });
     }
 
+    let runtime_hosts = Arc::new(crate::runtime_hosts::RuntimeHostManager::new());
+    let runtime_project_cache =
+        Arc::new(crate::runtime_project_cache::RuntimeProjectCacheManager::new());
+    let runtime_state_store = {
+        let runtime_state_db_path =
+            harness_core::config::dirs::default_db_path(&dir, "runtime_state");
+        match crate::runtime_state_store::RuntimeStateStore::open(&runtime_state_db_path).await {
+            Ok(store) => Some(Arc::new(store)),
+            Err(e) => {
+                tracing::warn!(
+                    path = %runtime_state_db_path.display(),
+                    "runtime state store init failed, runtime host state will not persist: {e}"
+                );
+                None
+            }
+        }
+    };
+    if let Some(store) = runtime_state_store.as_ref() {
+        match store.load_snapshot().await {
+            Ok(Some(snapshot)) => {
+                let restored_hosts = runtime_hosts.restore_state(snapshot.hosts, snapshot.leases);
+                let restored_project_caches =
+                    runtime_project_cache.restore_state(snapshot.project_caches);
+                tracing::info!(
+                    restored_hosts = restored_hosts.0,
+                    restored_leases = restored_hosts.1,
+                    restored_project_caches,
+                    "runtime state restored from persistent snapshot"
+                );
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!("failed to load runtime state snapshot on startup: {e}");
+            }
+        }
+    }
+
     let signal_rate_limit = server.config.server.signal_rate_limit_per_minute;
     let password_reset_rate_limit = server.config.server.password_reset_rate_limit_per_hour;
     let home_dir = std::env::var("HOME")
@@ -598,6 +647,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             plan_db: Some(plan_db),
             plan_cache,
             project_registry: Some(project_registry),
+            runtime_state_store,
         },
         engines: EngineServices {
             skills: skills_arc,
@@ -627,6 +677,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             task_queue,
             workspace_mgr,
         },
+        runtime_hosts,
+        runtime_project_cache,
         notifications: NotificationServices {
             notification_tx: broadcast::channel(notification_broadcast_capacity).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),
@@ -1135,6 +1187,34 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         .route("/projects/queue-stats", get(project_queue_stats))
         .route("/api/dashboard", get(crate::handlers::dashboard::dashboard))
         .route("/api/intake", get(intake_status))
+        .route(
+            "/api/runtime-hosts",
+            get(crate::handlers::runtime_hosts::list_runtime_hosts),
+        )
+        .route(
+            "/api/runtime-hosts/register",
+            post(crate::handlers::runtime_hosts::register_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/heartbeat",
+            post(crate::handlers::runtime_hosts::heartbeat_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/deregister",
+            post(crate::handlers::runtime_hosts::deregister_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/tasks/claim",
+            post(crate::handlers::runtime_hosts::claim_task_for_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/projects",
+            get(crate::handlers::runtime_project_cache::list_runtime_host_projects),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/projects/sync",
+            post(crate::handlers::runtime_project_cache::sync_runtime_host_projects),
+        )
         .route(
             "/api/token-usage",
             get(crate::handlers::token_usage::token_usage),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -705,7 +705,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         runtime_hosts,
         runtime_project_cache,
         runtime_state_persist_lock: Mutex::new(()),
-            runtime_state_dirty: AtomicBool::new(false),
+        runtime_state_dirty: AtomicBool::new(false),
         notifications: NotificationServices {
             notification_tx: broadcast::channel(notification_broadcast_capacity).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -1,5 +1,7 @@
 use super::{resolve_reviewer, AppState};
-use crate::{services::execution::EnqueueTaskError, task_runner};
+use crate::{
+    project_registry::check_allowed_roots, services::execution::EnqueueTaskError, task_runner,
+};
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Deserialize;
 use serde_json::json;
@@ -62,16 +64,11 @@ pub(crate) async fn enqueue_task(
     // Enforce allowed_project_roots allowlist on the resolved canonical path so
     // callers cannot bypass it by supplying a real directory path directly
     // instead of registering the project first.
-    let allowed = &state.core.server.config.server.allowed_project_roots;
-    if !allowed.is_empty()
-        && !allowed
-            .iter()
-            .any(|base| canonical_project.starts_with(base))
-    {
-        return Err(EnqueueTaskError::BadRequest(
-            "project root is not under an allowed base directory".to_string(),
-        ));
-    }
+    check_allowed_roots(
+        &canonical_project,
+        &state.core.server.config.server.allowed_project_roots,
+    )
+    .map_err(EnqueueTaskError::BadRequest)?;
 
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);
@@ -260,16 +257,11 @@ async fn enqueue_task_background(
         .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
 
     // Enforce allowed_project_roots allowlist (same guard as enqueue_task).
-    let allowed = &state.core.server.config.server.allowed_project_roots;
-    if !allowed.is_empty()
-        && !allowed
-            .iter()
-            .any(|base| canonical_project.starts_with(base))
-    {
-        return Err(EnqueueTaskError::BadRequest(
-            "project root is not under an allowed base directory".to_string(),
-        ));
-    }
+    check_allowed_roots(
+        &canonical_project,
+        &state.core.server.config.server.allowed_project_roots,
+    )
+    .map_err(EnqueueTaskError::BadRequest)?;
 
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -151,7 +151,7 @@ async fn make_test_state_with(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
-            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+        runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx: tokio::sync::broadcast::channel(32).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -122,6 +122,7 @@ async fn make_test_state_with(
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
             project_registry: None,
+            runtime_state_store: None,
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(tokio::sync::RwLock::new(
@@ -144,6 +145,10 @@ async fn make_test_state_with(
             task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             workspace_mgr: None,
         },
+        runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+        runtime_project_cache: Arc::new(
+            crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
         notifications: crate::http::NotificationServices {
             notification_tx: tokio::sync::broadcast::channel(32).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -9,6 +9,7 @@ use harness_core::{
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tower::ServiceExt;
 
@@ -149,6 +150,7 @@ async fn make_test_state_with(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         notifications: crate::http::NotificationServices {
             notification_tx: tokio::sync::broadcast::channel(32).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),
@@ -177,6 +179,31 @@ async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<Arc<AppState>>
         harness_agents::registry::AgentRegistry::new("test"),
     )
     .await
+}
+
+#[tokio::test]
+async fn persist_runtime_state_is_serialized() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let lock_guard = state.runtime_state_persist_lock.lock().await;
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let state_for_task = state.clone();
+    let persist_task = tokio::spawn(async move {
+        let _ = started_tx.send(());
+        state_for_task.persist_runtime_state().await
+    });
+
+    started_rx.await?;
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert!(
+        !persist_task.is_finished(),
+        "persist_runtime_state should wait for the in-flight persist lock"
+    );
+
+    drop(lock_guard);
+    tokio::time::timeout(Duration::from_secs(1), persist_task).await???;
+    Ok(())
 }
 
 async fn make_test_state_with_agent(

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -151,6 +151,7 @@ async fn make_test_state_with(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx: tokio::sync::broadcast::channel(32).0,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -29,6 +29,11 @@ pub mod quality_trigger;
 pub mod review_store;
 pub mod router;
 pub mod rule_enforcer;
+pub mod runtime_hosts;
+pub mod runtime_hosts_state;
+pub mod runtime_project_cache;
+pub mod runtime_project_cache_state;
+pub mod runtime_state_store;
 pub mod scheduler;
 pub mod self_evolution;
 pub mod server;
@@ -48,3 +53,9 @@ pub mod workspace;
 
 #[cfg(test)]
 pub(crate) mod test_helpers;
+
+#[cfg(test)]
+mod runtime_hosts_tests;
+
+#[cfg(test)]
+mod runtime_state_store_tests;

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -77,6 +77,29 @@ impl ProjectRegistry {
     }
 }
 
+/// Check that `canonical_root` falls under at least one of the
+/// `allowed_project_roots`.  Each allowlist entry is canonicalized before the
+/// prefix check so that relative paths and symlinks in the config don't cause
+/// false 403s.  Returns `Ok(())` when the allowlist is empty (i.e. no
+/// restriction configured).
+pub fn check_allowed_roots(
+    canonical_root: &std::path::Path,
+    allowed: &[std::path::PathBuf],
+) -> Result<(), String> {
+    if allowed.is_empty() {
+        return Ok(());
+    }
+    let matched = allowed.iter().any(|base| {
+        base.canonicalize()
+            .map(|canon_base| canonical_root.starts_with(&canon_base))
+            .unwrap_or(false)
+    });
+    if !matched {
+        return Err("project root is not under an allowed base directory".to_string());
+    }
+    Ok(())
+}
+
 /// Validate that a path is an existing directory and a git repository.
 pub fn validate_project_root(root: &std::path::Path) -> Result<(), String> {
     if !root.is_dir() {

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -74,6 +74,7 @@ async fn make_test_state_with_config_and_registry(
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
             project_registry: None,
+            runtime_state_store: None,
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),
@@ -94,6 +95,10 @@ async fn make_test_state_with_config_and_registry(
             task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             workspace_mgr: None,
         },
+        runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+        runtime_project_cache: Arc::new(
+            crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1383,6 +1388,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             plan_db: Some(plan_db),
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
             project_registry: None,
+            runtime_state_store: None,
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),
@@ -1403,6 +1409,10 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             workspace_mgr: None,
         },
+        runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+        runtime_project_cache: Arc::new(
+            crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -100,6 +100,7 @@ async fn make_test_state_with_config_and_registry(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1415,6 +1416,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -99,6 +99,7 @@ async fn make_test_state_with_config_and_registry(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1413,6 +1414,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -100,7 +100,7 @@ async fn make_test_state_with_config_and_registry(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
-            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+        runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -1416,7 +1416,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
-            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+        runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -128,11 +128,12 @@ impl RuntimeHostManager {
         lease_secs: Option<i64>,
         project_filter: Option<&str>,
     ) -> anyhow::Result<Option<TaskClaimResult>> {
-        if !self.hosts.contains_key(host_id) {
-            return Err(anyhow::anyhow!(
-                "runtime host '{host_id}' is not registered"
-            ));
-        }
+        // Hold a read reference during claim so concurrent deregister() cannot
+        // remove the host between membership check and lease insertion.
+        let host_guard = self
+            .hosts
+            .get(host_id)
+            .ok_or_else(|| anyhow::anyhow!("runtime host '{host_id}' is not registered"))?;
 
         let now = Utc::now();
         self.cleanup_expired_leases(now);
@@ -152,6 +153,7 @@ impl RuntimeHostManager {
                         host_id: host_id.to_string(),
                         expires_at,
                     });
+                    drop(host_guard);
                     return Ok(Some(TaskClaimResult {
                         task_id: candidate.task_id,
                         lease_expires_at: expires_at.to_rfc3339(),
@@ -160,6 +162,7 @@ impl RuntimeHostManager {
                 Entry::Occupied(_) => continue,
             }
         }
+        drop(host_guard);
         Ok(None)
     }
 

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -148,12 +148,12 @@ impl RuntimeHostManager {
     }
 
     pub fn deregister(&self, host_id: &str) -> bool {
+        let _lease_guard = self
+            .lease_mutation_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let removed = self.hosts.remove(host_id).is_some();
         if removed {
-            let _lease_guard = self
-                .lease_mutation_lock
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner());
             let lease_ids = self
                 .host_leases
                 .remove(host_id)
@@ -185,13 +185,6 @@ impl RuntimeHostManager {
         lease_secs: Option<i64>,
         project_filter: Option<&str>,
     ) -> Result<Option<TaskClaimResult>, ClaimTaskError> {
-        // Hold a read reference during claim so concurrent deregister() cannot
-        // remove the host between membership check and lease insertion.
-        let host_guard = self
-            .hosts
-            .get(host_id)
-            .ok_or_else(|| ClaimTaskError::HostNotRegistered(host_id.to_string()))?;
-
         let now = Utc::now();
         candidates.retain(|c| c.status.as_ref() == "pending" && project_matches(c, project_filter));
         candidates.sort_by(|a, b| {
@@ -205,16 +198,17 @@ impl RuntimeHostManager {
             .lease_mutation_lock
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
+        if !self.hosts.contains_key(host_id) {
+            return Err(ClaimTaskError::HostNotRegistered(host_id.to_string()));
+        }
         self.cleanup_expired_leases(now);
         for candidate in candidates {
             if let Some(claim) =
                 self.try_claim_task_id_locked(host_id, &candidate.task_id, ttl, now)?
             {
-                drop(host_guard);
                 return Ok(Some(claim));
             }
         }
-        drop(host_guard);
         Ok(None)
     }
 
@@ -224,20 +218,17 @@ impl RuntimeHostManager {
         task_id: &TaskId,
         lease_secs: Option<i64>,
     ) -> Result<Option<TaskClaimResult>, ClaimTaskError> {
-        let host_guard = self
-            .hosts
-            .get(host_id)
-            .ok_or_else(|| ClaimTaskError::HostNotRegistered(host_id.to_string()))?;
         let now = Utc::now();
         let ttl = lease_secs.unwrap_or(self.default_lease_secs).max(0);
         let _lease_guard = self
             .lease_mutation_lock
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
+        if !self.hosts.contains_key(host_id) {
+            return Err(ClaimTaskError::HostNotRegistered(host_id.to_string()));
+        }
         self.cleanup_expired_leases(now);
-        let claim = self.try_claim_task_id_locked(host_id, task_id, ttl, now)?;
-        drop(host_guard);
-        Ok(claim)
+        self.try_claim_task_id_locked(host_id, task_id, ttl, now)
     }
 
     fn cleanup_expired_leases(&self, now: DateTime<Utc>) {
@@ -347,6 +338,13 @@ impl RuntimeHostManager {
             last_heartbeat_at: record.last_heartbeat_at.to_rfc3339(),
             online,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hold_lease_mutation_lock_for_test(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.lease_mutation_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
     }
 }
 

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -1,0 +1,196 @@
+use crate::task_runner::{TaskId, TaskStatus};
+use chrono::{DateTime, Duration, Utc};
+use dashmap::{mapref::entry::Entry, DashMap};
+use serde::Serialize;
+
+pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
+pub const DEFAULT_LEASE_SECS: i64 = 60;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeHostInfo {
+    pub id: String,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub registered_at: String,
+    pub last_heartbeat_at: String,
+    pub online: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimCandidate {
+    pub task_id: TaskId,
+    pub status: TaskStatus,
+    pub created_at: Option<String>,
+    pub project: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskClaimResult {
+    pub task_id: TaskId,
+    pub lease_expires_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeHostRecord {
+    pub(crate) id: String,
+    pub(crate) display_name: String,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) registered_at: DateTime<Utc>,
+    pub(crate) last_heartbeat_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskLease {
+    pub(crate) host_id: String,
+    pub(crate) expires_at: DateTime<Utc>,
+}
+
+pub struct RuntimeHostManager {
+    pub(crate) hosts: DashMap<String, RuntimeHostRecord>,
+    pub(crate) leases: DashMap<TaskId, TaskLease>,
+    pub(crate) heartbeat_timeout_secs: i64,
+    default_lease_secs: i64,
+}
+
+impl RuntimeHostManager {
+    pub fn new() -> Self {
+        Self::with_timeouts(DEFAULT_HEARTBEAT_TIMEOUT_SECS, DEFAULT_LEASE_SECS)
+    }
+
+    pub fn with_timeouts(heartbeat_timeout_secs: i64, default_lease_secs: i64) -> Self {
+        Self {
+            hosts: DashMap::new(),
+            leases: DashMap::new(),
+            heartbeat_timeout_secs,
+            default_lease_secs,
+        }
+    }
+
+    pub fn register(
+        &self,
+        host_id: String,
+        display_name: Option<String>,
+        capabilities: Vec<String>,
+    ) -> RuntimeHostInfo {
+        let now = Utc::now();
+        let record = RuntimeHostRecord {
+            id: host_id.clone(),
+            display_name: display_name.unwrap_or_else(|| host_id.clone()),
+            capabilities,
+            registered_at: now,
+            last_heartbeat_at: now,
+        };
+        self.hosts.insert(host_id, record.clone());
+        self.to_info(&record, now)
+    }
+
+    pub fn heartbeat(&self, host_id: &str) -> anyhow::Result<RuntimeHostInfo> {
+        let now = Utc::now();
+        let mut host = self
+            .hosts
+            .get_mut(host_id)
+            .ok_or_else(|| anyhow::anyhow!("runtime host '{host_id}' is not registered"))?;
+        host.last_heartbeat_at = now;
+        Ok(self.to_info(&host, now))
+    }
+
+    pub fn deregister(&self, host_id: &str) -> bool {
+        let removed = self.hosts.remove(host_id).is_some();
+        if removed {
+            let to_remove: Vec<TaskId> = self
+                .leases
+                .iter()
+                .filter(|e| e.value().host_id == host_id)
+                .map(|e| e.key().clone())
+                .collect();
+            for task_id in to_remove {
+                self.leases.remove(&task_id);
+            }
+        }
+        removed
+    }
+
+    pub fn list_hosts(&self) -> Vec<RuntimeHostInfo> {
+        let now = Utc::now();
+        let mut hosts: Vec<RuntimeHostInfo> = self
+            .hosts
+            .iter()
+            .map(|entry| self.to_info(entry.value(), now))
+            .collect();
+        hosts.sort_by(|a, b| a.id.cmp(&b.id));
+        hosts
+    }
+
+    pub fn claim_task(
+        &self,
+        host_id: &str,
+        mut candidates: Vec<ClaimCandidate>,
+        lease_secs: Option<i64>,
+        project_filter: Option<&str>,
+    ) -> anyhow::Result<Option<TaskClaimResult>> {
+        if !self.hosts.contains_key(host_id) {
+            return Err(anyhow::anyhow!(
+                "runtime host '{host_id}' is not registered"
+            ));
+        }
+
+        let now = Utc::now();
+        self.cleanup_expired_leases(now);
+        candidates.retain(|c| c.status.as_ref() == "pending" && project_matches(c, project_filter));
+        candidates.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.task_id.as_str().cmp(b.task_id.as_str()))
+        });
+
+        let ttl = lease_secs.unwrap_or(self.default_lease_secs).max(0);
+        for candidate in candidates {
+            match self.leases.entry(candidate.task_id.clone()) {
+                Entry::Vacant(v) => {
+                    let expires_at = now + Duration::seconds(ttl);
+                    v.insert(TaskLease {
+                        host_id: host_id.to_string(),
+                        expires_at,
+                    });
+                    return Ok(Some(TaskClaimResult {
+                        task_id: candidate.task_id,
+                        lease_expires_at: expires_at.to_rfc3339(),
+                    }));
+                }
+                Entry::Occupied(_) => continue,
+            }
+        }
+        Ok(None)
+    }
+
+    fn cleanup_expired_leases(&self, now: DateTime<Utc>) {
+        let expired: Vec<TaskId> = self
+            .leases
+            .iter()
+            .filter(|entry| entry.value().expires_at <= now)
+            .map(|entry| entry.key().clone())
+            .collect();
+        for task_id in expired {
+            self.leases.remove(&task_id);
+        }
+    }
+
+    fn to_info(&self, record: &RuntimeHostRecord, now: DateTime<Utc>) -> RuntimeHostInfo {
+        let online = (now - record.last_heartbeat_at).num_seconds() <= self.heartbeat_timeout_secs;
+        RuntimeHostInfo {
+            id: record.id.clone(),
+            display_name: record.display_name.clone(),
+            capabilities: record.capabilities.clone(),
+            registered_at: record.registered_at.to_rfc3339(),
+            last_heartbeat_at: record.last_heartbeat_at.to_rfc3339(),
+            online,
+        }
+    }
+}
+
+fn project_matches(candidate: &ClaimCandidate, project_filter: Option<&str>) -> bool {
+    match project_filter {
+        None => true,
+        Some(filter) => candidate.project.as_deref() == Some(filter),
+    }
+}

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -1,5 +1,5 @@
 use crate::task_runner::{TaskId, TaskStatus};
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use dashmap::{mapref::entry::Entry, DashMap};
 use serde::Serialize;
 use std::{
@@ -34,6 +34,28 @@ pub struct TaskClaimResult {
     pub task_id: TaskId,
     pub lease_expires_at: String,
 }
+
+#[derive(Debug, Clone)]
+pub enum ClaimTaskError {
+    HostNotRegistered(String),
+    LeaseTtlOutOfRange(i64),
+}
+
+impl std::fmt::Display for ClaimTaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HostNotRegistered(host_id) => {
+                write!(f, "runtime host '{host_id}' is not registered")
+            }
+            Self::LeaseTtlOutOfRange(ttl) => write!(
+                f,
+                "lease_secs value {ttl} is too large to compute a valid expiration timestamp"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ClaimTaskError {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeHostRecord {
@@ -155,13 +177,13 @@ impl RuntimeHostManager {
         mut candidates: Vec<ClaimCandidate>,
         lease_secs: Option<i64>,
         project_filter: Option<&str>,
-    ) -> anyhow::Result<Option<TaskClaimResult>> {
+    ) -> Result<Option<TaskClaimResult>, ClaimTaskError> {
         // Hold a read reference during claim so concurrent deregister() cannot
         // remove the host between membership check and lease insertion.
         let host_guard = self
             .hosts
             .get(host_id)
-            .ok_or_else(|| anyhow::anyhow!("runtime host '{host_id}' is not registered"))?;
+            .ok_or_else(|| ClaimTaskError::HostNotRegistered(host_id.to_string()))?;
 
         let now = Utc::now();
         self.cleanup_expired_leases(now);
@@ -176,7 +198,11 @@ impl RuntimeHostManager {
         for candidate in candidates {
             match self.leases.entry(candidate.task_id.clone()) {
                 Entry::Vacant(v) => {
-                    let expires_at = now + Duration::seconds(ttl);
+                    let lease_duration = chrono::TimeDelta::try_seconds(ttl)
+                        .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
+                    let expires_at = now
+                        .checked_add_signed(lease_duration)
+                        .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
                     v.insert(TaskLease {
                         host_id: host_id.to_string(),
                         expires_at,

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -97,6 +97,7 @@ pub struct RuntimeHostManager {
     pub(crate) leases: DashMap<TaskId, TaskLease>,
     pub(crate) host_leases: DashMap<String, HashSet<TaskId>>,
     pub(crate) lease_expirations: Mutex<BinaryHeap<Reverse<LeaseExpiry>>>,
+    lease_mutation_lock: Mutex<()>,
     pub(crate) heartbeat_timeout_secs: i64,
     default_lease_secs: i64,
 }
@@ -112,6 +113,7 @@ impl RuntimeHostManager {
             leases: DashMap::new(),
             host_leases: DashMap::new(),
             lease_expirations: Mutex::new(BinaryHeap::new()),
+            lease_mutation_lock: Mutex::new(()),
             heartbeat_timeout_secs,
             default_lease_secs,
         }
@@ -148,6 +150,10 @@ impl RuntimeHostManager {
     pub fn deregister(&self, host_id: &str) -> bool {
         let removed = self.hosts.remove(host_id).is_some();
         if removed {
+            let _lease_guard = self
+                .lease_mutation_lock
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
             let lease_ids = self
                 .host_leases
                 .remove(host_id)
@@ -156,6 +162,7 @@ impl RuntimeHostManager {
             for task_id in lease_ids {
                 self.leases.remove(&task_id);
             }
+            self.rebuild_lease_expirations();
         }
         removed
     }
@@ -186,7 +193,6 @@ impl RuntimeHostManager {
             .ok_or_else(|| ClaimTaskError::HostNotRegistered(host_id.to_string()))?;
 
         let now = Utc::now();
-        self.cleanup_expired_leases(now);
         candidates.retain(|c| c.status.as_ref() == "pending" && project_matches(c, project_filter));
         candidates.sort_by(|a, b| {
             a.created_at
@@ -195,30 +201,43 @@ impl RuntimeHostManager {
         });
 
         let ttl = lease_secs.unwrap_or(self.default_lease_secs).max(0);
+        let _lease_guard = self
+            .lease_mutation_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        self.cleanup_expired_leases(now);
         for candidate in candidates {
-            match self.leases.entry(candidate.task_id.clone()) {
-                Entry::Vacant(v) => {
-                    let lease_duration = chrono::TimeDelta::try_seconds(ttl)
-                        .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
-                    let expires_at = now
-                        .checked_add_signed(lease_duration)
-                        .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
-                    v.insert(TaskLease {
-                        host_id: host_id.to_string(),
-                        expires_at,
-                    });
-                    self.index_lease(host_id, candidate.task_id.clone(), expires_at);
-                    drop(host_guard);
-                    return Ok(Some(TaskClaimResult {
-                        task_id: candidate.task_id,
-                        lease_expires_at: expires_at.to_rfc3339(),
-                    }));
-                }
-                Entry::Occupied(_) => continue,
+            if let Some(claim) =
+                self.try_claim_task_id_locked(host_id, &candidate.task_id, ttl, now)?
+            {
+                drop(host_guard);
+                return Ok(Some(claim));
             }
         }
         drop(host_guard);
         Ok(None)
+    }
+
+    pub fn claim_task_id(
+        &self,
+        host_id: &str,
+        task_id: &TaskId,
+        lease_secs: Option<i64>,
+    ) -> Result<Option<TaskClaimResult>, ClaimTaskError> {
+        let host_guard = self
+            .hosts
+            .get(host_id)
+            .ok_or_else(|| ClaimTaskError::HostNotRegistered(host_id.to_string()))?;
+        let now = Utc::now();
+        let ttl = lease_secs.unwrap_or(self.default_lease_secs).max(0);
+        let _lease_guard = self
+            .lease_mutation_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        self.cleanup_expired_leases(now);
+        let claim = self.try_claim_task_id_locked(host_id, task_id, ttl, now)?;
+        drop(host_guard);
+        Ok(claim)
     }
 
     fn cleanup_expired_leases(&self, now: DateTime<Utc>) {
@@ -274,6 +293,48 @@ impl RuntimeHostManager {
                 self.host_leases.remove(&lease.host_id);
             }
         }
+    }
+
+    fn try_claim_task_id_locked(
+        &self,
+        host_id: &str,
+        task_id: &TaskId,
+        ttl: i64,
+        now: DateTime<Utc>,
+    ) -> Result<Option<TaskClaimResult>, ClaimTaskError> {
+        match self.leases.entry(task_id.clone()) {
+            Entry::Vacant(v) => {
+                let lease_duration = chrono::TimeDelta::try_seconds(ttl)
+                    .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
+                let expires_at = now
+                    .checked_add_signed(lease_duration)
+                    .ok_or(ClaimTaskError::LeaseTtlOutOfRange(ttl))?;
+                v.insert(TaskLease {
+                    host_id: host_id.to_string(),
+                    expires_at,
+                });
+                self.index_lease(host_id, task_id.clone(), expires_at);
+                Ok(Some(TaskClaimResult {
+                    task_id: task_id.clone(),
+                    lease_expires_at: expires_at.to_rfc3339(),
+                }))
+            }
+            Entry::Occupied(_) => Ok(None),
+        }
+    }
+
+    fn rebuild_lease_expirations(&self) {
+        let mut rebuilt = BinaryHeap::new();
+        for entry in self.leases.iter() {
+            rebuilt.push(Reverse(LeaseExpiry {
+                expires_at: entry.value().expires_at,
+                task_id: entry.key().clone(),
+            }));
+        }
+        *self
+            .lease_expirations
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = rebuilt;
     }
 
     fn to_info(&self, record: &RuntimeHostRecord, now: DateTime<Utc>) -> RuntimeHostInfo {

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -2,6 +2,11 @@ use crate::task_runner::{TaskId, TaskStatus};
 use chrono::{DateTime, Duration, Utc};
 use dashmap::{mapref::entry::Entry, DashMap};
 use serde::Serialize;
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::{BinaryHeap, HashSet},
+    sync::Mutex,
+};
 
 pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
 pub const DEFAULT_LEASE_SECS: i64 = 60;
@@ -45,9 +50,31 @@ pub(crate) struct TaskLease {
     pub(crate) expires_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct LeaseExpiry {
+    pub(crate) expires_at: DateTime<Utc>,
+    pub(crate) task_id: TaskId,
+}
+
+impl Ord for LeaseExpiry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.expires_at
+            .cmp(&other.expires_at)
+            .then_with(|| self.task_id.0.cmp(&other.task_id.0))
+    }
+}
+
+impl PartialOrd for LeaseExpiry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub struct RuntimeHostManager {
     pub(crate) hosts: DashMap<String, RuntimeHostRecord>,
     pub(crate) leases: DashMap<TaskId, TaskLease>,
+    pub(crate) host_leases: DashMap<String, HashSet<TaskId>>,
+    pub(crate) lease_expirations: Mutex<BinaryHeap<Reverse<LeaseExpiry>>>,
     pub(crate) heartbeat_timeout_secs: i64,
     default_lease_secs: i64,
 }
@@ -61,6 +88,8 @@ impl RuntimeHostManager {
         Self {
             hosts: DashMap::new(),
             leases: DashMap::new(),
+            host_leases: DashMap::new(),
+            lease_expirations: Mutex::new(BinaryHeap::new()),
             heartbeat_timeout_secs,
             default_lease_secs,
         }
@@ -97,13 +126,12 @@ impl RuntimeHostManager {
     pub fn deregister(&self, host_id: &str) -> bool {
         let removed = self.hosts.remove(host_id).is_some();
         if removed {
-            let to_remove: Vec<TaskId> = self
-                .leases
-                .iter()
-                .filter(|e| e.value().host_id == host_id)
-                .map(|e| e.key().clone())
-                .collect();
-            for task_id in to_remove {
+            let lease_ids = self
+                .host_leases
+                .remove(host_id)
+                .map(|(_, ids)| ids)
+                .unwrap_or_default();
+            for task_id in lease_ids {
                 self.leases.remove(&task_id);
             }
         }
@@ -153,6 +181,7 @@ impl RuntimeHostManager {
                         host_id: host_id.to_string(),
                         expires_at,
                     });
+                    self.index_lease(host_id, candidate.task_id.clone(), expires_at);
                     drop(host_guard);
                     return Ok(Some(TaskClaimResult {
                         task_id: candidate.task_id,
@@ -167,14 +196,57 @@ impl RuntimeHostManager {
     }
 
     fn cleanup_expired_leases(&self, now: DateTime<Utc>) {
-        let expired: Vec<TaskId> = self
-            .leases
-            .iter()
-            .filter(|entry| entry.value().expires_at <= now)
-            .map(|entry| entry.key().clone())
-            .collect();
-        for task_id in expired {
-            self.leases.remove(&task_id);
+        loop {
+            let next = {
+                let mut heap = self
+                    .lease_expirations
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                match heap.peek() {
+                    Some(Reverse(expiry)) if expiry.expires_at <= now => {
+                        heap.pop().map(|Reverse(item)| item)
+                    }
+                    _ => None,
+                }
+            };
+            let Some(expiry) = next else {
+                break;
+            };
+            let should_remove = self
+                .leases
+                .get(&expiry.task_id)
+                .map(|lease| lease.expires_at <= now && lease.expires_at == expiry.expires_at)
+                .unwrap_or(false);
+            if should_remove {
+                self.remove_lease(&expiry.task_id);
+            }
+        }
+    }
+
+    pub(crate) fn index_lease(&self, host_id: &str, task_id: TaskId, expires_at: DateTime<Utc>) {
+        self.host_leases
+            .entry(host_id.to_string())
+            .or_default()
+            .insert(task_id.clone());
+        self.lease_expirations
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .push(Reverse(LeaseExpiry {
+                expires_at,
+                task_id,
+            }));
+    }
+
+    fn remove_lease(&self, task_id: &TaskId) {
+        let Some((_, lease)) = self.leases.remove(task_id) else {
+            return;
+        };
+        if let Some(mut owned_ids) = self.host_leases.get_mut(&lease.host_id) {
+            owned_ids.remove(task_id);
+            if owned_ids.is_empty() {
+                drop(owned_ids);
+                self.host_leases.remove(&lease.host_id);
+            }
         }
     }
 

--- a/crates/harness-server/src/runtime_hosts_state.rs
+++ b/crates/harness-server/src/runtime_hosts_state.rs
@@ -57,6 +57,11 @@ impl RuntimeHostManager {
     ) -> (usize, usize) {
         self.hosts.clear();
         self.leases.clear();
+        self.host_leases.clear();
+        self.lease_expirations
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clear();
 
         for host in hosts {
             self.hosts.insert(
@@ -80,12 +85,13 @@ impl RuntimeHostManager {
                 continue;
             }
             self.leases.insert(
-                lease.task_id,
+                lease.task_id.clone(),
                 TaskLease {
-                    host_id: lease.host_id,
+                    host_id: lease.host_id.clone(),
                     expires_at: lease.expires_at,
                 },
             );
+            self.index_lease(&lease.host_id, lease.task_id, lease.expires_at);
         }
         (self.hosts.len(), self.leases.len())
     }

--- a/crates/harness-server/src/runtime_hosts_state.rs
+++ b/crates/harness-server/src/runtime_hosts_state.rs
@@ -1,0 +1,92 @@
+use crate::runtime_hosts::{RuntimeHostManager, RuntimeHostRecord, TaskLease};
+use crate::task_runner::TaskId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedRuntimeHost {
+    pub id: String,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub registered_at: DateTime<Utc>,
+    pub last_heartbeat_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedTaskLease {
+    pub task_id: TaskId,
+    pub host_id: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl RuntimeHostManager {
+    pub fn snapshot_state(&self) -> (Vec<PersistedRuntimeHost>, Vec<PersistedTaskLease>) {
+        let hosts = self
+            .hosts
+            .iter()
+            .map(|entry| {
+                let host = entry.value();
+                PersistedRuntimeHost {
+                    id: host.id.clone(),
+                    display_name: host.display_name.clone(),
+                    capabilities: host.capabilities.clone(),
+                    registered_at: host.registered_at,
+                    last_heartbeat_at: host.last_heartbeat_at,
+                }
+            })
+            .collect();
+        let leases = self
+            .leases
+            .iter()
+            .map(|entry| {
+                let lease = entry.value();
+                PersistedTaskLease {
+                    task_id: entry.key().clone(),
+                    host_id: lease.host_id.clone(),
+                    expires_at: lease.expires_at,
+                }
+            })
+            .collect();
+        (hosts, leases)
+    }
+
+    pub fn restore_state(
+        &self,
+        hosts: Vec<PersistedRuntimeHost>,
+        leases: Vec<PersistedTaskLease>,
+    ) -> (usize, usize) {
+        self.hosts.clear();
+        self.leases.clear();
+
+        for host in hosts {
+            self.hosts.insert(
+                host.id.clone(),
+                RuntimeHostRecord {
+                    id: host.id,
+                    display_name: host.display_name,
+                    capabilities: host.capabilities,
+                    registered_at: host.registered_at,
+                    last_heartbeat_at: host.last_heartbeat_at,
+                },
+            );
+        }
+
+        let now = Utc::now();
+        for lease in leases {
+            if lease.expires_at <= now {
+                continue;
+            }
+            if !self.hosts.contains_key(&lease.host_id) {
+                continue;
+            }
+            self.leases.insert(
+                lease.task_id,
+                TaskLease {
+                    host_id: lease.host_id,
+                    expires_at: lease.expires_at,
+                },
+            );
+        }
+        (self.hosts.len(), self.leases.len())
+    }
+}

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -54,6 +54,7 @@ fn deregister_releases_owned_leases() -> anyhow::Result<()> {
     let first = manager.claim_task("host-a", candidates.clone(), Some(30), None)?;
     assert!(first.is_some());
     assert!(manager.deregister("host-a"));
+    assert!(manager.host_leases.get("host-a").is_none());
 
     let second = manager.claim_task("host-b", candidates, Some(30), None)?;
     assert!(second.is_some());

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -1,0 +1,61 @@
+use crate::runtime_hosts::{ClaimCandidate, RuntimeHostManager};
+use crate::task_runner::{TaskId, TaskStatus};
+
+fn candidate(task_id: TaskId, created_at: &str) -> ClaimCandidate {
+    ClaimCandidate {
+        task_id,
+        status: TaskStatus::Pending,
+        created_at: Some(created_at.to_string()),
+        project: None,
+    }
+}
+
+#[test]
+fn active_lease_blocks_double_claim() -> anyhow::Result<()> {
+    let manager = RuntimeHostManager::with_timeouts(60, 30);
+    manager.register("host-a".to_string(), None, vec![]);
+    manager.register("host-b".to_string(), None, vec![]);
+
+    let task_id = TaskId::new();
+    let candidates = vec![candidate(task_id.clone(), "2026-04-02T00:00:00Z")];
+
+    let first = manager.claim_task("host-a", candidates.clone(), Some(30), None)?;
+    assert!(first.is_some());
+    let second = manager.claim_task("host-b", candidates, Some(30), None)?;
+    assert!(second.is_none());
+    Ok(())
+}
+
+#[test]
+fn zero_ttl_lease_is_reclaimable() -> anyhow::Result<()> {
+    let manager = RuntimeHostManager::with_timeouts(60, 30);
+    manager.register("host-a".to_string(), None, vec![]);
+    manager.register("host-b".to_string(), None, vec![]);
+
+    let task_id = TaskId::new();
+    let candidates = vec![candidate(task_id.clone(), "2026-04-02T00:00:00Z")];
+
+    let first = manager.claim_task("host-a", candidates.clone(), Some(0), None)?;
+    assert!(first.is_some());
+    let second = manager.claim_task("host-b", candidates, Some(30), None)?;
+    assert!(second.is_some());
+    Ok(())
+}
+
+#[test]
+fn deregister_releases_owned_leases() -> anyhow::Result<()> {
+    let manager = RuntimeHostManager::with_timeouts(60, 30);
+    manager.register("host-a".to_string(), None, vec![]);
+    manager.register("host-b".to_string(), None, vec![]);
+
+    let task_id = TaskId::new();
+    let candidates = vec![candidate(task_id.clone(), "2026-04-02T00:00:00Z")];
+
+    let first = manager.claim_task("host-a", candidates.clone(), Some(30), None)?;
+    assert!(first.is_some());
+    assert!(manager.deregister("host-a"));
+
+    let second = manager.claim_task("host-b", candidates, Some(30), None)?;
+    assert!(second.is_some());
+    Ok(())
+}

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -1,5 +1,13 @@
 use crate::runtime_hosts::{ClaimCandidate, RuntimeHostManager};
 use crate::task_runner::{TaskId, TaskStatus};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::Duration,
+};
 
 fn candidate(task_id: TaskId, created_at: &str) -> ClaimCandidate {
     ClaimCandidate {
@@ -88,4 +96,36 @@ fn deregister_compacts_lease_expiry_heap() -> anyhow::Result<()> {
         0
     );
     Ok(())
+}
+
+#[test]
+fn deregister_waits_for_lease_lock_before_removing_host() {
+    let manager = Arc::new(RuntimeHostManager::with_timeouts(60, 30));
+    manager.register("host-a".to_string(), None, vec![]);
+
+    let lease_guard = manager.hold_lease_mutation_lock_for_test();
+    let barrier = Arc::new(Barrier::new(2));
+    let finished = Arc::new(AtomicBool::new(false));
+
+    let manager_for_thread = Arc::clone(&manager);
+    let barrier_for_thread = Arc::clone(&barrier);
+    let finished_for_thread = Arc::clone(&finished);
+    let join = thread::spawn(move || {
+        barrier_for_thread.wait();
+        manager_for_thread.deregister("host-a");
+        finished_for_thread.store(true, Ordering::SeqCst);
+    });
+
+    barrier.wait();
+
+    for _ in 0..25 {
+        assert!(manager.hosts.contains_key("host-a"));
+        assert!(!finished.load(Ordering::SeqCst));
+        thread::sleep(Duration::from_millis(2));
+    }
+
+    drop(lease_guard);
+    join.join().unwrap();
+
+    assert!(!manager.hosts.contains_key("host-a"));
 }

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -60,3 +60,32 @@ fn deregister_releases_owned_leases() -> anyhow::Result<()> {
     assert!(second.is_some());
     Ok(())
 }
+
+#[test]
+fn deregister_compacts_lease_expiry_heap() -> anyhow::Result<()> {
+    let manager = RuntimeHostManager::with_timeouts(60, 300);
+    manager.register("host-a".to_string(), None, vec![]);
+
+    let task_id = TaskId::new();
+    let first = manager.claim_task_id("host-a", &task_id, Some(300))?;
+    assert!(first.is_some());
+    assert_eq!(
+        manager
+            .lease_expirations
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .len(),
+        1
+    );
+
+    assert!(manager.deregister("host-a"));
+    assert_eq!(
+        manager
+            .lease_expirations
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .len(),
+        0
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/runtime_project_cache.rs
+++ b/crates/harness-server/src/runtime_project_cache.rs
@@ -1,0 +1,115 @@
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct WatchedProjectInput {
+    pub project_id: Option<String>,
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WatchedProject {
+    pub project_id: Option<String>,
+    pub root: String,
+    pub synced_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostProjectCacheSnapshot {
+    pub host_id: String,
+    pub last_synced_at: String,
+    pub project_count: usize,
+    pub projects: Vec<WatchedProject>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedProjectRecord {
+    pub(crate) project_id: Option<String>,
+    pub(crate) root: String,
+    pub(crate) synced_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HostProjectCacheRecord {
+    pub(crate) last_synced_at: DateTime<Utc>,
+    pub(crate) projects: Vec<CachedProjectRecord>,
+}
+
+pub struct RuntimeProjectCacheManager {
+    pub(crate) caches: DashMap<String, HostProjectCacheRecord>,
+}
+
+impl RuntimeProjectCacheManager {
+    pub fn new() -> Self {
+        Self {
+            caches: DashMap::new(),
+        }
+    }
+
+    pub fn sync_host_projects(
+        &self,
+        host_id: &str,
+        projects: Vec<WatchedProjectInput>,
+    ) -> HostProjectCacheSnapshot {
+        let now = Utc::now();
+        let mut dedup: BTreeMap<String, CachedProjectRecord> = BTreeMap::new();
+        for project in projects {
+            dedup.insert(
+                project.root.clone(),
+                CachedProjectRecord {
+                    project_id: project.project_id,
+                    root: project.root,
+                    synced_at: now,
+                },
+            );
+        }
+        let cache = HostProjectCacheRecord {
+            last_synced_at: now,
+            projects: dedup.into_values().collect(),
+        };
+        self.caches.insert(host_id.to_string(), cache.clone());
+        self.to_snapshot(host_id, &cache)
+    }
+
+    pub fn get_host_cache(&self, host_id: &str) -> Option<HostProjectCacheSnapshot> {
+        self.caches
+            .get(host_id)
+            .map(|cache| self.to_snapshot(host_id, &cache))
+    }
+
+    pub fn empty_snapshot(&self, host_id: &str) -> HostProjectCacheSnapshot {
+        HostProjectCacheSnapshot {
+            host_id: host_id.to_string(),
+            last_synced_at: Utc::now().to_rfc3339(),
+            project_count: 0,
+            projects: vec![],
+        }
+    }
+
+    pub fn clear_host(&self, host_id: &str) -> bool {
+        self.caches.remove(host_id).is_some()
+    }
+
+    fn to_snapshot(
+        &self,
+        host_id: &str,
+        cache: &HostProjectCacheRecord,
+    ) -> HostProjectCacheSnapshot {
+        HostProjectCacheSnapshot {
+            host_id: host_id.to_string(),
+            last_synced_at: cache.last_synced_at.to_rfc3339(),
+            project_count: cache.projects.len(),
+            projects: cache
+                .projects
+                .iter()
+                .map(|project| WatchedProject {
+                    project_id: project.project_id.clone(),
+                    root: project.root.clone(),
+                    synced_at: project.synced_at.to_rfc3339(),
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/harness-server/src/runtime_project_cache_state.rs
+++ b/crates/harness-server/src/runtime_project_cache_state.rs
@@ -1,0 +1,77 @@
+use crate::runtime_project_cache::{
+    CachedProjectRecord, HostProjectCacheRecord, RuntimeProjectCacheManager,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedWatchedProject {
+    pub project_id: Option<String>,
+    pub root: String,
+    pub synced_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedHostProjectCache {
+    pub host_id: String,
+    pub last_synced_at: DateTime<Utc>,
+    pub projects: Vec<PersistedWatchedProject>,
+}
+
+impl RuntimeProjectCacheManager {
+    pub fn snapshot_state(&self) -> Vec<PersistedHostProjectCache> {
+        let mut snapshots: Vec<PersistedHostProjectCache> = self
+            .caches
+            .iter()
+            .map(|entry| {
+                let cache = entry.value();
+                PersistedHostProjectCache {
+                    host_id: entry.key().clone(),
+                    last_synced_at: cache.last_synced_at,
+                    projects: cache
+                        .projects
+                        .iter()
+                        .map(|project| PersistedWatchedProject {
+                            project_id: project.project_id.clone(),
+                            root: project.root.clone(),
+                            synced_at: project.synced_at,
+                        })
+                        .collect(),
+                }
+            })
+            .collect();
+        snapshots.sort_by(|a, b| a.host_id.cmp(&b.host_id));
+        snapshots
+    }
+
+    pub fn restore_state(&self, caches: Vec<PersistedHostProjectCache>) -> usize {
+        self.caches.clear();
+
+        for cache in caches {
+            if cache.host_id.trim().is_empty() {
+                continue;
+            }
+            let mut dedup: BTreeMap<String, CachedProjectRecord> = BTreeMap::new();
+            for project in cache.projects {
+                dedup.insert(
+                    project.root.clone(),
+                    CachedProjectRecord {
+                        project_id: project.project_id,
+                        root: project.root,
+                        synced_at: project.synced_at,
+                    },
+                );
+            }
+            self.caches.insert(
+                cache.host_id,
+                HostProjectCacheRecord {
+                    last_synced_at: cache.last_synced_at,
+                    projects: dedup.into_values().collect(),
+                },
+            );
+        }
+
+        self.caches.len()
+    }
+}

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -1,0 +1,117 @@
+use crate::runtime_hosts_state::{PersistedRuntimeHost, PersistedTaskLease};
+use crate::runtime_project_cache_state::PersistedHostProjectCache;
+use chrono::{DateTime, Utc};
+use harness_core::db::{Db, DbEntity};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const SNAPSHOT_ID: &str = "runtime-state";
+const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeStateSnapshot {
+    pub id: String,
+    pub schema_version: u32,
+    pub updated_at: DateTime<Utc>,
+    pub hosts: Vec<PersistedRuntimeHost>,
+    pub leases: Vec<PersistedTaskLease>,
+    pub project_caches: Vec<PersistedHostProjectCache>,
+}
+
+impl RuntimeStateSnapshot {
+    fn new(
+        hosts: Vec<PersistedRuntimeHost>,
+        leases: Vec<PersistedTaskLease>,
+        project_caches: Vec<PersistedHostProjectCache>,
+    ) -> Self {
+        Self {
+            id: SNAPSHOT_ID.to_string(),
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            updated_at: Utc::now(),
+            hosts,
+            leases,
+            project_caches,
+        }
+    }
+}
+
+impl DbEntity for RuntimeStateSnapshot {
+    fn table_name() -> &'static str {
+        "runtime_state"
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn create_table_sql() -> &'static str {
+        "CREATE TABLE IF NOT EXISTS runtime_state (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )"
+    }
+}
+
+pub struct RuntimeStateStore {
+    inner: Db<RuntimeStateSnapshot>,
+}
+
+impl RuntimeStateStore {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        Ok(Self {
+            inner: Db::open(path).await?,
+        })
+    }
+
+    pub async fn load_snapshot(&self) -> anyhow::Result<Option<RuntimeStateSnapshot>> {
+        self.inner.get(SNAPSHOT_ID).await
+    }
+
+    pub async fn persist_snapshot(
+        &self,
+        hosts: Vec<PersistedRuntimeHost>,
+        leases: Vec<PersistedTaskLease>,
+        project_caches: Vec<PersistedHostProjectCache>,
+    ) -> anyhow::Result<()> {
+        let snapshot = RuntimeStateSnapshot::new(hosts, leases, project_caches);
+        self.inner.upsert(&snapshot).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn runtime_state_store_roundtrip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = RuntimeStateStore::open(&dir.path().join("runtime_state.db")).await?;
+        store.persist_snapshot(vec![], vec![], vec![]).await?;
+
+        let snapshot = store.load_snapshot().await?.expect("snapshot should exist");
+        assert_eq!(snapshot.id, SNAPSHOT_ID);
+        assert_eq!(snapshot.schema_version, SNAPSHOT_SCHEMA_VERSION);
+        assert!(snapshot.hosts.is_empty());
+        assert!(snapshot.leases.is_empty());
+        assert!(snapshot.project_caches.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_state_store_survives_reopen() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("runtime_state.db");
+
+        {
+            let store = RuntimeStateStore::open(&db_path).await?;
+            store.persist_snapshot(vec![], vec![], vec![]).await?;
+        }
+
+        let reopened = RuntimeStateStore::open(&db_path).await?;
+        let snapshot = reopened.load_snapshot().await?;
+        assert!(snapshot.is_some());
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -1,0 +1,81 @@
+use crate::runtime_hosts::ClaimCandidate;
+use crate::runtime_project_cache::WatchedProjectInput;
+use crate::task_runner::{TaskId, TaskStatus};
+use crate::{http::build_app_state, server::HarnessServer, thread_manager::ThreadManager};
+use harness_agents::registry::AgentRegistry;
+use harness_core::config::HarnessConfig;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn build_app_state_restores_runtime_snapshot() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let project_root = crate::test_helpers::tempdir_in_home("runtime-state-root-")?;
+    let data_dir = tempfile::tempdir()?;
+
+    let mut config = HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+
+    let first_server = Arc::new(HarnessServer::new(
+        config.clone(),
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let first_state = build_app_state(first_server).await?;
+
+    first_state.runtime_hosts.register(
+        "host-a".to_string(),
+        Some("Host A".to_string()),
+        vec!["codex".to_string()],
+    );
+    let task_id = TaskId::new();
+    first_state.runtime_hosts.claim_task(
+        "host-a",
+        vec![ClaimCandidate {
+            task_id: task_id.clone(),
+            status: TaskStatus::Pending,
+            created_at: Some("2026-04-02T00:00:00Z".to_string()),
+            project: None,
+        }],
+        Some(120),
+        None,
+    )?;
+    first_state.runtime_project_cache.sync_host_projects(
+        "host-a",
+        vec![WatchedProjectInput {
+            project_id: Some("default".to_string()),
+            root: project_root
+                .path()
+                .canonicalize()?
+                .to_string_lossy()
+                .into_owned(),
+        }],
+    );
+    first_state.persist_runtime_state().await?;
+    drop(first_state);
+
+    let second_server = Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let restored_state = build_app_state(second_server).await?;
+
+    let hosts = restored_state.runtime_hosts.list_hosts();
+    assert_eq!(hosts.len(), 1);
+    assert_eq!(hosts[0].id, "host-a");
+    let (_, leases) = restored_state.runtime_hosts.snapshot_state();
+    assert_eq!(leases.len(), 1);
+    assert_eq!(leases[0].task_id, task_id);
+
+    let project_cache = restored_state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .expect("runtime project cache for host-a should be restored");
+    assert_eq!(project_cache.project_count, 1);
+    assert_eq!(
+        project_cache.projects[0].project_id.as_deref(),
+        Some("default")
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -4,7 +4,7 @@
 use crate::{
     complexity_router,
     http::resolve_reviewer,
-    project_registry::ProjectRegistry,
+    project_registry::{check_allowed_roots, ProjectRegistry},
     task_queue::TaskQueue,
     task_runner::{self, CompletionCallback, CreateTaskRequest, TaskId, TaskStore},
     workspace::WorkspaceManager,
@@ -143,17 +143,8 @@ impl DefaultExecutionService {
 
     /// Check the resolved canonical project against `allowed_project_roots`.
     fn check_allowed_roots(&self, canonical: &std::path::Path) -> Result<(), EnqueueTaskError> {
-        if !self.allowed_project_roots.is_empty()
-            && !self
-                .allowed_project_roots
-                .iter()
-                .any(|base| canonical.starts_with(base))
-        {
-            return Err(EnqueueTaskError::BadRequest(
-                "project root is not under an allowed base directory".to_string(),
-            ));
-        }
-        Ok(())
+        check_allowed_roots(canonical, &self.allowed_project_roots)
+            .map_err(EnqueueTaskError::BadRequest)
     }
 
     /// Select the agent for this request (explicit name or complexity-routed).
@@ -447,12 +438,15 @@ mod tests {
 
     #[tokio::test]
     async fn check_allowed_roots_permits_inside_root() -> anyhow::Result<()> {
+        let base_dir = tempfile::tempdir()?;
+        let project_dir = base_dir.path().join("project");
+        std::fs::create_dir_all(&project_dir)?;
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("t.db")).await?;
-        let allowed = vec![PathBuf::from("/allowed/base")];
+        let allowed = vec![base_dir.path().to_path_buf()];
         let svc = make_svc_with_allowed_roots(store, allowed).await;
-        let inside = PathBuf::from("/allowed/base/project");
-        assert!(svc.check_allowed_roots(&inside).is_ok());
+        let canonical_project = project_dir.canonicalize()?;
+        assert!(svc.check_allowed_roots(&canonical_project).is_ok());
         Ok(())
     }
 

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -215,6 +215,7 @@ mod tests {
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
+            runtime_state_persist_lock: tokio::sync::Mutex::new(()),
             notifications: crate::http::NotificationServices {
                 notification_tx: tokio::sync::broadcast::channel(32).0,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -190,6 +190,7 @@ mod tests {
                 plan_db: None,
                 plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
                 project_registry: None,
+                runtime_state_store: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),
@@ -210,6 +211,10 @@ mod tests {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
             },
+            runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+            runtime_project_cache: Arc::new(
+                crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
             notifications: crate::http::NotificationServices {
                 notification_tx: tokio::sync::broadcast::channel(32).0,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -216,6 +216,7 @@ mod tests {
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
             notifications: crate::http::NotificationServices {
                 notification_tx: tokio::sync::broadcast::channel(32).0,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -606,6 +606,19 @@ impl TaskStore {
         self.cache.iter().map(|e| e.value().clone()).collect()
     }
 
+    /// Run `f` only if the task still exists and is live-`pending`.
+    ///
+    /// Holding the mutable cache guard across `f` prevents a concurrent status
+    /// transition from changing this task out of `pending` between the check
+    /// and a follow-up side effect such as runtime-host lease insertion.
+    pub(crate) fn with_task_if_pending<R>(&self, id: &TaskId, f: impl FnOnce() -> R) -> Option<R> {
+        let entry = self.cache.get_mut(id)?;
+        if !matches!(entry.status, TaskStatus::Pending) {
+            return None;
+        }
+        Some(f())
+    }
+
     /// Return the `pr_url` of the most recently created Done task, ordered by `created_at DESC`
     /// from the database (stable ordering, unlike the in-memory DashMap cache).
     pub async fn latest_done_pr_url(&self) -> Option<String> {

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -178,6 +178,7 @@ async fn make_state_inner(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -177,6 +177,7 @@ async fn make_state_inner(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -154,6 +154,7 @@ async fn make_state_inner(
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
             project_registry: None,
+            runtime_state_store: None,
         },
         engines: crate::http::EngineServices {
             skills: Default::default(),
@@ -172,6 +173,10 @@ async fn make_state_inner(
             task_queue,
             workspace_mgr: None,
         },
+        runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+        runtime_project_cache: Arc::new(
+            crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -178,7 +178,7 @@ async fn make_state_inner(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
-            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+        runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         notifications: crate::http::NotificationServices {
             notification_tx,
             notification_lagged_total: Arc::new(AtomicU64::new(0)),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -328,6 +328,7 @@ mod tests {
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
             notifications: crate::http::NotificationServices {
                 notification_tx,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -327,6 +327,7 @@ mod tests {
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
+            runtime_state_persist_lock: tokio::sync::Mutex::new(()),
             notifications: crate::http::NotificationServices {
                 notification_tx,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -302,6 +302,7 @@ mod tests {
                 plan_db: None,
                 plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
                 project_registry: None,
+                runtime_state_store: None,
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),
@@ -322,6 +323,10 @@ mod tests {
                 task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
                 workspace_mgr: None,
             },
+            runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+            runtime_project_cache: Arc::new(
+                crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
             notifications: crate::http::NotificationServices {
                 notification_tx,
                 notification_lagged_total: Arc::new(std::sync::atomic::AtomicU64::new(0)),

--- a/crates/harness-server/static/dashboard.css
+++ b/crates/harness-server/static/dashboard.css
@@ -161,6 +161,18 @@ body {
   letter-spacing: -0.02em;
 }
 
+.section-subtitle {
+  margin: 1rem 0 0.55rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.runtime-hosts-section {
+  margin-top: 0.35rem;
+}
+
 .board {
   margin-top: 1rem;
 }

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -63,6 +63,15 @@ async function fetchIntake() {
   } catch {}
 }
 
+async function fetchDashboardSummary() {
+  try {
+    const resp = await fetch("/api/dashboard", { headers: authHeaders() });
+    if (!resp.ok) return;
+    const data = await resp.json();
+    renderRuntimeHosts(data.runtime_hosts || []);
+  } catch {}
+}
+
 // --- Metrics ---
 
 function updateMetrics(tasks) {
@@ -130,6 +139,30 @@ function renderIntakeChannels(channels) {
       (detail ? `<div class="channel-detail">${escapeHtml(detail)}</div>` : "") +
       `<div class="channel-status">${enabled ? "enabled" : "disabled"}</div>` +
       `<div class="channel-active">${escapeHtml(String(ch.active))} active</div>`;
+    grid.appendChild(card);
+  });
+}
+
+function renderRuntimeHosts(hosts) {
+  const grid = document.getElementById("runtime-host-grid");
+  if (!grid) return;
+  grid.innerHTML = "";
+  if (!hosts.length) {
+    grid.innerHTML = '<p class="empty-state">No runtime hosts registered</p>';
+    return;
+  }
+  hosts.forEach((host) => {
+    const online = Boolean(host.online);
+    const card = document.createElement("div");
+    card.className = "channel-card" + (online ? " channel-card-enabled" : " channel-card-disabled");
+    const caps = Array.isArray(host.capabilities) ? host.capabilities.join(", ") : "";
+    const watched = Number(host.watched_projects || 0);
+    const heartbeat = relativeTime(host.last_heartbeat_at) || "unknown";
+    card.innerHTML =
+      `<div class="channel-name">${escapeHtml(host.display_name || host.id || "runtime-host")}</div>` +
+      `<div class="channel-detail">${escapeHtml(caps || "no capabilities")}</div>` +
+      `<div class="channel-status">${online ? "online" : "offline"}</div>` +
+      `<div class="channel-active">${escapeHtml(String(watched))} watched \u00b7 ${escapeHtml(heartbeat)}</div>`;
     grid.appendChild(card);
   });
 }
@@ -767,6 +800,7 @@ function init() {
   initTabs();
   fetchTasks();
   fetchIntake();
+  fetchDashboardSummary();
   fetchTokenUsage();
   connectWebSocket();
   initForm();
@@ -776,6 +810,7 @@ function init() {
   });
   pollTimer = setInterval(fetchTasks, POLL_INTERVAL_MS);
   setInterval(fetchIntake, POLL_INTERVAL_MS);
+  setInterval(fetchDashboardSummary, POLL_INTERVAL_MS);
   setInterval(fetchTokenUsage, POLL_INTERVAL_MS);
 }
 

--- a/docs/runtime-host-model-spec.md
+++ b/docs/runtime-host-model-spec.md
@@ -1,0 +1,84 @@
+# Runtime Host Model (Issue #595)
+
+## Goal
+
+Add a minimal runtime host control surface so Harness can track external executors and safely lease pending tasks to them.
+
+## Why
+
+Harness is strong as a centralized control plane, but runtime host lifecycle is implicit today. We need explicit host registration and claim semantics before scaling execution beyond directly attached local agents.
+
+## In Scope
+
+1. In-memory runtime host registry with:
+- host `register`
+- host `deregister`
+- host `heartbeat`
+- host listing with `online` status derived from heartbeat freshness
+2. In-memory task lease manager for pending tasks:
+- runtime host can claim one pending task
+- duplicate claim prevention across hosts
+- lease TTL support
+3. HTTP API endpoints:
+- `GET /api/runtime-hosts`
+- `POST /api/runtime-hosts/register`
+- `POST /api/runtime-hosts/{id}/heartbeat`
+- `POST /api/runtime-hosts/{id}/deregister`
+- `POST /api/runtime-hosts/{id}/tasks/claim`
+4. Tests for lease correctness and heartbeat-driven status.
+
+## Out of Scope
+
+1. Persisting runtime hosts and leases across restart.
+2. Remote executor callback APIs (`start/progress/complete/fail`).
+3. Scheduler integration that auto-routes all tasks to runtime hosts.
+4. Workspace/multi-tenant model migration.
+
+## Data Model (V1)
+
+`RuntimeHost`
+- `id: String`
+- `display_name: String`
+- `capabilities: Vec<String>`
+- `registered_at: DateTime<Utc>`
+- `last_heartbeat_at: DateTime<Utc>`
+
+`TaskLease`
+- `task_id: TaskId`
+- `host_id: String`
+- `claimed_at: DateTime<Utc>`
+- `expires_at: DateTime<Utc>`
+
+## Behavior Rules
+
+1. `register` is idempotent by `host_id` (upsert metadata and refresh heartbeat).
+2. `heartbeat` on unknown host returns error.
+3. `deregister` removes host and all leases owned by host.
+4. `claim` selects only tasks in `pending` status.
+5. A non-expired lease blocks claims by other hosts.
+6. Expired leases are reclaimable by any host.
+
+## API Response Shape (V1)
+
+`GET /api/runtime-hosts`
+- `hosts: [{ id, display_name, capabilities, registered_at, last_heartbeat_at, online }]`
+- `online` is computed as `now - last_heartbeat_at <= heartbeat_timeout_secs`
+
+`POST /api/runtime-hosts/{id}/tasks/claim`
+- success: `{ claimed: true, task_id, lease_expires_at }`
+- none available: `{ claimed: false }`
+
+## Risks
+
+1. In-memory leases can be lost on restart.
+2. Claim fairness is best-effort because pending selection is linear scan.
+
+## Verification
+
+1. Unit tests for manager:
+- duplicate claim blocked while lease active
+- claim succeeds after lease expiry
+- deregister clears leases
+2. Handler tests:
+- register + heartbeat + list returns online host
+- claim endpoint returns expected payload and prevents double-claim

--- a/docs/runtime-project-cache-spec.md
+++ b/docs/runtime-project-cache-spec.md
@@ -1,0 +1,70 @@
+# Runtime Project Cache (Issue #594)
+
+## Goal
+
+Add a watched project cache for long-lived runtime hosts so project context can be warm-synced and reused across claims.
+
+## Why
+
+Runtime hosts should not start from a cold project view on every cycle. We need an explicit host-scoped cache of watched projects, with a sync API and predictable lifecycle.
+
+## In Scope
+
+1. In-memory host project cache manager.
+2. Host-scoped project sync endpoint.
+3. Host-scoped project list endpoint.
+4. Registry/path resolution for project tokens during sync.
+5. Cache cleanup when runtime host deregisters.
+6. API tests for path sync, project-id sync, and unknown host handling.
+
+## Out of Scope
+
+1. Persistent cache storage across restart.
+2. Background file watcher or git index prefetch.
+3. Automatic scheduler routing based on watched-project affinity.
+4. Multi-tenant workspace model migration.
+
+## API (V1)
+
+`POST /api/runtime-hosts/{host_id}/projects/sync`
+- request: `{ "projects": [{ "project": "<id-or-path>" }] }`
+- behavior:
+- if token is an existing directory, use canonical path
+- else resolve as registered project ID
+- enforce `allowed_project_roots` and project-root validation
+- response:
+- `{ host_id, last_synced_at, project_count, projects[] }`
+
+`GET /api/runtime-hosts/{host_id}/projects`
+- response:
+- same snapshot shape as sync response
+
+## Data Model
+
+`WatchedProjectInput`
+- `project_id: Option<String>`
+- `root: String`
+
+`HostProjectCacheSnapshot`
+- `host_id: String`
+- `last_synced_at: String`
+- `project_count: usize`
+- `projects: [{ project_id, root, synced_at }]`
+
+## Rules
+
+1. Sync is full replacement for that host cache (latest snapshot wins).
+2. Project roots are deduplicated by canonical root path.
+3. Unknown runtime host returns `404`.
+4. Deregistered host clears cached projects.
+
+## Risks
+
+1. In-memory cache is lost on restart.
+2. Sync does not currently warm git metadata; only project identity/root is cached.
+
+## Verification
+
+1. Sync by project path then list returns cached canonical root.
+2. Sync by project ID resolves registry root and stores `project_id`.
+3. Sync on unknown host returns `404`.


### PR DESCRIPTION
## Summary
- add runtime host register/heartbeat/deregister/claim APIs
- add watched project sync/list APIs for runtime hosts
- persist and restore runtime host/lease/project-cache state on server restart

## Validation
- cargo check -p harness-server
- cargo test -p harness-server runtime_ -- --nocapture
- cargo test -p harness-server dashboard -- --nocapture