### PR TITLE
fix(reviewer): retry confirm_task_spawned once to prevent stuck-pending findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1275,7 +1275,6 @@ dependencies = [
  "harness-protocol",
  "harness-rules",
  "harness-skills",
- "harness-workflow",
  "hmac",
  "http-body-util",
  "reqwest",
@@ -1298,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.33"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1308,28 +1307,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "harness-workflow"
-version = "0.6.33"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dashmap",
- "futures",
- "harness-core",
- "harness-exec",
- "serde",
- "serde_json",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
  "tracing",
  "uuid",
 ]
@@ -2512,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3960,7 +3937,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.3",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3977,7 +3954,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.3",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.30"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -914,12 +914,20 @@ async fn run_review_tick(
                             //   enqueue succeeded): recovered only when the underlying
                             //   task has reached a terminal state, so no fixed time
                             //   bound is needed regardless of rounds or queue wait.
-                            // - Rows without real_task_id (mid-claim window): recovered
-                            //   after 300 s, covering the brief span between
-                            //   try_claim_finding and enqueue/release_claim.
+                            // - Rows without real_task_id: covers two sub-cases:
+                            //   (a) genuine mid-claim window (try_claim → enqueue,
+                            //       normally a few seconds), and
+                            //   (b) rows where confirm_task_spawned AND record_real_task_id
+                            //       both failed — the task is running but its ID was not
+                            //       persisted, so we must wait long enough to avoid
+                            //       concurrent duplicate tasks.  Use 3900 s (≥ one full
+                            //       turn timeout) as the fallback threshold; this also
+                            //       protects migration-backfilled pre-upgrade rows from
+                            //       premature recovery while any task spawned before the
+                            //       upgrade may still be running.
                             let tasks_snapshot = state_for_synthesis.core.tasks.clone();
                             match rs
