### PR TITLE
fix(periodic_reviewer): only advance watermark after review produces output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -770,23 +770,12 @@ async fn run_review_tick(
             return;
         }
 
-        // Primary confirmed new commits exist — advance the watermark now.
-        // Advancing at enqueue time creates a duplicate-review gap: commits
-        // arriving between enqueue and execution are covered by this agent
-        // (--since has no --until bound) but would also fall inside the next
-        // tick's --since window, producing duplicate issues.  By advancing here
-        // we set the boundary to the agent's execution completion time, ensuring
-        // the next tick's --since is always ≥ all commits this agent reviewed.
-        let review_complete_ts = Utc::now();
-        fallback_ts_for_poll.lock().await.fallback_ts = Some(review_complete_ts);
-        let watermark_event = Event::new(SessionId::new(), &hook_key, "scheduler", Decision::Pass);
-        if let Err(err) = state_for_synthesis
-            .observability
-            .events
-            .log(&watermark_event)
-            .await
-        {
-            tracing::error!("scheduler: failed to log periodic_review event (continuing): {err}");
+        if primary_output.is_none() {
+            tracing::error!(
+                task_id = %primary_review_id,
+                "scheduler: primary review produced no output (agent failed/timed out) — watermark not advanced, next tick will re-review"
+            );
+            return;
         }
 
         // Now it is safe to enqueue the secondary reviewer (Cross strategy only).
@@ -868,17 +857,30 @@ async fn run_review_tick(
                         final_output = primary_output;
                     }
                 }
-            } else if primary_output.is_none() {
-                // Primary failed/no output: fall back to secondary output if available.
-                final_task_id = secondary_id.clone();
-                final_output = secondary_output;
             }
         }
 
         let Some(output) = final_output else {
-            tracing::warn!("scheduler: no review output to parse");
+            tracing::warn!("scheduler: no review output to parse — watermark not advanced, next tick will re-review");
             return;
         };
+
+        // Advance the watermark only after the review produced parseable output.
+        // Moving this here (from the earlier unconditional advance) prevents
+        // a failed/timed-out agent from silently marking its commit window as
+        // "reviewed" and skipping it on the next tick.
+        let review_complete_ts = Utc::now();
+        fallback_ts_for_poll.lock().await.fallback_ts = Some(review_complete_ts);
+        let watermark_event = Event::new(SessionId::new(), &hook_key, "scheduler", Decision::Pass);
+        if let Err(err) = state_for_synthesis
+            .observability
+            .events
+            .log(&watermark_event)
+            .await
+        {
+            tracing::error!("scheduler: failed to log periodic_review event (continuing): {err}");
+        }
+
         match crate::review_store::parse_review_output(&output) {
             Ok(review) => {
                 tracing::info!(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -744,6 +744,11 @@ async fn run_review_tick(
     // correct repository — without this they fall back to main-worktree
     // detection and can execute against the wrong project.
     let project_root_for_poll = project_root.clone();
+    // Capture the scan boundary before the review agents run. Using this
+    // timestamp (rather than Utc::now() after synthesis completes) as the
+    // watermark ensures that commits arriving while secondary/synthesis agents
+    // are executing are NOT silently skipped on the next tick.
+    let scan_ts = Utc::now();
     let handle = tokio::spawn(async move {
         let primary_output = poll_task_output(&store, &primary_review_id, timeout_secs).await;
         tracing::info!(
@@ -865,24 +870,30 @@ async fn run_review_tick(
             return;
         };
 
-        // Advance the watermark only after the review produced parseable output.
-        // Moving this here (from the earlier unconditional advance) prevents
-        // a failed/timed-out agent from silently marking its commit window as
-        // "reviewed" and skipping it on the next tick.
-        let review_complete_ts = Utc::now();
-        fallback_ts_for_poll.lock().await.fallback_ts = Some(review_complete_ts);
-        let watermark_event = Event::new(SessionId::new(), &hook_key, "scheduler", Decision::Pass);
-        if let Err(err) = state_for_synthesis
-            .observability
-            .events
-            .log(&watermark_event)
-            .await
-        {
-            tracing::error!("scheduler: failed to log periodic_review event (continuing): {err}");
-        }
-
         match crate::review_store::parse_review_output(&output) {
             Ok(review) => {
+                // Advance the watermark only after parse succeeds.
+                // Doing this here (rather than before the match) prevents a
+                // non-empty but malformed JSON response from permanently
+                // dropping its commit window — on parse failure the watermark
+                // stays put and the next tick will re-review the same window.
+                // `scan_ts` is the boundary captured before agents were
+                // enqueued, so commits arriving during secondary/synthesis are
+                // NOT included in the advanced watermark and will be reviewed
+                // on the next tick (fixes the Cross-strategy skip-forever bug).
+                fallback_ts_for_poll.lock().await.fallback_ts = Some(scan_ts);
+                let watermark_event =
+                    Event::new(SessionId::new(), &hook_key, "scheduler", Decision::Pass);
+                if let Err(err) = state_for_synthesis
+                    .observability
+                    .events
+                    .log(&watermark_event)
+                    .await
+                {
+                    tracing::error!(
+                        "scheduler: failed to log periodic_review event (continuing): {err}"
+                    );
+                }
                 tracing::info!(
                     findings = review.findings.len(),
                     health_score = review.summary.health_score,


### PR DESCRIPTION
## Summary

- When the primary review agent fails/times out, `poll_task_output` returns `None`. The existing `REVIEW_SKIPPED` guard uses `unwrap_or(false)` so `None` fell through to the unconditional watermark advance, silently marking the commit window as "reviewed" with zero findings
- Added explicit `primary_output.is_none()` guard that logs an error and returns without advancing the watermark — next tick re-reviews the same window from the last successful watermark
- Moved the watermark advance to after `final_output` is confirmed `Some`, so it is only persisted when the review actually produced output
- Removed the now-unreachable `else if primary_output.is_none()` branch in the secondary-fallback logic

## Test plan

- [ ] All existing tests pass (`cargo test --workspace`: 0 failures)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [ ] Simulate agent timeout: watermark should remain at previous value and next tick re-reviews same commit window
- [ ] Normal review path: watermark advances after `final_output` is `Some`
- [ ] `REVIEW_SKIPPED` path: watermark still does not advance (unchanged behaviour)

Closes #665