### PR TITLE
feat(post_validator): classify validation errors with structured prefixes

### DIFF
--- a/crates/harness-server/src/post_validator.rs
+++ b/crates/harness-server/src/post_validator.rs
@@ -22,6 +22,42 @@ pub struct PostExecutionValidator {
     gh_bin: String,
 }
 
+/// Classify a command string into a human-readable error prefix.
+///
+/// Matches on substrings in priority order (first match wins). Commands
+/// always carry args (e.g. `cargo test -- --nocapture`), so substring
+/// matching on the full command string handles path-prefixed binaries
+/// (e.g. `/home/ci/bin/cargo check`) without extra processing.
+fn classify_command(cmd: &str) -> &'static str {
+    // Compile: check/build commands
+    if cmd.contains("cargo check")
+        || cmd.contains("cargo build")
+        || cmd.contains("go build")
+        || cmd.contains("tsc")
+    {
+        return "[COMPILE ERROR]";
+    }
+    // Test: test runner commands
+    if cmd.contains("cargo test")
+        || cmd.contains("go test")
+        || cmd.contains("pytest")
+        || cmd.contains("bun test")
+        || cmd.contains("jest")
+    {
+        return "[TEST FAILURE]";
+    }
+    // Lint: formatting and linting commands
+    if cmd.contains("cargo clippy")
+        || cmd.contains("cargo fmt")
+        || cmd.contains("ruff")
+        || cmd.contains("eslint")
+        || cmd.contains("golangci-lint")
+    {
+        return "[LINT ERROR]";
+    }
+    "[VALIDATION ERROR]"
+}
+
 /// Validate that a command string does not contain unquoted shell operators
 /// that could enable command chaining or execution escalation.
 ///
@@ -226,7 +262,7 @@ impl TurnInterceptor for PostExecutionValidator {
                 Ok(()) => tracing::debug!(cmd = %cmd, "post_validator: passed"),
                 Err(e) => {
                     tracing::warn!(cmd = %cmd, error = %e, "post_validator: failed");
-                    errors.push(e);
+                    errors.push(format!("{}\n{}", classify_command(cmd), e));
                 }
             }
         }
@@ -239,7 +275,7 @@ impl TurnInterceptor for PostExecutionValidator {
                     Ok(()) => tracing::debug!(cmd = %cmd, "post_validator: passed"),
                     Err(e) => {
                         tracing::warn!(cmd = %cmd, error = %e, "post_validator: failed");
-                        errors.push(e);
+                        errors.push(format!("{}\n{}", classify_command(cmd), e));
                     }
                 }
             }
@@ -553,6 +589,116 @@ mod tests {
     }
 
     // ── PR existence verification ─────────────────────────────────────────────
+
+    // ── classify_command ──────────────────────────────────────────────────────
+
+    #[test]
+    fn classify_compile_commands() {
+        for cmd in &[
+            "cargo check --workspace",
+            "cargo build --release",
+            "go build ./...",
+            "npx tsc --noEmit",
+            "/home/ci/bin/cargo check",
+        ] {
+            assert_eq!(
+                classify_command(cmd),
+                "[COMPILE ERROR]",
+                "expected [COMPILE ERROR] for `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_test_commands() {
+        for cmd in &[
+            "cargo test",
+            "cargo test -- --nocapture",
+            "go test ./...",
+            "pytest",
+            "bun test",
+            "jest --coverage",
+        ] {
+            assert_eq!(
+                classify_command(cmd),
+                "[TEST FAILURE]",
+                "expected [TEST FAILURE] for `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_lint_commands() {
+        for cmd in &[
+            "cargo clippy --workspace -- -D warnings",
+            "cargo fmt --check",
+            "ruff check .",
+            "eslint src/",
+            "golangci-lint run",
+        ] {
+            assert_eq!(
+                classify_command(cmd),
+                "[LINT ERROR]",
+                "expected [LINT ERROR] for `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unknown_command() {
+        for cmd in &["false", "./scripts/check.sh", "make verify", "true"] {
+            assert_eq!(
+                classify_command(cmd),
+                "[VALIDATION ERROR]",
+                "expected [VALIDATION ERROR] for `{cmd}`"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn error_prefix_appears_in_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = ValidationConfig {
+            pre_commit: vec!["cargo check --workspace".to_string()],
+            ..Default::default()
+        };
+        let validator = PostExecutionValidator::new(config);
+        let req = make_req(dir.path().to_path_buf());
+        let resp = make_resp("done");
+        let result = validator.post_execute(&req, &resp).await;
+        // `cargo check` will fail (not a real Rust project), error must carry prefix
+        let err = result.error.unwrap();
+        assert!(
+            err.contains("[COMPILE ERROR]"),
+            "expected [COMPILE ERROR] prefix, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_error_different_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        // Both commands run in pre_commit so both can fail in the same pass.
+        let config = ValidationConfig {
+            pre_commit: vec![
+                "cargo check --workspace".to_string(),
+                "cargo clippy --workspace -- -D warnings".to_string(),
+            ],
+            ..Default::default()
+        };
+        let validator = PostExecutionValidator::new(config);
+        let req = make_req(dir.path().to_path_buf());
+        let resp = make_resp("done");
+        let result = validator.post_execute(&req, &resp).await;
+        let err = result.error.unwrap();
+        assert!(
+            err.contains("[COMPILE ERROR]"),
+            "expected [COMPILE ERROR] in combined error, got: {err}"
+        );
+        assert!(
+            err.contains("[LINT ERROR]"),
+            "expected [LINT ERROR] in combined error, got: {err}"
+        );
+    }
 
     #[tokio::test]
     async fn pr_verification_skipped_when_output_has_no_pr_url() {

--- a/crates/harness-server/src/post_validator.rs
+++ b/crates/harness-server/src/post_validator.rs
@@ -316,7 +316,7 @@ impl TurnInterceptor for PostExecutionValidator {
                                 "post_validator: PR verification failed"
                             );
                             errors.push(format!(
-                                "PR {pr_url} could not be verified via GitHub API: {e}"
+                                "[VALIDATION ERROR] PR {pr_url} could not be verified via GitHub API: {e}"
                             ));
                         }
                     }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1066,7 +1066,7 @@ pub(crate) async fn run_task(
                     let tool_violations = validate_tool_usage(&r.output, impl_tools);
                     let violation_err: Option<String> = if !tool_violations.is_empty() {
                         let msg = format!(
-                        "Tool isolation violation: agent used disallowed tools: [{}]. Only [{}] are permitted.",
+                        "[VALIDATION ERROR] Tool isolation violation: agent used disallowed tools: [{}]. Only [{}] are permitted.",
                         tool_violations.join(", "),
                         impl_tools.join(", ")
                     );
@@ -1112,7 +1112,7 @@ pub(crate) async fn run_task(
                             );
                             let truncated = truncate_validation_error(&err, 2000);
                             impl_req.prompt = format!(
-                                "{}\n\nPost-execution validation failed (attempt {}/{}).\nErrors are prefixed with [COMPILE ERROR], [TEST FAILURE], [LINT ERROR], or [VALIDATION ERROR] — focus your fix on the indicated error type:\n{}",
+                                "{}\n\nPost-execution validation failed (attempt {}/{}).\nErrors are prefixed with [COMPILE ERROR], [TEST FAILURE], [LINT ERROR], or [VALIDATION ERROR] for classified failures, or with an interceptor name (e.g. [hook_name]) for hook/policy violations — focus your fix on the indicated error type:\n{}",
                                 first_req.prompt,
                                 validation_attempt,
                                 max_validation_retries,

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1112,7 +1112,7 @@ pub(crate) async fn run_task(
                             );
                             let truncated = truncate_validation_error(&err, 2000);
                             impl_req.prompt = format!(
-                                "{}\n\nPost-execution validation failed (attempt {}/{}):\n{}",
+                                "{}\n\nPost-execution validation failed (attempt {}/{}).\nErrors are prefixed with [COMPILE ERROR], [TEST FAILURE], [LINT ERROR], or [VALIDATION ERROR] — focus your fix on the indicated error type:\n{}",
                                 first_req.prompt,
                                 validation_attempt,
                                 max_validation_retries,


### PR DESCRIPTION
## Summary

- Add `classify_command(cmd: &str) -> &'static str` in `post_validator.rs` that maps command strings to `[COMPILE ERROR]`, `[TEST FAILURE]`, `[LINT ERROR]`, or `[VALIDATION ERROR]` via substring matching
- Prefix each collected error with its classification at push time — handles N failures of different kinds correctly with no `PostExecuteResult` API change
- Update retry prompt in `task_executor.rs` to explain the prefix scheme so the agent focuses on the right error category

## Test plan

- [ ] `classify_compile_commands` — `cargo check`, `cargo build`, `go build`, `npx tsc --noEmit`, path-prefixed variants → `[COMPILE ERROR]`
- [ ] `classify_test_commands` — `cargo test`, `go test`, `pytest`, `bun test`, `jest` → `[TEST FAILURE]`
- [ ] `classify_lint_commands` — `cargo clippy`, `cargo fmt`, `ruff`, `eslint`, `golangci-lint` → `[LINT ERROR]`
- [ ] `classify_unknown_command` — `false`, `./scripts/check.sh` → `[VALIDATION ERROR]`
- [ ] `error_prefix_appears_in_output` — single failing pre_commit command carries correct prefix
- [ ] `multi_error_different_kinds` — two failing commands of different kinds both appear in joined output
- [ ] All 26 post_validator tests pass (`cargo test -p harness-server post_validator`)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #636