### PR TITLE
feat(quality): wire challenger-agent LLM judge into QualityTrigger (#637)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1275,6 +1275,7 @@ dependencies = [
  "harness-protocol",
  "harness-rules",
  "harness-skills",
+ "harness-workflow",
  "hmac",
  "http-body-util",
  "reqwest",
@@ -1297,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,6 +1308,28 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "harness-workflow"
+version = "0.6.33"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "futures",
+ "harness-core",
+ "harness-exec",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]
@@ -2489,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3937,7 +3960,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3954,7 +3977,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1275,7 +1275,6 @@ dependencies = [
  "harness-protocol",
  "harness-rules",
  "harness-skills",
- "harness-workflow",
  "hmac",
  "http-body-util",
  "reqwest",
@@ -1298,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.33"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1308,28 +1307,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "harness-workflow"
-version = "0.6.33"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dashmap",
- "futures",
- "harness-core",
- "harness-exec",
- "serde",
- "serde_json",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/harness-observe/src/quality.rs
+++ b/crates/harness-observe/src/quality.rs
@@ -7,6 +7,9 @@ pub struct QualityReport {
     pub grade: Grade,
     pub dimensions: QualityDimensions,
     pub recommended_gc_interval: std::time::Duration,
+    /// Semantic verdict from challenger-agent cross-review.
+    /// "APPROVED" | "NOT_CONVERGED" | None (cross-review not run)
+    pub semantic_verdict: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +68,7 @@ impl QualityGrader {
                 performance,
             },
             recommended_gc_interval: grade.recommended_gc_interval(),
+            semantic_verdict: None,
         }
     }
 }

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -35,10 +35,11 @@ pub async fn cross_review(
     let challenger = state.core.server.agent_registry.get("codex");
     let rounds = max_rounds.unwrap_or(DEFAULT_MAX_ROUNDS);
 
-    let result = match run_cross_review(primary, challenger, project_root, target, rounds).await {
-        Ok(r) => r,
-        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
-    };
+    let result =
+        match run_cross_review(primary, challenger, project_root, target, rounds, None).await {
+            Ok(r) => r,
+            Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+        };
 
     match serde_json::to_value(&result) {
         Ok(v) => RpcResponse::success(id, v),
@@ -54,12 +55,18 @@ pub async fn cross_review(
 /// 3. Challenger iterates up to `max_rounds - 1` times, classifying each issue as
 ///    CONFIRMED, FALSE-POSITIVE, or MISSED.
 /// 4. Returns APPROVED when no consensus issues remain; NOT_CONVERGED after max rounds.
+///
+/// `allowed_tools` controls agent execution permissions:
+/// - `None`        → Full profile (`--dangerously-skip-permissions`). Use for interactive calls.
+/// - `Some(tools)` → Restricted to the listed tools. Pass `Some(vec![])` to deny all tools
+///   (read-only text review where all content is in the prompt).
 pub async fn run_cross_review(
     primary: Arc<dyn CodeAgent>,
     challenger: Option<Arc<dyn CodeAgent>>,
     project_root: PathBuf,
     target: String,
     max_rounds: u32,
+    allowed_tools: Option<Vec<String>>,
 ) -> Result<CrossReviewResult, String> {
     let safe_target = harness_core::prompts::wrap_external_data(&target);
     let primary_prompt = format!(
@@ -72,6 +79,7 @@ pub async fn run_cross_review(
         .execute(AgentRequest {
             prompt: primary_prompt,
             project_root: project_root.clone(),
+            allowed_tools: allowed_tools.clone(),
             ..Default::default()
         })
         .await
@@ -129,6 +137,7 @@ pub async fn run_cross_review(
             .execute(AgentRequest {
                 prompt: challenge_prompt,
                 project_root: project_root.clone(),
+                allowed_tools: allowed_tools.clone(),
                 ..Default::default()
             })
             .await
@@ -302,6 +311,7 @@ mod tests {
             proj.path().to_path_buf(),
             "fn foo() {}".to_string(),
             3,
+            None,
         )
         .await
         .expect("run_cross_review should succeed");
@@ -321,6 +331,7 @@ mod tests {
             proj.path().to_path_buf(),
             "fn foo() {}".to_string(),
             3,
+            None,
         )
         .await
         .expect("single-agent should succeed");
@@ -343,6 +354,7 @@ mod tests {
             proj.path().to_path_buf(),
             "fn foo() {}".to_string(),
             3,
+            None,
         )
         .await
         .expect("lgtm path should succeed");

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -854,16 +854,26 @@ fn build_completion_callback(
             // Grade recent events and auto-trigger GC if quality is poor.
             if let Some(qt) = quality_trigger {
                 let task_ctx = task.pr_url.as_ref().and_then(|pr| {
-                    // Use the last implementation-affecting round (implement or
-                    // agent_review_fix) with non-empty detail so the challenger
-                    // judges the final PR state, not the initial draft.
-                    let diff = task
+                    // Find the most recent implementation-affecting round.
+                    // agent_review_fix rounds always store detail: None, so if
+                    // the most recent such round is a fix round we have no
+                    // usable diff for the final PR state — skip cross-review
+                    // entirely to avoid judging stale initial-implement content
+                    // and spuriously downgrading an already-fixed PR.
+                    let last_impl_round = task
                         .rounds
                         .iter()
                         .rev()
-                        .filter(|r| r.action == "implement" || r.action == "agent_review_fix")
-                        .find_map(|r| r.detail.clone().filter(|d| !d.is_empty()))
-                        .unwrap_or_default();
+                        .find(|r| r.action == "implement" || r.action == "agent_review_fix");
+                    let diff = match last_impl_round {
+                        Some(r) if r.action == "implement" => r
+                            .detail
+                            .clone()
+                            .filter(|d| !d.is_empty())
+                            .unwrap_or_default(),
+                        // agent_review_fix (detail always None) or no round at all
+                        _ => String::new(),
+                    };
                     if diff.is_empty() {
                         None
                     } else {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -552,6 +552,38 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
 
     let quality_trigger = {
         let gc_cfg = &server.config.gc;
+        // Select a read-only challenger dynamically: find the first registered agent
+        // that (a) differs from the default primary and (b) does not advertise
+        // Write or Execute capabilities.  Hard-coding "anthropic-api" makes the gate
+        // unreachable when that agent is not registered or when it is also the
+        // configured default (which triggers the identity guard in QualityTrigger).
+        let default_name = server
+            .agent_registry
+            .resolved_default_agent_name()
+            .map(|s| s.to_owned());
+        let all_names: Vec<String> = server
+            .agent_registry
+            .list()
+            .iter()
+            .map(|&s| s.to_owned())
+            .collect();
+        let challenger = all_names.iter().find_map(|name| {
+            if Some(name.as_str()) == default_name.as_deref() {
+                return None;
+            }
+            let agent = server.agent_registry.get(name)?;
+            if agent.capabilities().iter().any(|c| {
+                matches!(
+                    c,
+                    harness_core::types::Capability::Write
+                        | harness_core::types::Capability::Execute
+                )
+            }) {
+                None
+            } else {
+                Some(agent)
+            }
+        });
         Arc::new(crate::quality_trigger::QualityTrigger::new(
             events.clone(),
             gc_agent.clone(),
@@ -559,11 +591,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             project_root.clone(),
             gc_cfg.auto_gc_grades.clone(),
             gc_cfg.auto_gc_cooldown_secs,
-            // anthropic-api has only Read capability and passes the
-            // read-only capability check in QualityTrigger.  codex/claude
-            // advertise Write|Execute and are always silently dropped,
-            // causing the single-model false-positive fallback path to run.
-            server.agent_registry.get("anthropic-api"),
+            challenger,
         ))
     };
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -859,7 +859,8 @@ fn build_completion_callback(
                         .map(|pr| crate::quality_trigger::TaskReviewContext {
                             diff: task
                                 .rounds
-                                .last()
+                                .iter()
+                                .find(|r| r.action == "implement")
                                 .and_then(|r| r.detail.clone())
                                 .unwrap_or_default(),
                             pr_description: pr.clone(),

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -854,11 +854,15 @@ fn build_completion_callback(
             // Grade recent events and auto-trigger GC if quality is poor.
             if let Some(qt) = quality_trigger {
                 let task_ctx = task.pr_url.as_ref().and_then(|pr| {
+                    // Use the last implementation-affecting round (implement or
+                    // agent_review_fix) with non-empty detail so the challenger
+                    // judges the final PR state, not the initial draft.
                     let diff = task
                         .rounds
                         .iter()
-                        .find(|r| r.action == "implement")
-                        .and_then(|r| r.detail.clone())
+                        .rev()
+                        .filter(|r| r.action == "implement" || r.action == "agent_review_fix")
+                        .find_map(|r| r.detail.clone().filter(|d| !d.is_empty()))
                         .unwrap_or_default();
                     if diff.is_empty() {
                         None

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -870,21 +870,13 @@ fn build_completion_callback(
                         .rev()
                         .find(|r| r.action == "implement" || r.action == "agent_review_fix");
                     let diff = match last_impl_round {
-                        Some(r) if r.action == "implement" => r
-                            .detail
-                            .clone()
-                            .filter(|d| {
-                                // detail is raw implement-agent output; only treat it
-                                // as a usable diff when it contains recognisable diff
-                                // markers.  Narrative/metadata text lacks these and
-                                // would produce spurious NOT_CONVERGED verdicts.
-                                !d.is_empty()
-                                    && (d.contains("diff --git")
-                                        || d.contains("\n@@")
-                                        || d.contains("\n--- a/")
-                                        || d.contains("\n+++ b/"))
-                            })
-                            .unwrap_or_default(),
+                        Some(r) if r.action == "implement" => {
+                            // Use the full implement-agent output as review context.
+                            // The implementation prompt contract requires a PR_URL line
+                            // but does not mandate unified-diff format, so accepting
+                            // any non-empty detail avoids silently dropping valid rounds.
+                            r.detail.clone().unwrap_or_default()
+                        }
                         // agent_review_fix (detail always None) or no round at all
                         _ => String::new(),
                     };

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -853,18 +853,22 @@ fn build_completion_callback(
         Box::pin(async move {
             // Grade recent events and auto-trigger GC if quality is poor.
             if let Some(qt) = quality_trigger {
-                let task_ctx =
-                    task.pr_url
-                        .as_ref()
-                        .map(|pr| crate::quality_trigger::TaskReviewContext {
-                            diff: task
-                                .rounds
-                                .iter()
-                                .find(|r| r.action == "implement")
-                                .and_then(|r| r.detail.clone())
-                                .unwrap_or_default(),
+                let task_ctx = task.pr_url.as_ref().and_then(|pr| {
+                    let diff = task
+                        .rounds
+                        .iter()
+                        .find(|r| r.action == "implement")
+                        .and_then(|r| r.detail.clone())
+                        .unwrap_or_default();
+                    if diff.is_empty() {
+                        None
+                    } else {
+                        Some(crate::quality_trigger::TaskReviewContext {
+                            diff,
                             pr_description: pr.clone(),
-                        });
+                        })
+                    }
+                });
                 qt.check_and_maybe_trigger(task_ctx.as_ref()).await;
             }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -860,7 +860,7 @@ fn build_completion_callback(
                             diff: task
                                 .rounds
                                 .last()
-                                .map(|r| r.result.clone())
+                                .and_then(|r| r.detail.clone())
                                 .unwrap_or_default(),
                             pr_description: pr.clone(),
                         });

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -559,6 +559,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             project_root.clone(),
             gc_cfg.auto_gc_grades.clone(),
             gc_cfg.auto_gc_cooldown_secs,
+            server.agent_registry.get("codex"),
         ))
     };
 
@@ -852,7 +853,18 @@ fn build_completion_callback(
         Box::pin(async move {
             // Grade recent events and auto-trigger GC if quality is poor.
             if let Some(qt) = quality_trigger {
-                qt.check_and_maybe_trigger().await;
+                let task_ctx =
+                    task.pr_url
+                        .as_ref()
+                        .map(|pr| crate::quality_trigger::TaskReviewContext {
+                            diff: task
+                                .rounds
+                                .last()
+                                .map(|r| r.result.clone())
+                                .unwrap_or_default(),
+                            pr_description: pr.clone(),
+                        });
+                qt.check_and_maybe_trigger(task_ctx.as_ref()).await;
             }
 
             // Auto-trigger review bot comment when task completes with a PR URL.

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -559,7 +559,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             project_root.clone(),
             gc_cfg.auto_gc_grades.clone(),
             gc_cfg.auto_gc_cooldown_secs,
-            server.agent_registry.get("codex"),
+            // anthropic-api has only Read capability and passes the
+            // read-only capability check in QualityTrigger.  codex/claude
+            // advertise Write|Execute and are always silently dropped,
+            // causing the single-model false-positive fallback path to run.
+            server.agent_registry.get("anthropic-api"),
         ))
     };
 
@@ -869,7 +873,17 @@ fn build_completion_callback(
                         Some(r) if r.action == "implement" => r
                             .detail
                             .clone()
-                            .filter(|d| !d.is_empty())
+                            .filter(|d| {
+                                // detail is raw implement-agent output; only treat it
+                                // as a usable diff when it contains recognisable diff
+                                // markers.  Narrative/metadata text lacks these and
+                                // would produce spurious NOT_CONVERGED verdicts.
+                                !d.is_empty()
+                                    && (d.contains("diff --git")
+                                        || d.contains("\n@@")
+                                        || d.contains("\n--- a/")
+                                        || d.contains("\n+++ b/"))
+                            })
                             .unwrap_or_default(),
                         // agent_review_fix (detail always None) or no round at all
                         _ => String::new(),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -67,3 +67,6 @@ mod runtime_state_store_tests;
 
 #[cfg(test)]
 mod thread_manager_tests;
+
+#[cfg(test)]
+mod quality_trigger_tests;

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -155,44 +155,51 @@ impl QualityTrigger {
                         } else {
                             Some(challenger.clone())
                         };
-                        const CROSS_REVIEW_TIMEOUT_SECS: u64 = 120;
-                        match tokio::time::timeout(
-                            std::time::Duration::from_secs(CROSS_REVIEW_TIMEOUT_SECS),
-                            run_cross_review(
-                                primary,
-                                review_challenger,
-                                self.project_root.clone(),
-                                target,
-                                2,
-                                // Deny all tools: review is text-only, agents must not
-                                // mutate the repo during this background quality gate.
-                                Some(vec![]),
-                            ),
-                        )
-                        .await
-                        {
-                            Ok(Ok(result)) => {
-                                report.semantic_verdict = Some(result.final_verdict.clone());
-                                if result.final_verdict == "NOT_CONVERGED" {
-                                    let original = report.grade;
-                                    report.grade = Self::downgrade(report.grade);
-                                    tracing::info!(
-                                        original_grade = ?original,
-                                        effective_grade = ?report.grade,
-                                        "quality_trigger: NOT_CONVERGED — grade downgraded"
+                        // Guard: skip cross-review when challenger was filtered to None
+                        // due to Write/Execute capabilities.  Calling run_cross_review
+                        // with challenger=None degrades to single-model mode where the
+                        // primary alone can produce NOT_CONVERGED, downgrading the grade
+                        // without two-party verification.
+                        if let Some(rc) = review_challenger {
+                            const CROSS_REVIEW_TIMEOUT_SECS: u64 = 120;
+                            match tokio::time::timeout(
+                                std::time::Duration::from_secs(CROSS_REVIEW_TIMEOUT_SECS),
+                                run_cross_review(
+                                    primary,
+                                    Some(rc),
+                                    self.project_root.clone(),
+                                    target,
+                                    2,
+                                    // Deny all tools: review is text-only, agents must not
+                                    // mutate the repo during this background quality gate.
+                                    Some(vec![]),
+                                ),
+                            )
+                            .await
+                            {
+                                Ok(Ok(result)) => {
+                                    report.semantic_verdict = Some(result.final_verdict.clone());
+                                    if result.final_verdict == "NOT_CONVERGED" {
+                                        let original = report.grade;
+                                        report.grade = Self::downgrade(report.grade);
+                                        tracing::info!(
+                                            original_grade = ?original,
+                                            effective_grade = ?report.grade,
+                                            "quality_trigger: NOT_CONVERGED — grade downgraded"
+                                        );
+                                    }
+                                }
+                                Ok(Err(e)) => {
+                                    tracing::warn!(
+                                        "quality_trigger: cross-review failed: {e}; using numeric grade only"
                                     );
                                 }
-                            }
-                            Ok(Err(e)) => {
-                                tracing::warn!(
-                                    "quality_trigger: cross-review failed: {e}; using numeric grade only"
-                                );
-                            }
-                            Err(_elapsed) => {
-                                tracing::warn!(
-                                    "quality_trigger: cross-review timed out after {CROSS_REVIEW_TIMEOUT_SECS}s; \
-                                     using numeric grade only"
-                                );
+                                Err(_elapsed) => {
+                                    tracing::warn!(
+                                        "quality_trigger: cross-review timed out after {CROSS_REVIEW_TIMEOUT_SECS}s; \
+                                         using numeric grade only"
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -1,3 +1,5 @@
+use crate::handlers::cross_review::run_cross_review;
+use harness_core::agent::CodeAgent;
 use harness_core::types::{EventFilters, Grade, Project};
 use harness_gc::gc_agent::GcAgent;
 use harness_observe::event_store::EventStore;
@@ -13,6 +15,12 @@ fn unix_now() -> u64 {
         .as_secs()
 }
 
+/// Task context passed to cross-review: the diff output and PR URL.
+pub struct TaskReviewContext {
+    pub diff: String,
+    pub pr_description: String,
+}
+
 /// Evaluates project quality after each task completion and triggers GC when
 /// the grade falls below a configured threshold.
 pub struct QualityTrigger {
@@ -23,6 +31,7 @@ pub struct QualityTrigger {
     auto_gc_grades: Vec<Grade>,
     cooldown_secs: u64,
     last_triggered: Arc<AtomicU64>,
+    challenger_agent: Option<Arc<dyn CodeAgent>>,
 }
 
 impl QualityTrigger {
@@ -33,6 +42,7 @@ impl QualityTrigger {
         project_root: PathBuf,
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
+        challenger_agent: Option<Arc<dyn CodeAgent>>,
     ) -> Self {
         Self {
             events,
@@ -42,6 +52,7 @@ impl QualityTrigger {
             auto_gc_grades,
             cooldown_secs,
             last_triggered: Arc::new(AtomicU64::new(0)),
+            challenger_agent,
         }
     }
 
@@ -56,8 +67,19 @@ impl QualityTrigger {
         unix_now().saturating_sub(last) >= self.cooldown_secs
     }
 
-    /// Grade recent events, log the result, and auto-trigger GC if warranted.
-    pub async fn check_and_maybe_trigger(&self) {
+    /// Downgrade a grade by one step. D stays at D (floor).
+    fn downgrade(grade: Grade) -> Grade {
+        match grade {
+            Grade::A => Grade::A, // gated before call; kept for completeness
+            Grade::B => Grade::C,
+            Grade::C => Grade::D,
+            Grade::D => Grade::D,
+        }
+    }
+
+    /// Grade recent events, run optional cross-review, log the result, and
+    /// auto-trigger GC if warranted.
+    pub async fn check_and_maybe_trigger(&self, task_ctx: Option<&TaskReviewContext>) {
         let events = match self.events.query(&EventFilters::default()).await {
             Ok(e) => e,
             Err(e) => {
@@ -66,7 +88,51 @@ impl QualityTrigger {
             }
         };
 
-        let report = QualityGrader::grade(&events, 0);
+        let mut report = QualityGrader::grade(&events, 0);
+
+        // Cross-review gate: skip if no challenger, no task context, or grade=A.
+        if let (Some(challenger), Some(ctx)) = (&self.challenger_agent, task_ctx) {
+            if report.grade != Grade::A {
+                let target = format!("PR: {}\n\nDiff summary:\n{}", ctx.pr_description, ctx.diff);
+                let primary = match self.agent_registry.default_agent() {
+                    Some(a) => a,
+                    None => {
+                        tracing::warn!(
+                            "quality_trigger: no primary agent for cross-review, skipping"
+                        );
+                        Arc::new(NoOpAgent)
+                    }
+                };
+                match run_cross_review(
+                    primary,
+                    Some(challenger.clone()),
+                    self.project_root.clone(),
+                    target,
+                    2,
+                )
+                .await
+                {
+                    Ok(result) => {
+                        report.semantic_verdict = Some(result.final_verdict.clone());
+                        if result.final_verdict == "NOT_CONVERGED" {
+                            let original = report.grade;
+                            report.grade = Self::downgrade(report.grade);
+                            tracing::info!(
+                                original_grade = ?original,
+                                effective_grade = ?report.grade,
+                                "quality_trigger: NOT_CONVERGED — grade downgraded"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "quality_trigger: cross-review failed: {e}; using numeric grade only"
+                        );
+                    }
+                }
+            }
+        }
+
         self.events
             .log_quality_grade(report.grade, report.score)
             .await;
@@ -74,6 +140,7 @@ impl QualityTrigger {
         tracing::info!(
             grade = ?report.grade,
             score = report.score,
+            semantic_verdict = ?report.semantic_verdict,
             "quality_trigger: post-task quality check"
         );
 
@@ -111,19 +178,65 @@ impl QualityTrigger {
     }
 }
 
+/// Fallback primary agent used when the registry has no default agent during
+/// cross-review. Returns an empty LGTM so the cross-review degrades gracefully.
+struct NoOpAgent;
+
+#[async_trait::async_trait]
+impl CodeAgent for NoOpAgent {
+    fn name(&self) -> &str {
+        "noop"
+    }
+    fn capabilities(&self) -> Vec<harness_core::types::Capability> {
+        vec![]
+    }
+    async fn execute(
+        &self,
+        _req: harness_core::agent::AgentRequest,
+    ) -> harness_core::error::Result<harness_core::agent::AgentResponse> {
+        Ok(harness_core::agent::AgentResponse {
+            output: "LGTM".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: harness_core::types::TokenUsage::default(),
+            model: "noop".to_string(),
+            exit_code: Some(0),
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _req: harness_core::agent::AgentRequest,
+        _tx: tokio::sync::mpsc::Sender<harness_core::agent::StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::types::{Decision, Event, Grade, SessionId};
+    use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
+    use harness_core::error::Result as HarnessResult;
+    use harness_core::types::{Capability, Decision, Event, Grade, SessionId, TokenUsage};
     use harness_gc::draft_store::DraftStore;
     use harness_gc::gc_agent::GcAgent;
     use harness_gc::signal_detector::SignalDetector;
     use std::path::Path;
+    use tokio::sync::mpsc::Sender;
 
     async fn make_trigger(
         dir: &Path,
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
+    ) -> QualityTrigger {
+        make_trigger_with_challenger(dir, auto_gc_grades, cooldown_secs, None).await
+    }
+
+    async fn make_trigger_with_challenger(
+        dir: &Path,
+        auto_gc_grades: Vec<Grade>,
+        cooldown_secs: u64,
+        challenger: Option<Arc<dyn CodeAgent>>,
     ) -> QualityTrigger {
         let events = Arc::new(EventStore::new(dir).await.expect("event store"));
         let gc_config = harness_core::config::misc::GcConfig::default();
@@ -146,7 +259,76 @@ mod tests {
             dir.to_path_buf(),
             auto_gc_grades,
             cooldown_secs,
+            challenger,
         )
+    }
+
+    // Mock that returns "ISSUE: foo" (primary) or "CONFIRMED: foo" (challenger) — NOT_CONVERGED
+    struct NotConvergedMock;
+
+    #[async_trait::async_trait]
+    impl CodeAgent for NotConvergedMock {
+        fn name(&self) -> &str {
+            "not-converged-mock"
+        }
+        fn capabilities(&self) -> Vec<Capability> {
+            vec![]
+        }
+        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+            Ok(AgentResponse {
+                output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
+                stderr: String::new(),
+                items: vec![],
+                token_usage: TokenUsage::default(),
+                model: "mock".to_string(),
+                exit_code: Some(0),
+            })
+        }
+        async fn execute_stream(
+            &self,
+            _req: AgentRequest,
+            _tx: Sender<StreamItem>,
+        ) -> HarnessResult<()> {
+            Ok(())
+        }
+    }
+
+    // Mock that returns LGTM — APPROVED
+    struct ApprovedMock;
+
+    #[async_trait::async_trait]
+    impl CodeAgent for ApprovedMock {
+        fn name(&self) -> &str {
+            "approved-mock"
+        }
+        fn capabilities(&self) -> Vec<Capability> {
+            vec![]
+        }
+        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+            Ok(AgentResponse {
+                output: "LGTM".to_string(),
+                stderr: String::new(),
+                items: vec![],
+                token_usage: TokenUsage::default(),
+                model: "mock".to_string(),
+                exit_code: Some(0),
+            })
+        }
+        async fn execute_stream(
+            &self,
+            _req: AgentRequest,
+            _tx: Sender<StreamItem>,
+        ) -> HarnessResult<()> {
+            Ok(())
+        }
+    }
+
+    fn block_event(hook: &str) -> Event {
+        Event::new(SessionId::new(), hook, "Edit", Decision::Block)
+    }
+
+    fn pass_event() -> Event {
+        Event::new(SessionId::new(), "pre_tool_use", "Edit", Decision::Pass)
     }
 
     // --- grade_triggers_gc mapping tests ---
@@ -243,7 +425,7 @@ mod tests {
             .await
             .unwrap();
 
-        trigger.check_and_maybe_trigger().await;
+        trigger.check_and_maybe_trigger(None).await;
 
         let events = trigger
             .events
@@ -259,5 +441,217 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .starts_with("grade="));
+    }
+
+    // --- challenger cross-review tests (6 new scenarios) ---
+
+    // Scenario 1: challenger=None, task_ctx=None → existing behavior, one quality_grade event
+    #[tokio::test]
+    async fn no_challenger_no_ctx_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+        trigger.events.log(&pass_event()).await.unwrap();
+        trigger.check_and_maybe_trigger(None).await;
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    // Scenario 2: challenger=Some, grade=A → cross-review skipped
+    #[tokio::test]
+    async fn challenger_grade_a_skips_cross_review() {
+        let dir = tempfile::tempdir().unwrap();
+        // Many pass events → grade A
+        let trigger = make_trigger_with_challenger(
+            dir.path(),
+            vec![Grade::D],
+            300,
+            Some(Arc::new(NotConvergedMock)),
+        )
+        .await;
+        for _ in 0..20 {
+            trigger.events.log(&pass_event()).await.unwrap();
+        }
+        let ctx = TaskReviewContext {
+            diff: "diff".to_string(),
+            pr_description: "https://github.com/o/r/pull/1".to_string(),
+        };
+        trigger.check_and_maybe_trigger(Some(&ctx)).await;
+        // Grade should remain A (no downgrade happened)
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let detail = events[0].detail.as_deref().unwrap_or("");
+        assert!(detail.contains("A"), "expected grade A in detail: {detail}");
+    }
+
+    // Scenario 3: challenger=Some, grade=B, verdict=APPROVED → grade stays B
+    #[tokio::test]
+    async fn challenger_grade_b_approved_stays_b() {
+        let dir = tempfile::tempdir().unwrap();
+        // Mix: many pass, a few security blocks to land on B
+        // security=70, stability=70, coverage=100, perf=100 → score=79 → B
+        let trigger = make_trigger_with_challenger(
+            dir.path(),
+            vec![Grade::D],
+            300,
+            Some(Arc::new(ApprovedMock)),
+        )
+        .await;
+        for _ in 0..7 {
+            trigger.events.log(&pass_event()).await.unwrap();
+        }
+        for _ in 0..3 {
+            trigger
+                .events
+                .log(&block_event("security_check"))
+                .await
+                .unwrap();
+        }
+        let ctx = TaskReviewContext {
+            diff: "diff".to_string(),
+            pr_description: "https://github.com/o/r/pull/1".to_string(),
+        };
+        trigger.check_and_maybe_trigger(Some(&ctx)).await;
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        // Grade must not have dropped below B (APPROVED verdict, no downgrade)
+        let detail = events[0].detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains("B") || detail.contains("A"),
+            "expected B or A in detail after APPROVED: {detail}"
+        );
+    }
+
+    // Scenario 4: challenger=Some, grade=B, verdict=NOT_CONVERGED → downgraded to C
+    #[tokio::test]
+    async fn challenger_grade_b_not_converged_downgraded_to_c() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger_with_challenger(
+            dir.path(),
+            vec![Grade::D],
+            300,
+            Some(Arc::new(NotConvergedMock)),
+        )
+        .await;
+        // security=70, stability=70, coverage=100, perf=100 → score=79 → grade B
+        for _ in 0..7 {
+            trigger.events.log(&pass_event()).await.unwrap();
+        }
+        for _ in 0..3 {
+            trigger
+                .events
+                .log(&block_event("security_check"))
+                .await
+                .unwrap();
+        }
+        let ctx = TaskReviewContext {
+            diff: "diff".to_string(),
+            pr_description: "https://github.com/o/r/pull/1".to_string(),
+        };
+        trigger.check_and_maybe_trigger(Some(&ctx)).await;
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let detail = events[0].detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains("C") || detail.contains("D"),
+            "expected downgrade to C or D after NOT_CONVERGED: {detail}"
+        );
+    }
+
+    // Scenario 5: challenger=Some, grade=C, NOT_CONVERGED → D, GC triggered (D in auto_gc_grades)
+    #[tokio::test]
+    async fn challenger_grade_c_not_converged_triggers_gc() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger_with_challenger(
+            dir.path(),
+            vec![Grade::D],
+            0, // zero cooldown so GC fires immediately
+            Some(Arc::new(NotConvergedMock)),
+        )
+        .await;
+        // security=50, stability=50, coverage=100, perf=100 → score=65 → grade C
+        for _ in 0..5 {
+            trigger.events.log(&pass_event()).await.unwrap();
+        }
+        for _ in 0..5 {
+            trigger
+                .events
+                .log(&block_event("security_check"))
+                .await
+                .unwrap();
+        }
+        let ctx = TaskReviewContext {
+            diff: "diff".to_string(),
+            pr_description: "https://github.com/o/r/pull/1".to_string(),
+        };
+        // Does not panic; grade C → D after NOT_CONVERGED; GC fires (no agent registered so
+        // the GC path logs a warning — that's acceptable in this unit test)
+        trigger.check_and_maybe_trigger(Some(&ctx)).await;
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let detail = events[0].detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains("C") || detail.contains("D"),
+            "expected C or D after NOT_CONVERGED on C input: {detail}"
+        );
+    }
+
+    // Scenario 6: task_ctx=None, challenger=Some → cross-review skipped, numeric grade only
+    #[tokio::test]
+    async fn challenger_no_ctx_skips_cross_review() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = make_trigger_with_challenger(
+            dir.path(),
+            vec![Grade::D],
+            300,
+            Some(Arc::new(NotConvergedMock)),
+        )
+        .await;
+        trigger.events.log(&pass_event()).await.unwrap();
+        // No ctx → cross-review skipped despite challenger being present
+        trigger.check_and_maybe_trigger(None).await;
+        let events = trigger
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("quality_grade".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
     }
 }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -1,6 +1,6 @@
 use crate::handlers::cross_review::run_cross_review;
 use harness_core::agent::CodeAgent;
-use harness_core::types::{EventFilters, Grade, Project};
+use harness_core::types::{Capability, EventFilters, Grade, Project};
 use harness_gc::gc_agent::GcAgent;
 use harness_observe::event_store::EventStore;
 use harness_observe::quality::QualityGrader;
@@ -120,12 +120,32 @@ impl QualityTrigger {
                              skipping cross-review to preserve independence"
                         );
                     } else {
+                        // Only allow the challenger when its capabilities are
+                        // read-only.  Agents that advertise Write or Execute
+                        // capabilities (e.g. CodexAgent) do not honour
+                        // allowed_tools and will run with their configured
+                        // sandbox, potentially mutating the workspace.
+                        let review_challenger = if challenger
+                            .capabilities()
+                            .iter()
+                            .any(|c| matches!(c, Capability::Write | Capability::Execute))
+                        {
+                            tracing::warn!(
+                                agent = challenger.name(),
+                                "quality_trigger: challenger has Write/Execute capabilities \
+                                 and does not honour allowed_tools; skipping as \
+                                 cross-review challenger to prevent workspace mutation"
+                            );
+                            None
+                        } else {
+                            Some(challenger.clone())
+                        };
                         const CROSS_REVIEW_TIMEOUT_SECS: u64 = 120;
                         match tokio::time::timeout(
                             std::time::Duration::from_secs(CROSS_REVIEW_TIMEOUT_SECS),
                             run_cross_review(
                                 primary,
-                                Some(challenger.clone()),
+                                review_challenger,
                                 self.project_root.clone(),
                                 target,
                                 2,

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-fn unix_now() -> u64 {
+pub(crate) fn unix_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -24,13 +24,13 @@ pub struct TaskReviewContext {
 /// Evaluates project quality after each task completion and triggers GC when
 /// the grade falls below a configured threshold.
 pub struct QualityTrigger {
-    events: Arc<EventStore>,
+    pub(crate) events: Arc<EventStore>,
     gc_agent: Arc<GcAgent>,
     agent_registry: Arc<harness_agents::registry::AgentRegistry>,
     project_root: PathBuf,
     auto_gc_grades: Vec<Grade>,
     cooldown_secs: u64,
-    last_triggered: Arc<AtomicU64>,
+    pub(crate) last_triggered: Arc<AtomicU64>,
     challenger_agent: Option<Arc<dyn CodeAgent>>,
 }
 
@@ -62,7 +62,7 @@ impl QualityTrigger {
     }
 
     /// Returns true if the cooldown period has elapsed since the last trigger.
-    fn cooldown_elapsed(&self) -> bool {
+    pub(crate) fn cooldown_elapsed(&self) -> bool {
         let last = self.last_triggered.load(Ordering::Relaxed);
         unix_now().saturating_sub(last) >= self.cooldown_secs
     }
@@ -118,6 +118,21 @@ impl QualityTrigger {
                             agent = primary.name(),
                             "quality_trigger: primary and challenger are the same agent; \
                              skipping cross-review to preserve independence"
+                        );
+                    } else if primary
+                        .capabilities()
+                        .iter()
+                        .any(|c| matches!(c, Capability::Write | Capability::Execute))
+                    {
+                        // Guard the primary as well: agents that advertise Write or
+                        // Execute capabilities (e.g. CodexAgent) ignore allowed_tools
+                        // and run with their configured sandbox, potentially mutating
+                        // the workspace during this background quality gate.
+                        tracing::warn!(
+                            agent = primary.name(),
+                            "quality_trigger: primary agent has Write/Execute capabilities \
+                             and does not honour allowed_tools; skipping cross-review \
+                             to prevent workspace mutation"
                         );
                     } else {
                         // Only allow the challenger when its capabilities are
@@ -229,490 +244,5 @@ impl QualityTrigger {
         {
             tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
-    use harness_core::error::Result as HarnessResult;
-    use harness_core::types::{Capability, Decision, Event, Grade, SessionId, TokenUsage};
-    use harness_gc::draft_store::DraftStore;
-    use harness_gc::gc_agent::GcAgent;
-    use harness_gc::signal_detector::SignalDetector;
-    use std::path::Path;
-    use tokio::sync::mpsc::Sender;
-
-    async fn make_trigger(
-        dir: &Path,
-        auto_gc_grades: Vec<Grade>,
-        cooldown_secs: u64,
-    ) -> QualityTrigger {
-        make_trigger_with_challenger(dir, auto_gc_grades, cooldown_secs, None, None).await
-    }
-
-    async fn make_trigger_with_challenger(
-        dir: &Path,
-        auto_gc_grades: Vec<Grade>,
-        cooldown_secs: u64,
-        primary: Option<Arc<dyn CodeAgent>>,
-        challenger: Option<Arc<dyn CodeAgent>>,
-    ) -> QualityTrigger {
-        let events = Arc::new(EventStore::new(dir).await.expect("event store"));
-        let gc_config = harness_core::config::misc::GcConfig::default();
-        let signal_detector = SignalDetector::new(
-            gc_config.signal_thresholds.clone().into(),
-            harness_core::types::ProjectId::new(),
-        );
-        let draft_store = DraftStore::new(dir).expect("draft store");
-        let gc_agent = Arc::new(GcAgent::new(
-            gc_config,
-            signal_detector,
-            draft_store,
-            dir.to_path_buf(),
-        ));
-        let mut registry = harness_agents::registry::AgentRegistry::new("test");
-        if let Some(p) = primary {
-            registry.register("test", p);
-        }
-        let agent_registry = Arc::new(registry);
-        QualityTrigger::new(
-            events,
-            gc_agent,
-            agent_registry,
-            dir.to_path_buf(),
-            auto_gc_grades,
-            cooldown_secs,
-            challenger,
-        )
-    }
-
-    // Mock that returns "ISSUE: foo\nCONFIRMED: foo" — used as primary in NOT_CONVERGED tests.
-    // Has a distinct name from NotConvergedMock so the identity guard does not skip cross-review.
-    struct NotConvergedPrimaryMock;
-
-    #[async_trait::async_trait]
-    impl CodeAgent for NotConvergedPrimaryMock {
-        fn name(&self) -> &str {
-            "not-converged-primary"
-        }
-        fn capabilities(&self) -> Vec<Capability> {
-            vec![]
-        }
-        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
-            Ok(AgentResponse {
-                output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
-                stderr: String::new(),
-                items: vec![],
-                token_usage: TokenUsage::default(),
-                model: "mock".to_string(),
-                exit_code: Some(0),
-            })
-        }
-        async fn execute_stream(
-            &self,
-            _req: AgentRequest,
-            _tx: Sender<StreamItem>,
-        ) -> HarnessResult<()> {
-            Ok(())
-        }
-    }
-
-    // Mock that returns "ISSUE: foo" (primary) or "CONFIRMED: foo" (challenger) — NOT_CONVERGED
-    struct NotConvergedMock;
-
-    #[async_trait::async_trait]
-    impl CodeAgent for NotConvergedMock {
-        fn name(&self) -> &str {
-            "not-converged-mock"
-        }
-        fn capabilities(&self) -> Vec<Capability> {
-            vec![]
-        }
-        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
-            Ok(AgentResponse {
-                output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
-                stderr: String::new(),
-                items: vec![],
-                token_usage: TokenUsage::default(),
-                model: "mock".to_string(),
-                exit_code: Some(0),
-            })
-        }
-        async fn execute_stream(
-            &self,
-            _req: AgentRequest,
-            _tx: Sender<StreamItem>,
-        ) -> HarnessResult<()> {
-            Ok(())
-        }
-    }
-
-    // Mock that returns LGTM — APPROVED
-    struct ApprovedMock;
-
-    #[async_trait::async_trait]
-    impl CodeAgent for ApprovedMock {
-        fn name(&self) -> &str {
-            "approved-mock"
-        }
-        fn capabilities(&self) -> Vec<Capability> {
-            vec![]
-        }
-        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
-            Ok(AgentResponse {
-                output: "LGTM".to_string(),
-                stderr: String::new(),
-                items: vec![],
-                token_usage: TokenUsage::default(),
-                model: "mock".to_string(),
-                exit_code: Some(0),
-            })
-        }
-        async fn execute_stream(
-            &self,
-            _req: AgentRequest,
-            _tx: Sender<StreamItem>,
-        ) -> HarnessResult<()> {
-            Ok(())
-        }
-    }
-
-    fn block_event(hook: &str) -> Event {
-        Event::new(SessionId::new(), hook, "Edit", Decision::Block)
-    }
-
-    fn pass_event() -> Event {
-        Event::new(SessionId::new(), "pre_tool_use", "Edit", Decision::Pass)
-    }
-
-    // --- grade_triggers_gc mapping tests ---
-
-    #[tokio::test]
-    async fn grade_d_triggers_gc_by_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        assert!(trigger.grade_triggers_gc(Grade::D));
-    }
-
-    #[tokio::test]
-    async fn grade_a_does_not_trigger_gc_by_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        assert!(!trigger.grade_triggers_gc(Grade::A));
-    }
-
-    #[tokio::test]
-    async fn grade_b_does_not_trigger_gc_by_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        assert!(!trigger.grade_triggers_gc(Grade::B));
-    }
-
-    #[tokio::test]
-    async fn grade_c_does_not_trigger_gc_by_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        assert!(!trigger.grade_triggers_gc(Grade::C));
-    }
-
-    #[tokio::test]
-    async fn configuring_c_and_d_both_trigger() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::C, Grade::D], 300).await;
-        assert!(trigger.grade_triggers_gc(Grade::C));
-        assert!(trigger.grade_triggers_gc(Grade::D));
-        assert!(!trigger.grade_triggers_gc(Grade::A));
-        assert!(!trigger.grade_triggers_gc(Grade::B));
-    }
-
-    #[tokio::test]
-    async fn empty_auto_gc_grades_never_triggers() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![], 300).await;
-        assert!(!trigger.grade_triggers_gc(Grade::A));
-        assert!(!trigger.grade_triggers_gc(Grade::B));
-        assert!(!trigger.grade_triggers_gc(Grade::C));
-        assert!(!trigger.grade_triggers_gc(Grade::D));
-    }
-
-    // --- cooldown tests ---
-
-    #[tokio::test]
-    async fn cooldown_elapsed_when_never_triggered() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        assert!(trigger.cooldown_elapsed());
-    }
-
-    #[tokio::test]
-    async fn cooldown_not_elapsed_immediately_after_trigger() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
-        assert!(!trigger.cooldown_elapsed());
-    }
-
-    #[tokio::test]
-    async fn zero_cooldown_always_elapsed() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 0).await;
-        trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
-        assert!(trigger.cooldown_elapsed());
-    }
-
-    // --- log_quality_grade integration test ---
-
-    #[tokio::test]
-    async fn check_logs_quality_grade_event() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-
-        // Seed a passing event so grade comes back as A (score ~ 100)
-        trigger
-            .events
-            .log(&Event::new(
-                SessionId::new(),
-                "pre_tool_use",
-                "Edit",
-                Decision::Pass,
-            ))
-            .await
-            .unwrap();
-
-        trigger.check_and_maybe_trigger(None).await;
-
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1, "expected exactly one quality_grade event");
-        assert!(events[0]
-            .detail
-            .as_deref()
-            .unwrap_or("")
-            .starts_with("grade="));
-    }
-
-    // --- challenger cross-review tests (6 new scenarios) ---
-
-    // Scenario 1: challenger=None, task_ctx=None → existing behavior, one quality_grade event
-    #[tokio::test]
-    async fn no_challenger_no_ctx_baseline() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
-        trigger.events.log(&pass_event()).await.unwrap();
-        trigger.check_and_maybe_trigger(None).await;
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
-    }
-
-    // Scenario 2: challenger=Some, grade=A → cross-review skipped
-    #[tokio::test]
-    async fn challenger_grade_a_skips_cross_review() {
-        let dir = tempfile::tempdir().unwrap();
-        // Many pass events → grade A
-        let trigger = make_trigger_with_challenger(
-            dir.path(),
-            vec![Grade::D],
-            300,
-            None,
-            Some(Arc::new(NotConvergedMock)),
-        )
-        .await;
-        for _ in 0..20 {
-            trigger.events.log(&pass_event()).await.unwrap();
-        }
-        let ctx = TaskReviewContext {
-            diff: "diff".to_string(),
-            pr_description: "https://github.com/o/r/pull/1".to_string(),
-        };
-        trigger.check_and_maybe_trigger(Some(&ctx)).await;
-        // Grade should remain A (no downgrade happened)
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
-        let detail = events[0].detail.as_deref().unwrap_or("");
-        assert!(detail.contains("A"), "expected grade A in detail: {detail}");
-    }
-
-    // Scenario 3: challenger=Some, grade=B, verdict=APPROVED → grade stays B
-    #[tokio::test]
-    async fn challenger_grade_b_approved_stays_b() {
-        let dir = tempfile::tempdir().unwrap();
-        // Mix: many pass, a few security blocks to land on B
-        // security=70, stability=70, coverage=100, perf=100 → score=79 → B
-        let trigger = make_trigger_with_challenger(
-            dir.path(),
-            vec![Grade::D],
-            300,
-            None,
-            Some(Arc::new(ApprovedMock)),
-        )
-        .await;
-        for _ in 0..7 {
-            trigger.events.log(&pass_event()).await.unwrap();
-        }
-        for _ in 0..3 {
-            trigger
-                .events
-                .log(&block_event("security_check"))
-                .await
-                .unwrap();
-        }
-        let ctx = TaskReviewContext {
-            diff: "diff".to_string(),
-            pr_description: "https://github.com/o/r/pull/1".to_string(),
-        };
-        trigger.check_and_maybe_trigger(Some(&ctx)).await;
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
-        // Grade must not have dropped below B (APPROVED verdict, no downgrade)
-        let detail = events[0].detail.as_deref().unwrap_or("");
-        assert!(
-            detail.contains("B") || detail.contains("A"),
-            "expected B or A in detail after APPROVED: {detail}"
-        );
-    }
-
-    // Scenario 4: challenger=Some, grade=B, verdict=NOT_CONVERGED → downgraded to C
-    #[tokio::test]
-    async fn challenger_grade_b_not_converged_downgraded_to_c() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger_with_challenger(
-            dir.path(),
-            vec![Grade::D],
-            300,
-            Some(Arc::new(NotConvergedPrimaryMock)),
-            Some(Arc::new(NotConvergedMock)),
-        )
-        .await;
-        // security=70, stability=70, coverage=100, perf=100 → score=79 → grade B
-        for _ in 0..7 {
-            trigger.events.log(&pass_event()).await.unwrap();
-        }
-        for _ in 0..3 {
-            trigger
-                .events
-                .log(&block_event("security_check"))
-                .await
-                .unwrap();
-        }
-        let ctx = TaskReviewContext {
-            diff: "diff".to_string(),
-            pr_description: "https://github.com/o/r/pull/1".to_string(),
-        };
-        trigger.check_and_maybe_trigger(Some(&ctx)).await;
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
-        let detail = events[0].detail.as_deref().unwrap_or("");
-        assert!(
-            detail.contains("C") || detail.contains("D"),
-            "expected downgrade to C or D after NOT_CONVERGED: {detail}"
-        );
-    }
-
-    // Scenario 5: challenger=Some, grade=C, NOT_CONVERGED → D, GC triggered (D in auto_gc_grades)
-    #[tokio::test]
-    async fn challenger_grade_c_not_converged_triggers_gc() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger_with_challenger(
-            dir.path(),
-            vec![Grade::D],
-            0, // zero cooldown so GC fires immediately
-            None,
-            Some(Arc::new(NotConvergedMock)),
-        )
-        .await;
-        // security=50, stability=50, coverage=100, perf=100 → score=65 → grade C
-        for _ in 0..5 {
-            trigger.events.log(&pass_event()).await.unwrap();
-        }
-        for _ in 0..5 {
-            trigger
-                .events
-                .log(&block_event("security_check"))
-                .await
-                .unwrap();
-        }
-        let ctx = TaskReviewContext {
-            diff: "diff".to_string(),
-            pr_description: "https://github.com/o/r/pull/1".to_string(),
-        };
-        // Does not panic; grade C → D after NOT_CONVERGED; GC fires (no agent registered so
-        // the GC path logs a warning — that's acceptable in this unit test)
-        trigger.check_and_maybe_trigger(Some(&ctx)).await;
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
-        let detail = events[0].detail.as_deref().unwrap_or("");
-        assert!(
-            detail.contains("C") || detail.contains("D"),
-            "expected C or D after NOT_CONVERGED on C input: {detail}"
-        );
-    }
-
-    // Scenario 6: task_ctx=None, challenger=Some → cross-review skipped, numeric grade only
-    #[tokio::test]
-    async fn challenger_no_ctx_skips_cross_review() {
-        let dir = tempfile::tempdir().unwrap();
-        let trigger = make_trigger_with_challenger(
-            dir.path(),
-            vec![Grade::D],
-            300,
-            None,
-            Some(Arc::new(NotConvergedMock)),
-        )
-        .await;
-        trigger.events.log(&pass_event()).await.unwrap();
-        // No ctx → cross-review skipped despite challenger being present
-        trigger.check_and_maybe_trigger(None).await;
-        let events = trigger
-            .events
-            .query(&harness_core::types::EventFilters {
-                hook: Some("quality_grade".to_string()),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        assert_eq!(events.len(), 1);
     }
 }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -94,9 +94,14 @@ impl QualityTrigger {
         if let (Some(challenger), Some(ctx)) = (&self.challenger_agent, task_ctx) {
             if report.grade != Grade::A {
                 // Cap diff to avoid oversized LLM requests (latency/cost spikes).
-                const MAX_DIFF_CHARS: usize = 4096;
-                let diff_excerpt = if ctx.diff.len() > MAX_DIFF_CHARS {
-                    &ctx.diff[..MAX_DIFF_CHARS]
+                // Use char-boundary-safe truncation to prevent panics on multibyte UTF-8.
+                const MAX_DIFF_BYTES: usize = 4096;
+                let diff_excerpt = if ctx.diff.len() > MAX_DIFF_BYTES {
+                    let end = (0..=MAX_DIFF_BYTES)
+                        .rev()
+                        .find(|&i| ctx.diff.is_char_boundary(i))
+                        .unwrap_or(0);
+                    &ctx.diff[..end]
                 } else {
                     &ctx.diff
                 };
@@ -115,16 +120,20 @@ impl QualityTrigger {
                              skipping cross-review to preserve independence"
                         );
                     } else {
-                        match run_cross_review(
-                            primary,
-                            Some(challenger.clone()),
-                            self.project_root.clone(),
-                            target,
-                            2,
+                        const CROSS_REVIEW_TIMEOUT_SECS: u64 = 120;
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(CROSS_REVIEW_TIMEOUT_SECS),
+                            run_cross_review(
+                                primary,
+                                Some(challenger.clone()),
+                                self.project_root.clone(),
+                                target,
+                                2,
+                            ),
                         )
                         .await
                         {
-                            Ok(result) => {
+                            Ok(Ok(result)) => {
                                 report.semantic_verdict = Some(result.final_verdict.clone());
                                 if result.final_verdict == "NOT_CONVERGED" {
                                     let original = report.grade;
@@ -136,9 +145,15 @@ impl QualityTrigger {
                                     );
                                 }
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 tracing::warn!(
                                     "quality_trigger: cross-review failed: {e}; using numeric grade only"
+                                );
+                            }
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    "quality_trigger: cross-review timed out after {CROSS_REVIEW_TIMEOUT_SECS}s; \
+                                     using numeric grade only"
                                 );
                             }
                         }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -94,41 +94,36 @@ impl QualityTrigger {
         if let (Some(challenger), Some(ctx)) = (&self.challenger_agent, task_ctx) {
             if report.grade != Grade::A {
                 let target = format!("PR: {}\n\nDiff summary:\n{}", ctx.pr_description, ctx.diff);
-                let primary = match self.agent_registry.default_agent() {
-                    Some(a) => a,
-                    None => {
-                        tracing::warn!(
-                            "quality_trigger: no primary agent for cross-review, skipping"
-                        );
-                        Arc::new(NoOpAgent)
-                    }
-                };
-                match run_cross_review(
-                    primary,
-                    Some(challenger.clone()),
-                    self.project_root.clone(),
-                    target,
-                    2,
-                )
-                .await
-                {
-                    Ok(result) => {
-                        report.semantic_verdict = Some(result.final_verdict.clone());
-                        if result.final_verdict == "NOT_CONVERGED" {
-                            let original = report.grade;
-                            report.grade = Self::downgrade(report.grade);
-                            tracing::info!(
-                                original_grade = ?original,
-                                effective_grade = ?report.grade,
-                                "quality_trigger: NOT_CONVERGED — grade downgraded"
+                if let Some(primary) = self.agent_registry.default_agent() {
+                    match run_cross_review(
+                        primary,
+                        Some(challenger.clone()),
+                        self.project_root.clone(),
+                        target,
+                        2,
+                    )
+                    .await
+                    {
+                        Ok(result) => {
+                            report.semantic_verdict = Some(result.final_verdict.clone());
+                            if result.final_verdict == "NOT_CONVERGED" {
+                                let original = report.grade;
+                                report.grade = Self::downgrade(report.grade);
+                                tracing::info!(
+                                    original_grade = ?original,
+                                    effective_grade = ?report.grade,
+                                    "quality_trigger: NOT_CONVERGED — grade downgraded"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "quality_trigger: cross-review failed: {e}; using numeric grade only"
                             );
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            "quality_trigger: cross-review failed: {e}; using numeric grade only"
-                        );
-                    }
+                } else {
+                    tracing::warn!("quality_trigger: no primary agent for cross-review, skipping");
                 }
             }
         }
@@ -178,40 +173,6 @@ impl QualityTrigger {
     }
 }
 
-/// Fallback primary agent used when the registry has no default agent during
-/// cross-review. Returns an empty LGTM so the cross-review degrades gracefully.
-struct NoOpAgent;
-
-#[async_trait::async_trait]
-impl CodeAgent for NoOpAgent {
-    fn name(&self) -> &str {
-        "noop"
-    }
-    fn capabilities(&self) -> Vec<harness_core::types::Capability> {
-        vec![]
-    }
-    async fn execute(
-        &self,
-        _req: harness_core::agent::AgentRequest,
-    ) -> harness_core::error::Result<harness_core::agent::AgentResponse> {
-        Ok(harness_core::agent::AgentResponse {
-            output: "LGTM".to_string(),
-            stderr: String::new(),
-            items: vec![],
-            token_usage: harness_core::types::TokenUsage::default(),
-            model: "noop".to_string(),
-            exit_code: Some(0),
-        })
-    }
-    async fn execute_stream(
-        &self,
-        _req: harness_core::agent::AgentRequest,
-        _tx: tokio::sync::mpsc::Sender<harness_core::agent::StreamItem>,
-    ) -> harness_core::error::Result<()> {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,13 +190,14 @@ mod tests {
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
     ) -> QualityTrigger {
-        make_trigger_with_challenger(dir, auto_gc_grades, cooldown_secs, None).await
+        make_trigger_with_challenger(dir, auto_gc_grades, cooldown_secs, None, None).await
     }
 
     async fn make_trigger_with_challenger(
         dir: &Path,
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
+        primary: Option<Arc<dyn CodeAgent>>,
         challenger: Option<Arc<dyn CodeAgent>>,
     ) -> QualityTrigger {
         let events = Arc::new(EventStore::new(dir).await.expect("event store"));
@@ -251,7 +213,11 @@ mod tests {
             draft_store,
             dir.to_path_buf(),
         ));
-        let agent_registry = Arc::new(harness_agents::registry::AgentRegistry::new("test"));
+        let mut registry = harness_agents::registry::AgentRegistry::new("test");
+        if let Some(p) = primary {
+            registry.register("test", p);
+        }
+        let agent_registry = Arc::new(registry);
         QualityTrigger::new(
             events,
             gc_agent,
@@ -472,6 +438,7 @@ mod tests {
             dir.path(),
             vec![Grade::D],
             300,
+            None,
             Some(Arc::new(NotConvergedMock)),
         )
         .await;
@@ -507,6 +474,7 @@ mod tests {
             dir.path(),
             vec![Grade::D],
             300,
+            None,
             Some(Arc::new(ApprovedMock)),
         )
         .await;
@@ -551,6 +519,7 @@ mod tests {
             vec![Grade::D],
             300,
             Some(Arc::new(NotConvergedMock)),
+            Some(Arc::new(NotConvergedMock)),
         )
         .await;
         // security=70, stability=70, coverage=100, perf=100 → score=79 → grade B
@@ -593,6 +562,7 @@ mod tests {
             dir.path(),
             vec![Grade::D],
             0, // zero cooldown so GC fires immediately
+            None,
             Some(Arc::new(NotConvergedMock)),
         )
         .await;
@@ -638,6 +608,7 @@ mod tests {
             dir.path(),
             vec![Grade::D],
             300,
+            None,
             Some(Arc::new(NotConvergedMock)),
         )
         .await;

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -93,33 +93,54 @@ impl QualityTrigger {
         // Cross-review gate: skip if no challenger, no task context, or grade=A.
         if let (Some(challenger), Some(ctx)) = (&self.challenger_agent, task_ctx) {
             if report.grade != Grade::A {
-                let target = format!("PR: {}\n\nDiff summary:\n{}", ctx.pr_description, ctx.diff);
+                // Cap diff to avoid oversized LLM requests (latency/cost spikes).
+                const MAX_DIFF_CHARS: usize = 4096;
+                let diff_excerpt = if ctx.diff.len() > MAX_DIFF_CHARS {
+                    &ctx.diff[..MAX_DIFF_CHARS]
+                } else {
+                    &ctx.diff
+                };
+                let target = format!(
+                    "PR: {}\n\nDiff summary:\n{}",
+                    ctx.pr_description, diff_excerpt
+                );
                 if let Some(primary) = self.agent_registry.default_agent() {
-                    match run_cross_review(
-                        primary,
-                        Some(challenger.clone()),
-                        self.project_root.clone(),
-                        target,
-                        2,
-                    )
-                    .await
-                    {
-                        Ok(result) => {
-                            report.semantic_verdict = Some(result.final_verdict.clone());
-                            if result.final_verdict == "NOT_CONVERGED" {
-                                let original = report.grade;
-                                report.grade = Self::downgrade(report.grade);
-                                tracing::info!(
-                                    original_grade = ?original,
-                                    effective_grade = ?report.grade,
-                                    "quality_trigger: NOT_CONVERGED — grade downgraded"
+                    // Identity guard: skip cross-review when primary and challenger are the
+                    // same agent — identical models produce correlated verdicts that cannot
+                    // serve as an independent check.
+                    if primary.name() == challenger.name() {
+                        tracing::warn!(
+                            agent = primary.name(),
+                            "quality_trigger: primary and challenger are the same agent; \
+                             skipping cross-review to preserve independence"
+                        );
+                    } else {
+                        match run_cross_review(
+                            primary,
+                            Some(challenger.clone()),
+                            self.project_root.clone(),
+                            target,
+                            2,
+                        )
+                        .await
+                        {
+                            Ok(result) => {
+                                report.semantic_verdict = Some(result.final_verdict.clone());
+                                if result.final_verdict == "NOT_CONVERGED" {
+                                    let original = report.grade;
+                                    report.grade = Self::downgrade(report.grade);
+                                    tracing::info!(
+                                        original_grade = ?original,
+                                        effective_grade = ?report.grade,
+                                        "quality_trigger: NOT_CONVERGED — grade downgraded"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "quality_trigger: cross-review failed: {e}; using numeric grade only"
                                 );
                             }
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "quality_trigger: cross-review failed: {e}; using numeric grade only"
-                            );
                         }
                     }
                 } else {
@@ -227,6 +248,37 @@ mod tests {
             cooldown_secs,
             challenger,
         )
+    }
+
+    // Mock that returns "ISSUE: foo\nCONFIRMED: foo" — used as primary in NOT_CONVERGED tests.
+    // Has a distinct name from NotConvergedMock so the identity guard does not skip cross-review.
+    struct NotConvergedPrimaryMock;
+
+    #[async_trait::async_trait]
+    impl CodeAgent for NotConvergedPrimaryMock {
+        fn name(&self) -> &str {
+            "not-converged-primary"
+        }
+        fn capabilities(&self) -> Vec<Capability> {
+            vec![]
+        }
+        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+            Ok(AgentResponse {
+                output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
+                stderr: String::new(),
+                items: vec![],
+                token_usage: TokenUsage::default(),
+                model: "mock".to_string(),
+                exit_code: Some(0),
+            })
+        }
+        async fn execute_stream(
+            &self,
+            _req: AgentRequest,
+            _tx: Sender<StreamItem>,
+        ) -> HarnessResult<()> {
+            Ok(())
+        }
     }
 
     // Mock that returns "ISSUE: foo" (primary) or "CONFIRMED: foo" (challenger) — NOT_CONVERGED
@@ -518,7 +570,7 @@ mod tests {
             dir.path(),
             vec![Grade::D],
             300,
-            Some(Arc::new(NotConvergedMock)),
+            Some(Arc::new(NotConvergedPrimaryMock)),
             Some(Arc::new(NotConvergedMock)),
         )
         .await;

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -129,6 +129,9 @@ impl QualityTrigger {
                                 self.project_root.clone(),
                                 target,
                                 2,
+                                // Deny all tools: review is text-only, agents must not
+                                // mutate the repo during this background quality gate.
+                                Some(vec![]),
                             ),
                         )
                         .await

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -1,0 +1,541 @@
+use crate::quality_trigger::{unix_now, QualityTrigger, TaskReviewContext};
+use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
+use harness_core::error::Result as HarnessResult;
+use harness_core::types::{Capability, Decision, Event, Grade, SessionId, TokenUsage};
+use harness_gc::draft_store::DraftStore;
+use harness_gc::gc_agent::GcAgent;
+use harness_gc::signal_detector::SignalDetector;
+use harness_observe::event_store::EventStore;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+
+async fn make_trigger(
+    dir: &Path,
+    auto_gc_grades: Vec<Grade>,
+    cooldown_secs: u64,
+) -> QualityTrigger {
+    make_trigger_with_challenger(dir, auto_gc_grades, cooldown_secs, None, None).await
+}
+
+async fn make_trigger_with_challenger(
+    dir: &Path,
+    auto_gc_grades: Vec<Grade>,
+    cooldown_secs: u64,
+    primary: Option<Arc<dyn CodeAgent>>,
+    challenger: Option<Arc<dyn CodeAgent>>,
+) -> QualityTrigger {
+    let events = Arc::new(EventStore::new(dir).await.expect("event store"));
+    let gc_config = harness_core::config::misc::GcConfig::default();
+    let signal_detector = SignalDetector::new(
+        gc_config.signal_thresholds.clone().into(),
+        harness_core::types::ProjectId::new(),
+    );
+    let draft_store = DraftStore::new(dir).expect("draft store");
+    let gc_agent = Arc::new(GcAgent::new(
+        gc_config,
+        signal_detector,
+        draft_store,
+        dir.to_path_buf(),
+    ));
+    let mut registry = harness_agents::registry::AgentRegistry::new("test");
+    if let Some(p) = primary {
+        registry.register("test", p);
+    }
+    let agent_registry = Arc::new(registry);
+    QualityTrigger::new(
+        events,
+        gc_agent,
+        agent_registry,
+        dir.to_path_buf(),
+        auto_gc_grades,
+        cooldown_secs,
+        challenger,
+    )
+}
+
+// Mock that returns "ISSUE: foo\nCONFIRMED: foo" — used as primary in NOT_CONVERGED tests.
+// Has a distinct name from NotConvergedMock so the identity guard does not skip cross-review.
+struct NotConvergedPrimaryMock;
+
+#[async_trait::async_trait]
+impl CodeAgent for NotConvergedPrimaryMock {
+    fn name(&self) -> &str {
+        "not-converged-primary"
+    }
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+    async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+        Ok(AgentResponse {
+            output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: Sender<StreamItem>,
+    ) -> HarnessResult<()> {
+        Ok(())
+    }
+}
+
+// Mock that returns "ISSUE: foo\nCONFIRMED: foo" — NOT_CONVERGED
+struct NotConvergedMock;
+
+#[async_trait::async_trait]
+impl CodeAgent for NotConvergedMock {
+    fn name(&self) -> &str {
+        "not-converged-mock"
+    }
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+    async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+        Ok(AgentResponse {
+            output: "ISSUE: foo\nCONFIRMED: foo".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: Sender<StreamItem>,
+    ) -> HarnessResult<()> {
+        Ok(())
+    }
+}
+
+// Mock that returns LGTM — APPROVED
+struct ApprovedMock;
+
+#[async_trait::async_trait]
+impl CodeAgent for ApprovedMock {
+    fn name(&self) -> &str {
+        "approved-mock"
+    }
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+    async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+        Ok(AgentResponse {
+            output: "LGTM".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: Sender<StreamItem>,
+    ) -> HarnessResult<()> {
+        Ok(())
+    }
+}
+
+// Mock primary that advertises Write/Execute (like CodexAgent) — verifies that the
+// primary capability guard skips cross-review and never calls execute().
+struct WritePrimaryMock;
+
+#[async_trait::async_trait]
+impl CodeAgent for WritePrimaryMock {
+    fn name(&self) -> &str {
+        "write-primary"
+    }
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::Read, Capability::Write, Capability::Execute]
+    }
+    async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+        panic!("WritePrimaryMock.execute must never be called during cross-review");
+    }
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: Sender<StreamItem>,
+    ) -> HarnessResult<()> {
+        Ok(())
+    }
+}
+
+fn block_event(hook: &str) -> Event {
+    Event::new(SessionId::new(), hook, "Edit", Decision::Block)
+}
+
+fn pass_event() -> Event {
+    Event::new(SessionId::new(), "pre_tool_use", "Edit", Decision::Pass)
+}
+
+// --- grade_triggers_gc mapping tests ---
+
+#[tokio::test]
+async fn grade_d_triggers_gc_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    assert!(trigger.grade_triggers_gc(Grade::D));
+}
+
+#[tokio::test]
+async fn grade_a_does_not_trigger_gc_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    assert!(!trigger.grade_triggers_gc(Grade::A));
+}
+
+#[tokio::test]
+async fn grade_b_does_not_trigger_gc_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    assert!(!trigger.grade_triggers_gc(Grade::B));
+}
+
+#[tokio::test]
+async fn grade_c_does_not_trigger_gc_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    assert!(!trigger.grade_triggers_gc(Grade::C));
+}
+
+#[tokio::test]
+async fn configuring_c_and_d_both_trigger() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::C, Grade::D], 300).await;
+    assert!(trigger.grade_triggers_gc(Grade::C));
+    assert!(trigger.grade_triggers_gc(Grade::D));
+    assert!(!trigger.grade_triggers_gc(Grade::A));
+    assert!(!trigger.grade_triggers_gc(Grade::B));
+}
+
+#[tokio::test]
+async fn empty_auto_gc_grades_never_triggers() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![], 300).await;
+    assert!(!trigger.grade_triggers_gc(Grade::A));
+    assert!(!trigger.grade_triggers_gc(Grade::B));
+    assert!(!trigger.grade_triggers_gc(Grade::C));
+    assert!(!trigger.grade_triggers_gc(Grade::D));
+}
+
+// --- cooldown tests ---
+
+#[tokio::test]
+async fn cooldown_elapsed_when_never_triggered() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    assert!(trigger.cooldown_elapsed());
+}
+
+#[tokio::test]
+async fn cooldown_not_elapsed_immediately_after_trigger() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
+    assert!(!trigger.cooldown_elapsed());
+}
+
+#[tokio::test]
+async fn zero_cooldown_always_elapsed() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 0).await;
+    trigger.last_triggered.store(unix_now(), Ordering::Relaxed);
+    assert!(trigger.cooldown_elapsed());
+}
+
+// --- log_quality_grade integration test ---
+
+#[tokio::test]
+async fn check_logs_quality_grade_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+
+    trigger
+        .events
+        .log(&Event::new(
+            SessionId::new(),
+            "pre_tool_use",
+            "Edit",
+            Decision::Pass,
+        ))
+        .await
+        .unwrap();
+
+    trigger.check_and_maybe_trigger(None).await;
+
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1, "expected exactly one quality_grade event");
+    assert!(events[0]
+        .detail
+        .as_deref()
+        .unwrap_or("")
+        .starts_with("grade="));
+}
+
+// --- challenger cross-review tests ---
+
+// Scenario 1: challenger=None, task_ctx=None → existing behavior, one quality_grade event
+#[tokio::test]
+async fn no_challenger_no_ctx_baseline() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger(dir.path(), vec![Grade::D], 300).await;
+    trigger.events.log(&pass_event()).await.unwrap();
+    trigger.check_and_maybe_trigger(None).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+}
+
+// Scenario 2: challenger=Some, grade=A → cross-review skipped
+#[tokio::test]
+async fn challenger_grade_a_skips_cross_review() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        300,
+        None,
+        Some(Arc::new(NotConvergedMock)),
+    )
+    .await;
+    for _ in 0..20 {
+        trigger.events.log(&pass_event()).await.unwrap();
+    }
+    let ctx = TaskReviewContext {
+        diff: "diff".to_string(),
+        pr_description: "https://github.com/o/r/pull/1".to_string(),
+    };
+    trigger.check_and_maybe_trigger(Some(&ctx)).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    let detail = events[0].detail.as_deref().unwrap_or("");
+    assert!(detail.contains("A"), "expected grade A in detail: {detail}");
+}
+
+// Scenario 3: challenger=Some, grade=B, verdict=APPROVED → grade stays B
+#[tokio::test]
+async fn challenger_grade_b_approved_stays_b() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        300,
+        None,
+        Some(Arc::new(ApprovedMock)),
+    )
+    .await;
+    for _ in 0..7 {
+        trigger.events.log(&pass_event()).await.unwrap();
+    }
+    for _ in 0..3 {
+        trigger
+            .events
+            .log(&block_event("security_check"))
+            .await
+            .unwrap();
+    }
+    let ctx = TaskReviewContext {
+        diff: "diff".to_string(),
+        pr_description: "https://github.com/o/r/pull/1".to_string(),
+    };
+    trigger.check_and_maybe_trigger(Some(&ctx)).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    let detail = events[0].detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("B") || detail.contains("A"),
+        "expected B or A in detail after APPROVED: {detail}"
+    );
+}
+
+// Scenario 4: challenger=Some, grade=B, verdict=NOT_CONVERGED → downgraded to C
+#[tokio::test]
+async fn challenger_grade_b_not_converged_downgraded_to_c() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        300,
+        Some(Arc::new(NotConvergedPrimaryMock)),
+        Some(Arc::new(NotConvergedMock)),
+    )
+    .await;
+    for _ in 0..7 {
+        trigger.events.log(&pass_event()).await.unwrap();
+    }
+    for _ in 0..3 {
+        trigger
+            .events
+            .log(&block_event("security_check"))
+            .await
+            .unwrap();
+    }
+    let ctx = TaskReviewContext {
+        diff: "diff".to_string(),
+        pr_description: "https://github.com/o/r/pull/1".to_string(),
+    };
+    trigger.check_and_maybe_trigger(Some(&ctx)).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    let detail = events[0].detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("C") || detail.contains("D"),
+        "expected downgrade to C or D after NOT_CONVERGED: {detail}"
+    );
+}
+
+// Scenario 5: challenger=Some, grade=C, NOT_CONVERGED → D, GC triggered
+#[tokio::test]
+async fn challenger_grade_c_not_converged_triggers_gc() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        0, // zero cooldown so GC fires immediately
+        None,
+        Some(Arc::new(NotConvergedMock)),
+    )
+    .await;
+    for _ in 0..5 {
+        trigger.events.log(&pass_event()).await.unwrap();
+    }
+    for _ in 0..5 {
+        trigger
+            .events
+            .log(&block_event("security_check"))
+            .await
+            .unwrap();
+    }
+    let ctx = TaskReviewContext {
+        diff: "diff".to_string(),
+        pr_description: "https://github.com/o/r/pull/1".to_string(),
+    };
+    trigger.check_and_maybe_trigger(Some(&ctx)).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    let detail = events[0].detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("C") || detail.contains("D"),
+        "expected C or D after NOT_CONVERGED on C input: {detail}"
+    );
+}
+
+// Scenario 6: task_ctx=None, challenger=Some → cross-review skipped, numeric grade only
+#[tokio::test]
+async fn challenger_no_ctx_skips_cross_review() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        300,
+        None,
+        Some(Arc::new(NotConvergedMock)),
+    )
+    .await;
+    trigger.events.log(&pass_event()).await.unwrap();
+    trigger.check_and_maybe_trigger(None).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+}
+
+// Scenario 7: primary has Write/Execute capabilities → cross-review skipped,
+// grade unchanged (WritePrimaryMock.execute panics if called, proving the guard fires).
+#[tokio::test]
+async fn write_primary_skips_cross_review() {
+    let dir = tempfile::tempdir().unwrap();
+    let trigger = make_trigger_with_challenger(
+        dir.path(),
+        vec![Grade::D],
+        300,
+        Some(Arc::new(WritePrimaryMock)),
+        Some(Arc::new(NotConvergedMock)),
+    )
+    .await;
+    for _ in 0..7 {
+        trigger.events.log(&pass_event()).await.unwrap();
+    }
+    for _ in 0..3 {
+        trigger
+            .events
+            .log(&block_event("security_check"))
+            .await
+            .unwrap();
+    }
+    let ctx = TaskReviewContext {
+        diff: "diff".to_string(),
+        pr_description: "https://github.com/o/r/pull/1".to_string(),
+    };
+    trigger.check_and_maybe_trigger(Some(&ctx)).await;
+    let events = trigger
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("quality_grade".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    let detail = events[0].detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("B") || detail.contains("A"),
+        "expected B or A (no downgrade) when primary is skipped: {detail}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `semantic_verdict: Option<String>` to `QualityReport` to carry cross-review outcome alongside the numeric grade
- Extends `QualityTrigger` with an optional `challenger_agent` field and a `TaskReviewContext` input struct; `check_and_maybe_trigger` now accepts task diff + PR description
- Cross-review gate: skipped when `challenger=None`, `task_ctx=None`, or numeric `grade=A`; on `NOT_CONVERGED` the effective grade is downgraded one step (B→C, C→D, D stays D) before GC trigger evaluation
- `http.rs` wires the `codex` agent as challenger and threads `TaskReviewContext` from the task's last round result and `pr_url` into the completion callback

## Test plan

- [x] 6 new tests covering all gate scenarios (no challenger, grade=A gate, APPROVED stays grade, NOT_CONVERGED downgrades B→C, NOT_CONVERGED downgrades C→D triggers GC, no ctx skips review)
- [x] All 16 `quality_trigger` tests pass
- [x] Full workspace `cargo test --workspace` — 0 failures
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --all` — no diff

Closes #637