### PR TITLE
fix(dep-watcher): dispatch AwaitingDeps tasks when deps complete (#634)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.29"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2489,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3937,7 +3937,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3954,7 +3954,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.31"
+version = "0.6.32"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.29"
+version = "0.6.30"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -90,6 +90,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        pending_request: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -178,6 +179,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        pending_request: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -199,6 +201,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        pending_request: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -271,6 +274,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        pending_request: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -334,6 +338,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        pending_request: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -622,6 +622,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         let workspace_mgr_w = workspace_mgr.clone();
         let task_queue_w = task_queue.clone();
         let completion_callback_w = completion_callback.clone();
+        let allowed_roots_w = server.config.server.allowed_project_roots.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -716,11 +717,15 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     // canonical path at registration time, but we resolve again here
                     // to guard against None / relative / symlink edge cases so the
                     // semaphore bucket is always consistent with other dispatch paths.
-                    let project_id =
+                    // We also re-apply the allowed_project_roots allowlist to prevent
+                    // a tampered/stale persisted project path from escaping the
+                    // configured sandbox (mirrors the check in execution.rs:182 and
+                    // task_routes.rs:260-264).
+                    let canonical =
                         match crate::task_runner::resolve_canonical_project(req.project.clone())
                             .await
                         {
-                            Ok(canonical) => canonical.to_string_lossy().into_owned(),
+                            Ok(c) => c,
                             Err(e) => {
                                 tracing::error!(
                                     task_id = %task_id.0,
@@ -744,6 +749,29 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 continue;
                             }
                         };
+                    if let Err(e) =
+                        crate::project_registry::check_allowed_roots(&canonical, &allowed_roots_w)
+                    {
+                        tracing::error!(
+                            task_id = %task_id.0,
+                            "dep-watcher: project not in allowed_project_roots — failing task: {e}"
+                        );
+                        if let Err(pe) =
+                            crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
+                                s.status = crate::task_runner::TaskStatus::Failed;
+                                s.error =
+                                    Some(format!("dep-watcher: project not in allowed roots: {e}"));
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = %task_id.0,
+                                "dep-watcher: failed to persist failure state: {pe}"
+                            );
+                        }
+                        continue;
+                    }
+                    let project_id = canonical.to_string_lossy().into_owned();
 
                     let task_id2 = task_id.clone();
                     let store2 = store.clone();
@@ -779,8 +807,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 if let Err(e) = store2.persist(&task_id2).await {
                                     tracing::warn!(
                                         task_id = %task_id2.0,
-                                        "dep-watcher: failed to persist task before dispatch: {e}"
+                                        "dep-watcher: failed to persist task before dispatch: {e} \
+                                         — aborting dispatch, restoring state for next tick retry"
                                     );
+                                    // Restore in-memory state so the next watcher tick retries.
+                                    // The DB still holds the original pending_request_json
+                                    // because persist failed, so restart recovery is also safe.
+                                    if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
+                                        entry.pending_request = Some(req);
+                                        entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
+                                    }
+                                    return; // drops permit
                                 }
                                 crate::task_runner::spawn_preregistered_task(
                                     task_id2,

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -665,6 +665,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     "dep-watcher: failed to persist failure state: {e}"
                                 );
                             }
+                            store.close_task_stream(&task_id);
+                            if let Some(ref cb) = completion_callback_w {
+                                if let Some(final_state) = store.get(&task_id) {
+                                    cb(final_state).await;
+                                } else {
+                                    tracing::warn!(
+                                        task_id = %task_id.0,
+                                        "dep-watcher: task not found in store after fail-close"
+                                    );
+                                }
+                            }
                             continue;
                         }
                     };
@@ -702,6 +713,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     task_id = %task_id.0,
                                     "dep-watcher: failed to persist failure state: {e}"
                                 );
+                            }
+                            store.close_task_stream(&task_id);
+                            if let Some(ref cb) = completion_callback_w {
+                                if let Some(final_state) = store.get(&task_id) {
+                                    cb(final_state).await;
+                                } else {
+                                    tracing::warn!(
+                                        task_id = %task_id.0,
+                                        "dep-watcher: task not found in store after fail-close"
+                                    );
+                                }
                             }
                             continue;
                         }
@@ -745,6 +767,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                         task_id = %task_id.0,
                                         "dep-watcher: failed to persist failure state: {pe}"
                                     );
+                                }
+                                store.close_task_stream(&task_id);
+                                if let Some(ref cb) = completion_callback_w {
+                                    if let Some(final_state) = store.get(&task_id) {
+                                        cb(final_state).await;
+                                    } else {
+                                        tracing::warn!(
+                                            task_id = %task_id.0,
+                                            "dep-watcher: task not found in store after fail-close"
+                                        );
+                                    }
                                 }
                                 continue;
                             }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -802,6 +802,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 "dep-watcher: failed to persist failure state: {pe}"
                             );
                         }
+                        store.close_task_stream(&task_id);
+                        if let Some(ref cb) = completion_callback_w {
+                            if let Some(final_state) = store.get(&task_id) {
+                                cb(final_state).await;
+                            } else {
+                                tracing::warn!(
+                                    task_id = %task_id.0,
+                                    "dep-watcher: task not found in store after fail-close"
+                                );
+                            }
+                        }
                         continue;
                     }
                     let project_id = canonical.to_string_lossy().into_owned();

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -614,6 +614,14 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     // Spawn background watcher for AwaitingDeps tasks.
     {
         let store = tasks.clone();
+        let agent_registry = server.agent_registry.clone();
+        let server_config = Arc::new(server.config.clone());
+        let skills = skills_arc.clone();
+        let events_w = events.clone();
+        let interceptors_w = interceptors.clone();
+        let workspace_mgr_w = workspace_mgr.clone();
+        let task_queue_w = task_queue.clone();
+        let completion_callback_w = completion_callback.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -621,12 +629,98 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                 interval.tick().await;
                 let ready_ids = crate::task_runner::check_awaiting_deps(&store);
                 for task_id in ready_ids {
+                    // Atomically take pending_request before dispatch to prevent double-dispatch.
+                    let pending_req = store
+                        .cache
+                        .get_mut(&task_id)
+                        .and_then(|mut e| e.pending_request.take());
+
                     if let Err(e) = store.persist(&task_id).await {
                         tracing::warn!(
                             "dep-watcher: failed to persist {} after transition: {e}",
                             task_id.0
                         );
                     }
+
+                    let req = match pending_req {
+                        Some(r) => r,
+                        None => {
+                            tracing::warn!(
+                                task_id = %task_id.0,
+                                "dep-watcher: task ready but pending_request is None, skipping dispatch"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let agent = if let Some(ref name) = req.agent {
+                        agent_registry.get(name)
+                    } else {
+                        let cls = crate::complexity_router::classify(
+                            req.prompt.as_deref().unwrap_or_default(),
+                            req.issue,
+                            req.pr,
+                        );
+                        agent_registry.dispatch(&cls).ok()
+                    };
+                    let agent = match agent {
+                        Some(a) => a,
+                        None => {
+                            tracing::error!(
+                                task_id = %task_id.0,
+                                "dep-watcher: could not resolve agent, skipping dispatch"
+                            );
+                            continue;
+                        }
+                    };
+                    let (reviewer, _) = resolve_reviewer(
+                        &agent_registry,
+                        &server_config.agents.review,
+                        agent.name(),
+                    );
+                    let project_id = req
+                        .project
+                        .as_ref()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+
+                    let task_id2 = task_id.clone();
+                    let store2 = store.clone();
+                    let server_config2 = server_config.clone();
+                    let skills2 = skills.clone();
+                    let events2 = events_w.clone();
+                    let interceptors2 = interceptors_w.clone();
+                    let workspace_mgr2 = workspace_mgr_w.clone();
+                    let task_queue2 = task_queue_w.clone();
+                    let cb2 = completion_callback_w.clone();
+                    tokio::spawn(async move {
+                        match task_queue2.acquire(&project_id).await {
+                            Ok(permit) => {
+                                crate::task_runner::spawn_preregistered_task(
+                                    task_id2,
+                                    store2,
+                                    agent,
+                                    reviewer,
+                                    server_config2,
+                                    skills2,
+                                    events2,
+                                    interceptors2,
+                                    req,
+                                    workspace_mgr2,
+                                    permit,
+                                    cb2,
+                                    None,
+                                )
+                                .await;
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    task_id = %task_id2.0,
+                                    "dep-watcher: failed to acquire concurrency permit: {e}"
+                                );
+                            }
+                        }
+                    });
                 }
             }
         });

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -650,7 +650,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 task_id = %task_id.0,
                                 "dep-watcher: task ready but pending_request is None — failing task"
                             );
-                            if let Err(e) =
+                            let persist_result =
                                 crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
                                     s.status = crate::task_runner::TaskStatus::Failed;
                                     s.error = Some(
@@ -658,22 +658,28 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                             .to_string(),
                                     );
                                 })
-                                .await
-                            {
+                                .await;
+                            if let Err(ref e) = persist_result {
                                 tracing::error!(
                                     task_id = %task_id.0,
                                     "dep-watcher: failed to persist failure state: {e}"
                                 );
                             }
                             store.close_task_stream(&task_id);
-                            if let Some(ref cb) = completion_callback_w {
-                                if let Some(final_state) = store.get(&task_id) {
-                                    cb(final_state).await;
-                                } else {
-                                    tracing::warn!(
-                                        task_id = %task_id.0,
-                                        "dep-watcher: task not found in store after fail-close"
-                                    );
+                            // Only invoke the completion callback when the terminal state has
+                            // been durably written; if persist failed the SQLite row still has
+                            // a non-terminal status and the callback must not fire (would cause
+                            // duplicate processing after restart).
+                            if persist_result.is_ok() {
+                                if let Some(ref cb) = completion_callback_w {
+                                    if let Some(final_state) = store.get(&task_id) {
+                                        cb(final_state).await;
+                                    } else {
+                                        tracing::warn!(
+                                            task_id = %task_id.0,
+                                            "dep-watcher: task not found in store after fail-close"
+                                        );
+                                    }
                                 }
                             }
                             continue;
@@ -699,7 +705,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 task_id = %task_id.0,
                                 "dep-watcher: could not resolve agent — failing task"
                             );
-                            if let Err(e) =
+                            let persist_result =
                                 crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
                                     s.status = crate::task_runner::TaskStatus::Failed;
                                     s.error = Some(
@@ -707,22 +713,24 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                             .to_string(),
                                     );
                                 })
-                                .await
-                            {
+                                .await;
+                            if let Err(ref e) = persist_result {
                                 tracing::error!(
                                     task_id = %task_id.0,
                                     "dep-watcher: failed to persist failure state: {e}"
                                 );
                             }
                             store.close_task_stream(&task_id);
-                            if let Some(ref cb) = completion_callback_w {
-                                if let Some(final_state) = store.get(&task_id) {
-                                    cb(final_state).await;
-                                } else {
-                                    tracing::warn!(
-                                        task_id = %task_id.0,
-                                        "dep-watcher: task not found in store after fail-close"
-                                    );
+                            if persist_result.is_ok() {
+                                if let Some(ref cb) = completion_callback_w {
+                                    if let Some(final_state) = store.get(&task_id) {
+                                        cb(final_state).await;
+                                    } else {
+                                        tracing::warn!(
+                                            task_id = %task_id.0,
+                                            "dep-watcher: task not found in store after fail-close"
+                                        );
+                                    }
                                 }
                             }
                             continue;
@@ -743,32 +751,34 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     // a tampered/stale persisted project path from escaping the
                     // configured sandbox (mirrors the check in execution.rs:182 and
                     // task_routes.rs:260-264).
-                    let canonical =
-                        match crate::task_runner::resolve_canonical_project(req.project.clone())
-                            .await
-                        {
-                            Ok(c) => c,
-                            Err(e) => {
+                    let canonical = match crate::task_runner::resolve_canonical_project(
+                        req.project.clone(),
+                    )
+                    .await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = %task_id.0,
+                                "dep-watcher: cannot resolve canonical project \
+                                 for concurrency key — failing task: {e}"
+                            );
+                            let persist_result =
+                                crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
+                                    s.status = crate::task_runner::TaskStatus::Failed;
+                                    s.error = Some(format!(
+                                        "dep-watcher: cannot resolve project path: {e}"
+                                    ));
+                                })
+                                .await;
+                            if let Err(ref pe) = persist_result {
                                 tracing::error!(
                                     task_id = %task_id.0,
-                                    "dep-watcher: cannot resolve canonical project \
-                                     for concurrency key — failing task: {e}"
+                                    "dep-watcher: failed to persist failure state: {pe}"
                                 );
-                                if let Err(pe) =
-                                    crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
-                                        s.status = crate::task_runner::TaskStatus::Failed;
-                                        s.error = Some(format!(
-                                            "dep-watcher: cannot resolve project path: {e}"
-                                        ));
-                                    })
-                                    .await
-                                {
-                                    tracing::error!(
-                                        task_id = %task_id.0,
-                                        "dep-watcher: failed to persist failure state: {pe}"
-                                    );
-                                }
-                                store.close_task_stream(&task_id);
+                            }
+                            store.close_task_stream(&task_id);
+                            if persist_result.is_ok() {
                                 if let Some(ref cb) = completion_callback_w {
                                     if let Some(final_state) = store.get(&task_id) {
                                         cb(final_state).await;
@@ -779,9 +789,10 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                         );
                                     }
                                 }
-                                continue;
                             }
-                        };
+                            continue;
+                        }
+                    };
                     if let Err(e) =
                         crate::project_registry::check_allowed_roots(&canonical, &allowed_roots_w)
                     {
@@ -789,28 +800,30 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                             task_id = %task_id.0,
                             "dep-watcher: project not in allowed_project_roots — failing task: {e}"
                         );
-                        if let Err(pe) =
+                        let persist_result =
                             crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
                                 s.status = crate::task_runner::TaskStatus::Failed;
                                 s.error =
                                     Some(format!("dep-watcher: project not in allowed roots: {e}"));
                             })
-                            .await
-                        {
+                            .await;
+                        if let Err(ref pe) = persist_result {
                             tracing::error!(
                                 task_id = %task_id.0,
                                 "dep-watcher: failed to persist failure state: {pe}"
                             );
                         }
                         store.close_task_stream(&task_id);
-                        if let Some(ref cb) = completion_callback_w {
-                            if let Some(final_state) = store.get(&task_id) {
-                                cb(final_state).await;
-                            } else {
-                                tracing::warn!(
-                                    task_id = %task_id.0,
-                                    "dep-watcher: task not found in store after fail-close"
-                                );
+                        if persist_result.is_ok() {
+                            if let Some(ref cb) = completion_callback_w {
+                                if let Some(final_state) = store.get(&task_id) {
+                                    cb(final_state).await;
+                                } else {
+                                    tracing::warn!(
+                                        task_id = %task_id.0,
+                                        "dep-watcher: task not found in store after fail-close"
+                                    );
+                                }
                             }
                         }
                         continue;
@@ -854,12 +867,19 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                         "dep-watcher: failed to persist task before dispatch: {e} \
                                          — aborting dispatch, restoring state for next tick retry"
                                     );
-                                    // Restore in-memory state so the next watcher tick retries.
-                                    // The DB still holds the original pending_request_json
-                                    // because persist failed, so restart recovery is also safe.
+                                    // Restore in-memory state so the next watcher tick retries,
+                                    // but only if the task has not been cancelled (or otherwise
+                                    // transitioned) during the persist await — resurrecting a
+                                    // cancelled task would re-dispatch it on the next tick.
                                     if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
-                                        entry.pending_request = Some(req);
-                                        entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
+                                        if matches!(
+                                            entry.status,
+                                            crate::task_runner::TaskStatus::Pending
+                                        ) {
+                                            entry.pending_request = Some(req);
+                                            entry.status =
+                                                crate::task_runner::TaskStatus::AwaitingDeps;
+                                        }
                                     }
                                     return; // drops permit
                                 }
@@ -906,9 +926,16 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                 // watcher tick (which only scans AwaitingDeps) can retry.
                                 // The DB still holds the original values because we have
                                 // not persisted yet, so no re-persist is needed.
+                                // Guard against resurrecting a cancelled task: only restore
+                                // if the status is still Pending (set by check_awaiting_deps).
                                 if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
-                                    entry.pending_request = Some(req);
-                                    entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
+                                    if matches!(
+                                        entry.status,
+                                        crate::task_runner::TaskStatus::Pending
+                                    ) {
+                                        entry.pending_request = Some(req);
+                                        entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
+                                    }
                                 }
                             }
                         }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -710,11 +710,40 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                         &server_config.agents.review,
                         agent.name(),
                     );
-                    let project_id = req
-                        .project
-                        .as_ref()
-                        .map(|p| p.to_string_lossy().into_owned())
-                        .unwrap_or_default();
+                    // Re-canonicalize project to derive the concurrency-permit key,
+                    // matching what the direct-dispatch paths (execution.rs,
+                    // task_routes.rs) do.  `pending_request` was stored with a
+                    // canonical path at registration time, but we resolve again here
+                    // to guard against None / relative / symlink edge cases so the
+                    // semaphore bucket is always consistent with other dispatch paths.
+                    let project_id =
+                        match crate::task_runner::resolve_canonical_project(req.project.clone())
+                            .await
+                        {
+                            Ok(canonical) => canonical.to_string_lossy().into_owned(),
+                            Err(e) => {
+                                tracing::error!(
+                                    task_id = %task_id.0,
+                                    "dep-watcher: cannot resolve canonical project \
+                                     for concurrency key — failing task: {e}"
+                                );
+                                if let Err(pe) =
+                                    crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
+                                        s.status = crate::task_runner::TaskStatus::Failed;
+                                        s.error = Some(format!(
+                                            "dep-watcher: cannot resolve project path: {e}"
+                                        ));
+                                    })
+                                    .await
+                                {
+                                    tracing::error!(
+                                        task_id = %task_id.0,
+                                        "dep-watcher: failed to persist failure state: {pe}"
+                                    );
+                                }
+                                continue;
+                            }
+                        };
 
                     let task_id2 = task_id.clone();
                     let store2 = store.clone();

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -863,6 +863,23 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     }
                                     return; // drops permit
                                 }
+                                // Re-check status after persist — cancel_task may have
+                                // flipped status to Cancelled during the await above.
+                                let still_pending_post_persist = store2
+                                    .cache
+                                    .get(&task_id2)
+                                    .map(|e| {
+                                        matches!(e.status, crate::task_runner::TaskStatus::Pending)
+                                    })
+                                    .unwrap_or(false);
+                                if !still_pending_post_persist {
+                                    tracing::warn!(
+                                        task_id = %task_id2.0,
+                                        "dep-watcher: task cancelled during persist — \
+                                         aborting dispatch"
+                                    );
+                                    return; // drops permit; DB already has no pending_request
+                                }
                                 crate::task_runner::spawn_preregistered_task(
                                     task_id2,
                                     store2,

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -629,18 +629,14 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                 interval.tick().await;
                 let ready_ids = crate::task_runner::check_awaiting_deps(&store);
                 for task_id in ready_ids {
-                    // Atomically take pending_request before dispatch to prevent double-dispatch.
+                    // Take pending_request from the in-memory cache only — do NOT persist
+                    // yet.  Deferring the DB write until after permit acquisition means that
+                    // if the process crashes before acquire, the DB still contains the
+                    // pending_request and startup recovery can retry the dispatch.
                     let pending_req = store
                         .cache
                         .get_mut(&task_id)
                         .and_then(|mut e| e.pending_request.take());
-
-                    if let Err(e) = store.persist(&task_id).await {
-                        tracing::warn!(
-                            "dep-watcher: failed to persist {} after transition: {e}",
-                            task_id.0
-                        );
-                    }
 
                     let req = match pending_req {
                         Some(r) => r,
@@ -666,10 +662,27 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     let agent = match agent {
                         Some(a) => a,
                         None => {
+                            // Fail-close: mark the task failed so it surfaces to the
+                            // operator rather than silently hanging in pending forever.
                             tracing::error!(
                                 task_id = %task_id.0,
-                                "dep-watcher: could not resolve agent, skipping dispatch"
+                                "dep-watcher: could not resolve agent — failing task"
                             );
+                            if let Err(e) =
+                                crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
+                                    s.status = crate::task_runner::TaskStatus::Failed;
+                                    s.error = Some(
+                                        "dep-watcher: no agent could be resolved for dispatch"
+                                            .to_string(),
+                                    );
+                                })
+                                .await
+                            {
+                                tracing::error!(
+                                    task_id = %task_id.0,
+                                    "dep-watcher: failed to persist failure state: {e}"
+                                );
+                            }
                             continue;
                         }
                     };
@@ -696,6 +709,14 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     tokio::spawn(async move {
                         match task_queue2.acquire(&project_id).await {
                             Ok(permit) => {
+                                // Permit acquired — commit the pending_request clear to DB
+                                // now that dispatch is guaranteed to proceed.
+                                if let Err(e) = store2.persist(&task_id2).await {
+                                    tracing::warn!(
+                                        task_id = %task_id2.0,
+                                        "dep-watcher: failed to persist task before dispatch: {e}"
+                                    );
+                                }
                                 crate::task_runner::spawn_preregistered_task(
                                     task_id2,
                                     store2,
@@ -718,6 +739,12 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     task_id = %task_id2.0,
                                     "dep-watcher: failed to acquire concurrency permit: {e}"
                                 );
+                                // Restore pending_request so the next watcher tick can
+                                // retry.  The DB still holds the original value because we
+                                // have not persisted yet, so no re-persist is needed.
+                                if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
+                                    entry.pending_request = Some(req);
+                                }
                             }
                         }
                     });

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -641,10 +641,29 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     let req = match pending_req {
                         Some(r) => r,
                         None => {
-                            tracing::warn!(
+                            // pending_request missing means the row is corrupt/invalid.
+                            // The task is already in Pending status (set by
+                            // check_awaiting_deps) but will never be dispatched, so
+                            // fail it explicitly rather than leaving it stuck.
+                            tracing::error!(
                                 task_id = %task_id.0,
-                                "dep-watcher: task ready but pending_request is None, skipping dispatch"
+                                "dep-watcher: task ready but pending_request is None — failing task"
                             );
+                            if let Err(e) =
+                                crate::task_runner::mutate_and_persist(&store, &task_id, |s| {
+                                    s.status = crate::task_runner::TaskStatus::Failed;
+                                    s.error = Some(
+                                        "dep-watcher: missing pending_request; cannot dispatch"
+                                            .to_string(),
+                                    );
+                                })
+                                .await
+                            {
+                                tracing::error!(
+                                    task_id = %task_id.0,
+                                    "dep-watcher: failed to persist failure state: {e}"
+                                );
+                            }
                             continue;
                         }
                     };
@@ -709,6 +728,23 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     tokio::spawn(async move {
                         match task_queue2.acquire(&project_id).await {
                             Ok(permit) => {
+                                // Re-check status — user may have cancelled while we were
+                                // waiting for the permit.
+                                let still_pending = store2
+                                    .cache
+                                    .get(&task_id2)
+                                    .map(|e| {
+                                        matches!(e.status, crate::task_runner::TaskStatus::Pending)
+                                    })
+                                    .unwrap_or(false);
+                                if !still_pending {
+                                    tracing::warn!(
+                                        task_id = %task_id2.0,
+                                        "dep-watcher: task status changed while waiting for \
+                                         permit — aborting dispatch"
+                                    );
+                                    return;
+                                }
                                 // Permit acquired — commit the pending_request clear to DB
                                 // now that dispatch is guaranteed to proceed.
                                 if let Err(e) = store2.persist(&task_id2).await {
@@ -739,11 +775,13 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     task_id = %task_id2.0,
                                     "dep-watcher: failed to acquire concurrency permit: {e}"
                                 );
-                                // Restore pending_request so the next watcher tick can
-                                // retry.  The DB still holds the original value because we
-                                // have not persisted yet, so no re-persist is needed.
+                                // Restore both pending_request AND status so the next
+                                // watcher tick (which only scans AwaitingDeps) can retry.
+                                // The DB still holds the original values because we have
+                                // not persisted yet, so no re-persist is needed.
                                 if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
                                     entry.pending_request = Some(req);
+                                    entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
                                 }
                             }
                         }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -630,14 +630,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                 interval.tick().await;
                 let ready_ids = crate::task_runner::check_awaiting_deps(&store);
                 for task_id in ready_ids {
-                    // Take pending_request from the in-memory cache only — do NOT persist
-                    // yet.  Deferring the DB write until after permit acquisition means that
-                    // if the process crashes before acquire, the DB still contains the
-                    // pending_request and startup recovery can retry the dispatch.
+                    // Clone pending_request from cache (do NOT take/remove it yet).
+                    // Keeping pending_request in cache means that when we persist after
+                    // permit acquisition the DB row retains pending_request_json.  If the
+                    // server crashes between that persist and spawn_preregistered_task, the
+                    // DB will show status=Pending + pending_request set, and startup recovery
+                    // can detect and re-dispatch the task.  The entry is cleared from cache
+                    // (and DB) after spawn_preregistered_task returns successfully.
                     let pending_req = store
                         .cache
-                        .get_mut(&task_id)
-                        .and_then(|mut e| e.pending_request.take());
+                        .get(&task_id)
+                        .and_then(|e| e.pending_request.clone());
 
                     let req = match pending_req {
                         Some(r) => r,
@@ -859,24 +862,26 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     );
                                     return;
                                 }
-                                // Permit acquired — commit the pending_request clear to DB
-                                // now that dispatch is guaranteed to proceed.
+                                // Permit acquired — persist Pending status to DB while
+                                // retaining pending_request_json (cloned, not taken).  If the
+                                // server crashes between this persist and the spawn below,
+                                // startup recovery detects Pending + pending_request and
+                                // re-dispatches the task.
                                 if let Err(e) = store2.persist(&task_id2).await {
                                     tracing::warn!(
                                         task_id = %task_id2.0,
                                         "dep-watcher: failed to persist task before dispatch: {e} \
                                          — aborting dispatch, restoring state for next tick retry"
                                     );
-                                    // Restore in-memory state so the next watcher tick retries,
-                                    // but only if the task has not been cancelled (or otherwise
-                                    // transitioned) during the persist await — resurrecting a
-                                    // cancelled task would re-dispatch it on the next tick.
+                                    // Restore status so the next watcher tick retries.
+                                    // Guard: only restore if still Pending — don't resurrect
+                                    // a cancelled task.  pending_request was cloned (not taken)
+                                    // so it is already in the cache; only status needs resetting.
                                     if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
                                         if matches!(
                                             entry.status,
                                             crate::task_runner::TaskStatus::Pending
                                         ) {
-                                            entry.pending_request = Some(req);
                                             entry.status =
                                                 crate::task_runner::TaskStatus::AwaitingDeps;
                                         }
@@ -898,8 +903,10 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                         "dep-watcher: task cancelled during persist — \
                                          aborting dispatch"
                                     );
-                                    return; // drops permit; DB already has no pending_request
+                                    return; // drops permit; task cancelled, no re-dispatch needed
                                 }
+                                let store3 = store2.clone();
+                                let task_id3 = task_id2.clone();
                                 crate::task_runner::spawn_preregistered_task(
                                     task_id2,
                                     store2,
@@ -916,24 +923,30 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                                     None,
                                 )
                                 .await;
+                                // Task is now executing.  Clear pending_request from cache so
+                                // the dep-watcher does not attempt a second dispatch and so
+                                // subsequent persists (e.g. status → Implementing) write
+                                // pending_request_json = NULL to the DB.
+                                if let Some(mut entry) = store3.cache.get_mut(&task_id3) {
+                                    entry.pending_request = None;
+                                };
                             }
                             Err(e) => {
                                 tracing::error!(
                                     task_id = %task_id2.0,
                                     "dep-watcher: failed to acquire concurrency permit: {e}"
                                 );
-                                // Restore both pending_request AND status so the next
-                                // watcher tick (which only scans AwaitingDeps) can retry.
-                                // The DB still holds the original values because we have
-                                // not persisted yet, so no re-persist is needed.
-                                // Guard against resurrecting a cancelled task: only restore
-                                // if the status is still Pending (set by check_awaiting_deps).
+                                // Restore status so the next watcher tick (which only scans
+                                // AwaitingDeps) can retry.  DB still holds the original values
+                                // (no persist yet) so no re-persist is needed.
+                                // Guard: only restore if still Pending — don't resurrect a
+                                // cancelled task.  pending_request was cloned (not taken) so
+                                // it is already in the cache; only status needs resetting.
                                 if let Some(mut entry) = store2.cache.get_mut(&task_id2) {
                                     if matches!(
                                         entry.status,
                                         crate::task_runner::TaskStatus::Pending
                                     ) {
-                                        entry.pending_request = Some(req);
                                         entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
                                     }
                                 }
@@ -1478,6 +1491,126 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         None,
                     )
                     .await;
+                });
+            }
+        }
+    }
+
+    // Re-dispatch dep-watcher tasks that were in mid-dispatch when the server crashed.
+    // These tasks have status=Pending and pending_request persisted in the DB as
+    // pending_request_json, but have no pr_url (the task had not yet started executing).
+    // The pr_url-based recovery block above will NOT pick them up, so without this
+    // second pass they silently stay stuck in Pending forever.
+    {
+        let dep_watcher_stuck: Vec<_> = state
+            .core
+            .tasks
+            .list_all()
+            .into_iter()
+            .filter(|t| {
+                matches!(t.status, task_runner::TaskStatus::Pending)
+                    && t.pending_request.is_some()
+                    && t.pr_url.is_none()
+            })
+            .collect();
+        if !dep_watcher_stuck.is_empty() {
+            tracing::info!(
+                count = dep_watcher_stuck.len(),
+                "startup: re-dispatching dep-watcher pending task(s) with stored requests"
+            );
+            for task in dep_watcher_stuck {
+                let state = state.clone();
+                tokio::spawn(async move {
+                    let req = match task.pending_request.clone() {
+                        Some(r) => r,
+                        None => {
+                            // Unreachable: the filter guarantees Some, but guard
+                            // defensively so we never produce a stuck task.
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery (dep-watcher): \
+                                 pending_request is None despite filter — skipping"
+                            );
+                            return;
+                        }
+                    };
+
+                    // Resolve canonical project path from the stored request, falling
+                    // back to the repo slug if the request had no explicit project set.
+                    let project_path = req
+                        .project
+                        .clone()
+                        .or_else(|| task.repo.as_deref().map(std::path::PathBuf::from));
+                    let canonical = match task_runner::resolve_canonical_project(project_path).await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery (dep-watcher): \
+                                 failed to resolve project path: {e}"
+                            );
+                            return;
+                        }
+                    };
+                    let project_id = canonical.to_string_lossy().into_owned();
+
+                    let permit = match state.concurrency.task_queue.acquire(&project_id).await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery (dep-watcher): \
+                                 failed to acquire permit: {e}"
+                            );
+                            return;
+                        }
+                    };
+
+                    let classification = crate::complexity_router::classify(
+                        req.prompt.as_deref().unwrap_or(""),
+                        req.issue,
+                        req.pr,
+                    );
+                    let agent = match state.core.server.agent_registry.dispatch(&classification) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery (dep-watcher): \
+                                 failed to dispatch agent: {e}"
+                            );
+                            return;
+                        }
+                    };
+                    let (reviewer, _) = resolve_reviewer(
+                        &state.core.server.agent_registry,
+                        &state.core.server.config.agents.review,
+                        agent.name(),
+                    );
+
+                    state.core.tasks.register_task_stream(&task.id);
+                    task_runner::spawn_preregistered_task(
+                        task.id.clone(),
+                        state.core.tasks.clone(),
+                        agent,
+                        reviewer,
+                        Arc::new(state.core.server.config.clone()),
+                        state.engines.skills.clone(),
+                        state.observability.events.clone(),
+                        state.interceptors.clone(),
+                        req,
+                        state.concurrency.workspace_mgr.clone(),
+                        permit,
+                        state.intake.completion_callback.clone(),
+                        None,
+                    )
+                    .await;
+                    // Clear pending_request from cache so subsequent persists
+                    // (e.g. status → Implementing) write pending_request_json = NULL.
+                    if let Some(mut entry) = state.core.tasks.cache.get_mut(&task.id) {
+                        entry.pending_request = None;
+                    }
                 });
             }
         }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1550,9 +1550,69 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                                 "startup recovery (dep-watcher): \
                                  failed to resolve project path: {e}"
                             );
+                            // Fail-close: mark Failed so the task is not stuck in Pending
+                            // forever (check_awaiting_deps only scans AwaitingDeps, not Pending).
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(format!(
+                                        "startup recovery: cannot resolve project path: {e}"
+                                    ));
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery (dep-watcher): \
+                                     failed to persist failure state: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };
+
+                    // Enforce allowed_project_roots: mirrors the check in execution.rs:182
+                    // and task_routes.rs:260-264 so a stale/tampered persisted project path
+                    // cannot execute outside the current allowlist after a restart.
+                    if let Err(e) = crate::project_registry::check_allowed_roots(
+                        &canonical,
+                        &state.core.server.config.server.allowed_project_roots,
+                    ) {
+                        tracing::error!(
+                            task_id = ?task.id,
+                            "startup recovery (dep-watcher): \
+                             project not in allowed_project_roots — marking task failed: {e}"
+                        );
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(format!(
+                                    "startup recovery: project not in allowed roots: {e}"
+                                ));
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery (dep-watcher): \
+                                 failed to persist failure state: {pe}"
+                            );
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
                     let project_id = canonical.to_string_lossy().into_owned();
 
                     let permit = match state.concurrency.task_queue.acquire(&project_id).await {
@@ -1563,23 +1623,81 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                                 "startup recovery (dep-watcher): \
                                  failed to acquire permit: {e}"
                             );
+                            // Fail-close: mark Failed so the task is not stuck in Pending.
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(format!(
+                                        "startup recovery: failed to acquire concurrency permit: {e}"
+                                    ));
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery (dep-watcher): \
+                                     failed to persist failure state: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };
 
-                    let classification = crate::complexity_router::classify(
-                        req.prompt.as_deref().unwrap_or(""),
-                        req.issue,
-                        req.pr,
-                    );
-                    let agent = match state.core.server.agent_registry.dispatch(&classification) {
-                        Ok(a) => a,
-                        Err(e) => {
+                    // Honor req.agent if explicitly set (mirrors runtime dep-watcher dispatch
+                    // at http.rs:692-701) so crash recovery runs the same agent as originally
+                    // requested rather than always re-classifying by complexity.
+                    let agent = if let Some(ref name) = req.agent {
+                        state.core.server.agent_registry.get(name)
+                    } else {
+                        let classification = crate::complexity_router::classify(
+                            req.prompt.as_deref().unwrap_or(""),
+                            req.issue,
+                            req.pr,
+                        );
+                        state
+                            .core
+                            .server
+                            .agent_registry
+                            .dispatch(&classification)
+                            .ok()
+                    };
+                    let agent = match agent {
+                        Some(a) => a,
+                        None => {
                             tracing::error!(
                                 task_id = ?task.id,
                                 "startup recovery (dep-watcher): \
-                                 failed to dispatch agent: {e}"
+                                 failed to resolve agent — marking task failed"
                             );
+                            if let Err(pe) =
+                                task_runner::mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(
+                                        "startup recovery: no agent could be resolved for dispatch"
+                                            .to_string(),
+                                    );
+                                })
+                                .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery (dep-watcher): \
+                                     failed to persist failure state: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -119,6 +119,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            pending_request: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -158,6 +159,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            pending_request: None,
         };
         store.insert(&parent_state).await;
 
@@ -181,6 +183,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            pending_request: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -707,7 +707,17 @@ impl TaskRow {
         let pending_request = pending_request_json
             .as_deref()
             .filter(|s| !s.is_empty())
-            .and_then(|s| serde_json::from_str(s).ok());
+            .and_then(|s| match serde_json::from_str(s) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::error!(
+                        task_id = %id,
+                        "task_db: failed to deserialize pending_request \
+                         (DB may be corrupted) — task will not be dispatched: {e}"
+                    );
+                    None
+                }
+            });
 
         Ok(TaskState {
             id: harness_core::types::TaskId(id),

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -92,7 +92,7 @@ static TASK_MIGRATIONS: &[Migration] = &[
               ON tasks(project, status, updated_at DESC)",
     },
     Migration {
-        version: 11,
+        version: 12,
         description: "add pending_request_json column for AwaitingDeps tasks",
         sql: "ALTER TABLE tasks ADD COLUMN pending_request_json TEXT",
     },

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -91,6 +91,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_tasks_project_status_updated \
               ON tasks(project, status, updated_at DESC)",
     },
+    Migration {
+        version: 11,
+        description: "add pending_request_json column for AwaitingDeps tasks",
+        sql: "ALTER TABLE tasks ADD COLUMN pending_request_json TEXT",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -159,10 +164,15 @@ impl TaskDb {
     pub async fn insert(&self, state: &TaskState) -> anyhow::Result<()> {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
+        let pending_request_json = state
+            .pending_request
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
         let status = state.status.as_ref();
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, pending_request_json)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -177,6 +187,7 @@ impl TaskDb {
         .bind(&state.repo)
         .bind(&depends_on_json)
         .bind(state.project_root.as_ref().map(|p| p.to_string_lossy().into_owned()))
+        .bind(pending_request_json)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -185,10 +196,16 @@ impl TaskDb {
     pub async fn update(&self, state: &TaskState) -> anyhow::Result<()> {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
+        let pending_request_json = state
+            .pending_request
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
         let status = state.status.as_ref();
         sqlx::query(
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
-                    source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?, updated_at = datetime('now')
+                    source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
+                    pending_request_json = ?, updated_at = datetime('now')
              WHERE id = ?",
         )
         .bind(status)
@@ -200,7 +217,13 @@ impl TaskDb {
         .bind(&state.external_id)
         .bind(&state.repo)
         .bind(&depends_on_json)
-        .bind(state.project_root.as_ref().map(|p| p.to_string_lossy().into_owned()))
+        .bind(
+            state
+                .project_root
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned()),
+        )
+        .bind(pending_request_json)
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -209,7 +232,7 @@ impl TaskDb {
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<TaskState>> {
         let row = sqlx::query_as::<_, TaskRow>(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, pending_request_json
              FROM tasks WHERE id = ?",
         )
         .bind(id)
@@ -220,7 +243,7 @@ impl TaskDb {
 
     pub async fn list(&self) -> anyhow::Result<Vec<TaskState>> {
         let rows = sqlx::query_as::<_, TaskRow>(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, pending_request_json
              FROM tasks ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
@@ -571,7 +594,7 @@ impl TaskDb {
     /// Return all tasks whose `parent_id` matches the given parent task ID.
     pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
         let rows = sqlx::query_as::<_, TaskRow>(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, pending_request_json
              FROM tasks WHERE parent_id = ? ORDER BY created_at DESC",
         )
         .bind(parent_id)
@@ -647,6 +670,7 @@ struct TaskRow {
     repo: Option<String>,
     depends_on: String,
     project: Option<String>,
+    pending_request_json: Option<String>,
 }
 
 impl TaskRow {
@@ -665,6 +689,7 @@ impl TaskRow {
             repo,
             depends_on,
             project,
+            pending_request_json,
         } = self;
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
@@ -679,6 +704,10 @@ impl TaskRow {
                 source,
             }
         })?;
+        let pending_request = pending_request_json
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .and_then(|s| serde_json::from_str(s).ok());
 
         Ok(TaskState {
             id: harness_core::types::TaskId(id),
@@ -700,6 +729,7 @@ impl TaskRow {
             triage_output: None,
             plan_output: None,
             repo,
+            pending_request,
         })
     }
 }
@@ -725,6 +755,7 @@ mod tests {
             repo: None,
             depends_on: depends_on.to_string(),
             project: None,
+            pending_request_json: None,
         }
     }
 
@@ -832,6 +863,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            pending_request: None,
         }
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1301,6 +1301,25 @@ where
         // spawn_preregistered_task returns, which happens almost immediately).
         let _permit = permit;
         let _group_permit = group_permit;
+
+        // Guard against the cancel-before-abort-handle-registration race:
+        // the dep-watcher checks status before calling spawn_preregistered_task,
+        // but store_abort_handle() runs *after* tokio::spawn() returns — so a
+        // concurrent cancel arriving in that gap is a no-op on the abort handle.
+        // Re-check here before doing any real work so we never execute a task
+        // that was already cancelled.
+        if store
+            .cache
+            .get(&id)
+            .is_some_and(|e| matches!(e.status, TaskStatus::Cancelled))
+        {
+            tracing::info!(
+                task_id = %id.0,
+                "task cancelled before execution began — skipping"
+            );
+            return Ok(());
+        }
+
         let detect_worktree = detect_worktree.clone();
         let raw_project =
             resolve_project_root_with(req.project.clone(), move || detect_worktree()).await?;

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -150,6 +150,10 @@ pub struct TaskState {
     /// Output from the Plan phase (Architect plan). Not persisted to DB.
     #[serde(skip)]
     pub plan_output: Option<String>,
+    /// Original request stored for AwaitingDeps tasks; cleared after dispatch.
+    /// Not persisted via serde — task_db handles serialization as JSON.
+    #[serde(skip)]
+    pub pending_request: Option<CreateTaskRequest>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -212,6 +216,7 @@ impl TaskState {
             triage_output: None,
             plan_output: None,
             repo: None,
+            pending_request: None,
         }
     }
 
@@ -239,7 +244,7 @@ impl TaskState {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTaskRequest {
     /// Free-text task description (prompt, issue URL, etc.).
     pub prompt: Option<String>,
@@ -1711,6 +1716,7 @@ pub async fn spawn_task_awaiting_deps(
 
     if !all_done && !state.depends_on.is_empty() {
         state.status = TaskStatus::AwaitingDeps;
+        state.pending_request = Some(req.clone());
     }
 
     store.insert(&state).await;
@@ -2674,6 +2680,162 @@ mod tests {
         assert!(counts.contains_key(&key_b), "beta counts missing");
         assert_eq!(counts[&key_b].done, 1, "beta done");
         assert_eq!(counts[&key_b].failed, 2, "beta failed");
+        Ok(())
+    }
+
+    // ── depends_on / dep-watcher tests ───────────────────────────────────────
+
+    fn make_request(prompt: &str) -> CreateTaskRequest {
+        CreateTaskRequest {
+            prompt: Some(prompt.into()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_task_awaiting_deps_stores_request() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        // Upstream task that is NOT done.
+        let mut upstream = TaskState::new(TaskId::new());
+        upstream.status = TaskStatus::Implementing;
+        store.insert(&upstream).await;
+
+        let req = CreateTaskRequest {
+            prompt: Some("downstream task".into()),
+            depends_on: vec![upstream.id.clone()],
+            ..Default::default()
+        };
+
+        let task_id = spawn_task_awaiting_deps(store.clone(), req.clone()).await?;
+        let state = store.get(&task_id).expect("task must exist");
+
+        assert!(
+            matches!(state.status, TaskStatus::AwaitingDeps),
+            "expected AwaitingDeps, got {:?}",
+            state.status
+        );
+        let stored_req = state.pending_request.expect("pending_request must be Some");
+        assert_eq!(stored_req.prompt, req.prompt);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dep_watcher_dispatches_ready_task() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        // T1: dependency, starts Implementing then transitions to Done.
+        let mut t1 = TaskState::new(TaskId::new());
+        t1.status = TaskStatus::Implementing;
+        store.insert(&t1).await;
+
+        // T2: awaiting T1.
+        let req = make_request("downstream");
+        let t2_id = spawn_task_awaiting_deps(
+            store.clone(),
+            CreateTaskRequest {
+                depends_on: vec![t1.id.clone()],
+                ..req
+            },
+        )
+        .await?;
+
+        // Transition T1 to Done.
+        if let Some(mut entry) = store.cache.get_mut(&t1.id) {
+            entry.status = TaskStatus::Done;
+        }
+
+        let ready = check_awaiting_deps(&store);
+        assert_eq!(ready, vec![t2_id.clone()], "T2 should be ready");
+
+        let state = store.get(&t2_id).expect("T2 must exist");
+        assert!(
+            matches!(state.status, TaskStatus::Pending),
+            "expected Pending after transition, got {:?}",
+            state.status
+        );
+        assert!(
+            state.pending_request.is_some(),
+            "pending_request must survive check_awaiting_deps"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn awaiting_deps_persists_and_reloads_request() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut upstream = TaskState::new(TaskId::new());
+        upstream.status = TaskStatus::Implementing;
+        store.insert(&upstream).await;
+
+        let req = CreateTaskRequest {
+            prompt: Some("reload-test".into()),
+            depends_on: vec![upstream.id.clone()],
+            ..Default::default()
+        };
+        let task_id = spawn_task_awaiting_deps(store.clone(), req.clone()).await?;
+
+        // Reload from DB.
+        let reloaded = store
+            .db
+            .get(task_id.as_str())
+            .await?
+            .expect("task must be in DB");
+        assert!(
+            matches!(reloaded.status, TaskStatus::AwaitingDeps),
+            "reloaded status should be AwaitingDeps"
+        );
+        let stored = reloaded
+            .pending_request
+            .expect("pending_request must survive DB round-trip");
+        assert_eq!(stored.prompt, req.prompt);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dep_watcher_clears_request_after_taking() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut upstream = TaskState::new(TaskId::new());
+        upstream.status = TaskStatus::Implementing;
+        store.insert(&upstream).await;
+
+        let task_id = spawn_task_awaiting_deps(
+            store.clone(),
+            CreateTaskRequest {
+                prompt: Some("clear-test".into()),
+                depends_on: vec![upstream.id.clone()],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Transition upstream to Done.
+        if let Some(mut e) = store.cache.get_mut(&upstream.id) {
+            e.status = TaskStatus::Done;
+        }
+        check_awaiting_deps(&store);
+
+        // Simulate the dep-watcher clearing pending_request before dispatch.
+        let taken = store
+            .cache
+            .get_mut(&task_id)
+            .and_then(|mut e| e.pending_request.take());
+        assert!(taken.is_some(), "dep-watcher should take pending_request");
+
+        store.persist(&task_id).await?;
+
+        // Second tick: pending_request is None, so dispatch is skipped.
+        let reloaded = store.cache.get(&task_id).expect("task must exist");
+        assert!(
+            reloaded.pending_request.is_none(),
+            "pending_request must be cleared after first dispatch"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -31,6 +31,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         triage_output: None,
         plan_output: None,
         repo: None,
+        pending_request: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- `TaskState` gains a `pending_request: Option<CreateTaskRequest>` field (skipped by serde; persisted as JSON by task_db) that stores the original request when a task enters `AwaitingDeps` status
- DB migration v11 adds `pending_request_json TEXT` column; insert/update/select queries updated; `TaskRow::try_into_task_state` deserializes it on load
- The dep-watcher in `http.rs` now captures execution resources and, after `check_awaiting_deps` returns ready IDs, atomically takes `pending_request`, resolves the agent, and spawns `spawn_preregistered_task` behind a concurrency permit — tasks blocked on deps now actually execute when dependencies complete
- If `pending_request` is `None` (old DB row or already-dispatched second tick), the watcher logs a warning and skips, preventing double-dispatch and panics

## Test plan

- [x] `spawn_task_awaiting_deps_stores_request` — verifies `pending_request` is set on `AwaitingDeps` registration
- [x] `dep_watcher_dispatches_ready_task` — transitions T1→Done, verifies T2 reaches `Pending` with non-`None` `pending_request`
- [x] `awaiting_deps_persists_and_reloads_request` — verifies the request survives a DB round-trip (covers restart scenario)
- [x] `dep_watcher_clears_request_after_taking` — simulates the watcher's atomic-take, verifies `pending_request` is `None` after first dispatch
- [x] All 640 existing harness-server tests pass, clippy clean, `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)