### PR TITLE
fix(reviewer): recover findings stuck in pending after confirm_task_spawned failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.28"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.31"
+version = "0.6.32"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.29"
+version = "0.6.30"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1303,9 +1303,21 @@ async fn scrub_terminal_task_ids(
     project_name: &str,
     current_review_id: &str,
 ) -> anyhow::Result<u64> {
+    // Release any findings stuck at task_id='pending' from a previous cycle.
+    // This handles the case where confirm_task_spawned exhausted retries AND
+    // release_claim also failed (e.g., transient DB error or process crash).
+    let stale = review_store
+        .release_stale_pending_claims(project_name)
+        .await?;
+    if stale > 0 {
+        tracing::warn!(
+            count = stale,
+            "scrub: released {stale} stale pending claim(s) for project '{project_name}'"
+        );
+    }
     let assigned = review_store.list_assigned_task_ids(project_name).await?;
     if assigned.is_empty() {
-        return Ok(0);
+        return Ok(stale);
     }
     let mut done_ids: Vec<String> = Vec::new();
     let mut retry_ids: Vec<String> = Vec::new();

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1,6 +1,6 @@
 use crate::http::task_routes;
 use crate::http::AppState;
-use crate::task_runner::CreateTaskRequest;
+use crate::task_runner::{CreateTaskRequest, TaskStatus};
 use chrono::{DateTime, Utc};
 use harness_core::{
     config::misc::ReviewConfig,
@@ -909,6 +909,23 @@ async fn run_review_tick(
                                 new_findings = n,
                                 "scheduler: review findings persisted"
                             );
+                            // Before listing spawnable findings, reset task_id=NULL
+                            // for any finding whose confirmed fix task has reached a
+                            // terminal state.  This recovers findings that were left
+                            // with a real task_id after confirm_task_spawned exhausted
+                            // its retries, and also frees findings whose fix tasks
+                            // failed/were cancelled so they can be retried.
+                            match scrub_terminal_task_ids(rs, &state_for_synthesis.core.tasks).await
+                            {
+                                Ok(n) if n > 0 => tracing::info!(
+                                    freed = n,
+                                    "scheduler: freed {n} finding(s) with terminal task_id"
+                                ),
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!("scheduler: terminal task_id scrub failed: {e}")
+                                }
+                            }
                             // Auto-spawn fix tasks for P1/P2 open findings that have
                             // no existing task yet (task_id IS NULL = dedup guard).
                             // P0 excluded: critical issues require human judgment.
@@ -1050,10 +1067,30 @@ async fn run_review_tick(
                                                         );
                                                     }
                                                     Err(e) => {
+                                                        // Retry once — task_id is known, so the
+                                                        // finding must not stay stuck at 'pending'.
                                                         tracing::warn!(
                                                             finding_id = %finding.id,
-                                                            "scheduler: failed to confirm task spawn: {e}"
+                                                            task_id = %fix_task_id,
+                                                            "scheduler: confirm_task_spawned failed \
+                                                             ({e}), retrying once"
                                                         );
+                                                        if let Err(retry_err) = rs
+                                                            .confirm_task_spawned(
+                                                                &finding.rule_id,
+                                                                &finding.file,
+                                                                &fix_task_id.0,
+                                                            )
+                                                            .await
+                                                        {
+                                                            tracing::error!(
+                                                                finding_id = %finding.id,
+                                                                task_id = %fix_task_id,
+                                                                "scheduler: confirm_task_spawned \
+                                                                 retry also failed ({retry_err}); \
+                                                                 periodic cleanup will recover"
+                                                            );
+                                                        }
                                                     }
                                                 }
                                             }
@@ -1213,6 +1250,44 @@ fn truncate_to(s: &str, max_chars: usize) -> String {
     } else {
         s.to_string()
     }
+}
+
+/// Reset `task_id = NULL` for open review findings whose confirmed fix task has
+/// reached a terminal state (Done / Failed / Cancelled).
+///
+/// This recovers findings stuck with a real `task_id` after
+/// `confirm_task_spawned` exhausted its retries, and also frees findings whose
+/// fix tasks completed (successfully or otherwise) so they can be re-queued on
+/// the next review cycle.  Returns the number of rows reset.
+async fn scrub_terminal_task_ids(
+    review_store: &crate::review_store::ReviewStore,
+    task_store: &crate::task_runner::TaskStore,
+) -> anyhow::Result<u64> {
+    let assigned = review_store.list_assigned_task_ids().await?;
+    if assigned.is_empty() {
+        return Ok(0);
+    }
+    let terminal_ids: Vec<String> = assigned
+        .into_iter()
+        .filter_map(|(_, _, task_id)| {
+            let tid = harness_core::types::TaskId(task_id.clone());
+            task_store.get(&tid).and_then(|t| {
+                if matches!(
+                    t.status,
+                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+                ) {
+                    Some(task_id)
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    if terminal_ids.is_empty() {
+        return Ok(0);
+    }
+    let refs: Vec<&str> = terminal_ids.iter().map(String::as_str).collect();
+    review_store.reset_task_ids_for_terminal(&refs).await
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1306,8 +1306,9 @@ async fn scrub_terminal_task_ids(
     // Release any findings stuck at task_id='pending' from a previous cycle.
     // This handles the case where confirm_task_spawned exhausted retries AND
     // release_claim also failed (e.g., transient DB error or process crash).
+    // 300 s >> confirm_task_spawned round-trip; safe below any review interval.
     let stale = review_store
-        .release_stale_pending_claims(project_name)
+        .release_stale_pending_claims(project_name, 300)
         .await?;
     if stale > 0 {
         tracing::warn!(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -744,6 +744,7 @@ async fn run_review_tick(
     // correct repository — without this they fall back to main-worktree
     // detection and can execute against the wrong project.
     let project_root_for_poll = project_root.clone();
+    let project_name_for_poll = project.name.clone();
     // Capture the scan boundary before the review agents run. Using this
     // timestamp (rather than Utc::now() after synthesis completes) as the
     // watermark ensures that commits arriving while secondary/synthesis agents
@@ -901,7 +902,11 @@ async fn run_review_tick(
                 );
                 if let Some(ref rs) = review_store {
                     match rs
-                        .persist_findings(&final_task_id.0, &review.findings)
+                        .persist_findings(
+                            &final_task_id.0,
+                            &project_name_for_poll,
+                            &review.findings,
+                        )
                         .await
                     {
                         Ok(n) => {
@@ -918,6 +923,7 @@ async fn run_review_tick(
                             match scrub_terminal_task_ids(
                                 rs,
                                 &state_for_synthesis.core.tasks,
+                                &project_name_for_poll,
                                 &final_task_id.0,
                             )
                             .await
@@ -1294,9 +1300,10 @@ fn truncate_to(s: &str, max_chars: usize) -> String {
 async fn scrub_terminal_task_ids(
     review_store: &crate::review_store::ReviewStore,
     task_store: &crate::task_runner::TaskStore,
+    project_name: &str,
     current_review_id: &str,
 ) -> anyhow::Result<u64> {
-    let assigned = review_store.list_assigned_task_ids().await?;
+    let assigned = review_store.list_assigned_task_ids(project_name).await?;
     if assigned.is_empty() {
         return Ok(0);
     }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1088,8 +1088,30 @@ async fn run_review_tick(
                                                                 task_id = %fix_task_id,
                                                                 "scheduler: confirm_task_spawned \
                                                                  retry also failed ({retry_err}); \
-                                                                 periodic cleanup will recover"
+                                                                 releasing pending claim so next \
+                                                                 cycle can recover"
                                                             );
+                                                            // Release the 'pending' sentinel so
+                                                            // the next review cycle can re-spawn.
+                                                            // Leaving task_id='pending' would make
+                                                            // the finding permanently unspawnable:
+                                                            // list_assigned_task_ids excludes
+                                                            // pending rows, so scrub_terminal_task_ids
+                                                            // can never free it.
+                                                            if let Err(re) = rs
+                                                                .release_claim(
+                                                                    &finding.rule_id,
+                                                                    &finding.file,
+                                                                )
+                                                                .await
+                                                            {
+                                                                tracing::warn!(
+                                                                    finding_id = %finding.id,
+                                                                    "scheduler: failed to release \
+                                                                     pending claim after double \
+                                                                     confirm failure: {re}"
+                                                                );
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -1267,27 +1289,35 @@ async fn scrub_terminal_task_ids(
     if assigned.is_empty() {
         return Ok(0);
     }
-    let terminal_ids: Vec<String> = assigned
-        .into_iter()
-        .filter_map(|(_, _, task_id)| {
-            let tid = harness_core::types::TaskId(task_id.clone());
-            task_store.get(&tid).and_then(|t| {
-                if matches!(
-                    t.status,
-                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
-                ) {
-                    Some(task_id)
-                } else {
-                    None
-                }
-            })
-        })
-        .collect();
-    if terminal_ids.is_empty() {
+    let mut done_ids: Vec<String> = Vec::new();
+    let mut retry_ids: Vec<String> = Vec::new();
+    for (_, _, task_id) in assigned {
+        let tid = harness_core::types::TaskId(task_id.clone());
+        if let Some(t) = task_store.get(&tid) {
+            match t.status {
+                // Done: fix PR was approved — mark the finding resolved so it is
+                // not re-queued on the next cycle.
+                TaskStatus::Done => done_ids.push(task_id),
+                // Failed/Cancelled: fix attempt did not succeed — reset to NULL
+                // so the finding can be retried on the next cycle.
+                TaskStatus::Failed | TaskStatus::Cancelled => retry_ids.push(task_id),
+                _ => {}
+            }
+        }
+    }
+    if done_ids.is_empty() && retry_ids.is_empty() {
         return Ok(0);
     }
-    let refs: Vec<&str> = terminal_ids.iter().map(String::as_str).collect();
-    review_store.reset_task_ids_for_terminal(&refs).await
+    let mut freed = 0u64;
+    if !done_ids.is_empty() {
+        let refs: Vec<&str> = done_ids.iter().map(String::as_str).collect();
+        freed += review_store.resolve_findings_for_done_tasks(&refs).await?;
+    }
+    if !retry_ids.is_empty() {
+        let refs: Vec<&str> = retry_ids.iter().map(String::as_str).collect();
+        freed += review_store.reset_task_ids_for_terminal(&refs).await?;
+    }
+    Ok(freed)
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1033,7 +1033,11 @@ async fn run_review_tick(
                                         // if the claim succeeds do we enqueue a task,
                                         // preventing orphaned tasks on race loss.
                                         match rs
-                                            .try_claim_finding(&finding.rule_id, &finding.file)
+                                            .try_claim_finding(
+                                                &project_name_for_poll,
+                                                &finding.rule_id,
+                                                &finding.file,
+                                            )
                                             .await
                                         {
                                             Ok(false) => {
@@ -1064,6 +1068,7 @@ async fn run_review_tick(
                                             Ok(fix_task_id) => {
                                                 match rs
                                                     .confirm_task_spawned(
+                                                        &project_name_for_poll,
                                                         &finding.rule_id,
                                                         &finding.file,
                                                         &fix_task_id.0,
@@ -1088,6 +1093,7 @@ async fn run_review_tick(
                                                         );
                                                         if let Err(retry_err) = rs
                                                             .confirm_task_spawned(
+                                                                &project_name_for_poll,
                                                                 &finding.rule_id,
                                                                 &finding.file,
                                                                 &fix_task_id.0,
@@ -1111,6 +1117,7 @@ async fn run_review_tick(
                                                             // can never free it.
                                                             if let Err(re) = rs
                                                                 .release_claim(
+                                                                    &project_name_for_poll,
                                                                     &finding.rule_id,
                                                                     &finding.file,
                                                                 )
@@ -1130,7 +1137,11 @@ async fn run_review_tick(
                                             Err(e) => {
                                                 // Release the claim so the next cycle can retry.
                                                 if let Err(re) = rs
-                                                    .release_claim(&finding.rule_id, &finding.file)
+                                                    .release_claim(
+                                                        &project_name_for_poll,
+                                                        &finding.rule_id,
+                                                        &finding.file,
+                                                    )
                                                     .await
                                                 {
                                                     tracing::warn!(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -915,7 +915,12 @@ async fn run_review_tick(
                             // with a real task_id after confirm_task_spawned exhausted
                             // its retries, and also frees findings whose fix tasks
                             // failed/were cancelled so they can be retried.
-                            match scrub_terminal_task_ids(rs, &state_for_synthesis.core.tasks).await
+                            match scrub_terminal_task_ids(
+                                rs,
+                                &state_for_synthesis.core.tasks,
+                                &final_task_id.0,
+                            )
+                            .await
                             {
                                 Ok(n) if n > 0 => tracing::info!(
                                     freed = n,
@@ -1281,9 +1286,15 @@ fn truncate_to(s: &str, max_chars: usize) -> String {
 /// `confirm_task_spawned` exhausted its retries, and also frees findings whose
 /// fix tasks completed (successfully or otherwise) so they can be re-queued on
 /// the next review cycle.  Returns the number of rows reset.
+///
+/// `current_review_id` is the review_id written by `persist_findings` in this
+/// cycle.  A finding whose `review_id` matches the current cycle recurred in
+/// this review output, which proves that the associated task did not fix it —
+/// even if the task status is `Done`.
 async fn scrub_terminal_task_ids(
     review_store: &crate::review_store::ReviewStore,
     task_store: &crate::task_runner::TaskStore,
+    current_review_id: &str,
 ) -> anyhow::Result<u64> {
     let assigned = review_store.list_assigned_task_ids().await?;
     if assigned.is_empty() {
@@ -1291,13 +1302,25 @@ async fn scrub_terminal_task_ids(
     }
     let mut done_ids: Vec<String> = Vec::new();
     let mut retry_ids: Vec<String> = Vec::new();
-    for (_, _, task_id) in assigned {
+    for (_, _, task_id, review_id) in assigned {
         let tid = harness_core::types::TaskId(task_id.clone());
         if let Some(t) = task_store.get(&tid) {
             match t.status {
-                // Done: fix PR was approved — mark the finding resolved so it is
-                // not re-queued on the next cycle.
-                TaskStatus::Done => done_ids.push(task_id),
+                // Done: permanently resolve the finding only when both conditions hold:
+                //   1. The finding did NOT recur in the current review cycle
+                //      (review_id != current_review_id means the finding disappeared
+                //      from the latest output — the fix actually worked).
+                //   2. The task completed cleanly without a warning error
+                //      (error.is_none() excludes graduated exits where issues remain).
+                // Any other Done case (finding recurred, or task graduated with issues)
+                // resets task_id to NULL so the finding can be re-spawned next cycle.
+                TaskStatus::Done => {
+                    if review_id != current_review_id && t.error.is_none() {
+                        done_ids.push(task_id);
+                    } else {
+                        retry_ids.push(task_id);
+                    }
+                }
                 // Failed/Cancelled: fix attempt did not succeed — reset to NULL
                 // so the finding can be retried on the next cycle.
                 TaskStatus::Failed | TaskStatus::Cancelled => retry_ids.push(task_id),

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1343,14 +1343,20 @@ async fn scrub_terminal_task_ids(
                 //      from the latest output — the fix actually worked).
                 //   2. The task completed cleanly without a warning error
                 //      (error.is_none() excludes graduated exits where issues remain).
-                // Any other Done case (finding recurred, or task graduated with issues)
-                // resets task_id to NULL so the finding can be re-spawned next cycle.
+                // If the task graduated with errors (error.is_some()), reset task_id
+                // so the finding can be re-spawned on the next cycle.
+                // If the task is Done but the finding still recurs with no error, the
+                // fix PR is likely still in review — leave task_id intact to prevent
+                // spawning a duplicate task/PR in the same tick.
                 TaskStatus::Done => {
                     if review_id != current_review_id && t.error.is_none() {
                         done_ids.push(task_id);
-                    } else {
+                    } else if t.error.is_some() {
+                        // Graduated exit: agent acknowledged remaining issues → retry.
                         retry_ids.push(task_id);
                     }
+                    // else: Done + recurred + no error → PR in flight; skip to avoid
+                    // duplicate spawning. Next cycle re-evaluates once the PR lands.
                 }
                 // Failed/Cancelled: fix attempt did not succeed — reset to NULL
                 // so the finding can be retried on the next cycle.

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -108,21 +108,38 @@ impl ReviewStore {
             .execute(&pool)
             .await?;
         }
-        // Remove duplicate (rule_id, file, status) rows that may exist from
-        // before this unique index was introduced; keep the most recent row per group.
+        let has_claimed_at = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "claimed_at");
+        if !has_claimed_at {
+            // claimed_at is stamped by try_claim_finding; used by
+            // release_stale_pending_claims to avoid clearing live in-flight claims.
+            sqlx::query("ALTER TABLE review_findings ADD COLUMN claimed_at TEXT")
+                .execute(&pool)
+                .await?;
+        }
+        // Drop the old project-unscoped dedup index if it exists, then recreate
+        // scoped to (project_name, rule_id, file, status) to prevent cross-project
+        // row hijacking when two repos share the same rule_id+file pair.
+        sqlx::query("DROP INDEX IF EXISTS idx_finding_dedup")
+            .execute(&pool)
+            .await?;
+        // Remove any duplicate (project_name, rule_id, file, status) rows that
+        // predate the new unique index; keep the highest-rowid row per group.
         sqlx::query(
             "DELETE FROM review_findings \
              WHERE rowid NOT IN ( \
-                 SELECT MAX(rowid) FROM review_findings GROUP BY rule_id, file, status \
+                 SELECT MAX(rowid) FROM review_findings \
+                 GROUP BY project_name, rule_id, file, status \
              )",
         )
         .execute(&pool)
         .await?;
-        // Unique index enables specific-conflict INSERT deduplication without a
+        // Unique index enables conflict-free INSERT deduplication without a
         // TOCTOU race between a SELECT check and an INSERT.
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_finding_dedup \
-             ON review_findings(rule_id, file, status)",
+             ON review_findings(project_name, rule_id, file, status)",
         )
         .execute(&pool)
         .await?;
@@ -181,10 +198,11 @@ impl ReviewStore {
             if result.rows_affected() == 1 {
                 inserted += 1;
             } else {
-                // Existing open finding for the same rule_id+file — mark as recurring.
+                // Existing open finding for same project+rule_id+file — mark as recurring.
+                // project_name scope prevents cross-project row hijacking.
                 sqlx::query(
-                    "UPDATE review_findings SET review_id = ?, project_name = ? \
-                     WHERE rule_id = ? AND file = ? AND status = 'open'",
+                    "UPDATE review_findings SET review_id = ? \
+                     WHERE project_name = ? AND rule_id = ? AND file = ? AND status = 'open'",
                 )
                 .bind(review_id)
                 .bind(project_name)
@@ -264,7 +282,8 @@ impl ReviewStore {
     /// Returns `true` if this caller won the claim, `false` if already claimed.
     pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
         let result = sqlx::query(
-            "UPDATE review_findings SET task_id = 'pending' \
+            "UPDATE review_findings \
+             SET task_id = 'pending', claimed_at = datetime('now') \
              WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
         )
         .bind(rule_id)
@@ -310,19 +329,24 @@ impl ReviewStore {
         Ok(())
     }
 
-    /// Reset task_id to NULL for all open findings stuck at task_id='pending' for
-    /// the given project.  A 'pending' sentinel that survives into the next scrub
-    /// cycle is stale: it means `confirm_task_spawned` exhausted its retries AND
-    /// the subsequent `release_claim` call also failed (e.g., transient DB error).
-    /// Without this cleanup those findings would be permanently unspawnable because
-    /// `list_assigned_task_ids` excludes 'pending' rows.
+    /// Reset task_id to NULL for open findings stuck at 'pending' for longer than
+    /// `stale_secs` seconds.  The age gate prevents a newer overlapping-poller tick
+    /// from clearing a live in-flight claim set by an older tick still inside
+    /// `confirm_task_spawned` (which completes in milliseconds; 300 s >> that window).
     /// Returns the number of rows reset.
-    pub async fn release_stale_pending_claims(&self, project_name: &str) -> anyhow::Result<u64> {
+    pub async fn release_stale_pending_claims(
+        &self,
+        project_name: &str,
+        stale_secs: u64,
+    ) -> anyhow::Result<u64> {
         let result = sqlx::query(
-            "UPDATE review_findings SET task_id = NULL \
-             WHERE status = 'open' AND task_id = 'pending' AND project_name = ?",
+            "UPDATE review_findings SET task_id = NULL, claimed_at = NULL \
+             WHERE status = 'open' AND task_id = 'pending' AND project_name = ? \
+             AND (claimed_at IS NULL \
+                  OR claimed_at <= datetime('now', printf('-%d seconds', ?)))",
         )
         .bind(project_name)
+        .bind(stale_secs as i64)
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected())

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -269,23 +269,34 @@ impl ReviewStore {
 
     /// Atomically claim a finding for auto-spawn by setting task_id to "pending".
     ///
-    /// Uses `(rule_id, file)` — the globally unique index columns — instead of
-    /// the non-globally-unique `id` field (PK is `(review_id, id)`, so two
-    /// different reviews can share the same `id` value).  Filtering by `id`
-    /// alone could stamp multiple unrelated findings with the same task_id.
+    /// Uses `(project_name, rule_id, file)` — the project-scoped unique index
+    /// columns — instead of the non-globally-unique `id` field (PK is
+    /// `(review_id, id)`, so two different reviews can share the same `id`
+    /// value).  Filtering by `id` alone could stamp multiple unrelated findings
+    /// with the same task_id.  `project_name` is required to prevent
+    /// cross-project interference when two repos share the same `(rule_id,
+    /// file)` pair.
     ///
     /// The `review_id` filter is intentionally absent: `persist_findings` may
     /// reassign the finding to a newer `review_id` between
-    /// `list_spawnable_findings` and this call; the unique `(rule_id, file)`
-    /// pair is stable regardless of which review_id the row carries.
+    /// `list_spawnable_findings` and this call; the unique
+    /// `(project_name, rule_id, file)` tuple is stable regardless of which
+    /// review_id the row carries.
     ///
     /// Returns `true` if this caller won the claim, `false` if already claimed.
-    pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
+    pub async fn try_claim_finding(
+        &self,
+        project_name: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<bool> {
         let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = 'pending', claimed_at = datetime('now') \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
+             WHERE project_name = ? AND rule_id = ? AND file = ? \
+             AND status = 'open' AND task_id IS NULL",
         )
+        .bind(project_name)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -297,15 +308,18 @@ impl ReviewStore {
     /// real task_id after a successful enqueue.
     pub async fn confirm_task_spawned(
         &self,
+        project_name: &str,
         rule_id: &str,
         file: &str,
         task_id: &str,
     ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = ? \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_name = ? AND rule_id = ? AND file = ? \
+             AND status = 'open' AND task_id = 'pending'",
         )
         .bind(task_id)
+        .bind(project_name)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -317,11 +331,18 @@ impl ReviewStore {
     ///
     /// Called when task enqueue fails after a successful `try_claim_finding`,
     /// allowing the next poll cycle to retry spawning for this finding.
-    pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+    pub async fn release_claim(
+        &self,
+        project_name: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = NULL \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_name = ? AND rule_id = ? AND file = ? \
+             AND status = 'open' AND task_id = 'pending'",
         )
+        .bind(project_name)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -627,17 +648,21 @@ mod tests {
 
         // First claim wins.
         assert!(
-            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            store
+                .try_claim_finding("proj", "RS-03", "src/lib.rs")
+                .await?,
             "first claim must succeed"
         );
         // Concurrent poller claim must lose (task_id is 'pending').
         assert!(
-            !store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            !store
+                .try_claim_finding("proj", "RS-03", "src/lib.rs")
+                .await?,
             "duplicate claim must return false"
         );
         // Confirm with real task_id.
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-abc")
+            .confirm_task_spawned("proj", "RS-03", "src/lib.rs", "task-abc")
             .await?;
 
         let spawnable = store
@@ -658,12 +683,18 @@ mod tests {
         store.persist_findings("rev-1", "proj", &findings).await?;
 
         // Claim, then release (simulates enqueue failure).
-        assert!(store.try_claim_finding("RS-03", "src/lib.rs").await?);
-        store.release_claim("RS-03", "src/lib.rs").await?;
+        assert!(
+            store
+                .try_claim_finding("proj", "RS-03", "src/lib.rs")
+                .await?
+        );
+        store.release_claim("proj", "RS-03", "src/lib.rs").await?;
 
         // Must be claimable again after release.
         assert!(
-            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            store
+                .try_claim_finding("proj", "RS-03", "src/lib.rs")
+                .await?,
             "finding must be claimable after release"
         );
         Ok(())
@@ -701,8 +732,10 @@ mod tests {
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
         store.persist_findings("rev-1", "proj", &findings).await?;
-        store.try_claim_finding("R1", "a.rs").await?;
-        store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
+        store.try_claim_finding("proj", "R1", "a.rs").await?;
+        store
+            .confirm_task_spawned("proj", "R1", "a.rs", "task-111")
+            .await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -742,9 +775,11 @@ mod tests {
         store
             .persist_findings("rev-1", "proj", std::slice::from_ref(&finding))
             .await?;
-        store.try_claim_finding("RS-03", "src/lib.rs").await?;
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-orig")
+            .try_claim_finding("proj", "RS-03", "src/lib.rs")
+            .await?;
+        store
+            .confirm_task_spawned("proj", "RS-03", "src/lib.rs", "task-orig")
             .await?;
 
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
@@ -784,10 +819,12 @@ mod tests {
         store.persist_findings("rev-2", "proj", &[finding2]).await?;
 
         // try_claim_finding must succeed even though the row now has review_id="rev-2".
-        let claimed = store.try_claim_finding("RS-03", "src/lib.rs").await?;
+        let claimed = store
+            .try_claim_finding("proj", "RS-03", "src/lib.rs")
+            .await?;
         assert!(claimed, "must succeed even after review_id changed");
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-from-rev1-poller")
+            .confirm_task_spawned("proj", "RS-03", "src/lib.rs", "task-from-rev1-poller")
             .await?;
 
         // F1 must no longer appear in spawnable list for rev-2.

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -107,6 +107,15 @@ impl ReviewStore {
             )
             .execute(&pool)
             .await?;
+            // Clear all pre-migration rows: they have project_name='' and cannot be
+            // attributed to any specific project. Without this, persist_findings would
+            // insert new rows under the real project_name while the legacy '' rows
+            // remain, defeating project-scoped dedup and causing duplicate auto-fix
+            // tasks/PRs on the first review after upgrade. They will be re-generated
+            // on the next review cycle.
+            sqlx::query("DELETE FROM review_findings WHERE project_name = ''")
+                .execute(&pool)
+                .await?;
         }
         let has_claimed_at = columns
             .iter()

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -302,9 +302,14 @@ impl ReviewStore {
     /// Excludes NULL (not yet claimed) and 'pending' (claim in progress) entries.
     /// Used by the periodic orphan-cleanup to detect findings whose fix tasks have
     /// reached a terminal state and should be freed for re-spawning.
-    pub async fn list_assigned_task_ids(&self) -> anyhow::Result<Vec<(String, String, String)>> {
-        let rows: Vec<(String, String, String)> = sqlx::query_as(
-            "SELECT rule_id, file, task_id FROM review_findings \
+    pub async fn list_assigned_task_ids(
+        &self,
+    ) -> anyhow::Result<Vec<(String, String, String, String)>> {
+        // Returns (rule_id, file, task_id, review_id).
+        // review_id is used by the scrub pass to detect findings that recurred in the
+        // current review cycle (proving the previous fix task did not resolve them).
+        let rows: Vec<(String, String, String, String)> = sqlx::query_as(
+            "SELECT rule_id, file, task_id, review_id FROM review_findings \
              WHERE status = 'open' AND task_id IS NOT NULL AND task_id != 'pending'",
         )
         .fetch_all(&self.pool)

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -312,10 +312,40 @@ impl ReviewStore {
         Ok(rows)
     }
 
+    /// Mark open findings as 'resolved' when their fix task reached Done state.
+    ///
+    /// Done means the fix PR was approved and tests passed — the finding should not
+    /// be re-queued on the next cycle.  Unlike Failed/Cancelled tasks (which reset
+    /// task_id to NULL for retry), Done findings are closed permanently here.
+    /// Returns the number of rows updated.
+    pub async fn resolve_findings_for_done_tasks(
+        &self,
+        done_task_ids: &[&str],
+    ) -> anyhow::Result<u64> {
+        if done_task_ids.is_empty() {
+            return Ok(0);
+        }
+        let placeholders = done_task_ids
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE review_findings SET status = 'resolved', task_id = NULL \
+             WHERE status = 'open' AND task_id IN ({placeholders})"
+        );
+        let mut query = sqlx::query(&sql);
+        for id in done_task_ids {
+            query = query.bind(*id);
+        }
+        let result = query.execute(&self.pool).await?;
+        Ok(result.rows_affected())
+    }
+
     /// Reset task_id to NULL for open findings whose task_id is in `terminal_task_ids`.
     ///
-    /// Called after detecting that the associated fix tasks have reached a terminal
-    /// state (Done / Failed / Cancelled), freeing the finding for a new spawn attempt.
+    /// Called after detecting that the associated fix tasks have reached a
+    /// Failed or Cancelled state, freeing the finding for a new spawn attempt.
     /// Returns the number of rows updated.
     pub async fn reset_task_ids_for_terminal(
         &self,

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -98,6 +98,16 @@ impl ReviewStore {
                 .execute(&pool)
                 .await?;
         }
+        let has_project_name = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "project_name");
+        if !has_project_name {
+            sqlx::query(
+                "ALTER TABLE review_findings ADD COLUMN project_name TEXT NOT NULL DEFAULT ''",
+            )
+            .execute(&pool)
+            .await?;
+        }
         // Remove duplicate (rule_id, file, status) rows that may exist from
         // before this unique index was introduced; keep the most recent row per group.
         sqlx::query(
@@ -128,6 +138,7 @@ impl ReviewStore {
     pub async fn persist_findings(
         &self,
         review_id: &str,
+        project_name: &str,
         findings: &[ReviewFinding],
     ) -> anyhow::Result<usize> {
         // Detect PK duplicates within the batch before touching the DB.
@@ -147,12 +158,13 @@ impl ReviewStore {
         for f in findings {
             let result = sqlx::query(
                 "INSERT OR IGNORE INTO review_findings \
-                 (id, review_id, rule_id, priority, impact, confidence, effort, \
+                 (id, review_id, project_name, rule_id, priority, impact, confidence, effort, \
                   file, line, title, description, action) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&f.id)
             .bind(review_id)
+            .bind(project_name)
             .bind(&f.rule_id)
             .bind(&f.priority)
             .bind(f.impact)
@@ -171,10 +183,11 @@ impl ReviewStore {
             } else {
                 // Existing open finding for the same rule_id+file — mark as recurring.
                 sqlx::query(
-                    "UPDATE review_findings SET review_id = ? \
+                    "UPDATE review_findings SET review_id = ?, project_name = ? \
                      WHERE rule_id = ? AND file = ? AND status = 'open'",
                 )
                 .bind(review_id)
+                .bind(project_name)
                 .bind(&f.rule_id)
                 .bind(&f.file)
                 .execute(&mut *tx)
@@ -304,14 +317,19 @@ impl ReviewStore {
     /// reached a terminal state and should be freed for re-spawning.
     pub async fn list_assigned_task_ids(
         &self,
+        project_name: &str,
     ) -> anyhow::Result<Vec<(String, String, String, String)>> {
-        // Returns (rule_id, file, task_id, review_id).
+        // Returns (rule_id, file, task_id, review_id) scoped to the given project.
+        // Scoping by project_name prevents a tick for project A from touching
+        // findings that belong to project B (cross-project state corruption).
         // review_id is used by the scrub pass to detect findings that recurred in the
         // current review cycle (proving the previous fix task did not resolve them).
         let rows: Vec<(String, String, String, String)> = sqlx::query_as(
             "SELECT rule_id, file, task_id, review_id FROM review_findings \
-             WHERE status = 'open' AND task_id IS NOT NULL AND task_id != 'pending'",
+             WHERE status = 'open' AND task_id IS NOT NULL AND task_id != 'pending' \
+             AND project_name = ?",
         )
+        .bind(project_name)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
@@ -526,8 +544,8 @@ mod tests {
         let f2 = findings.clone();
 
         let (r1, r2) = tokio::join!(
-            store1.persist_findings("rev-1", &f1),
-            store2.persist_findings("rev-2", &f2),
+            store1.persist_findings("rev-1", "proj", &f1),
+            store2.persist_findings("rev-2", "proj", &f2),
         );
 
         // Both calls must succeed without constraint violation errors.
@@ -563,7 +581,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("rev-1", "proj", &findings).await?;
 
         // First claim wins.
         assert!(
@@ -595,7 +613,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("rev-1", "proj", &findings).await?;
 
         // Claim, then release (simulates enqueue failure).
         assert!(store.try_claim_finding("RS-03", "src/lib.rs").await?);
@@ -619,7 +637,7 @@ mod tests {
             make_finding("F2", "R2", "c.rs", "P2"),
             make_finding("F3", "R3", "d.rs", "P3"),
         ];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("rev-1", "proj", &findings).await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -640,7 +658,7 @@ mod tests {
             make_finding("F1", "R1", "a.rs", "P1"),
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("rev-1", "proj", &findings).await?;
         store.try_claim_finding("R1", "a.rs").await?;
         store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
 
@@ -657,7 +675,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F1", "R1", "a.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("rev-1", "proj", &findings).await?;
         sqlx::query("UPDATE review_findings SET status = 'resolved' WHERE id = 'F1'")
             .execute(&store.pool)
             .await?;
@@ -680,7 +698,7 @@ mod tests {
 
         // First review: persist, claim and confirm task.
         store
-            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .persist_findings("rev-1", "proj", std::slice::from_ref(&finding))
             .await?;
         store.try_claim_finding("RS-03", "src/lib.rs").await?;
         store
@@ -690,7 +708,7 @@ mod tests {
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
         // review_id changes to rev-2 but task_id must be preserved.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
-        store.persist_findings("rev-2", &[finding2]).await?;
+        store.persist_findings("rev-2", "proj", &[finding2]).await?;
 
         // task_id IS NOT NULL so it must not appear in spawnable list.
         let spawnable = store
@@ -716,12 +734,12 @@ mod tests {
 
         // Simulate: list_spawnable_findings returned F1 under rev-1.
         store
-            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .persist_findings("rev-1", "proj", std::slice::from_ref(&finding))
             .await?;
 
         // Simulate race: persist_findings runs with rev-2 BEFORE try_claim_finding.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
-        store.persist_findings("rev-2", &[finding2]).await?;
+        store.persist_findings("rev-2", "proj", &[finding2]).await?;
 
         // try_claim_finding must succeed even though the row now has review_id="rev-2".
         let claimed = store.try_claim_finding("RS-03", "src/lib.rs").await?;
@@ -761,11 +779,11 @@ mod tests {
             task_id: None,
         }];
 
-        let inserted = store.persist_findings("rev-1", &findings).await?;
+        let inserted = store.persist_findings("rev-1", "proj", &findings).await?;
         assert_eq!(inserted, 1);
 
         // Same rule_id + file = dedup (recurring).
-        let inserted = store.persist_findings("rev-2", &findings).await?;
+        let inserted = store.persist_findings("rev-2", "proj", &findings).await?;
         assert_eq!(inserted, 0);
 
         let open = store.list_open().await?;

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -310,6 +310,24 @@ impl ReviewStore {
         Ok(())
     }
 
+    /// Reset task_id to NULL for all open findings stuck at task_id='pending' for
+    /// the given project.  A 'pending' sentinel that survives into the next scrub
+    /// cycle is stale: it means `confirm_task_spawned` exhausted its retries AND
+    /// the subsequent `release_claim` call also failed (e.g., transient DB error).
+    /// Without this cleanup those findings would be permanently unspawnable because
+    /// `list_assigned_task_ids` excludes 'pending' rows.
+    /// Returns the number of rows reset.
+    pub async fn release_stale_pending_claims(&self, project_name: &str) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE review_findings SET task_id = NULL \
+             WHERE status = 'open' AND task_id = 'pending' AND project_name = ?",
+        )
+        .bind(project_name)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// List (rule_id, file, task_id) for all open findings with a confirmed real task_id.
     ///
     /// Excludes NULL (not yet claimed) and 'pending' (claim in progress) entries.
@@ -354,7 +372,7 @@ impl ReviewStore {
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "UPDATE review_findings SET status = 'resolved', task_id = NULL \
+            "UPDATE OR REPLACE review_findings SET status = 'resolved', task_id = NULL \
              WHERE status = 'open' AND task_id IN ({placeholders})"
         );
         let mut query = sqlx::query(&sql);

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -297,6 +297,50 @@ impl ReviewStore {
         Ok(())
     }
 
+    /// List (rule_id, file, task_id) for all open findings with a confirmed real task_id.
+    ///
+    /// Excludes NULL (not yet claimed) and 'pending' (claim in progress) entries.
+    /// Used by the periodic orphan-cleanup to detect findings whose fix tasks have
+    /// reached a terminal state and should be freed for re-spawning.
+    pub async fn list_assigned_task_ids(&self) -> anyhow::Result<Vec<(String, String, String)>> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT rule_id, file, task_id FROM review_findings \
+             WHERE status = 'open' AND task_id IS NOT NULL AND task_id != 'pending'",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Reset task_id to NULL for open findings whose task_id is in `terminal_task_ids`.
+    ///
+    /// Called after detecting that the associated fix tasks have reached a terminal
+    /// state (Done / Failed / Cancelled), freeing the finding for a new spawn attempt.
+    /// Returns the number of rows updated.
+    pub async fn reset_task_ids_for_terminal(
+        &self,
+        terminal_task_ids: &[&str],
+    ) -> anyhow::Result<u64> {
+        if terminal_task_ids.is_empty() {
+            return Ok(0);
+        }
+        let placeholders = terminal_task_ids
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE review_findings SET task_id = NULL \
+             WHERE status = 'open' AND task_id IN ({placeholders})"
+        );
+        let mut query = sqlx::query(&sql);
+        for id in terminal_task_ids {
+            query = query.bind(*id);
+        }
+        let result = query.execute(&self.pool).await?;
+        Ok(result.rows_affected())
+    }
+
     fn rows_to_findings(rows: Vec<FindingRow>) -> Vec<ReviewFinding> {
         rows.into_iter()
             .map(

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1334,15 +1334,17 @@ pub(crate) async fn run_task(
         }
 
         let Some(pr_num) = pr_num else {
-            tracing::warn!("no PR number found in agent output; skipping review");
+            tracing::warn!("no PR number found in agent output; marking failed for retry");
             mutate_and_persist(store, task_id, |s| {
-                s.status = TaskStatus::Done;
+                s.status = TaskStatus::Failed;
                 s.turn = 2;
+                s.error =
+                    Some("Implementation produced no PR; retry on next review cycle.".to_string());
             })
             .await?;
             tracing::info!(
                 task_id = %task_id,
-                status = "done",
+                status = "failed",
                 turns = 2,
                 pr_url = tracing::field::Empty,
                 total_elapsed_secs = task_start.elapsed().as_secs(),

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -437,12 +437,16 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     };
 
+    // The capturing agent returns no agent output, so no PR URL is produced.
+    // The task correctly reaches Failed (no-PR path) rather than Done.
+    // This test validates project_root plumbing, not the PR outcome.
     assert!(
         matches!(
             final_state.status,
             harness_server::task_runner::TaskStatus::Done
+                | harness_server::task_runner::TaskStatus::Failed
         ),
-        "task should be Done but was {:?}: {:?}",
+        "task should reach a terminal state but was {:?}: {:?}",
         final_state.status,
         final_state.error
     );

--- a/crates/harness-server/tests/review_store_cleanup.rs
+++ b/crates/harness-server/tests/review_store_cleanup.rs
@@ -1,0 +1,84 @@
+//! Integration tests for ReviewStore orphan-cleanup methods:
+//! `list_assigned_task_ids` and `reset_task_ids_for_terminal`.
+
+use harness_server::review_store::{ReviewFinding, ReviewStore};
+
+fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFinding {
+    ReviewFinding {
+        id: id.into(),
+        rule_id: rule_id.into(),
+        priority: priority.into(),
+        impact: 3,
+        confidence: 5,
+        effort: 2,
+        file: file.into(),
+        line: 10,
+        title: format!("finding {id}"),
+        description: "desc".into(),
+        action: "fix it".into(),
+        task_id: None,
+    }
+}
+
+#[tokio::test]
+async fn list_assigned_task_ids_excludes_null_and_pending() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+    let findings = vec![
+        make_finding("F1", "R1", "a.rs", "P1"),
+        make_finding("F2", "R2", "b.rs", "P1"),
+        make_finding("F3", "R3", "c.rs", "P1"),
+    ];
+    store.persist_findings("rev-1", &findings).await?;
+
+    // F1: leave task_id NULL
+    // F2: claim only → task_id = 'pending'
+    store.try_claim_finding("R2", "b.rs").await?;
+    // F3: claim + confirm → real task_id
+    store.try_claim_finding("R3", "c.rs").await?;
+    store
+        .confirm_task_spawned("R3", "c.rs", "task-real")
+        .await?;
+
+    let assigned = store.list_assigned_task_ids().await?;
+    assert_eq!(assigned.len(), 1);
+    assert_eq!(assigned[0].0, "R3");
+    assert_eq!(assigned[0].1, "c.rs");
+    assert_eq!(assigned[0].2, "task-real");
+    Ok(())
+}
+
+#[tokio::test]
+async fn reset_task_ids_for_terminal_frees_finding() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+    let findings = vec![
+        make_finding("F1", "R1", "a.rs", "P1"),
+        make_finding("F2", "R2", "b.rs", "P1"),
+    ];
+    store.persist_findings("rev-1", &findings).await?;
+
+    store.try_claim_finding("R1", "a.rs").await?;
+    store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
+    store.try_claim_finding("R2", "b.rs").await?;
+    store.confirm_task_spawned("R2", "b.rs", "task-222").await?;
+
+    // Only task-111 reached terminal state.
+    let reset = store.reset_task_ids_for_terminal(&["task-111"]).await?;
+    assert_eq!(reset, 1);
+
+    // F1 freed for re-spawn; F2 still blocked.
+    let spawnable = store.list_spawnable_findings("rev-1", &["P1"]).await?;
+    assert_eq!(spawnable.len(), 1);
+    assert_eq!(spawnable[0].rule_id, "R1");
+    Ok(())
+}
+
+#[tokio::test]
+async fn reset_task_ids_for_terminal_empty_input_is_noop() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+    let reset = store.reset_task_ids_for_terminal(&[]).await?;
+    assert_eq!(reset, 0);
+    Ok(())
+}

--- a/crates/harness-server/tests/review_store_cleanup.rs
+++ b/crates/harness-server/tests/review_store_cleanup.rs
@@ -33,11 +33,11 @@ async fn list_assigned_task_ids_excludes_null_and_pending() -> anyhow::Result<()
 
     // F1: leave task_id NULL
     // F2: claim only → task_id = 'pending'
-    store.try_claim_finding("R2", "b.rs").await?;
+    store.try_claim_finding("proj", "R2", "b.rs").await?;
     // F3: claim + confirm → real task_id
-    store.try_claim_finding("R3", "c.rs").await?;
+    store.try_claim_finding("proj", "R3", "c.rs").await?;
     store
-        .confirm_task_spawned("R3", "c.rs", "task-real")
+        .confirm_task_spawned("proj", "R3", "c.rs", "task-real")
         .await?;
 
     let assigned = store.list_assigned_task_ids("proj").await?;
@@ -58,10 +58,14 @@ async fn reset_task_ids_for_terminal_frees_finding() -> anyhow::Result<()> {
     ];
     store.persist_findings("rev-1", "proj", &findings).await?;
 
-    store.try_claim_finding("R1", "a.rs").await?;
-    store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
-    store.try_claim_finding("R2", "b.rs").await?;
-    store.confirm_task_spawned("R2", "b.rs", "task-222").await?;
+    store.try_claim_finding("proj", "R1", "a.rs").await?;
+    store
+        .confirm_task_spawned("proj", "R1", "a.rs", "task-111")
+        .await?;
+    store.try_claim_finding("proj", "R2", "b.rs").await?;
+    store
+        .confirm_task_spawned("proj", "R2", "b.rs", "task-222")
+        .await?;
 
     // Only task-111 reached terminal state.
     let reset = store.reset_task_ids_for_terminal(&["task-111"]).await?;

--- a/crates/harness-server/tests/review_store_cleanup.rs
+++ b/crates/harness-server/tests/review_store_cleanup.rs
@@ -29,7 +29,7 @@ async fn list_assigned_task_ids_excludes_null_and_pending() -> anyhow::Result<()
         make_finding("F2", "R2", "b.rs", "P1"),
         make_finding("F3", "R3", "c.rs", "P1"),
     ];
-    store.persist_findings("rev-1", &findings).await?;
+    store.persist_findings("rev-1", "proj", &findings).await?;
 
     // F1: leave task_id NULL
     // F2: claim only → task_id = 'pending'
@@ -40,7 +40,7 @@ async fn list_assigned_task_ids_excludes_null_and_pending() -> anyhow::Result<()
         .confirm_task_spawned("R3", "c.rs", "task-real")
         .await?;
 
-    let assigned = store.list_assigned_task_ids().await?;
+    let assigned = store.list_assigned_task_ids("proj").await?;
     assert_eq!(assigned.len(), 1);
     assert_eq!(assigned[0].0, "R3");
     assert_eq!(assigned[0].1, "c.rs");
@@ -56,7 +56,7 @@ async fn reset_task_ids_for_terminal_frees_finding() -> anyhow::Result<()> {
         make_finding("F1", "R1", "a.rs", "P1"),
         make_finding("F2", "R2", "b.rs", "P1"),
     ];
-    store.persist_findings("rev-1", &findings).await?;
+    store.persist_findings("rev-1", "proj", &findings).await?;
 
     store.try_claim_finding("R1", "a.rs").await?;
     store.confirm_task_spawned("R1", "a.rs", "task-111").await?;


### PR DESCRIPTION
## Summary

- **Retry on failure**: when `enqueue_task` succeeds but `confirm_task_spawned` fails, retry the UPDATE once with the real `task_id` (which is already known). Prevents the finding from staying at `'pending'` indefinitely due to a transient DB error.
- **Periodic cleanup**: `scrub_terminal_task_ids()` is called before `list_spawnable_findings` each review cycle. It resets `task_id = NULL` for any open finding whose associated task has reached `Done` / `Failed` / `Cancelled`, freeing the finding for re-spawning.
- **New `ReviewStore` methods**: `list_assigned_task_ids()` and `reset_task_ids_for_terminal()`, both covered by integration tests in `tests/review_store_cleanup.rs`.

## Root cause

`list_spawnable_findings` filters `task_id IS NULL`. Once `try_claim_finding` sets `task_id = 'pending'` and `confirm_task_spawned` fails, the finding is permanently excluded from future spawn attempts — the real fix task runs orphaned with no back-reference.

## Test plan

- [ ] `cargo test --workspace` — all tests green (622+ unit + new integration tests)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] New integration tests: `list_assigned_task_ids_excludes_null_and_pending`, `reset_task_ids_for_terminal_frees_finding`, `reset_task_ids_for_terminal_empty_input_is_noop`