### PR TITLE
fix: fail closed Feishu webhook without token

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1826,7 +1826,7 @@ async fn intake_status(State(state): State<Arc<AppState>>) -> Json<serde_json::V
 
     let feishu_channel = json!({
         "name": "feishu",
-        "enabled": intake_config.feishu.as_ref().map(|c| c.enabled).unwrap_or(false),
+        "enabled": state.intake.feishu_intake.is_some(),
         "keyword": intake_config.feishu.as_ref().map(|c| c.trigger_keyword.as_str()).unwrap_or(""),
         "active": feishu_active,
     });

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -505,17 +505,22 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     );
 
     let feishu_intake = server.config.intake.feishu.as_ref().and_then(|cfg| {
-        if cfg.enabled {
-            tracing::info!(
-                trigger_keyword = %cfg.trigger_keyword,
-                "intake: Feishu bot registered"
-            );
-            Some(Arc::new(crate::intake::feishu::FeishuIntake::new(
-                cfg.clone(),
-            )))
-        } else {
-            None
+        if !cfg.enabled {
+            return None;
         }
+        if !crate::intake::feishu::has_verification_token(cfg) {
+            tracing::error!(
+                "intake: Feishu enabled but verification_token is missing; webhook will fail closed"
+            );
+            return None;
+        }
+        tracing::info!(
+            trigger_keyword = %cfg.trigger_keyword,
+            "intake: Feishu bot registered"
+        );
+        Some(Arc::new(crate::intake::feishu::FeishuIntake::new(
+            cfg.clone(),
+        )))
     });
 
     // Build ALL GitHub pollers once. The same Arc instances are shared between

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -55,9 +55,10 @@ fn percent_decode(s: &str) -> String {
 
 /// Bearer token authentication middleware.
 ///
-/// Exempts `/health`, `/webhook`, `/webhook/feishu`, and `/signals` (which
-/// have their own HMAC-based protection). All other endpoints require an
-/// `Authorization: Bearer <token>` header when `api_token` is configured.
+/// Exempts `/health`, `/webhook`, `/webhook/feishu`, and `/signals`.
+/// `/webhook/feishu` relies on Feishu verification-token validation and must
+/// fail closed when that token is not configured. All other endpoints require
+/// an `Authorization: Bearer <token>` header when `api_token` is configured.
 /// When no token is configured the middleware is a no-op (backward compat).
 pub(crate) async fn api_auth_middleware(
     State(state): State<Arc<AppState>>,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -66,6 +66,10 @@ async fn make_test_state_with(
     config: harness_core::config::HarnessConfig,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
+    let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
+        cfg.enabled
+            .then(|| Arc::new(crate::intake::feishu::FeishuIntake::new(cfg.clone())))
+    });
     let thread_manager = crate::thread_manager::ThreadManager::new();
     let server = Arc::new(crate::server::HarnessServer::new(
         config,
@@ -164,7 +168,7 @@ async fn make_test_state_with(
         },
         interceptors: vec![],
         intake: crate::http::IntakeServices {
-            feishu_intake: None,
+            feishu_intake,
             github_pollers: vec![],
             completion_callback: None,
         },
@@ -253,7 +257,80 @@ fn webhook_app(state: Arc<AppState>) -> Router {
             "/webhook",
             post(github_webhook).layer(DefaultBodyLimit::max(body_limit)),
         )
+        .route(
+            "/webhook/feishu",
+            post(crate::intake::feishu::feishu_webhook).layer(DefaultBodyLimit::max(body_limit)),
+        )
         .with_state(state)
+}
+
+fn make_feishu_config(
+    verification_token: Option<&str>,
+) -> harness_core::config::intake::FeishuIntakeConfig {
+    harness_core::config::intake::FeishuIntakeConfig {
+        enabled: true,
+        app_id: None,
+        app_secret: None,
+        verification_token: verification_token.map(ToString::to_string),
+        trigger_keyword: "harness".to_string(),
+        default_repo: None,
+    }
+}
+
+async fn make_test_state_with_feishu(
+    dir: &std::path::Path,
+    verification_token: Option<&str>,
+) -> anyhow::Result<Arc<AppState>> {
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.feishu = Some(make_feishu_config(verification_token));
+    make_test_state_with(
+        dir,
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await
+}
+
+fn feishu_challenge_payload(token: Option<&str>) -> serde_json::Value {
+    match token {
+        Some(token) => serde_json::json!({ "challenge": "challenge-123", "token": token }),
+        None => serde_json::json!({ "challenge": "challenge-123" }),
+    }
+}
+
+fn feishu_event_payload(token: Option<&str>) -> serde_json::Value {
+    let content = serde_json::to_string(&serde_json::json!({ "text": "harness fix login bug" }))
+        .expect("serialize feishu content");
+    match token {
+        Some(token) => serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1", "token": token },
+            "event": {
+                "message": {
+                    "message_id": "msg-001",
+                    "chat_id": "chat-001",
+                    "message_type": "text",
+                    "content": content
+                }
+            }
+        }),
+        None => serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {
+                "message": {
+                    "message_id": "msg-001",
+                    "chat_id": "chat-001",
+                    "message_type": "text",
+                    "content": content
+                }
+            }
+        }),
+    }
+}
+
+async fn response_json(response: axum::response::Response) -> anyhow::Result<serde_json::Value> {
+    use http_body_util::BodyExt;
+    let body = response.into_body().collect().await?.to_bytes();
+    Ok(serde_json::from_slice(&body)?)
 }
 
 fn webhook_signature(secret: &str, payload: &[u8]) -> String {
@@ -932,6 +1009,98 @@ async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
         .await?;
 
     assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn feishu_webhook_returns_service_unavailable_when_token_missing() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_feishu(dir.path(), None).await?;
+    let app = webhook_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook/feishu")
+                .header("content-type", "application/json")
+                .body(Body::from(feishu_challenge_payload(None).to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let json = response_json(response).await?;
+    assert_eq!(json["error"], "Feishu verification token not configured");
+    Ok(())
+}
+
+#[tokio::test]
+async fn feishu_webhook_returns_service_unavailable_when_token_is_empty() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_feishu(dir.path(), Some("")).await?;
+    let app = webhook_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook/feishu")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    feishu_challenge_payload(Some("secret-123")).to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let json = response_json(response).await?;
+    assert_eq!(json["error"], "Feishu verification token not configured");
+    Ok(())
+}
+
+#[tokio::test]
+async fn feishu_webhook_accepts_challenge_with_valid_token() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_feishu(dir.path(), Some("secret-123")).await?;
+    let app = webhook_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook/feishu")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    feishu_challenge_payload(Some("secret-123")).to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    assert_eq!(json["challenge"], "challenge-123");
+    Ok(())
+}
+
+#[tokio::test]
+async fn feishu_webhook_rejects_invalid_token() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_feishu(dir.path(), Some("secret-123")).await?;
+    let app = webhook_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook/feishu")
+                .header("content-type", "application/json")
+                .body(Body::from(feishu_event_payload(Some("wrong")).to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let json = response_json(response).await?;
+    assert_eq!(json["error"], "invalid verification token");
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -67,7 +67,7 @@ async fn make_test_state_with(
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
     let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
-        cfg.enabled
+        (cfg.enabled && crate::intake::feishu::has_verification_token(cfg))
             .then(|| Arc::new(crate::intake::feishu::FeishuIntake::new(cfg.clone())))
     });
     let thread_manager = crate::thread_manager::ThreadManager::new();
@@ -910,6 +910,31 @@ async fn intake_status_recent_dispatches_empty_initially() -> anyhow::Result<()>
     Ok(())
 }
 
+#[tokio::test]
+async fn intake_status_disables_feishu_when_verification_token_missing() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_feishu(dir.path(), None).await?;
+    let app = intake_app(state);
+
+    use http_body_util::BodyExt;
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await?.to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    let feishu = json["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"] == "feishu")
+        .expect("feishu channel present");
+    assert_eq!(feishu["enabled"], false);
+    assert_eq!(feishu["keyword"], "harness");
+    Ok(())
+}
+
 /// Build a minimal router that includes the auth middleware, mirroring how the
 /// real server wires up the dashboard and tasks endpoints.
 fn authed_app(state: Arc<AppState>) -> Router {
@@ -1030,7 +1055,7 @@ async fn feishu_webhook_returns_service_unavailable_when_token_missing() -> anyh
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let json = response_json(response).await?;
-    assert_eq!(json["error"], "Feishu verification token not configured");
+    assert_eq!(json["error"], "Feishu intake not configured");
     Ok(())
 }
 
@@ -1054,7 +1079,7 @@ async fn feishu_webhook_returns_service_unavailable_when_token_is_empty() -> any
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let json = response_json(response).await?;
-    assert_eq!(json["error"], "Feishu verification token not configured");
+    assert_eq!(json["error"], "Feishu intake not configured");
     Ok(())
 }
 

--- a/crates/harness-server/src/intake/feishu.rs
+++ b/crates/harness-server/src/intake/feishu.rs
@@ -181,22 +181,44 @@ impl IntakeSource for FeishuIntake {
 /// - For `im.message.receive_v1` events containing the trigger keyword,
 ///   creates a Harness task and replies in the originating chat.
 ///
+pub(crate) fn has_verification_token(
+    config: &harness_core::config::intake::FeishuIntakeConfig,
+) -> bool {
+    config
+        .verification_token
+        .as_deref()
+        .is_some_and(|token| !token.trim().is_empty())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum FeishuTokenVerification {
+    Valid,
+    Invalid,
+    Misconfigured,
+}
+
 /// Verify the token field in a Feishu webhook payload against the configured verification_token.
-///
-/// Returns true if no verification_token is configured (open mode) or if the token matches.
 fn verify_feishu_token(
     config: &harness_core::config::intake::FeishuIntakeConfig,
     payload: &serde_json::Value,
-) -> bool {
-    let Some(expected) = &config.verification_token else {
-        return true;
+) -> FeishuTokenVerification {
+    let Some(expected) = config.verification_token.as_deref() else {
+        return FeishuTokenVerification::Misconfigured;
     };
+    if expected.trim().is_empty() {
+        return FeishuTokenVerification::Misconfigured;
+    }
+
     // Challenge payloads carry "token" at root; event payloads carry "header.token".
     let token = payload["token"]
         .as_str()
         .or_else(|| payload["header"]["token"].as_str())
         .unwrap_or("");
-    token.as_bytes().ct_eq(expected.as_bytes()).into()
+    if bool::from(token.as_bytes().ct_eq(expected.as_bytes())) {
+        FeishuTokenVerification::Valid
+    } else {
+        FeishuTokenVerification::Invalid
+    }
 }
 
 pub async fn feishu_webhook(
@@ -211,11 +233,20 @@ pub async fn feishu_webhook(
     };
 
     // 1. Verify token before processing any payload.
-    if !verify_feishu_token(&feishu.config, &payload) {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "invalid verification token"})),
-        );
+    match verify_feishu_token(&feishu.config, &payload) {
+        FeishuTokenVerification::Valid => {}
+        FeishuTokenVerification::Invalid => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "invalid verification token"})),
+            );
+        }
+        FeishuTokenVerification::Misconfigured => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "Feishu verification token not configured"})),
+            );
+        }
     }
 
     // 2. Handle Feishu verification challenge.
@@ -354,10 +385,24 @@ mod tests {
     }
 
     #[test]
-    fn verify_token_passes_when_no_token_configured() {
+    fn verify_token_rejects_when_no_token_configured() {
         let config = make_feishu_config();
         let payload = serde_json::json!({"challenge": "test"});
-        assert!(verify_feishu_token(&config, &payload));
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Misconfigured
+        );
+    }
+
+    #[test]
+    fn verify_token_rejects_when_token_configured_as_empty_string() {
+        let mut config = make_feishu_config();
+        config.verification_token = Some(String::new());
+        let payload = serde_json::json!({"challenge": "test", "token": "secret-123"});
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Misconfigured
+        );
     }
 
     #[test]
@@ -365,7 +410,10 @@ mod tests {
         let mut config = make_feishu_config();
         config.verification_token = Some("secret-123".to_string());
         let payload = serde_json::json!({"challenge": "test", "token": "secret-123"});
-        assert!(verify_feishu_token(&config, &payload));
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Valid
+        );
     }
 
     #[test]
@@ -375,7 +423,10 @@ mod tests {
         let payload = serde_json::json!({
             "header": { "token": "secret-123", "event_type": "im.message.receive_v1" }
         });
-        assert!(verify_feishu_token(&config, &payload));
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Valid
+        );
     }
 
     #[test]
@@ -383,7 +434,10 @@ mod tests {
         let mut config = make_feishu_config();
         config.verification_token = Some("secret-123".to_string());
         let payload = serde_json::json!({"challenge": "test", "token": "wrong"});
-        assert!(!verify_feishu_token(&config, &payload));
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Invalid
+        );
     }
 
     #[test]
@@ -391,7 +445,24 @@ mod tests {
         let mut config = make_feishu_config();
         config.verification_token = Some("secret-123".to_string());
         let payload = serde_json::json!({"challenge": "test"});
-        assert!(!verify_feishu_token(&config, &payload));
+        assert_eq!(
+            verify_feishu_token(&config, &payload),
+            FeishuTokenVerification::Invalid
+        );
+    }
+
+    #[test]
+    fn has_verification_token_rejects_empty_string() {
+        let mut config = make_feishu_config();
+        config.verification_token = Some("   ".to_string());
+        assert!(!has_verification_token(&config));
+    }
+
+    #[test]
+    fn has_verification_token_accepts_non_empty_string() {
+        let mut config = make_feishu_config();
+        config.verification_token = Some("secret-123".to_string());
+        assert!(has_verification_token(&config));
     }
 
     #[test]

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -578,13 +578,19 @@ pub fn build_orchestrator(
 
     if let Some(feishu_config) = &config.feishu {
         if feishu_config.enabled {
-            let intake = feishu_intake
-                .unwrap_or_else(|| Arc::new(feishu::FeishuIntake::new(feishu_config.clone())));
-            sources.push(intake);
-            tracing::info!(
-                trigger_keyword = %feishu_config.trigger_keyword,
-                "intake: Feishu bot registered in orchestrator"
-            );
+            if !feishu::has_verification_token(feishu_config) {
+                tracing::error!(
+                    "intake: Feishu enabled but verification_token is missing; orchestrator skipped registration"
+                );
+            } else {
+                let intake = feishu_intake
+                    .unwrap_or_else(|| Arc::new(feishu::FeishuIntake::new(feishu_config.clone())));
+                sources.push(intake);
+                tracing::info!(
+                    trigger_keyword = %feishu_config.trigger_keyword,
+                    "intake: Feishu bot registered in orchestrator"
+                );
+            }
         }
     }
 
@@ -800,5 +806,21 @@ mod tests {
         assert_eq!(orchestrator.sources.len(), 1);
         assert_eq!(orchestrator.sources[0].name(), "github");
         assert_eq!(orchestrator.poll_interval, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn build_orchestrator_skips_feishu_when_verification_token_missing() {
+        let mut config = harness_core::config::intake::IntakeConfig::default();
+        config.feishu = Some(harness_core::config::intake::FeishuIntakeConfig {
+            enabled: true,
+            app_id: None,
+            app_secret: None,
+            verification_token: None,
+            trigger_keyword: "harness".to_string(),
+            default_repo: None,
+        });
+
+        let orchestrator = build_orchestrator(&config, None, None, vec![]);
+        assert!(orchestrator.sources.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- fail closed when Feishu verification_token is missing or empty
- return 503 for misconfiguration and keep 401 for invalid tokens
- skip Feishu intake registration at startup and orchestrator when token is not ready

## Test plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace
- [x] RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets