### PR TITLE
feat(sse): add 30s heartbeat to task stream endpoint

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -7,7 +7,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     middleware::{self},
     response::{
-        sse::{Event, Sse},
+        sse::{Event, KeepAlive, Sse},
         IntoResponse, Response,
     },
     routing::{get, post},
@@ -1529,55 +1529,40 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
         }
     };
 
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        match rx.recv().await {
+            Ok(item) => {
+                let data = match serde_json::to_string(&item) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!("sse: failed to serialize event: {e}");
+                        String::new()
+                    }
+                };
+                Some((
+                    Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
+                    rx,
+                ))
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                let event = Event::default()
+                    .event("lag")
+                    .data(format!("dropped {n} events due to slow consumer"));
+                Some((Ok(event), rx))
+            }
+        }
+    });
+
     // Send a heartbeat comment every 30 s so reverse proxies (nginx default
     // 60 s idle timeout) don't drop the connection while the agent is silent.
-    let heartbeat_interval = {
-        let start = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
-        let mut iv = tokio::time::interval_at(start, std::time::Duration::from_secs(30));
-        iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        iv
-    };
-
-    let stream = futures::stream::unfold(
-        (rx, heartbeat_interval),
-        |(mut rx, mut interval)| async move {
-            tokio::select! {
-                biased;
-                result = rx.recv() => {
-                    match result {
-                        Ok(item) => {
-                            let data = match serde_json::to_string(&item) {
-                                Ok(s) => s,
-                                Err(e) => {
-                                    tracing::warn!("sse: failed to serialize event: {e}");
-                                    String::new()
-                                }
-                            };
-                            Some((
-                                Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
-                                (rx, interval),
-                            ))
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            let event = Event::default()
-                                .event("lag")
-                                .data(format!("dropped {n} events due to slow consumer"));
-                            Some((Ok(event), (rx, interval)))
-                        }
-                    }
-                }
-                _ = interval.tick() => {
-                    Some((
-                        Ok::<Event, std::convert::Infallible>(Event::default().comment("heartbeat")),
-                        (rx, interval),
-                    ))
-                }
-            }
-        },
-    );
-
-    Sse::new(stream).into_response()
+    Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(std::time::Duration::from_secs(30))
+                .text("heartbeat"),
+        )
+        .into_response()
 }
 
 /// GET /api/intake — current status of all intake channels and recent dispatches.

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1529,30 +1529,51 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
         }
     };
 
-    let stream = futures::stream::unfold(rx, |mut rx| async move {
-        match rx.recv().await {
-            Ok(item) => {
-                let data = match serde_json::to_string(&item) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        tracing::warn!("sse: failed to serialize event: {e}");
-                        String::new()
+    // Send a heartbeat comment every 30 s so reverse proxies (nginx default
+    // 60 s idle timeout) don't drop the connection while the agent is silent.
+    let heartbeat_interval = {
+        let start = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        tokio::time::interval_at(start, std::time::Duration::from_secs(30))
+    };
+
+    let stream = futures::stream::unfold(
+        (rx, heartbeat_interval),
+        |(mut rx, mut interval)| async move {
+            tokio::select! {
+                biased;
+                result = rx.recv() => {
+                    match result {
+                        Ok(item) => {
+                            let data = match serde_json::to_string(&item) {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    tracing::warn!("sse: failed to serialize event: {e}");
+                                    String::new()
+                                }
+                            };
+                            Some((
+                                Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
+                                (rx, interval),
+                            ))
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            let event = Event::default()
+                                .event("lag")
+                                .data(format!("dropped {n} events due to slow consumer"));
+                            Some((Ok(event), (rx, interval)))
+                        }
                     }
-                };
-                Some((
-                    Ok::<Event, std::convert::Infallible>(Event::default().data(data)),
-                    rx,
-                ))
+                }
+                _ = interval.tick() => {
+                    Some((
+                        Ok::<Event, std::convert::Infallible>(Event::default().comment("heartbeat")),
+                        (rx, interval),
+                    ))
+                }
             }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                let event = Event::default()
-                    .event("lag")
-                    .data(format!("dropped {n} events due to slow consumer"));
-                Some((Ok(event), rx))
-            }
-        }
-    });
+        },
+    );
 
     Sse::new(stream).into_response()
 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1533,7 +1533,9 @@ async fn stream_task_sse(State(state): State<Arc<AppState>>, Path(id): Path<Stri
     // 60 s idle timeout) don't drop the connection while the agent is silent.
     let heartbeat_interval = {
         let start = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
-        tokio::time::interval_at(start, std::time::Duration::from_secs(30))
+        let mut iv = tokio::time::interval_at(start, std::time::Duration::from_secs(30));
+        iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        iv
     };
 
     let stream = futures::stream::unfold(


### PR DESCRIPTION
## Summary
- Adds a periodic SSE comment (`": heartbeat"`) every 30 s on `GET /tasks/{id}/stream`
- Uses `tokio::time::interval_at` with 30 s initial delay so the first heartbeat is deferred
- Uses `tokio::select! { biased; }` to prioritize real task events over the timer tick

## Why
Reverse proxies with idle timeouts (nginx defaults to 60 s) can silently drop an SSE connection when the agent produces no output (e.g. waiting for compilation). Clients have no way to distinguish a dropped connection from a live-but-quiet one. SSE comment lines are ignored by browsers/clients but keep the TCP stream active through proxies.

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Manual: connect to `/tasks/{id}/stream` via `curl -N`, observe `": heartbeat"` lines every 30 s when agent is idle

Fixes #633