### PR TITLE
fix(agents): log warn when child.kill() fails in codex_adapter

### DIFF
--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -225,7 +225,9 @@ impl AgentAdapter for CodexAdapter {
             if let Err(e) = Self::send_request(&mut state, "turn/interrupt", json!({})).await {
                 tracing::warn!("failed to send turn/interrupt: {e}, killing process");
                 if let Some(ref mut child) = state.child {
-                    let _ = child.kill().await;
+                    if let Err(e) = child.kill().await {
+                        tracing::warn!(pid = ?child.id(), "kill failed: {e}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Replace `let _ = child.kill().await` with `if let Err(e)` pattern that emits a `tracing::warn!` with the PID and error
- Orphaned processes are now visible in traces instead of silently failing

Fixes #627

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass