### PR TITLE
fix: remove redundant .clone() in http.rs completion callback

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -774,7 +774,6 @@ fn build_completion_callback(
                             harness_core::prompts::parse_github_pr_url(pr_url)
                         {
                             let resolved_token = github_token
-                                .clone()
                                 .or_else(|| std::env::var("GITHUB_TOKEN").ok())
                                 .filter(|t| !t.is_empty());
                             match resolved_token {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -774,7 +774,6 @@ fn build_completion_callback(
                             harness_core::prompts::parse_github_pr_url(pr_url)
                         {
                             let resolved_token = github_token
-                                .filter(|t| !t.is_empty())
                                 .or_else(|| std::env::var("GITHUB_TOKEN").ok())
                                 .filter(|t| !t.is_empty());
                             match resolved_token {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -774,6 +774,7 @@ fn build_completion_callback(
                             harness_core::prompts::parse_github_pr_url(pr_url)
                         {
                             let resolved_token = github_token
+                                .filter(|t| !t.is_empty())
                                 .or_else(|| std::env::var("GITHUB_TOKEN").ok())
                                 .filter(|t| !t.is_empty());
                             match resolved_token {


### PR DESCRIPTION
## Summary
- Remove unnecessary `.clone()` on `github_token` at `http.rs:777`
- `github_token` is moved into the `async move` block and consumed exactly once by the `or_else` chain; no second use exists

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all tests pass

Closes #604