### PR TITLE
feat: memory-pressure-aware task admission (#621)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,5 +96,8 @@ subtle = "2"
 # HTTP client (for Anthropic API)
 reqwest = { version = "0.12", features = ["json", "stream"] }
 
+# System info (memory pressure monitoring)
+sysinfo = { version = "0.32", default-features = false, features = ["system"] }
+
 # Testing
 tempfile = "3"

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -81,6 +81,17 @@ pub struct ConcurrencyConfig {
     /// the task is marked Failed with "review loop detected". Default: 0.85.
     #[serde(default = "default_loop_jaccard_threshold")]
     pub loop_jaccard_threshold: f64,
+    /// Minimum available system memory (MB) required to admit new tasks.
+    /// When available memory falls below this threshold the task queue
+    /// rejects new `acquire()` calls until memory recovers.
+    /// `None` (default) disables the check entirely.
+    #[serde(default)]
+    pub memory_pressure_threshold_mb: Option<u64>,
+    /// How often (seconds) the memory monitor re-samples available memory.
+    /// Values below 1 are clamped to 1. Default: 5.
+    /// Only meaningful when `memory_pressure_threshold_mb` is `Some`.
+    #[serde(default = "default_memory_poll_interval_secs")]
+    pub memory_poll_interval_secs: u64,
 }
 
 fn default_max_concurrent_tasks() -> usize {
@@ -99,6 +110,10 @@ fn default_loop_jaccard_threshold() -> f64 {
     0.85
 }
 
+fn default_memory_poll_interval_secs() -> u64 {
+    5
+}
+
 impl Default for ConcurrencyConfig {
     fn default() -> Self {
         Self {
@@ -108,6 +123,8 @@ impl Default for ConcurrencyConfig {
             per_project: HashMap::new(),
             max_turns: None,
             loop_jaccard_threshold: default_loop_jaccard_threshold(),
+            memory_pressure_threshold_mb: None,
+            memory_poll_interval_secs: default_memory_poll_interval_secs(),
         }
     }
 }
@@ -403,5 +420,38 @@ impl Default for ReviewConfig {
             strategy: ReviewStrategy::Single,
             timeout_secs: default_review_timeout_secs(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_default_disables_monitor() {
+        let cfg = ConcurrencyConfig::default();
+        assert!(
+            cfg.memory_pressure_threshold_mb.is_none(),
+            "memory monitor must be disabled by default"
+        );
+        assert_eq!(cfg.memory_poll_interval_secs, 5);
+    }
+
+    #[test]
+    fn toml_roundtrip_with_threshold() {
+        let toml = r#"
+            memory_pressure_threshold_mb = 512
+            memory_poll_interval_secs = 10
+        "#;
+        let cfg: ConcurrencyConfig = toml::from_str(toml).expect("toml parse failed");
+        assert_eq!(cfg.memory_pressure_threshold_mb, Some(512));
+        assert_eq!(cfg.memory_poll_interval_secs, 10);
+    }
+
+    #[test]
+    fn toml_roundtrip_without_threshold_uses_defaults() {
+        let cfg: ConcurrencyConfig = toml::from_str("").expect("toml parse failed");
+        assert!(cfg.memory_pressure_threshold_mb.is_none());
+        assert_eq!(cfg.memory_poll_interval_secs, 5);
     }
 }

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -33,6 +33,7 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
+sysinfo = { workspace = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -472,8 +472,19 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             .await;
     }
 
-    let task_queue = Arc::new(crate::task_queue::TaskQueue::new(
+    let memory_pressure =
+        server
+            .config
+            .concurrency
+            .memory_pressure_threshold_mb
+            .map(|threshold_mb| {
+                let poll_secs = server.config.concurrency.memory_poll_interval_secs;
+                tracing::info!(threshold_mb, poll_secs, "memory pressure monitor enabled");
+                crate::memory_monitor::start(threshold_mb, poll_secs)
+            });
+    let task_queue = Arc::new(crate::task_queue::TaskQueue::new_with_pressure(
         &server.config.concurrency,
+        memory_pressure,
     ));
     tracing::debug!(
         max_concurrent = server.config.concurrency.max_concurrent_tasks,

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -20,6 +20,7 @@ pub mod handlers;
 pub mod hook_enforcer;
 pub mod http;
 pub mod intake;
+pub mod memory_monitor;
 pub mod notify;
 pub mod parallel_dispatch;
 pub mod periodic_reviewer;

--- a/crates/harness-server/src/memory_monitor.rs
+++ b/crates/harness-server/src/memory_monitor.rs
@@ -1,0 +1,102 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Start a background task that sets the returned flag to `true` whenever
+/// available system memory falls below `threshold_mb` MB, and `false` when
+/// it recovers.  Sampling occurs every `poll_secs` seconds (clamped to ≥ 1).
+///
+/// The monitor runs for the caller's lifetime; dropping the returned
+/// `Arc<AtomicBool>` does **not** stop the task — the task stops when the
+/// tokio runtime shuts down.
+///
+/// This function is a no-op until a tokio runtime is active (it calls
+/// `tokio::spawn` internally).
+pub fn start(threshold_mb: u64, poll_secs: u64) -> Arc<AtomicBool> {
+    start_with_sampler(threshold_mb, poll_secs, sample_available_mb)
+}
+
+/// Like [`start`] but accepts a custom sampler that returns available memory
+/// in megabytes.  Intended for unit tests that must not call real system APIs.
+pub fn start_with_sampler<F>(threshold_mb: u64, poll_secs: u64, sampler: F) -> Arc<AtomicBool>
+where
+    F: Fn() -> u64 + Send + 'static,
+{
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_clone = flag.clone();
+    let interval = Duration::from_secs(poll_secs.max(1));
+
+    tokio::spawn(async move {
+        loop {
+            let available_mb = sampler();
+            let under_pressure = available_mb < threshold_mb;
+            flag_clone.store(under_pressure, Ordering::Relaxed);
+            if under_pressure {
+                tracing::warn!(
+                    available_mb,
+                    threshold_mb,
+                    "memory pressure: available memory below threshold; new tasks will be rejected"
+                );
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+
+    flag
+}
+
+/// Sample the system's available memory and return it in megabytes.
+fn sample_available_mb() -> u64 {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    sys.available_memory() / (1024 * 1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn monitor_sets_flag_when_below_threshold() {
+        // Simulates 256 MB available with a 512 MB threshold → pressure.
+        let flag = start_with_sampler(512, 1, || 256);
+        sleep(Duration::from_millis(1100)).await;
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "flag should be true under pressure"
+        );
+    }
+
+    #[tokio::test]
+    async fn monitor_clears_flag_when_above_threshold() {
+        // Counter starts high (above threshold), then drops below.
+        let counter = Arc::new(AtomicU64::new(1024));
+        let counter_clone = counter.clone();
+        let flag = start_with_sampler(512, 1, move || counter_clone.load(Ordering::Relaxed));
+
+        // First poll: 1024 MB available → no pressure.
+        sleep(Duration::from_millis(1100)).await;
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "flag should be false when memory is sufficient"
+        );
+
+        // Drop available memory below threshold.
+        counter.store(256, Ordering::Relaxed);
+        sleep(Duration::from_millis(1100)).await;
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "flag should be true after memory drops"
+        );
+
+        // Recover memory.
+        counter.store(800, Ordering::Relaxed);
+        sleep(Duration::from_millis(1100)).await;
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "flag should clear when memory recovers"
+        );
+    }
+}

--- a/crates/harness-server/src/task_queue.rs
+++ b/crates/harness-server/src/task_queue.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use harness_core::config::misc::ConcurrencyConfig;
 use serde::Serialize;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
@@ -33,6 +33,11 @@ impl std::fmt::Debug for TaskPermit {
 /// Maintains a global semaphore limiting total concurrent tasks across all projects,
 /// plus per-project semaphores so one project cannot starve others. Acquiring a slot
 /// requires holding BOTH permits simultaneously.
+///
+/// When a `memory_pressure` flag is supplied (via [`TaskQueue::new_with_pressure`]),
+/// `acquire()` returns an error immediately when the flag is `true`, preventing new
+/// tasks from being admitted while available system memory is below the configured
+/// threshold.
 pub struct TaskQueue {
     global_semaphore: Arc<Semaphore>,
     global_limit: usize,
@@ -48,10 +53,24 @@ pub struct TaskQueue {
     /// waiting for the global slot. These are "queued" not "running" from an
     /// observability standpoint — they haven't started executing yet.
     project_awaiting_global: DashMap<String, Arc<AtomicUsize>>,
+    /// Optional memory-pressure flag set by [`crate::memory_monitor`].
+    /// When `true`, `acquire()` rejects new tasks immediately.
+    /// `None` means the feature is disabled (default).
+    memory_pressure: Option<Arc<AtomicBool>>,
 }
 
 impl TaskQueue {
     pub fn new(config: &ConcurrencyConfig) -> Self {
+        Self::new_with_pressure(config, None)
+    }
+
+    /// Like [`TaskQueue::new`] but wires in an optional memory-pressure flag.
+    /// When the flag is `Some` and its value is `true`, `acquire()` returns an
+    /// error immediately instead of waiting for a semaphore slot.
+    pub fn new_with_pressure(
+        config: &ConcurrencyConfig,
+        memory_pressure: Option<Arc<AtomicBool>>,
+    ) -> Self {
         let project_limits: DashMap<String, usize> = config
             .per_project
             .iter()
@@ -66,6 +85,7 @@ impl TaskQueue {
             project_limits,
             project_queued: DashMap::new(),
             project_awaiting_global: DashMap::new(),
+            memory_pressure,
         }
     }
 
@@ -105,9 +125,21 @@ impl TaskQueue {
     /// Acquiring a project permit first prevents a single project from
     /// monopolizing all global slots while waiting for its own limit.
     ///
-    /// Returns `Err` immediately if `max_queue_size` tasks are already waiting.
+    /// Returns `Err` immediately if `max_queue_size` tasks are already waiting,
+    /// or if the memory-pressure flag (set by `memory_monitor`) is `true`.
     /// The returned permit releases both slots on drop (even on panic).
     pub async fn acquire(&self, project_id: &str) -> anyhow::Result<TaskPermit> {
+        // Reject immediately when system memory is below the configured threshold.
+        if self
+            .memory_pressure
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::Relaxed))
+        {
+            return Err(anyhow::anyhow!(
+                "task rejected: available system memory is below the configured threshold"
+            ));
+        }
+
         // Reserve a global queue slot. fetch_add returns value before increment,
         // so if prev == max_queue_size the queue is already full.
         let prev = self.queued_count.fetch_add(1, Ordering::SeqCst);
@@ -443,5 +475,31 @@ mod tests {
         let stats2 = q2.project_stats("capped");
         assert_eq!(stats2.running, 1);
         assert_eq!(stats2.queued, 1);
+    }
+
+    #[tokio::test]
+    async fn task_admission_blocked_under_pressure() {
+        let pressure = Arc::new(AtomicBool::new(true));
+        let q = TaskQueue::new_with_pressure(&config(4, 16), Some(pressure));
+        let result = q.acquire("proj").await;
+        assert!(result.is_err(), "acquire must fail under memory pressure");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("available system memory"),
+            "error message should mention memory"
+        );
+    }
+
+    #[tokio::test]
+    async fn task_admission_succeeds_no_pressure() {
+        let pressure = Arc::new(AtomicBool::new(false));
+        let q = TaskQueue::new_with_pressure(&config(4, 16), Some(pressure));
+        let result = q.acquire("proj").await;
+        assert!(
+            result.is_ok(),
+            "acquire must succeed when pressure flag is false"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds opt-in memory pressure monitoring to the task queue via `sysinfo` (pure-safe Rust, cross-platform)
- New `ConcurrencyConfig` fields: `memory_pressure_threshold_mb: Option<u64>` (default `None` = disabled) and `memory_poll_interval_secs: u64` (default `5`)
- When enabled, `TaskQueue::acquire()` rejects new tasks immediately when available RAM falls below the threshold, preventing OOM during heavy parallel Rust builds (closes #621)
- Feature is off by default — existing deployments are unaffected

## Architecture

```
concurrency.memory_pressure_threshold_mb = 512  # MB; omit or set to None to disable
concurrency.memory_poll_interval_secs = 5       # how often to re-sample
```

`MemoryMonitor::start()` spawns a tokio task that polls `sysinfo::System::available_memory()` and sets an `Arc<AtomicBool>`. `TaskQueue::new_with_pressure()` receives this flag and checks it lock-free before acquiring any semaphore.

## Test plan

- [x] `config_default_disables_monitor` — `ConcurrencyConfig::default()` has `memory_pressure_threshold_mb = None`
- [x] `toml_roundtrip_with_threshold` — TOML with `memory_pressure_threshold_mb = 512` deserializes correctly
- [x] `toml_roundtrip_without_threshold_uses_defaults` — empty TOML uses defaults
- [x] `monitor_sets_flag_when_below_threshold` — flag becomes `true` within one poll cycle (mock sampler)
- [x] `monitor_clears_flag_when_above_threshold` — flag transitions correctly across memory changes (mock sampler)
- [x] `task_admission_blocked_under_pressure` — `acquire()` returns error when flag is `true`
- [x] `task_admission_succeeds_no_pressure` — `acquire()` succeeds when flag is `false`
- [x] All 1220 existing tests pass (`cargo test --workspace`)
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` clean