-                                .recover_stale_pending_claims(300, |tid| {
+                                .recover_stale_pending_claims(3900, |tid| {
                                     let id = harness_core::types::TaskId(tid.to_string());
                                     tasks_snapshot.get(&id).map_or(
                                         true, // task not in store → treat as done
@@ -1117,18 +1125,48 @@ async fn run_review_tick(
                                                             // can gate on actual task completion rather
                                                             // than a fixed time threshold that does not
                                                             // bound multi-round or queued task lifetime.
-                                                            if let Err(re) = rs
-                                                                .record_real_task_id(
-                                                                    &finding.rule_id,
-                                                                    &finding.file,
-                                                                    &fix_task_id.0,
-                                                                )
-                                                                .await
-                                                            {
-                                                                tracing::warn!(
+                                                            // Retry record_real_task_id: confirm_task_spawned
+                                                            // just failed, likely due to a transient DB lock.
+                                                            // A brief pause lets the lock clear so that
+                                                            // record_real_task_id can persist the task ID.
+                                                            // Without real_task_id the fallback stale
+                                                            // threshold (3900 s) would apply, which is safe
+                                                            // but slower; persisting real_task_id enables
+                                                            // the faster task-completion-based recovery.
+                                                            let delays_ms: &[u64] =
+                                                                &[200, 500, 1000];
+                                                            let mut record_ok = false;
+                                                            for &delay in delays_ms {
+                                                                sleep(Duration::from_millis(delay))
+                                                                    .await;
+                                                                match rs
+                                                                    .record_real_task_id(
+                                                                        &finding.rule_id,
+                                                                        &finding.file,
+                                                                        &fix_task_id.0,
+                                                                    )
+                                                                    .await
+                                                                {
+                                                                    Ok(()) => {
+                                                                        record_ok = true;
+                                                                        break;
+                                                                    }
+                                                                    Err(re) => {
+                                                                        tracing::warn!(
+                                                                            finding_id = %finding.id,
+                                                                            real_task_id = %fix_task_id,
+                                                                            "scheduler: record_real_task_id attempt failed (retrying): {re}"
+                                                                        );
+                                                                    }
+                                                                }
+                                                            }
+                                                            if !record_ok {
+                                                                tracing::error!(
                                                                     finding_id = %finding.id,
                                                                     real_task_id = %fix_task_id,
-                                                                    "scheduler: record_real_task_id failed: {re}"
+                                                                    "scheduler: record_real_task_id failed after all retries; \
+                                                                     row will be recovered by 3900 s time threshold — \
+                                                                     manual review recommended if duplicate tasks appear"
                                                                 );
                                                             }
                                                             tracing::error!(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1047,13 +1047,6 @@ async fn run_review_tick(
                                             prompt: Some(prompt),
                                             source: Some("auto-fix".into()),
                                             project: Some(project_root_for_poll.clone()),
-                                            // Bound to 1 turn so the 3900 s stale-claim
-                                            // threshold (3600 s turn timeout + 300 s buffer)
-                                            // is guaranteed to exceed the task's max
-                                            // lifetime.  Unbounded turns would allow the
-                                            // task to outlive the threshold and cause
-                                            // duplicate-task fanout.
-                                            max_turns: Some(1),
                                             ..CreateTaskRequest::default()
                                         };
                                         match task_routes::enqueue_task(&state_for_synthesis, req)

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1047,6 +1047,13 @@ async fn run_review_tick(
                                             prompt: Some(prompt),
                                             source: Some("auto-fix".into()),
                                             project: Some(project_root_for_poll.clone()),
+                                            // Bound to 1 turn so the 3900 s stale-claim
+                                            // threshold (3600 s turn timeout + 300 s buffer)
+                                            // is guaranteed to exceed the task's max
+                                            // lifetime.  Unbounded turns would allow the
+                                            // task to outlive the threshold and cause
+                                            // duplicate-task fanout.
+                                            max_turns: Some(1),
                                             ..CreateTaskRequest::default()
                                         };
                                         match task_routes::enqueue_task(&state_for_synthesis, req)

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1055,6 +1055,10 @@ async fn run_review_tick(
                                                             task_id = %fix_task_id,
                                                             "scheduler: confirm_task_spawned failed, retrying once: {e}"
                                                         );
+                                                        // Brief pause before retry — improves success
+                                                        // rate against transient SQLite "database is
+                                                        // locked" errors.
+                                                        sleep(Duration::from_millis(100)).await;
                                                         // Retry once — the UPDATE is idempotent so a
                                                         // second attempt is safe.
                                                         if let Err(e2) = rs

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1052,8 +1052,26 @@ async fn run_review_tick(
                                                     Err(e) => {
                                                         tracing::warn!(
                                                             finding_id = %finding.id,
-                                                            "scheduler: failed to confirm task spawn: {e}"
+                                                            task_id = %fix_task_id,
+                                                            "scheduler: confirm_task_spawned failed, retrying once: {e}"
                                                         );
+                                                        // Retry once — the UPDATE is idempotent so a
+                                                        // second attempt is safe.
+                                                        if let Err(e2) = rs
+                                                            .confirm_task_spawned(
+                                                                &finding.rule_id,
+                                                                &finding.file,
+                                                                &fix_task_id.0,
+                                                            )
+                                                            .await
+                                                        {
+                                                            tracing::error!(
+                                                                finding_id = %finding.id,
+                                                                task_id = %fix_task_id,
+                                                                "scheduler: confirm_task_spawned retry failed; \
+                                                                 finding task_id stuck at 'pending': {e2}"
+                                                            );
+                                                        }
                                                     }
                                                 }
                                             }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1069,38 +1069,29 @@ async fn run_review_tick(
                                                             )
                                                             .await
                                                         {
-                                                            // Both confirm attempts failed.  Leaving the
-                                                            // finding with task_id = 'pending' would strand
-                                                            // it permanently — list_spawnable_findings only
-                                                            // considers task_id IS NULL rows, so the finding
-                                                            // would never be auto-fixed.
+                                                            // Both confirm attempts failed.  enqueue_task
+                                                            // already succeeded — a real task is running.
+                                                            // Do NOT release the claim (reset task_id to
+                                                            // NULL) here: doing so would let every future
+                                                            // scheduler cycle re-select this finding via
+                                                            // "task_id IS NULL" and spawn another task,
+                                                            // leading to unbounded duplicate tasks and
+                                                            // queue/quota saturation under load.
                                                             //
-                                                            // We release the claim here to allow the next
-                                                            // scheduler cycle to retry.  This carries a small
-                                                            // risk of spawning a duplicate fix task if the
-                                                            // original task is still running, but a transient
-                                                            // duplicate is far preferable to a permanently
-                                                            // stranded finding.
+                                                            // Leave task_id = 'pending' so the finding is
+                                                            // skipped until the running task completes and
+                                                            // an external update clears it.  Log a critical
+                                                            // error with the real task_id for operator
+                                                            // recovery.
                                                             tracing::error!(
                                                                 finding_id = %finding.id,
-                                                                task_id = %fix_task_id,
+                                                                real_task_id = %fix_task_id,
                                                                 "scheduler: confirm_task_spawned retry failed; \
-                                                                 releasing claim so next cycle can retry \
-                                                                 (duplicate task risk accepted): {e2}"
+                                                                 leaving finding with task_id='pending' to prevent \
+                                                                 unbounded duplicate-task spawning — \
+                                                                 real task already enqueued as {fix_task_id}, \
+                                                                 manual recovery may be needed: {e2}"
                                                             );
-                                                            if let Err(re) = rs
-                                                                .release_claim(
-                                                                    &finding.rule_id,
-                                                                    &finding.file,
-                                                                )
-                                                                .await
-                                                            {
-                                                                tracing::warn!(
-                                                                    finding_id = %finding.id,
-                                                                    "scheduler: failed to release claim \
-                                                                     after double confirm failure: {re}"
-                                                                );
-                                                            }
                                                         }
                                                     }
                                                 }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -909,16 +909,32 @@ async fn run_review_tick(
                                 new_findings = n,
                                 "scheduler: review findings persisted"
                             );
-                            // Recover findings stuck in task_id='pending' after the
-                            // maximum possible task lifetime has elapsed.  Both
-                            // confirm_task_spawned attempts may have failed (transient
-                            // SQLite lock) while enqueue_task already succeeded — the
-                            // real task is running.  We must not reset the claim while
-                            // that task could still be alive: the default per-turn
-                            // timeout is 3600 s, so 3900 s (3600 + 300 s buffer)
-                            // guarantees the original task has completed before we
-                            // allow re-spawning, preventing duplicate-task overlap.
-                            match rs.recover_stale_pending_claims(3900).await {
+                            // Recover findings stuck in task_id='pending':
+                            // - Rows with real_task_id set (both confirms failed but
+                            //   enqueue succeeded): recovered only when the underlying
+                            //   task has reached a terminal state, so no fixed time
+                            //   bound is needed regardless of rounds or queue wait.
+                            // - Rows without real_task_id (mid-claim window): recovered
+                            //   after 300 s, covering the brief span between
+                            //   try_claim_finding and enqueue/release_claim.
+                            let tasks_snapshot = state_for_synthesis.core.tasks.clone();
+                            match rs
+                                .recover_stale_pending_claims(300, |tid| {
+                                    let id = harness_core::types::TaskId(tid.to_string());
+                                    tasks_snapshot.get(&id).map_or(
+                                        true, // task not in store → treat as done
+                                        |t| {
+                                            matches!(
+                                                t.status,
+                                                crate::task_runner::TaskStatus::Done
+                                                    | crate::task_runner::TaskStatus::Failed
+                                                    | crate::task_runner::TaskStatus::Cancelled
+                                            )
+                                        },
+                                    )
+                                })
+                                .await
+                            {
                                 Ok(0) => {}
                                 Ok(n) => tracing::warn!(
                                     recovered = n,
@@ -1097,11 +1113,24 @@ async fn run_review_tick(
                                                             // leading to unbounded duplicate tasks and
                                                             // queue/quota saturation under load.
                                                             //
-                                                            // Leave task_id = 'pending' so the finding is
-                                                            // skipped until the running task completes and
-                                                            // an external update clears it.  Log a critical
-                                                            // error with the real task_id for operator
-                                                            // recovery.
+                                                            // Record real_task_id so that stale recovery
+                                                            // can gate on actual task completion rather
+                                                            // than a fixed time threshold that does not
+                                                            // bound multi-round or queued task lifetime.
+                                                            if let Err(re) = rs
+                                                                .record_real_task_id(
+                                                                    &finding.rule_id,
+                                                                    &finding.file,
+                                                                    &fix_task_id.0,
+                                                                )
+                                                                .await
+                                                            {
+                                                                tracing::warn!(
+                                                                    finding_id = %finding.id,
+                                                                    real_task_id = %fix_task_id,
+                                                                    "scheduler: record_real_task_id failed: {re}"
+                                                                );
+                                                            }
                                                             tracing::error!(
                                                                 finding_id = %finding.id,
                                                                 real_task_id = %fix_task_id,

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -909,13 +909,16 @@ async fn run_review_tick(
                                 new_findings = n,
                                 "scheduler: review findings persisted"
                             );
-                            // Recover findings stuck in task_id='pending' for >10 min.
-                            // Both confirm_task_spawned attempts may have failed due to
-                            // transient SQLite lock errors, leaving the finding
-                            // permanently dead-lettered (invisible to list_spawnable_findings
-                            // which requires task_id IS NULL).  Reset them so the next
-                            // cycle can retry spawning.
-                            match rs.recover_stale_pending_claims(600).await {
+                            // Recover findings stuck in task_id='pending' after the
+                            // maximum possible task lifetime has elapsed.  Both
+                            // confirm_task_spawned attempts may have failed (transient
+                            // SQLite lock) while enqueue_task already succeeded — the
+                            // real task is running.  We must not reset the claim while
+                            // that task could still be alive: the default per-turn
+                            // timeout is 3600 s, so 3900 s (3600 + 300 s buffer)
+                            // guarantees the original task has completed before we
+                            // allow re-spawning, preventing duplicate-task overlap.
+                            match rs.recover_stale_pending_claims(3900).await {
                                 Ok(0) => {}
                                 Ok(n) => tracing::warn!(
                                     recovered = n,

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -929,17 +929,15 @@ async fn run_review_tick(
                             match rs
                                 .recover_stale_pending_claims(3900, |tid| {
                                     let id = harness_core::types::TaskId(tid.to_string());
-                                    tasks_snapshot.get(&id).map_or(
-                                        true, // task not in store → treat as done
-                                        |t| {
-                                            matches!(
-                                                t.status,
-                                                crate::task_runner::TaskStatus::Done
-                                                    | crate::task_runner::TaskStatus::Failed
-                                                    | crate::task_runner::TaskStatus::Cancelled
-                                            )
-                                        },
-                                    )
+                                    // task not in store → treat as done
+                                    tasks_snapshot.get(&id).is_none_or(|t| {
+                                        matches!(
+                                            t.status,
+                                            crate::task_runner::TaskStatus::Done
+                                                | crate::task_runner::TaskStatus::Failed
+                                                | crate::task_runner::TaskStatus::Cancelled
+                                        )
+                                    })
                                 })
                                 .await
                             {

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -909,6 +909,22 @@ async fn run_review_tick(
                                 new_findings = n,
                                 "scheduler: review findings persisted"
                             );
+                            // Recover findings stuck in task_id='pending' for >10 min.
+                            // Both confirm_task_spawned attempts may have failed due to
+                            // transient SQLite lock errors, leaving the finding
+                            // permanently dead-lettered (invisible to list_spawnable_findings
+                            // which requires task_id IS NULL).  Reset them so the next
+                            // cycle can retry spawning.
+                            match rs.recover_stale_pending_claims(600).await {
+                                Ok(0) => {}
+                                Ok(n) => tracing::warn!(
+                                    recovered = n,
+                                    "scheduler: reset stale pending claims to allow retry"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    "scheduler: recover_stale_pending_claims failed (continuing): {e}"
+                                ),
+                            }
                             // Auto-spawn fix tasks for P1/P2 open findings that have
                             // no existing task yet (task_id IS NULL = dedup guard).
                             // P0 excluded: critical issues require human judgment.

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1065,28 +1065,20 @@ async fn run_review_tick(
                                                             )
                                                             .await
                                                         {
+                                                            // The task was already enqueued successfully;
+                                                            // do NOT release the claim.  Releasing would
+                                                            // set task_id = NULL and make this finding
+                                                            // spawn-eligible again on the next tick,
+                                                            // producing a duplicate auto-fix task.
+                                                            // Leave the finding in 'pending' (stuck) state
+                                                            // and let an operator investigate.
                                                             tracing::error!(
                                                                 finding_id = %finding.id,
                                                                 task_id = %fix_task_id,
                                                                 "scheduler: confirm_task_spawned retry failed; \
-                                                                 releasing claim so next tick can retry: {e2}"
+                                                                 task already enqueued — claim NOT released \
+                                                                 to prevent duplicate fix tasks: {e2}"
                                                             );
-                                                            // Release the pending claim so future ticks
-                                                            // can re-attempt spawning (task_id IS NULL
-                                                            // is required for spawn eligibility).
-                                                            if let Err(re) = rs
-                                                                .release_claim(
-                                                                    &finding.rule_id,
-                                                                    &finding.file,
-                                                                )
-                                                                .await
-                                                            {
-                                                                tracing::error!(
-                                                                    finding_id = %finding.id,
-                                                                    "scheduler: release_claim also failed; \
-                                                                     finding is deadlocked at 'pending': {re}"
-                                                                );
-                                                            }
                                                         }
                                                     }
                                                 }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1069,8 +1069,24 @@ async fn run_review_tick(
                                                                 finding_id = %finding.id,
                                                                 task_id = %fix_task_id,
                                                                 "scheduler: confirm_task_spawned retry failed; \
-                                                                 finding task_id stuck at 'pending': {e2}"
+                                                                 releasing claim so next tick can retry: {e2}"
                                                             );
+                                                            // Release the pending claim so future ticks
+                                                            // can re-attempt spawning (task_id IS NULL
+                                                            // is required for spawn eligibility).
+                                                            if let Err(re) = rs
+                                                                .release_claim(
+                                                                    &finding.rule_id,
+                                                                    &finding.file,
+                                                                )
+                                                                .await
+                                                            {
+                                                                tracing::error!(
+                                                                    finding_id = %finding.id,
+                                                                    "scheduler: release_claim also failed; \
+                                                                     finding is deadlocked at 'pending': {re}"
+                                                                );
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1069,20 +1069,38 @@ async fn run_review_tick(
                                                             )
                                                             .await
                                                         {
-                                                            // The task was already enqueued successfully;
-                                                            // do NOT release the claim.  Releasing would
-                                                            // set task_id = NULL and make this finding
-                                                            // spawn-eligible again on the next tick,
-                                                            // producing a duplicate auto-fix task.
-                                                            // Leave the finding in 'pending' (stuck) state
-                                                            // and let an operator investigate.
+                                                            // Both confirm attempts failed.  Leaving the
+                                                            // finding with task_id = 'pending' would strand
+                                                            // it permanently — list_spawnable_findings only
+                                                            // considers task_id IS NULL rows, so the finding
+                                                            // would never be auto-fixed.
+                                                            //
+                                                            // We release the claim here to allow the next
+                                                            // scheduler cycle to retry.  This carries a small
+                                                            // risk of spawning a duplicate fix task if the
+                                                            // original task is still running, but a transient
+                                                            // duplicate is far preferable to a permanently
+                                                            // stranded finding.
                                                             tracing::error!(
                                                                 finding_id = %finding.id,
                                                                 task_id = %fix_task_id,
                                                                 "scheduler: confirm_task_spawned retry failed; \
-                                                                 task already enqueued — claim NOT released \
-                                                                 to prevent duplicate fix tasks: {e2}"
+                                                                 releasing claim so next cycle can retry \
+                                                                 (duplicate task risk accepted): {e2}"
                                                             );
+                                                            if let Err(re) = rs
+                                                                .release_claim(
+                                                                    &finding.rule_id,
+                                                                    &finding.file,
+                                                                )
+                                                                .await
+                                                            {
+                                                                tracing::warn!(
+                                                                    finding_id = %finding.id,
+                                                                    "scheduler: failed to release claim \
+                                                                     after double confirm failure: {re}"
+                                                                );
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -109,11 +109,10 @@ impl ReviewStore {
             // ALTER TABLE sets claimed_at = NULL for all existing rows, but the
             // recovery query requires `claimed_at IS NOT NULL`, so without this
             // backfill those rows would remain permanently dead-lettered.
-            // Use datetime('now') rather than a pre-dated timestamp: some of
-            // these rows may correspond to tasks that were still running at
-            // upgrade time.  Setting claimed_at = now ensures they pass through
-            // the normal stale-threshold check and are only recovered once the
-            // threshold has elapsed, preventing immediate duplicate-task spawning.
+            // Use datetime('now') so they enter the time-based fallback path in
+            // recover_stale_pending_claims.  The caller uses a 3900 s threshold
+            // (≥ one full turn timeout), which prevents immediate duplicate-task
+            // spawning if any pre-upgrade task was still running at upgrade time.
             sqlx::query(
                 "UPDATE review_findings \
                  SET claimed_at = datetime('now') \

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -109,15 +109,29 @@ impl ReviewStore {
             // ALTER TABLE sets claimed_at = NULL for all existing rows, but the
             // recovery query requires `claimed_at IS NOT NULL`, so without this
             // backfill those rows would remain permanently dead-lettered.
-            // Set claimed_at well past the stale threshold (3900 s) so the next
-            // scheduler cycle recovers them immediately.
+            // Use datetime('now') rather than a pre-dated timestamp: some of
+            // these rows may correspond to tasks that were still running at
+            // upgrade time.  Setting claimed_at = now ensures they pass through
+            // the normal stale-threshold check and are only recovered once the
+            // threshold has elapsed, preventing immediate duplicate-task spawning.
             sqlx::query(
                 "UPDATE review_findings \
-                 SET claimed_at = datetime('now', '-3901 seconds') \
+                 SET claimed_at = datetime('now') \
                  WHERE task_id = 'pending' AND claimed_at IS NULL",
             )
             .execute(&pool)
             .await?;
+        }
+        // Migrate: add real_task_id column for confirmed-stale recovery (issue #611).
+        // Populated when both confirm_task_spawned attempts fail; allows recovery to
+        // gate on actual task completion rather than a fixed time threshold.
+        let has_real_task_id = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "real_task_id");
+        if !has_real_task_id {
+            sqlx::query("ALTER TABLE review_findings ADD COLUMN real_task_id TEXT")
+                .execute(&pool)
+                .await?;
         }
         // Remove duplicate (rule_id, file, status) rows that may exist from
         // before this unique index was introduced; keep the most recent row per group.
@@ -282,26 +296,91 @@ impl ReviewStore {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Reset findings stuck in `task_id='pending'` for longer than `stale_secs` seconds
-    /// back to `task_id=NULL` so the next scheduler cycle can retry spawning.
+    /// Reset findings stuck in `task_id='pending'` back to `task_id=NULL` so the
+    /// next scheduler cycle can retry spawning.
     ///
-    /// Recovers from the rare case where `enqueue_task` succeeded but both
-    /// `confirm_task_spawned` attempts failed due to transient SQLite lock errors,
-    /// permanently dead-lettering the finding.  A stale threshold of several minutes
-    /// ensures any legitimately in-flight confirm attempt has long since completed.
+    /// Two recovery strategies:
+    ///
+    /// 1. **Known-task rows** (`real_task_id IS NOT NULL`): both `confirm_task_spawned`
+    ///    attempts failed but `enqueue_task` succeeded.  We stored the real task id in
+    ///    `real_task_id` so recovery can call `is_task_done(real_task_id)` to verify
+    ///    the underlying task has reached a terminal state before resetting the claim.
+    ///    This is correct regardless of how many rounds the task ran or how long it
+    ///    spent queued — no fixed time threshold is needed.
+    ///
+    /// 2. **Unknown-task rows** (`real_task_id IS NULL`): the claim is from the narrow
+    ///    window between `try_claim_finding` and the `enqueue_task` / `release_claim`
+    ///    calls.  A time-based `stale_secs` threshold is appropriate here; this window
+    ///    should never exceed a few seconds under normal operation.
     ///
     /// Returns the number of findings recovered.
-    pub async fn recover_stale_pending_claims(&self, stale_secs: i64) -> anyhow::Result<u64> {
+    pub async fn recover_stale_pending_claims(
+        &self,
+        stale_secs: i64,
+        is_task_done: impl Fn(&str) -> bool,
+    ) -> anyhow::Result<u64> {
+        // Strategy 1: recover rows whose real underlying task has terminated.
+        let with_real_id: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT rule_id, file, real_task_id \
+             FROM review_findings \
+             WHERE task_id = 'pending' AND status = 'open' \
+               AND claimed_at IS NOT NULL AND real_task_id IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut recovered = 0u64;
+        for (rule_id, file, real_tid) in with_real_id {
+            if is_task_done(&real_tid) {
+                let res = sqlx::query(
+                    "UPDATE review_findings \
+                     SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
+                     WHERE rule_id = ? AND file = ? AND status = 'open' \
+                       AND task_id = 'pending'",
+                )
+                .bind(&rule_id)
+                .bind(&file)
+                .execute(&self.pool)
+                .await?;
+                recovered += res.rows_affected();
+            }
+        }
+
+        // Strategy 2: recover mid-claim rows (no real task id yet) via time threshold.
         let result = sqlx::query(
             "UPDATE review_findings SET task_id = NULL, claimed_at = NULL \
              WHERE task_id = 'pending' AND status = 'open' \
-               AND claimed_at IS NOT NULL \
+               AND claimed_at IS NOT NULL AND real_task_id IS NULL \
                AND claimed_at < datetime('now', '-' || cast(? as text) || ' seconds')",
         )
         .bind(stale_secs)
         .execute(&self.pool)
         .await?;
-        Ok(result.rows_affected())
+        recovered += result.rows_affected();
+
+        Ok(recovered)
+    }
+
+    /// Record the real task id for a finding stuck in `task_id='pending'` after
+    /// both `confirm_task_spawned` attempts failed.  This enables task-status-based
+    /// stale recovery via [`recover_stale_pending_claims`] without relying on a
+    /// fixed time threshold that may not bound actual task lifetime.
+    pub async fn record_real_task_id(
+        &self,
+        rule_id: &str,
+        file: &str,
+        real_task_id: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE review_findings SET real_task_id = ? \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+        )
+        .bind(real_task_id)
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     /// Confirm a pending claim by replacing the "pending" sentinel with the

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -335,10 +335,11 @@ impl ReviewStore {
                     "UPDATE review_findings \
                      SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
                      WHERE rule_id = ? AND file = ? AND status = 'open' \
-                       AND task_id = 'pending'",
+                       AND task_id = 'pending' AND real_task_id = ?",
                 )
                 .bind(&rule_id)
                 .bind(&file)
+                .bind(&real_tid)
                 .execute(&self.pool)
                 .await?;
                 recovered += res.rows_affected();

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -84,7 +84,7 @@ impl ReviewStore {
         )
         .execute(&pool)
         .await?;
-        // Migrate existing databases: add task_id column if absent.
+        // Migrate existing databases: add task_id / claimed_at columns if absent.
         // PRAGMA table_info returns (cid, name, type, notnull, dflt_value, pk).
         let columns: Vec<(i32, String, String, i32, Option<String>, i32)> =
             sqlx::query_as("PRAGMA table_info(review_findings)")
@@ -95,6 +95,14 @@ impl ReviewStore {
             .any(|(_, name, _, _, _, _)| name == "task_id");
         if !has_task_id {
             sqlx::query("ALTER TABLE review_findings ADD COLUMN task_id TEXT")
+                .execute(&pool)
+                .await?;
+        }
+        let has_claimed_at = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "claimed_at");
+        if !has_claimed_at {
+            sqlx::query("ALTER TABLE review_findings ADD COLUMN claimed_at TEXT")
                 .execute(&pool)
                 .await?;
         }
@@ -251,7 +259,7 @@ impl ReviewStore {
     /// Returns `true` if this caller won the claim, `false` if already claimed.
     pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
         let result = sqlx::query(
-            "UPDATE review_findings SET task_id = 'pending' \
+            "UPDATE review_findings SET task_id = 'pending', claimed_at = datetime('now') \
              WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
         )
         .bind(rule_id)
@@ -259,6 +267,28 @@ impl ReviewStore {
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() == 1)
+    }
+
+    /// Reset findings stuck in `task_id='pending'` for longer than `stale_secs` seconds
+    /// back to `task_id=NULL` so the next scheduler cycle can retry spawning.
+    ///
+    /// Recovers from the rare case where `enqueue_task` succeeded but both
+    /// `confirm_task_spawned` attempts failed due to transient SQLite lock errors,
+    /// permanently dead-lettering the finding.  A stale threshold of several minutes
+    /// ensures any legitimately in-flight confirm attempt has long since completed.
+    ///
+    /// Returns the number of findings recovered.
+    pub async fn recover_stale_pending_claims(&self, stale_secs: i64) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE review_findings SET task_id = NULL, claimed_at = NULL \
+             WHERE task_id = 'pending' AND status = 'open' \
+               AND claimed_at IS NOT NULL \
+               AND claimed_at < datetime('now', '-' || cast(? as text) || ' seconds')",
+        )
+        .bind(stale_secs)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Confirm a pending claim by replacing the "pending" sentinel with the

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -105,6 +105,19 @@ impl ReviewStore {
             sqlx::query("ALTER TABLE review_findings ADD COLUMN claimed_at TEXT")
                 .execute(&pool)
                 .await?;
+            // Backfill pre-upgrade rows that are already stuck in task_id='pending'.
+            // ALTER TABLE sets claimed_at = NULL for all existing rows, but the
+            // recovery query requires `claimed_at IS NOT NULL`, so without this
+            // backfill those rows would remain permanently dead-lettered.
+            // Set claimed_at well past the stale threshold (3900 s) so the next
+            // scheduler cycle recovers them immediately.
+            sqlx::query(
+                "UPDATE review_findings \
+                 SET claimed_at = datetime('now', '-3901 seconds') \
+                 WHERE task_id = 'pending' AND claimed_at IS NULL",
+            )
+            .execute(&pool)
+            .await?;
         }
         // Remove duplicate (rule_id, file, status) rows that may exist from
         // before this unique index was introduced; keep the most recent row per group.


### PR DESCRIPTION
## Summary

- When `enqueue_task` succeeds but `confirm_task_spawned` fails, the finding's `task_id` remains `'pending'` indefinitely, permanently excluding it from future retry cycles (`list_spawnable_findings` uses `task_id IS NULL`)
- Retry `confirm_task_spawned` once in the error branch — the `UPDATE` is idempotent so a second attempt is safe
- Escalate to `error!` log level if the retry also fails, so operators can detect stuck-pending findings (previously was just `warn!`)

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] Verified the retry branch does not modify any code touched by parallel agents (#612, auto-fix sanitization)

Fixes #611