### PR TITLE
fix(q-value): gate REWARD_MERGED on pr_url presence for Done tasks

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -621,9 +621,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                         // task execution. Non-terminal states (Pending, Implementing, etc.)
                         // must not trigger Q-updates — they would incorrectly penalize rules
                         // that are still in the middle of a task.
+                        //
+                        // For Done tasks, gate the merged reward on pr_url presence: a task
+                        // that exits cleanly without creating a PR (e.g. prompt tasks, analysis
+                        // tasks) should not emit REWARD_MERGED, as that would inflate Q-values
+                        // for rules that contributed nothing to an actual PR merge outcome.
                         let reward = match state.status {
                             task_runner::TaskStatus::Done => {
-                                Some(crate::q_value_store::REWARD_MERGED)
+                                if state.pr_url.is_some() {
+                                    Some(crate::q_value_store::REWARD_MERGED)
+                                } else {
+                                    None
+                                }
                             }
                             task_runner::TaskStatus::Failed => {
                                 Some(crate::q_value_store::REWARD_CLOSED)


### PR DESCRIPTION
## Summary

- `TaskStatus::Done` was unconditionally emitting `REWARD_MERGED (1.0)`, even for non-PR tasks (prompt tasks, analysis tasks) that exit cleanly without creating a PR
- This inflated Q-values for rules that contributed nothing to an actual PR merge outcome, corrupting the MemRL utility signal over time
- Fix: gate `REWARD_MERGED` on `state.pr_url.is_some()`; tasks that complete without a PR emit no Q-update (`None`)

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass