### PR TITLE
feat(observability): add 4 LLM metrics to dashboard (#624)

### DIFF
--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -1,5 +1,6 @@
-use crate::{http::AppState, task_runner::DashboardCounts};
+use crate::{handlers::token_usage::load_cost_stats, http::AppState, task_runner::DashboardCounts};
 use axum::{extract::State, http::StatusCode, Json};
+use chrono::Utc;
 use harness_core::types::EventFilters;
 use harness_observe::quality::QualityGrader;
 use serde_json::{json, Value};
@@ -38,7 +39,10 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     // Grade from the global quality event store.
     // Derive violation_count from the most recent rule_scan session so we don't
     // permanently depress the grade with historical violations from old scans.
-    let grade: Option<Value> = match state
+    // Also count rule_check events in the rolling 24-hour window as a proxy for
+    // linter/guard feedback (guard_triggers_24h metric).
+    let since_24h = Utc::now() - chrono::Duration::hours(24);
+    let (grade, guard_triggers_24h): (Option<Value>, u64) = match state
         .observability
         .events
         .query(&EventFilters::default())
@@ -57,13 +61,22 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                 })
                 .unwrap_or(0);
             let report = QualityGrader::grade(&events, violation_count);
-            serde_json::to_value(report.grade).ok()
+            let guard_count = events
+                .iter()
+                .filter(|e| e.hook == "rule_check" && e.ts >= since_24h)
+                .count() as u64;
+            (serde_json::to_value(report.grade).ok(), guard_count)
         }
         Err(e) => {
             tracing::warn!("dashboard: failed to query events for grade: {e}");
-            None
+            (None, 0)
         }
     };
+
+    // LLM observability metrics (#624).
+    let avg_review_turns = state.core.tasks.avg_review_turns().await;
+    let avg_first_token_latency_ms = state.core.tasks.avg_first_token_latency_ms().await;
+    let (cost_total_usd, avg_cost_per_task_usd) = load_cost_stats(&state).await;
 
     // Fetch latest PR URLs for all projects in one bulk query to avoid N+1.
     let project_pr_urls = state.core.tasks.latest_done_pr_urls_all_projects().await;
@@ -147,6 +160,16 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
             "grade": grade,
             "runtime_hosts_total": runtime_hosts_total,
             "runtime_hosts_online": runtime_hosts_online,
+            // LLM observability metrics (#624)
+            // null when no completed tasks exist yet.
+            "cost_total_usd": if cost_total_usd == 0.0 { Value::Null } else { json!(cost_total_usd) },
+            "avg_cost_per_task_usd": if avg_cost_per_task_usd == 0.0 { Value::Null } else { json!(avg_cost_per_task_usd) },
+            "avg_review_turns": avg_review_turns,
+            "avg_first_token_latency_ms": avg_first_token_latency_ms,
+            // Proxy for linter feedback: count of guard rule triggers in the last 24 hours.
+            // Label is intentionally "guard_triggers_24h" — these are harness guard checks,
+            // not compiler errors (Claude Code build errors are internal to the agent).
+            "guard_triggers_24h": guard_triggers_24h,
         }
     });
 
@@ -285,6 +308,50 @@ mod tests {
         assert_eq!(
             host["assignment_pressure"], 0.0,
             "idle host must have 0.0 assignment_pressure"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dashboard_global_contains_observability_metric_keys() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-dashboard-obs-")?;
+        let state = Arc::new(make_test_state(dir.path()).await?);
+
+        let app = Router::new()
+            .route("/api/dashboard", get(dashboard))
+            .with_state(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/api/dashboard")
+            .body(axum::body::Body::empty())?;
+
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+        let global = body.get("global").expect("missing global key");
+
+        // All 5 LLM observability metric keys must be present (null is valid when
+        // no completed tasks exist yet).
+        assert!(
+            global.get("cost_total_usd").is_some(),
+            "cost_total_usd key missing"
+        );
+        assert!(
+            global.get("avg_cost_per_task_usd").is_some(),
+            "avg_cost_per_task_usd key missing"
+        );
+        assert!(
+            global.get("avg_review_turns").is_some(),
+            "avg_review_turns key missing"
+        );
+        assert!(
+            global.get("avg_first_token_latency_ms").is_some(),
+            "avg_first_token_latency_ms key missing"
+        );
+        assert!(
+            global.get("guard_triggers_24h").is_some(),
+            "guard_triggers_24h key missing"
         );
         Ok(())
     }

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -3,9 +3,26 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 
 use crate::http::AppState;
+
+/// Cached result of the last full JSONL cost scan with its expiry time.
+struct CostStatsCache {
+    total: f64,
+    avg: f64,
+    expires: Instant,
+}
+
+/// TTL for the cost stats cache: avoids re-scanning all JSONL files on every poll.
+const COST_CACHE_TTL: Duration = Duration::from_secs(60);
+
+fn cost_cache() -> &'static Mutex<Option<CostStatsCache>> {
+    static CACHE: OnceLock<Mutex<Option<CostStatsCache>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
 
 #[derive(Debug, Default, Clone, Serialize)]
 struct UsageBucket {
@@ -432,10 +449,37 @@ fn aggregate_cost_stats(task_usage: &HashMap<String, UsageBucket>) -> (f64, f64)
 
 /// Load per-task cost statistics from Claude CLI session JSONL files.
 ///
-/// Returns `(total_cost_usd, avg_cost_per_task_usd)`.  Returns `(0.0, 0.0)`
-/// on any error (missing directory, unreadable files, etc.) so that the
-/// dashboard degrades gracefully without an error response.
+/// Results are cached for [`COST_CACHE_TTL`] to avoid re-scanning all JSONL
+/// files on every dashboard poll.  Returns `(0.0, 0.0)` on any error so that
+/// the dashboard degrades gracefully without an error response.
 pub(crate) async fn load_cost_stats(state: &Arc<crate::http::AppState>) -> (f64, f64) {
+    // Fast path: return cached result if still fresh.
+    {
+        let guard = cost_cache().lock().await;
+        if let Some(ref c) = *guard {
+            if c.expires > Instant::now() {
+                return (c.total, c.avg);
+            }
+        }
+    }
+
+    let result = load_cost_stats_uncached(state).await;
+
+    // Update cache regardless of success/failure so repeated errors don't
+    // cause a thundering herd.
+    {
+        let mut guard = cost_cache().lock().await;
+        *guard = Some(CostStatsCache {
+            total: result.0,
+            avg: result.1,
+            expires: Instant::now() + COST_CACHE_TTL,
+        });
+    }
+
+    result
+}
+
+async fn load_cost_stats_uncached(state: &Arc<crate::http::AppState>) -> (f64, f64) {
     let home = match home_dir() {
         Ok(p) => p,
         Err(_) => return (0.0, 0.0),

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -452,29 +452,30 @@ fn aggregate_cost_stats(task_usage: &HashMap<String, UsageBucket>) -> (f64, f64)
 /// Results are cached for [`COST_CACHE_TTL`] to avoid re-scanning all JSONL
 /// files on every dashboard poll.  Returns `(0.0, 0.0)` on any error so that
 /// the dashboard degrades gracefully without an error response.
+///
+/// Single-flight: the mutex is held for the entire check+compute+update cycle,
+/// so concurrent callers after TTL expiry wait on the lock rather than each
+/// starting an independent full-tree scan.
 pub(crate) async fn load_cost_stats(state: &Arc<crate::http::AppState>) -> (f64, f64) {
+    let mut guard = cost_cache().lock().await;
+
     // Fast path: return cached result if still fresh.
-    {
-        let guard = cost_cache().lock().await;
-        if let Some(ref c) = *guard {
-            if c.expires > Instant::now() {
-                return (c.total, c.avg);
-            }
+    if let Some(ref c) = *guard {
+        if c.expires > Instant::now() {
+            return (c.total, c.avg);
         }
     }
 
-    let result = load_cost_stats_uncached(state).await;
-
+    // Slow path (single caller at a time): recompute then update cache.
     // Update cache regardless of success/failure so repeated errors don't
     // cause a thundering herd.
-    {
-        let mut guard = cost_cache().lock().await;
-        *guard = Some(CostStatsCache {
-            total: result.0,
-            avg: result.1,
-            expires: Instant::now() + COST_CACHE_TTL,
-        });
-    }
+    let result = load_cost_stats_uncached(state).await;
+
+    *guard = Some(CostStatsCache {
+        total: result.0,
+        avg: result.1,
+        expires: Instant::now() + COST_CACHE_TTL,
+    });
 
     result
 }
@@ -485,23 +486,36 @@ async fn load_cost_stats_uncached(state: &Arc<crate::http::AppState>) -> (f64, f
         Err(_) => return (0.0, 0.0),
     };
     let claude_projects_dir = home.join(".claude").join("projects");
-    if std::fs::metadata(&claude_projects_dir)
-        .map(|m| !m.is_dir())
-        .unwrap_or(true)
-    {
-        return (0.0, 0.0);
-    }
-    let files = match collect_session_files(&claude_projects_dir) {
-        Ok(f) if !f.is_empty() => f,
-        _ => return (0.0, 0.0),
-    };
 
+    // Fetch known task IDs via async DB query before entering the blocking section.
     let all_tasks = match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(t) => t,
         Err(_) => return (0.0, 0.0),
     };
     let task_ids: std::collections::HashSet<String> =
         all_tasks.iter().map(|t| t.id.0.clone()).collect();
+
+    // Offload all blocking filesystem I/O (directory walk + file reads) to a
+    // dedicated blocking thread so Tokio async workers are never stalled.
+    tokio::task::spawn_blocking(move || scan_cost_files_blocking(&claude_projects_dir, task_ids))
+        .await
+        .unwrap_or((0.0, 0.0))
+}
+
+fn scan_cost_files_blocking(
+    claude_projects_dir: &Path,
+    task_ids: std::collections::HashSet<String>,
+) -> (f64, f64) {
+    if std::fs::metadata(claude_projects_dir)
+        .map(|m| !m.is_dir())
+        .unwrap_or(true)
+    {
+        return (0.0, 0.0);
+    }
+    let files = match collect_session_files(claude_projects_dir) {
+        Ok(f) if !f.is_empty() => f,
+        _ => return (0.0, 0.0),
+    };
 
     let mut task_usage: HashMap<String, UsageBucket> = HashMap::new();
     for file in &files {

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 use crate::http::AppState;
+use crate::task_runner::TaskStatus;
 
 /// Cached result of the last full JSONL cost scan with its expiry time.
 struct CostStatsCache {
@@ -491,9 +492,19 @@ async fn load_cost_stats_uncached(state: &Arc<crate::http::AppState>) -> (f64, f
     // Fetch known task IDs via async DB query before entering the blocking section.
     // list_all_statuses_with_terminal is lighter than list_all_summaries_with_terminal
     // because it only deserializes IDs and status strings, not full dependency lists.
+    //
+    // Only include Done tasks: in-flight (Implementing, Reviewing, …) and Failed/
+    // Cancelled tasks must be excluded so that cost_total_usd / avg_cost_per_task_usd
+    // reflect completed work only, matching the dashboard contract ("null when no
+    // completed tasks exist yet").  Including partial or failed sessions would cause
+    // the metric to fluctuate as tasks progress, contradicting its definition.
     let task_ids: std::collections::HashSet<String> =
         match state.core.tasks.list_all_statuses_with_terminal().await {
-            Ok(statuses) => statuses.into_keys().map(|id| id.0).collect(),
+            Ok(statuses) => statuses
+                .into_iter()
+                .filter(|(_, status)| matches!(status, TaskStatus::Done))
+                .map(|(id, _)| id.0)
+                .collect(),
             Err(_) => return (0.0, 0.0),
         };
 

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -384,6 +384,10 @@ fn accumulate(dst: &mut UsageBucket, src: &UsageBucket) {
 }
 
 /// Estimate API-equivalent cost at Sonnet 4.6 pricing.
+///
+/// TODO(#624): multi-model pricing — currently hardcoded to Sonnet 4.6 rates.
+/// Supporting per-task model detection requires parsing JSONL session files
+/// per task and is out of scope for this issue.
 fn estimate_cost(usage: &UsageBucket) -> f64 {
     let has_cache = usage.cache_read_tokens > 0 || usage.cache_create_tokens > 0;
     let (eff_input, eff_cache_read) = if has_cache {
@@ -412,6 +416,86 @@ fn parse_timestamp(ts: &str) -> Result<(String, String), String> {
         return Err(format!("invalid timestamp '{ts}': hour is not numeric"));
     }
     Ok((day.to_string(), format!("{day} {hour}:00")))
+}
+
+/// Compute `(total_cost_usd, avg_cost_per_task_usd)` from a per-task usage map.
+///
+/// Returns `(0.0, 0.0)` when the map is empty to avoid division by zero.
+fn aggregate_cost_stats(task_usage: &HashMap<String, UsageBucket>) -> (f64, f64) {
+    if task_usage.is_empty() {
+        return (0.0, 0.0);
+    }
+    let total: f64 = task_usage.values().map(estimate_cost).sum();
+    let avg = total / task_usage.len() as f64;
+    (total, avg)
+}
+
+/// Load per-task cost statistics from Claude CLI session JSONL files.
+///
+/// Returns `(total_cost_usd, avg_cost_per_task_usd)`.  Returns `(0.0, 0.0)`
+/// on any error (missing directory, unreadable files, etc.) so that the
+/// dashboard degrades gracefully without an error response.
+pub(crate) async fn load_cost_stats(state: &Arc<crate::http::AppState>) -> (f64, f64) {
+    let home = match home_dir() {
+        Ok(p) => p,
+        Err(_) => return (0.0, 0.0),
+    };
+    let claude_projects_dir = home.join(".claude").join("projects");
+    if std::fs::metadata(&claude_projects_dir)
+        .map(|m| !m.is_dir())
+        .unwrap_or(true)
+    {
+        return (0.0, 0.0);
+    }
+    let files = match collect_session_files(&claude_projects_dir) {
+        Ok(f) if !f.is_empty() => f,
+        _ => return (0.0, 0.0),
+    };
+
+    let all_tasks = match state.core.tasks.list_all_summaries_with_terminal().await {
+        Ok(t) => t,
+        Err(_) => return (0.0, 0.0),
+    };
+    let task_ids: std::collections::HashSet<String> =
+        all_tasks.iter().map(|t| t.id.0.clone()).collect();
+
+    let mut task_usage: HashMap<String, UsageBucket> = HashMap::new();
+    for file in &files {
+        let task_id = extract_task_id(file);
+        let content = match std::fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let mut sess = UsageBucket::default();
+        for (idx, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let entry: serde_json::Value = match serde_json::from_str(line) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let ctx = format!("{}:{}", file.display(), idx + 1);
+            let parsed = match parse_usage_record(&entry, &ctx) {
+                Ok(Some(r)) => r,
+                _ => continue,
+            };
+            sess.input_tokens += parsed.input;
+            sess.output_tokens += parsed.output;
+            sess.cache_read_tokens += parsed.cache_read;
+            sess.cache_create_tokens += parsed.cache_create;
+            sess.request_count += 1;
+        }
+        if sess.request_count == 0 {
+            continue;
+        }
+        if let Some(tid) = &task_id {
+            if task_ids.contains(tid) {
+                accumulate(task_usage.entry(tid.clone()).or_default(), &sess);
+            }
+        }
+    }
+    aggregate_cost_stats(&task_usage)
 }
 
 fn collect_session_files(claude_projects_dir: &Path) -> Result<Vec<PathBuf>, String> {
@@ -557,5 +641,39 @@ mod tests {
         assert_eq!(parsed.cache_create, 10);
         assert_eq!(parsed.day, "2026-03-26");
         assert_eq!(parsed.hour, "2026-03-26 03:00");
+    }
+
+    #[test]
+    fn aggregate_cost_stats_empty_returns_zero() {
+        let empty: HashMap<String, UsageBucket> = HashMap::new();
+        let (total, avg) = aggregate_cost_stats(&empty);
+        assert_eq!(total, 0.0);
+        assert_eq!(avg, 0.0);
+    }
+
+    #[test]
+    fn aggregate_cost_stats_multiple_tasks() {
+        let mut tasks: HashMap<String, UsageBucket> = HashMap::new();
+        // Each task: 1M output tokens at Sonnet 4.6 pricing ($15/M out) = $15/task.
+        tasks.insert(
+            "task-a".to_string(),
+            UsageBucket {
+                output_tokens: 1_000_000,
+                ..Default::default()
+            },
+        );
+        tasks.insert(
+            "task-b".to_string(),
+            UsageBucket {
+                output_tokens: 1_000_000,
+                ..Default::default()
+            },
+        );
+        let (total, avg) = aggregate_cost_stats(&tasks);
+        assert!(
+            (total - 30.0).abs() < 0.01,
+            "expected ~$30 total, got {total}"
+        );
+        assert!((avg - 15.0).abs() < 0.01, "expected ~$15 avg, got {avg}");
     }
 }

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -2,6 +2,7 @@ use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
@@ -488,12 +489,13 @@ async fn load_cost_stats_uncached(state: &Arc<crate::http::AppState>) -> (f64, f
     let claude_projects_dir = home.join(".claude").join("projects");
 
     // Fetch known task IDs via async DB query before entering the blocking section.
-    let all_tasks = match state.core.tasks.list_all_summaries_with_terminal().await {
-        Ok(t) => t,
-        Err(_) => return (0.0, 0.0),
-    };
+    // list_all_statuses_with_terminal is lighter than list_all_summaries_with_terminal
+    // because it only deserializes IDs and status strings, not full dependency lists.
     let task_ids: std::collections::HashSet<String> =
-        all_tasks.iter().map(|t| t.id.0.clone()).collect();
+        match state.core.tasks.list_all_statuses_with_terminal().await {
+            Ok(statuses) => statuses.into_keys().map(|id| id.0).collect(),
+            Err(_) => return (0.0, 0.0),
+        };
 
     // Offload all blocking filesystem I/O (directory walk + file reads) to a
     // dedicated blocking thread so Tokio async workers are never stalled.
@@ -520,16 +522,21 @@ fn scan_cost_files_blocking(
     let mut task_usage: HashMap<String, UsageBucket> = HashMap::new();
     for file in &files {
         let task_id = extract_task_id(file);
-        let content = match std::fs::read_to_string(file) {
-            Ok(c) => c,
+        let f = match std::fs::File::open(file) {
+            Ok(f) => f,
             Err(_) => continue,
         };
+        let reader = std::io::BufReader::new(f);
         let mut sess = UsageBucket::default();
-        for (idx, line) in content.lines().enumerate() {
+        for (idx, line) in reader.lines().enumerate() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
             if line.trim().is_empty() {
                 continue;
             }
-            let entry: serde_json::Value = match serde_json::from_str(line) {
+            let entry: serde_json::Value = match serde_json::from_str(&line) {
                 Ok(e) => e,
                 Err(_) => continue,
             };

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -19,6 +19,8 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// v10 – add composite index on (project, status, updated_at).
 /// v11 – add task_checkpoints table for phase recovery.
 /// v12 – add priority column for priority-based task scheduling.
+/// v13 – add review_turns column for tracking review cycles per task.
+/// v14 – add first_output_at column for first-token latency tracking.
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -98,6 +100,16 @@ static TASK_MIGRATIONS: &[Migration] = &[
         version: 12,
         description: "add priority column for task scheduling",
         sql: "ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
+    },
+    Migration {
+        version: 13,
+        description: "add review_turns column for tracking review cycles",
+        sql: "ALTER TABLE tasks ADD COLUMN review_turns INTEGER NOT NULL DEFAULT 0",
+    },
+    Migration {
+        version: 14,
+        description: "add first_output_at column for first-token latency tracking",
+        sql: "ALTER TABLE tasks ADD COLUMN first_output_at TEXT",
     },
 ];
 
@@ -738,6 +750,70 @@ impl TaskDb {
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
+    }
+
+    /// Increment `review_turns` by 1 for the given task.
+    ///
+    /// A "review turn" is a non-LGTM review cycle outcome (i.e. FIXED) that
+    /// requires another round before the task can complete. WAITING outcomes
+    /// (bot not yet responded) are not counted because they do not represent
+    /// agent work.
+    pub async fn increment_review_turns(&self, task_id: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET review_turns = review_turns + 1, updated_at = datetime('now') \
+             WHERE id = ?",
+        )
+        .bind(task_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Set `first_output_at` for the given task if it has not been set yet.
+    ///
+    /// Idempotent: subsequent calls are no-ops because the WHERE clause
+    /// requires `first_output_at IS NULL`.
+    pub async fn set_first_output_at(&self, task_id: &str, ts: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET first_output_at = ? \
+             WHERE id = ? AND first_output_at IS NULL",
+        )
+        .bind(ts)
+        .bind(task_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return the average `review_turns` across all done tasks, or `None`
+    /// when no done tasks exist.
+    pub async fn avg_review_turns(&self) -> anyhow::Result<Option<f64>> {
+        let row: Option<(Option<f64>,)> = sqlx::query_as(
+            "SELECT AVG(CAST(review_turns AS REAL)) \
+             FROM tasks WHERE status = 'done'",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|(v,)| v))
+    }
+
+    /// Return the average first-token latency in milliseconds across done tasks
+    /// that have `first_output_at` set, or `None` when no such tasks exist.
+    ///
+    /// Latency is computed as `(first_output_at - created_at)` using SQLite's
+    /// `julianday` function converted to milliseconds. Results clamped to >= 0
+    /// in the query to guard against clock skew.
+    pub async fn avg_first_token_latency_ms(&self) -> anyhow::Result<Option<f64>> {
+        let row: Option<(Option<f64>,)> = sqlx::query_as(
+            "SELECT AVG(MAX(0.0, (julianday(first_output_at) - julianday(created_at)) * 86400000.0)) \
+             FROM tasks \
+             WHERE status = 'done' \
+               AND first_output_at IS NOT NULL \
+               AND created_at IS NOT NULL",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|(v,)| v))
     }
 }
 
@@ -1555,6 +1631,73 @@ mod tests {
             .expect_err("unknown status must return an explicit error");
         let message = format!("{err:#}");
         assert!(message.contains("unknown task status"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn increment_review_turns_counts_correctly() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let task = make_task("task-rt", TaskStatus::Done);
+        db.insert(&task).await?;
+
+        // Initially 0.
+        let avg = db.avg_review_turns().await?.unwrap_or(0.0);
+        assert_eq!(avg, 0.0);
+
+        db.increment_review_turns("task-rt").await?;
+        db.increment_review_turns("task-rt").await?;
+        db.increment_review_turns("task-rt").await?;
+
+        let avg = db.avg_review_turns().await?.unwrap_or(0.0);
+        assert_eq!(avg, 3.0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn avg_review_turns_returns_none_when_no_done_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        assert!(db.avg_review_turns().await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_first_output_at_is_idempotent() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-foa", TaskStatus::Done);
+        task.created_at = Some("2026-04-12T10:00:00Z".to_string());
+        db.insert(&task).await?;
+
+        // First write sets the value.
+        db.set_first_output_at("task-foa", "2026-04-12T10:00:02Z")
+            .await?;
+        // Second write is a no-op (WHERE first_output_at IS NULL).
+        db.set_first_output_at("task-foa", "2026-04-12T10:00:99Z")
+            .await?;
+
+        // Latency should reflect the first write (2s = 2000ms), not the second.
+        let latency = db.avg_first_token_latency_ms().await?.unwrap_or(0.0);
+        assert!(
+            (latency - 2000.0).abs() < 100.0,
+            "expected ~2000ms latency, got {latency}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn avg_first_token_latency_null_when_no_output_recorded() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let task = make_task("task-nofoa", TaskStatus::Done);
+        db.insert(&task).await?;
+        // No set_first_output_at call — first_output_at remains NULL.
+
+        assert!(db.avg_first_token_latency_ms().await?.is_none());
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -21,6 +21,8 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// v12 – add priority column for priority-based task scheduling.
 /// v13 – add review_turns column for tracking review cycles per task.
 /// v14 – add first_output_at column for first-token latency tracking.
+/// v15 – add execution_started_at column: stamped when task transitions to
+///        Implementing, used for accurate first-token latency (excludes queue wait).
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -110,6 +112,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         version: 14,
         description: "add first_output_at column for first-token latency tracking",
         sql: "ALTER TABLE tasks ADD COLUMN first_output_at TEXT",
+    },
+    Migration {
+        version: 15,
+        description: "add execution_started_at column for accurate first-token latency",
+        sql: "ALTER TABLE tasks ADD COLUMN execution_started_at TEXT",
     },
 ];
 
@@ -769,6 +776,23 @@ impl TaskDb {
         Ok(())
     }
 
+    /// Set `execution_started_at` for the given task if it has not been set yet.
+    ///
+    /// Called when the task transitions to `Implementing` so that
+    /// `avg_first_token_latency_ms` measures agent response time only, excluding
+    /// queue-wait time.  Idempotent via `WHERE execution_started_at IS NULL`.
+    pub async fn set_execution_started_at(&self, task_id: &str, ts: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET execution_started_at = ? \
+             WHERE id = ? AND execution_started_at IS NULL",
+        )
+        .bind(ts)
+        .bind(task_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Set `first_output_at` for the given task if it has not been set yet.
     ///
     /// Idempotent: subsequent calls are no-ops because the WHERE clause
@@ -800,16 +824,20 @@ impl TaskDb {
     /// Return the average first-token latency in milliseconds across done tasks
     /// that have `first_output_at` set, or `None` when no such tasks exist.
     ///
-    /// Latency is computed as `(first_output_at - created_at)` using SQLite's
-    /// `julianday` function converted to milliseconds. Results clamped to >= 0
-    /// in the query to guard against clock skew.
+    /// Latency is computed as `first_output_at - execution_started_at` when the
+    /// latter is available (tasks created after v15 migration), falling back to
+    /// `created_at` for older rows.  This ensures queue-wait time is excluded
+    /// from the metric on new tasks while retaining data for historical ones.
     pub async fn avg_first_token_latency_ms(&self) -> anyhow::Result<Option<f64>> {
         let row: Option<(Option<f64>,)> = sqlx::query_as(
-            "SELECT AVG(MAX(0.0, (julianday(first_output_at) - julianday(created_at)) * 86400000.0)) \
+            "SELECT AVG(MAX(0.0, \
+               (julianday(first_output_at) \
+                - julianday(COALESCE(execution_started_at, created_at))) \
+               * 86400000.0)) \
              FROM tasks \
              WHERE status = 'done' \
                AND first_output_at IS NOT NULL \
-               AND created_at IS NOT NULL",
+               AND COALESCE(execution_started_at, created_at) IS NOT NULL",
         )
         .fetch_optional(&self.pool)
         .await?;

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -275,7 +275,7 @@ impl TaskDb {
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project
+            "SELECT id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority
              FROM tasks WHERE status IN ({placeholders}) ORDER BY created_at DESC"
         );
         let mut q = sqlx::query_as::<_, TaskRow>(&sql);

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -793,6 +793,20 @@ impl TaskDb {
         Ok(())
     }
 
+    /// Unconditionally overwrite `execution_started_at` for the given task.
+    ///
+    /// Used after a forced planning phase completes so that the timestamp
+    /// reflects the start of actual implementation rather than the start of
+    /// planning, keeping `avg_first_token_latency_ms` accurate.
+    pub async fn force_execution_started_at(&self, task_id: &str, ts: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE tasks SET execution_started_at = ? WHERE id = ?")
+            .bind(ts)
+            .bind(task_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Set `first_output_at` for the given task if it has not been set yet.
     ///
     /// Idempotent: subsequent calls are no-ops because the WHERE clause

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -861,7 +861,16 @@ pub(crate) async fn run_task(
             // it and fail-close it (no pr_url → mark failed), rather than leaving it stuck
             // as a plain 'pending' that is never re-dispatched.
             update_status(store, task_id, TaskStatus::Implementing, 1).await?;
-            run_plan_for_prompt(agent, store, task_id, &cargo_env, &project, req).await?
+            let result =
+                run_plan_for_prompt(agent, store, task_id, &cargo_env, &project, req).await?;
+            // Re-stamp execution_started_at to the moment planning finishes so that
+            // avg_first_token_latency_ms measures implementation latency only, not
+            // planning time.  Uses an unconditional overwrite because the earlier
+            // update_status call already set it.
+            store
+                .force_execution_started_at(task_id, &chrono::Utc::now().to_rfc3339())
+                .await;
+            result
         } else {
             (None, prompts::TriageComplexity::Medium, 0u32)
         }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -487,15 +487,14 @@ async fn run_agent_streaming(
                             StreamItem::ItemCompleted {
                                 item: Item::AgentReasoning { content },
                             } => {
-                                // Do NOT set first_output_at here: backends that emit
-                                // ItemCompleted without any prior MessageDelta (e.g.
-                                // AnthropicApiAgent) only produce this event after the
-                                // entire blocking execute() call returns, so recording
-                                // it as first-token latency would measure full-turn
-                                // completion time instead.  first_output_at is only
-                                // meaningful for genuinely streaming backends (set in
-                                // the MessageDelta arm above).
-                                //
+                                // For non-streaming backends (e.g. AnthropicApiAgent)
+                                // that never emit MessageDelta, capture first_output_at
+                                // here so the latency metric is not permanently null for
+                                // those backends.  Streaming backends set it in the
+                                // MessageDelta arm above, so this is a no-op for them.
+                                if first_output_at.is_none() {
+                                    first_output_at = Some(Utc::now().to_rfc3339());
+                                }
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
                             }
@@ -845,6 +844,15 @@ pub(crate) async fn run_task(
         (None, prompts::TriageComplexity::Medium, 0u32)
     } else if let Some(plan) = resumed_plan {
         // Plan checkpoint found — use saved plan, skip triage/plan pipeline.
+        // Re-stamp execution_started_at so avg_first_token_latency_ms measures
+        // implementation latency only.  This also closes the crash window: if the
+        // server died after writing the plan_done checkpoint but before the
+        // force_execution_started_at() call in the normal path, the idempotent
+        // set_execution_started_at() in update_status() would not repair the stale
+        // pre-planning timestamp.
+        store
+            .force_execution_started_at(task_id, &chrono::Utc::now().to_rfc3339())
+            .await;
         tracing::info!(task_id = %task_id, "checkpoint resume: using saved plan, skipping triage/plan");
         (Some(plan), prompts::TriageComplexity::Medium, 0u32)
     } else if let Some(issue) = req.issue {

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -487,6 +487,12 @@ async fn run_agent_streaming(
                             StreamItem::ItemCompleted {
                                 item: Item::AgentReasoning { content },
                             } => {
+                                // Also capture first-token timestamp for backends that emit
+                                // ItemCompleted directly without MessageDelta chunks
+                                // (e.g. AnthropicApiAgent).
+                                if first_output_at.is_none() {
+                                    first_output_at = Some(Utc::now().to_rfc3339());
+                                }
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
                             }
@@ -514,10 +520,14 @@ async fn run_agent_streaming(
     }
 
     // Persist first-token timestamp once the stream is done (deferred from the
-    // select! body to avoid blocking the receive loop).  Only writes if the
-    // value has not been set for this task yet (idempotent DB query).
-    if let Some(ts) = first_output_at {
-        store.set_first_output_at(task_id, &ts).await;
+    // select! body to avoid blocking the receive loop).  Only write for the
+    // implementation turn (turn == 1) so that triage/plan tokens don't lock in
+    // the timestamp before execution_started_at is set; that would make the DB
+    // latency expression negative and get clamped to 0.
+    if turn == 1 {
+        if let Some(ts) = first_output_at {
+            store.set_first_output_at(task_id, &ts).await;
+        }
     }
 
     match exec_result.unwrap_or_else(|| {
@@ -1765,10 +1775,11 @@ pub(crate) async fn run_task(
             result: result_label.to_string(),
         });
 
-        // Count FIXED rounds (non-LGTM outcomes) as review turns for the
-        // avg_review_turns observability metric.  WAITING (bot not ready) rounds
-        // never reach this point because they `continue` earlier in the loop.
-        if !lgtm {
+        // Count only genuine FIXED rounds (non-LGTM, non-WAITING outcomes) for
+        // avg_review_turns.  When waiting_count >= MAX_CONSECUTIVE_WAITS the code
+        // falls through here with `waiting == true` to consume a round and reset
+        // the counter — that is not a real review cycle, so exclude it.
+        if !lgtm && !waiting {
             store.increment_review_turns(task_id).await;
         }
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -5,6 +5,7 @@ use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskStatus, TaskStore,
 };
 use anyhow::Context;
+use chrono::Utc;
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
 use harness_core::config::agents::CapabilityProfile;
 use harness_core::error::HarnessError;
@@ -462,6 +463,10 @@ async fn run_agent_streaming(
     let mut channel_closed = false;
     let mut output = String::new();
     let mut token_usage = TokenUsage::default();
+    // Capture the RFC3339 timestamp of the first non-empty output chunk for
+    // first-token latency tracking. The DB write is deferred to after the loop
+    // so it does not block the select! inner body.
+    let mut first_output_at: Option<String> = None;
 
     loop {
         tokio::select! {
@@ -474,6 +479,9 @@ async fn run_agent_streaming(
                         store.publish_stream_item(task_id, item.clone());
                         match &item {
                             StreamItem::MessageDelta { text } => {
+                                if !text.is_empty() && first_output_at.is_none() {
+                                    first_output_at = Some(Utc::now().to_rfc3339());
+                                }
                                 output.push_str(text);
                             }
                             StreamItem::ItemCompleted {
@@ -503,6 +511,13 @@ async fn run_agent_streaming(
         if exec_result.is_some() && channel_closed {
             break;
         }
+    }
+
+    // Persist first-token timestamp once the stream is done (deferred from the
+    // select! body to avoid blocking the receive loop).  Only writes if the
+    // value has not been set for this task yet (idempotent DB query).
+    if let Some(ts) = first_output_at {
+        store.set_first_output_at(task_id, &ts).await;
     }
 
     match exec_result.unwrap_or_else(|| {
@@ -1740,6 +1755,13 @@ pub(crate) async fn run_task(
             round,
             result: result_label.to_string(),
         });
+
+        // Count FIXED rounds (non-LGTM outcomes) as review turns for the
+        // avg_review_turns observability metric.  WAITING (bot not ready) rounds
+        // never reach this point because they `continue` earlier in the loop.
+        if !lgtm {
+            store.increment_review_turns(task_id).await;
+        }
 
         // Log pr_review event for observability and GC signal detection.
         let mut ev = Event::new(

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -487,12 +487,15 @@ async fn run_agent_streaming(
                             StreamItem::ItemCompleted {
                                 item: Item::AgentReasoning { content },
                             } => {
-                                // Also capture first-token timestamp for backends that emit
-                                // ItemCompleted directly without MessageDelta chunks
-                                // (e.g. AnthropicApiAgent).
-                                if first_output_at.is_none() {
-                                    first_output_at = Some(Utc::now().to_rfc3339());
-                                }
+                                // Do NOT set first_output_at here: backends that emit
+                                // ItemCompleted without any prior MessageDelta (e.g.
+                                // AnthropicApiAgent) only produce this event after the
+                                // entire blocking execute() call returns, so recording
+                                // it as first-token latency would measure full-turn
+                                // completion time instead.  first_output_at is only
+                                // meaningful for genuinely streaming backends (set in
+                                // the MessageDelta arm above).
+                                //
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
                             }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -974,6 +974,44 @@ impl TaskStore {
         }
     }
 
+    /// Increment `review_turns` for the given task in the database.
+    /// Logs and swallows errors so that a DB failure does not abort task execution.
+    pub(crate) async fn increment_review_turns(&self, id: &TaskId) {
+        if let Err(e) = self.db.increment_review_turns(id.0.as_str()).await {
+            tracing::warn!(task_id = %id.0, "failed to increment review_turns: {e}");
+        }
+    }
+
+    /// Set `first_output_at` for the given task if not already set.
+    /// Idempotent; logs and swallows errors so that a DB failure does not abort task execution.
+    pub(crate) async fn set_first_output_at(&self, id: &TaskId, ts: &str) {
+        if let Err(e) = self.db.set_first_output_at(id.0.as_str(), ts).await {
+            tracing::warn!(task_id = %id.0, "failed to set first_output_at: {e}");
+        }
+    }
+
+    /// Return the average number of review turns across completed tasks, or `None` when empty.
+    pub(crate) async fn avg_review_turns(&self) -> Option<f64> {
+        match self.db.avg_review_turns().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("avg_review_turns: DB query failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Return the average first-token latency in milliseconds across completed tasks, or `None`.
+    pub(crate) async fn avg_first_token_latency_ms(&self) -> Option<f64> {
+        match self.db.avg_first_token_latency_ms().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("avg_first_token_latency_ms: DB query failed: {e}");
+                None
+            }
+        }
+    }
+
     /// Activate the global rate-limit circuit breaker. All tasks will pause
     /// before their next agent call until `duration` elapses.
     pub async fn set_rate_limit(&self, duration: std::time::Duration) {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -984,6 +984,15 @@ impl TaskStore {
 
     /// Set `execution_started_at` for the given task if not already set.
     /// Idempotent; logs and swallows errors so that a DB failure does not abort task execution.
+    /// Overwrite `execution_started_at` unconditionally.  Call this after a
+    /// forced planning phase so the timestamp marks implementation start, not
+    /// planning start, keeping `avg_first_token_latency_ms` accurate.
+    pub(crate) async fn force_execution_started_at(&self, id: &TaskId, ts: &str) {
+        if let Err(e) = self.db.force_execution_started_at(id.0.as_str(), ts).await {
+            tracing::warn!(task_id = %id.0, "failed to force execution_started_at: {e}");
+        }
+    }
+
     pub(crate) async fn set_execution_started_at(&self, id: &TaskId, ts: &str) {
         if let Err(e) = self.db.set_execution_started_at(id.0.as_str(), ts).await {
             tracing::warn!(task_id = %id.0, "failed to set execution_started_at: {e}");

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -982,6 +982,14 @@ impl TaskStore {
         }
     }
 
+    /// Set `execution_started_at` for the given task if not already set.
+    /// Idempotent; logs and swallows errors so that a DB failure does not abort task execution.
+    pub(crate) async fn set_execution_started_at(&self, id: &TaskId, ts: &str) {
+        if let Err(e) = self.db.set_execution_started_at(id.0.as_str(), ts).await {
+            tracing::warn!(task_id = %id.0, "failed to set execution_started_at: {e}");
+        }
+    }
+
     /// Set `first_output_at` for the given task if not already set.
     /// Idempotent; logs and swallows errors so that a DB failure does not abort task execution.
     pub(crate) async fn set_first_output_at(&self, id: &TaskId, ts: &str) {
@@ -1845,6 +1853,12 @@ pub(crate) async fn update_status(
     turn: u32,
 ) -> anyhow::Result<()> {
     let status_str = status.as_ref().to_string();
+    // Stamp execution_started_at the first time a task enters Implementing so
+    // that first-token latency excludes queue-wait time.
+    if matches!(status, TaskStatus::Implementing) {
+        let ts = chrono::Utc::now().to_rfc3339();
+        store.set_execution_started_at(task_id, &ts).await;
+    }
     mutate_and_persist(store, task_id, |s| {
         s.status = status;
         s.turn = turn;


### PR DESCRIPTION
## Summary

- Add `cost_total_usd`, `avg_cost_per_task_usd`, `avg_review_turns`, `avg_first_token_latency_ms`, `guard_triggers_24h` to `GET /api/dashboard` global response
- DB migrations v13/v14 add `review_turns` (INTEGER DEFAULT 0) and `first_output_at` (TEXT nullable) to tasks table — additive ALTER TABLE, existing databases survive without data loss
- `first_output_at` captured at first non-empty `MessageDelta` in `run_agent_streaming`; DB write deferred to after stream closes, idempotent so review retries don't overwrite the initial value
- `review_turns` incremented on every FIXED review round (non-LGTM, non-WAITING); `guard_triggers_24h` reuses existing event store query, filtered to rolling 24h window
- `cost_per_task_usd` computed from JSONL session files via new `load_cost_stats()` helper; pricing stays Sonnet 4.6 hardcoded with `TODO(#624)` comment

## Test plan

- [x] 658 lib unit tests pass (+7 new: 4 in `task_db`, 2 in `token_usage`, 1 in `handlers::dashboard`)
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all` + `cargo clippy -- -D warnings` clean
- [x] Pre-commit hook (fmt + clippy + test) passed on commit
- [ ] Pre-existing `checkpoint_recovery` integration test failures confirmed on `main` — unrelated to this change