### PR TITLE
fix(q-value): gate reward signal on pr_url presence

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -207,6 +207,31 @@ fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
     path.to_path_buf()
 }
 
+/// Select the Q-value reward signal for a terminal task state.
+///
+/// Returns `Some(reward)` only for PR-backed tasks (i.e. `pr_url` is `Some`).
+/// Non-PR tasks (periodic_review, sprint_planner, free-prompt, etc.) return `None`
+/// so their cancellation or completion never pollutes rule Q-values.
+pub(crate) fn q_value_reward_for_state(
+    status: &crate::task_runner::TaskStatus,
+    pr_url: &Option<String>,
+) -> Option<f64> {
+    match (status, pr_url) {
+        (crate::task_runner::TaskStatus::Done, Some(_)) => {
+            Some(crate::q_value_store::REWARD_MERGED)
+        }
+        (crate::task_runner::TaskStatus::Failed, Some(_)) => {
+            Some(crate::q_value_store::REWARD_CLOSED)
+        }
+        (crate::task_runner::TaskStatus::Cancelled, Some(_)) => {
+            Some(crate::q_value_store::REWARD_UNKNOWN_CLOSED)
+        }
+        // Non-PR tasks (no pr_url): skip Q-value update to avoid
+        // spuriously inflating rule Q-values for prompt/analysis tasks.
+        _ => None,
+    }
+}
+
 /// Build an AppState with all stores. Used by both HTTP and stdio transports.
 pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppState> {
     let dir = expand_tilde(&server.config.server.data_dir);
@@ -621,20 +646,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                         // task execution. Non-terminal states (Pending, Implementing, etc.)
                         // must not trigger Q-updates — they would incorrectly penalize rules
                         // that are still in the middle of a task.
-                        let reward = match (&state.status, &state.pr_url) {
-                            (task_runner::TaskStatus::Done, Some(_)) => {
-                                Some(crate::q_value_store::REWARD_MERGED)
-                            }
-                            (task_runner::TaskStatus::Failed, Some(_)) => {
-                                Some(crate::q_value_store::REWARD_CLOSED)
-                            }
-                            (task_runner::TaskStatus::Cancelled, _) => {
-                                Some(crate::q_value_store::REWARD_UNKNOWN_CLOSED)
-                            }
-                            // Non-PR tasks (no pr_url): skip Q-value update to avoid
-                            // spuriously inflating rule Q-values for prompt/analysis tasks.
-                            _ => None,
-                        };
+                        let reward = q_value_reward_for_state(&state.status, &state.pr_url);
                         if let Some(reward) = reward {
                             match qv.get_experiences_for_task(&state.id.0).await {
                                 Ok(exp_ids) if !exp_ids.is_empty() => {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -621,16 +621,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                         // task execution. Non-terminal states (Pending, Implementing, etc.)
                         // must not trigger Q-updates — they would incorrectly penalize rules
                         // that are still in the middle of a task.
-                        let reward = match state.status {
-                            task_runner::TaskStatus::Done => {
+                        let reward = match (&state.status, &state.pr_url) {
+                            (task_runner::TaskStatus::Done, Some(_)) => {
                                 Some(crate::q_value_store::REWARD_MERGED)
                             }
-                            task_runner::TaskStatus::Failed => {
+                            (task_runner::TaskStatus::Failed, Some(_)) => {
                                 Some(crate::q_value_store::REWARD_CLOSED)
                             }
-                            task_runner::TaskStatus::Cancelled => {
+                            (task_runner::TaskStatus::Cancelled, _) => {
                                 Some(crate::q_value_store::REWARD_UNKNOWN_CLOSED)
                             }
+                            // Non-PR tasks (no pr_url): skip Q-value update to avoid
+                            // spuriously inflating rule Q-values for prompt/analysis tasks.
                             _ => None,
                         };
                         if let Some(reward) = reward {

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1217,3 +1217,77 @@ async fn dispatch_simple_prompt_selects_default_agent() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+// ── q_value_reward_for_state unit tests ──────────────────────────────────────
+//
+// These tests guard the PR-gate invariant: only tasks with a pr_url set should
+// emit a Q-value reward signal.  Non-PR tasks (periodic_review, sprint_planner,
+// free-prompt, etc.) must always return None regardless of terminal status so
+// they cannot pollute rule Q-values.
+
+#[test]
+fn q_reward_done_with_pr_url_returns_merged() {
+    let reward = super::q_value_reward_for_state(
+        &crate::task_runner::TaskStatus::Done,
+        &Some("https://github.com/org/repo/pull/1".to_string()),
+    );
+    assert_eq!(reward, Some(crate::q_value_store::REWARD_MERGED));
+}
+
+#[test]
+fn q_reward_failed_with_pr_url_returns_closed() {
+    let reward = super::q_value_reward_for_state(
+        &crate::task_runner::TaskStatus::Failed,
+        &Some("https://github.com/org/repo/pull/2".to_string()),
+    );
+    assert_eq!(reward, Some(crate::q_value_store::REWARD_CLOSED));
+}
+
+#[test]
+fn q_reward_cancelled_with_pr_url_returns_unknown_closed() {
+    let reward = super::q_value_reward_for_state(
+        &crate::task_runner::TaskStatus::Cancelled,
+        &Some("https://github.com/org/repo/pull/3".to_string()),
+    );
+    assert_eq!(reward, Some(crate::q_value_store::REWARD_UNKNOWN_CLOSED));
+}
+
+#[test]
+fn q_reward_cancelled_without_pr_url_returns_none() {
+    // Regression: non-PR tasks (periodic_review, sprint_planner) must not emit
+    // a reward even when cancelled — this was the bug fixed in PR #679.
+    let reward = super::q_value_reward_for_state(&crate::task_runner::TaskStatus::Cancelled, &None);
+    assert_eq!(reward, None, "cancelled non-PR task must not emit Q-update");
+}
+
+#[test]
+fn q_reward_done_without_pr_url_returns_none() {
+    let reward = super::q_value_reward_for_state(&crate::task_runner::TaskStatus::Done, &None);
+    assert_eq!(reward, None);
+}
+
+#[test]
+fn q_reward_failed_without_pr_url_returns_none() {
+    let reward = super::q_value_reward_for_state(&crate::task_runner::TaskStatus::Failed, &None);
+    assert_eq!(reward, None);
+}
+
+#[test]
+fn q_reward_non_terminal_statuses_return_none() {
+    for status in [
+        crate::task_runner::TaskStatus::Pending,
+        crate::task_runner::TaskStatus::Implementing,
+        crate::task_runner::TaskStatus::Reviewing,
+        crate::task_runner::TaskStatus::Waiting,
+    ] {
+        let with_pr = super::q_value_reward_for_state(
+            &status,
+            &Some("https://github.com/org/repo/pull/9".to_string()),
+        );
+        assert_eq!(
+            with_pr, None,
+            "non-terminal status {:?} must not emit Q-update even with pr_url",
+            status
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #674: Q-value reward was applied based on task terminal status alone, incorrectly emitting `REWARD_MERGED` (1.0) for prompt-only and analysis tasks that complete without producing a PR
- Gates the reward on `state.pr_url.is_some()` so only tasks that produced an actual PR receive a PR-outcome reward signal
- Non-PR task completions now produce no Q-update, preventing spurious inflation of rule Q-values

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 86 tests pass