### PR TITLE
fix(checkpoint): atomic write-then-rename to prevent partial JSON on crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.24"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.25"
+version = "0.6.26"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -32,8 +32,8 @@ hmac = { workspace = true }
 sha2 = { workspace = true }
 subtle = { workspace = true }
 reqwest = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
 http-body-util = "0.1"
 tokio-tungstenite = "0.26"

--- a/crates/harness-server/src/checkpoint.rs
+++ b/crates/harness-server/src/checkpoint.rs
@@ -135,7 +135,10 @@ impl TaskCheckpoint {
 
         // Unique suffix prevents races when save() is called concurrently for
         // the same task_id (e.g. from two tokio tasks).
-        let tmp_name = format!("{}.{}.tmp", self.task_id, uuid::Uuid::new_v4());
+        // Sanitize task_id so path separators in the ID don't create a
+        // nested path under `parent` that hasn't been mkdir'd.
+        let safe_id = self.task_id.replace(['/', '\\'], "_");
+        let tmp_name = format!("{}.{}.tmp", safe_id, uuid::Uuid::new_v4());
         let tmp_path = parent.join(tmp_name);
 
         // Write and sync the temp file before rename so data is on disk.
@@ -146,9 +149,15 @@ impl TaskCheckpoint {
         }
         std::fs::rename(&tmp_path, &path)?;
 
-        // fsync the parent directory so the renamed directory entry is durable.
-        let dir = std::fs::File::open(parent)?;
-        dir.sync_all()?;
+        // Best-effort: fsync the parent directory so the renamed entry is
+        // durable.  Directory fsync is unsupported on some filesystems
+        // (notably Windows); treat failure as non-fatal so a successful
+        // rename is never rolled back into an error.
+        if let Ok(dir) = std::fs::File::open(parent) {
+            if let Err(e) = dir.sync_all() {
+                tracing::debug!("checkpoint: parent dir fsync not supported (non-fatal): {e}");
+            }
+        }
 
         Ok(())
     }

--- a/crates/harness-server/src/checkpoint.rs
+++ b/crates/harness-server/src/checkpoint.rs
@@ -107,20 +107,49 @@ impl TaskCheckpoint {
 
     /// Save the checkpoint to the filesystem path for this task.
     ///
-    /// Uses an atomic write: the JSON is first written to a `.tmp` side-car
-    /// file and then renamed into place.  POSIX guarantees that `rename(2)`
-    /// is atomic with respect to readers, so a concurrent `load` will always
-    /// see either the previous complete checkpoint or the new one — never a
-    /// partial write.
+    /// Uses an atomic write: the JSON is first written to a uniquely-named
+    /// `.tmp` side-car file, synced to disk, then renamed into place.
+    ///
+    /// * **Unique temp name** — a UUID suffix prevents two concurrent `save()`
+    ///   calls for the same task from clobbering each other's temp file.
+    /// * **`sync_all()` before rename** — ensures the data bytes are on disk
+    ///   before the directory entry is updated; without this a power loss after
+    ///   `rename` can leave a zero-byte or truncated checkpoint file.
+    /// * **Parent-directory fsync after rename** — makes the new directory
+    ///   entry itself durable so the file is not lost on power loss even after
+    ///   the rename syscall returns.
+    ///
+    /// POSIX guarantees that `rename(2)` is atomic with respect to readers, so
+    /// a concurrent `load` will always see either the previous complete
+    /// checkpoint or the new one — never a partial write.
     pub fn save(&self) -> anyhow::Result<()> {
+        use std::io::Write as _;
+
         let path = Self::default_path(&self.task_id);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("checkpoint path has no parent directory"))?;
+        std::fs::create_dir_all(parent)?;
+
         let data = serde_json::to_string_pretty(self)?;
-        let tmp_path = path.with_extension("tmp");
-        std::fs::write(&tmp_path, &data)?;
+
+        // Unique suffix prevents races when save() is called concurrently for
+        // the same task_id (e.g. from two tokio tasks).
+        let tmp_name = format!("{}.{}.tmp", self.task_id, uuid::Uuid::new_v4());
+        let tmp_path = parent.join(tmp_name);
+
+        // Write and sync the temp file before rename so data is on disk.
+        {
+            let mut tmp_file = std::fs::File::create(&tmp_path)?;
+            tmp_file.write_all(data.as_bytes())?;
+            tmp_file.sync_all()?;
+        }
         std::fs::rename(&tmp_path, &path)?;
+
+        // fsync the parent directory so the renamed directory entry is durable.
+        let dir = std::fs::File::open(parent)?;
+        dir.sync_all()?;
+
         Ok(())
     }
 

--- a/crates/harness-server/src/checkpoint.rs
+++ b/crates/harness-server/src/checkpoint.rs
@@ -106,13 +106,21 @@ impl TaskCheckpoint {
     }
 
     /// Save the checkpoint to the filesystem path for this task.
