### PR TITLE
fix(config): redact secrets in ServerConfig Debug impl (SEC-10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use super::dirs::dirs_data_dir;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub transport: Transport,
     pub http_addr: SocketAddr,
@@ -61,6 +62,50 @@ pub struct ServerConfig {
     /// Falls back to `GITHUB_TOKEN` env var when not configured.
     #[serde(default)]
     pub github_token: Option<String>,
+}
+
+impl fmt::Debug for ServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerConfig")
+            .field("transport", &self.transport)
+            .field("http_addr", &self.http_addr)
+            .field("data_dir", &self.data_dir)
+            .field("project_root", &self.project_root)
+            .field(
+                "github_webhook_secret",
+                &self.github_webhook_secret.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "notification_broadcast_capacity",
+                &self.notification_broadcast_capacity,
+            )
+            .field(
+                "notification_lag_log_every",
+                &self.notification_lag_log_every,
+            )
+            .field(
+                "ws_heartbeat_interval_secs",
+                &self.ws_heartbeat_interval_secs,
+            )
+            .field("trusted_proxies", &self.trusted_proxies)
+            .field("api_token", &self.api_token.as_ref().map(|_| "[REDACTED]"))
+            .field("allowed_project_roots", &self.allowed_project_roots)
+            .field("max_webhook_body_bytes", &self.max_webhook_body_bytes)
+            .field(
+                "signal_rate_limit_per_minute",
+                &self.signal_rate_limit_per_minute,
+            )
+            .field(
+                "password_reset_rate_limit_per_hour",
+                &self.password_reset_rate_limit_per_hour,
+            )
+            .field("constitution_enabled", &self.constitution_enabled)
+            .field(
+                "github_token",
+                &self.github_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl Default for ServerConfig {
@@ -124,4 +169,46 @@ fn default_password_reset_rate_limit_per_hour() -> u32 {
 
 fn default_constitution_enabled() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_config_debug_redacts_secrets() {
+        let config = ServerConfig {
+            github_webhook_secret: Some("wh-secret-abc".to_string()),
+            api_token: Some("tok-xyz".to_string()),
+            github_token: Some("gh-token-123".to_string()),
+            ..ServerConfig::default()
+        };
+        let debug_output = format!("{config:?}");
+        assert!(
+            !debug_output.contains("wh-secret-abc"),
+            "github_webhook_secret must not appear in Debug output"
+        );
+        assert!(
+            !debug_output.contains("tok-xyz"),
+            "api_token must not appear in Debug output"
+        );
+        assert!(
+            !debug_output.contains("gh-token-123"),
+            "github_token must not appear in Debug output"
+        );
+        assert!(
+            debug_output.contains("[REDACTED]"),
+            "Debug output must contain [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn server_config_debug_shows_none_for_absent_secrets() {
+        let config = ServerConfig::default();
+        let debug_output = format!("{config:?}");
+        assert!(
+            debug_output.contains("None"),
+            "absent secrets should show as None"
+        );
+    }
 }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -207,8 +207,16 @@ mod tests {
         let config = ServerConfig::default();
         let debug_output = format!("{config:?}");
         assert!(
-            debug_output.contains("None"),
-            "absent secrets should show as None"
+            debug_output.contains("github_webhook_secret: None"),
+            "absent github_webhook_secret should show as None"
+        );
+        assert!(
+            debug_output.contains("api_token: None"),
+            "absent api_token should show as None"
+        );
+        assert!(
+            debug_output.contains("github_token: None"),
+            "absent github_token should show as None"
         );
     }
 }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -66,44 +66,51 @@ pub struct ServerConfig {
 
 impl fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Exhaustive destructure: compiler error if a new field is added but omitted here.
+        let Self {
+            transport,
+            http_addr,
+            data_dir,
+            project_root,
+            github_webhook_secret,
+            notification_broadcast_capacity,
+            notification_lag_log_every,
+            ws_heartbeat_interval_secs,
+            trusted_proxies,
+            api_token,
+            allowed_project_roots,
+            max_webhook_body_bytes,
+            signal_rate_limit_per_minute,
+            password_reset_rate_limit_per_hour,
+            constitution_enabled,
+            github_token,
+        } = self;
         f.debug_struct("ServerConfig")
-            .field("transport", &self.transport)
-            .field("http_addr", &self.http_addr)
-            .field("data_dir", &self.data_dir)
-            .field("project_root", &self.project_root)
+            .field("transport", transport)
+            .field("http_addr", http_addr)
+            .field("data_dir", data_dir)
+            .field("project_root", project_root)
             .field(
                 "github_webhook_secret",
-                &self.github_webhook_secret.as_ref().map(|_| "[REDACTED]"),
+                &github_webhook_secret.as_ref().map(|_| "[REDACTED]"),
             )
             .field(
                 "notification_broadcast_capacity",
-                &self.notification_broadcast_capacity,
+                notification_broadcast_capacity,
             )
-            .field(
-                "notification_lag_log_every",
-                &self.notification_lag_log_every,
-            )
-            .field(
-                "ws_heartbeat_interval_secs",
-                &self.ws_heartbeat_interval_secs,
-            )
-            .field("trusted_proxies", &self.trusted_proxies)
-            .field("api_token", &self.api_token.as_ref().map(|_| "[REDACTED]"))
-            .field("allowed_project_roots", &self.allowed_project_roots)
-            .field("max_webhook_body_bytes", &self.max_webhook_body_bytes)
-            .field(
-                "signal_rate_limit_per_minute",
-                &self.signal_rate_limit_per_minute,
-            )
+            .field("notification_lag_log_every", notification_lag_log_every)
+            .field("ws_heartbeat_interval_secs", ws_heartbeat_interval_secs)
+            .field("trusted_proxies", trusted_proxies)
+            .field("api_token", &api_token.as_ref().map(|_| "[REDACTED]"))
+            .field("allowed_project_roots", allowed_project_roots)
+            .field("max_webhook_body_bytes", max_webhook_body_bytes)
+            .field("signal_rate_limit_per_minute", signal_rate_limit_per_minute)
             .field(
                 "password_reset_rate_limit_per_hour",
-                &self.password_reset_rate_limit_per_hour,
+                password_reset_rate_limit_per_hour,
             )
-            .field("constitution_enabled", &self.constitution_enabled)
-            .field(
-                "github_token",
-                &self.github_token.as_ref().map(|_| "[REDACTED]"),
-            )
+            .field("constitution_enabled", constitution_enabled)
+            .field("github_token", &github_token.as_ref().map(|_| "[REDACTED]"))
             .finish()
     }
 }


### PR DESCRIPTION
## Summary
- Replace `#[derive(Debug)]` on `ServerConfig` with a custom `fmt::Debug` impl
- Redacts `github_webhook_secret`, `api_token`, and `github_token` as `[REDACTED]` (shows `None` when absent)
- Follows the existing `FeishuIntakeConfig` pattern in `config/intake.rs`

## Test plan
- [ ] `server_config_debug_redacts_secrets` — verifies secret values do not appear in debug output
- [ ] `server_config_debug_shows_none_for_absent_secrets` — verifies `None` fields are still visible

Closes #603