### PR TITLE
fix(q_value_store): log parse errors in get_experiences_for_task instead of silently discarding

### DIFF
--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -131,7 +131,15 @@ impl QValueStore {
 
         let mut ids = Vec::new();
         for (json,) in rows {
-            let parsed: Vec<String> = serde_json::from_str(&json).unwrap_or_default();
+            let parsed: Vec<String> = serde_json::from_str(&json).unwrap_or_else(|e| {
+                tracing::error!(
+                    task_id = %task_id,
+                    json = %json,
+                    error = %e,
+                    "Failed to parse experiences_used JSON; skipping row"
+                );
+                Vec::new()
+            });
             ids.extend(parsed);
         }
         ids.sort();

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -133,7 +133,11 @@ impl QValueStore {
         for (json,) in rows {
             let parsed: Vec<String> = serde_json::from_str(&json).unwrap_or_else(|e| {
                 let truncated = if json.len() > 200 {
-                    format!("{}…({} bytes total)", &json[..200], json.len())
+                    let end = (0..=200)
+                        .rev()
+                        .find(|&i| json.is_char_boundary(i))
+                        .unwrap_or(0);
+                    format!("{}…({} bytes total)", &json[..end], json.len())
                 } else {
                     json.clone()
                 };

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -132,9 +132,14 @@ impl QValueStore {
         let mut ids = Vec::new();
         for (json,) in rows {
             let parsed: Vec<String> = serde_json::from_str(&json).unwrap_or_else(|e| {
+                let truncated = if json.len() > 200 {
+                    format!("{}…({} bytes total)", &json[..200], json.len())
+                } else {
+                    json.clone()
+                };
                 tracing::error!(
                     task_id = %task_id,
-                    json = %json,
+                    json = %truncated,
                     error = %e,
                     "Failed to parse experiences_used JSON; skipping row"
                 );


### PR DESCRIPTION
## Summary

- Replace `unwrap_or_default()` with `unwrap_or_else(|e| { tracing::error!(...); Vec::new() })` in `get_experiences_for_task`
- Corrupt or malformed `experiences_used` JSON rows now emit a `tracing::error!` log with `task_id`, the raw JSON, and the parse error
- Fixes RS-10 / U-29 violation: silent degradation was causing backprop to skip affected rules without any observable signal

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass