### PR TITLE
fix(agents): add --no-session-persistence for background agent spawns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.16"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.19"
+version = "0.6.20"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -23,6 +23,10 @@ pub struct ClaudeCodeAgent {
     /// Maximum seconds of idle silence on the output stream before the
     /// subprocess is declared a zombie and terminated. `None` = no timeout.
     pub stream_timeout_secs: Option<u64>,
+    /// Whether the CLI binary supports `--no-session-persistence`. Probed once
+    /// at construction via `--help`; older builds that lack the flag will skip
+    /// it rather than failing every agent spawn with "unknown option".
+    pub no_session_persistence: bool,
 }
 
 impl ClaudeCodeAgent {
@@ -33,7 +37,18 @@ impl ClaudeCodeAgent {
             sandbox_mode,
             reasoning_budget: None,
             stream_timeout_secs: Some(1800),
+            // Probe is opt-in via `with_no_session_persistence_probe()` so that
+            // tests using mock scripts are not affected by the subprocess spawn.
+            no_session_persistence: false,
         }
+    }
+
+    /// Probe the CLI binary once for `--no-session-persistence` support and
+    /// cache the result. Call this from production code paths after `new()`
+    /// to enable the flag when the binary supports it.
+    pub fn with_no_session_persistence_probe(mut self) -> Self {
+        self.no_session_persistence = crate::probe_no_session_persistence(&self.cli_path);
+        self
     }
 
     /// Attach a ReasoningBudget for per-phase model selection.
@@ -67,8 +82,11 @@ impl ClaudeCodeAgent {
             OsString::from("--model"),
             OsString::from(model),
             OsString::from("--verbose"),
-            OsString::from("--no-session-persistence"),
         ];
+
+        if self.no_session_persistence {
+            base_args.push(OsString::from("--no-session-persistence"));
+        }
 
         // Hard tool enforcement at the CLI boundary (issue #514):
         //   Full profile  (allowed_tools = None)    → --dangerously-skip-permissions
@@ -293,12 +311,16 @@ mod tests {
     }
 
     #[test]
-    fn base_args_always_includes_no_session_persistence() {
-        let agent = ClaudeCodeAgent::new(
+    fn base_args_includes_no_session_persistence_when_supported() {
+        let mut agent = ClaudeCodeAgent::new(
             PathBuf::from("claude"),
             "test-model".to_string(),
             SandboxMode::DangerFullAccess,
         );
+        // Force the flag on regardless of what the probe found in the test
+        // environment — the test is validating arg construction logic, not
+        // CLI version detection.
+        agent.no_session_persistence = true;
         for (label, allowed_tools) in [
             ("full", None),
             (
@@ -316,6 +338,22 @@ mod tests {
                 "--no-session-persistence must be present for {label} profile; got: {args:?}"
             );
         }
+    }
+
+    #[test]
+    fn base_args_omits_no_session_persistence_when_not_supported() {
+        let mut agent = ClaudeCodeAgent::new(
+            PathBuf::from("claude"),
+            "test-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        );
+        agent.no_session_persistence = false;
+        let req = AgentRequest::default();
+        let args = args_to_strings(&agent.base_args(&req));
+        assert!(
+            !args.contains(&"--no-session-persistence".to_string()),
+            "flag must be absent when no_session_persistence=false; got: {args:?}"
+        );
     }
 
     #[test]

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -67,6 +67,7 @@ impl ClaudeCodeAgent {
             OsString::from("--model"),
             OsString::from(model),
             OsString::from("--verbose"),
+            OsString::from("--no-session-persistence"),
         ];
 
         // Hard tool enforcement at the CLI boundary (issue #514):
@@ -289,6 +290,32 @@ mod tests {
         })
         .await
         .is_ok()
+    }
+
+    #[test]
+    fn base_args_always_includes_no_session_persistence() {
+        let agent = ClaudeCodeAgent::new(
+            PathBuf::from("claude"),
+            "test-model".to_string(),
+            SandboxMode::DangerFullAccess,
+        );
+        for (label, allowed_tools) in [
+            ("full", None),
+            (
+                "standard",
+                Some(vec!["Read".to_string(), "Bash".to_string()]),
+            ),
+        ] {
+            let req = AgentRequest {
+                allowed_tools,
+                ..AgentRequest::default()
+            };
+            let args = args_to_strings(&agent.base_args(&req));
+            assert!(
+                args.contains(&"--no-session-persistence".to_string()),
+                "--no-session-persistence must be present for {label} profile; got: {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -47,6 +47,7 @@ impl AgentAdapter for ClaudeAdapter {
             .arg("--model")
             .arg(model)
             .arg("--verbose")
+            .arg("--no-session-persistence")
             .current_dir(&req.project_root)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -15,14 +15,19 @@ pub struct ClaudeAdapter {
     cli_path: PathBuf,
     default_model: String,
     child: Arc<Mutex<Option<tokio::process::Child>>>,
+    /// Whether the CLI binary supports `--no-session-persistence`. Probed once
+    /// at construction via `--help`; older builds skip the flag gracefully.
+    no_session_persistence: bool,
 }
 
 impl ClaudeAdapter {
     pub fn new(cli_path: PathBuf, default_model: String) -> Self {
+        let no_session_persistence = crate::probe_no_session_persistence(&cli_path);
         Self {
             cli_path,
             default_model,
             child: Arc::new(Mutex::new(None)),
+            no_session_persistence,
         }
     }
 }
@@ -47,13 +52,16 @@ impl AgentAdapter for ClaudeAdapter {
             .arg("--model")
             .arg(model)
             .arg("--verbose")
-            .arg("--no-session-persistence")
             .current_dir(&req.project_root)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
         crate::strip_claude_env(&mut cmd);
+
+        if self.no_session_persistence {
+            cmd.arg("--no-session-persistence");
+        }
 
         if !req.allowed_tools.is_empty() {
             cmd.arg("--allowedTools").arg(req.allowed_tools.join(","));

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -13,10 +13,20 @@ mod streaming;
 /// Returns `false` on any spawn or read error so that agents on older CLI builds
 /// degrade gracefully (flag omitted) rather than failing every spawn with
 /// "unknown option --no-session-persistence".
+///
+/// All `CLAUDE`-prefixed environment variables are stripped before spawning to
+/// prevent nested-Claude SIGTRAP in environments launched from within Claude Code.
 pub(crate) fn probe_no_session_persistence(cli_path: &std::path::Path) -> bool {
-    std::process::Command::new(cli_path)
-        .arg("--help")
-        .output()
+    let claude_keys: Vec<String> = std::env::vars()
+        .filter(|(k, _)| k.starts_with("CLAUDE"))
+        .map(|(k, _)| k)
+        .collect();
+    let mut cmd = std::process::Command::new(cli_path);
+    cmd.arg("--help");
+    for key in &claude_keys {
+        cmd.env_remove(key);
+    }
+    cmd.output()
         .map(|out| {
             let stdout = String::from_utf8_lossy(&out.stdout);
             let stderr = String::from_utf8_lossy(&out.stderr);

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -16,24 +16,114 @@ mod streaming;
 ///
 /// All `CLAUDE`-prefixed environment variables are stripped before spawning to
 /// prevent nested-Claude SIGTRAP in environments launched from within Claude Code.
+///
+/// A 5-second wall-clock timeout is enforced: if `claude --help` does not exit
+/// within that window (e.g. bad wrapper script, blocked NFS mount, first-run
+/// interactive prompt), the child is killed and the probe returns `false`.
 pub(crate) fn probe_no_session_persistence(cli_path: &std::path::Path) -> bool {
     let claude_keys: Vec<String> = std::env::vars()
         .filter(|(k, _)| k.starts_with("CLAUDE"))
         .map(|(k, _)| k)
         .collect();
     let mut cmd = std::process::Command::new(cli_path);
-    cmd.arg("--help");
+    cmd.arg("--help")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
     for key in &claude_keys {
         cmd.env_remove(key);
     }
-    cmd.output()
-        .map(|out| {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            stdout.contains("--no-session-persistence")
-                || stderr.contains("--no-session-persistence")
-        })
-        .unwrap_or(false)
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    // Drain stdout/stderr in background threads to prevent pipe-buffer deadlock
+    // when the help output is large.
+    use std::io::Read;
+    let (tx_out, rx_out) = std::sync::mpsc::channel();
+    let (tx_err, rx_err) = std::sync::mpsc::channel();
+    if let Some(mut stdout) = child.stdout.take() {
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            if let Err(e) = stdout.read_to_string(&mut buf) {
+                tracing::warn!("probe_no_session_persistence: failed to read stdout: {e}");
+            }
+            // Send is fire-and-forget; receiver may have already gone on timeout.
+            if tx_out.send(buf).is_err() {
+                tracing::debug!(
+                    "probe_no_session_persistence: stdout receiver dropped (probe timed out)"
+                );
+            }
+        });
+    }
+    if let Some(mut stderr) = child.stderr.take() {
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            if let Err(e) = stderr.read_to_string(&mut buf) {
+                tracing::warn!("probe_no_session_persistence: failed to read stderr: {e}");
+            }
+            if tx_err.send(buf).is_err() {
+                tracing::debug!(
+                    "probe_no_session_persistence: stderr receiver dropped (probe timed out)"
+                );
+            }
+        });
+    }
+
+    // Poll for exit with a 5-second deadline; kill and return false on timeout.
+    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    if let Err(e) = child.kill() {
+                        tracing::warn!(
+                            path = %cli_path.display(),
+                            "probe_no_session_persistence: failed to kill timed-out process: {e}"
+                        );
+                    }
+                    tracing::warn!(
+                        path = %cli_path.display(),
+                        "probe_no_session_persistence: claude --help timed out after 5 s; \
+                         treating --no-session-persistence as unsupported"
+                    );
+                    return false;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => {
+                if let Err(kill_err) = child.kill() {
+                    tracing::warn!(
+                        "probe_no_session_persistence: failed to kill process after wait error \
+                         ({e}): {kill_err}"
+                    );
+                }
+                return false;
+            }
+        }
+    }
+
+    // Collect output — background threads finish once pipes close on process exit.
+    let one_sec = std::time::Duration::from_secs(1);
+    let stdout_content = match rx_out.recv_timeout(one_sec) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!("probe_no_session_persistence: stdout not received within 1 s: {e}");
+            String::new()
+        }
+    };
+    let stderr_content = match rx_err.recv_timeout(one_sec) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!("probe_no_session_persistence: stderr not received within 1 s: {e}");
+            String::new()
+        }
+    };
+    stdout_content.contains("--no-session-persistence")
+        || stderr_content.contains("--no-session-persistence")
 }
 
 /// Remove all `CLAUDE`-prefixed environment variables from a command to prevent

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -21,6 +21,35 @@ mod streaming;
 /// within that window (e.g. bad wrapper script, blocked NFS mount, first-run
 /// interactive prompt), the child is killed and the probe returns `false`.
 pub(crate) fn probe_no_session_persistence(cli_path: &std::path::Path) -> bool {
+    // Validate cli_path before spawning: must be absolute and an existing regular
+    // file.  This prevents an unsandboxed execution of an arbitrary/misconfigured
+    // path before wrap_command sandboxing has been applied.
+    if !cli_path.is_absolute() {
+        tracing::warn!(
+            path = %cli_path.display(),
+            "probe_no_session_persistence: cli_path is not absolute; skipping probe"
+        );
+        return false;
+    }
+    match std::fs::metadata(cli_path) {
+        Ok(meta) if meta.is_file() => {}
+        Ok(_) => {
+            tracing::warn!(
+                path = %cli_path.display(),
+                "probe_no_session_persistence: cli_path is not a regular file; skipping probe"
+            );
+            return false;
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %cli_path.display(),
+                error = %e,
+                "probe_no_session_persistence: cannot stat cli_path; skipping probe"
+            );
+            return false;
+        }
+    }
+
     let claude_keys: Vec<String> = std::env::vars()
         .filter(|(k, _)| k.starts_with("CLAUDE"))
         .map(|(k, _)| k)

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -21,32 +21,29 @@ mod streaming;
 /// within that window (e.g. bad wrapper script, blocked NFS mount, first-run
 /// interactive prompt), the child is killed and the probe returns `false`.
 pub(crate) fn probe_no_session_persistence(cli_path: &std::path::Path) -> bool {
-    // Validate cli_path before spawning: must be absolute and an existing regular
-    // file.  This prevents an unsandboxed execution of an arbitrary/misconfigured
-    // path before wrap_command sandboxing has been applied.
-    if !cli_path.is_absolute() {
-        tracing::warn!(
-            path = %cli_path.display(),
-            "probe_no_session_persistence: cli_path is not absolute; skipping probe"
-        );
-        return false;
-    }
-    match std::fs::metadata(cli_path) {
-        Ok(meta) if meta.is_file() => {}
-        Ok(_) => {
-            tracing::warn!(
-                path = %cli_path.display(),
-                "probe_no_session_persistence: cli_path is not a regular file; skipping probe"
-            );
-            return false;
-        }
-        Err(e) => {
-            tracing::warn!(
-                path = %cli_path.display(),
-                error = %e,
-                "probe_no_session_persistence: cannot stat cli_path; skipping probe"
-            );
-            return false;
+    // For absolute paths, validate the file exists before spawning.  This
+    // catches misconfigured paths early without reaching the spawn syscall.
+    // PATH-resolved names (e.g. "claude") are allowed through — the spawn
+    // itself returns an error if the binary is not found, and the error path
+    // below returns false gracefully.
+    if cli_path.is_absolute() {
+        match std::fs::metadata(cli_path) {
+            Ok(meta) if meta.is_file() => {}
+            Ok(_) => {
+                tracing::warn!(
+                    path = %cli_path.display(),
+                    "probe_no_session_persistence: cli_path is not a regular file; skipping probe"
+                );
+                return false;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %cli_path.display(),
+                    error = %e,
+                    "probe_no_session_persistence: cannot stat cli_path; skipping probe"
+                );
+                return false;
+            }
         }
     }
 

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -7,6 +7,25 @@ pub mod codex_adapter;
 pub mod registry;
 mod streaming;
 
+/// Probe whether the Claude CLI at `cli_path` supports `--no-session-persistence`.
+///
+/// Runs `cli_path --help` once and checks the combined stdout/stderr output.
+/// Returns `false` on any spawn or read error so that agents on older CLI builds
+/// degrade gracefully (flag omitted) rather than failing every spawn with
+/// "unknown option --no-session-persistence".
+pub(crate) fn probe_no_session_persistence(cli_path: &std::path::Path) -> bool {
+    std::process::Command::new(cli_path)
+        .arg("--help")
+        .output()
+        .map(|out| {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            stdout.contains("--no-session-persistence")
+                || stderr.contains("--no-session-persistence")
+        })
+        .unwrap_or(false)
+}
+
 /// Remove all `CLAUDE`-prefixed environment variables from a command to prevent
 /// nested Claude Code detection (SIGTRAP).
 pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -493,6 +493,7 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
                 config.agents.claude.default_model.clone(),
                 config.agents.sandbox_mode,
             )
+            .with_no_session_persistence_probe()
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
     );

