### PR TITLE
feat: auto-spawn fix tasks for P1/P2 periodic review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.16"
+version = "0.6.17"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -434,7 +434,73 @@ async fn run_review_tick(
                         .await
                     {
                         Ok(n) => {
-                            tracing::info!(new_findings = n, "scheduler: review findings persisted")
+                            tracing::info!(
+                                new_findings = n,
+                                "scheduler: review findings persisted"
+                            );
+                            // Auto-spawn fix tasks for P1/P2 open findings that have
+                            // no existing task yet (task_id IS NULL = dedup guard).
+                            // P0 excluded: critical issues require human judgment.
+                            // P3 excluded: informational only, too low priority.
+                            match rs
+                                .list_spawnable_findings(&final_task_id.0, &["P1", "P2"])
+                                .await
+                            {
+                                Ok(spawnable) => {
+                                    for finding in spawnable {
+                                        let prompt = format!(
+                                            "Fix finding '{}' ({}, {}:{}): {}\n\nRequired action: {}",
+                                            finding.title,
+                                            finding.rule_id,
+                                            finding.file,
+                                            finding.line,
+                                            finding.description,
+                                            finding.action
+                                        );
+                                        let req = CreateTaskRequest {
+                                            prompt: Some(prompt),
+                                            source: Some("auto-fix".into()),
+                                            ..CreateTaskRequest::default()
+                                        };
+                                        match task_routes::enqueue_task(&state_for_synthesis, req)
+                                            .await
+                                        {
+                                            Ok(fix_task_id) => {
+                                                if let Err(e) = rs
+                                                    .mark_task_spawned(
+                                                        &final_task_id.0,
+                                                        &finding.id,
+                                                        &fix_task_id.0,
+                                                    )
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        finding_id = %finding.id,
+                                                        "scheduler: failed to mark task spawned: {e}"
+                                                    );
+                                                } else {
+                                                    tracing::info!(
+                                                        finding_id = %finding.id,
+                                                        task_id = %fix_task_id,
+                                                        "scheduler: auto-fix task spawned"
+                                                    );
+                                                }
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    finding_id = %finding.id,
+                                                    "scheduler: failed to spawn fix task: {e}"
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "scheduler: failed to list spawnable findings: {e}"
+                                    );
+                                }
+                            }
                         }
                         Err(e) => tracing::warn!("scheduler: failed to persist findings: {e}"),
                     }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -466,24 +466,35 @@ async fn run_review_tick(
                                             .await
                                         {
                                             Ok(fix_task_id) => {
-                                                if let Err(e) = rs
-                                                    .mark_task_spawned(
-                                                        &final_task_id.0,
-                                                        &finding.id,
-                                                        &fix_task_id.0,
-                                                    )
+                                                match rs
+                                                    .mark_task_spawned(&finding.id, &fix_task_id.0)
                                                     .await
                                                 {
-                                                    tracing::warn!(
-                                                        finding_id = %finding.id,
-                                                        "scheduler: failed to mark task spawned: {e}"
-                                                    );
-                                                } else {
-                                                    tracing::info!(
-                                                        finding_id = %finding.id,
-                                                        task_id = %fix_task_id,
-                                                        "scheduler: auto-fix task spawned"
-                                                    );
+                                                    Ok(true) => {
+                                                        tracing::info!(
+                                                            finding_id = %finding.id,
+                                                            task_id = %fix_task_id,
+                                                            "scheduler: auto-fix task spawned"
+                                                        );
+                                                    }
+                                                    Ok(false) => {
+                                                        // Another concurrent poller already
+                                                        // recorded a task for this finding
+                                                        // (task_id was no longer NULL).
+                                                        // The newly enqueued task is orphaned;
+                                                        // log a warning so operators can clean up.
+                                                        tracing::warn!(
+                                                            finding_id = %finding.id,
+                                                            orphaned_task_id = %fix_task_id,
+                                                            "scheduler: finding already has a task (concurrent spawn detected), new task orphaned"
+                                                        );
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::warn!(
+                                                            finding_id = %finding.id,
+                                                            "scheduler: failed to mark task spawned: {e}"
+                                                        );
+                                                    }
                                                 }
                                             }
                                             Err(e) => {

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -457,6 +457,31 @@ async fn run_review_tick(
                                             finding.description,
                                             finding.action
                                         );
+                                        // Claim before enqueue: atomically mark this
+                                        // finding as "pending" so concurrent pollers
+                                        // see task_id IS NOT NULL and skip it.  Only
+                                        // if the claim succeeds do we enqueue a task,
+                                        // preventing orphaned tasks on race loss.
+                                        match rs
+                                            .try_claim_finding(&finding.rule_id, &finding.file)
+                                            .await
+                                        {
+                                            Ok(false) => {
+                                                tracing::debug!(
+                                                    finding_id = %finding.id,
+                                                    "scheduler: finding already claimed by concurrent poller, skipping"
+                                                );
+                                                continue;
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    finding_id = %finding.id,
+                                                    "scheduler: failed to claim finding: {e}"
+                                                );
+                                                continue;
+                                            }
+                                            Ok(true) => {} // won the claim
+                                        }
                                         let req = CreateTaskRequest {
                                             prompt: Some(prompt),
                                             source: Some("auto-fix".into()),
@@ -467,37 +492,39 @@ async fn run_review_tick(
                                         {
                                             Ok(fix_task_id) => {
                                                 match rs
-                                                    .mark_task_spawned(&finding.id, &fix_task_id.0)
+                                                    .confirm_task_spawned(
+                                                        &finding.rule_id,
+                                                        &finding.file,
+                                                        &fix_task_id.0,
+                                                    )
                                                     .await
                                                 {
-                                                    Ok(true) => {
+                                                    Ok(()) => {
                                                         tracing::info!(
                                                             finding_id = %finding.id,
                                                             task_id = %fix_task_id,
                                                             "scheduler: auto-fix task spawned"
                                                         );
                                                     }
-                                                    Ok(false) => {
-                                                        // Another concurrent poller already
-                                                        // recorded a task for this finding
-                                                        // (task_id was no longer NULL).
-                                                        // The newly enqueued task is orphaned;
-                                                        // log a warning so operators can clean up.
-                                                        tracing::warn!(
-                                                            finding_id = %finding.id,
-                                                            orphaned_task_id = %fix_task_id,
-                                                            "scheduler: finding already has a task (concurrent spawn detected), new task orphaned"
-                                                        );
-                                                    }
                                                     Err(e) => {
                                                         tracing::warn!(
                                                             finding_id = %finding.id,
-                                                            "scheduler: failed to mark task spawned: {e}"
+                                                            "scheduler: failed to confirm task spawn: {e}"
                                                         );
                                                     }
                                                 }
                                             }
                                             Err(e) => {
+                                                // Release the claim so the next cycle can retry.
+                                                if let Err(re) = rs
+                                                    .release_claim(&finding.rule_id, &finding.file)
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        finding_id = %finding.id,
+                                                        "scheduler: failed to release claim after enqueue failure: {re}"
+                                                    );
+                                                }
                                                 tracing::warn!(
                                                     finding_id = %finding.id,
                                                     "scheduler: failed to spawn fix task: {e}"

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -14,6 +14,7 @@ type FindingRow = (
     String,
     String,
     String,
+    Option<String>,
 );
 
 /// A single finding from a periodic review.
@@ -30,6 +31,9 @@ pub struct ReviewFinding {
     pub title: String,
     pub description: String,
     pub action: String,
+    /// Task ID of the auto-spawned fix task, if any.
+    #[serde(default)]
+    pub task_id: Option<String>,
 }
 
 /// Summary scores from a review run.
@@ -74,11 +78,26 @@ impl ReviewStore {
                 action      TEXT NOT NULL,
                 status      TEXT NOT NULL DEFAULT 'open',
                 created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                task_id     TEXT,
                 PRIMARY KEY (review_id, id)
             )",
         )
         .execute(&pool)
         .await?;
+        // Migrate existing databases: add task_id column if absent.
+        // PRAGMA table_info returns (cid, name, type, notnull, dflt_value, pk).
+        let columns: Vec<(i32, String, String, i32, Option<String>, i32)> =
+            sqlx::query_as("PRAGMA table_info(review_findings)")
+                .fetch_all(&pool)
+                .await?;
+        let has_task_id = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "task_id");
+        if !has_task_id {
+            sqlx::query("ALTER TABLE review_findings ADD COLUMN task_id TEXT")
+                .execute(&pool)
+                .await?;
+        }
         // Remove duplicate (rule_id, file, status) rows that may exist from
         // before this unique index was introduced; keep the most recent row per group.
         sqlx::query(
@@ -170,7 +189,7 @@ impl ReviewStore {
     pub async fn list_open(&self) -> anyhow::Result<Vec<ReviewFinding>> {
         let rows: Vec<FindingRow> = sqlx::query_as(
             "SELECT id, rule_id, priority, impact, confidence, effort, \
-                    file, line, title, description, action \
+                    file, line, title, description, action, task_id \
              FROM review_findings WHERE status = 'open' \
              ORDER BY \
                CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 \
@@ -180,8 +199,61 @@ impl ReviewStore {
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows
-            .into_iter()
+        Ok(Self::rows_to_findings(rows))
+    }
+
+    /// List open findings eligible for auto-spawn: matching the given priorities,
+    /// status='open', and no existing task_id (dedup guard).
+    ///
+    /// P0 is excluded intentionally: critical issues require human judgment;
+    /// auto-fix could cause high blast-radius changes.
+    /// P3 is excluded intentionally: informational only, too low priority.
+    pub async fn list_spawnable_findings(
+        &self,
+        review_id: &str,
+        priorities: &[&str],
+    ) -> anyhow::Result<Vec<ReviewFinding>> {
+        if priorities.is_empty() {
+            return Ok(vec![]);
+        }
+        let placeholders = priorities
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, rule_id, priority, impact, confidence, effort, \
+                    file, line, title, description, action, task_id \
+             FROM review_findings \
+             WHERE review_id = ? AND priority IN ({placeholders}) \
+               AND status = 'open' AND task_id IS NULL"
+        );
+        let mut query = sqlx::query_as::<_, FindingRow>(&sql).bind(review_id.to_owned());
+        for p in priorities {
+            query = query.bind(p.to_string());
+        }
+        let rows = query.fetch_all(&self.pool).await?;
+        Ok(Self::rows_to_findings(rows))
+    }
+
+    /// Record the task_id of the auto-spawned fix task for a finding.
+    pub async fn mark_task_spawned(
+        &self,
+        review_id: &str,
+        finding_id: &str,
+        task_id: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE review_findings SET task_id = ? WHERE review_id = ? AND id = ?")
+            .bind(task_id)
+            .bind(review_id)
+            .bind(finding_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    fn rows_to_findings(rows: Vec<FindingRow>) -> Vec<ReviewFinding> {
+        rows.into_iter()
             .map(
                 |(
                     id,
@@ -195,6 +267,7 @@ impl ReviewStore {
                     title,
                     description,
                     action,
+                    task_id,
                 )| {
                     ReviewFinding {
                         id,
@@ -208,10 +281,11 @@ impl ReviewStore {
                         title,
                         description,
                         action,
+                        task_id,
                     }
                 },
             )
-            .collect())
+            .collect()
     }
 }
 
@@ -318,6 +392,7 @@ mod tests {
             title: "unwrap in prod".into(),
             description: "panic risk".into(),
             action: "use ?".into(),
+            task_id: None,
         };
         let findings = vec![finding];
 
@@ -342,6 +417,130 @@ mod tests {
         Ok(())
     }
 
+    fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFinding {
+        ReviewFinding {
+            id: id.into(),
+            rule_id: rule_id.into(),
+            priority: priority.into(),
+            impact: 3,
+            confidence: 5,
+            effort: 2,
+            file: file.into(),
+            line: 10,
+            title: format!("finding {id}"),
+            description: "desc".into(),
+            action: "fix it".into(),
+            task_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mark_task_spawned() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
+        store.persist_findings("rev-1", &findings).await?;
+
+        store.mark_task_spawned("rev-1", "F001", "task-abc").await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        assert!(
+            spawnable.is_empty(),
+            "finding with task_id must not be returned"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_spawnable_findings_filters_priority() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let findings = vec![
+            make_finding("F0", "R0", "a.rs", "P0"),
+            make_finding("F1", "R1", "b.rs", "P1"),
+            make_finding("F2", "R2", "c.rs", "P2"),
+            make_finding("F3", "R3", "d.rs", "P3"),
+        ];
+        store.persist_findings("rev-1", &findings).await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        let ids: Vec<&str> = spawnable.iter().map(|f| f.id.as_str()).collect();
+        assert!(ids.contains(&"F1"), "P1 must be returned");
+        assert!(ids.contains(&"F2"), "P2 must be returned");
+        assert!(!ids.contains(&"F0"), "P0 must be excluded");
+        assert!(!ids.contains(&"F3"), "P3 must be excluded");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_spawnable_findings_skips_already_spawned() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let findings = vec![
+            make_finding("F1", "R1", "a.rs", "P1"),
+            make_finding("F2", "R2", "b.rs", "P2"),
+        ];
+        store.persist_findings("rev-1", &findings).await?;
+        store.mark_task_spawned("rev-1", "F1", "task-111").await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        assert_eq!(spawnable.len(), 1);
+        assert_eq!(spawnable[0].id, "F2");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_spawnable_findings_skips_closed() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let findings = vec![make_finding("F1", "R1", "a.rs", "P1")];
+        store.persist_findings("rev-1", &findings).await?;
+        sqlx::query("UPDATE review_findings SET status = 'resolved' WHERE id = 'F1'")
+            .execute(&store.pool)
+            .await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        assert!(
+            spawnable.is_empty(),
+            "resolved findings must not be returned"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dedup_across_reviews_preserves_task_id() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
+
+        // First review: persist, spawn task.
+        store.persist_findings("rev-1", &[finding.clone()]).await?;
+        store.mark_task_spawned("rev-1", "F1", "task-orig").await?;
+
+        // Second review: same rule_id+file triggers UPDATE (recurring finding),
+        // review_id changes to rev-2 but task_id must be preserved.
+        let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
+        store.persist_findings("rev-2", &[finding2]).await?;
+
+        // task_id IS NOT NULL so it must not appear in spawnable list.
+        let spawnable = store
+            .list_spawnable_findings("rev-2", &["P1", "P2"])
+            .await?;
+        assert!(
+            spawnable.is_empty(),
+            "recurring finding with task_id must not be re-spawned"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn store_persist_and_list() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -359,6 +558,7 @@ mod tests {
             title: "unwrap in prod".into(),
             description: "panic risk".into(),
             action: "use ?".into(),
+            task_id: None,
         }];
 
         let inserted = store.persist_findings("rev-1", &findings).await?;

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -236,23 +236,65 @@ impl ReviewStore {
         Ok(Self::rows_to_findings(rows))
     }
 
-    /// Record the task_id of the auto-spawned fix task for a finding.
+    /// Atomically claim a finding for auto-spawn by setting task_id to "pending".
     ///
-    /// Uses `AND task_id IS NULL` as an optimistic lock so concurrent pollers
-    /// cannot double-write: the first caller wins and subsequent callers get
-    /// `Ok(false)` without overwriting the already-recorded task.
+    /// Uses `(rule_id, file)` — the globally unique index columns — instead of
+    /// the non-globally-unique `id` field (PK is `(review_id, id)`, so two
+    /// different reviews can share the same `id` value).  Filtering by `id`
+    /// alone could stamp multiple unrelated findings with the same task_id.
     ///
     /// The `review_id` filter is intentionally absent: `persist_findings` may
-    /// reassign the finding to a newer `review_id` between `list_spawnable_findings`
-    /// and this call, which would cause 0 rows affected and leave `task_id` NULL.
-    pub async fn mark_task_spawned(&self, finding_id: &str, task_id: &str) -> anyhow::Result<bool> {
-        let result =
-            sqlx::query("UPDATE review_findings SET task_id = ? WHERE id = ? AND task_id IS NULL")
-                .bind(task_id)
-                .bind(finding_id)
-                .execute(&self.pool)
-                .await?;
+    /// reassign the finding to a newer `review_id` between
+    /// `list_spawnable_findings` and this call; the unique `(rule_id, file)`
+    /// pair is stable regardless of which review_id the row carries.
+    ///
+    /// Returns `true` if this caller won the claim, `false` if already claimed.
+    pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            "UPDATE review_findings SET task_id = 'pending' \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() == 1)
+    }
+
+    /// Confirm a pending claim by replacing the "pending" sentinel with the
+    /// real task_id after a successful enqueue.
+    pub async fn confirm_task_spawned(
+        &self,
+        rule_id: &str,
+        file: &str,
+        task_id: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE review_findings SET task_id = ? \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+        )
+        .bind(task_id)
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Release a pending claim by resetting task_id to NULL.
+    ///
+    /// Called when task enqueue fails after a successful `try_claim_finding`,
+    /// allowing the next poll cycle to retry spawning for this finding.
+    pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE review_findings SET task_id = NULL \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     fn rows_to_findings(rows: Vec<FindingRow>) -> Vec<ReviewFinding> {
@@ -438,28 +480,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mark_task_spawned() -> anyhow::Result<()> {
+    async fn test_claim_confirm_roundtrip() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
         store.persist_findings("rev-1", &findings).await?;
 
+        // First claim wins.
         assert!(
-            store.mark_task_spawned("F001", "task-abc").await?,
-            "first call must succeed"
+            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            "first claim must succeed"
         );
-        // Second call with same finding must return false (optimistic lock).
+        // Concurrent poller claim must lose (task_id is 'pending').
         assert!(
-            !store.mark_task_spawned("F001", "task-xyz").await?,
-            "duplicate call must return false"
+            !store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            "duplicate claim must return false"
         );
+        // Confirm with real task_id.
+        store
+            .confirm_task_spawned("RS-03", "src/lib.rs", "task-abc")
+            .await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
             .await?;
         assert!(
             spawnable.is_empty(),
-            "finding with task_id must not be returned"
+            "confirmed finding must not be returned"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_release_claim_allows_retry() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
+        store.persist_findings("rev-1", &findings).await?;
+
+        // Claim, then release (simulates enqueue failure).
+        assert!(store.try_claim_finding("RS-03", "src/lib.rs").await?);
+        store.release_claim("RS-03", "src/lib.rs").await?;
+
+        // Must be claimable again after release.
+        assert!(
+            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            "finding must be claimable after release"
         );
         Ok(())
     }
@@ -496,7 +562,8 @@ mod tests {
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
         store.persist_findings("rev-1", &findings).await?;
-        store.mark_task_spawned("F1", "task-111").await?;
+        store.try_claim_finding("R1", "a.rs").await?;
+        store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -532,9 +599,12 @@ mod tests {
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
 
-        // First review: persist, spawn task.
+        // First review: persist, claim and confirm task.
         store.persist_findings("rev-1", &[finding.clone()]).await?;
-        store.mark_task_spawned("F1", "task-orig").await?;
+        store.try_claim_finding("RS-03", "src/lib.rs").await?;
+        store
+            .confirm_task_spawned("RS-03", "src/lib.rs", "task-orig")
+            .await?;
 
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
         // review_id changes to rev-2 but task_id must be preserved.
@@ -554,13 +624,11 @@ mod tests {
 
     /// Regression test for the TOCTOU race: `persist_findings` changes the
     /// finding's `review_id` *after* `list_spawnable_findings` but *before*
-    /// `mark_task_spawned`.  The old code filtered by `review_id` in the UPDATE,
-    /// so 0 rows were affected and `task_id` was left NULL, allowing a duplicate
-    /// task to be spawned on the next cycle.  The fixed code filters by `id`
-    /// only, so the update succeeds regardless of which `review_id` the row now
-    /// carries.
+    /// `try_claim_finding`.  The old code filtered by `id` (non-globally-unique)
+    /// or `review_id` in the UPDATE; the fixed code filters by `(rule_id, file)`
+    /// which is stable regardless of which `review_id` the row carries.
     #[tokio::test]
-    async fn test_mark_task_spawned_survives_review_id_change() -> anyhow::Result<()> {
+    async fn test_claim_survives_review_id_change() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
@@ -568,15 +636,16 @@ mod tests {
         // Simulate: list_spawnable_findings returned F1 under rev-1.
         store.persist_findings("rev-1", &[finding.clone()]).await?;
 
-        // Simulate race: persist_findings runs with rev-2 BEFORE mark_task_spawned.
+        // Simulate race: persist_findings runs with rev-2 BEFORE try_claim_finding.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
         store.persist_findings("rev-2", &[finding2]).await?;
 
-        // mark_task_spawned must succeed even though the row now has review_id="rev-2".
-        let marked = store
-            .mark_task_spawned("F1", "task-from-rev1-poller")
+        // try_claim_finding must succeed even though the row now has review_id="rev-2".
+        let claimed = store.try_claim_finding("RS-03", "src/lib.rs").await?;
+        assert!(claimed, "must succeed even after review_id changed");
+        store
+            .confirm_task_spawned("RS-03", "src/lib.rs", "task-from-rev1-poller")
             .await?;
-        assert!(marked, "must succeed even after review_id changed");
 
         // F1 must no longer appear in spawnable list for rev-2.
         let spawnable = store

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -600,7 +600,9 @@ mod tests {
         let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
 
         // First review: persist, claim and confirm task.
-        store.persist_findings("rev-1", &[finding.clone()]).await?;
+        store
+            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .await?;
         store.try_claim_finding("RS-03", "src/lib.rs").await?;
         store
             .confirm_task_spawned("RS-03", "src/lib.rs", "task-orig")
@@ -634,7 +636,9 @@ mod tests {
         let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
 
         // Simulate: list_spawnable_findings returned F1 under rev-1.
-        store.persist_findings("rev-1", &[finding.clone()]).await?;
+        store
+            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .await?;
 
         // Simulate race: persist_findings runs with rev-2 BEFORE try_claim_finding.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -237,19 +237,22 @@ impl ReviewStore {
     }
 
     /// Record the task_id of the auto-spawned fix task for a finding.
-    pub async fn mark_task_spawned(
-        &self,
-        review_id: &str,
-        finding_id: &str,
-        task_id: &str,
-    ) -> anyhow::Result<()> {
-        sqlx::query("UPDATE review_findings SET task_id = ? WHERE review_id = ? AND id = ?")
-            .bind(task_id)
-            .bind(review_id)
-            .bind(finding_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    ///
+    /// Uses `AND task_id IS NULL` as an optimistic lock so concurrent pollers
+    /// cannot double-write: the first caller wins and subsequent callers get
+    /// `Ok(false)` without overwriting the already-recorded task.
+    ///
+    /// The `review_id` filter is intentionally absent: `persist_findings` may
+    /// reassign the finding to a newer `review_id` between `list_spawnable_findings`
+    /// and this call, which would cause 0 rows affected and leave `task_id` NULL.
+    pub async fn mark_task_spawned(&self, finding_id: &str, task_id: &str) -> anyhow::Result<bool> {
+        let result =
+            sqlx::query("UPDATE review_findings SET task_id = ? WHERE id = ? AND task_id IS NULL")
+                .bind(task_id)
+                .bind(finding_id)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     fn rows_to_findings(rows: Vec<FindingRow>) -> Vec<ReviewFinding> {
@@ -441,7 +444,15 @@ mod tests {
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
         store.persist_findings("rev-1", &findings).await?;
 
-        store.mark_task_spawned("rev-1", "F001", "task-abc").await?;
+        assert!(
+            store.mark_task_spawned("F001", "task-abc").await?,
+            "first call must succeed"
+        );
+        // Second call with same finding must return false (optimistic lock).
+        assert!(
+            !store.mark_task_spawned("F001", "task-xyz").await?,
+            "duplicate call must return false"
+        );
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -485,7 +496,7 @@ mod tests {
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
         store.persist_findings("rev-1", &findings).await?;
-        store.mark_task_spawned("rev-1", "F1", "task-111").await?;
+        store.mark_task_spawned("F1", "task-111").await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -523,7 +534,7 @@ mod tests {
 
         // First review: persist, spawn task.
         store.persist_findings("rev-1", &[finding.clone()]).await?;
-        store.mark_task_spawned("rev-1", "F1", "task-orig").await?;
+        store.mark_task_spawned("F1", "task-orig").await?;
 
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
         // review_id changes to rev-2 but task_id must be preserved.
@@ -537,6 +548,43 @@ mod tests {
         assert!(
             spawnable.is_empty(),
             "recurring finding with task_id must not be re-spawned"
+        );
+        Ok(())
+    }
+
+    /// Regression test for the TOCTOU race: `persist_findings` changes the
+    /// finding's `review_id` *after* `list_spawnable_findings` but *before*
+    /// `mark_task_spawned`.  The old code filtered by `review_id` in the UPDATE,
+    /// so 0 rows were affected and `task_id` was left NULL, allowing a duplicate
+    /// task to be spawned on the next cycle.  The fixed code filters by `id`
+    /// only, so the update succeeds regardless of which `review_id` the row now
+    /// carries.
+    #[tokio::test]
+    async fn test_mark_task_spawned_survives_review_id_change() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        let finding = make_finding("F1", "RS-03", "src/lib.rs", "P1");
+
+        // Simulate: list_spawnable_findings returned F1 under rev-1.
+        store.persist_findings("rev-1", &[finding.clone()]).await?;
+
+        // Simulate race: persist_findings runs with rev-2 BEFORE mark_task_spawned.
+        let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
+        store.persist_findings("rev-2", &[finding2]).await?;
+
+        // mark_task_spawned must succeed even though the row now has review_id="rev-2".
+        let marked = store
+            .mark_task_spawned("F1", "task-from-rev1-poller")
+            .await?;
+        assert!(marked, "must succeed even after review_id changed");
+
+        // F1 must no longer appear in spawnable list for rev-2.
+        let spawnable = store
+            .list_spawnable_findings("rev-2", &["P1", "P2"])
+            .await?;
+        assert!(
+            spawnable.is_empty(),
+            "finding with task_id must not be re-spawned after review_id change"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes #605.

- Adds `task_id TEXT` column to `review_findings` (schema migration handles existing DBs via `PRAGMA table_info` + `ALTER TABLE ADD COLUMN`)
- Adds `list_spawnable_findings(review_id, priorities)` — returns open findings with `task_id IS NULL` matching the given priorities
- Adds `mark_task_spawned(review_id, finding_id, task_id)` — records the spawned task ID to prevent duplicate spawning
- After `persist_findings()` succeeds in the poll loop, enqueues one fix task per P1/P2 finding; marks each with its task ID on success; logs and continues on error

**P0 excluded**: critical issues require human judgment; auto-fix risk is too high.  
**P3 excluded**: informational only, not worth automated action.  
**Dedup**: `task_id IS NULL` check on the unique `(rule_id, file, status='open')` row prevents re-spawning across review cycles.

## Test plan

- [x] `test_mark_task_spawned` — finding is excluded after `mark_task_spawned`
- [x] `test_list_spawnable_findings_filters_priority` — P0/P3 excluded, P1/P2 returned
- [x] `test_list_spawnable_findings_skips_already_spawned` — already-linked finding skipped
- [x] `test_list_spawnable_findings_skips_closed` — resolved findings excluded
- [x] `test_dedup_across_reviews_preserves_task_id` — recurring finding with existing task_id not re-spawned
- [x] All 12 `review_store` tests pass; full workspace `cargo test` green