### PR TITLE
fix(event-replay): stream log with BufReader and compact on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1275,6 +1275,7 @@ dependencies = [
  "harness-protocol",
  "harness-rules",
  "harness-skills",
+ "harness-workflow",
  "hmac",
  "http-body-util",
  "reqwest",
@@ -1297,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,6 +1308,28 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "harness-workflow"
+version = "0.6.33"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "futures",
+ "harness-core",
+ "harness-exec",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -319,8 +319,10 @@ pub fn replay_events(log_path: &Path) -> anyhow::Result<ReplayResult> {
 /// committed their state to the database.  Removing them prevents the log from
 /// growing unboundedly across server restarts.
 ///
-/// Uses an atomic rename (write to a sibling `.tmp` file, then `rename`) so
-/// that a crash during compaction leaves the original log intact.
+/// Uses an atomic rename (write to a per-process `.tmp` file, then `rename`)
+/// so that a crash during compaction leaves the original log intact.  A
+/// [`CompactLock`] serialises concurrent server instances that share the same
+/// data directory, preventing silent event loss from a rename race.
 ///
 /// Returns the number of event lines removed.
 fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyhow::Result<u32> {
@@ -334,45 +336,177 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
         return Ok(0);
     }
 
+    // Acquire an exclusive lock to prevent concurrent server instances from
+    // racing on the same log file.
+    let lock_path = {
+        let stem = log_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let mut p = log_path.to_path_buf();
+        p.set_file_name(format!("{stem}.compact.lock"));
+        p
+    };
+    let _lock = match CompactLock::try_acquire(&lock_path) {
+        Ok(Some(lock)) => lock,
+        Ok(None) => {
+            tracing::warn!(
+                path = %log_path.display(),
+                "event_replay: compaction lock held by another process, skipping"
+            );
+            return Ok(0);
+        }
+        Err(e) => return Err(e),
+    };
+
+    // Unique tmp path per process (PID + sub-second nonce) so two instances
+    // that somehow both pass the lock check cannot clobber each other's tmp.
+    let tmp_path = {
+        let pid = std::process::id();
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let stem = log_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let mut p = log_path.to_path_buf();
+        p.set_file_name(format!("{stem}.{pid}.{nonce}.tmp"));
+        p
+    };
+
     let file = std::fs::File::open(log_path)?;
     let reader = BufReader::new(file);
-    let mut kept: Vec<String> = Vec::new();
     let mut removed = 0u32;
 
-    for line_result in reader.lines() {
-        let line = line_result?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let keep = match serde_json::from_str::<TaskEvent>(trimmed) {
-            Ok(event) => !terminal_ids.contains(event.task_id()),
-            // Keep lines we cannot parse — do not silently drop unknown data.
-            Err(_) => true,
-        };
-        if keep {
-            kept.push(line);
-        } else {
-            removed += 1;
-        }
-    }
-
-    // Atomic write: write to a sibling .tmp file, then rename into place.
-    let mut tmp_path = log_path.to_path_buf();
-    let mut tmp_name = log_path.file_name().unwrap_or_default().to_os_string();
-    tmp_name.push(".tmp");
-    tmp_path.set_file_name(tmp_name);
-
+    // Stream directly to the tmp file line-by-line — never buffer all lines
+    // in memory, which could OOM the server on a large log.
     {
         let mut tmp_file = std::fs::File::create(&tmp_path)?;
-        for line in &kept {
-            writeln!(tmp_file, "{line}")?;
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let keep = match serde_json::from_str::<TaskEvent>(trimmed) {
+                Ok(event) => !terminal_ids.contains(event.task_id()),
+                // Keep lines we cannot parse — do not silently drop unknown data.
+                Err(_) => true,
+            };
+            if keep {
+                writeln!(tmp_file, "{trimmed}")?;
+            } else {
+                removed += 1;
+            }
         }
+        // Flush buffered writer state then sync to durable storage before the
+        // rename.  This ensures the compacted data survives a power failure
+        // that occurs between flush and rename.
         tmp_file.flush()?;
+        tmp_file.sync_all()?;
+        // File is closed (dropped) here, before rename.
     }
+
     std::fs::rename(&tmp_path, log_path)?;
 
+    // Sync the parent directory to make the directory-entry rename durable.
+    if let Some(parent) = log_path.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            if let Err(e) = dir.sync_all() {
+                tracing::warn!(
+                    path = %log_path.display(),
+                    "event_replay: failed to fsync parent dir after compaction: {e}"
+                );
+            }
+        }
+    }
+
     Ok(removed)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CompactLock — per-directory mutex for log compaction
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// RAII guard for the compaction lock file.
+///
+/// Uses [`std::fs::OpenOptions::create_new`] for atomic creation (mutual
+/// exclusion without `libc`).  Stale locks left by crashed processes are
+/// detected via the file's modification time: a lock older than
+/// [`STALE_SECS`](CompactLock::STALE_SECS) is assumed abandoned and removed.
+struct CompactLock {
+    path: std::path::PathBuf,
+}
+
+impl CompactLock {
+    /// A lock file older than this many seconds is considered stale.
+    const STALE_SECS: u64 = 60;
+
+    /// Try to acquire the lock.
+    ///
+    /// Returns:
+    /// - `Ok(Some(guard))` — lock acquired; compaction may proceed.
+    /// - `Ok(None)` — lock is held by a live process; caller must skip.
+    /// - `Err(_)` — unexpected I/O failure.
+    fn try_acquire(lock_path: &Path) -> anyhow::Result<Option<Self>> {
+        // Remove stale locks from crashed/killed processes.
+        if let Ok(meta) = std::fs::metadata(lock_path) {
+            let stale = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.elapsed().ok())
+                .map(|d| d.as_secs() > Self::STALE_SECS)
+                .unwrap_or(false);
+            if stale {
+                tracing::debug!(
+                    path = %lock_path.display(),
+                    "event_replay: removing stale compaction lock"
+                );
+                if let Err(e) = std::fs::remove_file(lock_path) {
+                    tracing::warn!(
+                        path = %lock_path.display(),
+                        "event_replay: failed to remove stale lock: {e}"
+                    );
+                }
+            }
+        }
+
+        let pid = std::process::id().to_string();
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(lock_path)
+        {
+            Ok(mut f) => {
+                if let Err(e) = IoWrite::write_all(&mut f, pid.as_bytes()) {
+                    tracing::warn!(
+                        path = %lock_path.display(),
+                        "event_replay: failed to write PID to lock file: {e}"
+                    );
+                }
+                Ok(Some(Self {
+                    path: lock_path.to_path_buf(),
+                }))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl Drop for CompactLock {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            tracing::warn!(
+                path = %self.path.display(),
+                "event_replay: failed to remove compaction lock: {e}"
+            );
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -481,8 +481,40 @@ struct CompactLock {
 }
 
 impl CompactLock {
-    /// A lock file older than this many seconds is considered stale.
-    const STALE_SECS: u64 = 60;
+    /// Fallback age threshold (seconds) used on platforms where PID-based
+    /// liveness cannot be determined.  5 minutes is conservative enough to
+    /// cover realistic compaction durations on large logs.
+    const STALE_SECS: u64 = 300;
+
+    /// On Linux: reads the PID from the lock file and returns `true` iff
+    /// `/proc/{pid}` does not exist — a race-free, zero-overhead liveness test
+    /// that is independent of how long compaction takes.
+    #[cfg(target_os = "linux")]
+    fn is_stale(lock_path: &Path, meta: &std::fs::Metadata) -> bool {
+        if let Some(pid) = std::fs::read_to_string(lock_path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok())
+        {
+            return !std::path::Path::new(&format!("/proc/{pid}")).exists();
+        }
+        // Can't read PID — fall back to age-based check.
+        meta.modified()
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .map(|d| d.as_secs() > Self::STALE_SECS)
+            .unwrap_or(false)
+    }
+
+    /// On non-Linux: falls back to an age-based check with a conservative
+    /// threshold so a slow compaction on a large log is not incorrectly evicted.
+    #[cfg(not(target_os = "linux"))]
+    fn is_stale(_lock_path: &Path, meta: &std::fs::Metadata) -> bool {
+        meta.modified()
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .map(|d| d.as_secs() > Self::STALE_SECS)
+            .unwrap_or(false)
+    }
 
     /// Try to acquire the lock.
     ///
@@ -493,13 +525,7 @@ impl CompactLock {
     fn try_acquire(lock_path: &Path) -> anyhow::Result<Option<Self>> {
         // Remove stale locks from crashed/killed processes.
         if let Ok(meta) = std::fs::metadata(lock_path) {
-            let stale = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.elapsed().ok())
-                .map(|d| d.as_secs() > Self::STALE_SECS)
-                .unwrap_or(false);
-            if stale {
+            if Self::is_stale(lock_path, &meta) {
                 tracing::debug!(
                     path = %lock_path.display(),
                     "event_replay: removing stale compaction lock"

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -424,6 +424,13 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
     let reader = BufReader::new(src_file);
     let mut removed = 0u32;
 
+    // Open a second fd to the source file seeked to snapshot_len.  We keep
+    // this fd open across the rename so we can perform a post-rename second
+    // drain to capture any bytes written to the old inode between the first
+    // drain and the rename.
+    let mut drain = std::fs::File::open(log_path)?;
+    drain.seek(SeekFrom::Start(snapshot_len))?;
+
     // Stream directly to the tmp file line-by-line — never buffer all lines
     // in memory, which could OOM the server on a large log.
     {
@@ -446,19 +453,9 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
             }
         }
 
-        // Drain bytes appended to the source file while the filter pass was
-        // running.  A concurrent appender in another process may have written
-        // events to the original inode after we opened it (snapshot_len).
-        // Copy those bytes verbatim into the tmp file before the rename so
-        // they are preserved.  The tiny window between this drain and the
-        // rename is handled by the inode-detection reopen logic in
-        // TaskEventLog::append, which redirects the next write to the new
-        // inode if it detects the path has been replaced.
-        {
-            let mut drain = std::fs::File::open(log_path)?;
-            drain.seek(SeekFrom::Start(snapshot_len))?;
-            std::io::copy(&mut drain, &mut tmp_file)?;
-        }
+        // First drain: copy bytes appended to the source inode during the
+        // filter pass (positions snapshot_len..current_end).
+        std::io::copy(&mut drain, &mut tmp_file)?;
 
         // Flush buffered writer state then sync to durable storage before the
         // rename.  This ensures the compacted data survives a power failure
@@ -469,6 +466,41 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
     }
 
     std::fs::rename(&tmp_path, log_path)?;
+
+    // Second drain: capture bytes written to the old inode between the first
+    // drain and the rename.  On Unix, rename() is atomic; a concurrent
+    // appender that had not yet detected the inode change may have written
+    // events to the pre-rename inode during that window.  `drain` still holds
+    // an open fd to the now-unlinked old inode, so we copy any remaining
+    // bytes into the new file.  The inode-detection reopen in
+    // TaskEventLog::append redirects the next write to the new inode once the
+    // appender observes the path replacement, closing the window from the
+    // appender's side.
+    {
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_path)
+        {
+            Ok(mut new_file) => {
+                if let Err(e) =
+                    std::io::copy(&mut drain, &mut new_file).and_then(|_| new_file.sync_all())
+                {
+                    tracing::warn!(
+                        path = %log_path.display(),
+                        "event_replay: second drain after rename failed (non-fatal): {e}"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %log_path.display(),
+                    "event_replay: failed to open new log for second drain (non-fatal): {e}"
+                );
+            }
+        }
+    }
+    drop(drain);
 
     // Sync the parent directory to make the directory-entry rename durable.
     if let Some(parent) = log_path.parent() {

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -13,7 +13,7 @@ use crate::task_runner::TaskStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Write as IoWrite};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write as IoWrite};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -416,8 +416,12 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
         p
     };
 
-    let file = std::fs::File::open(log_path)?;
-    let reader = BufReader::new(file);
+    let src_file = std::fs::File::open(log_path)?;
+    // Record the file size at open time.  After the filter pass, we drain any
+    // bytes appended by concurrent writers between now and the rename below,
+    // so events written during the compaction window are not silently lost.
+    let snapshot_len = src_file.metadata()?.len();
+    let reader = BufReader::new(src_file);
     let mut removed = 0u32;
 
     // Stream directly to the tmp file line-by-line — never buffer all lines
@@ -441,6 +445,21 @@ fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyh
                 removed += 1;
             }
         }
+
+        // Drain bytes appended to the source file while the filter pass was
+        // running.  A concurrent appender in another process may have written
+        // events to the original inode after we opened it (snapshot_len).
+        // Copy those bytes verbatim into the tmp file before the rename so
+        // they are preserved.  The tiny window between this drain and the
+        // rename is handled by the inode-detection reopen logic in
+        // TaskEventLog::append, which redirects the next write to the new
+        // inode if it detects the path has been replaced.
+        {
+            let mut drain = std::fs::File::open(log_path)?;
+            drain.seek(SeekFrom::Start(snapshot_len))?;
+            std::io::copy(&mut drain, &mut tmp_file)?;
+        }
+
         // Flush buffered writer state then sync to durable storage before the
         // rename.  This ensures the compacted data survives a power failure
         // that occurs between flush and rename.
@@ -486,18 +505,58 @@ impl CompactLock {
     /// cover realistic compaction durations on large logs.
     const STALE_SECS: u64 = 300;
 
-    /// On Linux: reads the PID from the lock file and returns `true` iff
-    /// `/proc/{pid}` does not exist — a race-free, zero-overhead liveness test
-    /// that is independent of how long compaction takes.
+    /// Read `starttime` (field 22) from `/proc/<pid>/stat`.
+    ///
+    /// The start time is clock ticks since system boot.  It is unique per
+    /// boot: if a PID is recycled the new process will have a different start
+    /// time, letting us distinguish a live holder from a reuse.
+    #[cfg(target_os = "linux")]
+    fn read_proc_start_time(pid: u32) -> Option<u64> {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        // Format: "pid (comm) state ppid pgrp session tty_nr tpgid flags
+        //   minflt cminflt majflt cmajflt utime stime cutime cstime
+        //   priority nice num_threads itrealvalue starttime ..."
+        // `comm` may contain spaces/parens — use rfind to find the last ')'.
+        let after_comm = stat.rfind(')')?;
+        // After ')': state(0) ppid(1) pgrp(2) session(3) tty_nr(4)
+        //   tpgid(5) flags(6) minflt(7) cminflt(8) majflt(9) cmajflt(10)
+        //   utime(11) stime(12) cutime(13) cstime(14) priority(15) nice(16)
+        //   num_threads(17) itrealvalue(18) starttime(19)
+        let fields: Vec<&str> = stat[after_comm + 1..].split_whitespace().collect();
+        fields.get(19)?.parse().ok()
+    }
+
+    /// On Linux: reads `pid:starttime` from the lock file.  Returns `true`
+    /// iff the process is gone **or** its start time differs from the stored
+    /// value (PID reuse).  Falls back to age-based check when the lock cannot
+    /// be read or parsed.
     #[cfg(target_os = "linux")]
     fn is_stale(lock_path: &Path, meta: &std::fs::Metadata) -> bool {
-        if let Some(pid) = std::fs::read_to_string(lock_path)
-            .ok()
-            .and_then(|s| s.trim().parse::<u32>().ok())
-        {
-            return !std::path::Path::new(&format!("/proc/{pid}")).exists();
+        if let Some(content) = std::fs::read_to_string(lock_path).ok() {
+            let trimmed = content.trim();
+            // Lock file format: "pid:starttime" (new) or bare "pid" (legacy).
+            let (pid_opt, stored_start_opt) = if let Some((p, s)) = trimmed.split_once(':') {
+                (p.parse::<u32>().ok(), s.parse::<u64>().ok())
+            } else {
+                (trimmed.parse::<u32>().ok(), None)
+            };
+            if let Some(pid) = pid_opt {
+                if !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+                    return true; // Process is gone.
+                }
+                // Guard against PID reuse: a mismatch means the original
+                // writer exited and a different process inherited the PID.
+                if let (Some(stored), Some(current)) =
+                    (stored_start_opt, Self::read_proc_start_time(pid))
+                {
+                    if stored != current {
+                        return true; // PID reused; lock is stale.
+                    }
+                }
+                return false; // Process is live and PID not reused.
+            }
         }
-        // Can't read PID — fall back to age-based check.
+        // Cannot read the lock file — fall back to age-based check.
         meta.modified()
             .ok()
             .and_then(|t| t.elapsed().ok())
@@ -539,14 +598,23 @@ impl CompactLock {
             }
         }
 
-        let pid = std::process::id().to_string();
+        let pid = std::process::id();
+        // On Linux include the process start time so is_stale can detect PID
+        // reuse (a recycled PID has a different start time).
+        #[cfg(target_os = "linux")]
+        let lock_content = {
+            let start = Self::read_proc_start_time(pid).unwrap_or(0);
+            format!("{pid}:{start}")
+        };
+        #[cfg(not(target_os = "linux"))]
+        let lock_content = pid.to_string();
         match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(lock_path)
         {
             Ok(mut f) => {
-                if let Err(e) = IoWrite::write_all(&mut f, pid.as_bytes()) {
+                if let Err(e) = IoWrite::write_all(&mut f, lock_content.as_bytes()) {
                     tracing::warn!(
                         path = %lock_path.display(),
                         "event_replay: failed to write PID to lock file: {e}"

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -564,7 +564,7 @@ impl CompactLock {
     /// be read or parsed.
     #[cfg(target_os = "linux")]
     fn is_stale(lock_path: &Path, meta: &std::fs::Metadata) -> bool {
-        if let Some(content) = std::fs::read_to_string(lock_path).ok() {
+        if let Ok(content) = std::fs::read_to_string(lock_path) {
             let trimmed = content.trim();
             // Lock file format: "pid:starttime" (new) or bare "pid" (legacy).
             let (pid_opt, stored_start_opt) = if let Some((p, s)) = trimmed.split_once(':') {

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -136,7 +136,45 @@ impl TaskEventLog {
             }
         };
         let mut file = self.file.lock().unwrap();
-        if let Err(e) = writeln!(file, "{line}") {
+
+        // On Unix, `rename()` is atomic but leaves existing file descriptors
+        // pointing to the old (now unlinked) inode.  When compaction replaces
+        // `task-events.jsonl`, a running appender would silently write events
+        // to the unlinked inode — events are lost once the fd is closed.
+        // Detect the replacement by comparing inodes and reopen if needed.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let replaced = file
+                .metadata()
+                .ok()
+                .zip(std::fs::metadata(&self.path).ok())
+                .map(|(fd_meta, path_meta)| fd_meta.ino() != path_meta.ino())
+                .unwrap_or(false);
+            if replaced {
+                match std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.path)
+                {
+                    Ok(new_file) => {
+                        tracing::debug!(
+                            path = %self.path.display(),
+                            "event_log: log file replaced by compaction; reopened"
+                        );
+                        *file = new_file;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %self.path.display(),
+                            "event_log: log file replaced but reopen failed: {e}"
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Err(e) = writeln!(*file, "{line}") {
             tracing::warn!(
                 path = %self.path.display(),
                 "event_log: failed to append event: {e}"

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -11,7 +11,7 @@
 use crate::task_db::TaskDb;
 use crate::task_runner::TaskStatus;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::Path;
@@ -312,6 +312,69 @@ pub fn replay_events(log_path: &Path) -> anyhow::Result<ReplayResult> {
     })
 }
 
+/// Compact `task-events.jsonl` by removing all events for tasks that have
+/// reached a terminal state.
+///
+/// Terminal-task events are redundant after [`replay_and_recover`] has
+/// committed their state to the database.  Removing them prevents the log from
+/// growing unboundedly across server restarts.
+///
+/// Uses an atomic rename (write to a sibling `.tmp` file, then `rename`) so
+/// that a crash during compaction leaves the original log intact.
+///
+/// Returns the number of event lines removed.
+fn compact_log(log_path: &Path, states: &HashMap<String, ReplayedState>) -> anyhow::Result<u32> {
+    let terminal_ids: HashSet<&str> = states
+        .iter()
+        .filter(|(_, s)| s.terminal)
+        .map(|(id, _)| id.as_str())
+        .collect();
+
+    if terminal_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let file = std::fs::File::open(log_path)?;
+    let reader = BufReader::new(file);
+    let mut kept: Vec<String> = Vec::new();
+    let mut removed = 0u32;
+
+    for line_result in reader.lines() {
+        let line = line_result?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let keep = match serde_json::from_str::<TaskEvent>(trimmed) {
+            Ok(event) => !terminal_ids.contains(event.task_id()),
+            // Keep lines we cannot parse — do not silently drop unknown data.
+            Err(_) => true,
+        };
+        if keep {
+            kept.push(line);
+        } else {
+            removed += 1;
+        }
+    }
+
+    // Atomic write: write to a sibling .tmp file, then rename into place.
+    let mut tmp_path = log_path.to_path_buf();
+    let mut tmp_name = log_path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".tmp");
+    tmp_path.set_file_name(tmp_name);
+
+    {
+        let mut tmp_file = std::fs::File::create(&tmp_path)?;
+        for line in &kept {
+            writeln!(tmp_file, "{line}")?;
+        }
+        tmp_file.flush()?;
+    }
+    std::fs::rename(&tmp_path, log_path)?;
+
+    Ok(removed)
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Startup integration
 // ──────────────────────────────────────────────────────────────────────────────
@@ -362,6 +425,19 @@ pub async fn replay_and_recover(db: &TaskDb, log_path: &Path) -> anyhow::Result<
 
     if updated > 0 {
         tracing::info!("event_replay: applied replayed state to {updated} task(s)");
+    }
+
+    // Compact the log: remove events for tasks that have reached terminal
+    // state — they are now committed to the DB and no longer needed.
+    match compact_log(log_path, &states) {
+        Ok(removed) if removed > 0 => {
+            tracing::info!("event_replay: compacted log, removed {removed} terminal-task line(s)");
+        }
+        Ok(_) => {}
+        Err(e) => {
+            // Compaction failure is non-fatal: recovery already succeeded.
+            tracing::warn!("event_replay: log compaction failed (non-fatal): {e}");
+        }
     }
 
     Ok(updated)

--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -359,6 +359,45 @@ fn replay_events_errors_on_unreadable_path() {
     assert!(result.is_err());
 }
 
+// ── CompactLock PID-reuse detection tests (Linux only) ────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn compact_lock_is_stale_when_start_time_mismatches() {
+    // Simulate PID reuse: write a lock with the current PID but a start time
+    // that cannot match (start time 1 is before any real process).
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("task-events.jsonl.compact.lock");
+    let pid = std::process::id();
+    let real_start =
+        CompactLock::read_proc_start_time(pid).expect("must be able to read our own start time");
+    let wrong_start = real_start.wrapping_add(1);
+    std::fs::write(&lock_path, format!("{pid}:{wrong_start}")).unwrap();
+
+    let meta = std::fs::metadata(&lock_path).unwrap();
+    assert!(
+        CompactLock::is_stale(&lock_path, &meta),
+        "lock with mismatched start time should be stale (PID reuse)"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn compact_lock_is_not_stale_for_live_process_with_correct_start_time() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("task-events.jsonl.compact.lock");
+    let pid = std::process::id();
+    let start =
+        CompactLock::read_proc_start_time(pid).expect("must be able to read our own start time");
+    std::fs::write(&lock_path, format!("{pid}:{start}")).unwrap();
+
+    let meta = std::fs::metadata(&lock_path).unwrap();
+    assert!(
+        !CompactLock::is_stale(&lock_path, &meta),
+        "lock held by current live process with correct start time should not be stale"
+    );
+}
+
 // ── Integration: full round-trip ──────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1283,6 +1283,10 @@ pub(crate) async fn run_task(
                 });
             })
             .await?;
+            store.log_event(crate::event_replay::TaskEvent::Completed {
+                task_id: task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+            });
             tracing::info!(
                 task_id = %task_id,
                 status = "done",
@@ -1388,6 +1392,10 @@ pub(crate) async fn run_task(
                 s.turn = 2;
             })
             .await?;
+            store.log_event(crate::event_replay::TaskEvent::Completed {
+                task_id: task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+            });
             tracing::info!(
                 task_id = %task_id,
                 status = "done",
@@ -1444,6 +1452,10 @@ pub(crate) async fn run_task(
             s.turn = 2;
         })
         .await?;
+        store.log_event(crate::event_replay::TaskEvent::Completed {
+            task_id: task_id.0.clone(),
+            ts: crate::event_replay::now_ts(),
+        });
         tracing::info!(
             task_id = %task_id,
             status = "done",
@@ -1766,6 +1778,10 @@ pub(crate) async fn run_task(
                         s.turn = round.saturating_add(1);
                     })
                     .await?;
+                    store.log_event(crate::event_replay::TaskEvent::Completed {
+                        task_id: task_id.0.clone(),
+                        ts: crate::event_replay::now_ts(),
+                    });
                     tracing::info!(
                         task_id = %task_id,
                         phase = "reviewing",


### PR DESCRIPTION
## Summary

- **BufReader streaming**: Replace `std::fs::read_to_string` in `replay_events()` with `BufReader` line-by-line iteration, eliminating full-file allocation and preventing OOM on large `task-events.jsonl` files.
- **Log compaction**: Add `compact_log()` called from `replay_and_recover()` after successful DB apply. Removes all events for terminal tasks (state already committed to DB) using an atomic rename (`write .tmp` → `rename`) so a crash during compaction leaves the original log intact.
- **Elevated error logging**: File-open and mid-stream read failures now log at `error` level (was `warn`) with explicit documentation of recovery degradation: lost `pr_url` values and tasks that completed between the last DB write and crash incorrectly retaining interrupted status.

## Test plan

- [ ] `cargo test -p harness-server event_replay` — 17 tests pass (existing coverage preserved)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — clean
- [ ] Manual: verify log shrinks after restart when terminal tasks are present