--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -9,6 +9,7 @@ fn create_agent(config: &HarnessConfig) -> ClaudeCodeAgent {
         config.agents.claude.default_model.clone(),
         config.agents.sandbox_mode,
     )
+    .with_no_session_persistence_probe()
     .with_stream_timeout(config.agents.stream_timeout_secs)
 }
 

--- a/crates/harness-cli/src/commands/exec.rs
+++ b/crates/harness-cli/src/commands/exec.rs
@@ -361,6 +361,7 @@ pub async fn run(
                 config.agents.claude.default_model.clone(),
                 runtime_sandbox_mode,
             )
+            .with_no_session_persistence_probe()
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
     );

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -136,7 +136,8 @@ pub async fn run(
         serve_config.agents.claude.cli_path.clone(),
         serve_config.agents.claude.default_model.clone(),
         serve_config.agents.sandbox_mode,
-    );
+    )
+    .with_no_session_persistence_probe();
     if let Some(budget) = serve_config.agents.claude.reasoning_budget.clone() {
         claude_agent = claude_agent.with_reasoning_budget(budget);
     }

--- a/crates/harness-cli/src/gc.rs
+++ b/crates/harness-cli/src/gc.rs
@@ -160,6 +160,7 @@ fn build_agent_registry(
                 config.agents.claude.default_model.clone(),
                 config.agents.sandbox_mode,
             )
+            .with_no_session_persistence_probe()
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
     );

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -80,11 +80,15 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
             ));
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            tracing::warn!(
+            // NotFound is the expected steady state when --no-session-persistence
+            // is active.  Log at debug so that normal deployments do not flood
+            // warn-level logs on every 5 s dashboard poll.  The source_dir_missing
+            // flag in the JSON response surfaces the diagnostic to operators via
+            // the dashboard UI instead.
+            tracing::debug!(
                 path = %claude_projects_dir.display(),
                 "token_usage: session projects directory not found; \
-                 possible misconfiguration (wrong $HOME, deleted directory, \
-                 or path regression) — returning empty metrics"
+                 returning empty metrics (expected with --no-session-persistence)"
             );
             return missing_dir_response();
         }

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -56,11 +56,13 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     };
 
     let claude_projects_dir = home.join(".claude").join("projects");
+
+    // When --no-session-persistence is active, Claude Code does not write
+    // session JSONL files to disk, so the projects directory may be absent or
+    // empty. Return empty (zeroed) metrics rather than a 500 error so that
+    // callers receive a valid response in stateless agent environments.
     if !claude_projects_dir.is_dir() {
-        return error_response(format!(
-            "token usage source directory missing: {}",
-            claude_projects_dir.display()
-        ));
+        return empty_usage_response();
     }
 
     let files = match collect_session_files(&claude_projects_dir) {
@@ -69,10 +71,7 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     };
 
     if files.is_empty() {
-        return error_response(format!(
-            "no token usage JSONL files found under {}",
-            claude_projects_dir.display()
-        ));
+        return empty_usage_response();
     }
 
     let mut by_day: BTreeMap<String, UsageBucket> = BTreeMap::new();
