### PR TITLE
fix(task_runner): replace .expect() with ok_or_else+? to avoid panic

### DIFF
--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -2115,7 +2115,9 @@ mod tests {
         // Allow async task to complete.
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let state = store.get(&task_id).expect("task must exist");
+        let state = store.get(&task_id).ok_or_else(|| {
+            anyhow::anyhow!("task not found in store — possible concurrent deletion")
+        })?;
         assert!(
             matches!(state.status, TaskStatus::Failed),
             "expected Failed, got {:?}",
@@ -2206,7 +2208,9 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let state = store.get(&task_id).expect("task must exist");
+        let state = store.get(&task_id).ok_or_else(|| {
+            anyhow::anyhow!("task not found in store — possible concurrent deletion")
+        })?;
         assert!(
             matches!(state.status, TaskStatus::Failed),
             "expected Failed, got {:?}",
@@ -2258,7 +2262,9 @@ mod tests {
         };
 
         let task_id = register_pending_task(store.clone(), &req).await;
-        let state = store.get(&task_id).expect("task should exist");
+        let state = store.get(&task_id).ok_or_else(|| {
+            anyhow::anyhow!("task not found in store — possible concurrent deletion")
+        })?;
 
         assert_eq!(state.source.as_deref(), Some("github"));
         assert_eq!(state.external_id.as_deref(), Some("20"));


### PR DESCRIPTION
## Summary

- Fixes 3 `.expect("task must exist")` calls in `task_runner.rs` tests (lines ~2118, ~2209, ~2261)
- Replaces each with `ok_or_else(|| anyhow::anyhow!(...))` + `?`, so a missing task produces a proper test failure instead of a panic
- No production-code changes; no new dependencies; no unrelated refactoring

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test -p harness-server` — all tests pass
- [x] `rg 'expect\(' crates/harness-server/src/task_runner.rs` — no remaining `.expect()` calls

Closes #622