### PR TITLE
fix(executor): propagate complete_turn failure instead of silent warn

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -299,11 +299,24 @@ pub(crate) async fn run_turn_lifecycle(
             }
             Ok(None) => {}
             Err(err) => {
+                let error_msg = err.to_string();
                 tracing::error!(
                     thread_id = %thread_id,
                     turn_id = %turn_id,
-                    "failed to complete turn after execution: {err}"
+                    "failed to complete turn after execution: {error_msg}"
                 );
+                if let Err(e) = server.thread_manager.add_item(
+                    &thread_id,
+                    &turn_id,
+                    harness_core::types::Item::Error {
+                        code: -1,
+                        message: format!("Failed to complete turn: {error_msg}"),
+                    },
+                ) {
+                    tracing::warn!("failed to add error item to turn: {e}");
+                } else {
+                    persist_runtime_thread(&thread_db, &server, &thread_id).await;
+                }
                 mark_turn_failed(
                     &server,
                     &thread_db,
@@ -311,7 +324,7 @@ pub(crate) async fn run_turn_lifecycle(
                     &notification_tx,
                     &thread_id,
                     &turn_id,
-                    err.to_string(),
+                    error_msg,
                 )
                 .await;
             }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -298,7 +298,23 @@ pub(crate) async fn run_turn_lifecycle(
                 );
             }
             Ok(None) => {}
-            Err(err) => tracing::warn!("failed to complete turn after execution: {err}"),
+            Err(err) => {
+                tracing::error!(
+                    thread_id = %thread_id,
+                    turn_id = %turn_id,
+                    "failed to complete turn after execution: {err}"
+                );
+                mark_turn_failed(
+                    &server,
+                    &thread_db,
+                    &notify_tx,
+                    &notification_tx,
+                    &thread_id,
+                    &turn_id,
+                    err.to_string(),
+                )
+                .await;
+            }
         },
         Err(err) => {
             let error_msg = err.to_string();


### PR DESCRIPTION
## Summary

- Fixes #626: complete_turn failure was only logged as warn, leaving the turn state inconsistent
- Upgrades to tracing::error! with structured thread_id and turn_id fields
- Calls mark_turn_failed to properly mark the turn failed, persist thread state, and emit TurnCompleted{Failed} notification
- Eliminates the silent degradation that violated U-29

## Test plan

- [x] cargo fmt --all — clean
- [x] cargo clippy --workspace --all-targets -- -D warnings — clean
- [x] cargo test -p harness-server — all 5 turn lifecycle tests pass