@@ -234,6 +233,28 @@ fn error_response(message: String) -> (StatusCode, Json<Value>) {
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(serde_json::json!({ "error": message })),
     )
+}
+
+/// Return zeroed metrics with 200 OK when no session files are available.
+///
+/// This is the correct response when `--no-session-persistence` is active:
+/// agents do not write JSONL files, so an absent or empty projects directory
+/// is expected, not an error.
+fn empty_usage_response() -> (StatusCode, Json<Value>) {
+    let body = serde_json::json!({
+        "by_day": {},
+        "by_hour": {},
+        "model_trend": {},
+        "by_model": {},
+        "models": [],
+        "totals": UsageBucket::default(),
+        "total_context": 0,
+        "total_requests": 0,
+        "estimated_cost_usd": 0.0,
+        "task_usage": [],
+        "session_count": 0,
+    });
+    (StatusCode::OK, Json(body))
 }
 
 fn parse_usage_record(entry: &Value, ctx: &str) -> Result<Option<ParsedUsageRecord>, String> {

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -58,23 +58,42 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     let claude_projects_dir = home.join(".claude").join("projects");
 
     // When --no-session-persistence is active, Claude Code does not write
-    // session JSONL files to disk. Distinguish two absence cases:
+    // session JSONL files to disk. Distinguish three cases:
     //
-    //   1. Projects directory absent entirely — potentially a misconfiguration
+    //   1. Projects directory absent (NotFound) — potentially a misconfiguration
     //      (wrong $HOME, deleted directory, path regression). Emit a warning
     //      so operators can detect it in logs, and include a diagnostic field
     //      in the response so callers can distinguish from genuine empty usage.
     //
     //   2. Directory present but no JSONL files — the expected steady-state
     //      when --no-session-persistence is active. Silently return empty.
-    if !claude_projects_dir.is_dir() {
-        tracing::warn!(
-            path = %claude_projects_dir.display(),
-            "token_usage: session projects directory not found; \
-             possible misconfiguration (wrong $HOME, deleted directory, \
-             or path regression) — returning empty metrics"
-        );
-        return missing_dir_response();
+    //
+    //   3. Metadata error other than NotFound (e.g. permission denied) — this
+    //      is a real OS-level failure that must surface as an error, not be
+    //      silently treated as "directory absent".
+    match std::fs::metadata(&claude_projects_dir) {
+        Ok(meta) if meta.is_dir() => {}
+        Ok(_) => {
+            return error_response(format!(
+                "token usage path is not a directory: {}",
+                claude_projects_dir.display()
+            ));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!(
+                path = %claude_projects_dir.display(),
+                "token_usage: session projects directory not found; \
+                 possible misconfiguration (wrong $HOME, deleted directory, \
+                 or path regression) — returning empty metrics"
+            );
+            return missing_dir_response();
+        }
+        Err(e) => {
+            return error_response(format!(
+                "cannot access token usage directory {}: {e}",
+                claude_projects_dir.display()
+            ));
+        }
     }
 
     let files = match collect_session_files(&claude_projects_dir) {

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -58,11 +58,23 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     let claude_projects_dir = home.join(".claude").join("projects");
 
     // When --no-session-persistence is active, Claude Code does not write
-    // session JSONL files to disk, so the projects directory may be absent or
-    // empty. Return empty (zeroed) metrics rather than a 500 error so that
-    // callers receive a valid response in stateless agent environments.
+    // session JSONL files to disk. Distinguish two absence cases:
+    //
+    //   1. Projects directory absent entirely — potentially a misconfiguration
+    //      (wrong $HOME, deleted directory, path regression). Emit a warning
+    //      so operators can detect it in logs, and include a diagnostic field
+    //      in the response so callers can distinguish from genuine empty usage.
+    //
+    //   2. Directory present but no JSONL files — the expected steady-state
+    //      when --no-session-persistence is active. Silently return empty.
     if !claude_projects_dir.is_dir() {
-        return empty_usage_response();
+        tracing::warn!(
+            path = %claude_projects_dir.display(),
+            "token_usage: session projects directory not found; \
+             possible misconfiguration (wrong $HOME, deleted directory, \
+             or path regression) — returning empty metrics"
+        );
+        return missing_dir_response();
     }
 
     let files = match collect_session_files(&claude_projects_dir) {
@@ -233,6 +245,30 @@ fn error_response(message: String) -> (StatusCode, Json<Value>) {
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(serde_json::json!({ "error": message })),
     )
+}
+
+/// Return zeroed metrics with 200 OK when the projects directory is missing.
+///
+/// Unlike `empty_usage_response`, this includes `"source_dir_missing": true`
+/// so callers and monitoring can distinguish "directory absent" (potentially a
+/// misconfiguration) from "directory present but no sessions yet" (expected
+/// in --no-session-persistence environments).
+fn missing_dir_response() -> (StatusCode, Json<Value>) {
+    let body = serde_json::json!({
+        "by_day": {},
+        "by_hour": {},
+        "model_trend": {},
+        "by_model": {},
+        "models": [],
+        "totals": UsageBucket::default(),
+        "total_context": 0,
+        "total_requests": 0,
+        "estimated_cost_usd": 0.0,
+        "task_usage": [],
+        "session_count": 0,
+        "source_dir_missing": true,
+    });
+    (StatusCode::OK, Json(body))
 }
 
 /// Return zeroed metrics with 200 OK when no session files are available.

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -579,18 +579,22 @@ async function fetchTokenUsage() {
       return;
     }
     const data = await resp.json();
+    renderTokenMetrics(data);
     if (data.source_dir_missing) {
+      // Inject the diagnostic warning into the chart container instead of
+      // calling renderRequestChart, which would immediately replace this
+      // message with "No data" when by_hour is empty.
       const chart = document.getElementById("tok-req-chart");
       if (chart) {
         chart.innerHTML =
           '<p class="empty-state" style="color:#f59e0b">' +
-          "⚠ Session directory (~/.claude/projects) not found — " +
+          "&#9888; Session directory (~/.claude/projects) not found &mdash; " +
           "check $HOME configuration, or expected when using --no-session-persistence" +
           "</p>";
       }
+    } else {
+      renderRequestChart(data.by_hour || {});
     }
-    renderTokenMetrics(data);
-    renderRequestChart(data.by_hour || {});
     renderModelTrend(data.model_trend || {}, data.models || []);
     renderTokenDayTable(data.by_day || {});
     renderTokenModelTable(data.by_model || {});

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -580,10 +580,14 @@ async function fetchTokenUsage() {
     }
     const data = await resp.json();
     if (data.source_dir_missing) {
-      console.warn(
-        "token_usage: session directory (~/.claude/projects) not found — " +
-        "check $HOME configuration or expected when using --no-session-persistence"
-      );
+      const chart = document.getElementById("tok-req-chart");
+      if (chart) {
+        chart.innerHTML =
+          '<p class="empty-state" style="color:#f59e0b">' +
+          "⚠ Session directory (~/.claude/projects) not found — " +
+          "check $HOME configuration, or expected when using --no-session-persistence" +
+          "</p>";
+      }
     }
     renderTokenMetrics(data);
     renderRequestChart(data.by_hour || {});

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -579,6 +579,12 @@ async function fetchTokenUsage() {
       return;
     }
     const data = await resp.json();
+    if (data.source_dir_missing) {
+      console.warn(
+        "token_usage: session directory (~/.claude/projects) not found — " +
+        "check $HOME configuration or expected when using --no-session-persistence"
+      );
+    }
     renderTokenMetrics(data);
     renderRequestChart(data.by_hour || {});
     renderModelTrend(data.model_trend || {}, data.models || []);


### PR DESCRIPTION
## Summary
- Add `--no-session-persistence` to `ClaudeCodeAgent::base_args()` in `claude.rs`
- Add `--no-session-persistence` to `ClaudeAdapter::start_turn()` in `claude_adapter.rs`
- Add test `base_args_always_includes_no_session_persistence` verifying the flag is present for both full and restricted profiles

## Test plan
- [ ] `cargo test --workspace` passes (87 harness-agents tests pass)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied

Closes #609