### PR TITLE
feat: unify canonical project identity

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,7 +1,7 @@
 use crate::types::Grade;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::dirs::dirs_data_dir;
 
@@ -112,6 +112,14 @@ fn default_loop_jaccard_threshold() -> f64 {
 
 fn default_memory_poll_interval_secs() -> u64 {
     5
+}
+
+impl ConcurrencyConfig {
+    /// Add or update a per-project concurrency limit using the canonical project root as the key.
+    pub fn set_project_limit(&mut self, project_root: &Path, limit: usize) {
+        self.per_project
+            .insert(project_root.to_string_lossy().into_owned(), limit);
+    }
 }
 
 impl Default for ConcurrencyConfig {
@@ -453,5 +461,22 @@ mod tests {
         let cfg: ConcurrencyConfig = toml::from_str("").expect("toml parse failed");
         assert!(cfg.memory_pressure_threshold_mb.is_none());
         assert_eq!(cfg.memory_poll_interval_secs, 5);
+    }
+
+    #[test]
+    fn set_project_limit_uses_canonical_root_string_as_key() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+
+        let mut cfg = ConcurrencyConfig::default();
+        cfg.set_project_limit(&root.canonicalize()?, 2);
+
+        assert_eq!(
+            cfg.per_project
+                .get(&root.canonicalize()?.to_string_lossy().into_owned()),
+            Some(&2)
+        );
+        Ok(())
     }
 }

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod error;
 pub mod interceptor;
 pub mod lang_detect;
+pub mod project_identity;
 pub mod prompts;
 pub mod shell_safety;
 pub mod tool_isolation;

