### PR TITLE
fix(parallel_dispatch): scale chunk count dynamically, cap at 8 parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.31"
+version = "0.6.32"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.32"
+version = "0.6.33"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -7,6 +7,19 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::time::Duration;
 
+/// RAII guard that aborts a spawned Tokio task when dropped.
+///
+/// This ensures that if the parent future is cancelled (e.g. via the external
+/// cancel endpoint), the child task is also aborted rather than running to
+/// completion detached.
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// Maximum number of parallel subtasks — caps both chunk count in `decompose`
 /// and concurrent agent executions in `run_parallel_subtasks`.
 /// Wire up `--max-parallel` CLI flag to override this in a follow-up (see #638).
@@ -291,16 +304,22 @@ async fn run_sequential_subtasks(
         };
         // Spawn into a task so a panic in agent.execute surfaces as JoinError
         // instead of unwinding through this function and skipping cleanup.
+        //
+        // The AbortOnDrop guard ensures the child task is aborted whenever
+        // `handle` is dropped — including when the *parent* future is cancelled
+        // by an external abort (task_runner cancel endpoint).  Without it,
+        // dropping a JoinHandle merely detaches the child; the agent would keep
+        // running and writing to the shared workspace after cancellation.
         let agent_clone = agent.clone();
-        let mut handle = tokio::spawn(async move { agent_clone.execute(req).await });
-        let outcome = match tokio::time::timeout(turn_timeout, &mut handle).await {
+        let handle = tokio::spawn(async move { agent_clone.execute(req).await });
+        let _abort_guard = AbortOnDrop(handle.abort_handle());
+        let outcome = match tokio::time::timeout(turn_timeout, handle).await {
             Ok(Ok(Ok(resp))) => Ok(resp),
             Ok(Ok(Err(e))) => Err(format!("agent error: {e}")),
             Ok(Err(join_err)) => Err(format!("subtask panicked: {join_err}")),
             Err(_) => {
-                // Abort the detached task so it does not keep mutating the
-                // workspace or consuming resources after the timeout fires.
-                handle.abort();
+                // _abort_guard is dropped at end of scope and aborts the task;
+                // the explicit Err here records the timeout reason.
                 Err(format!(
                     "subtask timed out after {}s",
                     turn_timeout.as_secs()

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -97,6 +97,7 @@ pub(crate) fn extract_file_refs(prompt: &str) -> Vec<String> {
 }
 
 /// A subtask produced by decomposing a complex prompt.
+#[derive(Debug)]
 pub struct SubtaskSpec {
     /// The full prompt for this subtask (including focus directive).
     pub prompt: String,
@@ -122,7 +123,7 @@ fn is_numbered_list(prompt: &str) -> bool {
 /// parallel specs with no dependencies.
 ///
 /// Returns a single-element vec when decomposition is not meaningful.
-pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
+pub fn decompose(prompt: &str) -> Result<Vec<SubtaskSpec>, String> {
     // Numbered list → sequential subtasks.
     if is_numbered_list(prompt) {
         let items: Vec<&str> = prompt
@@ -134,22 +135,19 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             })
             .collect();
         if items.len() >= 2 {
-            // Cap to MAX_SEQUENTIAL_STEPS to prevent queue starvation.
+            // Reject over-limit lists explicitly to prevent silent partial execution.
             // Each step runs serially with the full turn_timeout (default 3600 s);
             // an unbounded list would occupy a worker for N × timeout seconds.
-            let items: &[&str] = if items.len() > MAX_SEQUENTIAL_STEPS {
-                tracing::warn!(
-                    "parallel_dispatch: numbered-list has {} steps, \
-                     capping at {} to prevent queue starvation",
+            if items.len() > MAX_SEQUENTIAL_STEPS {
+                return Err(format!(
+                    "Prompt contains {} sequential steps, which exceeds the {} step limit. \
+                     Please split your request into smaller tasks.",
                     items.len(),
                     MAX_SEQUENTIAL_STEPS
-                );
-                &items[..MAX_SEQUENTIAL_STEPS]
-            } else {
-                &items
-            };
+                ));
+            }
             let total = items.len();
-            return items
+            return Ok(items
                 .iter()
                 .enumerate()
                 .map(|(i, item)| SubtaskSpec {
@@ -162,17 +160,17 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
                     ),
                     depends_on_indices: if i == 0 { vec![] } else { vec![i - 1] },
                 })
-                .collect();
+                .collect());
         }
     }
 
     // File-ref partitioning → parallel subtasks.
     let files = extract_file_refs(prompt);
     if files.len() < 2 {
-        return vec![SubtaskSpec {
+        return Ok(vec![SubtaskSpec {
             prompt: prompt.to_string(),
             depends_on_indices: vec![],
-        }];
+        }]);
     }
     // Scale chunk count linearly with file count, floor at 2, cap at MAX_PARALLEL.
     let n_chunks = (files.len() / 3).clamp(2, MAX_PARALLEL);
@@ -181,7 +179,7 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
     // when file count is not evenly divisible, e.g. 16 files → 4 chunks not 5).
     let groups: Vec<Vec<String>> = files.chunks(chunk_size).map(|g| g.to_vec()).collect();
     let actual_count = groups.len();
-    groups
+    Ok(groups
         .into_iter()
         .enumerate()
         .map(|(i, group)| SubtaskSpec {
@@ -194,7 +192,7 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             ),
             depends_on_indices: vec![],
         })
-        .collect()
+        .collect())
 }
 
 /// Result of a single parallel subtask execution.
@@ -519,7 +517,7 @@ mod tests {
     #[test]
     fn decompose_no_files_returns_original() {
         let prompt = "Fix the login bug";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 1);
         assert_eq!(subtasks[0].prompt, prompt);
     }
@@ -527,7 +525,7 @@ mod tests {
     #[test]
     fn decompose_one_file_returns_original() {
         let prompt = "Fix the bug in src/main.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 1);
         assert_eq!(subtasks[0].prompt, prompt);
     }
@@ -535,14 +533,14 @@ mod tests {
     #[test]
     fn decompose_two_files_yields_two_subtasks() {
         let prompt = "Update src/auth.rs and src/db.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
     }
 
     #[test]
     fn decompose_multiple_files_splits_into_two() {
         let prompt = "Refactor src/a.rs src/b.rs src/c.rs src/d.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
         assert!(subtasks[0].prompt.contains("[Parallel subtask 1/2]"));
         assert!(subtasks[1].prompt.contains("[Parallel subtask 2/2]"));
@@ -551,7 +549,7 @@ mod tests {
     #[test]
     fn decompose_subtasks_start_with_original_prompt() {
         let prompt = "Fix auth.rs and db.rs together";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         for subtask in &subtasks {
             assert!(subtask.prompt.starts_with(prompt));
         }
@@ -560,7 +558,7 @@ mod tests {
     #[test]
     fn decompose_six_files_yields_two_subtasks() {
         let prompt = "Refactor src/a.rs src/b.rs src/c.rs src/d.rs src/e.rs src/f.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
     }
 
@@ -619,7 +617,7 @@ mod tests {
     #[test]
     fn decompose_subtask_contains_focus_directive() {
         let prompt = "Update auth.rs and db.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
         assert!(subtasks[0].prompt.contains("Focus on these files:"));
         assert!(subtasks[1].prompt.contains("Focus on these files:"));
@@ -628,7 +626,7 @@ mod tests {
     #[test]
     fn decompose_numbered_list_yields_sequential_specs() {
         let prompt = "1. Write the auth module\n2. Refactor the db layer";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
         assert!(subtasks[0].depends_on_indices.is_empty());
         assert_eq!(subtasks[1].depends_on_indices, vec![0]);
@@ -637,7 +635,7 @@ mod tests {
     #[test]
     fn decompose_parallel_specs_have_no_dependencies() {
         let prompt = "Update src/auth.rs and src/db.rs";
-        let subtasks = decompose(prompt);
+        let subtasks = decompose(prompt).unwrap();
         assert_eq!(subtasks.len(), 2);
         assert!(subtasks[0].depends_on_indices.is_empty());
         assert!(subtasks[1].depends_on_indices.is_empty());
@@ -655,28 +653,28 @@ mod tests {
     #[test]
     fn test_decompose_small() {
         // 2 files: (2/3).clamp(2,8) = 2 — minimum clamp
-        let subtasks = decompose(&make_prompt(2));
+        let subtasks = decompose(&make_prompt(2)).unwrap();
         assert_eq!(subtasks.len(), 2);
     }
 
     #[test]
     fn test_decompose_medium() {
         // 9 files: (9/3).clamp(2,8) = 3
-        let subtasks = decompose(&make_prompt(9));
+        let subtasks = decompose(&make_prompt(9)).unwrap();
         assert_eq!(subtasks.len(), 3);
     }
 
     #[test]
     fn test_decompose_large() {
         // 24 files: (24/3).clamp(2,8) = 8
-        let subtasks = decompose(&make_prompt(24));
+        let subtasks = decompose(&make_prompt(24)).unwrap();
         assert_eq!(subtasks.len(), 8);
     }
 
     #[test]
     fn test_decompose_very_large() {
         // 30 files: (30/3).clamp(2,8) = 8 — cap
-        let subtasks = decompose(&make_prompt(30));
+        let subtasks = decompose(&make_prompt(30)).unwrap();
         assert_eq!(subtasks.len(), 8);
     }
 
@@ -684,7 +682,7 @@ mod tests {
     fn decompose_labels_reflect_actual_chunk_count() {
         // 16 files: n_chunks = (16/3).clamp(2,8) = 5, chunk_size = ceil(16/5) = 4
         // actual chunks from .chunks(4) = 4, so labels must be X/4 not X/5.
-        let subtasks = decompose(&make_prompt(16));
+        let subtasks = decompose(&make_prompt(16)).unwrap();
         let actual = subtasks.len();
         assert_eq!(actual, 4, "expected 4 actual chunks for 16 files");
         for (i, s) in subtasks.iter().enumerate() {
@@ -706,7 +704,7 @@ mod tests {
             .map(|i| format!("{}. task {}", i, i))
             .collect::<Vec<_>>()
             .join("\n");
-        let subtasks = decompose(&prompt);
+        let subtasks = decompose(&prompt).unwrap();
         assert_eq!(
             subtasks.len(),
             n,
@@ -717,27 +715,22 @@ mod tests {
     }
 
     #[test]
-    fn decompose_numbered_list_caps_at_max_sequential_steps() {
-        // Inputs exceeding MAX_SEQUENTIAL_STEPS must be truncated to prevent
-        // queue starvation (N × turn_timeout seconds of serial execution).
+    fn decompose_numbered_list_rejects_over_limit() {
+        // Inputs exceeding MAX_SEQUENTIAL_STEPS must be rejected with an explicit
+        // error — silent truncation causes partial execution marked as Done.
         let n = MAX_SEQUENTIAL_STEPS + 5;
         let prompt: String = (1..=n)
             .map(|i| format!("{}. task {}", i, i))
             .collect::<Vec<_>>()
             .join("\n");
-        let subtasks = decompose(&prompt);
-        assert_eq!(
-            subtasks.len(),
-            MAX_SEQUENTIAL_STEPS,
-            "expected cap at {}, got {}",
-            MAX_SEQUENTIAL_STEPS,
-            subtasks.len()
+        let err = decompose(&prompt).unwrap_err();
+        assert!(
+            err.contains(&n.to_string()),
+            "error should mention actual step count: {err}"
         );
-        // Dependency chain must remain intact within the capped set.
-        assert!(subtasks[0].depends_on_indices.is_empty());
-        assert_eq!(
-            subtasks[MAX_SEQUENTIAL_STEPS - 1].depends_on_indices,
-            vec![MAX_SEQUENTIAL_STEPS - 2]
+        assert!(
+            err.contains(&MAX_SEQUENTIAL_STEPS.to_string()),
+            "error should mention the limit: {err}"
         );
     }
 
@@ -746,7 +739,7 @@ mod tests {
         // 12 files: every file appears exactly once across all chunks
         let n = 12;
         let prompt = make_prompt(n);
-        let subtasks = decompose(&prompt);
+        let subtasks = decompose(&prompt).unwrap();
         let expected: Vec<String> = (0..n).map(|i| format!("src/file{i:02}.rs")).collect();
         let mut found: Vec<String> = subtasks
             .iter()

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -292,15 +292,20 @@ async fn run_sequential_subtasks(
         // Spawn into a task so a panic in agent.execute surfaces as JoinError
         // instead of unwinding through this function and skipping cleanup.
         let agent_clone = agent.clone();
-        let handle = tokio::spawn(async move { agent_clone.execute(req).await });
-        let outcome = match tokio::time::timeout(turn_timeout, handle).await {
+        let mut handle = tokio::spawn(async move { agent_clone.execute(req).await });
+        let outcome = match tokio::time::timeout(turn_timeout, &mut handle).await {
             Ok(Ok(Ok(resp))) => Ok(resp),
             Ok(Ok(Err(e))) => Err(format!("agent error: {e}")),
             Ok(Err(join_err)) => Err(format!("subtask panicked: {join_err}")),
-            Err(_) => Err(format!(
-                "subtask timed out after {}s",
-                turn_timeout.as_secs()
-            )),
+            Err(_) => {
+                // Abort the detached task so it does not keep mutating the
+                // workspace or consuming resources after the timeout fires.
+                handle.abort();
+                Err(format!(
+                    "subtask timed out after {}s",
+                    turn_timeout.as_secs()
+                ))
+            }
         };
 
         let (response, error) = match outcome {

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -112,18 +112,10 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             })
             .collect();
         if items.len() >= 2 {
-            // Cap sequential subtasks to prevent unbounded semaphore queue depth.
-            if items.len() > MAX_PARALLEL {
-                tracing::warn!(
-                    "parallel_dispatch: numbered-list prompt has {} steps but MAX_PARALLEL={}: \
-                     steps {} through {} will NOT be executed",
-                    items.len(),
-                    MAX_PARALLEL,
-                    MAX_PARALLEL + 1,
-                    items.len()
-                );
-            }
-            let items: Vec<&str> = items.into_iter().take(MAX_PARALLEL).collect();
+            // Sequential numbered-list steps are not capped: each step depends on
+            // the previous, so they execute one-at-a-time and the semaphore queue
+            // depth is bounded by the number of concurrent parallel batches, not
+            // by the number of sequential steps within a single prompt.
             return items
                 .iter()
                 .enumerate()
@@ -481,17 +473,20 @@ mod tests {
     }
 
     #[test]
-    fn decompose_numbered_list_caps_at_max_parallel() {
-        // Build a list with MAX_PARALLEL + 2 items; result must not exceed MAX_PARALLEL.
-        let prompt: String = (1..=(MAX_PARALLEL + 2))
+    fn decompose_numbered_list_preserves_all_steps() {
+        // Sequential steps must ALL be preserved — dropping later steps is a
+        // correctness regression (e.g. a migration checklist must run every step).
+        let n = MAX_PARALLEL + 2;
+        let prompt: String = (1..=n)
             .map(|i| format!("{}. task {}", i, i))
             .collect::<Vec<_>>()
             .join("\n");
         let subtasks = decompose(&prompt);
-        assert!(
-            subtasks.len() <= MAX_PARALLEL,
-            "expected <= {} subtasks, got {}",
-            MAX_PARALLEL,
+        assert_eq!(
+            subtasks.len(),
+            n,
+            "expected all {} steps preserved, got {}",
+            n,
             subtasks.len()
         );
     }

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -112,6 +112,8 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             })
             .collect();
         if items.len() >= 2 {
+            // Cap sequential subtasks to prevent unbounded semaphore queue depth.
+            let items: Vec<&str> = items.into_iter().take(MAX_PARALLEL).collect();
             return items
                 .iter()
                 .enumerate()
@@ -140,15 +142,19 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
     // Scale chunk count linearly with file count, floor at 2, cap at MAX_PARALLEL.
     let n_chunks = (files.len() / 3).clamp(2, MAX_PARALLEL);
     let chunk_size = files.len().div_ceil(n_chunks);
-    files
-        .chunks(chunk_size)
+    // Collect first so actual_count reflects real chunk count (may be < n_chunks
+    // when file count is not evenly divisible, e.g. 16 files → 4 chunks not 5).
+    let groups: Vec<Vec<String>> = files.chunks(chunk_size).map(|g| g.to_vec()).collect();
+    let actual_count = groups.len();
+    groups
+        .into_iter()
         .enumerate()
         .map(|(i, group)| SubtaskSpec {
             prompt: format!(
                 "{}\n\n[Parallel subtask {}/{}] Focus on these files: {}",
                 prompt,
                 i + 1,
-                n_chunks,
+                actual_count,
                 group.join(", ")
             ),
             depends_on_indices: vec![],
@@ -209,16 +215,23 @@ pub async fn run_parallel_subtasks(
                 };
                 let sem = Arc::clone(&sem);
                 handles.push(tokio::spawn(async move {
-                    let _permit = match sem.acquire_owned().await {
-                        Ok(p) => p,
-                        Err(_) => return (i, Err("semaphore closed unexpectedly".to_string())),
-                    };
-                    let result = match tokio::time::timeout(turn_timeout, agent.execute(req)).await
-                    {
-                        Ok(Ok(resp)) => Ok(resp),
-                        Ok(Err(e)) => Err(format!("agent error: {e}")),
+                    // Timeout covers both semaphore queue wait and execution so that
+                    // a task cannot be stuck waiting unbounded before it even starts.
+                    let timed = tokio::time::timeout(turn_timeout, async move {
+                        let _permit = match sem.acquire_owned().await {
+                            Ok(p) => p,
+                            Err(_) => return Err("semaphore closed unexpectedly".to_string()),
+                        };
+                        match agent.execute(req).await {
+                            Ok(resp) => Ok(resp),
+                            Err(e) => Err(format!("agent error: {e}")),
+                        }
+                    })
+                    .await;
+                    let result = match timed {
+                        Ok(r) => r,
                         Err(_) => Err(format!(
-                            "subtask timed out after {}s",
+                            "subtask timed out after {}s (including queue wait)",
                             turn_timeout.as_secs()
                         )),
                     };
@@ -438,6 +451,39 @@ mod tests {
         // 30 files: (30/3).clamp(2,8) = 8 — cap
         let subtasks = decompose(&make_prompt(30));
         assert_eq!(subtasks.len(), 8);
+    }
+
+    #[test]
+    fn decompose_labels_reflect_actual_chunk_count() {
+        // 16 files: n_chunks = (16/3).clamp(2,8) = 5, chunk_size = ceil(16/5) = 4
+        // actual chunks from .chunks(4) = 4, so labels must be X/4 not X/5.
+        let subtasks = decompose(&make_prompt(16));
+        let actual = subtasks.len();
+        assert_eq!(actual, 4, "expected 4 actual chunks for 16 files");
+        for (i, s) in subtasks.iter().enumerate() {
+            let expected = format!("[Parallel subtask {}/{}]", i + 1, actual);
+            assert!(
+                s.prompt.contains(&expected),
+                "label mismatch: expected '{}' in prompt",
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn decompose_numbered_list_caps_at_max_parallel() {
+        // Build a list with MAX_PARALLEL + 2 items; result must not exceed MAX_PARALLEL.
+        let prompt: String = (1..=(MAX_PARALLEL + 2))
+            .map(|i| format!("{}. task {}", i, i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let subtasks = decompose(&prompt);
+        assert!(
+            subtasks.len() <= MAX_PARALLEL,
+            "expected <= {} subtasks, got {}",
+            MAX_PARALLEL,
+            subtasks.len()
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -25,6 +25,15 @@ impl Drop for AbortOnDrop {
 /// Wire up `--max-parallel` CLI flag to override this in a follow-up (see #638).
 const MAX_PARALLEL: usize = 8;
 
+/// Maximum number of sequential steps accepted from a numbered-list prompt.
+///
+/// Each step executes serially with the full `turn_timeout` (default 3600 s).
+/// Without this cap a single numbered-list prompt with N steps would occupy a
+/// worker for up to `N × turn_timeout` seconds — a practical queue-starvation
+/// / DoS path. The limit is intentionally generous (20 × 3600 s = 20 h worst
+/// case) but cuts off adversarially large inputs.
+const MAX_SEQUENTIAL_STEPS: usize = 20;
+
 const PARALLEL_EXTENSIONS: &[&str] = &[
     "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt", "swift", "cpp", "c", "h", "toml",
     "yaml", "yml", "json", "sh", "md",
@@ -125,10 +134,21 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             })
             .collect();
         if items.len() >= 2 {
-            // Sequential numbered-list steps are not capped: each step depends on
-            // the previous, so they execute one-at-a-time and the semaphore queue
-            // depth is bounded by the number of concurrent parallel batches, not
-            // by the number of sequential steps within a single prompt.
+            // Cap to MAX_SEQUENTIAL_STEPS to prevent queue starvation.
+            // Each step runs serially with the full turn_timeout (default 3600 s);
+            // an unbounded list would occupy a worker for N × timeout seconds.
+            let items: &[&str] = if items.len() > MAX_SEQUENTIAL_STEPS {
+                tracing::warn!(
+                    "parallel_dispatch: numbered-list has {} steps, \
+                     capping at {} to prevent queue starvation",
+                    items.len(),
+                    MAX_SEQUENTIAL_STEPS
+                );
+                &items[..MAX_SEQUENTIAL_STEPS]
+            } else {
+                &items
+            };
+            let total = items.len();
             return items
                 .iter()
                 .enumerate()
@@ -137,7 +157,7 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
                         "{}\n\n[Sequential subtask {}/{}] {}",
                         prompt,
                         i + 1,
-                        items.len(),
+                        total,
                         item.trim()
                     ),
                     depends_on_indices: if i == 0 { vec![] } else { vec![i - 1] },
@@ -387,6 +407,12 @@ async fn run_concurrent_subtasks(
     let mut handles: Vec<tokio::task::JoinHandle<(usize, Result<AgentResponse, String>)>> =
         Vec::with_capacity(count);
     let mut sub_ids: Vec<Option<TaskId>> = Vec::with_capacity(count);
+    // RAII abort guards: when this Vec is dropped (including when the parent
+    // future is cancelled via the cancel endpoint), every spawned task is
+    // aborted.  Without these guards, dropping a JoinHandle merely detaches
+    // the child; agent processes would keep running and mutating worktrees
+    // even after the parent task is cancelled.
+    let mut abort_guards: Vec<AbortOnDrop> = Vec::with_capacity(count);
     let sem = Arc::new(tokio::sync::Semaphore::new(MAX_PARALLEL));
 
     for (i, spec) in subtasks.into_iter().enumerate() {
@@ -406,7 +432,7 @@ async fn run_concurrent_subtasks(
                     ..Default::default()
                 };
                 let sem = Arc::clone(&sem);
-                handles.push(tokio::spawn(async move {
+                let handle = tokio::spawn(async move {
                     // Acquire semaphore first (unbounded wait), then apply timeout
                     // only to the actual agent execution — subtasks beyond the first
                     // MAX_PARALLEL do not time out while waiting in the queue.
@@ -424,14 +450,19 @@ async fn run_concurrent_subtasks(
                         )),
                     };
                     (i, result)
-                }));
+                });
+                abort_guards.push(AbortOnDrop(handle.abort_handle()));
+                handles.push(handle);
             }
             Err(e) => {
                 tracing::warn!("parallel_dispatch: workspace creation failed for subtask {i}: {e}");
                 sub_ids.push(None);
-                handles.push(tokio::spawn(async move {
-                    (i, Err(format!("workspace creation failed: {e}")))
-                }));
+                let handle =
+                    tokio::spawn(
+                        async move { (i, Err(format!("workspace creation failed: {e}"))) },
+                    );
+                abort_guards.push(AbortOnDrop(handle.abort_handle()));
+                handles.push(handle);
             }
         }
     }
@@ -469,6 +500,11 @@ async fn run_concurrent_subtasks(
             tracing::warn!("parallel_dispatch: workspace cleanup failed for {sub_id:?}: {e}");
         }
     }
+
+    // All tasks have completed — dropping abort_guards here is a no-op.
+    // On parent-future cancellation they would have been dropped earlier,
+    // aborting every task before this point is reached.
+    drop(abort_guards);
 
     ParallelRunResult {
         results,
@@ -662,10 +698,10 @@ mod tests {
     }
 
     #[test]
-    fn decompose_numbered_list_preserves_all_steps() {
-        // Sequential steps must ALL be preserved — dropping later steps is a
+    fn decompose_numbered_list_preserves_all_steps_within_cap() {
+        // Steps within the cap must ALL be preserved — dropping steps is a
         // correctness regression (e.g. a migration checklist must run every step).
-        let n = MAX_PARALLEL + 2;
+        let n = MAX_PARALLEL + 2; // 10 < MAX_SEQUENTIAL_STEPS (20)
         let prompt: String = (1..=n)
             .map(|i| format!("{}. task {}", i, i))
             .collect::<Vec<_>>()
@@ -677,6 +713,31 @@ mod tests {
             "expected all {} steps preserved, got {}",
             n,
             subtasks.len()
+        );
+    }
+
+    #[test]
+    fn decompose_numbered_list_caps_at_max_sequential_steps() {
+        // Inputs exceeding MAX_SEQUENTIAL_STEPS must be truncated to prevent
+        // queue starvation (N × turn_timeout seconds of serial execution).
+        let n = MAX_SEQUENTIAL_STEPS + 5;
+        let prompt: String = (1..=n)
+            .map(|i| format!("{}. task {}", i, i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let subtasks = decompose(&prompt);
+        assert_eq!(
+            subtasks.len(),
+            MAX_SEQUENTIAL_STEPS,
+            "expected cap at {}, got {}",
+            MAX_SEQUENTIAL_STEPS,
+            subtasks.len()
+        );
+        // Dependency chain must remain intact within the capped set.
+        assert!(subtasks[0].depends_on_indices.is_empty());
+        assert_eq!(
+            subtasks[MAX_SEQUENTIAL_STEPS - 1].depends_on_indices,
+            vec![MAX_SEQUENTIAL_STEPS - 2]
         );
     }
 

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -174,11 +174,22 @@ pub fn decompose(prompt: &str) -> Result<Vec<SubtaskSpec>, String> {
     }
     // Scale chunk count linearly with file count, floor at 2, cap at MAX_PARALLEL.
     let n_chunks = (files.len() / 3).clamp(2, MAX_PARALLEL);
-    let chunk_size = files.len().div_ceil(n_chunks);
-    // Collect first so actual_count reflects real chunk count (may be < n_chunks
-    // when file count is not evenly divisible, e.g. 16 files → 4 chunks not 5).
-    let groups: Vec<Vec<String>> = files.chunks(chunk_size).map(|g| g.to_vec()).collect();
-    let actual_count = groups.len();
+    // Partition into exactly n_chunks groups (array-split style) so that actual
+    // parallelism is monotonically non-decreasing as file count grows.
+    // Using div_ceil for chunk_size causes files.chunks() to produce fewer than
+    // n_chunks groups (e.g. 25 files → 7 groups instead of 8).  Instead,
+    // distribute files as evenly as possible: first `extra` groups get one extra
+    // file, the rest get `base` files each.
+    let base = files.len() / n_chunks;
+    let extra = files.len() % n_chunks;
+    let mut groups: Vec<Vec<String>> = Vec::with_capacity(n_chunks);
+    let mut start = 0;
+    for i in 0..n_chunks {
+        let size = base + usize::from(i < extra);
+        groups.push(files[start..start + size].to_vec());
+        start += size;
+    }
+    let actual_count = n_chunks;
     Ok(groups
         .into_iter()
         .enumerate()
@@ -680,11 +691,11 @@ mod tests {
 
     #[test]
     fn decompose_labels_reflect_actual_chunk_count() {
-        // 16 files: n_chunks = (16/3).clamp(2,8) = 5, chunk_size = ceil(16/5) = 4
-        // actual chunks from .chunks(4) = 4, so labels must be X/4 not X/5.
+        // 16 files: n_chunks = (16/3).clamp(2,8) = 5; array-split gives exactly 5
+        // groups, so labels must be X/5.
         let subtasks = decompose(&make_prompt(16)).unwrap();
         let actual = subtasks.len();
-        assert_eq!(actual, 4, "expected 4 actual chunks for 16 files");
+        assert_eq!(actual, 5, "expected 5 actual chunks for 16 files");
         for (i, s) in subtasks.iter().enumerate() {
             let expected = format!("[Parallel subtask {}/{}]", i + 1, actual);
             assert!(
@@ -693,6 +704,18 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn test_decompose_chunk_count_monotone() {
+        // Chunk count must be monotonically non-decreasing as file count grows
+        // within the [2, MAX_PARALLEL] band (24→25 was a known regression).
+        let chunks_24 = decompose(&make_prompt(24)).unwrap().len();
+        let chunks_25 = decompose(&make_prompt(25)).unwrap().len();
+        assert!(
+            chunks_25 >= chunks_24,
+            "expected monotone: 25 files ({chunks_25} chunks) >= 24 files ({chunks_24} chunks)"
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -7,6 +7,11 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::time::Duration;
 
+/// Maximum number of parallel subtasks — caps both chunk count in `decompose`
+/// and concurrent agent executions in `run_parallel_subtasks`.
+/// Wire up `--max-parallel` CLI flag to override this in a follow-up (see #638).
+const MAX_PARALLEL: usize = 8;
+
 const PARALLEL_EXTENSIONS: &[&str] = &[
     "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt", "swift", "cpp", "c", "h", "toml",
     "yaml", "yml", "json", "sh", "md",
@@ -132,17 +137,18 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             depends_on_indices: vec![],
         }];
     }
-    let mid = files.len().div_ceil(2);
-    let total_chunks = files.chunks(mid).count();
+    // Scale chunk count linearly with file count, floor at 2, cap at MAX_PARALLEL.
+    let n_chunks = (files.len() / 3).clamp(2, MAX_PARALLEL);
+    let chunk_size = files.len().div_ceil(n_chunks);
     files
-        .chunks(mid)
+        .chunks(chunk_size)
         .enumerate()
         .map(|(i, group)| SubtaskSpec {
             prompt: format!(
                 "{}\n\n[Parallel subtask {}/{}] Focus on these files: {}",
                 prompt,
                 i + 1,
-                total_chunks,
+                n_chunks,
                 group.join(", ")
             ),
             depends_on_indices: vec![],
@@ -183,6 +189,7 @@ pub async fn run_parallel_subtasks(
     let mut handles: Vec<tokio::task::JoinHandle<(usize, Result<AgentResponse, String>)>> =
         Vec::with_capacity(count);
     let mut sub_ids: Vec<Option<TaskId>> = Vec::with_capacity(count);
+    let sem = Arc::new(tokio::sync::Semaphore::new(MAX_PARALLEL));
 
     for (i, spec) in subtasks.into_iter().enumerate() {
         let sub_id = harness_core::types::TaskId(format!("{}-p{i}", task_id.0));
@@ -200,7 +207,12 @@ pub async fn run_parallel_subtasks(
                     context,
                     ..Default::default()
                 };
+                let sem = Arc::clone(&sem);
                 handles.push(tokio::spawn(async move {
+                    let _permit = match sem.acquire_owned().await {
+                        Ok(p) => p,
+                        Err(_) => return (i, Err("semaphore closed unexpectedly".to_string())),
+                    };
                     let result = match tokio::time::timeout(turn_timeout, agent.execute(req)).await
                     {
                         Ok(Ok(resp)) => Ok(resp),
@@ -389,5 +401,67 @@ mod tests {
         assert_eq!(subtasks.len(), 2);
         assert!(subtasks[0].depends_on_indices.is_empty());
         assert!(subtasks[1].depends_on_indices.is_empty());
+    }
+
+    // --- dynamic chunk-count tests ---
+
+    fn make_prompt(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("src/file{i:02}.rs"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn test_decompose_small() {
+        // 2 files: (2/3).clamp(2,8) = 2 — minimum clamp
+        let subtasks = decompose(&make_prompt(2));
+        assert_eq!(subtasks.len(), 2);
+    }
+
+    #[test]
+    fn test_decompose_medium() {
+        // 9 files: (9/3).clamp(2,8) = 3
+        let subtasks = decompose(&make_prompt(9));
+        assert_eq!(subtasks.len(), 3);
+    }
+
+    #[test]
+    fn test_decompose_large() {
+        // 24 files: (24/3).clamp(2,8) = 8
+        let subtasks = decompose(&make_prompt(24));
+        assert_eq!(subtasks.len(), 8);
+    }
+
+    #[test]
+    fn test_decompose_very_large() {
+        // 30 files: (30/3).clamp(2,8) = 8 — cap
+        let subtasks = decompose(&make_prompt(30));
+        assert_eq!(subtasks.len(), 8);
+    }
+
+    #[test]
+    fn test_decompose_covers_all_files() {
+        // 12 files: every file appears exactly once across all chunks
+        let n = 12;
+        let prompt = make_prompt(n);
+        let subtasks = decompose(&prompt);
+        let expected: Vec<String> = (0..n).map(|i| format!("src/file{i:02}.rs")).collect();
+        let mut found: Vec<String> = subtasks
+            .iter()
+            .flat_map(|s| {
+                s.prompt
+                    .split_whitespace()
+                    .filter(|t| t.ends_with(".rs") && t.starts_with("src/file"))
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        found.sort();
+        let mut sorted_expected = expected.clone();
+        sorted_expected.sort();
+        assert_eq!(found, sorted_expected);
     }
 }

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -174,14 +174,27 @@ pub struct SubtaskResult {
     pub error: Option<String>,
 }
 
-/// Run multiple agent executions concurrently, each in an isolated git worktree.
+/// Combined result returned by `run_parallel_subtasks`.
+pub struct ParallelRunResult {
+    /// Per-subtask outcomes (may be shorter than input when sequential execution
+    /// aborted early after a step failure).
+    pub results: Vec<SubtaskResult>,
+    /// True when subtasks ran serially in dependency order (numbered-list mode).
+    /// Callers must require *all* steps succeeded; `any_success` is not sufficient.
+    pub is_sequential: bool,
+}
+
+/// Run multiple agent executions, either serially (sequential deps) or concurrently
+/// (no deps), each in an isolated git worktree.
 ///
-/// Each subtask gets a derived `TaskId` of the form `{task_id}-p{index}` and its
-/// own worktree branch. Workspaces are removed after all executions finish,
-/// regardless of individual subtask outcome.
+/// **Sequential mode** (any subtask has `depends_on_indices`): subtasks execute
+/// one-at-a-time in order. The first failure aborts the remaining steps so that
+/// later steps never run without their prerequisites.
 ///
-/// Individual subtask failures are captured in `SubtaskResult::error` and do not
-/// abort the other subtasks.
+/// **Parallel mode** (no deps): subtasks execute concurrently, bounded by
+/// `MAX_PARALLEL`. Individual failures are captured and do not abort siblings.
+///
+/// Workspaces are removed after all executions finish.
 pub async fn run_parallel_subtasks(
     task_id: &TaskId,
     agent: Arc<dyn CodeAgent>,
@@ -192,7 +205,127 @@ pub async fn run_parallel_subtasks(
     base_branch: &str,
     context: Vec<ContextItem>,
     turn_timeout: Duration,
-) -> Vec<SubtaskResult> {
+) -> ParallelRunResult {
+    let is_sequential = subtasks.iter().any(|s| !s.depends_on_indices.is_empty());
+
+    if is_sequential {
+        return run_sequential_subtasks(
+            task_id,
+            agent,
+            subtasks,
+            workspace_mgr,
+            source_repo,
+            remote,
+            base_branch,
+            context,
+            turn_timeout,
+        )
+        .await;
+    }
+
+    run_concurrent_subtasks(
+        task_id,
+        agent,
+        subtasks,
+        workspace_mgr,
+        source_repo,
+        remote,
+        base_branch,
+        context,
+        turn_timeout,
+    )
+    .await
+}
+
+/// Execute subtasks one-at-a-time in order, stopping on the first failure.
+async fn run_sequential_subtasks(
+    task_id: &TaskId,
+    agent: Arc<dyn CodeAgent>,
+    subtasks: Vec<SubtaskSpec>,
+    workspace_mgr: Arc<WorkspaceManager>,
+    source_repo: &Path,
+    remote: &str,
+    base_branch: &str,
+    context: Vec<ContextItem>,
+    turn_timeout: Duration,
+) -> ParallelRunResult {
+    let total = subtasks.len();
+    let mut results = Vec::with_capacity(total);
+
+    for (i, spec) in subtasks.into_iter().enumerate() {
+        let sub_id = harness_core::types::TaskId(format!("{}-p{i}", task_id.0));
+        let outcome = match workspace_mgr
+            .create_workspace(&sub_id, source_repo, remote, base_branch)
+            .await
+        {
+            Ok(workspace) => {
+                let req = AgentRequest {
+                    prompt: spec.prompt,
+                    project_root: workspace,
+                    context: context.clone(),
+                    ..Default::default()
+                };
+                // Timeout covers only actual execution — no semaphore queue here.
+                match tokio::time::timeout(turn_timeout, agent.execute(req)).await {
+                    Ok(Ok(resp)) => Ok(resp),
+                    Ok(Err(e)) => Err(format!("agent error: {e}")),
+                    Err(_) => Err(format!(
+                        "subtask timed out after {}s",
+                        turn_timeout.as_secs()
+                    )),
+                }
+            }
+            Err(e) => {
+                tracing::warn!("parallel_dispatch: workspace creation failed for subtask {i}: {e}");
+                Err(format!("workspace creation failed: {e}"))
+            }
+        };
+
+        // Workspace cleanup happens immediately after each step.
+        if let Err(e) = workspace_mgr.remove_workspace(&sub_id).await {
+            tracing::warn!("parallel_dispatch: workspace cleanup failed for {sub_id:?}: {e}");
+        }
+
+        let (response, error) = match outcome {
+            Ok(resp) => (Some(resp), None),
+            Err(e) => {
+                tracing::warn!(
+                    "sequential subtask {i} failed: {e}; aborting remaining {} step(s)",
+                    total - i - 1
+                );
+                (None, Some(e))
+            }
+        };
+        let failed = response.is_none();
+        results.push(SubtaskResult {
+            index: i,
+            response,
+            error,
+        });
+
+        if failed {
+            break;
+        }
+    }
+
+    ParallelRunResult {
+        results,
+        is_sequential: true,
+    }
+}
+
+/// Execute subtasks concurrently, bounded by `MAX_PARALLEL`.
+async fn run_concurrent_subtasks(
+    task_id: &TaskId,
+    agent: Arc<dyn CodeAgent>,
+    subtasks: Vec<SubtaskSpec>,
+    workspace_mgr: Arc<WorkspaceManager>,
+    source_repo: &Path,
+    remote: &str,
+    base_branch: &str,
+    context: Vec<ContextItem>,
+    turn_timeout: Duration,
+) -> ParallelRunResult {
     let count = subtasks.len();
     let mut handles: Vec<tokio::task::JoinHandle<(usize, Result<AgentResponse, String>)>> =
         Vec::with_capacity(count);
@@ -217,23 +350,19 @@ pub async fn run_parallel_subtasks(
                 };
                 let sem = Arc::clone(&sem);
                 handles.push(tokio::spawn(async move {
-                    // Timeout covers both semaphore queue wait and execution so that
-                    // a task cannot be stuck waiting unbounded before it even starts.
-                    let timed = tokio::time::timeout(turn_timeout, async move {
-                        let _permit = match sem.acquire_owned().await {
-                            Ok(p) => p,
-                            Err(_) => return Err("semaphore closed unexpectedly".to_string()),
-                        };
-                        match agent.execute(req).await {
-                            Ok(resp) => Ok(resp),
-                            Err(e) => Err(format!("agent error: {e}")),
-                        }
-                    })
-                    .await;
-                    let result = match timed {
-                        Ok(r) => r,
+                    // Acquire semaphore first (unbounded wait), then apply timeout
+                    // only to the actual agent execution — subtasks beyond the first
+                    // MAX_PARALLEL do not time out while waiting in the queue.
+                    let _permit = match sem.acquire_owned().await {
+                        Ok(p) => p,
+                        Err(_) => return (i, Err("semaphore closed unexpectedly".to_string())),
+                    };
+                    let result = match tokio::time::timeout(turn_timeout, agent.execute(req)).await
+                    {
+                        Ok(Ok(resp)) => Ok(resp),
+                        Ok(Err(e)) => Err(format!("agent error: {e}")),
                         Err(_) => Err(format!(
-                            "subtask timed out after {}s (including queue wait)",
+                            "subtask timed out after {}s",
                             turn_timeout.as_secs()
                         )),
                     };
@@ -284,7 +413,10 @@ pub async fn run_parallel_subtasks(
         }
     }
 
-    results
+    ParallelRunResult {
+        results,
+        is_sequential: false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -238,6 +238,16 @@ pub async fn run_parallel_subtasks(
 }
 
 /// Execute subtasks one-at-a-time in order, stopping on the first failure.
+///
+/// All steps share a **single workspace** so that step N can observe the
+/// filesystem outputs of step N-1 (written files, applied patches, etc.).
+/// Creating a fresh workspace per step would give each step a clean clone of
+/// `source_repo`/`base_branch`, making the dependency chain meaningless.
+///
+/// Each `agent.execute` call is spawned into its own `tokio::task` so that a
+/// panic inside the agent surfaces as a `JoinError` rather than unwinding
+/// through this function — which would bypass the workspace cleanup and leave
+/// the task in an inconsistent in-progress state.
 async fn run_sequential_subtasks(
     task_id: &TaskId,
     agent: Arc<dyn CodeAgent>,
@@ -252,39 +262,46 @@ async fn run_sequential_subtasks(
     let total = subtasks.len();
     let mut results = Vec::with_capacity(total);
 
-    for (i, spec) in subtasks.into_iter().enumerate() {
-        let sub_id = harness_core::types::TaskId(format!("{}-p{i}", task_id.0));
-        let outcome = match workspace_mgr
-            .create_workspace(&sub_id, source_repo, remote, base_branch)
-            .await
-        {
-            Ok(workspace) => {
-                let req = AgentRequest {
-                    prompt: spec.prompt,
-                    project_root: workspace,
-                    context: context.clone(),
-                    ..Default::default()
-                };
-                // Timeout covers only actual execution — no semaphore queue here.
-                match tokio::time::timeout(turn_timeout, agent.execute(req)).await {
-                    Ok(Ok(resp)) => Ok(resp),
-                    Ok(Err(e)) => Err(format!("agent error: {e}")),
-                    Err(_) => Err(format!(
-                        "subtask timed out after {}s",
-                        turn_timeout.as_secs()
-                    )),
-                }
-            }
-            Err(e) => {
-                tracing::warn!("parallel_dispatch: workspace creation failed for subtask {i}: {e}");
-                Err(format!("workspace creation failed: {e}"))
-            }
-        };
-
-        // Workspace cleanup happens immediately after each step.
-        if let Err(e) = workspace_mgr.remove_workspace(&sub_id).await {
-            tracing::warn!("parallel_dispatch: workspace cleanup failed for {sub_id:?}: {e}");
+    // One shared workspace for all sequential steps — step N sees step N-1 outputs.
+    let seq_id = harness_core::types::TaskId(format!("{}-seq", task_id.0));
+    let workspace = match workspace_mgr
+        .create_workspace(&seq_id, source_repo, remote, base_branch)
+        .await
+    {
+        Ok(ws) => ws,
+        Err(e) => {
+            tracing::warn!("parallel_dispatch: workspace creation failed for sequential run: {e}");
+            return ParallelRunResult {
+                results: vec![SubtaskResult {
+                    index: 0,
+                    response: None,
+                    error: Some(format!("workspace creation failed: {e}")),
+                }],
+                is_sequential: true,
+            };
         }
+    };
+
+    for (i, spec) in subtasks.into_iter().enumerate() {
+        let req = AgentRequest {
+            prompt: spec.prompt,
+            project_root: workspace.clone(),
+            context: context.clone(),
+            ..Default::default()
+        };
+        // Spawn into a task so a panic in agent.execute surfaces as JoinError
+        // instead of unwinding through this function and skipping cleanup.
+        let agent_clone = agent.clone();
+        let handle = tokio::spawn(async move { agent_clone.execute(req).await });
+        let outcome = match tokio::time::timeout(turn_timeout, handle).await {
+            Ok(Ok(Ok(resp))) => Ok(resp),
+            Ok(Ok(Err(e))) => Err(format!("agent error: {e}")),
+            Ok(Err(join_err)) => Err(format!("subtask panicked: {join_err}")),
+            Err(_) => Err(format!(
+                "subtask timed out after {}s",
+                turn_timeout.as_secs()
+            )),
+        };
 
         let (response, error) = match outcome {
             Ok(resp) => (Some(resp), None),
@@ -306,6 +323,11 @@ async fn run_sequential_subtasks(
         if failed {
             break;
         }
+    }
+
+    // Workspace is cleaned up once after all steps complete (or on early abort).
+    if let Err(e) = workspace_mgr.remove_workspace(&seq_id).await {
+        tracing::warn!("parallel_dispatch: workspace cleanup failed for {seq_id:?}: {e}");
     }
 
     ParallelRunResult {

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -113,6 +113,16 @@ pub fn decompose(prompt: &str) -> Vec<SubtaskSpec> {
             .collect();
         if items.len() >= 2 {
             // Cap sequential subtasks to prevent unbounded semaphore queue depth.
+            if items.len() > MAX_PARALLEL {
+                tracing::warn!(
+                    "parallel_dispatch: numbered-list prompt has {} steps but MAX_PARALLEL={}: \
+                     steps {} through {} will NOT be executed",
+                    items.len(),
+                    MAX_PARALLEL,
+                    MAX_PARALLEL + 1,
+                    items.len()
+                );
+            }
             let items: Vec<&str> = items.into_iter().take(MAX_PARALLEL).collect();
             return items
                 .iter()

--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -311,15 +311,26 @@ async fn run_sequential_subtasks(
         // dropping a JoinHandle merely detaches the child; the agent would keep
         // running and writing to the shared workspace after cancellation.
         let agent_clone = agent.clone();
-        let handle = tokio::spawn(async move { agent_clone.execute(req).await });
+        let mut handle = tokio::spawn(async move { agent_clone.execute(req).await });
         let _abort_guard = AbortOnDrop(handle.abort_handle());
-        let outcome = match tokio::time::timeout(turn_timeout, handle).await {
+        let outcome = match tokio::time::timeout(turn_timeout, &mut handle).await {
             Ok(Ok(Ok(resp))) => Ok(resp),
             Ok(Ok(Err(e))) => Err(format!("agent error: {e}")),
             Ok(Err(join_err)) => Err(format!("subtask panicked: {join_err}")),
             Err(_) => {
-                // _abort_guard is dropped at end of scope and aborts the task;
-                // the explicit Err here records the timeout reason.
+                // Abort and await the task so it is fully stopped before
+                // workspace cleanup begins.  Tokio abort() is asynchronous —
+                // the task can still run until its next yield point — so
+                // awaiting guarantees no background mutations occur after
+                // remove_workspace is called.
+                handle.abort();
+                if let Err(e) = handle.await {
+                    if !e.is_cancelled() {
+                        tracing::warn!(
+                            "sequential subtask {i} did not exit cleanly after abort: {e}"
+                        );
+                    }
+                }
                 Err(format!(
                     "subtask timed out after {}s",
                     turn_timeout.as_secs()

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1484,8 +1484,20 @@ where
         let is_non_decomposable_source = is_non_decomposable_prompt_source(req.source.as_deref());
         if req.issue.is_none() && req.pr.is_none() && is_complex && !is_non_decomposable_source {
             if let Some(ref wmgr) = workspace_mgr {
-                let mut subtask_specs =
-                    crate::parallel_dispatch::decompose(req.prompt.as_deref().unwrap_or_default());
+                let mut subtask_specs = match crate::parallel_dispatch::decompose(
+                    req.prompt.as_deref().unwrap_or_default(),
+                ) {
+                    Ok(specs) => specs,
+                    Err(msg) => {
+                        tracing::warn!(task_id = %id.0, "parallel_dispatch rejected: {}", msg);
+                        mutate_and_persist(&store, &id, |s| {
+                            s.status = TaskStatus::Failed;
+                            s.error = Some(msg);
+                        })
+                        .await?;
+                        return Ok(());
+                    }
+                };
                 if subtask_specs.len() > 1 {
                     // Prepend sibling-awareness context to each subtask prompt so parallel
                     // agents know what other top-level tasks are running on the same project.

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1557,13 +1557,10 @@ where
                     )
                     .await;
 
-                    // Sequential (numbered-list) tasks require every step to succeed;
-                    // parallel (file-partitioned) tasks tolerate partial success.
-                    let succeeded = if run_result.is_sequential {
-                        run_result.results.iter().all(|r| r.response.is_some())
-                    } else {
-                        run_result.results.iter().any(|r| r.response.is_some())
-                    };
+                    // Both sequential and parallel tasks require ALL subtasks to succeed.
+                    // With up to MAX_PARALLEL (8) chunks, any() would mark Done on 1/8
+                    // success, silently dropping failed work.
+                    let succeeded = run_result.results.iter().all(|r| r.response.is_some());
                     mutate_and_persist(&store, &id, |s| {
                         for r in &run_result.results {
                             let detail = if let Some(ref resp) = r.response {
@@ -1589,11 +1586,23 @@ where
                         if succeeded {
                             s.status = TaskStatus::Done;
                         } else {
+                            let failed_count = run_result
+                                .results
+                                .iter()
+                                .filter(|r| r.response.is_none())
+                                .count();
+                            let total_count = run_result.results.len();
                             s.status = TaskStatus::Failed;
                             s.error = Some(if run_result.is_sequential {
-                                "one or more sequential subtasks failed; remaining steps were skipped".to_string()
+                                format!(
+                                    "{}/{} sequential subtasks failed; remaining steps were skipped",
+                                    failed_count, total_count
+                                )
                             } else {
-                                "all parallel subtasks failed".to_string()
+                                format!(
+                                    "{}/{} parallel subtasks failed",
+                                    failed_count, total_count
+                                )
                             });
                         }
                     })

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1544,7 +1544,7 @@ where
                     .await;
 
                     let turn_timeout = effective_turn_timeout(req.turn_timeout_secs);
-                    let results = crate::parallel_dispatch::run_parallel_subtasks(
+                    let run_result = crate::parallel_dispatch::run_parallel_subtasks(
                         &id,
                         agent.clone(),
                         subtask_specs,
@@ -1557,9 +1557,15 @@ where
                     )
                     .await;
 
-                    let any_success = results.iter().any(|r| r.response.is_some());
+                    // Sequential (numbered-list) tasks require every step to succeed;
+                    // parallel (file-partitioned) tasks tolerate partial success.
+                    let succeeded = if run_result.is_sequential {
+                        run_result.results.iter().all(|r| r.response.is_some())
+                    } else {
+                        run_result.results.iter().any(|r| r.response.is_some())
+                    };
                     mutate_and_persist(&store, &id, |s| {
-                        for r in &results {
+                        for r in &run_result.results {
                             let detail = if let Some(ref resp) = r.response {
                                 if resp.output.is_empty() {
                                     None
@@ -1580,11 +1586,15 @@ where
                                 detail,
                             });
                         }
-                        if any_success {
+                        if succeeded {
                             s.status = TaskStatus::Done;
                         } else {
                             s.status = TaskStatus::Failed;
-                            s.error = Some("all parallel subtasks failed".to_string());
+                            s.error = Some(if run_result.is_sequential {
+                                "one or more sequential subtasks failed; remaining steps were skipped".to_string()
+                            } else {
+                                "all parallel subtasks failed".to_string()
+                            });
                         }
                     })
                     .await?;

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -271,14 +271,21 @@ impl WorkspaceManager {
                 Some(n) => n.to_string(),
                 None => continue,
             };
-            // Match both the exact task ID and any sub-workspace derived from it
-            // (e.g. `{task}-seq` for sequential runs, `{task}-p*` for parallel chunks).
-            // Without prefix matching, a crash between workspace creation and
-            // remove_workspace leaves `{task}-seq` / `{task}-p*` directories that the
-            // orphan sweep can never discover or clean up.
-            let is_terminal = terminal_dirs
-                .iter()
-                .any(|td| dir_name == *td || dir_name.starts_with(&format!("{td}-")));
+            // Match the exact task ID or a known derived sub-workspace suffix:
+            //   `{task}-seq`   — sequential run workspace
+            //   `{task}-p{N}`  — parallel chunk workspace (N = decimal digits only)
+            // A broad `starts_with("{td}-")` would also match unrelated workspaces
+            // like `task-42-hotfix`, incorrectly deleting them when `task-42` is
+            // terminal.  Restricting to the two known suffixes prevents false positives.
+            let is_terminal = terminal_dirs.iter().any(|td| {
+                dir_name == *td
+                    || dir_name == format!("{td}-seq")
+                    || dir_name
+                        .strip_prefix(&format!("{td}-p"))
+                        .map_or(false, |rest| {
+                            !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+                        })
+            });
             if !is_terminal {
                 continue;
             }

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -282,7 +282,7 @@ impl WorkspaceManager {
                     || dir_name == format!("{td}-seq")
                     || dir_name
                         .strip_prefix(&format!("{td}-p"))
-                        .map_or(false, |rest| {
+                        .is_some_and(|rest| {
                             !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
                         })
             });

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -271,7 +271,15 @@ impl WorkspaceManager {
                 Some(n) => n.to_string(),
                 None => continue,
             };
-            if !terminal_dirs.contains(&dir_name) {
+            // Match both the exact task ID and any sub-workspace derived from it
+            // (e.g. `{task}-seq` for sequential runs, `{task}-p*` for parallel chunks).
+            // Without prefix matching, a crash between workspace creation and
+            // remove_workspace leaves `{task}-seq` / `{task}-p*` directories that the
+            // orphan sweep can never discover or clean up.
+            let is_terminal = terminal_dirs
+                .iter()
+                .any(|td| dir_name == *td || dir_name.starts_with(&format!("{td}-")));
+            if !is_terminal {
                 continue;
             }
             if self.active.iter().any(|e| e.workspace_path == path) {


### PR DESCRIPTION
## Summary

- Replace hardcoded `div_ceil(2)` with `(files.len() / 3).clamp(2, MAX_PARALLEL)` so `decompose()` produces proportional chunk counts: 9 files → 3 chunks, 24 files → 8 chunks (capped)
- Add `const MAX_PARALLEL: usize = 8` shared by both `decompose` and `run_parallel_subtasks`
- Add `Semaphore(MAX_PARALLEL)` in `run_parallel_subtasks` to bound concurrent agent executions and prevent resource exhaustion
- Add 5 new unit tests: `test_decompose_small`, `test_decompose_medium`, `test_decompose_large`, `test_decompose_very_large`, `test_decompose_covers_all_files`

Note: `--max-parallel` CLI flag to override `MAX_PARALLEL` is deferred to a follow-up issue.

Closes #638

## Test plan

- [ ] `cargo test -p harness-server --lib` — all 641 tests pass
- [ ] `test_decompose_medium`: 9 files → 3 chunks
- [ ] `test_decompose_large`: 24 files → 8 chunks
- [ ] `test_decompose_very_large`: 30 files → 8 chunks (cap enforced)
- [ ] `test_decompose_covers_all_files`: every file appears exactly once across chunks
- [ ] Existing tests unchanged (4-file and 6-file prompts still → 2 chunks, matching clamp floor)