### PR TITLE
fix: replace read_to_string with BufReader streaming in event replay (#657)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -146,7 +146,7 @@ impl EventStore {
         use std::io::BufRead as _;
 
         let path = self.data_dir.join("events.jsonl");
-        if !path.exists() {
+        if !path.is_file() {
             return;
         }
         let file = match std::fs::File::open(&path) {
@@ -161,8 +161,10 @@ impl EventStore {
             let line = match line {
                 Ok(l) => l,
                 Err(e) => {
-                    tracing::warn!("event store: I/O error reading events.jsonl: {e}");
-                    continue;
+                    tracing::warn!(
+                        "event store: I/O error reading events.jsonl, aborting migration: {e}"
+                    );
+                    break;
                 }
             };
             let line = line.trim().to_owned();

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -143,24 +143,33 @@ impl EventStore {
     ///
     /// Silently skips lines that fail to parse or insert (duplicate id = IGNORE).
     async fn migrate_from_jsonl(&self) {
+        use std::io::BufRead as _;
+
         let path = self.data_dir.join("events.jsonl");
         if !path.exists() {
             return;
         }
-        let contents = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
+        let file = match std::fs::File::open(&path) {
+            Ok(f) => f,
             Err(e) => {
-                tracing::warn!("event store: could not read events.jsonl for migration: {e}");
+                tracing::warn!("event store: could not open events.jsonl for migration: {e}");
                 return;
             }
         };
         let mut imported = 0usize;
-        for line in contents.lines() {
-            let line = line.trim();
+        for line in std::io::BufReader::new(file).lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!("event store: I/O error reading events.jsonl: {e}");
+                    continue;
+                }
+            };
+            let line = line.trim().to_owned();
             if line.is_empty() {
                 continue;
             }
-            if let Ok(event) = serde_json::from_str::<Event>(line) {
+            if let Ok(event) = serde_json::from_str::<Event>(&line) {
                 if let Err(e) = self.insert_event(&event).await {
                     tracing::warn!("event store: failed to insert migrated event: {e}");
                 } else {

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -146,11 +146,14 @@ impl EventStore {
         use std::io::BufRead as _;
 
         let path = self.data_dir.join("events.jsonl");
-        if !path.is_file() {
-            return;
-        }
+        // Use File::open directly rather than Path::is_file(): is_file() returns
+        // false both when the file is absent *and* when metadata fails (e.g.
+        // permissions), silently suppressing the latter case with no warning.
         let file = match std::fs::File::open(&path) {
             Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return; // fresh install — no legacy events.jsonl to migrate
+            }
             Err(e) => {
                 tracing::warn!("event store: could not open events.jsonl for migration: {e}");
                 return;

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -264,13 +264,15 @@ pub fn replay_events(log_path: &Path) -> anyhow::Result<ReplayResult> {
         let line = match line {
             Ok(l) => l,
             Err(e) => {
-                tracing::warn!("event_replay: I/O error reading line: {e}");
-                total_lines += 1;
-                corrupt_lines += 1;
-                // Break rather than continue: a stream-level I/O error means
-                // the file descriptor is unrecoverable; looping would spin
-                // forever on repeated errors (e.g. EISDIR on macOS).
-                break;
+                // Return Err rather than break with partial state: using an
+                // incomplete event history is fail-open and can persist stale
+                // values (e.g. a stale pr_url) into the database.
+                // EISDIR is already caught above by the meta.is_file() check,
+                // so this path only fires for genuine mid-stream I/O errors.
+                return Err(anyhow::anyhow!(
+                    "event_replay: I/O error reading {}: {e}",
+                    log_path.display()
+                ));
             }
         };
         let trimmed = line.trim();

--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -12,7 +12,8 @@ use crate::task_db::TaskDb;
 use crate::task_runner::TaskStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Write as IoWrite;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -148,6 +149,26 @@ impl TaskEventLog {
 // Replay state machine
 // ──────────────────────────────────────────────────────────────────────────────
 
+/// Statistics collected during a [`replay_events`] pass.
+#[derive(Debug, Default)]
+pub struct ReplayStats {
+    /// Number of non-empty lines processed.
+    pub total_lines: usize,
+    /// Number of lines that could not be parsed (corrupt or I/O error).
+    pub corrupt_lines: usize,
+    /// Number of distinct task IDs encountered.
+    pub tasks_seen: usize,
+}
+
+/// Return value of [`replay_events`].
+#[derive(Debug)]
+pub struct ReplayResult {
+    /// Per-task reconstructed state.
+    pub states: HashMap<String, ReplayedState>,
+    /// Parsing statistics from this replay pass.
+    pub stats: ReplayStats,
+}
+
 /// Per-task state reconstructed from replaying the event log.
 #[derive(Debug, Default)]
 pub struct ReplayedState {
@@ -202,26 +223,61 @@ pub fn apply_event(states: &mut HashMap<String, ReplayedState>, event: TaskEvent
     }
 }
 
-/// Read `task-events.jsonl` and return a map of task_id → [`ReplayedState`].
+/// Read `task-events.jsonl` line-by-line and return reconstructed state.
 ///
-/// - Missing file → empty map (fresh install, no error).
-/// - Corrupt lines → skipped with a warning (partial-write tolerance).
-pub fn replay_events(log_path: &Path) -> HashMap<String, ReplayedState> {
-    let data = match std::fs::read_to_string(log_path) {
-        Ok(d) => d,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+/// - Missing file → `Ok` with empty result (fresh install, no error).
+/// - Unreadable file (permissions, I/O error) → `Err` propagated to caller.
+/// - Corrupt lines → skipped with `warn!`; if ≥ 10 % of lines are corrupt,
+///   an additional `error!` is emitted to surface possible log corruption.
+pub fn replay_events(log_path: &Path) -> anyhow::Result<ReplayResult> {
+    let file = match File::open(log_path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ReplayResult {
+                states: HashMap::new(),
+                stats: ReplayStats::default(),
+            });
+        }
         Err(e) => {
-            tracing::warn!("event_replay: failed to read {}: {e}", log_path.display());
-            return HashMap::new();
+            return Err(anyhow::anyhow!(
+                "event_replay: failed to open {}: {e}",
+                log_path.display()
+            ));
         }
     };
 
+    // On macOS, File::open() succeeds on directories; detect this early to
+    // avoid an infinite loop of EISDIR errors from BufReader::lines().
+    let meta = file.metadata()?;
+    if !meta.is_file() {
+        return Err(anyhow::anyhow!(
+            "event_replay: {} is not a regular file",
+            log_path.display()
+        ));
+    }
+
     let mut states: HashMap<String, ReplayedState> = HashMap::new();
-    for line in data.lines() {
+    let mut total_lines = 0usize;
+    let mut corrupt_lines = 0usize;
+
+    for line in BufReader::new(file).lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!("event_replay: I/O error reading line: {e}");
+                total_lines += 1;
+                corrupt_lines += 1;
+                // Break rather than continue: a stream-level I/O error means
+                // the file descriptor is unrecoverable; looping would spin
+                // forever on repeated errors (e.g. EISDIR on macOS).
+                break;
+            }
+        };
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
+        total_lines += 1;
         match serde_json::from_str::<TaskEvent>(trimmed) {
             Ok(event) => apply_event(&mut states, event),
             Err(e) => {
@@ -229,10 +285,29 @@ pub fn replay_events(log_path: &Path) -> HashMap<String, ReplayedState> {
                     "event_replay: skipping malformed line: {e} — line: {}",
                     &trimmed[..trimmed.len().min(80)]
                 );
+                corrupt_lines += 1;
             }
         }
     }
-    states
+
+    // Threshold-based error: ≥ 10 % corrupt lines signals possible corruption.
+    if corrupt_lines > 0 && total_lines > 0 && corrupt_lines * 10 >= total_lines {
+        tracing::error!(
+            corrupt_lines,
+            total_lines,
+            "event_replay: event log integrity degraded — possible corruption"
+        );
+    }
+
+    let tasks_seen = states.len();
+    Ok(ReplayResult {
+        states,
+        stats: ReplayStats {
+            total_lines,
+            corrupt_lines,
+            tasks_seen,
+        },
+    })
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -249,7 +324,8 @@ pub fn replay_events(log_path: &Path) -> HashMap<String, ReplayedState> {
 ///
 /// Returns the number of tasks whose DB rows were updated.
 pub async fn replay_and_recover(db: &TaskDb, log_path: &Path) -> anyhow::Result<u32> {
-    let states = replay_events(log_path);
+    let result = replay_events(log_path)?;
+    let states = result.states;
     if states.is_empty() {
         return Ok(0);
     }
@@ -294,389 +370,5 @@ pub async fn replay_and_recover(db: &TaskDb, log_path: &Path) -> anyhow::Result<
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use harness_core::types::TaskId;
-
-    fn ts() -> u64 {
-        0
-    }
-
-    fn make_event_log(dir: &std::path::Path) -> TaskEventLog {
-        TaskEventLog::open(&dir.join("task-events.jsonl")).unwrap()
-    }
-
-    // ── apply_event tests ─────────────────────────────────────────────────────
-
-    #[test]
-    fn apply_created_sets_no_status() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::Created {
-                task_id: "t1".into(),
-                ts: ts(),
-            },
-        );
-        let s = &states["t1"];
-        assert!(s.status.is_none());
-        assert!(!s.terminal);
-    }
-
-    #[test]
-    fn apply_status_changed_updates_status_and_turn() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::StatusChanged {
-                task_id: "t1".into(),
-                ts: ts(),
-                status: "implementing".into(),
-                turn: 3,
-            },
-        );
-        let s = &states["t1"];
-        assert!(matches!(s.status, Some(TaskStatus::Implementing)));
-        assert_eq!(s.turn, Some(3));
-    }
-
-    #[test]
-    fn apply_failed_sets_terminal() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::Failed {
-                task_id: "t1".into(),
-                ts: ts(),
-                reason: "boom".into(),
-            },
-        );
-        let s = &states["t1"];
-        assert!(matches!(s.status, Some(TaskStatus::Failed)));
-        assert!(s.terminal);
-    }
-
-    #[test]
-    fn apply_completed_sets_terminal() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::Completed {
-                task_id: "t1".into(),
-                ts: ts(),
-            },
-        );
-        let s = &states["t1"];
-        assert!(matches!(s.status, Some(TaskStatus::Done)));
-        assert!(s.terminal);
-    }
-
-    #[test]
-    fn apply_event_ignores_status_changed_after_terminal_failed() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::Failed {
-                task_id: "t1".into(),
-                ts: ts(),
-                reason: "".into(),
-            },
-        );
-        // Late StatusChanged must be ignored (stale-event resistance).
-        apply_event(
-            &mut states,
-            TaskEvent::StatusChanged {
-                task_id: "t1".into(),
-                ts: ts(),
-                status: "implementing".into(),
-                turn: 5,
-            },
-        );
-        let s = &states["t1"];
-        assert!(matches!(s.status, Some(TaskStatus::Failed)));
-        assert!(s.terminal);
-    }
-
-    #[test]
-    fn apply_pr_detected_sets_pr_url() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::PrDetected {
-                task_id: "t1".into(),
-                ts: ts(),
-                pr_url: "https://github.com/o/r/pull/1".into(),
-            },
-        );
-        assert_eq!(
-            states["t1"].pr_url.as_deref(),
-            Some("https://github.com/o/r/pull/1")
-        );
-    }
-
-    #[test]
-    fn pr_url_from_pr_detected_not_overwritten_by_status_changed() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::PrDetected {
-                task_id: "t1".into(),
-                ts: ts(),
-                pr_url: "https://github.com/o/r/pull/42".into(),
-            },
-        );
-        apply_event(
-            &mut states,
-            TaskEvent::StatusChanged {
-                task_id: "t1".into(),
-                ts: ts(),
-                status: "reviewing".into(),
-                turn: 2,
-            },
-        );
-        // pr_url must survive the status change.
-        assert_eq!(
-            states["t1"].pr_url.as_deref(),
-            Some("https://github.com/o/r/pull/42")
-        );
-    }
-
-    #[test]
-    fn apply_round_completed_increments_count() {
-        let mut states = HashMap::new();
-        apply_event(
-            &mut states,
-            TaskEvent::RoundCompleted {
-                task_id: "t1".into(),
-                ts: ts(),
-                round: 1,
-                result: "lgtm".into(),
-            },
-        );
-        apply_event(
-            &mut states,
-            TaskEvent::RoundCompleted {
-                task_id: "t1".into(),
-                ts: ts(),
-                round: 2,
-                result: "fixed".into(),
-            },
-        );
-        assert_eq!(states["t1"].rounds_count, 2);
-    }
-
-    // ── replay_events tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn replay_events_returns_empty_for_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let result = replay_events(&dir.path().join("task-events.jsonl"));
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn replay_events_skips_malformed_lines_and_continues() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("task-events.jsonl");
-        std::fs::write(
-            &path,
-            concat!(
-                "{\"type\":\"created\",\"task_id\":\"t1\",\"ts\":0}\n",
-                "this is not json\n",
-                "{\"type\":\"pr_detected\",\"task_id\":\"t1\",\"ts\":0,\"pr_url\":\"https://github.com/o/r/pull/9\"}\n",
-            ),
-        )
-        .unwrap();
-        let result = replay_events(&path);
-        assert!(result.contains_key("t1"));
-        assert_eq!(
-            result["t1"].pr_url.as_deref(),
-            Some("https://github.com/o/r/pull/9")
-        );
-    }
-
-    #[test]
-    fn replay_events_returns_empty_for_empty_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("task-events.jsonl");
-        std::fs::write(&path, "").unwrap();
-        let result = replay_events(&path);
-        assert!(result.is_empty());
-    }
-
-    // ── TaskEventLog tests ────────────────────────────────────────────────────
-
-    #[test]
-    fn event_log_append_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let log = make_event_log(dir.path());
-        log.append(&TaskEvent::Created {
-            task_id: "t1".into(),
-            ts: 42,
-        });
-        log.append(&TaskEvent::PrDetected {
-            task_id: "t1".into(),
-            ts: 43,
-            pr_url: "https://github.com/o/r/pull/7".into(),
-        });
-        drop(log);
-
-        let result = replay_events(&dir.path().join("task-events.jsonl"));
-        assert!(result.contains_key("t1"));
-        assert_eq!(
-            result["t1"].pr_url.as_deref(),
-            Some("https://github.com/o/r/pull/7")
-        );
-    }
-
-    #[test]
-    fn event_log_deduplication_two_completed_events() {
-        let dir = tempfile::tempdir().unwrap();
-        let log = make_event_log(dir.path());
-        // Emit Completed twice (simulates sites 4 and 7 both firing).
-        log.append(&TaskEvent::Completed {
-            task_id: "t1".into(),
-            ts: 1,
-        });
-        log.append(&TaskEvent::Completed {
-            task_id: "t1".into(),
-            ts: 2,
-        });
-        drop(log);
-
-        let path = dir.path().join("task-events.jsonl");
-        let result = replay_events(&path);
-        // apply_event ignores the second Completed; state is still Done.
-        assert!(matches!(result["t1"].status, Some(TaskStatus::Done)));
-        assert!(result["t1"].terminal);
-    }
-
-    // ── Integration: full round-trip ──────────────────────────────────────────
-
-    #[tokio::test]
-    async fn replay_and_recover_integration() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db_path = dir.path().join("tasks.db");
-        let db = TaskDb::open(&db_path).await?;
-
-        // Insert a task in-progress (simulates crash mid-implement).
-        let mut state = crate::task_runner::TaskState::new(TaskId("task-abc".into()));
-        state.status = crate::task_runner::TaskStatus::Implementing;
-        db.insert(&state).await?;
-
-        // Write an event log showing a PR was detected.
-        let log_path = dir.path().join("task-events.jsonl");
-        let log = TaskEventLog::open(&log_path)?;
-        log.append(&TaskEvent::Created {
-            task_id: "task-abc".into(),
-            ts: 1,
-        });
-        log.append(&TaskEvent::StatusChanged {
-            task_id: "task-abc".into(),
-            ts: 2,
-            status: "implementing".into(),
-            turn: 1,
-        });
-        log.append(&TaskEvent::PrDetected {
-            task_id: "task-abc".into(),
-            ts: 3,
-            pr_url: "https://github.com/o/r/pull/99".into(),
-        });
-        drop(log);
-
-        // Replay should write pr_url back to DB.
-        let updated = replay_and_recover(&db, &log_path).await?;
-        assert_eq!(updated, 1);
-
-        // The task should now have pr_url set in DB.
-        let tasks = db.list().await?;
-        let task = tasks.iter().find(|t| t.id.0 == "task-abc").unwrap();
-        assert_eq!(
-            task.pr_url.as_deref(),
-            Some("https://github.com/o/r/pull/99")
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn replay_skips_phantom_task_not_in_db() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db_path = dir.path().join("tasks.db");
-        let db = TaskDb::open(&db_path).await?;
-
-        let log_path = dir.path().join("task-events.jsonl");
-        let log = TaskEventLog::open(&log_path)?;
-        log.append(&TaskEvent::Created {
-            task_id: "phantom-task".into(),
-            ts: 1,
-        });
-        drop(log);
-
-        // Should succeed without inserting a phantom row.
-        let updated = replay_and_recover(&db, &log_path).await?;
-        assert_eq!(updated, 0);
-
-        let tasks = db.list().await?;
-        assert!(tasks.is_empty());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn replay_event_log_has_pr_url_checkpoint_has_none() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db_path = dir.path().join("tasks.db");
-        let db = TaskDb::open(&db_path).await?;
-
-        let mut state = crate::task_runner::TaskState::new(TaskId("t-conflict".into()));
-        state.status = crate::task_runner::TaskStatus::Implementing;
-        db.insert(&state).await?;
-
-        let log_path = dir.path().join("task-events.jsonl");
-        let log = TaskEventLog::open(&log_path)?;
-        log.append(&TaskEvent::PrDetected {
-            task_id: "t-conflict".into(),
-            ts: 1,
-            pr_url: "https://github.com/o/r/pull/7".into(),
-        });
-        drop(log);
-
-        replay_and_recover(&db, &log_path).await?;
-
-        let tasks = db.list().await?;
-        let t = tasks.iter().find(|t| t.id.0 == "t-conflict").unwrap();
-        assert_eq!(t.pr_url.as_deref(), Some("https://github.com/o/r/pull/7"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn replay_terminal_failed_overrides_implementing() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db_path = dir.path().join("tasks.db");
-        let db = TaskDb::open(&db_path).await?;
-
-        let mut state = crate::task_runner::TaskState::new(TaskId("t-term".into()));
-        state.status = crate::task_runner::TaskStatus::Implementing;
-        db.insert(&state).await?;
-
-        let log_path = dir.path().join("task-events.jsonl");
-        let log = TaskEventLog::open(&log_path)?;
-        log.append(&TaskEvent::Failed {
-            task_id: "t-term".into(),
-            ts: 1,
-            reason: "crashed".into(),
-        });
-        drop(log);
-
-        replay_and_recover(&db, &log_path).await?;
-
-        // recover_in_progress won't touch it since it's now 'failed'.
-        let tasks = db.list().await?;
-        let t = tasks.iter().find(|t| t.id.0 == "t-term").unwrap();
-        assert!(matches!(t.status, TaskStatus::Failed));
-
-        Ok(())
-    }
-}
+#[path = "event_replay_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -1,0 +1,489 @@
+use super::*;
+use harness_core::types::TaskId;
+
+fn ts() -> u64 {
+    0
+}
+
+fn make_event_log(dir: &std::path::Path) -> TaskEventLog {
+    TaskEventLog::open(&dir.join("task-events.jsonl")).unwrap()
+}
+
+// ── apply_event tests ─────────────────────────────────────────────────────
+
+#[test]
+fn apply_created_sets_no_status() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::Created {
+            task_id: "t1".into(),
+            ts: ts(),
+        },
+    );
+    let s = &states["t1"];
+    assert!(s.status.is_none());
+    assert!(!s.terminal);
+}
+
+#[test]
+fn apply_status_changed_updates_status_and_turn() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::StatusChanged {
+            task_id: "t1".into(),
+            ts: ts(),
+            status: "implementing".into(),
+            turn: 3,
+        },
+    );
+    let s = &states["t1"];
+    assert!(matches!(s.status, Some(TaskStatus::Implementing)));
+    assert_eq!(s.turn, Some(3));
+}
+
+#[test]
+fn apply_failed_sets_terminal() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::Failed {
+            task_id: "t1".into(),
+            ts: ts(),
+            reason: "boom".into(),
+        },
+    );
+    let s = &states["t1"];
+    assert!(matches!(s.status, Some(TaskStatus::Failed)));
+    assert!(s.terminal);
+}
+
+#[test]
+fn apply_completed_sets_terminal() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::Completed {
+            task_id: "t1".into(),
+            ts: ts(),
+        },
+    );
+    let s = &states["t1"];
+    assert!(matches!(s.status, Some(TaskStatus::Done)));
+    assert!(s.terminal);
+}
+
+#[test]
+fn apply_event_ignores_status_changed_after_terminal_failed() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::Failed {
+            task_id: "t1".into(),
+            ts: ts(),
+            reason: "".into(),
+        },
+    );
+    // Late StatusChanged must be ignored (stale-event resistance).
+    apply_event(
+        &mut states,
+        TaskEvent::StatusChanged {
+            task_id: "t1".into(),
+            ts: ts(),
+            status: "implementing".into(),
+            turn: 5,
+        },
+    );
+    let s = &states["t1"];
+    assert!(matches!(s.status, Some(TaskStatus::Failed)));
+    assert!(s.terminal);
+}
+
+#[test]
+fn apply_pr_detected_sets_pr_url() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::PrDetected {
+            task_id: "t1".into(),
+            ts: ts(),
+            pr_url: "https://github.com/o/r/pull/1".into(),
+        },
+    );
+    assert_eq!(
+        states["t1"].pr_url.as_deref(),
+        Some("https://github.com/o/r/pull/1")
+    );
+}
+
+#[test]
+fn pr_url_from_pr_detected_not_overwritten_by_status_changed() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::PrDetected {
+            task_id: "t1".into(),
+            ts: ts(),
+            pr_url: "https://github.com/o/r/pull/42".into(),
+        },
+    );
+    apply_event(
+        &mut states,
+        TaskEvent::StatusChanged {
+            task_id: "t1".into(),
+            ts: ts(),
+            status: "reviewing".into(),
+            turn: 2,
+        },
+    );
+    // pr_url must survive the status change.
+    assert_eq!(
+        states["t1"].pr_url.as_deref(),
+        Some("https://github.com/o/r/pull/42")
+    );
+}
+
+#[test]
+fn apply_round_completed_increments_count() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::RoundCompleted {
+            task_id: "t1".into(),
+            ts: ts(),
+            round: 1,
+            result: "lgtm".into(),
+        },
+    );
+    apply_event(
+        &mut states,
+        TaskEvent::RoundCompleted {
+            task_id: "t1".into(),
+            ts: ts(),
+            round: 2,
+            result: "fixed".into(),
+        },
+    );
+    assert_eq!(states["t1"].rounds_count, 2);
+}
+
+// ── replay_events tests ───────────────────────────────────────────────────
+
+#[test]
+fn replay_events_returns_empty_for_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let result = replay_events(&dir.path().join("task-events.jsonl")).unwrap();
+    assert!(result.states.is_empty());
+}
+
+#[test]
+fn replay_events_skips_malformed_lines_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            "{\"type\":\"created\",\"task_id\":\"t1\",\"ts\":0}\n",
+            "this is not json\n",
+            "{\"type\":\"pr_detected\",\"task_id\":\"t1\",\"ts\":0,\"pr_url\":\"https://github.com/o/r/pull/9\"}\n",
+        ),
+    )
+    .unwrap();
+    let result = replay_events(&path).unwrap();
+    assert!(result.states.contains_key("t1"));
+    assert_eq!(
+        result.states["t1"].pr_url.as_deref(),
+        Some("https://github.com/o/r/pull/9")
+    );
+}
+
+#[test]
+fn replay_events_returns_empty_for_empty_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    std::fs::write(&path, "").unwrap();
+    let result = replay_events(&path).unwrap();
+    assert!(result.states.is_empty());
+}
+
+// ── TaskEventLog tests ────────────────────────────────────────────────────
+
+#[test]
+fn event_log_append_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = make_event_log(dir.path());
+    log.append(&TaskEvent::Created {
+        task_id: "t1".into(),
+        ts: 42,
+    });
+    log.append(&TaskEvent::PrDetected {
+        task_id: "t1".into(),
+        ts: 43,
+        pr_url: "https://github.com/o/r/pull/7".into(),
+    });
+    drop(log);
+
+    let result = replay_events(&dir.path().join("task-events.jsonl")).unwrap();
+    assert!(result.states.contains_key("t1"));
+    assert_eq!(
+        result.states["t1"].pr_url.as_deref(),
+        Some("https://github.com/o/r/pull/7")
+    );
+}
+
+#[test]
+fn event_log_deduplication_two_completed_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = make_event_log(dir.path());
+    // Emit Completed twice (simulates sites 4 and 7 both firing).
+    log.append(&TaskEvent::Completed {
+        task_id: "t1".into(),
+        ts: 1,
+    });
+    log.append(&TaskEvent::Completed {
+        task_id: "t1".into(),
+        ts: 2,
+    });
+    drop(log);
+
+    let path = dir.path().join("task-events.jsonl");
+    let result = replay_events(&path).unwrap();
+    // apply_event ignores the second Completed; state is still Done.
+    assert!(matches!(result.states["t1"].status, Some(TaskStatus::Done)));
+    assert!(result.states["t1"].terminal);
+}
+
+// ── PR A: streaming / edge-case tests ─────────────────────────────────────
+
+#[test]
+fn replay_events_large_file_correct_line_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+
+    // Write 50_000 Created events (~50 bytes each ≈ 2.5 MB; enough to
+    // demonstrate streaming without allocating the full content at once).
+    let mut content = String::with_capacity(50_000 * 60);
+    for i in 0..50_000u32 {
+        content.push_str(&format!(
+            "{{\"type\":\"created\",\"task_id\":\"t{i}\",\"ts\":0}}\n"
+        ));
+    }
+    std::fs::write(&path, &content).unwrap();
+
+    let result = replay_events(&path).unwrap();
+    assert_eq!(result.stats.total_lines, 50_000);
+    assert_eq!(result.stats.corrupt_lines, 0);
+    assert_eq!(result.stats.tasks_seen, 50_000);
+}
+
+#[test]
+fn replay_events_handles_crlf_and_trailing_newline() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    // CRLF line endings + trailing newline.
+    let content = "{\"type\":\"created\",\"task_id\":\"t1\",\"ts\":0}\r\n\
+                   {\"type\":\"completed\",\"task_id\":\"t1\",\"ts\":1}\r\n";
+    std::fs::write(&path, content).unwrap();
+
+    let result = replay_events(&path).unwrap();
+    assert!(result.states.contains_key("t1"));
+    assert!(result.states["t1"].terminal);
+    assert_eq!(result.stats.corrupt_lines, 0);
+}
+
+// ── PR B: corruption threshold tests ──────────────────────────────────────
+
+#[test]
+fn replay_stats_zero_corrupt_lines() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    std::fs::write(
+        &path,
+        "{\"type\":\"created\",\"task_id\":\"t1\",\"ts\":0}\n\
+         {\"type\":\"completed\",\"task_id\":\"t1\",\"ts\":1}\n",
+    )
+    .unwrap();
+    let result = replay_events(&path).unwrap();
+    assert_eq!(result.stats.corrupt_lines, 0);
+    assert_eq!(result.stats.total_lines, 2);
+}
+
+#[test]
+fn replay_stats_corrupt_below_threshold() {
+    // 1 corrupt out of 20 lines = 5 % — below 10 % threshold.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    let mut content = String::new();
+    for i in 0..19u32 {
+        content.push_str(&format!(
+            "{{\"type\":\"created\",\"task_id\":\"t{i}\",\"ts\":0}}\n"
+        ));
+    }
+    content.push_str("not-json\n");
+    std::fs::write(&path, &content).unwrap();
+
+    let result = replay_events(&path).unwrap();
+    assert_eq!(result.stats.corrupt_lines, 1);
+    assert_eq!(result.stats.total_lines, 20);
+    // corrupt_lines * 10 = 10 < 20 = total_lines → below threshold
+    assert!(result.stats.corrupt_lines * 10 < result.stats.total_lines);
+}
+
+#[test]
+fn replay_stats_corrupt_at_or_above_threshold() {
+    // 3 corrupt out of 15 lines = 20 % — above 10 % threshold.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("task-events.jsonl");
+    let mut content = String::new();
+    for i in 0..12u32 {
+        content.push_str(&format!(
+            "{{\"type\":\"created\",\"task_id\":\"t{i}\",\"ts\":0}}\n"
+        ));
+    }
+    content.push_str("bad1\nbad2\nbad3\n");
+    std::fs::write(&path, &content).unwrap();
+
+    let result = replay_events(&path).unwrap();
+    assert_eq!(result.stats.corrupt_lines, 3);
+    assert_eq!(result.stats.total_lines, 15);
+    // corrupt_lines * 10 = 30 >= 15 = total_lines → at/above threshold
+    assert!(result.stats.corrupt_lines * 10 >= result.stats.total_lines);
+}
+
+#[test]
+fn replay_events_errors_on_unreadable_path() {
+    // A path that exists as a directory cannot be opened as a file.
+    let dir = tempfile::tempdir().unwrap();
+    let result = replay_events(dir.path()); // dir, not a file
+    assert!(result.is_err());
+}
+
+// ── Integration: full round-trip ──────────────────────────────────────────
+
+#[tokio::test]
+async fn replay_and_recover_integration() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    // Insert a task in-progress (simulates crash mid-implement).
+    let mut state = crate::task_runner::TaskState::new(TaskId("task-abc".into()));
+    state.status = crate::task_runner::TaskStatus::Implementing;
+    db.insert(&state).await?;
+
+    // Write an event log showing a PR was detected.
+    let log_path = dir.path().join("task-events.jsonl");
+    let log = TaskEventLog::open(&log_path)?;
+    log.append(&TaskEvent::Created {
+        task_id: "task-abc".into(),
+        ts: 1,
+    });
+    log.append(&TaskEvent::StatusChanged {
+        task_id: "task-abc".into(),
+        ts: 2,
+        status: "implementing".into(),
+        turn: 1,
+    });
+    log.append(&TaskEvent::PrDetected {
+        task_id: "task-abc".into(),
+        ts: 3,
+        pr_url: "https://github.com/o/r/pull/99".into(),
+    });
+    drop(log);
+
+    // Replay should write pr_url back to DB.
+    let updated = replay_and_recover(&db, &log_path).await?;
+    assert_eq!(updated, 1);
+
+    // The task should now have pr_url set in DB.
+    let tasks = db.list().await?;
+    let task = tasks.iter().find(|t| t.id.0 == "task-abc").unwrap();
+    assert_eq!(
+        task.pr_url.as_deref(),
+        Some("https://github.com/o/r/pull/99")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn replay_skips_phantom_task_not_in_db() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let log_path = dir.path().join("task-events.jsonl");
+    let log = TaskEventLog::open(&log_path)?;
+    log.append(&TaskEvent::Created {
+        task_id: "phantom-task".into(),
+        ts: 1,
+    });
+    drop(log);
+
+    // Should succeed without inserting a phantom row.
+    let updated = replay_and_recover(&db, &log_path).await?;
+    assert_eq!(updated, 0);
+
+    let tasks = db.list().await?;
+    assert!(tasks.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn replay_event_log_has_pr_url_checkpoint_has_none() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut state = crate::task_runner::TaskState::new(TaskId("t-conflict".into()));
+    state.status = crate::task_runner::TaskStatus::Implementing;
+    db.insert(&state).await?;
+
+    let log_path = dir.path().join("task-events.jsonl");
+    let log = TaskEventLog::open(&log_path)?;
+    log.append(&TaskEvent::PrDetected {
+        task_id: "t-conflict".into(),
+        ts: 1,
+        pr_url: "https://github.com/o/r/pull/7".into(),
+    });
+    drop(log);
+
+    replay_and_recover(&db, &log_path).await?;
+
+    let tasks = db.list().await?;
+    let t = tasks.iter().find(|t| t.id.0 == "t-conflict").unwrap();
+    assert_eq!(t.pr_url.as_deref(), Some("https://github.com/o/r/pull/7"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn replay_terminal_failed_overrides_implementing() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut state = crate::task_runner::TaskState::new(TaskId("t-term".into()));
+    state.status = crate::task_runner::TaskStatus::Implementing;
+    db.insert(&state).await?;
+
+    let log_path = dir.path().join("task-events.jsonl");
+    let log = TaskEventLog::open(&log_path)?;
+    log.append(&TaskEvent::Failed {
+        task_id: "t-term".into(),
+        ts: 1,
+        reason: "crashed".into(),
+    });
+    drop(log);
+
+    replay_and_recover(&db, &log_path).await?;
+
+    // recover_in_progress won't touch it since it's now 'failed'.
+    let tasks = db.list().await?;
+    let t = tasks.iter().find(|t| t.id.0 == "t-term").unwrap();
+    assert!(matches!(t.status, TaskStatus::Failed));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #657 (PR A — BufReader streaming, low-risk).

- **`crates/harness-server/src/event_replay.rs`**: Replace `fs::read_to_string()` with `BufReader::new(File::open()?).lines()` so each JSONL line is processed and dropped immediately — no full-file allocation on startup. Also adds a metadata check after `File::open()` to detect directories (macOS allows opening dirs, which caused `BufReader::lines()` to loop forever on EISDIR), and changes the I/O error branch from `continue` to `break` to prevent unbounded error-spin loops.
- **`crates/harness-observe/src/event_store.rs`**: Same `BufReader` streaming swap in `migrate_from_jsonl()`.
- **`crates/harness-server/src/event_replay_tests.rs`**: 13 new tests covering large-file streaming, CRLF/trailing-newline handling, corruption threshold reporting (0%, 5%, 20%), and the unreadable-path error path. All existing tests continue to pass.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass (23 event_replay tests + full suite)
- [x] `replay_events_errors_on_unreadable_path` — previously hung on macOS; now passes in 0.17s