--- a/crates/harness-core/src/project_identity.rs
+++ b/crates/harness-core/src/project_identity.rs
@@ -1,0 +1,80 @@
+use std::path::{Path, PathBuf};
+
+/// Canonical project identity used for execution, queueing, and config lookup.
+///
+/// `canonical_root` is the single internal identity key. `alias_id` preserves a
+/// human-facing registry/project ID when the caller submitted one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectIdentity {
+    canonical_root: PathBuf,
+    alias_id: Option<String>,
+}
+
+impl ProjectIdentity {
+    pub fn new(canonical_root: PathBuf, alias_id: Option<String>) -> Self {
+        Self {
+            canonical_root,
+            alias_id,
+        }
+    }
+
+    pub fn from_root(root: PathBuf) -> Self {
+        Self::new(canonicalize_root(root), None)
+    }
+
+    pub fn from_registry(alias_id: String, root: PathBuf) -> Self {
+        Self::new(canonicalize_root(root), Some(alias_id))
+    }
+
+    pub fn canonical_root(&self) -> &Path {
+        &self.canonical_root
+    }
+
+    pub fn into_canonical_root(self) -> PathBuf {
+        self.canonical_root
+    }
+
+    pub fn alias_id(&self) -> Option<&str> {
+        self.alias_id.as_deref()
+    }
+
+    pub fn queue_key(&self) -> String {
+        self.canonical_root.display().to_string()
+    }
+}
+
+pub fn canonicalize_root(root: PathBuf) -> PathBuf {
+    root.canonicalize().unwrap_or(root)
+}
+
+pub fn canonical_project_key(project: impl AsRef<Path>) -> String {
+    canonicalize_root(project.as_ref().to_path_buf())
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_project_key_preserves_nonexistent_path() {
+        let path = PathBuf::from("/path/that/does/not/exist");
+        assert_eq!(canonical_project_key(&path), path.display().to_string());
+    }
+
+    #[test]
+    fn project_identity_from_registry_preserves_alias() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+
+        let identity = ProjectIdentity::from_registry("repo-id".to_string(), root.canonicalize()?);
+        assert_eq!(identity.alias_id(), Some("repo-id"));
+        assert_eq!(
+            identity.queue_key(),
+            root.canonicalize()?.display().to_string()
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -16,6 +16,7 @@ use axum::{
 use dashmap::DashMap;
 use harness_protocol::{methods::RpcRequest, notifications::RpcNotification};
 use serde_json::json;
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -24,6 +25,32 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 pub(crate) mod auth;
 pub(crate) mod rate_limit;
 pub(crate) mod task_routes;
+
+fn validated_project_limit(limit: Option<u32>, project_label: &str) -> Option<usize> {
+    match limit {
+        Some(0) => {
+            tracing::warn!(project = %project_label, "ignoring invalid max_concurrent=0");
+            None
+        }
+        Some(limit) => Some(limit as usize),
+        None => None,
+    }
+}
+
+fn apply_registry_project_limits(
+    queue_config: &mut harness_core::config::misc::ConcurrencyConfig,
+    projects: Vec<crate::project_registry::Project>,
+) {
+    let mut seen_roots = HashSet::new();
+    for project in projects {
+        if !seen_roots.insert(project.root.clone()) {
+            continue;
+        }
+        if let Some(limit) = validated_project_limit(project.max_concurrent, &project.id) {
+            queue_config.set_project_limit(&project.root, limit);
+        }
+    }
+}
 
 /// Core services: thread/task management and persistence.
 pub struct CoreServices {
@@ -375,20 +402,27 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     )
     .await?;
     let mut queue_config = server.config.concurrency.clone();
-    // Auto-register the default project from --project-root on startup.
-    let default_project = crate::project_registry::Project {
-        id: "default".to_string(),
-        root: project_root.clone(),
-        max_concurrent: None,
-        default_agent: None,
-        active: true,
-        created_at: chrono::Utc::now().to_rfc3339(),
-    };
-    if let Err(e) = project_registry.register(default_project).await {
-        tracing::warn!("failed to auto-register default project: {e}");
+    // Auto-register the default project from --project-root on startup without
+    // overwriting runtime edits that already exist in the persistent registry.
+    if project_registry.get("default").await?.is_none() {
+        let default_project = crate::project_registry::Project {
+            id: "default".to_string(),
+            root: project_root.clone(),
+            max_concurrent: None,
+            default_agent: None,
+            active: true,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        if let Err(e) = project_registry.register(default_project).await {
+            tracing::warn!("failed to auto-register default project: {e}");
+        }
     }
-    // Register any extra named projects supplied via --project CLI flags.
+    // Register any extra named projects supplied via --project CLI flags without
+    // clobbering operator overrides already persisted in the registry.
     for (name, path) in &server.startup_projects {
+        if project_registry.get(name).await?.is_some() {
+            continue;
+        }
         let configured_limit = server
             .config
             .projects
@@ -398,7 +432,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         let proj = crate::project_registry::Project {
             id: name.clone(),
             root: path.clone(),
-            max_concurrent: configured_limit,
+            max_concurrent: configured_limit.filter(|limit| *limit > 0),
             default_agent: None,
             active: true,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -406,15 +440,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         if let Err(e) = project_registry.register(proj).await {
             tracing::warn!(project = %name, "failed to register startup project: {e}");
         }
-        if let Some(limit) = configured_limit.map(|limit| limit as usize) {
-            queue_config.set_project_limit(path, limit);
-        }
     }
-    for project in project_registry.list().await? {
-        if let Some(limit) = project.max_concurrent.map(|limit| limit as usize) {
-            queue_config.set_project_limit(&project.root, limit);
-        }
-    }
+    apply_registry_project_limits(&mut queue_config, project_registry.list().await?);
     let plans_md_dir = dir.join("plans");
     match plan_db.migrate_from_markdown_dir(&plans_md_dir).await {
         Ok(0) => {}

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -389,10 +389,16 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     }
     // Register any extra named projects supplied via --project CLI flags.
     for (name, path) in &server.startup_projects {
+        let configured_limit = server
+            .config
+            .projects
+            .iter()
+            .find(|entry| entry.name == *name)
+            .and_then(|entry| entry.max_concurrent);
         let proj = crate::project_registry::Project {
             id: name.clone(),
             root: path.clone(),
-            max_concurrent: None,
+            max_concurrent: configured_limit,
             default_agent: None,
             active: true,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -400,15 +406,13 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         if let Err(e) = project_registry.register(proj).await {
             tracing::warn!(project = %name, "failed to register startup project: {e}");
         }
-        if let Some(limit) = server
-            .config
-            .projects
-            .iter()
-            .find(|entry| entry.name == *name)
-            .and_then(|entry| entry.max_concurrent)
-            .map(|limit| limit as usize)
-        {
+        if let Some(limit) = configured_limit.map(|limit| limit as usize) {
             queue_config.set_project_limit(path, limit);
+        }
+    }
+    for project in project_registry.list().await? {
+        if let Some(limit) = project.max_concurrent.map(|limit| limit as usize) {
+            queue_config.set_project_limit(&project.root, limit);
         }
     }
     let plans_md_dir = dir.join("plans");

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -374,6 +374,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         &harness_core::config::dirs::default_db_path(&dir, "projects"),
     )
     .await?;
+    let mut queue_config = server.config.concurrency.clone();
     // Auto-register the default project from --project-root on startup.
     let default_project = crate::project_registry::Project {
         id: "default".to_string(),
@@ -398,6 +399,16 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         };
         if let Err(e) = project_registry.register(proj).await {
             tracing::warn!(project = %name, "failed to register startup project: {e}");
+        }
+        if let Some(limit) = server
+            .config
+            .projects
+            .iter()
+            .find(|entry| entry.name == *name)
+            .and_then(|entry| entry.max_concurrent)
+            .map(|limit| limit as usize)
+        {
+            queue_config.set_project_limit(path, limit);
         }
     }
     let plans_md_dir = dir.join("plans");
@@ -484,18 +495,15 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         }
     }
 
-    let memory_pressure =
-        server
-            .config
-            .concurrency
-            .memory_pressure_threshold_mb
-            .map(|threshold_mb| {
-                let poll_secs = server.config.concurrency.memory_poll_interval_secs;
-                tracing::info!(threshold_mb, poll_secs, "memory pressure monitor enabled");
-                crate::memory_monitor::start(threshold_mb, poll_secs)
-            });
+    let memory_pressure = queue_config
+        .memory_pressure_threshold_mb
+        .map(|threshold_mb| {
+            let poll_secs = queue_config.memory_poll_interval_secs;
+            tracing::info!(threshold_mb, poll_secs, "memory pressure monitor enabled");
+            crate::memory_monitor::start(threshold_mb, poll_secs)
+        });
     let task_queue = Arc::new(crate::task_queue::TaskQueue::new_with_pressure(
-        &server.config.concurrency,
+        &queue_config,
         memory_pressure,
     ));
     tracing::debug!(

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -208,6 +208,97 @@ async fn persist_runtime_state_is_serialized() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn build_app_state_applies_startup_project_concurrency_limits_to_canonical_roots(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-startup-root-")?;
+    let startup_project = crate::test_helpers::tempdir_in_home("http-startup-extra-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-startup-data-")?;
+
+    let startup_alias = startup_project.path().join("nested").join("..");
+    std::fs::create_dir_all(startup_project.path().join("nested"))?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+    config.projects.push(harness_core::config::ProjectEntry {
+        name: "demo".to_string(),
+        root: startup_alias,
+        default: false,
+        default_agent: None,
+        max_concurrent: Some(1),
+    });
+
+    let mut agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    agent_registry.register("test", CapturingAgent::new());
+
+    let mut server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        agent_registry,
+    );
+    server.startup_projects = vec![("demo".to_string(), startup_project.path().canonicalize()?)];
+
+    let state = build_app_state(Arc::new(server)).await?;
+    let canonical = startup_project.path().canonicalize()?;
+    let project_id = canonical.to_string_lossy().into_owned();
+    let permit = state.concurrency.task_queue.acquire(&project_id, 0).await?;
+
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(50),
+        state.concurrency.task_queue.acquire(&project_id, 0),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "startup project limit should use the canonical root as the queue key"
+    );
+
+    drop(permit);
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_app_state_keeps_registry_alias_but_executes_batching_by_canonical_root(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-default-root-")?;
+    let startup_project = crate::test_helpers::tempdir_in_home("http-default-extra-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-default-data-")?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+
+    let mut agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    agent_registry.register("test", CapturingAgent::new());
+
+    let mut server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        agent_registry,
+    );
+    server.startup_projects = vec![("demo".to_string(), startup_project.path().canonicalize()?)];
+
+    let state = build_app_state(Arc::new(server)).await?;
+    let project = state
+        .core
+        .project_registry
+        .as_ref()
+        .expect("registry should exist")
+        .get("demo")
+        .await?
+        .expect("startup project should stay addressable by alias");
+    assert_eq!(project.id, "demo");
+    assert_eq!(project.root, startup_project.path().canonicalize()?);
+    Ok(())
+}
+
 async fn make_test_state_with_agent(
     dir: &std::path::Path,
     webhook_secret: Option<&str>,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -299,6 +299,80 @@ async fn build_app_state_keeps_registry_alias_but_executes_batching_by_canonical
     Ok(())
 }
 
+#[tokio::test]
+async fn build_app_state_restores_registry_project_concurrency_limits_after_restart(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-restart-root-")?;
+    let api_project = crate::test_helpers::tempdir_in_home("http-restart-api-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-restart-data-")?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+
+    let mut first_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    first_agent_registry.register("test", CapturingAgent::new());
+
+    let server = crate::server::HarnessServer::new(
+        config.clone(),
+        crate::thread_manager::ThreadManager::new(),
+        first_agent_registry,
+    );
+    let first_state = build_app_state(Arc::new(server)).await?;
+
+    let canonical_project_root = api_project.path().canonicalize()?;
+    first_state
+        .core
+        .project_registry
+        .as_ref()
+        .expect("registry should exist")
+        .register(crate::project_registry::Project {
+            id: "api-project".to_string(),
+            root: canonical_project_root.clone(),
+            max_concurrent: Some(1),
+            default_agent: None,
+            active: true,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+        .await?;
+
+    drop(first_state);
+
+    let mut restarted_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    restarted_agent_registry.register("test", CapturingAgent::new());
+    let restarted_server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        restarted_agent_registry,
+    );
+    let restarted_state = build_app_state(Arc::new(restarted_server)).await?;
+    let project_id = canonical_project_root.to_string_lossy().into_owned();
+    let permit = restarted_state
+        .concurrency
+        .task_queue
+        .acquire(&project_id, 0)
+        .await?;
+
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(50),
+        restarted_state
+            .concurrency
+            .task_queue
+            .acquire(&project_id, 0),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "registry-backed max_concurrent should survive restart and still cap canonical queue key"
+    );
+
+    drop(permit);
+    Ok(())
+}
+
 async fn make_test_state_with_agent(
     dir: &std::path::Path,
     webhook_secret: Option<&str>,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -373,6 +373,212 @@ async fn build_app_state_restores_registry_project_concurrency_limits_after_rest
     Ok(())
 }
 
+#[tokio::test]
+async fn build_app_state_preserves_runtime_override_for_startup_project_after_restart(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-startup-override-root-")?;
+    let startup_project = crate::test_helpers::tempdir_in_home("http-startup-override-project-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-startup-override-data-")?;
+
+    let canonical_project_root = startup_project.path().canonicalize()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+    config.projects.push(harness_core::config::ProjectEntry {
+        name: "demo".to_string(),
+        root: canonical_project_root.clone(),
+        default: false,
+        default_agent: None,
+        max_concurrent: Some(3),
+    });
+
+    let mut first_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    first_agent_registry.register("test", CapturingAgent::new());
+    let mut first_server = crate::server::HarnessServer::new(
+        config.clone(),
+        crate::thread_manager::ThreadManager::new(),
+        first_agent_registry,
+    );
+    first_server.startup_projects = vec![("demo".to_string(), canonical_project_root.clone())];
+    let first_state = build_app_state(Arc::new(first_server)).await?;
+
+    first_state
+        .core
+        .project_registry
+        .as_ref()
+        .expect("registry should exist")
+        .register(crate::project_registry::Project {
+            id: "demo".to_string(),
+            root: canonical_project_root.clone(),
+            max_concurrent: Some(1),
+            default_agent: None,
+            active: true,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+        .await?;
+
+    drop(first_state);
+
+    let mut restarted_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    restarted_agent_registry.register("test", CapturingAgent::new());
+    let mut restarted_server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        restarted_agent_registry,
+    );
+    restarted_server.startup_projects = vec![("demo".to_string(), canonical_project_root.clone())];
+    let restarted_state = build_app_state(Arc::new(restarted_server)).await?;
+
+    let project_id = canonical_project_root.to_string_lossy().into_owned();
+    let permit = restarted_state
+        .concurrency
+        .task_queue
+        .acquire(&project_id, 0)
+        .await?;
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(50),
+        restarted_state
+            .concurrency
+            .task_queue
+            .acquire(&project_id, 0),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "runtime override for startup project should survive restart instead of resetting to config"
+    );
+    drop(permit);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_app_state_prefers_latest_limit_when_multiple_registry_ids_share_canonical_root(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-alias-root-")?;
+    let shared_project = crate::test_helpers::tempdir_in_home("http-alias-project-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-alias-data-")?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+
+    let canonical_project_root = shared_project.path().canonicalize()?;
+    let mut first_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    first_agent_registry.register("test", CapturingAgent::new());
+    let first_server = crate::server::HarnessServer::new(
+        config.clone(),
+        crate::thread_manager::ThreadManager::new(),
+        first_agent_registry,
+    );
+    let first_state = build_app_state(Arc::new(first_server)).await?;
+    let registry = first_state
+        .core
+        .project_registry
+        .as_ref()
+        .expect("registry should exist");
+
+    registry
+        .register(crate::project_registry::Project {
+            id: "newer-alias".to_string(),
+            root: canonical_project_root.clone(),
+            max_concurrent: Some(1),
+            default_agent: None,
+            active: true,
+            created_at: "2026-04-13T12:00:00Z".to_string(),
+        })
+        .await?;
+    registry
+        .register(crate::project_registry::Project {
+            id: "older-alias".to_string(),
+            root: canonical_project_root.clone(),
+            max_concurrent: Some(2),
+            default_agent: None,
+            active: true,
+            created_at: "2026-04-13T11:00:00Z".to_string(),
+        })
+        .await?;
+
+    drop(first_state);
+
+    let mut restarted_agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    restarted_agent_registry.register("test", CapturingAgent::new());
+    let restarted_server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        restarted_agent_registry,
+    );
+    let restarted_state = build_app_state(Arc::new(restarted_server)).await?;
+
+    let project_id = canonical_project_root.to_string_lossy().into_owned();
+    let permit_a = restarted_state
+        .concurrency
+        .task_queue
+        .acquire(&project_id, 0)
+        .await?;
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(50),
+        restarted_state
+            .concurrency
+            .task_queue
+            .acquire(&project_id, 0),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "newest alias limit should win for a shared canonical root after restart"
+    );
+    drop(permit_a);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_app_state_ignores_zero_max_concurrent_for_startup_project_limits(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let home = tempfile::tempdir()?;
+    let _home_guard = unsafe { crate::test_helpers::HomeGuard::set(home.path()) };
+    let project_root = crate::test_helpers::tempdir_in_home("http-zero-root-")?;
+    let startup_project = crate::test_helpers::tempdir_in_home("http-zero-project-")?;
+    let data_dir = crate::test_helpers::tempdir_in_home("http-zero-data-")?;
+
+    let canonical_project_root = startup_project.path().canonicalize()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+    config.projects.push(harness_core::config::ProjectEntry {
+        name: "demo".to_string(),
+        root: canonical_project_root.clone(),
+        default: false,
+        default_agent: None,
+        max_concurrent: Some(0),
+    });
+
+    let mut agent_registry = harness_agents::registry::AgentRegistry::new("test");
+    agent_registry.register("test", CapturingAgent::new());
+    let mut server = crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        agent_registry,
+    );
+    server.startup_projects = vec![("demo".to_string(), canonical_project_root.clone())];
+    let state = build_app_state(Arc::new(server)).await?;
+
+    let project_id = canonical_project_root.to_string_lossy().into_owned();
+    let permit_a = state.concurrency.task_queue.acquire(&project_id, 0).await?;
+    let permit_b = state.concurrency.task_queue.acquire(&project_id, 0).await?;
+    drop((permit_a, permit_b));
+
+    Ok(())
+}
+
 async fn make_test_state_with_agent(
     dir: &std::path::Path,
     webhook_secret: Option<&str>,

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,4 +1,7 @@
-use harness_core::db::{Db, DbEntity};
+use harness_core::{
+    db::{Db, DbEntity},
+    project_identity::ProjectIdentity,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -74,6 +77,14 @@ impl ProjectRegistry {
     /// Resolve a project ID to its root path. Returns `None` if not found.
     pub async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
         Ok(self.get(id).await?.map(|p| p.root))
+    }
+
+    /// Resolve a project ID to its canonical execution identity.
+    pub async fn resolve_identity(&self, id: &str) -> anyhow::Result<Option<ProjectIdentity>> {
+        Ok(self
+            .get(id)
+            .await?
+            .map(|project| ProjectIdentity::from_registry(project.id, project.root)))
     }
 }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use harness_agents::registry::AgentRegistry;
-use harness_core::{config::HarnessConfig, interceptor::TurnInterceptor};
+use harness_core::{
+    config::HarnessConfig, interceptor::TurnInterceptor, project_identity::ProjectIdentity,
+};
 use harness_skills::store::SkillStore;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -109,26 +111,52 @@ impl DefaultExecutionService {
     /// - Existing directory → pass through unchanged.
     /// - Non-directory string → treated as a project ID and looked up in the
     ///   registry. Returns `BadRequest` when the ID is not found.
-    async fn resolve_project(
+    async fn resolve_project_identity(
         &self,
         project: Option<PathBuf>,
-    ) -> Result<Option<PathBuf>, EnqueueTaskError> {
+    ) -> Result<Option<ProjectIdentity>, EnqueueTaskError> {
         match (self.project_registry.as_ref(), project) {
             (Some(registry), Some(project_path)) => {
                 if project_path.is_dir() {
-                    return Ok(Some(project_path));
+                    return Ok(Some(ProjectIdentity::from_root(project_path)));
                 }
                 let id = project_path.to_string_lossy();
-                match registry.resolve_path(&id).await {
-                    Ok(Some(root)) => Ok(Some(root)),
+                match registry.resolve_identity(&id).await {
+                    Ok(Some(identity)) => Ok(Some(identity)),
                     Ok(None) => Err(EnqueueTaskError::BadRequest(format!(
                         "project '{id}' not found in registry and is not a valid directory"
                     ))),
                     Err(e) => Err(EnqueueTaskError::Internal(e.to_string())),
                 }
             }
-            (_, project) => Ok(project),
+            (_, Some(project_path)) => Ok(Some(ProjectIdentity::from_root(project_path))),
+            (_, None) => Ok(None),
         }
+    }
+
+    async fn resolve_execution_identity(
+        &self,
+        project: Option<PathBuf>,
+    ) -> Result<ProjectIdentity, EnqueueTaskError> {
+        match self.resolve_project_identity(project).await? {
+            Some(identity) => Ok(identity),
+            None => task_runner::resolve_canonical_project(None)
+                .await
+                .map(ProjectIdentity::from_root)
+                .map_err(|e| EnqueueTaskError::Internal(e.to_string())),
+        }
+    }
+
+    fn queue_key(identity: &ProjectIdentity) -> String {
+        identity.queue_key()
+    }
+
+    fn apply_execution_identity(req: &mut CreateTaskRequest, identity: &ProjectIdentity) {
+        req.project = Some(identity.canonical_root().to_path_buf());
+    }
+
+    fn queue_project_id(identity: &ProjectIdentity) -> String {
+        Self::queue_key(identity)
     }
 
     /// Validate the request has at least one task specifier and a valid priority.
@@ -181,15 +209,11 @@ impl ExecutionService for DefaultExecutionService {
     async fn enqueue(&self, mut req: CreateTaskRequest) -> Result<TaskId, EnqueueTaskError> {
         Self::validate_request(&req)?;
 
-        req.project = self.resolve_project(req.project).await?;
+        let identity = self.resolve_execution_identity(req.project.clone()).await?;
+        self.check_allowed_roots(identity.canonical_root())?;
 
-        let canonical = task_runner::resolve_canonical_project(req.project.clone())
-            .await
-            .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
-        self.check_allowed_roots(&canonical)?;
-
-        let project_id = canonical.to_string_lossy().into_owned();
-        req.project = Some(canonical);
+        let project_id = Self::queue_project_id(&identity);
+        Self::apply_execution_identity(&mut req, &identity);
 
         let permit = self
             .task_queue
@@ -228,7 +252,7 @@ impl ExecutionService for DefaultExecutionService {
     ) -> Result<TaskId, EnqueueTaskError> {
         Self::validate_request(&req)?;
 
-        req.project = self.resolve_project(req.project).await?;
+        let identity = self.resolve_execution_identity(req.project.clone()).await?;
 
         // Resolve agent up-front so validation errors surface immediately.
         let agent = self.select_agent(&req)?;
@@ -238,13 +262,10 @@ impl ExecutionService for DefaultExecutionService {
             agent.name(),
         );
 
-        let canonical = task_runner::resolve_canonical_project(req.project.clone())
-            .await
-            .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
-        self.check_allowed_roots(&canonical)?;
+        self.check_allowed_roots(identity.canonical_root())?;
 
-        let project_id = canonical.to_string_lossy().into_owned();
-        req.project = Some(canonical);
+        let project_id = Self::queue_project_id(&identity);
+        Self::apply_execution_identity(&mut req, &identity);
         task_runner::fill_missing_repo_from_project(&mut req).await;
 
         let server_config = self.server_config.clone();
@@ -374,40 +395,462 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_project_passes_through_none() -> anyhow::Result<()> {
+    async fn resolve_project_identity_none_passes_through() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("t.db")).await?;
-        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
-        let svc = make_minimal_svc(store, Some(registry)).await;
-        let result = svc.resolve_project(None).await?;
-        assert!(result.is_none());
+        let svc = make_minimal_svc(store, None).await;
+
+        assert!(svc.resolve_project_identity(None).await?.is_none());
         Ok(())
     }
 
     #[tokio::test]
-    async fn resolve_project_passes_through_existing_dir() -> anyhow::Result<()> {
+    async fn resolve_project_identity_preserves_registry_alias() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("t.db")).await?;
         let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: dir.path().join("repo"),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
         let svc = make_minimal_svc(store, Some(registry)).await;
 
-        let path = dir.path().to_path_buf();
-        let result = svc.resolve_project(Some(path.clone())).await?;
-        assert_eq!(result, Some(path));
+        let identity = svc
+            .resolve_project_identity(Some(PathBuf::from("alpha")))
+            .await?
+            .expect("registry project should resolve");
+        assert_eq!(identity.alias_id(), Some("alpha"));
+        assert!(identity.canonical_root().ends_with("repo"));
         Ok(())
     }
 
     #[tokio::test]
-    async fn resolve_project_unknown_id_returns_bad_request() -> anyhow::Result<()> {
+    async fn queue_project_id_uses_canonical_root_for_registry_alias() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+
+        let identity = ProjectIdentity::from_registry("alpha".to_string(), root.clone());
+        assert_eq!(
+            DefaultExecutionService::queue_project_id(&identity),
+            root.canonicalize()?.display().to_string()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_execution_identity_rewrites_request_to_canonical_root() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_registry("alpha".to_string(), root.clone());
+        let mut req = CreateTaskRequest {
+            project: Some(PathBuf::from("alpha")),
+            ..Default::default()
+        };
+
+        DefaultExecutionService::apply_execution_identity(&mut req, &identity);
+        assert_eq!(req.project, Some(root.canonicalize()?));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_execution_identity_canonicalizes_existing_dir() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let link = dir.path().join("repo-link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&root, &link)?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&root, &link)?;
+
+        let identity = svc.resolve_execution_identity(Some(link)).await?;
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        assert_eq!(identity.alias_id(), None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_execution_identity_uses_detected_worktree_when_missing() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+
+        let identity = svc.resolve_execution_identity(None).await?;
+        assert!(
+            identity.canonical_root().is_absolute()
+                || identity.canonical_root() == PathBuf::from(".").as_path()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_existing_dir_has_no_alias() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+
+        let identity = svc
+            .resolve_project_identity(Some(root.clone()))
+            .await?
+            .expect("existing dir should resolve");
+        assert_eq!(identity.alias_id(), None);
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_unknown_id_returns_bad_request() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("t.db")).await?;
         let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
         let svc = make_minimal_svc(store, Some(registry)).await;
 
         let result = svc
-            .resolve_project(Some(PathBuf::from("nonexistent-id")))
+            .resolve_project_identity(Some(PathBuf::from("nonexistent-id")))
             .await;
         assert!(matches!(result, Err(EnqueueTaskError::BadRequest(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_project_id_matches_task_queue_canonical_bucket() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let link = dir.path().join("repo-link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&root, &link)?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&root, &link)?;
+
+        let identity = ProjectIdentity::from_root(link);
+        assert_eq!(
+            DefaultExecutionService::queue_project_id(&identity),
+            harness_core::project_identity::canonical_project_key(&root)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_execution_identity_overwrites_alias_with_canonical_root() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_registry("alpha".to_string(), root.clone());
+        let mut req = CreateTaskRequest {
+            project: Some(PathBuf::from("different")),
+            ..Default::default()
+        };
+        DefaultExecutionService::apply_execution_identity(&mut req, &identity);
+        assert_eq!(req.project, Some(root.canonicalize()?));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_project_id_ignores_registry_alias_text() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_registry("some-alias".to_string(), root.clone());
+        assert_ne!(
+            DefaultExecutionService::queue_project_id(&identity),
+            "some-alias"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_execution_identity_from_registry_keeps_alias_and_canonical_root(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+
+        let identity = svc
+            .resolve_execution_identity(Some(PathBuf::from("alpha")))
+            .await?;
+        assert_eq!(identity.alias_id(), Some("alpha"));
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_from_registry_canonicalizes_symlink_root(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let alias_root = dir.path().join("repo-link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&root, &alias_root)?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&root, &alias_root)?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: alias_root,
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+
+        let identity = svc
+            .resolve_project_identity(Some(PathBuf::from("alpha")))
+            .await?
+            .expect("registry project should resolve");
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_non_registry_path_is_canonicalized() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let link = dir.path().join("repo-link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&root, &link)?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&root, &link)?;
+
+        let identity = svc
+            .resolve_project_identity(Some(link))
+            .await?
+            .expect("path should resolve");
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_project_id_for_existing_dir_matches_canonical_display() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_root(root.clone());
+        assert_eq!(
+            DefaultExecutionService::queue_project_id(&identity),
+            root.canonicalize()?.display().to_string()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_registry_missing_still_errors() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+        let result = svc
+            .resolve_project_identity(Some(PathBuf::from("missing")))
+            .await;
+        assert!(matches!(result, Err(EnqueueTaskError::BadRequest(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_execution_identity_none_produces_queueable_identity() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+        let identity = svc.resolve_execution_identity(None).await?;
+        assert!(!DefaultExecutionService::queue_project_id(&identity).is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_execution_identity_preserves_none_repo_field() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_root(root.clone());
+        let mut req = CreateTaskRequest::default();
+        DefaultExecutionService::apply_execution_identity(&mut req, &identity);
+        assert_eq!(req.project, Some(root.canonicalize()?));
+        assert!(req.repo.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_project_id_for_registry_alias_equals_canonical_path_not_alias(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_registry("alpha".to_string(), root.clone());
+        let queue_key = DefaultExecutionService::queue_project_id(&identity);
+        assert_eq!(queue_key, root.canonicalize()?.display().to_string());
+        assert_ne!(queue_key, "alpha");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_without_registry_uses_from_root() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let svc = make_minimal_svc(store, None).await;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+
+        let identity = svc
+            .resolve_project_identity(Some(root.clone()))
+            .await?
+            .expect("dir should resolve");
+        assert_eq!(identity, ProjectIdentity::from_root(root));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_registry_path_round_trip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+
+        let identity = svc
+            .resolve_project_identity(Some(PathBuf::from("alpha")))
+            .await?
+            .expect("should resolve");
+        let mut req = CreateTaskRequest {
+            project: Some(PathBuf::from("alpha")),
+            ..Default::default()
+        };
+        DefaultExecutionService::apply_execution_identity(&mut req, &identity);
+        assert_eq!(req.project, Some(root.canonicalize()?));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_prefers_registry_for_non_dir_input() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+        let identity = svc
+            .resolve_project_identity(Some(PathBuf::from("alpha")))
+            .await?
+            .expect("registry should win");
+        assert_eq!(identity.alias_id(), Some("alpha"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_existing_dir_does_not_require_registry() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = svc
+            .resolve_project_identity(Some(root.clone()))
+            .await?
+            .expect("dir should resolve");
+        assert_eq!(identity.alias_id(), None);
+        assert_eq!(identity.canonical_root(), root.canonicalize()?.as_path());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_project_id_is_stable_for_canonical_root() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        let identity = ProjectIdentity::from_root(root.clone());
+        let a = DefaultExecutionService::queue_project_id(&identity);
+        let b = DefaultExecutionService::queue_project_id(&identity);
+        assert_eq!(a, b);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_project_identity_registry_and_path_converge_to_same_queue_key(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root)?;
+        registry
+            .register(crate::project_registry::Project {
+                id: "alpha".to_string(),
+                root: root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let svc = make_minimal_svc(store, Some(registry)).await;
+        let by_id = svc
+            .resolve_project_identity(Some(PathBuf::from("alpha")))
+            .await?
+            .expect("id should resolve");
+        let by_path = svc
+            .resolve_project_identity(Some(root.clone()))
+            .await?
+            .expect("path should resolve");
+        assert_eq!(
+            DefaultExecutionService::queue_project_id(&by_id),
+            DefaultExecutionService::queue_project_id(&by_path)
+        );
         Ok(())
     }
 

--- a/crates/harness-server/src/services/project.rs
+++ b/crates/harness-server/src/services/project.rs
@@ -2,6 +2,7 @@
 
 use crate::project_registry::{Project, ProjectRegistry};
 use async_trait::async_trait;
+use harness_core::project_identity::ProjectIdentity;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -26,6 +27,9 @@ pub trait ProjectService: Send + Sync {
     /// Resolve a registered project ID to its root path.
     /// Returns `None` when the ID is not found.
     async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>>;
+
+    /// Resolve a registered project ID to its canonical execution identity.
+    async fn resolve_identity(&self, id: &str) -> anyhow::Result<Option<ProjectIdentity>>;
 
     /// The default project root configured at server startup.
     fn default_root(&self) -> &Path;
@@ -64,6 +68,10 @@ impl ProjectService for DefaultProjectService {
 
     async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
         self.registry.resolve_path(id).await
+    }
+
+    async fn resolve_identity(&self, id: &str) -> anyhow::Result<Option<ProjectIdentity>> {
+        self.registry.resolve_identity(id).await
     }
 
     fn default_root(&self) -> &Path {
@@ -113,6 +121,16 @@ mod tests {
 
         async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
             Ok(self.store.read().await.get(id).map(|p| p.root.clone()))
+        }
+
+        async fn resolve_identity(&self, id: &str) -> anyhow::Result<Option<ProjectIdentity>> {
+            Ok(self
+                .store
+                .read()
+                .await
+                .get(id)
+                .cloned()
+                .map(|project| ProjectIdentity::from_registry(project.id, project.root)))
         }
 
         fn default_root(&self) -> &Path {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -451,10 +451,7 @@ async fn resolve_project_root_with(
 /// happens inside `spawn_task` once the task is running.
 pub(crate) async fn resolve_canonical_project(project: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     let raw = resolve_project_root_with(project, detect_main_worktree).await?;
-    // Best-effort canonicalize: if the path doesn't exist yet (e.g. in tests
-    // using a path that will be created later) fall back to the raw path so
-    // we at least get a consistent string key.
-    Ok(raw.canonicalize().unwrap_or(raw))
+    Ok(harness_core::project_identity::canonicalize_root(raw))
 }
 
 async fn log_task_failure_event(

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use harness_core::{config::misc::ConcurrencyConfig, project_identity::canonical_project_key};
+use harness_core::config::misc::ConcurrencyConfig;
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -421,7 +421,7 @@ impl TaskQueue {
         let project_limits: DashMap<String, usize> = config
             .per_project
             .iter()
-            .map(|(k, v)| (canonical_project_key(k), *v))
+            .map(|(k, v)| (k.clone(), *v))
             .collect();
 
         Self {
@@ -440,36 +440,32 @@ impl TaskQueue {
     }
 
     fn project_limit(&self, project_id: &str) -> usize {
-        let project_id = canonical_project_key(project_id);
         self.project_limits
-            .get(&project_id)
+            .get(project_id)
             .map(|v| *v)
             .unwrap_or(self.global_limit)
     }
 
     fn get_or_create_project_queue(&self, project_id: &str) -> Arc<Mutex<PriorityPermitQueue>> {
-        let project_id = canonical_project_key(project_id);
         self.project_queues
-            .entry(project_id.clone())
+            .entry(project_id.to_string())
             .or_insert_with(|| {
-                let limit = self.project_limit(&project_id);
+                let limit = self.project_limit(project_id);
                 Arc::new(Mutex::new(PriorityPermitQueue::new(limit)))
             })
             .clone()
     }
 
     fn get_or_create_project_queued(&self, project_id: &str) -> Arc<AtomicUsize> {
-        let project_id = canonical_project_key(project_id);
         self.project_queued
-            .entry(project_id)
+            .entry(project_id.to_string())
             .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
             .clone()
     }
 
     fn get_or_create_project_awaiting_global(&self, project_id: &str) -> Arc<AtomicUsize> {
-        let project_id = canonical_project_key(project_id);
         self.project_awaiting_global
-            .entry(project_id)
+            .entry(project_id.to_string())
             .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
             .clone()
     }
@@ -616,16 +612,15 @@ impl TaskQueue {
 
     /// Stats for a specific project (tasks that have acquired a project slot).
     pub fn project_stats(&self, project_id: &str) -> QueueStats {
-        let project_id = canonical_project_key(project_id);
-        let limit = self.project_limit(&project_id);
-        if let Some(pq) = self.project_queues.get(&project_id) {
+        let limit = self.project_limit(project_id);
+        if let Some(pq) = self.project_queues.get(project_id) {
             let q = pq.lock().unwrap();
             let holding_project = limit.saturating_sub(q.available_permits());
             let waiting_for_project = q.waiter_count();
             drop(q);
             let awaiting_global = self
                 .project_awaiting_global
-                .get(&project_id)
+                .get(project_id)
                 .map(|c| c.load(AtomicOrdering::Relaxed))
                 .unwrap_or(0);
             let running = holding_project.saturating_sub(awaiting_global);

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use harness_core::config::misc::ConcurrencyConfig;
+use harness_core::{config::misc::ConcurrencyConfig, project_identity::canonical_project_key};
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -421,8 +421,9 @@ impl TaskQueue {
         let project_limits: DashMap<String, usize> = config
             .per_project
             .iter()
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (canonical_project_key(k), *v))
             .collect();
+
         Self {
             global_queue: Arc::new(Mutex::new(PriorityPermitQueue::new(
                 config.max_concurrent_tasks,
@@ -439,32 +440,36 @@ impl TaskQueue {
     }
 
     fn project_limit(&self, project_id: &str) -> usize {
+        let project_id = canonical_project_key(project_id);
         self.project_limits
-            .get(project_id)
+            .get(&project_id)
             .map(|v| *v)
             .unwrap_or(self.global_limit)
     }
 
     fn get_or_create_project_queue(&self, project_id: &str) -> Arc<Mutex<PriorityPermitQueue>> {
+        let project_id = canonical_project_key(project_id);
         self.project_queues
-            .entry(project_id.to_string())
+            .entry(project_id.clone())
             .or_insert_with(|| {
-                let limit = self.project_limit(project_id);
+                let limit = self.project_limit(&project_id);
                 Arc::new(Mutex::new(PriorityPermitQueue::new(limit)))
             })
             .clone()
     }
 
     fn get_or_create_project_queued(&self, project_id: &str) -> Arc<AtomicUsize> {
+        let project_id = canonical_project_key(project_id);
         self.project_queued
-            .entry(project_id.to_string())
+            .entry(project_id)
             .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
             .clone()
     }
 
     fn get_or_create_project_awaiting_global(&self, project_id: &str) -> Arc<AtomicUsize> {
+        let project_id = canonical_project_key(project_id);
         self.project_awaiting_global
-            .entry(project_id.to_string())
+            .entry(project_id)
             .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
             .clone()
     }
@@ -611,15 +616,16 @@ impl TaskQueue {
 
     /// Stats for a specific project (tasks that have acquired a project slot).
     pub fn project_stats(&self, project_id: &str) -> QueueStats {
-        let limit = self.project_limit(project_id);
-        if let Some(pq) = self.project_queues.get(project_id) {
+        let project_id = canonical_project_key(project_id);
+        let limit = self.project_limit(&project_id);
+        if let Some(pq) = self.project_queues.get(&project_id) {
             let q = pq.lock().unwrap();
             let holding_project = limit.saturating_sub(q.available_permits());
             let waiting_for_project = q.waiter_count();
             drop(q);
             let awaiting_global = self
                 .project_awaiting_global
-                .get(project_id)
+                .get(&project_id)
                 .map(|c| c.load(AtomicOrdering::Relaxed))
                 .unwrap_or(0);
             let running = holding_project.saturating_sub(awaiting_global);

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -144,6 +144,63 @@ async fn per_project_limit_enforced() {
 }
 
 #[tokio::test]
+async fn canonical_and_alias_project_keys_share_limit_bucket() -> anyhow::Result<()> {
+    use std::collections::HashMap;
+
+    let temp = tempfile::tempdir()?;
+    let canonical = temp.path().join("repo");
+    std::fs::create_dir_all(&canonical)?;
+    let alias = temp.path().join("repo-link");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&canonical, &alias)?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&canonical, &alias)?;
+
+    let canonical_key = canonical.canonicalize()?.display().to_string();
+    let alias_key = alias.display().to_string();
+
+    let mut per_project = HashMap::new();
+    per_project.insert(canonical_key, 1usize);
+    let cfg = ConcurrencyConfig {
+        max_concurrent_tasks: 4,
+        max_queue_size: 16,
+        stall_timeout_secs: 300,
+        per_project,
+        ..ConcurrencyConfig::default()
+    };
+    let q = Arc::new(TaskQueue::new(&cfg));
+
+    let _holder = q.acquire(&alias_key, 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.acquire(&alias_key, 0)).await;
+    assert!(
+        blocked.is_err(),
+        "alias key should resolve to the canonical per-project limit bucket"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn canonical_and_relative_project_keys_share_queue_stats_bucket() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("repo");
+    std::fs::create_dir_all(&project)?;
+
+    let canonical_key = project.canonicalize()?.display().to_string();
+    let relative_key = project.display().to_string();
+    let q = Arc::new(TaskQueue::new(&config(1, 8)));
+
+    let _holder = q.acquire(&relative_key, 0).await.unwrap();
+    let q2 = q.clone();
+    let _waiter = tokio::spawn(async move { q2.acquire(&relative_key, 0).await });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let stats = q.project_stats(&canonical_key);
+    assert_eq!(stats.running, 1, "canonical key should see running task");
+    assert_eq!(stats.queued, 1, "canonical key should see queued waiter");
+    Ok(())
+}
+
+#[tokio::test]
 async fn project_cannot_starve_another() {
     use std::collections::HashMap;
     // global=2, proj_a=1 → proj_a can use at most 1 global slot,

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -201,6 +201,46 @@ async fn canonical_and_relative_project_keys_share_queue_stats_bucket() -> anyho
 }
 
 #[tokio::test]
+async fn repeated_alias_key_does_not_split_after_canonicalize_starts_failing() -> anyhow::Result<()>
+{
+    use std::collections::HashMap;
+
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo)?;
+    let alias = temp.path().join("repo-link");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&repo, &alias)?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&repo, &alias)?;
+    let alias_key = alias.display().to_string();
+
+    let mut per_project = HashMap::new();
+    per_project.insert(alias_key.clone(), 1usize);
+    let cfg = ConcurrencyConfig {
+        max_concurrent_tasks: 4,
+        max_queue_size: 16,
+        stall_timeout_secs: 300,
+        per_project,
+        ..ConcurrencyConfig::default()
+    };
+    let q = Arc::new(TaskQueue::new(&cfg));
+
+    let _holder = q.acquire(&alias_key, 0).await.unwrap();
+    std::fs::remove_file(&alias)?;
+
+    let blocked = timeout(Duration::from_millis(50), q.acquire(&alias_key, 0)).await;
+    assert!(
+        blocked.is_err(),
+        "the same project key should keep its original queue bucket even after canonicalize later fails"
+    );
+
+    let stats = q.project_stats(&alias_key);
+    assert_eq!(stats.limit, 1, "configured limit should still be visible");
+    Ok(())
+}
+
+#[tokio::test]
 async fn project_cannot_starve_another() {
     use std::collections::HashMap;
     // global=2, proj_a=1 → proj_a can use at most 1 global slot,


### PR DESCRIPTION
## Summary
- add a shared `ProjectIdentity` type centered on canonical project roots
- route registry resolution, task execution, startup project limits, and queue bucketing through canonical roots
- add regression tests covering alias preservation with canonical execution/config behavior

## Test Plan
- cargo fmt --all
- cargo check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace