### PR TITLE
fix(agents): use process groups to prevent orphaned grandchild processes

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -151,6 +151,8 @@ impl CodeAgent for ClaudeCodeAgent {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
 
@@ -241,6 +243,8 @@ impl CodeAgent for ClaudeCodeAgent {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
 

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -54,6 +54,8 @@ impl AgentAdapter for ClaudeAdapter {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
 
         if !req.allowed_tools.is_empty() {

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -102,6 +102,8 @@ impl CodeAgent for CodexAgent {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
 
@@ -175,6 +177,8 @@ impl CodeAgent for CodexAgent {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
 

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -142,6 +142,8 @@ impl AgentAdapter for CodexAdapter {
                 .stderr(std::process::Stdio::piped())
                 .current_dir(&req.project_root)
                 .kill_on_drop(true);
+            #[cfg(unix)]
+            crate::set_process_group(&mut cmd);
             crate::strip_claude_env(&mut cmd);
 
             let mut child = cmd.spawn().map_err(|e| {

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -18,3 +18,41 @@ pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {
         cmd.env_remove(key);
     }
 }
+
+/// Place the child process into its own process group.
+///
+/// Uses the stable `CommandExt::process_group(0)` API (Rust 1.64+).
+/// When the child is later killed, we can send `SIGKILL` to the entire
+/// process group to also terminate grandchild processes like `cargo test`
+/// binaries.
+#[cfg(unix)]
+pub(crate) fn set_process_group(cmd: &mut tokio::process::Command) {
+    cmd.process_group(0);
+}
+
+/// Kill the entire process group rooted at `child`.
+///
+/// Sends `SIGKILL` to `-pid` (the process group) so that all descendants
+/// (cargo test binaries, shell subprocesses, etc.) are terminated together.
+#[cfg(unix)]
+pub(crate) fn kill_process_group(child: &tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        // kill(-pgid, SIGKILL) kills the entire process group.
+        // SAFETY: standard POSIX signal, no memory unsafety.
+        let ret = unsafe { nix_kill(-(pid as i32), 9) };
+        if ret == 0 {
+            tracing::debug!(pgid = pid, "killed process group");
+        } else {
+            tracing::warn!(pgid = pid, "failed to kill process group");
+        }
+    }
+}
+
+/// Raw kill(2) syscall without libc dependency.
+#[cfg(unix)]
+unsafe fn nix_kill(pid: i32, sig: i32) -> i32 {
+    extern "C" {
+        fn kill(pid: i32, sig: i32) -> i32;
+    }
+    kill(pid, sig)
+}

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -174,6 +174,10 @@ pub(crate) async fn stream_child_output(
             tokio::time::timeout(dur, lines.next_line())
                 .await
                 .map_err(|_| {
+                    // Kill entire process group to prevent orphaned grandchild
+                    // processes (e.g. cargo test binaries) from running forever.
+                    #[cfg(unix)]
+                    crate::kill_process_group(child);
                     HarnessError::AgentExecution(format!(
                         "{agent_name} stream idle timeout after {}s: zombie connection terminated",
                         dur.as_secs()


### PR DESCRIPTION
## Summary
- Agent subprocesses (claude, codex) spawn nested processes like `cargo test` which survive `kill_on_drop(true)` because SIGKILL only targets the immediate child PID
- Orphaned test binaries were observed running **21+ hours at 93% CPU each** (8 processes × ~93% = 750% total CPU)
- Fix: spawn all agent processes with `process_group(0)` so they become session leaders; on stream idle timeout, `kill_process_group()` sends SIGKILL to the entire process group (`-pgid`), terminating all descendants

## Changes
- `lib.rs`: add `set_process_group()` and `kill_process_group()` helpers (Unix only, stable API since Rust 1.64)
- `claude.rs`, `claude_adapter.rs`, `codex.rs`, `codex_adapter.rs`: apply `set_process_group` at all 5 spawn sites
- `streaming.rs`: call `kill_process_group` on idle timeout before returning error

## Test plan
- [x] `cargo check --workspace --all-targets` with `-Dwarnings` — 0 errors, 0 warnings
- [x] `cargo test --package harness-agents` — 86 passed, 0 failed
- [ ] Deploy and verify no orphaned `harness_server-*` test binaries after task timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)