### PR TITLE
fix: preserve startup project metadata in registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -27,3 +27,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -26,36 +26,25 @@ fn startup_default_project_for_root(
     default_project_id: Option<&str>,
     project_root: &std::path::Path,
 ) -> Option<harness_core::config::ProjectEntry> {
+    let canonical_project_root = project_root.canonicalize().ok();
     default_project_id.and_then(|id| {
         parsed_projects
             .iter()
             .find(|project| project.name == id)
-            .filter(|project| project.root == project_root)
+            .filter(|project| {
+                canonical_project_root
+                    .as_ref()
+                    .and_then(|canonical_root| {
+                        project
+                            .root
+                            .canonicalize()
+                            .ok()
+                            .map(|root| root == *canonical_root)
+                    })
+                    .unwrap_or_else(|| project.root == project_root)
+            })
             .cloned()
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::startup_default_project_for_root;
-    use harness_core::config::ProjectEntry;
-    use std::path::Path;
-
-    #[test]
-    fn startup_default_project_ignores_metadata_after_project_root_override() {
-        let project = ProjectEntry {
-            name: "repo-a".to_string(),
-            root: Path::new("/repo-a").to_path_buf(),
-            default: true,
-            default_agent: Some("claude".to_string()),
-            max_concurrent: Some(3),
-        };
-
-        let startup_default =
-            startup_default_project_for_root(&[project], Some("repo-a"), Path::new("/repo-b"));
-
-        assert!(startup_default.is_none());
-    }
 }
 
 pub async fn run(
@@ -255,4 +244,50 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::startup_default_project_for_root;
+    use harness_core::config::ProjectEntry;
+    use std::path::Path;
+
+    #[test]
+    fn startup_default_project_ignores_metadata_after_project_root_override() {
+        let project = ProjectEntry {
+            name: "repo-a".to_string(),
+            root: Path::new("/repo-a").to_path_buf(),
+            default: true,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: Some(3),
+        };
+
+        let startup_default =
+            startup_default_project_for_root(&[project], Some("repo-a"), Path::new("/repo-b"));
+
+        assert!(startup_default.is_none());
+    }
+
+    #[test]
+    fn startup_default_project_matches_same_root_via_relative_path_alias() {
+        let canonical_root = std::env::current_dir()
+            .expect("cwd")
+            .canonicalize()
+            .expect("canonical root");
+        let project = ProjectEntry {
+            name: "repo-a".to_string(),
+            root: canonical_root,
+            default: true,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: Some(3),
+        };
+
+        let startup_default =
+            startup_default_project_for_root(&[project], Some("repo-a"), Path::new("."));
+
+        assert_eq!(
+            startup_default.map(|project| project.name),
+            Some("repo-a".to_string())
+        );
+    }
 }

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -133,13 +133,6 @@ pub async fn run(
         None
     };
 
-    let startup_default_project = default_project_id.as_ref().and_then(|id| {
-        parsed_projects
-            .iter()
-            .find(|project| &project.name == id)
-            .cloned()
-    });
-
     let mut serve_config = config.clone();
     // When --project entries are provided, set project_root to the default project's path
     // so existing single-project behaviour is preserved.
@@ -151,6 +144,14 @@ pub async fn run(
     if let Some(project_root) = project_root {
         serve_config.server.project_root = project_root;
     }
+
+    let startup_default_project = default_project_id.as_ref().and_then(|id| {
+        parsed_projects
+            .iter()
+            .find(|project| &project.name == id)
+            .filter(|project| project.root == serve_config.server.project_root)
+            .cloned()
+    });
 
     let thread_manager = harness_server::thread_manager::ThreadManager::new();
     let mut agent_registry =

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -49,7 +49,7 @@ pub async fn run(
     }
 
     // Collect projects from config file `[[projects]]` entries.
-    let mut parsed_projects: Vec<(String, PathBuf)> = Vec::new();
+    let mut parsed_projects: Vec<harness_core::config::ProjectEntry> = Vec::new();
     let mut config_default_name: Option<String> = None;
     for entry in &config.projects {
         if entry.name.is_empty() {
@@ -58,7 +58,10 @@ pub async fn run(
         if entry.name == "default" {
             anyhow::bail!("[[projects]] name 'default' is reserved; choose a different name");
         }
-        if parsed_projects.iter().any(|(n, _)| n == &entry.name) {
+        if parsed_projects
+            .iter()
+            .any(|project| project.name == entry.name)
+        {
             anyhow::bail!(
                 "[[projects]] name '{}' is duplicated; each project name must be unique",
                 entry.name
@@ -77,15 +80,19 @@ pub async fn run(
         if entry.default {
             config_default_name = Some(entry.name.clone());
         }
-        parsed_projects.push((entry.name.clone(), canonical));
+        let mut project = entry.clone();
+        project.root = canonical;
+        parsed_projects.push(project);
     }
 
     // Merge CLI --project flags (override config entries with same name).
     for raw in &projects {
         let (name, path) = parse_project_entry(raw)?;
-        if parsed_projects.iter().any(|(n, _)| n == &name) {
-            parsed_projects.retain(|(n, _)| n != &name);
-        }
+        let existing = parsed_projects
+            .iter()
+            .find(|project| project.name == name)
+            .cloned();
+        parsed_projects.retain(|project| project.name != name);
         let canonical = path.canonicalize().map_err(|e| {
             anyhow::anyhow!(
                 "--project {name}: path '{}' is not accessible: {e}",
@@ -95,7 +102,15 @@ pub async fn run(
         if let Err(reason) = validate_project_root(&canonical) {
             anyhow::bail!("--project {name}: {reason}");
         }
-        parsed_projects.push((name, canonical));
+        let mut project = existing.unwrap_or(harness_core::config::ProjectEntry {
+            name,
+            root: canonical.clone(),
+            default: false,
+            default_agent: None,
+            max_concurrent: None,
+        });
+        project.root = canonical;
+        parsed_projects.push(project);
     }
 
     // Determine the default project id: CLI --default-project > config `default = true` > first entry.
@@ -103,9 +118,12 @@ pub async fn run(
         let id = default_project
             .clone()
             .or(config_default_name)
-            .unwrap_or_else(|| parsed_projects[0].0.clone());
-        if !parsed_projects.iter().any(|(n, _)| n == &id) {
-            let known: Vec<&str> = parsed_projects.iter().map(|(n, _)| n.as_str()).collect();
+            .unwrap_or_else(|| parsed_projects[0].name.clone());
+        if !parsed_projects.iter().any(|project| project.name == id) {
+            let known: Vec<&str> = parsed_projects
+                .iter()
+                .map(|project| project.name.as_str())
+                .collect();
             anyhow::bail!(
                 "default project {id:?} does not match any project name; known names: {known:?}"
             );
@@ -115,12 +133,19 @@ pub async fn run(
         None
     };
 
+    let startup_default_project = default_project_id.as_ref().and_then(|id| {
+        parsed_projects
+            .iter()
+            .find(|project| &project.name == id)
+            .cloned()
+    });
+
     let mut serve_config = config.clone();
     // When --project entries are provided, set project_root to the default project's path
     // so existing single-project behaviour is preserved.
     if let Some(ref id) = default_project_id {
-        if let Some((_, path)) = parsed_projects.iter().find(|(n, _)| n == id) {
-            serve_config.server.project_root = path.clone();
+        if let Some(project) = parsed_projects.iter().find(|project| &project.name == id) {
+            serve_config.server.project_root = project.root.clone();
         }
     }
     if let Some(project_root) = project_root {
@@ -170,6 +195,7 @@ pub async fn run(
         agent_registry,
     );
     server.startup_projects = parsed_projects;
+    server.startup_default_project = startup_default_project;
 
     let effective_transport = match transport.as_deref() {
         Some("stdio") => harness_core::config::server::Transport::Stdio,

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -21,6 +21,43 @@ fn parse_project_entry(s: &str) -> Result<(String, PathBuf)> {
     Ok((name.to_string(), PathBuf::from(path)))
 }
 
+fn startup_default_project_for_root(
+    parsed_projects: &[harness_core::config::ProjectEntry],
+    default_project_id: Option<&str>,
+    project_root: &std::path::Path,
+) -> Option<harness_core::config::ProjectEntry> {
+    default_project_id.and_then(|id| {
+        parsed_projects
+            .iter()
+            .find(|project| project.name == id)
+            .filter(|project| project.root == project_root)
+            .cloned()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::startup_default_project_for_root;
+    use harness_core::config::ProjectEntry;
+    use std::path::Path;
+
+    #[test]
+    fn startup_default_project_ignores_metadata_after_project_root_override() {
+        let project = ProjectEntry {
+            name: "repo-a".to_string(),
+            root: Path::new("/repo-a").to_path_buf(),
+            default: true,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: Some(3),
+        };
+
+        let startup_default =
+            startup_default_project_for_root(&[project], Some("repo-a"), Path::new("/repo-b"));
+
+        assert!(startup_default.is_none());
+    }
+}
+
 pub async fn run(
     config: HarnessConfig,
     transport: Option<String>,
@@ -145,13 +182,11 @@ pub async fn run(
         serve_config.server.project_root = project_root;
     }
 
-    let startup_default_project = default_project_id.as_ref().and_then(|id| {
-        parsed_projects
-            .iter()
-            .find(|project| &project.name == id)
-            .filter(|project| project.root == serve_config.server.project_root)
-            .cloned()
-    });
+    let startup_default_project = startup_default_project_for_root(
+        &parsed_projects,
+        default_project_id.as_deref(),
+        &serve_config.server.project_root,
+    );
 
     let thread_manager = harness_server::thread_manager::ThreadManager::new();
     let mut agent_registry =

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -312,18 +312,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     }
     // Load guards from each named startup project so non-default projects are
     // not silently unprotected.
-    for (name, path) in &server.startup_projects {
-        match rule_engine.auto_register_project_guards(&path.join(".harness/guards")) {
+    for project in &server.startup_projects {
+        match rule_engine.auto_register_project_guards(&project.root.join(".harness/guards")) {
             Ok(registered) => {
                 tracing::debug!(
-                    project = %name,
+                    project = %project.name,
                     registered_guard_count = registered,
                     total_guard_count = rule_engine.guards().len(),
                     "rules: startup project guard auto-registration completed"
                 );
             }
             Err(e) => {
-                tracing::warn!(project = %name, "failed to auto-register startup project guards: {e}");
+                tracing::warn!(project = %project.name, "failed to auto-register startup project guards: {e}");
             }
         }
     }
@@ -375,29 +375,51 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     )
     .await?;
     // Auto-register the default project from --project-root on startup.
+    let default_project_metadata = server.startup_default_project.as_ref().or_else(|| {
+        server
+            .startup_projects
+            .iter()
+            .find(|project| project.default)
+            .or_else(|| {
+                project_root
+                    .canonicalize()
+                    .ok()
+                    .as_ref()
+                    .and_then(|canonical_root| {
+                        server.startup_projects.iter().find(|project| {
+                            project
+                                .root
+                                .canonicalize()
+                                .map(|root| root == *canonical_root)
+                                .unwrap_or(false)
+                        })
+                    })
+            })
+    });
     let default_project = crate::project_registry::Project {
         id: "default".to_string(),
         root: project_root.clone(),
-        max_concurrent: None,
-        default_agent: None,
+        max_concurrent: default_project_metadata.and_then(|project| project.max_concurrent),
+        default_agent: default_project_metadata.and_then(|project| project.default_agent.clone()),
         active: true,
         created_at: chrono::Utc::now().to_rfc3339(),
     };
+
     if let Err(e) = project_registry.register(default_project).await {
         tracing::warn!("failed to auto-register default project: {e}");
     }
-    // Register any extra named projects supplied via --project CLI flags.
-    for (name, path) in &server.startup_projects {
+    // Register any extra named projects supplied via config or --project CLI flags.
+    for project in &server.startup_projects {
         let proj = crate::project_registry::Project {
-            id: name.clone(),
-            root: path.clone(),
-            max_concurrent: None,
-            default_agent: None,
+            id: project.name.clone(),
+            root: project.root.clone(),
+            max_concurrent: project.max_concurrent,
+            default_agent: project.default_agent.clone(),
             active: true,
             created_at: chrono::Utc::now().to_rfc3339(),
         };
         if let Err(e) = project_registry.register(proj).await {
-            tracing::warn!(project = %name, "failed to register startup project: {e}");
+            tracing::warn!(project = %project.name, "failed to register startup project: {e}");
         }
     }
     let plans_md_dir = dir.join("plans");
@@ -2173,6 +2195,119 @@ mod startup_tests {
                 .any(|guard| guard.id.as_str() == harness_rules::engine::BUILTIN_BASELINE_GUARD_ID),
             "expected build_app_state to auto-register builtin guard"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_app_state_registers_startup_project_metadata() -> anyhow::Result<()> {
+        let _lock = HOME_LOCK.lock().await;
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = project_root.clone();
+        config.server.data_dir = sandbox.path().join("data");
+
+        let mut server =
+            HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("test"));
+        server.startup_projects = vec![harness_core::config::ProjectEntry {
+            name: "named".to_string(),
+            root: project_root.clone(),
+            default: false,
+            default_agent: Some("codex".to_string()),
+            max_concurrent: Some(7),
+        }];
+
+        let state = build_app_state(Arc::new(server)).await?;
+        let registry = state
+            .core
+            .project_registry
+            .as_ref()
+            .expect("project registry should be initialized");
+        let project = registry
+            .get("named")
+            .await?
+            .expect("startup project should be registered");
+
+        assert_eq!(project.default_agent.as_deref(), Some("codex"));
+        assert_eq!(project.max_concurrent, Some(7));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_app_state_registers_default_project_metadata_from_startup_entry(
+    ) -> anyhow::Result<()> {
+        let _lock = HOME_LOCK.lock().await;
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = project_root.clone();
+        config.server.data_dir = sandbox.path().join("data");
+
+        let mut server =
+            HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("test"));
+        server.startup_projects = vec![harness_core::config::ProjectEntry {
+            name: "configured-default".to_string(),
+            root: project_root.clone(),
+            default: true,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: Some(3),
+        }];
+
+        let state = build_app_state(Arc::new(server)).await?;
+        let registry = state
+            .core
+            .project_registry
+            .as_ref()
+            .expect("project registry should be initialized");
+        let project = registry
+            .get("default")
+            .await?
+            .expect("default project should be registered");
+
+        assert_eq!(project.root.canonicalize()?, project_root.canonicalize()?);
+        assert_eq!(project.default_agent.as_deref(), Some("claude"));
+        assert_eq!(project.max_concurrent, Some(3));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_app_state_preserves_partial_startup_project_metadata() -> anyhow::Result<()> {
+        let _lock = HOME_LOCK.lock().await;
+        let sandbox = tempfile::tempdir()?;
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = project_root.clone();
+        config.server.data_dir = sandbox.path().join("data");
+
+        let mut server =
+            HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("test"));
+        server.startup_projects = vec![harness_core::config::ProjectEntry {
+            name: "partial".to_string(),
+            root: project_root,
+            default: false,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: None,
+        }];
+
+        let state = build_app_state(Arc::new(server)).await?;
+        let registry = state
+            .core
+            .project_registry
+            .as_ref()
+            .expect("project registry should be initialized");
+        let project = registry
+            .get("partial")
+            .await?
+            .expect("startup project should be registered");
+
+        assert_eq!(project.default_agent.as_deref(), Some("claude"));
+        assert_eq!(project.max_concurrent, None);
         Ok(())
     }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -375,27 +375,35 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     )
     .await?;
     // Auto-register the default project from --project-root on startup.
-    let default_project_metadata = server.startup_default_project.as_ref().or_else(|| {
-        server
-            .startup_projects
-            .iter()
-            .find(|project| project.default)
-            .or_else(|| {
-                project_root
+    let canonical_project_root = project_root.canonicalize().ok();
+    let project_matches_root = |project: &harness_core::config::ProjectEntry| {
+        canonical_project_root
+            .as_ref()
+            .and_then(|canonical_root| {
+                project
+                    .root
                     .canonicalize()
                     .ok()
-                    .as_ref()
-                    .and_then(|canonical_root| {
-                        server.startup_projects.iter().find(|project| {
-                            project
-                                .root
-                                .canonicalize()
-                                .map(|root| root == *canonical_root)
-                                .unwrap_or(false)
-                        })
-                    })
+                    .map(|root| root == *canonical_root)
             })
-    });
+            .unwrap_or_else(|| project.root == project_root)
+    };
+    let default_project_metadata = server
+        .startup_default_project
+        .as_ref()
+        .filter(|project| project_matches_root(project))
+        .or_else(|| {
+            server
+                .startup_projects
+                .iter()
+                .find(|project| project.default && project_matches_root(project))
+                .or_else(|| {
+                    server
+                        .startup_projects
+                        .iter()
+                        .find(|project| project_matches_root(project))
+                })
+        });
     let default_project = crate::project_registry::Project {
         id: "default".to_string(),
         root: project_root.clone(),
@@ -2307,6 +2315,49 @@ mod startup_tests {
             .expect("startup project should be registered");
 
         assert_eq!(project.default_agent.as_deref(), Some("claude"));
+        assert_eq!(project.max_concurrent, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_app_state_ignores_stale_default_project_metadata_for_different_root(
+    ) -> anyhow::Result<()> {
+        let _lock = HOME_LOCK.lock().await;
+        let sandbox = tempfile::tempdir()?;
+        let startup_root = sandbox.path().join("startup-project");
+        let override_root = sandbox.path().join("override-project");
+        std::fs::create_dir_all(&startup_root)?;
+        std::fs::create_dir_all(&override_root)?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = override_root.clone();
+        config.server.data_dir = sandbox.path().join("data");
+
+        let mut server =
+            HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("test"));
+        let startup_default_project = harness_core::config::ProjectEntry {
+            name: "configured-default".to_string(),
+            root: startup_root.clone(),
+            default: true,
+            default_agent: Some("claude".to_string()),
+            max_concurrent: Some(3),
+        };
+        server.startup_projects = vec![startup_default_project.clone()];
+        server.startup_default_project = Some(startup_default_project);
+
+        let state = build_app_state(Arc::new(server)).await?;
+        let registry = state
+            .core
+            .project_registry
+            .as_ref()
+            .expect("project registry should be initialized");
+        let project = registry
+            .get("default")
+            .await?
+            .expect("default project should be registered");
+
+        assert_eq!(project.root.canonicalize()?, override_root.canonicalize()?);
+        assert_eq!(project.default_agent, None);
         assert_eq!(project.max_concurrent, None);
         Ok(())
     }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -301,7 +301,7 @@ async fn collect_projects(state: &Arc<AppState>) -> Vec<ProjectInfo> {
         .server
         .startup_projects
         .iter()
-        .map(|(n, p)| (n.as_str(), p))
+        .map(|project| (project.name.as_str(), &project.root))
         .collect();
 
     // Pre-fetch live registry roots so that a runtime `POST /projects` upsert
@@ -503,30 +503,33 @@ async fn collect_projects(state: &Arc<AppState>) -> Vec<ProjectInfo> {
 
     // P1-1: Also include startup_projects entries not already covered by config
     // or registry, in case the registry registration failed at startup.
-    for (name, path) in state.core.server.startup_projects.iter() {
-        if seen_names.contains(name.as_str()) {
+    for project in state.core.server.startup_projects.iter() {
+        if seen_names.contains(project.name.as_str()) {
             continue;
         }
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
-        if seen_roots.contains(path) || seen_roots.contains(&canonical) {
+        let canonical = project
+            .root
+            .canonicalize()
+            .unwrap_or_else(|_| project.root.clone());
+        if seen_roots.contains(&project.root) || seen_roots.contains(&canonical) {
             continue;
         }
-        if !path.exists() {
+        if !project.root.exists() {
             tracing::warn!(
-                project = %name,
-                root = %path.display(),
+                project = %project.name,
+                root = %project.root.display(),
                 "scheduler: startup project root does not exist on disk, skipping"
             );
             continue;
         }
-        let (review_type, opted_out) = match load_project_config(path) {
+        let (review_type, opted_out) = match load_project_config(&project.root) {
             Ok(cfg) => {
                 let opted_out = cfg.review.as_ref().and_then(|r| r.enabled) == Some(false);
                 (cfg.review_type, opted_out)
             }
             Err(e) => {
                 tracing::warn!(
-                    project = %name,
+                    project = %project.name,
                     error = %e,
                     "scheduler: failed to load startup project config, skipping"
                 );
@@ -535,17 +538,17 @@ async fn collect_projects(state: &Arc<AppState>) -> Vec<ProjectInfo> {
         };
         if opted_out {
             tracing::debug!(
-                project = %name,
+                project = %project.name,
                 "scheduler: startup project opted out of periodic review, skipping"
             );
             continue;
         }
-        seen_names.insert(name.clone());
-        seen_roots.insert(path.clone());
+        seen_names.insert(project.name.clone());
+        seen_roots.insert(project.root.clone());
         seen_roots.insert(canonical);
         result.push(ProjectInfo {
-            name: name.clone(),
-            root: path.clone(),
+            name: project.name.clone(),
+            root: project.root.clone(),
             review_type,
         });
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1,6 +1,6 @@
 use crate::thread_manager::ThreadManager;
 use harness_agents::registry::{AdapterRegistry, AgentRegistry};
-use harness_core::config::HarnessConfig;
+use harness_core::config::{HarnessConfig, ProjectEntry};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -9,8 +9,10 @@ pub struct HarnessServer {
     pub thread_manager: ThreadManager,
     pub agent_registry: Arc<AgentRegistry>,
     pub adapter_registry: Arc<AdapterRegistry>,
-    /// Extra projects to register in the project registry at startup (from --project CLI flags).
-    pub startup_projects: Vec<(String, std::path::PathBuf)>,
+    /// Projects to register in the project registry at startup.
+    pub startup_projects: Vec<ProjectEntry>,
+    /// The startup project selected as the effective default project root.
+    pub startup_default_project: Option<ProjectEntry>,
 }
 
 impl HarnessServer {
@@ -25,6 +27,7 @@ impl HarnessServer {
             agent_registry: Arc::new(agent_registry),
             adapter_registry: Arc::new(AdapterRegistry::new("")),
             startup_projects: Vec::new(),
+            startup_default_project: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve full startup project metadata from config-backed `[[projects]]` entries
- propagate `default_agent` and `max_concurrent` into both named registry entries and the synthesized `default` project
- add startup registration tests covering named, default, and partial metadata propagation

## Test plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace