### PR TITLE
fix(task): deduplicate issue/PR submissions to prevent duplicate PRs

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -80,6 +80,32 @@ pub(crate) async fn enqueue_task(
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);
 
+    // Auto-populate external_id from issue/pr for deduplication.
+    if req.external_id.is_none() {
+        if let Some(issue) = req.issue {
+            req.external_id = Some(format!("issue:{issue}"));
+        } else if let Some(pr) = req.pr {
+            req.external_id = Some(format!("pr:{pr}"));
+        }
+    }
+
+    // Dedup: reject if an active task already exists for this project + external_id.
+    if let Some(ext_id) = &req.external_id {
+        if let Some(existing_id) = state
+            .core
+            .tasks
+            .find_active_duplicate(&project_id, ext_id)
+            .await
+        {
+            tracing::info!(
+                existing_task = %existing_id.0,
+                external_id = %ext_id,
+                "dedup: returning existing active task instead of creating duplicate"
+            );
+            return Ok(existing_id);
+        }
+    }
+
     // Acquire concurrency permit before spawning. Blocks if all slots are
     // occupied; rejects immediately if the waiting queue is full.
     let permit = state
@@ -280,6 +306,32 @@ async fn enqueue_task_background(
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);
     task_runner::fill_missing_repo_from_project(&mut req).await;
+
+    // Auto-populate external_id from issue/pr for deduplication.
+    if req.external_id.is_none() {
+        if let Some(issue) = req.issue {
+            req.external_id = Some(format!("issue:{issue}"));
+        } else if let Some(pr) = req.pr {
+            req.external_id = Some(format!("pr:{pr}"));
+        }
+    }
+
+    // Dedup: reject if an active task already exists for this project + external_id.
+    if let Some(ext_id) = &req.external_id {
+        if let Some(existing_id) = state
+            .core
+            .tasks
+            .find_active_duplicate(&project_id, ext_id)
+            .await
+        {
+            tracing::info!(
+                existing_task = %existing_id.0,
+                external_id = %ext_id,
+                "dedup: returning existing active task instead of creating duplicate (batch)"
+            );
+            return Ok(existing_id);
+        }
+    }
 
     let server_config = std::sync::Arc::new(state.core.server.config.clone());
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -270,6 +270,26 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Find an active (pending/running) task for the same project + external_id.
+    ///
+    /// Used for deduplication: if a task already exists for the same issue/PR in
+    /// the same project and hasn't reached a terminal state, we return its ID
+    /// instead of creating a duplicate.
+    pub async fn find_active_duplicate(
+        &self,
+        project: &str,
+        external_id: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT id FROM tasks WHERE project = ? AND external_id = ? AND status IN ('pending', 'running') LIMIT 1",
+        )
+        .bind(project)
+        .bind(external_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
     /// Return all tasks as lightweight summaries, skipping the heavy `rounds` column.
     ///
     /// Used by the `/tasks` list endpoint to avoid deserializing large round histories
@@ -1620,6 +1640,74 @@ mod tests {
 
         let empty = db.list_by_status(&[]).await?;
         assert!(empty.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_returns_matching_active_task() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-issue-42", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+
+        // Same project + external_id → finds duplicate.
+        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        assert_eq!(dup, Some("task-issue-42".to_string()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_ignores_terminal_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-done-42", TaskStatus::Done);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+
+        // Terminal task → no duplicate.
+        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        assert_eq!(dup, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_different_project_no_match() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-proj-a", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&task).await?;
+
+        // Different project → no match.
+        let dup = db.find_active_duplicate("/repo/b", "issue:42").await?;
+        assert_eq!(dup, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_different_external_id_no_match() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-issue-42", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+
+        // Different external_id → no match.
+        let dup = db.find_active_duplicate("/repo/foo", "issue:99").await?;
+        assert_eq!(dup, None);
+
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -719,6 +719,44 @@ impl TaskStore {
         }
     }
 
+    /// Find an active (pending/running) task for the same project + external_id.
+    ///
+    /// Checks the in-memory cache first, falls back to DB. Used by the enqueue
+    /// path to prevent duplicate tasks for the same issue/PR.
+    pub async fn find_active_duplicate(&self, project: &str, external_id: &str) -> Option<TaskId> {
+        // Check in-memory cache first (covers tasks not yet persisted).
+        for entry in self.cache.iter() {
+            let state = entry.value();
+            let is_active = matches!(
+                state.status,
+                TaskStatus::Pending
+                    | TaskStatus::AwaitingDeps
+                    | TaskStatus::Implementing
+                    | TaskStatus::AgentReview
+                    | TaskStatus::Waiting
+                    | TaskStatus::Reviewing
+            );
+            if is_active
+                && state.external_id.as_deref() == Some(external_id)
+                && state
+                    .project_root
+                    .as_ref()
+                    .is_some_and(|p| p.to_string_lossy() == project)
+            {
+                return Some(state.id.clone());
+            }
+        }
+        // Fall back to DB for tasks not in cache.
+        match self.db.find_active_duplicate(project, external_id).await {
+            Ok(Some(id)) => Some(harness_core::types::TaskId(id)),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!("dedup DB lookup failed (non-fatal): {e}");
+                None
+            }
+        }
+    }
+
     /// Return IDs of terminal tasks (Done, Failed, Cancelled) directly from the database.
     ///
     /// Used during startup for worktree cleanup. Only fetches task IDs to avoid
@@ -1347,6 +1385,7 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.depends_on = req.depends_on.clone();
     state.priority = req.priority;
     state.issue = req.issue;
+    state.project_root = req.project.clone();
     state.description = summarize_request_description(req);
     store.insert(&state).await;
     // Register stream channel now so SSE clients can subscribe before execution begins.


### PR DESCRIPTION
## Summary
- `POST /tasks` had no dedup — submitting the same issue twice spawned two agents creating duplicate PRs
- Auto-populate `external_id` from issue/pr number, check for active tasks before creating new ones
- Both `enqueue_task` (single) and `enqueue_task_background` (batch) paths covered

## Test plan
- [x] 4 new dedup unit tests (match, terminal ignored, different project, different external_id)
- [x] 1351 workspace tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check` clean