### PR TITLE
fix(task-store): filter terminal tasks from startup cache to bound memory growth

### DIFF
--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -116,7 +116,7 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     let mut totals = UsageBucket::default();
     let mut task_usage: HashMap<String, UsageBucket> = HashMap::new();
 
-    let all_tasks = match state.core.tasks.list_all_with_terminal().await {
+    let all_tasks = match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(tasks) => tasks,
         Err(e) => {
             return error_response(format!("failed to list tasks for usage attribution: {e}"))

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -116,7 +116,12 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     let mut totals = UsageBucket::default();
     let mut task_usage: HashMap<String, UsageBucket> = HashMap::new();
 
-    let all_tasks = state.core.tasks.list_all();
+    let all_tasks = match state.core.tasks.list_all_with_terminal().await {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            return error_response(format!("failed to list tasks for usage attribution: {e}"))
+        }
+    };
     let task_ids: std::collections::HashSet<String> =
         all_tasks.iter().map(|t| t.id.0.clone()).collect();
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -696,9 +696,9 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
-                let ready_ids = crate::task_runner::check_awaiting_deps(&store).await;
-                for task_id in ready_ids {
-                    if let Err(e) = store.persist(&task_id).await {
+                let (ready_ids, failed_ids) = crate::task_runner::check_awaiting_deps(&store).await;
+                for task_id in ready_ids.iter().chain(failed_ids.iter()) {
+                    if let Err(e) = store.persist(task_id).await {
                         tracing::warn!(
                             "dep-watcher: failed to persist {} after transition: {e}",
                             task_id.0

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -696,7 +696,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
-                let ready_ids = crate::task_runner::check_awaiting_deps(&store);
+                let ready_ids = crate::task_runner::check_awaiting_deps(&store).await;
                 for task_id in ready_ids {
                     if let Err(e) = store.persist(&task_id).await {
                         tracing::warn!(
@@ -1553,15 +1553,19 @@ async fn github_webhook(
     }
 }
 
-async fn list_tasks(State(state): State<Arc<AppState>>) -> Json<Vec<task_runner::TaskSummary>> {
-    let tasks = state
-        .core
-        .tasks
-        .list_all()
-        .into_iter()
-        .map(|t| t.summary())
-        .collect();
-    Json(tasks)
+async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
+    match state.core.tasks.list_all_with_terminal().await {
+        Ok(tasks) => {
+            let summaries: Vec<task_runner::TaskSummary> =
+                tasks.into_iter().map(|t| t.summary()).collect();
+            Json(summaries).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("database error: {e}")})),
+        )
+            .into_response(),
+    }
 }
 
 async fn get_task(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
@@ -1571,10 +1575,15 @@ async fn get_task(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
         .get_with_db_fallback(&harness_core::types::TaskId(id))
         .await
     {
-        Some(task) => Json(task).into_response(),
-        None => (
+        Ok(Some(task)) => Json(task).into_response(),
+        Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("database error: {e}")})),
         )
             .into_response(),
     }
@@ -1586,18 +1595,22 @@ async fn get_task_artifacts(
     Path(id): Path<String>,
 ) -> Response {
     let task_id = harness_core::types::TaskId(id);
-    if state
-        .core
-        .tasks
-        .get_with_db_fallback(&task_id)
-        .await
-        .is_none()
-    {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "task not found"})),
-        )
-            .into_response();
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("database error: {e}")})),
+            )
+                .into_response();
+        }
+        Ok(Some(_)) => {}
     }
     match state.core.tasks.list_artifacts(&task_id).await {
         Ok(artifacts) => Json(artifacts).into_response(),
@@ -1621,18 +1634,22 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
     let rx = match state.core.tasks.subscribe_task_stream(&task_id) {
         Some(rx) => rx,
         None => {
-            if state
-                .core
-                .tasks
-                .get_with_db_fallback(&task_id)
-                .await
-                .is_none()
-            {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({"error": "task not found"})),
-                )
-                    .into_response();
+            match state.core.tasks.get_with_db_fallback(&task_id).await {
+                Ok(None) => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(json!({"error": "task not found"})),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": format!("database error: {e}")})),
+                    )
+                        .into_response();
+                }
+                Ok(Some(_)) => {}
             }
             // Task exists but stream already closed (task completed before client connected).
             let stream = futures::stream::empty::<Result<Event, std::convert::Infallible>>();

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -473,10 +473,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     // Cleanup orphan worktrees from any previous crash.
     // Terminal tasks are no longer held in the in-memory cache, so query DB directly.
     if let Some(ref wmgr) = workspace_mgr {
-        match tasks.list_terminal_from_db().await {
-            Ok(terminal_tasks) => {
-                let terminal_ids: Vec<crate::task_runner::TaskId> =
-                    terminal_tasks.into_iter().map(|t| t.id).collect();
+        match tasks.list_terminal_ids_from_db().await {
+            Ok(terminal_ids) => {
                 wmgr.cleanup_orphan_worktrees(&project_root, &terminal_ids)
                     .await;
             }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -471,16 +471,13 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         };
 
     // Cleanup orphan worktrees from any previous crash.
+    // Terminal tasks are no longer held in the in-memory cache, so query DB directly.
     if let Some(ref wmgr) = workspace_mgr {
         let terminal_ids: Vec<crate::task_runner::TaskId> = tasks
-            .list_all()
+            .list_terminal_from_db()
+            .await
+            .unwrap_or_default()
             .into_iter()
-            .filter(|t| {
-                matches!(
-                    t.status,
-                    crate::task_runner::TaskStatus::Done | crate::task_runner::TaskStatus::Failed
-                )
-            })
             .map(|t| t.id)
             .collect();
         wmgr.cleanup_orphan_worktrees(&project_root, &terminal_ids)
@@ -1568,7 +1565,12 @@ async fn list_tasks(State(state): State<Arc<AppState>>) -> Json<Vec<task_runner:
 }
 
 async fn get_task(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
-    match state.core.tasks.get(&harness_core::types::TaskId(id)) {
+    match state
+        .core
+        .tasks
+        .get_with_db_fallback(&harness_core::types::TaskId(id))
+        .await
+    {
         Some(task) => Json(task).into_response(),
         None => (
             StatusCode::NOT_FOUND,
@@ -1584,7 +1586,13 @@ async fn get_task_artifacts(
     Path(id): Path<String>,
 ) -> Response {
     let task_id = harness_core::types::TaskId(id);
-    if state.core.tasks.get(&task_id).is_none() {
+    if state
+        .core
+        .tasks
+        .get_with_db_fallback(&task_id)
+        .await
+        .is_none()
+    {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),
@@ -1613,7 +1621,13 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
     let rx = match state.core.tasks.subscribe_task_stream(&task_id) {
         Some(rx) => rx,
         None => {
-            if state.core.tasks.get(&task_id).is_none() {
+            if state
+                .core
+                .tasks
+                .get_with_db_fallback(&task_id)
+                .await
+                .is_none()
+            {
                 return (
                     StatusCode::NOT_FOUND,
                     Json(json!({"error": "task not found"})),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1556,17 +1556,16 @@ async fn github_webhook(
 }
 
 async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
-    match state.core.tasks.list_all_with_terminal().await {
-        Ok(tasks) => {
-            let summaries: Vec<task_runner::TaskSummary> =
-                tasks.into_iter().map(|t| t.summary()).collect();
-            Json(summaries).into_response()
+    match state.core.tasks.list_all_summaries_with_terminal().await {
+        Ok(summaries) => Json(summaries).into_response(),
+        Err(e) => {
+            tracing::error!("list_tasks: database error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("database error: {e}")})),
-        )
-            .into_response(),
     }
 }
 
@@ -1583,11 +1582,14 @@ async fn get_task(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
             Json(json!({"error": "task not found"})),
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("database error: {e}")})),
-        )
-            .into_response(),
+        Err(e) => {
+            tracing::error!("get_task: database error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -1606,9 +1608,10 @@ async fn get_task_artifacts(
                 .into_response();
         }
         Err(e) => {
+            tracing::error!("get_task_artifacts: database error: {e}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("database error: {e}")})),
+                Json(json!({"error": "internal server error"})),
             )
                 .into_response();
         }
@@ -1616,11 +1619,14 @@ async fn get_task_artifacts(
     }
     match state.core.tasks.list_artifacts(&task_id).await {
         Ok(artifacts) => Json(artifacts).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": e.to_string()})),
-        )
-            .into_response(),
+        Err(e) => {
+            tracing::error!("get_task_artifacts: list artifacts error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -1645,9 +1651,10 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
                         .into_response();
                 }
                 Err(e) => {
+                    tracing::error!("stream_task_sse: database error: {e}");
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("database error: {e}")})),
+                        Json(json!({"error": "internal server error"})),
                     )
                         .into_response();
                 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -473,15 +473,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     // Cleanup orphan worktrees from any previous crash.
     // Terminal tasks are no longer held in the in-memory cache, so query DB directly.
     if let Some(ref wmgr) = workspace_mgr {
-        let terminal_ids: Vec<crate::task_runner::TaskId> = tasks
-            .list_terminal_from_db()
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .map(|t| t.id)
-            .collect();
-        wmgr.cleanup_orphan_worktrees(&project_root, &terminal_ids)
-            .await;
+        match tasks.list_terminal_from_db().await {
+            Ok(terminal_tasks) => {
+                let terminal_ids: Vec<crate::task_runner::TaskId> =
+                    terminal_tasks.into_iter().map(|t| t.id).collect();
+                wmgr.cleanup_orphan_worktrees(&project_root, &terminal_ids)
+                    .await;
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load terminal tasks for orphan worktree cleanup: {e}; skipping cleanup");
+            }
+        }
     }
 
     let memory_pressure =

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -519,12 +519,19 @@ pub(super) async fn cancel_task(
 
     let task_id = harness_core::types::TaskId(id);
 
-    let task = match state.core.tasks.get(&task_id) {
-        Some(t) => t,
-        None => {
+    let task = match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(json!({ "error": "task not found" })),
+            );
+        }
+        Err(e) => {
+            tracing::error!("cancel_task: DB lookup failed for {task_id:?}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "internal server error" })),
             );
         }
     };

--- a/crates/harness-server/src/skill_governor.rs
+++ b/crates/harness-server/src/skill_governor.rs
@@ -34,11 +34,11 @@ pub(crate) async fn run_skill_governance_tick(
     let task_statuses: HashMap<String, TaskStatus> = state
         .core
         .tasks
-        .list_all_with_terminal()
+        .list_all_statuses_with_terminal()
         .await
         .map_err(|e| anyhow::anyhow!("failed to list tasks for governance scoring: {e}"))?
         .into_iter()
-        .map(|task| (task.id.as_str().to_string(), task.status))
+        .map(|(id, status)| (id.as_str().to_string(), status))
         .collect();
 
     let mut seen_pairs: HashSet<(String, String)> = HashSet::new();

--- a/crates/harness-server/src/skill_governor.rs
+++ b/crates/harness-server/src/skill_governor.rs
@@ -34,7 +34,9 @@ pub(crate) async fn run_skill_governance_tick(
     let task_statuses: HashMap<String, TaskStatus> = state
         .core
         .tasks
-        .list_all()
+        .list_all_with_terminal()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list tasks for governance scoring: {e}"))?
         .into_iter()
         .map(|task| (task.id.as_str().to_string(), task.status))
         .collect();

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -267,6 +267,35 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Return all tasks as lightweight summaries, skipping the heavy `rounds` column.
+    ///
+    /// Used by the `/tasks` list endpoint to avoid deserializing large round histories
+    /// when only summary fields are needed.
+    pub async fn list_summaries(&self) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        let rows = sqlx::query_as::<_, TaskSummaryRow>(
+            "SELECT id, status, turn, pr_url, error, source, external_id, parent_id, \
+             created_at, repo, depends_on, project \
+             FROM tasks ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(TaskSummaryRow::try_into_summary)
+            .collect()
+    }
+
+    /// Return `(id, status)` pairs for all tasks — skips all heavy columns.
+    ///
+    /// Used by hot-path callers that only need task status for aggregation
+    /// (e.g. skill governance scoring).
+    pub async fn list_id_status(&self) -> anyhow::Result<Vec<(String, String)>> {
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, status FROM tasks ORDER BY created_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows)
+    }
+
     /// Return `true` if a task row with the given ID exists in the database.
     pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
         let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = ?")
@@ -742,6 +771,52 @@ impl TaskRow {
             triage_output: None,
             plan_output: None,
             repo,
+        })
+    }
+}
+
+/// Lightweight row for summary queries — omits the heavy `rounds` column.
+#[derive(sqlx::FromRow)]
+struct TaskSummaryRow {
+    id: String,
+    status: String,
+    turn: i64,
+    pr_url: Option<String>,
+    error: Option<String>,
+    source: Option<String>,
+    external_id: Option<String>,
+    parent_id: Option<String>,
+    created_at: Option<String>,
+    repo: Option<String>,
+    depends_on: String,
+    project: Option<String>,
+}
+
+impl TaskSummaryRow {
+    fn try_into_summary(self) -> anyhow::Result<crate::task_runner::TaskSummary> {
+        use harness_core::types::TaskId;
+        let depends_on: Vec<TaskId> = serde_json::from_str(&self.depends_on).map_err(|source| {
+            harness_core::error::TaskDbDecodeError::DependsOnDeserialize {
+                task_id: self.id.clone(),
+                source,
+            }
+        })?;
+        Ok(crate::task_runner::TaskSummary {
+            id: TaskId(self.id),
+            status: self.status.parse::<crate::task_runner::TaskStatus>()?,
+            turn: self.turn as u32,
+            pr_url: self.pr_url,
+            error: self.error,
+            source: self.source,
+            parent_id: self.parent_id.map(TaskId),
+            external_id: self.external_id,
+            repo: self.repo,
+            description: None,
+            created_at: self.created_at,
+            phase: crate::task_runner::TaskPhase::default(),
+            depends_on,
+            subtask_ids: Vec::new(),
+            project: self.project,
         })
     }
 }

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -244,6 +244,30 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Return tasks whose `status` column matches any value in `statuses`.
+    ///
+    /// Uses parameterized placeholders — safe for internal status string constants.
+    /// Returns an empty `Vec` when `statuses` is empty.
+    pub async fn list_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<TaskState>> {
+        if statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat("?")
+            .take(statuses.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project
+             FROM tasks WHERE status IN ({placeholders}) ORDER BY created_at DESC"
+        );
+        let mut q = sqlx::query_as::<_, TaskRow>(&sql);
+        for status in statuses {
+            q = q.bind(*status);
+        }
+        let rows = q.fetch_all(&self.pool).await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
     /// Return `true` if a task row with the given ID exists in the database.
     pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
         let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = ?")

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -252,8 +252,7 @@ impl TaskDb {
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = std::iter::repeat("?")
-            .take(statuses.len())
+        let placeholders = std::iter::repeat_n("?", statuses.len())
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -296,6 +296,26 @@ impl TaskDb {
         Ok(rows)
     }
 
+    /// Return only task IDs whose `status` matches any value in `statuses`.
+    ///
+    /// Skips all heavy columns (rounds, error, etc.) — use this when only IDs
+    /// are needed (e.g. orphan-worktree cleanup at startup).
+    pub async fn list_ids_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<String>> {
+        if statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat_n("?", statuses.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("SELECT id FROM tasks WHERE status IN ({placeholders})");
+        let mut q = sqlx::query_as::<_, (String,)>(&sql);
+        for status in statuses {
+            q = q.bind(*status);
+        }
+        let rows = q.fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Return `true` if a task row with the given ID exists in the database.
     pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
         let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = ?")

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -279,9 +279,17 @@ impl TaskDb {
         )
         .fetch_all(&self.pool)
         .await?;
-        rows.into_iter()
-            .map(TaskSummaryRow::try_into_summary)
-            .collect()
+        let mut summaries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id = row.id.clone();
+            match TaskSummaryRow::try_into_summary(row) {
+                Ok(summary) => summaries.push(summary),
+                Err(e) => {
+                    tracing::warn!(task_id = %id, "skipping malformed task row in list_summaries: {e}");
+                }
+            }
+        }
+        Ok(summaries)
     }
 
     /// Return `(id, status)` pairs for all tasks — skips all heavy columns.
@@ -314,6 +322,19 @@ impl TaskDb {
         }
         let rows = q.fetch_all(&self.pool).await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Return the status of a single task, fetching only the `status` column.
+    ///
+    /// Much lighter than `get()` — avoids deserializing the `rounds` JSON.
+    /// Used by `check_awaiting_deps` to resolve dependency status with a single
+    /// DB round-trip instead of a full row fetch.
+    pub async fn get_status_only(&self, id: &str) -> anyhow::Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|(s,)| s))
     }
 
     /// Return `true` if a task row with the given ID exists in the database.

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -775,6 +775,50 @@ impl TaskStore {
         Ok(by_id.into_values().collect())
     }
 
+    /// Return all tasks as lightweight [`TaskSummary`] values.
+    ///
+    /// Fetches summary columns from the DB (skipping the heavy `rounds` field),
+    /// then overrides with live cache entries so in-flight state is accurate.
+    /// Use this in the `/tasks` list endpoint instead of `list_all_with_terminal`.
+    pub async fn list_all_summaries_with_terminal(&self) -> anyhow::Result<Vec<TaskSummary>> {
+        let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
+            .db
+            .list_summaries()
+            .await?
+            .into_iter()
+            .map(|s| (s.id.clone(), s))
+            .collect();
+        for entry in self.cache.iter() {
+            by_id.insert(entry.key().clone(), entry.value().summary());
+        }
+        Ok(by_id.into_values().collect())
+    }
+
+    /// Return `(TaskId, TaskStatus)` pairs for all tasks without deserializing `rounds`.
+    ///
+    /// Hot-path callers (skill governance, token usage attribution) that only need
+    /// task status should use this instead of `list_all_with_terminal`.
+    pub async fn list_all_statuses_with_terminal(
+        &self,
+    ) -> anyhow::Result<HashMap<TaskId, TaskStatus>> {
+        let mut by_id: HashMap<TaskId, TaskStatus> = self
+            .db
+            .list_id_status()
+            .await?
+            .into_iter()
+            .filter_map(|(id, status)| {
+                status
+                    .parse::<TaskStatus>()
+                    .ok()
+                    .map(|s| (harness_core::types::TaskId(id), s))
+            })
+            .collect();
+        for entry in self.cache.iter() {
+            by_id.insert(entry.key().clone(), entry.value().status.clone());
+        }
+        Ok(by_id)
+    }
+
     /// Run `f` only if the task still exists and is live-`pending`.
     ///
     /// Holding the mutable cache guard across `f` prevents a concurrent status
@@ -1885,13 +1929,20 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
 
     for (task_id, failed_dep_id) in &failed_deps {
         if let Some(mut entry) = store.cache.get_mut(task_id) {
-            entry.status = TaskStatus::Failed;
-            entry.error = Some(format!("dependency {} failed", failed_dep_id.0));
+            // Only overwrite if the task is still AwaitingDeps — a concurrent
+            // cancel or status transition must not be clobbered.
+            if matches!(entry.status, TaskStatus::AwaitingDeps) {
+                entry.status = TaskStatus::Failed;
+                entry.error = Some(format!("dependency {} failed", failed_dep_id.0));
+            }
         }
     }
     for task_id in &ready {
         if let Some(mut entry) = store.cache.get_mut(task_id) {
-            entry.status = TaskStatus::Pending;
+            // Same guard: skip if status changed since we snapshotted.
+            if matches!(entry.status, TaskStatus::AwaitingDeps) {
+                entry.status = TaskStatus::Pending;
+            }
         }
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -707,7 +707,11 @@ impl TaskStore {
         }
         match self.db.get(id.0.as_str()).await {
             Ok(Some(task)) => matches!(task.status, TaskStatus::Done),
-            _ => false,
+            Ok(None) => false,
+            Err(e) => {
+                tracing::warn!(task_id = %id.0, "DB error checking dep done status: {e}; treating as not done");
+                false
+            }
         }
     }
 
@@ -719,7 +723,11 @@ impl TaskStore {
         }
         match self.db.get(id.0.as_str()).await {
             Ok(Some(task)) => matches!(task.status, TaskStatus::Failed),
-            _ => false,
+            Ok(None) => false,
+            Err(e) => {
+                tracing::warn!(task_id = %id.0, "DB error checking dep failed status: {e}; treating as not failed");
+                false
+            }
         }
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -657,7 +657,17 @@ impl TaskStore {
 
         let cache = DashMap::new();
         let persist_locks = DashMap::new();
-        for task in db.list().await? {
+        // Only load active (non-terminal) tasks into the in-memory cache to prevent
+        // unbounded memory growth from historical completed tasks.
+        let active_statuses = &[
+            "pending",
+            "awaiting_deps",
+            "implementing",
+            "agent_review",
+            "waiting",
+            "reviewing",
+        ];
+        for task in db.list_by_status(active_statuses).await? {
             persist_locks.insert(task.id.clone(), Arc::new(Mutex::new(())));
             cache.insert(task.id.clone(), task);
         }
@@ -677,10 +687,36 @@ impl TaskStore {
         self.cache.get(id).map(|r| r.value().clone())
     }
 
+    /// Look up a task by ID, checking the in-memory cache first.
+    /// Falls back to the database for terminal tasks that were evicted from
+    /// the cache at startup (Done, Failed, Cancelled).
+    /// Returns `None` only when the ID is unknown in both cache and DB.
+    pub async fn get_with_db_fallback(&self, id: &TaskId) -> Option<TaskState> {
+        if let Some(task) = self.cache.get(id) {
+            return Some(task.value().clone());
+        }
+        self.db.get(id.0.as_str()).await.ok().flatten()
+    }
+
+    /// Return terminal tasks (Done, Failed) directly from the database.
+    ///
+    /// Used during startup for worktree cleanup. Terminal tasks are not held
+    /// in the in-memory cache, so this is a targeted one-time DB query.
+    pub async fn list_terminal_from_db(&self) -> anyhow::Result<Vec<TaskState>> {
+        self.db.list_by_status(&["done", "failed"]).await
+    }
+
     pub fn count(&self) -> usize {
         self.cache.len()
     }
 
+    /// Return all tasks currently in the in-memory cache.
+    ///
+    /// **Semantic note**: since startup only loads active (non-terminal) tasks
+    /// into the cache, this method returns only Pending, AwaitingDeps,
+    /// Implementing, AgentReview, Waiting, and Reviewing tasks.
+    /// To look up a specific completed task use [`get_with_db_fallback`].
+    /// To enumerate terminal tasks use [`list_terminal_from_db`].
     pub fn list_all(&self) -> Vec<TaskState> {
         self.cache.iter().map(|e| e.value().clone()).collect()
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -699,34 +699,22 @@ impl TaskStore {
         self.db.get(id.0.as_str()).await
     }
 
-    /// Check whether a dependency task is in Done status, consulting DB for
-    /// tasks evicted from the startup cache.
-    async fn is_dep_done(&self, id: &TaskId) -> bool {
+    /// Return the status of a dependency task with a single DB lookup.
+    ///
+    /// Checks the in-memory cache first; falls back to a lightweight
+    /// `SELECT status` query (no `rounds` JSON decode) for terminal tasks
+    /// evicted from the startup cache.  Returns `None` when the task is
+    /// unknown in both cache and DB, or when the DB call fails.
+    async fn dep_status(&self, id: &TaskId) -> Option<TaskStatus> {
         if let Some(task) = self.cache.get(id) {
-            return matches!(task.status, TaskStatus::Done);
+            return Some(task.status.clone());
         }
-        match self.db.get(id.0.as_str()).await {
-            Ok(Some(task)) => matches!(task.status, TaskStatus::Done),
-            Ok(None) => false,
+        match self.db.get_status_only(id.0.as_str()).await {
+            Ok(Some(s)) => s.parse::<TaskStatus>().ok(),
+            Ok(None) => None,
             Err(e) => {
-                tracing::warn!(task_id = %id.0, "DB error checking dep done status: {e}; treating as not done");
-                false
-            }
-        }
-    }
-
-    /// Check whether a dependency task is in Failed status, consulting DB for
-    /// tasks evicted from the startup cache.
-    async fn is_dep_failed(&self, id: &TaskId) -> bool {
-        if let Some(task) = self.cache.get(id) {
-            return matches!(task.status, TaskStatus::Failed);
-        }
-        match self.db.get(id.0.as_str()).await {
-            Ok(Some(task)) => matches!(task.status, TaskStatus::Failed),
-            Ok(None) => false,
-            Err(e) => {
-                tracing::warn!(task_id = %id.0, "DB error checking dep failed status: {e}; treating as not failed");
-                false
+                tracing::warn!(task_id = %id.0, "DB error fetching dep status: {e}; treating as absent");
+                None
             }
         }
     }
@@ -1853,7 +1841,7 @@ pub async fn spawn_task_awaiting_deps(
 
     let mut all_done = true;
     for dep_id in &depends_on {
-        if !store.is_dep_done(dep_id).await {
+        if !matches!(store.dep_status(dep_id).await, Some(TaskStatus::Done)) {
             all_done = false;
             break;
         }
@@ -1902,26 +1890,27 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
         .collect();
 
     for (task_id, depends_on) in awaiting {
-        // Find first failed dep (cache then DB).
+        // Single pass: one DB lookup per dep (cache-first, then lightweight
+        // `SELECT status` — no `rounds` JSON decode).
         let mut failed_dep_id = None;
+        let mut all_done = true;
         for dep_id in &depends_on {
-            if store.is_dep_failed(dep_id).await {
-                failed_dep_id = Some(dep_id.clone());
-                break;
+            match store.dep_status(dep_id).await {
+                Some(TaskStatus::Failed) => {
+                    failed_dep_id = Some(dep_id.clone());
+                    break; // fail-fast — no need to inspect remaining deps
+                }
+                Some(TaskStatus::Done) => {} // this dep is satisfied
+                _ => {
+                    // Pending, Implementing, or unknown — not ready yet.
+                    // Keep scanning in case a later dep is Failed.
+                    all_done = false;
+                }
             }
         }
         if let Some(fd) = failed_dep_id {
             failed_deps.push((task_id, fd));
             continue;
-        }
-
-        // Check all deps are done (cache then DB).
-        let mut all_done = true;
-        for dep_id in &depends_on {
-            if !store.is_dep_done(dep_id).await {
-                all_done = false;
-                break;
-            }
         }
         if all_done {
             ready.push(task_id);

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -719,12 +719,15 @@ impl TaskStore {
         }
     }
 
-    /// Return IDs of terminal tasks (Done, Failed) directly from the database.
+    /// Return IDs of terminal tasks (Done, Failed, Cancelled) directly from the database.
     ///
     /// Used during startup for worktree cleanup. Only fetches task IDs to avoid
     /// deserializing the heavy `rounds` column for large historical datasets.
     pub async fn list_terminal_ids_from_db(&self) -> anyhow::Result<Vec<TaskId>> {
-        let ids = self.db.list_ids_by_status(&["done", "failed"]).await?;
+        let ids = self
+            .db
+            .list_ids_by_status(&["done", "failed", "cancelled"])
+            .await?;
         Ok(ids.into_iter().map(harness_core::types::TaskId).collect())
     }
 
@@ -1871,7 +1874,10 @@ pub async fn spawn_task_awaiting_deps(
 ///
 /// Async because dependency status checks fall back to the database for
 /// terminal tasks (Done/Failed) that were evicted from the startup cache.
-pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
+///
+/// Returns `(ready_ids, newly_failed_ids)`.  Both sets must be persisted by
+/// the caller so that status transitions survive a process restart.
+pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>) {
     let mut ready = Vec::new();
     let mut failed_deps: Vec<(TaskId, TaskId)> = Vec::new();
 
@@ -1917,6 +1923,7 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
         }
     }
 
+    let mut newly_failed: Vec<TaskId> = Vec::new();
     for (task_id, failed_dep_id) in &failed_deps {
         if let Some(mut entry) = store.cache.get_mut(task_id) {
             // Only overwrite if the task is still AwaitingDeps — a concurrent
@@ -1924,6 +1931,7 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
             if matches!(entry.status, TaskStatus::AwaitingDeps) {
                 entry.status = TaskStatus::Failed;
                 entry.error = Some(format!("dependency {} failed", failed_dep_id.0));
+                newly_failed.push(task_id.clone());
             }
         }
     }
@@ -1936,7 +1944,7 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
         }
     }
 
-    ready
+    (ready, newly_failed)
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -731,12 +731,13 @@ impl TaskStore {
         }
     }
 
-    /// Return terminal tasks (Done, Failed) directly from the database.
+    /// Return IDs of terminal tasks (Done, Failed) directly from the database.
     ///
-    /// Used during startup for worktree cleanup. Terminal tasks are not held
-    /// in the in-memory cache, so this is a targeted one-time DB query.
-    pub async fn list_terminal_from_db(&self) -> anyhow::Result<Vec<TaskState>> {
-        self.db.list_by_status(&["done", "failed"]).await
+    /// Used during startup for worktree cleanup. Only fetches task IDs to avoid
+    /// deserializing the heavy `rounds` column for large historical datasets.
+    pub async fn list_terminal_ids_from_db(&self) -> anyhow::Result<Vec<TaskId>> {
+        let ids = self.db.list_ids_by_status(&["done", "failed"]).await?;
+        Ok(ids.into_iter().map(harness_core::types::TaskId).collect())
     }
 
     pub fn count(&self) -> usize {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -690,12 +690,37 @@ impl TaskStore {
     /// Look up a task by ID, checking the in-memory cache first.
     /// Falls back to the database for terminal tasks that were evicted from
     /// the cache at startup (Done, Failed, Cancelled).
-    /// Returns `None` only when the ID is unknown in both cache and DB.
-    pub async fn get_with_db_fallback(&self, id: &TaskId) -> Option<TaskState> {
+    /// Returns `Ok(None)` only when the ID is unknown in both cache and DB.
+    /// Returns `Err` when the database query itself fails.
+    pub async fn get_with_db_fallback(&self, id: &TaskId) -> anyhow::Result<Option<TaskState>> {
         if let Some(task) = self.cache.get(id) {
-            return Some(task.value().clone());
+            return Ok(Some(task.value().clone()));
         }
-        self.db.get(id.0.as_str()).await.ok().flatten()
+        self.db.get(id.0.as_str()).await
+    }
+
+    /// Check whether a dependency task is in Done status, consulting DB for
+    /// tasks evicted from the startup cache.
+    async fn is_dep_done(&self, id: &TaskId) -> bool {
+        if let Some(task) = self.cache.get(id) {
+            return matches!(task.status, TaskStatus::Done);
+        }
+        match self.db.get(id.0.as_str()).await {
+            Ok(Some(task)) => matches!(task.status, TaskStatus::Done),
+            _ => false,
+        }
+    }
+
+    /// Check whether a dependency task is in Failed status, consulting DB for
+    /// tasks evicted from the startup cache.
+    async fn is_dep_failed(&self, id: &TaskId) -> bool {
+        if let Some(task) = self.cache.get(id) {
+            return matches!(task.status, TaskStatus::Failed);
+        }
+        match self.db.get(id.0.as_str()).await {
+            Ok(Some(task)) => matches!(task.status, TaskStatus::Failed),
+            _ => false,
+        }
     }
 
     /// Return terminal tasks (Done, Failed) directly from the database.
@@ -716,9 +741,30 @@ impl TaskStore {
     /// into the cache, this method returns only Pending, AwaitingDeps,
     /// Implementing, AgentReview, Waiting, and Reviewing tasks.
     /// To look up a specific completed task use [`get_with_db_fallback`].
-    /// To enumerate terminal tasks use [`list_terminal_from_db`].
+    /// To enumerate all tasks including historical ones use [`list_all_with_terminal`].
     pub fn list_all(&self) -> Vec<TaskState> {
         self.cache.iter().map(|e| e.value().clone()).collect()
+    }
+
+    /// Return all tasks: active ones from cache (most current state) merged
+    /// with terminal tasks from the database (Done, Failed, Cancelled).
+    ///
+    /// Cache entries take precedence over DB rows for the same task ID so that
+    /// in-flight state is always reflected accurately.
+    pub async fn list_all_with_terminal(&self) -> anyhow::Result<Vec<TaskState>> {
+        // DB is the authoritative record of all tasks ever created.
+        let mut by_id: std::collections::HashMap<TaskId, TaskState> = self
+            .db
+            .list()
+            .await?
+            .into_iter()
+            .map(|t| (t.id.clone(), t))
+            .collect();
+        // Override with cache values — these carry the live in-flight state.
+        for entry in self.cache.iter() {
+            by_id.insert(entry.key().clone(), entry.value().clone());
+        }
+        Ok(by_id.into_values().collect())
     }
 
     /// Run `f` only if the task still exists and is live-`pending`.
@@ -1752,12 +1798,13 @@ pub async fn spawn_task_awaiting_deps(
         anyhow::bail!("circular dependency detected for task {}", task_id.0);
     }
 
-    let all_done = depends_on.iter().all(|dep_id| {
-        store
-            .get(dep_id)
-            .map(|s| matches!(s.status, TaskStatus::Done))
-            .unwrap_or(false)
-    });
+    let mut all_done = true;
+    for dep_id in &depends_on {
+        if !store.is_dep_done(dep_id).await {
+            all_done = false;
+            break;
+        }
+    }
 
     let mut state = TaskState::new(task_id.clone());
     state.depends_on = depends_on;
@@ -1780,46 +1827,51 @@ pub async fn spawn_task_awaiting_deps(
 
 /// Check all AwaitingDeps tasks and transition ready ones to Pending.
 /// Returns the IDs of tasks that were transitioned to Pending.
-pub fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
+///
+/// Async because dependency status checks fall back to the database for
+/// terminal tasks (Done/Failed) that were evicted from the startup cache.
+pub async fn check_awaiting_deps(store: &TaskStore) -> Vec<TaskId> {
     let mut ready = Vec::new();
     let mut failed_deps: Vec<(TaskId, TaskId)> = Vec::new();
 
-    for entry in store.cache.iter() {
-        let task = entry.value();
-        if !matches!(task.status, TaskStatus::AwaitingDeps) {
+    // Snapshot AwaitingDeps tasks from cache before async work.
+    let awaiting: Vec<(TaskId, Vec<TaskId>)> = store
+        .cache
+        .iter()
+        .filter_map(|e| {
+            let task = e.value();
+            if matches!(task.status, TaskStatus::AwaitingDeps) {
+                Some((task.id.clone(), task.depends_on.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for (task_id, depends_on) in awaiting {
+        // Find first failed dep (cache then DB).
+        let mut failed_dep_id = None;
+        for dep_id in &depends_on {
+            if store.is_dep_failed(dep_id).await {
+                failed_dep_id = Some(dep_id.clone());
+                break;
+            }
+        }
+        if let Some(fd) = failed_dep_id {
+            failed_deps.push((task_id, fd));
             continue;
         }
-        let any_failed = task.depends_on.iter().any(|dep_id| {
-            store
-                .get(dep_id)
-                .map(|s| matches!(s.status, TaskStatus::Failed))
-                .unwrap_or(false)
-        });
-        if any_failed {
-            let Some(failed_dep) = task
-                .depends_on
-                .iter()
-                .find(|dep_id| {
-                    store
-                        .get(dep_id)
-                        .map(|s| matches!(s.status, TaskStatus::Failed))
-                        .unwrap_or(false)
-                })
-                .cloned()
-            else {
-                continue;
-            };
-            failed_deps.push((task.id.clone(), failed_dep));
-            continue;
+
+        // Check all deps are done (cache then DB).
+        let mut all_done = true;
+        for dep_id in &depends_on {
+            if !store.is_dep_done(dep_id).await {
+                all_done = false;
+                break;
+            }
         }
-        let all_done = task.depends_on.iter().all(|dep_id| {
-            store
-                .get(dep_id)
-                .map(|s| matches!(s.status, TaskStatus::Done))
-                .unwrap_or(false)
-        });
         if all_done {
-            ready.push(task.id.clone());
+            ready.push(task_id);
         }
     }
 

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -82,6 +82,7 @@ async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
         let task = store
             .get_with_db_fallback(&CoreTaskId(id.to_string()))
             .await
+            .expect("DB query should not fail")
             .unwrap_or_else(|| panic!("{id} should be fetchable from DB"));
         assert!(
             matches!(task.status, TaskStatus::Failed),
@@ -106,12 +107,14 @@ async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
     let done = store
         .get_with_db_fallback(&CoreTaskId("t-done".into()))
         .await
+        .expect("DB query should not fail")
         .expect("t-done must be fetchable from DB");
     assert!(matches!(done.status, TaskStatus::Done));
 
     let failed = store
         .get_with_db_fallback(&CoreTaskId("t-failed".into()))
         .await
+        .expect("DB query should not fail")
         .expect("t-failed must be fetchable from DB");
     assert!(matches!(failed.status, TaskStatus::Failed));
 
@@ -280,6 +283,7 @@ async fn restart_transient_retry_task_fails() -> anyhow::Result<()> {
     let transient = store
         .get_with_db_fallback(&CoreTaskId("t-transient".into()))
         .await
+        .expect("DB query should not fail")
         .expect("task must be fetchable from DB");
     assert!(
         matches!(transient.status, TaskStatus::Failed),
@@ -350,7 +354,7 @@ async fn restart_mixed_recovery_counts() -> anyhow::Result<()> {
     // Failed tasks are terminal and not in cache; fetch each from DB.
     let mut failed_count = 0;
     for id in ["t-fail-1", "t-fail-2"] {
-        if let Some(task) = store
+        if let Ok(Some(task)) = store
             .get_with_db_fallback(&CoreTaskId(id.to_string()))
             .await
         {

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -76,10 +76,13 @@ async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
     .await?;
 
     // All 4 interrupted tasks with no checkpoint → Failed.
+    // These are no longer in the in-memory cache (terminal tasks are excluded at startup),
+    // so fetch them from the DB via get_with_db_fallback.
     for id in ["t-impl", "t-review", "t-reviewing", "t-waiting"] {
         let task = store
-            .get(&CoreTaskId(id.to_string()))
-            .unwrap_or_else(|| panic!("{id} should be in cache"));
+            .get_with_db_fallback(&CoreTaskId(id.to_string()))
+            .await
+            .unwrap_or_else(|| panic!("{id} should be fetchable from DB"));
         assert!(
             matches!(task.status, TaskStatus::Failed),
             "{id}: expected Failed, got {:?}",
@@ -92,22 +95,24 @@ async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
         );
     }
 
-    // Pending stays Pending (no error set by recovery).
+    // Pending stays Pending (active — present in the in-memory cache).
     let pending = store
         .get(&CoreTaskId("t-pending".into()))
-        .expect("t-pending must exist");
+        .expect("t-pending must exist in cache");
     assert!(matches!(pending.status, TaskStatus::Pending));
     assert!(pending.error.is_none());
 
-    // Terminal states unchanged.
+    // Terminal states unchanged (not in cache; fetch from DB).
     let done = store
-        .get(&CoreTaskId("t-done".into()))
-        .expect("t-done must exist");
+        .get_with_db_fallback(&CoreTaskId("t-done".into()))
+        .await
+        .expect("t-done must be fetchable from DB");
     assert!(matches!(done.status, TaskStatus::Done));
 
     let failed = store
-        .get(&CoreTaskId("t-failed".into()))
-        .expect("t-failed must exist");
+        .get_with_db_fallback(&CoreTaskId("t-failed".into()))
+        .await
+        .expect("t-failed must be fetchable from DB");
     assert!(matches!(failed.status, TaskStatus::Failed));
 
     Ok(())
@@ -271,9 +276,11 @@ async fn restart_transient_retry_task_fails() -> anyhow::Result<()> {
     })
     .await?;
 
+    // Transient-retry task was failed by recovery; not in cache — fetch from DB.
     let transient = store
-        .get(&CoreTaskId("t-transient".into()))
-        .expect("task must exist");
+        .get_with_db_fallback(&CoreTaskId("t-transient".into()))
+        .await
+        .expect("task must be fetchable from DB");
     assert!(
         matches!(transient.status, TaskStatus::Failed),
         "transient-retry pending task should be Failed on restart, got {:?}",
@@ -332,15 +339,26 @@ async fn restart_mixed_recovery_counts() -> anyhow::Result<()> {
     })
     .await?;
 
-    let all = store.list_all();
-    let (resumed_count, failed_count) =
-        all.iter()
-            .fold((0, 0), |(resumed, failed), task| match task.status {
-                TaskStatus::Pending => (resumed + 1, failed),
-                TaskStatus::Failed => (resumed, failed + 1),
-                _ => (resumed, failed),
-            });
+    // Resumed tasks are Pending and present in the in-memory cache.
+    let resumed_count = store
+        .list_all()
+        .iter()
+        .filter(|t| matches!(t.status, TaskStatus::Pending))
+        .count();
     assert_eq!(resumed_count, 2, "two tasks should have been resumed");
+
+    // Failed tasks are terminal and not in cache; fetch each from DB.
+    let mut failed_count = 0;
+    for id in ["t-fail-1", "t-fail-2"] {
+        if let Some(task) = store
+            .get_with_db_fallback(&CoreTaskId(id.to_string()))
+            .await
+        {
+            if matches!(task.status, TaskStatus::Failed) {
+                failed_count += 1;
+            }
+        }
+    }
     assert_eq!(failed_count, 2, "two tasks should have been failed");
 
     Ok(())


### PR DESCRIPTION
## Summary

- **Root cause**: `TaskStore::open()` called `db.list()` at startup, loading all historical tasks (Done/Failed/Cancelled) into the `DashMap` cache — causing unbounded memory growth over time.
- **Fix**: only active tasks (Pending, AwaitingDeps, Implementing, AgentReview, Waiting, Reviewing) are loaded into cache. Terminal tasks remain in SQLite and are fetched on-demand via `get_with_db_fallback()`.
- **API compatibility**: `TaskStore::get()` is unchanged (cache-only, sync). A new async `get_with_db_fallback()` method handles the HTTP layer where completed tasks must remain accessible by ID.

## Changes

| File | Change |
|------|--------|
| `task_db.rs` | Add `list_by_status(statuses: &[&str])` — parameterized WHERE status IN (...) on the dedicated status column |
| `task_runner.rs` | Startup uses `list_by_status` for active statuses only; add `get_with_db_fallback()` and `list_terminal_from_db()`; update `list_all()` doc comment |
| `http.rs` | `get_task`, `get_task_artifacts`, `stream_task_sse` use `get_with_db_fallback`; startup worktree cleanup uses `list_terminal_from_db()` |
| `checkpoint_recovery.rs` | Update tests to use `get_with_db_fallback` for tasks that are terminal after recovery |

## Test plan

- [x] All 7 checkpoint recovery tests pass (updated to reflect active-only cache semantics)
- [x] Full workspace: 636 tests pass, 0 failures
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all` applied

Closes #631