### PR TITLE
fix: only clear rate-limit deadline if unchanged after sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -840,21 +840,37 @@ impl TaskStore {
     }
 
     /// Wait if the global rate-limit circuit breaker is active.
-    /// Returns immediately if no breaker is set or the deadline has passed.
+    /// Loops until the breaker is fully cleared, re-sleeping if the deadline
+    /// is extended during a sleep window (prevents early resume on 429 extension).
     pub async fn wait_for_rate_limit(&self) {
-        let deadline = { *self.rate_limit_until.read().await };
-        if let Some(until) = deadline {
-            if tokio::time::Instant::now() < until {
-                let remaining = until - tokio::time::Instant::now();
-                tracing::info!(
-                    remaining_secs = remaining.as_secs(),
-                    "task waiting for rate-limit circuit breaker to clear"
-                );
-                tokio::time::sleep_until(until).await;
-                // Only clear the breaker if it hasn't been extended during the sleep window.
-                let mut wl = self.rate_limit_until.write().await;
-                if *wl == Some(until) {
-                    *wl = None;
+        loop {
+            let deadline = { *self.rate_limit_until.read().await };
+            match deadline {
+                None => return,
+                Some(until) => {
+                    let now = tokio::time::Instant::now();
+                    if now >= until {
+                        // Deadline already passed; clear if unchanged and return.
+                        let mut wl = self.rate_limit_until.write().await;
+                        if *wl == Some(until) {
+                            *wl = None;
+                        }
+                        return;
+                    }
+                    let remaining = until - now;
+                    tracing::info!(
+                        remaining_secs = remaining.as_secs(),
+                        "task waiting for rate-limit circuit breaker to clear"
+                    );
+                    tokio::time::sleep_until(until).await;
+                    // Only clear if the deadline wasn't extended during sleep.
+                    // If it was extended, loop to re-check and sleep to the new deadline.
+                    let mut wl = self.rate_limit_until.write().await;
+                    if *wl == Some(until) {
+                        *wl = None;
+                        return;
+                    }
+                    // Deadline changed (extended or cleared by another waiter); loop again.
                 }
             }
         }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -851,8 +851,11 @@ impl TaskStore {
                     "task waiting for rate-limit circuit breaker to clear"
                 );
                 tokio::time::sleep_until(until).await;
-                // Clear the breaker after waking up.
-                *self.rate_limit_until.write().await = None;
+                // Only clear the breaker if it hasn't been extended during the sleep window.
+                let mut wl = self.rate_limit_until.write().await;
+                if *wl == Some(until) {
+                    *wl = None;
+                }
             }
         }
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -850,12 +850,15 @@ impl TaskStore {
                 Some(until) => {
                     let now = tokio::time::Instant::now();
                     if now >= until {
-                        // Deadline already passed; clear if unchanged and return.
+                        // Deadline passed; only clear+return if unchanged.
+                        // If a newer deadline was set between the read-lock and
+                        // write-lock, fall through and loop to respect it.
                         let mut wl = self.rate_limit_until.write().await;
                         if *wl == Some(until) {
                             *wl = None;
+                            return;
                         }
-                        return;
+                        // Deadline extended; drop write lock and loop.
                     }
                     let remaining = until - now;
                     tracing::info!(


### PR DESCRIPTION
## Summary

- `wait_for_rate_limit()` unconditionally cleared `rate_limit_until` after sleeping, even if `set_rate_limit()` was called again during the sleep window with a later deadline
- This allowed tasks to bypass the remaining backoff period and trigger additional 429 errors
- Fixed by comparing the stored deadline to the snapshotted value before clearing — only clear if `*wl == Some(until)`

## Root Cause

Race scenario:
1. Task A hits limit → `set_rate_limit(3600s)` → deadline D1
2. Tasks B/C/D snapshot D1 and sleep until D1
3. Task E hits limit again → `set_rate_limit(3600s)` → deadline D2 = now+5400s
4. B/C/D wake, each writes `rate_limit_until = None`, silently discarding D2
5. All tasks proceed immediately, bypassing 1800s of remaining backoff

## Fix

```rust
tokio::time::sleep_until(until).await;
let mut wl = self.rate_limit_until.write().await;
if *wl == Some(until) {
    *wl = None;
}
```

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass

Closes #656