+    ///
+    /// Uses an atomic write: the JSON is first written to a `.tmp` side-car
+    /// file and then renamed into place.  POSIX guarantees that `rename(2)`
+    /// is atomic with respect to readers, so a concurrent `load` will always
+    /// see either the previous complete checkpoint or the new one — never a
+    /// partial write.
     pub fn save(&self) -> anyhow::Result<()> {
         let path = Self::default_path(&self.task_id);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
         let data = serde_json::to_string_pretty(self)?;
-        std::fs::write(&path, data)?;
+        let tmp_path = path.with_extension("tmp");
+        std::fs::write(&tmp_path, &data)?;
+        std::fs::rename(&tmp_path, &path)?;
         Ok(())
     }
 

--- a/crates/harness-server/src/checkpoint.rs
+++ b/crates/harness-server/src/checkpoint.rs
@@ -107,20 +107,26 @@ impl TaskCheckpoint {
 
     /// Save the checkpoint to the filesystem path for this task.
     ///
-    /// Uses an atomic write: the JSON is first written to a uniquely-named
-    /// `.tmp` side-car file, synced to disk, then renamed into place.
+    /// Uses an atomic write: the JSON is first written to a temporary file
+    /// (via [`tempfile::NamedTempFile`]) that lives in the same directory as
+    /// the destination, synced to disk, then persisted (renamed) into place.
     ///
-    /// * **Unique temp name** — a UUID suffix prevents two concurrent `save()`
-    ///   calls for the same task from clobbering each other's temp file.
-    /// * **`sync_all()` before rename** — ensures the data bytes are on disk
-    ///   before the directory entry is updated; without this a power loss after
-    ///   `rename` can leave a zero-byte or truncated checkpoint file.
-    /// * **Parent-directory fsync after rename** — makes the new directory
-    ///   entry itself durable so the file is not lost on power loss even after
-    ///   the rename syscall returns.
+    /// * **Unique temp file** — `NamedTempFile::new_in` generates a unique
+    ///   name so two concurrent `save()` calls for the same task never
+    ///   clobber each other's temp file.
+    /// * **`sync_all()` before persist** — ensures data bytes are on disk
+    ///   before the directory entry is updated; without this a power loss
+    ///   after the rename can leave a zero-byte or truncated file.
+    /// * **`persist()` instead of `rename()`** — on Windows `std::fs::rename`
+    ///   fails when the destination already exists; `NamedTempFile::persist`
+    ///   uses `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` internally so it
+    ///   atomically replaces the destination on all platforms.
+    /// * **Parent-directory fsync after persist** — makes the new directory
+    ///   entry durable; unsupported on some filesystems (notably Windows) so
+    ///   failures are logged at debug level and treated as non-fatal.
     ///
-    /// POSIX guarantees that `rename(2)` is atomic with respect to readers, so
-    /// a concurrent `load` will always see either the previous complete
+    /// POSIX guarantees that `rename(2)` is atomic with respect to readers,
+    /// so a concurrent `load` will always see either the previous complete
     /// checkpoint or the new one — never a partial write.
     pub fn save(&self) -> anyhow::Result<()> {
         use std::io::Write as _;
@@ -133,26 +139,22 @@ impl TaskCheckpoint {
 
         let data = serde_json::to_string_pretty(self)?;
 
-        // Unique suffix prevents races when save() is called concurrently for
-        // the same task_id (e.g. from two tokio tasks).
-        // Sanitize task_id so path separators in the ID don't create a
-        // nested path under `parent` that hasn't been mkdir'd.
-        let safe_id = self.task_id.replace(['/', '\\'], "_");
-        let tmp_name = format!("{}.{}.tmp", safe_id, uuid::Uuid::new_v4());
-        let tmp_path = parent.join(tmp_name);
-
-        // Write and sync the temp file before rename so data is on disk.
-        {
-            let mut tmp_file = std::fs::File::create(&tmp_path)?;
-            tmp_file.write_all(data.as_bytes())?;
-            tmp_file.sync_all()?;
-        }
-        std::fs::rename(&tmp_path, &path)?;
+        // Create the temp file in the same directory as the destination so
+        // that persist() (rename) stays on the same filesystem.
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        tmp.write_all(data.as_bytes())?;
+        // Sync data to disk before rename so a power loss after rename does
+        // not leave a zero-byte or truncated checkpoint.
+        tmp.as_file().sync_all()?;
+        // persist() uses MoveFileExW(MOVEFILE_REPLACE_EXISTING) on Windows
+        // and rename(2) on Unix — both atomically replace the destination.
+        tmp.persist(&path)
+            .map_err(|e| anyhow::anyhow!("checkpoint persist failed: {}", e.error))?;
 
         // Best-effort: fsync the parent directory so the renamed entry is
         // durable.  Directory fsync is unsupported on some filesystems
         // (notably Windows); treat failure as non-fatal so a successful
-        // rename is never rolled back into an error.
+        // persist is never rolled back into an error.
         if let Ok(dir) = std::fs::File::open(parent) {
             if let Err(e) = dir.sync_all() {
                 tracing::debug!("checkpoint: parent dir fsync not supported (non-fatal): {e}");


### PR DESCRIPTION
## Summary

- Replace `std::fs::write` in `TaskCheckpoint::save()` with a write-to-`.tmp` + `rename` pattern
- POSIX `rename(2)` is atomic — readers always see either the previous complete checkpoint or the new one, never a partial file
- Prevents recoverable tasks from being unnecessarily marked as failed after a power loss or kill signal

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Existing checkpoint roundtrip tests pass unchanged

Fixes #632