### PR TITLE
refactor: unify agent and adapter registration

### DIFF
--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -1,21 +1,25 @@
 use async_trait::async_trait;
 use harness_core::{
-    agent::AgentAdapter, agent::AgentEvent, agent::ApprovalDecision, agent::TurnRequest,
+    agent::AgentAdapter,
+    agent::AgentEvent,
+    agent::ApprovalDecision,
+    agent::TurnRequest,
+    config::agents::{CodexCloudConfig, SandboxMode},
 };
 use serde_json::json;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex};
-use tracing;
 
 /// Codex App Server adapter (L3-L4).
 ///
-/// Spawns `codex` as a long-lived stdio subprocess speaking JSON-RPC 2.0.
-/// Bidirectional: sends requests via stdin, reads responses/notifications from stdout.
-/// Supports approval gates, interrupt, and steer.
+/// Spawns `codex app-server` as a stdio subprocess speaking JSON-RPC 2.0.
+/// Supports approval gates, interrupt, and steer for a single live turn.
 pub struct CodexAdapter {
     cli_path: PathBuf,
+    sandbox_mode: SandboxMode,
+    cloud: CodexCloudConfig,
     state: Arc<Mutex<AdapterState>>,
 }
 
@@ -42,14 +46,23 @@ impl AdapterState {
 }
 
 impl CodexAdapter {
-    pub fn new(cli_path: PathBuf) -> Self {
+    pub fn new(cli_path: PathBuf, sandbox_mode: SandboxMode, cloud: CodexCloudConfig) -> Self {
         Self {
             cli_path,
+            sandbox_mode,
+            cloud,
             state: Arc::new(Mutex::new(AdapterState::new())),
         }
     }
 
-    /// Send a JSON-RPC request via stdin and return the request id.
+    fn sandbox_policy(&self) -> &'static str {
+        match self.sandbox_mode {
+            SandboxMode::ReadOnly => "readOnly",
+            SandboxMode::WorkspaceWrite => "workspaceWrite",
+            SandboxMode::DangerFullAccess => "dangerFullAccess",
+        }
+    }
+
     async fn send_request(
         state: &mut AdapterState,
         method: &str,
@@ -88,7 +101,6 @@ impl CodexAdapter {
         Ok(id)
     }
 
-    /// Send a JSON-RPC notification (no id, no response expected).
     async fn send_notification(
         state: &mut AdapterState,
         method: &str,
@@ -133,97 +145,145 @@ impl AgentAdapter for CodexAdapter {
         tx: mpsc::Sender<AgentEvent>,
     ) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
+        if state.child.is_some() {
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "codex adapter cannot reuse an existing app-server process across turns"
+                    .to_string(),
+            ));
+        }
 
-        // Spawn codex if not already running
-        if state.child.is_none() {
-            let mut cmd = tokio::process::Command::new(&self.cli_path);
-            cmd.stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .current_dir(&req.project_root)
-                .kill_on_drop(true);
-            #[cfg(unix)]
-            crate::set_process_group(&mut cmd);
-            crate::strip_claude_env(&mut cmd);
+        if self.cloud.enabled {
+            crate::cloud_setup::run_setup_phase(&self.cloud, &req.project_root).await?;
+        }
 
-            let mut child = cmd.spawn().map_err(|e| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "failed to spawn codex: {e}"
-                ))
-            })?;
+        let mut cmd = tokio::process::Command::new(&self.cli_path);
+        cmd.arg("app-server")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .current_dir(&req.project_root)
+            .kill_on_drop(true);
+        if self.cloud.enabled {
+            cmd.arg("--ephemeral");
+        }
+        for key in &self.cloud.setup_secret_env {
+            cmd.env_remove(key);
+        }
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
+        crate::strip_claude_env(&mut cmd);
 
-            state.stdin = child.stdin.take();
-            let stdout = child.stdout.take().ok_or_else(|| {
-                harness_core::error::HarnessError::AgentExecution("no stdout from codex".into())
-            })?;
-            state.child = Some(child);
+        let mut child = cmd.spawn().map_err(|e| {
+            harness_core::error::HarnessError::AgentExecution(format!("failed to spawn codex: {e}"))
+        })?;
 
-            // Initialize handshake
-            Self::send_request(&mut state, "initialize", json!({})).await?;
+        state.stdin = child.stdin.take();
+        let stdout = child.stdout.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("no stdout from codex".into())
+        })?;
+        state.child = Some(child);
 
-            // Read initialize response (blocking on first line)
-            let reader = tokio::io::BufReader::new(stdout);
-            let mut lines = reader.lines();
+        Self::send_request(
+            &mut state,
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": "harness",
+                    "title": "Harness",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )
+        .await?;
+        Self::send_request(
+            &mut state,
+            "thread/start",
+            json!({
+                "cwd": req.project_root,
+                "sandboxPolicy": { "type": self.sandbox_policy() }
+            }),
+        )
+        .await?;
 
-            // Read init response
+        let reader = tokio::io::BufReader::new(stdout);
+        let mut lines = reader.lines();
+        let mut thread_id: Option<String> = None;
+
+        for _ in 0..2 {
             if let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!(line = %line, "codex initialize response");
-            }
-
-            // Send initialized notification
-            Self::send_notification(&mut state, "initialized").await?;
-
-            // Send turn/start
-            Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
-
-            // Release lock before reading event stream
-            drop(state);
-
-            if tx.send(AgentEvent::TurnStarted).await.is_err() {
-                return Ok(());
-            }
-
-            // Read event stream until turn completes
-            let mut output_buf = String::new();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if line.trim().is_empty() {
-                    continue;
-                }
-
-                if let Some(event) = parse_codex_message(&line) {
-                    if let AgentEvent::MessageDelta { ref text } = event {
-                        output_buf.push_str(text);
-                    }
-
-                    let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
-                    let is_error = matches!(event, AgentEvent::Error { .. });
-
-                    if tx.send(event).await.is_err() {
-                        break;
-                    }
-
-                    if is_turn_completed || is_error {
-                        break;
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                    if let Some(id) = value
+                        .get("result")
+                        .and_then(|result| result.get("thread"))
+                        .and_then(|thread| thread.get("id"))
+                        .and_then(|id| id.as_str())
+                    {
+                        thread_id = Some(id.to_string());
                     }
                 }
-            }
-        } else {
-            // Already running — just send a new turn
-            Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
-            drop(state);
-
-            if let Err(e) = tx.send(AgentEvent::TurnStarted).await {
-                tracing::debug!("stream channel closed: {e}");
             }
         }
 
+        Self::send_notification(&mut state, "initialized").await?;
+
+        let thread_id = thread_id.ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex thread/start did not return thread id".into(),
+            )
+        })?;
+        Self::send_request(
+            &mut state,
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "input": [{ "type": "text", "text": req.prompt }],
+                "sandboxPolicy": { "type": self.sandbox_policy() }
+            }),
+        )
+        .await?;
+
+        if let Ok(Some(_line)) = lines.next_line().await {
+            // Consume turn/start response before notifications.
+        }
+
+        drop(state);
+
+        let mut turn_started_sent = false;
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            if let Some(event) = parse_codex_message(&line) {
+                if !turn_started_sent {
+                    if tx.send(AgentEvent::TurnStarted).await.is_err() {
+                        break;
+                    }
+                    turn_started_sent = true;
+                }
+
+                let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
+                let is_error = matches!(event, AgentEvent::Error { .. });
+
+                if tx.send(event).await.is_err() {
+                    break;
+                }
+
+                if is_turn_completed || is_error {
+                    break;
+                }
+            }
+        }
+
+        let mut state = self.state.lock().await;
+        state.stdin = None;
+        state.child = None;
         Ok(())
     }
 
     async fn interrupt(&self) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
         if state.stdin.is_some() {
-            // Try graceful interrupt first
             if let Err(e) = Self::send_request(&mut state, "turn/interrupt", json!({})).await {
                 tracing::warn!("failed to send turn/interrupt: {e}, killing process");
                 if let Some(ref mut child) = state.child {
@@ -259,7 +319,6 @@ impl AgentAdapter for CodexAdapter {
             harness_core::error::HarnessError::AgentExecution("codex stdin not available".into())
         })?;
 
-        // Approval response uses the original request id
         let response = json!({
             "jsonrpc": "2.0",
             "id": id,
@@ -286,18 +345,14 @@ impl AgentAdapter for CodexAdapter {
 }
 
 /// Parse a Codex App Server JSON-RPC message into an AgentEvent.
-///
-/// Handles both notifications (method field, no id) and responses (id, result/error).
 pub fn parse_codex_message(line: &str) -> Option<AgentEvent> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
 
-    // Notification: has "method" field
     if let Some(method) = v.get("method").and_then(|m| m.as_str()) {
         let params = v.get("params").cloned().unwrap_or(serde_json::Value::Null);
         return parse_notification(method, &params);
     }
 
-    // Response: has "id" field
     if v.get("id").is_some() {
         if let Some(error) = v.get("error") {
             let message = error
@@ -307,7 +362,6 @@ pub fn parse_codex_message(line: &str) -> Option<AgentEvent> {
                 .to_string();
             return Some(AgentEvent::Error { message });
         }
-        // Successful response — typically handled by request correlation, skip here
         return None;
     }
 
@@ -316,7 +370,9 @@ pub fn parse_codex_message(line: &str) -> Option<AgentEvent> {
 
 fn parse_notification(method: &str, params: &serde_json::Value) -> Option<AgentEvent> {
     match method {
-        "turn/started" | "turn_started" => Some(AgentEvent::TurnStarted),
+        "turn/started" | "turn_started" | "thread/started" | "thread_started" => {
+            Some(AgentEvent::TurnStarted)
+        }
         "item/started" | "item_started" => {
             let item_type = params
                 .get("type")
@@ -458,9 +514,37 @@ mod tests {
         assert!(matches!(event, AgentEvent::TurnCompleted { .. }));
     }
 
+    #[test]
+    fn sandbox_policy_maps_config_values() {
+        let read_only = CodexAdapter::new(
+            PathBuf::from("codex"),
+            SandboxMode::ReadOnly,
+            CodexCloudConfig::default(),
+        );
+        assert_eq!(read_only.sandbox_policy(), "readOnly");
+
+        let workspace_write = CodexAdapter::new(
+            PathBuf::from("codex"),
+            SandboxMode::WorkspaceWrite,
+            CodexCloudConfig::default(),
+        );
+        assert_eq!(workspace_write.sandbox_policy(), "workspaceWrite");
+
+        let danger = CodexAdapter::new(
+            PathBuf::from("codex"),
+            SandboxMode::DangerFullAccess,
+            CodexCloudConfig::default(),
+        );
+        assert_eq!(danger.sandbox_policy(), "dangerFullAccess");
+    }
+
     #[tokio::test]
     async fn interrupt_noop_when_no_child() {
-        let adapter = CodexAdapter::new(PathBuf::from("codex"));
+        let adapter = CodexAdapter::new(
+            PathBuf::from("codex"),
+            SandboxMode::DangerFullAccess,
+            CodexCloudConfig::default(),
+        );
         adapter.interrupt().await.unwrap();
     }
 }

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -209,18 +209,28 @@ impl AgentAdapter for CodexAdapter {
         let mut lines = reader.lines();
         let mut thread_id: Option<String> = None;
 
-        for _ in 0..2 {
-            if let Ok(Some(line)) = lines.next_line().await {
-                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
-                    if let Some(id) = value
-                        .get("result")
-                        .and_then(|result| result.get("thread"))
-                        .and_then(|thread| thread.get("id"))
-                        .and_then(|id| id.as_str())
-                    {
-                        thread_id = Some(id.to_string());
+        // Loop until we find the thread/start response containing the thread id.
+        // codex app-server may emit intermediate notifications (e.g. thread/started)
+        // before the RPC response, so a fixed read count can miss the id.
+        let mut init_lines_read = 0u32;
+        const MAX_INIT_LINES: u32 = 20;
+        while thread_id.is_none() && init_lines_read < MAX_INIT_LINES {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    init_lines_read += 1;
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                        if let Some(id) = value
+                            .get("result")
+                            .and_then(|result| result.get("thread"))
+                            .and_then(|thread| thread.get("id"))
+                            .and_then(|id| id.as_str())
+                        {
+                            thread_id = Some(id.to_string());
+                        }
                     }
                 }
+                Ok(None) => break,
+                Err(_) => break,
             }
         }
 
@@ -231,7 +241,7 @@ impl AgentAdapter for CodexAdapter {
                 "codex thread/start did not return thread id".into(),
             )
         })?;
-        Self::send_request(
+        let turn_start_id = Self::send_request(
             &mut state,
             "turn/start",
             json!({
@@ -242,8 +252,27 @@ impl AgentAdapter for CodexAdapter {
         )
         .await?;
 
-        if let Ok(Some(_line)) = lines.next_line().await {
-            // Consume turn/start response before notifications.
+        // Consume lines until we see the RPC response for turn/start (matched by id).
+        // An unconditional single-line drop can lose early notifications that arrive
+        // before the turn/start ACK when JSON-RPC traffic is interleaved.
+        let mut turn_start_acked = false;
+        let mut ack_lines_read = 0u32;
+        const MAX_ACK_LINES: u32 = 20;
+        while !turn_start_acked && ack_lines_read < MAX_ACK_LINES {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    ack_lines_read += 1;
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                        if value.get("id").and_then(|v| v.as_u64()) == Some(turn_start_id) {
+                            turn_start_acked = true;
+                        }
+                        // Notifications arriving before the ack are intentionally skipped;
+                        // the main event loop below handles all subsequent notifications.
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => break,
+            }
         }
 
         drop(state);

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -182,7 +182,7 @@ impl AgentAdapter for CodexAdapter {
         })?;
         state.child = Some(child);
 
-        Self::send_request(
+        let init_id = Self::send_request(
             &mut state,
             "initialize",
             json!({
@@ -194,7 +194,36 @@ impl AgentAdapter for CodexAdapter {
             }),
         )
         .await?;
-        Self::send_request(
+
+        let reader = tokio::io::BufReader::new(stdout);
+        let mut lines = reader.lines();
+
+        // Wait for the initialize response before sending `initialized`.
+        // Forward any intermediate notifications so no events are lost.
+        let mut init_acked = false;
+        while !init_acked {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                        if value.get("id").and_then(|v| v.as_u64()) == Some(init_id) {
+                            init_acked = true;
+                        }
+                    }
+                    if let Some(event) = parse_codex_message(&line) {
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        // Correct handshake order: `initialized` must follow the initialize response
+        // and precede `thread/start` (per app-server protocol spec).
+        Self::send_notification(&mut state, "initialized").await?;
+
+        let thread_start_id = Self::send_request(
             &mut state,
             "thread/start",
             json!({
@@ -204,8 +233,6 @@ impl AgentAdapter for CodexAdapter {
         )
         .await?;
 
-        let reader = tokio::io::BufReader::new(stdout);
-        let mut lines = reader.lines();
         let mut thread_id: Option<String> = None;
 
         // Loop until we find the thread/start response containing the thread id.
@@ -215,24 +242,26 @@ impl AgentAdapter for CodexAdapter {
             match lines.next_line().await {
                 Ok(Some(line)) => {
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
-                        if let Some(id) = value
-                            .get("result")
-                            .and_then(|result| result.get("thread"))
-                            .and_then(|thread| thread.get("id"))
-                            .and_then(|id| id.as_str())
-                        {
-                            thread_id = Some(id.to_string());
+                        if value.get("id").and_then(|v| v.as_u64()) == Some(thread_start_id) {
+                            if let Some(id) = value
+                                .get("result")
+                                .and_then(|result| result.get("thread"))
+                                .and_then(|thread| thread.get("id"))
+                                .and_then(|id| id.as_str())
+                            {
+                                thread_id = Some(id.to_string());
+                            }
                         }
                     }
                     if let Some(event) = parse_codex_message(&line) {
-                        let _ = tx.send(event).await;
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
                     }
                 }
                 Ok(None) | Err(_) => break,
             }
         }
-
-        Self::send_notification(&mut state, "initialized").await?;
 
         let thread_id = thread_id.ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(
@@ -262,7 +291,9 @@ impl AgentAdapter for CodexAdapter {
                         }
                     }
                     if let Some(event) = parse_codex_message(&line) {
-                        let _ = tx.send(event).await;
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
                     }
                 }
                 Ok(None) | Err(_) => break,
@@ -272,35 +303,50 @@ impl AgentAdapter for CodexAdapter {
         drop(state);
 
         let mut turn_started_sent = false;
-        while let Ok(Some(line)) = lines.next_line().await {
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            if let Some(event) = parse_codex_message(&line) {
-                if !turn_started_sent {
-                    if tx.send(AgentEvent::TurnStarted).await.is_err() {
-                        break;
+        let mut turn_terminal_seen = false;
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if line.trim().is_empty() {
+                        continue;
                     }
-                    turn_started_sent = true;
-                }
 
-                let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
-                let is_error = matches!(event, AgentEvent::Error { .. });
+                    if let Some(event) = parse_codex_message(&line) {
+                        if !turn_started_sent {
+                            if tx.send(AgentEvent::TurnStarted).await.is_err() {
+                                break;
+                            }
+                            turn_started_sent = true;
+                        }
 
-                if tx.send(event).await.is_err() {
-                    break;
-                }
+                        let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
+                        let is_error = matches!(event, AgentEvent::Error { .. });
 
-                if is_turn_completed || is_error {
-                    break;
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+
+                        if is_turn_completed || is_error {
+                            turn_terminal_seen = true;
+                            break;
+                        }
+                    }
                 }
+                Ok(None) | Err(_) => break,
             }
         }
 
         let mut state = self.state.lock().await;
         state.stdin = None;
         state.child = None;
+
+        if !turn_terminal_seen {
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "codex app-server stream ended without a terminal event (TurnCompleted or Error)"
+                    .into(),
+            ));
+        }
+
         Ok(())
     }
 

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -145,11 +145,10 @@ impl AgentAdapter for CodexAdapter {
         tx: mpsc::Sender<AgentEvent>,
     ) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
-        if state.child.is_some() {
-            return Err(harness_core::error::HarnessError::AgentExecution(
-                "codex adapter cannot reuse an existing app-server process across turns"
-                    .to_string(),
-            ));
+        if let Some(mut old_child) = state.child.take() {
+            tracing::warn!("killing stale codex process from previous turn");
+            let _ = old_child.kill().await;
+            state.stdin = None;
         }
 
         if self.cloud.enabled {
@@ -210,14 +209,11 @@ impl AgentAdapter for CodexAdapter {
         let mut thread_id: Option<String> = None;
 
         // Loop until we find the thread/start response containing the thread id.
-        // codex app-server may emit intermediate notifications (e.g. thread/started)
-        // before the RPC response, so a fixed read count can miss the id.
-        let mut init_lines_read = 0u32;
-        const MAX_INIT_LINES: u32 = 20;
-        while thread_id.is_none() && init_lines_read < MAX_INIT_LINES {
+        // Forward intermediate notifications (e.g. thread/started) so they are not lost.
+        // No line count limit — loop until the id or EOF.
+        while thread_id.is_none() {
             match lines.next_line().await {
                 Ok(Some(line)) => {
-                    init_lines_read += 1;
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
                         if let Some(id) = value
                             .get("result")
@@ -228,9 +224,11 @@ impl AgentAdapter for CodexAdapter {
                             thread_id = Some(id.to_string());
                         }
                     }
+                    if let Some(event) = parse_codex_message(&line) {
+                        let _ = tx.send(event).await;
+                    }
                 }
-                Ok(None) => break,
-                Err(_) => break,
+                Ok(None) | Err(_) => break,
             }
         }
 
@@ -253,25 +251,21 @@ impl AgentAdapter for CodexAdapter {
         .await?;
 
         // Consume lines until we see the RPC response for turn/start (matched by id).
-        // An unconditional single-line drop can lose early notifications that arrive
-        // before the turn/start ACK when JSON-RPC traffic is interleaved.
+        // Forward intermediate notifications so events emitted before the ack are not lost.
         let mut turn_start_acked = false;
-        let mut ack_lines_read = 0u32;
-        const MAX_ACK_LINES: u32 = 20;
-        while !turn_start_acked && ack_lines_read < MAX_ACK_LINES {
+        while !turn_start_acked {
             match lines.next_line().await {
                 Ok(Some(line)) => {
-                    ack_lines_read += 1;
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
                         if value.get("id").and_then(|v| v.as_u64()) == Some(turn_start_id) {
                             turn_start_acked = true;
                         }
-                        // Notifications arriving before the ack are intentionally skipped;
-                        // the main event loop below handles all subsequent notifications.
+                    }
+                    if let Some(event) = parse_codex_message(&line) {
+                        let _ = tx.send(event).await;
                     }
                 }
-                Ok(None) => break,
-                Err(_) => break,
+                Ok(None) | Err(_) => break,
             }
         }
 

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -5,11 +5,13 @@ use harness_core::{
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+type AdapterFactory = Arc<dyn Fn() -> Arc<dyn AgentAdapter> + Send + Sync>;
+
 #[derive(Clone)]
 pub struct RegisteredAgentDescriptor {
     pub name: String,
     pub code_agent: Arc<dyn CodeAgent>,
-    pub adapter: Option<Arc<dyn AgentAdapter>>,
+    adapter_factory: Option<AdapterFactory>,
     pub registration_index: usize,
     pub capabilities: Vec<Capability>,
     pub is_default: bool,
@@ -22,8 +24,12 @@ impl RegisteredAgentDescriptor {
     }
 
     pub fn adapter(&self) -> Option<Arc<dyn AgentAdapter>> {
-        self.adapter.clone()
+        self.adapter_factory.as_ref().map(|factory| factory())
     }
+}
+
+fn singleton_adapter_factory(adapter: Arc<dyn AgentAdapter>) -> AdapterFactory {
+    Arc::new(move || adapter.clone())
 }
 
 pub struct AgentRegistry {
@@ -69,7 +75,7 @@ impl AgentRegistry {
             RegisteredAgentDescriptor {
                 name,
                 code_agent: agent.clone(),
-                adapter,
+                adapter_factory: adapter.map(singleton_adapter_factory),
                 registration_index,
                 capabilities: agent.capabilities(),
                 is_default: false,
@@ -82,9 +88,73 @@ impl AgentRegistry {
     pub fn register_adapter(&mut self, name: impl Into<String>, adapter: Arc<dyn AgentAdapter>) {
         let name = name.into();
         if let Some(existing) = self.descriptors.get_mut(&name) {
-            existing.adapter = Some(adapter);
+            existing.adapter_factory = Some(singleton_adapter_factory(adapter));
             self.refresh_metadata();
         }
+    }
+
+    pub fn register_with_adapter_factory(
+        &mut self,
+        name: impl Into<String>,
+        agent: Arc<dyn CodeAgent>,
+        adapter_factory: Option<AdapterFactory>,
+    ) {
+        let name = name.into();
+        let registration_index = self.ensure_registration_slot(&name);
+        self.descriptors.insert(
+            name.clone(),
+            RegisteredAgentDescriptor {
+                name,
+                code_agent: agent.clone(),
+                adapter_factory,
+                registration_index,
+                capabilities: agent.capabilities(),
+                is_default: false,
+                complexity_preferred: false,
+            },
+        );
+        self.refresh_metadata();
+    }
+
+    pub fn register_adapter_factory(
+        &mut self,
+        name: impl Into<String>,
+        adapter_factory: AdapterFactory,
+    ) {
+        let name = name.into();
+        if let Some(existing) = self.descriptors.get_mut(&name) {
+            existing.adapter_factory = Some(adapter_factory);
+            self.refresh_metadata();
+        }
+    }
+
+    pub fn register_with_fresh_adapter<A, F>(
+        &mut self,
+        name: impl Into<String>,
+        agent: Arc<dyn CodeAgent>,
+        adapter_factory: F,
+    ) where
+        A: AgentAdapter + 'static,
+        F: Fn() -> A + Send + Sync + 'static,
+    {
+        self.register_with_adapter_factory(
+            name,
+            agent,
+            Some(Arc::new(move || {
+                Arc::new(adapter_factory()) as Arc<dyn AgentAdapter>
+            })),
+        );
+    }
+
+    pub fn register_fresh_adapter<A, F>(&mut self, name: impl Into<String>, adapter_factory: F)
+    where
+        A: AgentAdapter + 'static,
+        F: Fn() -> A + Send + Sync + 'static,
+    {
+        self.register_adapter_factory(
+            name,
+            Arc::new(move || Arc::new(adapter_factory()) as Arc<dyn AgentAdapter>),
+        );
     }
 
     pub fn descriptor(&self, name: &str) -> Option<&RegisteredAgentDescriptor> {

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -1,12 +1,33 @@
 use harness_core::{
     agent::AgentAdapter, agent::CodeAgent, agent::TaskClassification, agent::TaskComplexity,
-    error::HarnessError,
+    error::HarnessError, types::Capability,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+#[derive(Clone)]
+pub struct RegisteredAgentDescriptor {
+    pub name: String,
+    pub code_agent: Arc<dyn CodeAgent>,
+    pub adapter: Option<Arc<dyn AgentAdapter>>,
+    pub registration_index: usize,
+    pub capabilities: Vec<Capability>,
+    pub is_default: bool,
+    pub complexity_preferred: bool,
+}
+
+impl RegisteredAgentDescriptor {
+    pub fn code_agent(&self) -> Arc<dyn CodeAgent> {
+        self.code_agent.clone()
+    }
+
+    pub fn adapter(&self) -> Option<Arc<dyn AgentAdapter>> {
+        self.adapter.clone()
+    }
+}
+
 pub struct AgentRegistry {
-    agents: HashMap<String, Arc<dyn CodeAgent>>,
+    descriptors: HashMap<String, RegisteredAgentDescriptor>,
     registration_order: Vec<String>,
     default_agent: String,
     complexity_preferred_agents: Vec<String>,
@@ -15,7 +36,7 @@ pub struct AgentRegistry {
 impl AgentRegistry {
     pub fn new(default_agent: impl Into<String>) -> Self {
         Self {
-            agents: HashMap::new(),
+            descriptors: HashMap::new(),
             registration_order: Vec::new(),
             default_agent: default_agent.into(),
             complexity_preferred_agents: Vec::new(),
@@ -28,92 +49,165 @@ impl AgentRegistry {
             .map(|name| name.trim().to_string())
             .filter(|name| !name.is_empty())
             .collect();
+        self.refresh_metadata();
     }
 
     pub fn register(&mut self, name: impl Into<String>, agent: Arc<dyn CodeAgent>) {
+        self.register_with_adapter(name, agent, None);
+    }
+
+    pub fn register_with_adapter(
+        &mut self,
+        name: impl Into<String>,
+        agent: Arc<dyn CodeAgent>,
+        adapter: Option<Arc<dyn AgentAdapter>>,
+    ) {
         let name = name.into();
-        if !self.agents.contains_key(&name) {
-            self.registration_order.push(name.clone());
+        let registration_index = self.ensure_registration_slot(&name);
+        self.descriptors.insert(
+            name.clone(),
+            RegisteredAgentDescriptor {
+                name,
+                code_agent: agent.clone(),
+                adapter,
+                registration_index,
+                capabilities: agent.capabilities(),
+                is_default: false,
+                complexity_preferred: false,
+            },
+        );
+        self.refresh_metadata();
+    }
+
+    pub fn register_adapter(&mut self, name: impl Into<String>, adapter: Arc<dyn AgentAdapter>) {
+        let name = name.into();
+        if let Some(existing) = self.descriptors.get_mut(&name) {
+            existing.adapter = Some(adapter);
+            self.refresh_metadata();
         }
-        self.agents.insert(name, agent);
+    }
+
+    pub fn descriptor(&self, name: &str) -> Option<&RegisteredAgentDescriptor> {
+        self.descriptors.get(name)
     }
 
     pub fn get(&self, name: &str) -> Option<Arc<dyn CodeAgent>> {
-        self.agents.get(name).cloned()
+        self.get_code_agent(name)
+    }
+
+    pub fn get_code_agent(&self, name: &str) -> Option<Arc<dyn CodeAgent>> {
+        self.descriptor(name)
+            .map(RegisteredAgentDescriptor::code_agent)
+    }
+
+    pub fn get_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
+        self.descriptor(name)
+            .and_then(RegisteredAgentDescriptor::adapter)
     }
 
     pub fn resolved_default_agent_name(&self) -> Option<&str> {
         let configured = self.default_agent.trim();
         if !configured.is_empty()
             && !configured.eq_ignore_ascii_case("auto")
-            && self.agents.contains_key(configured)
+            && self.descriptors.contains_key(configured)
+            && self.descriptor_has_code_agent(configured)
         {
             return Some(configured);
         }
         self.registration_order
             .iter()
-            .find(|name| self.agents.contains_key(name.as_str()))
+            .find(|name| self.descriptor_has_code_agent(name))
             .map(String::as_str)
     }
 
     pub fn default_agent(&self) -> Option<Arc<dyn CodeAgent>> {
         self.resolved_default_agent_name()
-            .and_then(|name| self.get(name))
+            .and_then(|name| self.get_code_agent(name))
+    }
+
+    pub fn default_descriptor(&self) -> Option<&RegisteredAgentDescriptor> {
+        self.resolved_default_agent_name()
+            .and_then(|name| self.descriptor(name))
     }
 
     pub fn dispatch(
         &self,
         task: &TaskClassification,
     ) -> harness_core::error::Result<Arc<dyn CodeAgent>> {
+        self.dispatch_descriptor(task)
+            .map(|descriptor| descriptor.code_agent())
+    }
+
+    pub fn dispatch_descriptor(
+        &self,
+        task: &TaskClassification,
+    ) -> harness_core::error::Result<&RegisteredAgentDescriptor> {
         let preferred = match task.complexity {
-            TaskComplexity::Critical | TaskComplexity::Complex => self
-                .complexity_preferred_agents
-                .iter()
-                .find_map(|name| self.get(name)),
+            TaskComplexity::Critical | TaskComplexity::Complex => {
+                self.complexity_preferred_agents.iter().find_map(|name| {
+                    self.descriptor(name)
+                        .filter(|_| self.descriptor_has_code_agent(name))
+                })
+            }
             _ => None,
         };
 
         preferred
-            .or_else(|| self.default_agent())
+            .or_else(|| self.default_descriptor())
             .ok_or_else(|| HarnessError::AgentNotFound("no agents registered".to_string()))
     }
 
     pub fn list(&self) -> Vec<&str> {
-        self.registration_order.iter().map(|k| k.as_str()).collect()
+        self.list_names()
     }
-}
 
-/// Registry for streaming `AgentAdapter` implementations.
-///
-/// Coexists with `AgentRegistry` — when an adapter is available for a given
-/// agent name, the task executor prefers it over the legacy `CodeAgent` path.
-pub struct AdapterRegistry {
-    adapters: HashMap<String, Arc<dyn AgentAdapter>>,
-    default_adapter: String,
-}
+    pub fn list_names(&self) -> Vec<&str> {
+        self.registration_order
+            .iter()
+            .map(|name| name.as_str())
+            .collect()
+    }
 
-impl AdapterRegistry {
-    pub fn new(default_adapter: impl Into<String>) -> Self {
-        Self {
-            adapters: HashMap::new(),
-            default_adapter: default_adapter.into(),
+    pub fn list_descriptors(&self) -> Vec<&RegisteredAgentDescriptor> {
+        self.registration_order
+            .iter()
+            .filter_map(|name| self.descriptor(name))
+            .collect()
+    }
+
+    fn ensure_registration_slot(&mut self, name: &str) -> usize {
+        if let Some(index) = self
+            .registration_order
+            .iter()
+            .position(|existing| existing == name)
+        {
+            index
+        } else {
+            let index = self.registration_order.len();
+            self.registration_order.push(name.to_string());
+            index
         }
     }
 
-    pub fn register(&mut self, name: impl Into<String>, adapter: Arc<dyn AgentAdapter>) {
-        self.adapters.insert(name.into(), adapter);
+    fn descriptor_has_code_agent(&self, name: &str) -> bool {
+        self.descriptors.contains_key(name)
     }
 
-    pub fn get(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
-        self.adapters.get(name).cloned()
-    }
+    fn refresh_metadata(&mut self) {
+        let default_name = self.resolved_default_agent_name().map(str::to_string);
+        let preferred: HashSet<&str> = self
+            .complexity_preferred_agents
+            .iter()
+            .map(String::as_str)
+            .collect();
 
-    pub fn default_adapter(&self) -> Option<Arc<dyn AgentAdapter>> {
-        self.get(&self.default_adapter)
-    }
-
-    pub fn list(&self) -> Vec<&str> {
-        self.adapters.keys().map(|k| k.as_str()).collect()
+        for name in &self.registration_order {
+            if let Some(descriptor) = self.descriptors.get_mut(name) {
+                descriptor.is_default = default_name.as_deref() == Some(name.as_str());
+                descriptor.complexity_preferred = preferred.contains(name.as_str());
+                descriptor.capabilities = descriptor.code_agent.capabilities();
+            }
+        }
     }
 }
 
@@ -123,7 +217,7 @@ mod tests {
     use harness_core::{
         agent::AgentEvent, agent::AgentRequest, agent::AgentResponse, agent::CodeAgent,
         agent::StreamItem, agent::TaskClassification, agent::TaskComplexity, agent::TurnRequest,
-        types::Capability, types::TokenUsage,
+        types::TokenUsage,
     };
 
     struct StubAgent {
@@ -328,49 +422,164 @@ mod tests {
     }
 
     #[test]
-    fn adapter_registry_register_and_get_roundtrip() {
-        let mut registry = AdapterRegistry::new("mock");
-        registry.register(
+    fn execution_only_descriptor_has_no_adapter() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+
+        let descriptor = registry.descriptor("mock").unwrap();
+        assert_eq!(descriptor.name, "mock");
+        assert_eq!(descriptor.code_agent().name(), "mock");
+        assert!(descriptor.adapter().is_none());
+    }
+
+    #[test]
+    fn register_with_adapter_roundtrip() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register_with_adapter(
             "mock",
-            Arc::new(StubAdapter {
+            Arc::new(StubAgent { agent_name: "mock" }),
+            Some(Arc::new(StubAdapter {
                 adapter_name: "mock",
+            })),
+        );
+
+        let descriptor = registry.descriptor("mock").unwrap();
+        assert_eq!(descriptor.name, "mock");
+        assert_eq!(descriptor.code_agent().name(), "mock");
+        assert_eq!(descriptor.adapter().unwrap().name(), "mock");
+    }
+
+    #[test]
+    fn register_adapter_without_agent_is_ignored() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register_adapter(
+            "missing",
+            Arc::new(StubAdapter {
+                adapter_name: "missing",
             }),
         );
 
-        let adapter = registry.get("mock");
-        assert!(adapter.is_some());
-        assert_eq!(adapter.unwrap().name(), "mock");
+        assert!(registry.descriptor("missing").is_none());
     }
 
     #[test]
-    fn adapter_registry_default_adapter_uses_configured_name() {
-        let mut registry = AdapterRegistry::new("mock");
-        registry.register(
+    fn list_names_contains_each_registered_agent_once() {
+        let mut registry = AgentRegistry::new("a");
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+        registry.register("b", Arc::new(StubAgent { agent_name: "b" }));
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+
+        assert_eq!(registry.list_names(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn dispatch_descriptor_returns_same_descriptor_used_for_adapter_lookup() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register_with_adapter(
             "mock",
-            Arc::new(StubAdapter {
+            Arc::new(StubAgent { agent_name: "mock" }),
+            Some(Arc::new(StubAdapter {
                 adapter_name: "mock",
-            }),
+            })),
         );
 
-        let adapter = registry.default_adapter();
-        assert!(adapter.is_some());
-        assert_eq!(adapter.unwrap().name(), "mock");
+        let descriptor = registry
+            .dispatch_descriptor(&classification(TaskComplexity::Simple))
+            .unwrap();
+        assert_eq!(descriptor.code_agent().name(), "mock");
+        assert_eq!(descriptor.adapter().unwrap().name(), "mock");
     }
 
     #[test]
-    fn adapter_registry_default_adapter_missing_returns_none() {
-        let registry = AdapterRegistry::new("missing");
-        assert!(registry.default_adapter().is_none());
-    }
+    fn list_descriptors_reflects_runnable_agents_exactly_once() {
+        let mut registry = AgentRegistry::new("a");
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+        registry.register_with_adapter(
+            "b",
+            Arc::new(StubAgent { agent_name: "b" }),
+            Some(Arc::new(StubAdapter { adapter_name: "b" })),
+        );
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
 
-    #[test]
-    fn adapter_registry_list_returns_registered_names() {
-        let mut registry = AdapterRegistry::new("a");
-        registry.register("a", Arc::new(StubAdapter { adapter_name: "a" }));
-        registry.register("b", Arc::new(StubAdapter { adapter_name: "b" }));
-
-        let mut names = registry.list();
-        names.sort_unstable();
+        let names: Vec<&str> = registry
+            .list_descriptors()
+            .into_iter()
+            .map(|descriptor| descriptor.name.as_str())
+            .collect();
         assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn descriptor_metadata_tracks_registration_order() {
+        let mut registry = AgentRegistry::new("a");
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+        registry.register("b", Arc::new(StubAgent { agent_name: "b" }));
+
+        assert_eq!(registry.descriptor("a").unwrap().registration_index, 0);
+        assert_eq!(registry.descriptor("b").unwrap().registration_index, 1);
+    }
+
+    #[test]
+    fn register_adapter_adds_adapter_to_existing_descriptor() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry.register_adapter(
+            "mock",
+            Arc::new(StubAdapter {
+                adapter_name: "mock",
+            }),
+        );
+
+        assert_eq!(registry.get_adapter("mock").unwrap().name(), "mock");
+    }
+
+    #[test]
+    fn register_with_adapter_replaces_existing_descriptor_without_duplication() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry.register_with_adapter(
+            "mock",
+            Arc::new(StubAgent { agent_name: "mock" }),
+            Some(Arc::new(StubAdapter {
+                adapter_name: "mock",
+            })),
+        );
+
+        assert_eq!(registry.list_names(), vec!["mock"]);
+        assert_eq!(registry.get_adapter("mock").unwrap().name(), "mock");
+    }
+
+    #[test]
+    fn list_descriptors_preserves_registration_order() {
+        let mut registry = AgentRegistry::new("a");
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+        registry.register("b", Arc::new(StubAgent { agent_name: "b" }));
+
+        let names: Vec<&str> = registry
+            .list_descriptors()
+            .into_iter()
+            .map(|descriptor| descriptor.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn metadata_marks_default_and_complexity_preference() {
+        let mut registry = AgentRegistry::new("alpha");
+        registry.register(
+            "alpha",
+            Arc::new(StubAgent {
+                agent_name: "alpha",
+            }),
+        );
+        registry.register("beta", Arc::new(StubAgent { agent_name: "beta" }));
+        registry.set_complexity_preferences(vec!["beta".to_string()]);
+
+        let alpha = registry.descriptor("alpha").unwrap();
+        let beta = registry.descriptor("beta").unwrap();
+        assert!(alpha.is_default);
+        assert!(!alpha.complexity_preferred);
+        assert!(!beta.is_default);
+        assert!(beta.complexity_preferred);
     }
 }

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -501,17 +501,22 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
         ),
         None,
     );
-    agent_registry.register_with_adapter(
+    let codex_cli_path = config.agents.codex.cli_path.clone();
+    let codex_sandbox_mode = config.agents.sandbox_mode;
+    let codex_cloud = config.agents.codex.cloud.clone();
+    agent_registry.register_with_fresh_adapter(
         "codex",
         Arc::new(
             CodexAgent::from_config(config.agents.codex.clone(), config.agents.sandbox_mode)
                 .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
-        Some(Arc::new(CodexAdapter::new(
-            config.agents.codex.cli_path.clone(),
-            config.agents.sandbox_mode,
-            config.agents.codex.cloud.clone(),
-        ))),
+        move || {
+            CodexAdapter::new(
+                codex_cli_path.clone(),
+                codex_sandbox_mode,
+                codex_cloud.clone(),
+            )
+        },
     );
 
     let default_agent_name = agent_registry

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use harness_agents::{
-    claude::ClaudeCodeAgent, claude_adapter::ClaudeAdapter, codex::CodexAgent,
-    codex_adapter::CodexAdapter, registry::AgentRegistry,
+    claude::ClaudeCodeAgent, codex::CodexAgent, codex_adapter::CodexAdapter,
+    registry::AgentRegistry,
 };
 use harness_core::{agent::AgentRequest, config::HarnessConfig, prompts, types::ThreadId};
 use serde::Deserialize;
@@ -499,10 +499,7 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
             .with_no_session_persistence_probe()
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
-        Some(Arc::new(ClaudeAdapter::new(
-            config.agents.claude.cli_path.clone(),
-            config.agents.claude.default_model.clone(),
-        ))),
+        None,
     );
     agent_registry.register_with_adapter(
         "codex",
@@ -512,6 +509,8 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
         ),
         Some(Arc::new(CodexAdapter::new(
             config.agents.codex.cli_path.clone(),
+            config.agents.sandbox_mode,
+            config.agents.codex.cloud.clone(),
         ))),
     );
 

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -1,5 +1,8 @@
 use anyhow::Context;
-use harness_agents::{claude::ClaudeCodeAgent, codex::CodexAgent, registry::AgentRegistry};
+use harness_agents::{
+    claude::ClaudeCodeAgent, claude_adapter::ClaudeAdapter, codex::CodexAgent,
+    codex_adapter::CodexAdapter, registry::AgentRegistry,
+};
 use harness_core::{agent::AgentRequest, config::HarnessConfig, prompts, types::ThreadId};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -43,8 +46,8 @@ impl PromptExecutor for RegistryExecutor {
         project_root: PathBuf,
         prompt: String,
     ) -> anyhow::Result<String> {
-        let code_agent = self.agent_registry.get(agent).with_context(|| {
-            let available = self.agent_registry.list().join(", ");
+        let code_agent = self.agent_registry.get_code_agent(agent).with_context(|| {
+            let available = self.agent_registry.list_names().join(", ");
             format!("unknown agent `{agent}` (available: [{available}])")
         })?;
 
@@ -485,7 +488,7 @@ async fn write_json_line(stdout: &mut tokio::io::Stdout, value: &Value) -> anyho
 pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
     let mut agent_registry = AgentRegistry::new(&config.agents.default_agent);
     agent_registry.set_complexity_preferences(config.agents.complexity_preferred_agents.clone());
-    agent_registry.register(
+    agent_registry.register_with_adapter(
         "claude",
         Arc::new(
             ClaudeCodeAgent::new(
@@ -496,13 +499,20 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
             .with_no_session_persistence_probe()
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
+        Some(Arc::new(ClaudeAdapter::new(
+            config.agents.claude.cli_path.clone(),
+            config.agents.claude.default_model.clone(),
+        ))),
     );
-    agent_registry.register(
+    agent_registry.register_with_adapter(
         "codex",
         Arc::new(
             CodexAgent::from_config(config.agents.codex.clone(), config.agents.sandbox_mode)
                 .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
+        Some(Arc::new(CodexAdapter::new(
+            config.agents.codex.cli_path.clone(),
+        ))),
     );
 
     let default_agent_name = agent_registry

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use harness_agents::{claude_adapter::ClaudeAdapter, codex_adapter::CodexAdapter};
+use harness_agents::codex_adapter::CodexAdapter;
 use harness_core::config::HarnessConfig;
 use harness_server::project_registry::validate_project_root;
 use std::path::PathBuf;
@@ -143,12 +143,10 @@ pub async fn run(
         claude_agent = claude_agent.with_reasoning_budget(budget);
     }
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
-    let claude_cli_path = serve_config.agents.claude.cli_path.clone();
-    let claude_default_model = serve_config.agents.claude.default_model.clone();
-    agent_registry.register_with_fresh_adapter("claude", Arc::new(claude_agent), move || {
-        ClaudeAdapter::new(claude_cli_path.clone(), claude_default_model.clone())
-    });
+    agent_registry.register("claude", Arc::new(claude_agent));
     let codex_cli_path = serve_config.agents.codex.cli_path.clone();
+    let codex_cloud = serve_config.agents.codex.cloud.clone();
+    let codex_sandbox_mode = serve_config.agents.sandbox_mode;
     agent_registry.register_with_fresh_adapter(
         "codex",
         Arc::new(
@@ -158,7 +156,13 @@ pub async fn run(
             )
             .with_stream_timeout(serve_config.agents.stream_timeout_secs),
         ),
-        move || CodexAdapter::new(codex_cli_path.clone()),
+        move || {
+            CodexAdapter::new(
+                codex_cli_path.clone(),
+                codex_sandbox_mode,
+                codex_cloud.clone(),
+            )
+        },
     );
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
         agent_registry.register(

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -143,15 +143,13 @@ pub async fn run(
         claude_agent = claude_agent.with_reasoning_budget(budget);
     }
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
-    agent_registry.register_with_adapter(
-        "claude",
-        Arc::new(claude_agent),
-        Some(Arc::new(ClaudeAdapter::new(
-            serve_config.agents.claude.cli_path.clone(),
-            serve_config.agents.claude.default_model.clone(),
-        ))),
-    );
-    agent_registry.register_with_adapter(
+    let claude_cli_path = serve_config.agents.claude.cli_path.clone();
+    let claude_default_model = serve_config.agents.claude.default_model.clone();
+    agent_registry.register_with_fresh_adapter("claude", Arc::new(claude_agent), move || {
+        ClaudeAdapter::new(claude_cli_path.clone(), claude_default_model.clone())
+    });
+    let codex_cli_path = serve_config.agents.codex.cli_path.clone();
+    agent_registry.register_with_fresh_adapter(
         "codex",
         Arc::new(
             harness_agents::codex::CodexAgent::from_config(
@@ -160,9 +158,7 @@ pub async fn run(
             )
             .with_stream_timeout(serve_config.agents.stream_timeout_secs),
         ),
-        Some(Arc::new(CodexAdapter::new(
-            serve_config.agents.codex.cli_path.clone(),
-        ))),
+        move || CodexAdapter::new(codex_cli_path.clone()),
     );
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
         agent_registry.register(

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use harness_agents::{claude_adapter::ClaudeAdapter, codex_adapter::CodexAdapter};
 use harness_core::config::HarnessConfig;
 use harness_server::project_registry::validate_project_root;
 use std::path::PathBuf;
@@ -142,8 +143,15 @@ pub async fn run(
         claude_agent = claude_agent.with_reasoning_budget(budget);
     }
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
-    agent_registry.register("claude", Arc::new(claude_agent));
-    agent_registry.register(
+    agent_registry.register_with_adapter(
+        "claude",
+        Arc::new(claude_agent),
+        Some(Arc::new(ClaudeAdapter::new(
+            serve_config.agents.claude.cli_path.clone(),
+            serve_config.agents.claude.default_model.clone(),
+        ))),
+    );
+    agent_registry.register_with_adapter(
         "codex",
         Arc::new(
             harness_agents::codex::CodexAgent::from_config(
@@ -152,6 +160,9 @@ pub async fn run(
             )
             .with_stream_timeout(serve_config.agents.stream_timeout_secs),
         ),
+        Some(Arc::new(CodexAdapter::new(
+            serve_config.agents.codex.cli_path.clone(),
+        ))),
     );
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
         agent_registry.register(

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -561,29 +561,26 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             .agent_registry
             .resolved_default_agent_name()
             .map(|s| s.to_owned());
-        let all_names: Vec<String> = server
+        let challenger = server
             .agent_registry
-            .list()
-            .iter()
-            .map(|&s| s.to_owned())
-            .collect();
-        let challenger = all_names.iter().find_map(|name| {
-            if Some(name.as_str()) == default_name.as_deref() {
-                return None;
-            }
-            let agent = server.agent_registry.get(name)?;
-            if agent.capabilities().iter().any(|c| {
-                matches!(
-                    c,
-                    harness_core::types::Capability::Write
-                        | harness_core::types::Capability::Execute
-                )
-            }) {
-                None
-            } else {
-                Some(agent)
-            }
-        });
+            .list_descriptors()
+            .into_iter()
+            .find_map(|descriptor| {
+                if Some(descriptor.name.as_str()) == default_name.as_deref() {
+                    return None;
+                }
+                if descriptor.capabilities.iter().any(|c| {
+                    matches!(
+                        c,
+                        harness_core::types::Capability::Write
+                            | harness_core::types::Capability::Execute
+                    )
+                }) {
+                    None
+                } else {
+                    Some(descriptor.code_agent())
+                }
+            });
         Arc::new(crate::quality_trigger::QualityTrigger::new(
             events.clone(),
             gc_agent.clone(),
@@ -1104,12 +1101,10 @@ pub(crate) fn resolve_reviewer(
         return (None, config.clone());
     }
 
-    // Auto-select: first agent != implementor
-    for name in registry.list() {
-        if name != implementor_name {
-            if let Some(agent) = registry.get(name) {
-                return (Some(agent), config.clone());
-            }
+    // Auto-select: first registered descriptor != implementor
+    for descriptor in registry.list_descriptors() {
+        if descriptor.name != implementor_name {
+            return (Some(descriptor.code_agent()), config.clone());
         }
     }
 

--- a/crates/harness-server/src/router/mod.rs
+++ b/crates/harness-server/src/router/mod.rs
@@ -193,7 +193,7 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> Option<RpcResp
 
         // === Agent management ===
         Method::AgentList => {
-            let agents = state.core.server.agent_registry.list();
+            let agents = state.core.server.agent_registry.list_names();
             Some(RpcResponse::success(
                 id,
                 serde_json::json!({ "agents": agents }),

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -1886,6 +1886,50 @@ async fn run_turn_lifecycle_uses_fresh_adapter_instance_per_turn() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn run_turn_lifecycle_claude_without_adapter_leaves_approval_unsupported(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("claude");
+    registry.register("claude", Arc::new(TestAgent::new("claude")));
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id,
+        turn_id.clone(),
+        "prompt".to_string(),
+        "claude".to_string(),
+    )
+    .await;
+
+    let result = server
+        .thread_manager
+        .respond_approval_on_turn(
+            &turn_id,
+            "req-1".to_string(),
+            harness_core::agent::ApprovalDecision::Accept,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "claude server turns should stay on CodeAgent path and not register live approval adapter"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn run_turn_lifecycle_without_adapter_leaves_approval_unsupported() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let mut registry = AgentRegistry::new("plain");

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -8,8 +8,10 @@ use crate::{
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
 use harness_protocol::{methods::Method, methods::RpcRequest, methods::INTERNAL_ERROR};
+use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tokio::time::{timeout, Duration};
 
 async fn make_test_state_with_config_and_registry(
     dir: &std::path::Path,
@@ -1441,6 +1443,241 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         task_svc,
         execution_svc,
     })
+}
+
+#[tokio::test]
+async fn agent_list_returns_registered_agents_once_in_order() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("alpha");
+    registry.register("alpha", Arc::new(TestAgent::new("alpha")));
+    registry.register_with_adapter(
+        "beta",
+        Arc::new(TestAgent::new("beta")),
+        Some(Arc::new(crate::test_helpers::NoopTestAdapter::new("beta"))),
+    );
+    registry.register("alpha", Arc::new(TestAgent::new("alpha")));
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(json!(1)),
+        method: Method::AgentList,
+    };
+    let resp = handle_request(&state, req)
+        .await
+        .expect("expected response for agent list");
+
+    assert!(
+        resp.error.is_none(),
+        "agent list should succeed: {:?}",
+        resp.error
+    );
+    assert_eq!(resp.result.unwrap()["agents"], json!(["alpha", "beta"]));
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_registers_active_adapter_from_descriptor() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("streaming");
+    registry.register_with_adapter(
+        "streaming",
+        Arc::new(TestAgent::new("streaming")),
+        Some(Arc::new(crate::test_helpers::NoopTestAdapter::new(
+            "streaming",
+        ))),
+    );
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    let lifecycle = tokio::spawn(crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "streaming".to_string(),
+    ));
+
+    timeout(Duration::from_millis(200), async {
+        loop {
+            if server
+                .thread_manager
+                .respond_approval_on_turn(
+                    &turn_id,
+                    "req-1".to_string(),
+                    harness_core::agent::ApprovalDecision::Accept,
+                )
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+
+    lifecycle.await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_without_adapter_leaves_approval_unsupported() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("plain");
+    registry.register("plain", Arc::new(TestAgent::new("plain")));
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id,
+        turn_id.clone(),
+        "prompt".to_string(),
+        "plain".to_string(),
+    )
+    .await;
+
+    let result = server
+        .thread_manager
+        .respond_approval_on_turn(
+            &turn_id,
+            "req-1".to_string(),
+            harness_core::agent::ApprovalDecision::Accept,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "plain agent should not register an active adapter"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_unknown_agent_records_not_found_error() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_config_and_registry(
+        dir.path(),
+        HarnessConfig::default(),
+        AgentRegistry::new("missing"),
+    )
+    .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "missing".to_string(),
+    )
+    .await;
+
+    let thread = server
+        .thread_manager
+        .get_thread(&thread_id)
+        .expect("thread should exist");
+    let turn = thread
+        .turns
+        .iter()
+        .find(|turn| turn.id == turn_id)
+        .expect("turn should exist");
+    assert!(turn.items.iter().any(|item| matches!(
+        item,
+        harness_core::types::Item::Error { message, .. }
+        if message.contains("agent `missing` not found in registry")
+    )));
+    Ok(())
+}
+
+struct TestAgent {
+    name: &'static str,
+}
+
+impl TestAgent {
+    fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+}
+
+#[async_trait::async_trait]
+impl harness_core::agent::CodeAgent for TestAgent {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn capabilities(&self) -> Vec<harness_core::types::Capability> {
+        vec![]
+    }
+
+    async fn execute(
+        &self,
+        _req: harness_core::agent::AgentRequest,
+    ) -> harness_core::error::Result<harness_core::agent::AgentResponse> {
+        Ok(harness_core::agent::AgentResponse {
+            output: String::new(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: harness_core::types::TokenUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+                cost_usd: 0.0,
+            },
+            model: self.name.to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: harness_core::agent::AgentRequest,
+        tx: tokio::sync::mpsc::Sender<harness_core::agent::StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        tx.send(harness_core::agent::StreamItem::ApprovalRequest {
+            id: "req-1".to_string(),
+            command: "echo test".to_string(),
+        })
+        .await
+        .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        tx.send(harness_core::agent::StreamItem::Done)
+            .await
+            .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        Ok(())
+    }
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -6,11 +6,17 @@ use crate::{
     thread_manager::ThreadManager,
 };
 use harness_agents::registry::AgentRegistry;
-use harness_core::config::HarnessConfig;
+use harness_core::{
+    agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest},
+    config::HarnessConfig,
+};
 use harness_protocol::{methods::Method, methods::RpcRequest, methods::INTERNAL_ERROR};
 use serde_json::json;
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::sync::{oneshot, Mutex, RwLock};
 use tokio::time::{timeout, Duration};
 
 async fn make_test_state_with_config_and_registry(
@@ -1515,11 +1521,7 @@ async fn run_turn_lifecycle_registers_active_adapter_from_descriptor() -> anyhow
         loop {
             if server
                 .thread_manager
-                .respond_approval_on_turn(
-                    &turn_id,
-                    "req-1".to_string(),
-                    harness_core::agent::ApprovalDecision::Accept,
-                )
+                .respond_approval_on_turn(&turn_id, "req-1".to_string(), ApprovalDecision::Accept)
                 .await
                 .is_ok()
             {
@@ -1532,6 +1534,210 @@ async fn run_turn_lifecycle_registers_active_adapter_from_descriptor() -> anyhow
 
     lifecycle.await?;
     Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_starts_codex_style_adapter_for_live_controls() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("codex");
+    let adapter = Arc::new(RecordingAdapter::new());
+    registry.register_with_adapter(
+        "codex",
+        Arc::new(TestAgent::new("codex")),
+        Some(adapter.clone()),
+    );
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    let lifecycle = tokio::spawn(crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "codex".to_string(),
+    ));
+
+    adapter.wait_until_started().await?;
+
+    server
+        .thread_manager
+        .steer_active_turn(&thread_id, &turn_id, "please adjust".to_string())
+        .await?;
+    server
+        .thread_manager
+        .respond_approval_on_turn(&turn_id, "req-1".to_string(), ApprovalDecision::Accept)
+        .await?;
+
+    lifecycle.await?;
+
+    assert!(
+        adapter.started.load(Ordering::SeqCst),
+        "adapter start_turn must be invoked for live-controlled turns"
+    );
+    assert_eq!(
+        adapter.take_steers().await,
+        vec!["please adjust".to_string()],
+        "steer should reach the live adapter"
+    );
+    assert_eq!(
+        adapter.take_approvals().await,
+        vec![("req-1".to_string(), ApprovalDecision::Accept)],
+        "approval should reach the live adapter"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_does_not_expose_unstarted_adapter_controls() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("codex");
+    registry.register_with_adapter(
+        "codex",
+        Arc::new(TestAgent::new("codex")),
+        Some(Arc::new(crate::test_helpers::NoopTestAdapter::new("codex"))),
+    );
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "codex".to_string(),
+    )
+    .await;
+
+    let steer_err = server
+        .thread_manager
+        .steer_active_turn(&thread_id, &turn_id, "please adjust".to_string())
+        .await
+        .expect_err("completed turn must not retain active adapter control");
+    assert!(
+        steer_err.to_string().contains("no active adapter"),
+        "expected no-active-adapter error, got: {steer_err}"
+    );
+    Ok(())
+}
+
+#[derive(Default)]
+struct RecordingState {
+    steers: Vec<String>,
+    approvals: Vec<(String, ApprovalDecision)>,
+}
+
+struct RecordingAdapter {
+    started: AtomicBool,
+    state: Mutex<RecordingState>,
+    started_tx: Mutex<Option<oneshot::Sender<()>>>,
+    started_rx: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl RecordingAdapter {
+    fn new() -> Self {
+        let (started_tx, started_rx) = oneshot::channel();
+        Self {
+            started: AtomicBool::new(false),
+            state: Mutex::new(RecordingState::default()),
+            started_tx: Mutex::new(Some(started_tx)),
+            started_rx: Mutex::new(Some(started_rx)),
+        }
+    }
+
+    async fn wait_until_started(&self) -> anyhow::Result<()> {
+        if self.started.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        let mut receiver = self.started_rx.lock().await;
+        let Some(rx) = receiver.take() else {
+            anyhow::bail!("start notification receiver missing")
+        };
+        rx.await.map_err(|err| anyhow::anyhow!(err.to_string()))
+    }
+
+    async fn take_steers(&self) -> Vec<String> {
+        let mut state = self.state.lock().await;
+        std::mem::take(&mut state.steers)
+    }
+
+    async fn take_approvals(&self) -> Vec<(String, ApprovalDecision)> {
+        let mut state = self.state.lock().await;
+        std::mem::take(&mut state.approvals)
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for RecordingAdapter {
+    fn name(&self) -> &str {
+        "recording"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        self.started.store(true, Ordering::SeqCst);
+        if let Some(started_tx) = self.started_tx.lock().await.take() {
+            let _ = started_tx.send(());
+        }
+        tx.send(AgentEvent::TurnStarted)
+            .await
+            .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        tx.send(AgentEvent::ApprovalRequest {
+            id: "req-1".to_string(),
+            command: "echo test".to_string(),
+        })
+        .await
+        .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tx.send(AgentEvent::TurnCompleted {
+            output: "done".to_string(),
+        })
+        .await
+        .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn steer(&self, text: String) -> harness_core::error::Result<()> {
+        self.state.lock().await.steers.push(text);
+        Ok(())
+    }
+
+    async fn respond_approval(
+        &self,
+        id: String,
+        decision: ApprovalDecision,
+    ) -> harness_core::error::Result<()> {
+        self.state.lock().await.approvals.push((id, decision));
+        Ok(())
+    }
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -9,11 +9,12 @@ use harness_agents::registry::AgentRegistry;
 use harness_core::{
     agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest},
     config::HarnessConfig,
+    types::TurnStatus,
 };
 use harness_protocol::{methods::Method, methods::RpcRequest, methods::INTERNAL_ERROR};
 use serde_json::json;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc,
 };
 use tokio::sync::{oneshot, Mutex, RwLock};
@@ -1488,12 +1489,12 @@ async fn agent_list_returns_registered_agents_once_in_order() -> anyhow::Result<
 async fn run_turn_lifecycle_registers_active_adapter_from_descriptor() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let mut registry = AgentRegistry::new("streaming");
+    let adapter_log = Arc::new(RecordingAdapterLog::default());
+    let adapter = Arc::new(RecordingAdapter::new(adapter_log));
     registry.register_with_adapter(
         "streaming",
         Arc::new(TestAgent::new("streaming")),
-        Some(Arc::new(crate::test_helpers::NoopTestAdapter::new(
-            "streaming",
-        ))),
+        Some(adapter),
     );
     let state =
         make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
@@ -1540,7 +1541,8 @@ async fn run_turn_lifecycle_registers_active_adapter_from_descriptor() -> anyhow
 async fn run_turn_lifecycle_starts_codex_style_adapter_for_live_controls() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let mut registry = AgentRegistry::new("codex");
-    let adapter = Arc::new(RecordingAdapter::new());
+    let adapter_log = Arc::new(RecordingAdapterLog::default());
+    let adapter = Arc::new(RecordingAdapter::new(adapter_log));
     registry.register_with_adapter(
         "codex",
         Arc::new(TestAgent::new("codex")),
@@ -1636,8 +1638,18 @@ async fn run_turn_lifecycle_does_not_expose_unstarted_adapter_controls() -> anyh
         .await
         .expect_err("completed turn must not retain active adapter control");
     assert!(
-        steer_err.to_string().contains("no active adapter"),
-        "expected no-active-adapter error, got: {steer_err}"
+        steer_err.to_string().contains("not in Running state"),
+        "expected completed turn to reject live steering, got: {steer_err}"
+    );
+
+    let approval_err = server
+        .thread_manager
+        .respond_approval_on_turn(&turn_id, "req-1".to_string(), ApprovalDecision::Accept)
+        .await
+        .expect_err("completed turn must not retain approval control");
+    assert!(
+        approval_err.to_string().contains("no active adapter"),
+        "expected adapter deregistration after completion, got: {approval_err}"
     );
     Ok(())
 }
@@ -1648,18 +1660,25 @@ struct RecordingState {
     approvals: Vec<(String, ApprovalDecision)>,
 }
 
+#[derive(Default)]
+struct RecordingAdapterLog {
+    started_instances: AtomicUsize,
+}
+
 struct RecordingAdapter {
     started: AtomicBool,
+    log: Arc<RecordingAdapterLog>,
     state: Mutex<RecordingState>,
     started_tx: Mutex<Option<oneshot::Sender<()>>>,
     started_rx: Mutex<Option<oneshot::Receiver<()>>>,
 }
 
 impl RecordingAdapter {
-    fn new() -> Self {
+    fn new(log: Arc<RecordingAdapterLog>) -> Self {
         let (started_tx, started_rx) = oneshot::channel();
         Self {
             started: AtomicBool::new(false),
+            log,
             state: Mutex::new(RecordingState::default()),
             started_tx: Mutex::new(Some(started_tx)),
             started_rx: Mutex::new(Some(started_rx)),
@@ -1699,6 +1718,7 @@ impl AgentAdapter for RecordingAdapter {
         _req: TurnRequest,
         tx: tokio::sync::mpsc::Sender<AgentEvent>,
     ) -> harness_core::error::Result<()> {
+        self.log.started_instances.fetch_add(1, Ordering::SeqCst);
         self.started.store(true, Ordering::SeqCst);
         if let Some(started_tx) = self.started_tx.lock().await.take() {
             let _ = started_tx.send(());
@@ -1738,6 +1758,131 @@ impl AgentAdapter for RecordingAdapter {
         self.state.lock().await.approvals.push((id, decision));
         Ok(())
     }
+}
+
+struct ErrorThenCompleteAdapter;
+
+#[async_trait::async_trait]
+impl AgentAdapter for ErrorThenCompleteAdapter {
+    fn name(&self) -> &str {
+        "error_then_complete"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        tx.send(AgentEvent::TurnStarted)
+            .await
+            .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        tx.send(AgentEvent::Error {
+            message: "adapter exploded".to_string(),
+        })
+        .await
+        .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        tx.send(AgentEvent::TurnCompleted {
+            output: "should not succeed".to_string(),
+        })
+        .await
+        .map_err(|err| harness_core::error::HarnessError::AgentExecution(err.to_string()))?;
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_marks_turn_failed_when_adapter_emits_error_event() -> anyhow::Result<()>
+{
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("claude");
+    registry.register_with_adapter(
+        "claude",
+        Arc::new(TestAgent::new("claude")),
+        Some(Arc::new(ErrorThenCompleteAdapter)),
+    );
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+    let turn_id = server.thread_manager.start_turn(
+        &thread_id,
+        "prompt".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+
+    crate::task_executor::run_turn_lifecycle(
+        server.clone(),
+        state.core.thread_db.clone(),
+        state.notifications.notify_tx.clone(),
+        state.notifications.notification_tx.clone(),
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "claude".to_string(),
+    )
+    .await;
+
+    let turn = server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn missing after lifecycle"))?;
+    assert_eq!(turn.status, TurnStatus::Failed);
+    assert!(
+        turn.items.iter().any(|item| matches!(
+            item,
+            harness_core::types::Item::Error { message, .. }
+            if message.contains("adapter exploded")
+        )),
+        "adapter error should be persisted on the failed turn"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_turn_lifecycle_uses_fresh_adapter_instance_per_turn() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut registry = AgentRegistry::new("codex");
+    let adapter_log = Arc::new(RecordingAdapterLog::default());
+    let adapter_log_for_factory = adapter_log.clone();
+    registry.register_with_fresh_adapter("codex", Arc::new(TestAgent::new("codex")), move || {
+        RecordingAdapter::new(adapter_log_for_factory.clone())
+    });
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), HarnessConfig::default(), registry)
+            .await?;
+    let server = state.core.server.clone();
+    let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+
+    for prompt in ["prompt one", "prompt two"] {
+        let turn_id = server.thread_manager.start_turn(
+            &thread_id,
+            prompt.to_string(),
+            harness_core::types::AgentId::new(),
+        )?;
+        crate::task_executor::run_turn_lifecycle(
+            server.clone(),
+            state.core.thread_db.clone(),
+            state.notifications.notify_tx.clone(),
+            state.notifications.notification_tx.clone(),
+            thread_id.clone(),
+            turn_id,
+            prompt.to_string(),
+            "codex".to_string(),
+        )
+        .await;
+    }
+
+    assert_eq!(
+        adapter_log.started_instances.load(Ordering::SeqCst),
+        2,
+        "each turn must start on a fresh adapter instance"
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1,5 +1,5 @@
 use crate::thread_manager::ThreadManager;
-use harness_agents::registry::{AdapterRegistry, AgentRegistry};
+use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -8,7 +8,6 @@ pub struct HarnessServer {
     pub config: HarnessConfig,
     pub thread_manager: ThreadManager,
     pub agent_registry: Arc<AgentRegistry>,
-    pub adapter_registry: Arc<AdapterRegistry>,
     /// Extra projects to register in the project registry at startup (from --project CLI flags).
     pub startup_projects: Vec<(String, std::path::PathBuf)>,
 }
@@ -23,7 +22,6 @@ impl HarnessServer {
             config,
             thread_manager,
             agent_registry: Arc::new(agent_registry),
-            adapter_registry: Arc::new(AdapterRegistry::new("")),
             startup_projects: Vec::new(),
         }
     }

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -160,7 +160,7 @@ impl DefaultExecutionService {
         req: &CreateTaskRequest,
     ) -> Result<Arc<dyn harness_core::agent::CodeAgent>, EnqueueTaskError> {
         if let Some(name) = &req.agent {
-            self.agent_registry.get(name).ok_or_else(|| {
+            self.agent_registry.get_code_agent(name).ok_or_else(|| {
                 EnqueueTaskError::BadRequest(format!("agent '{name}' not registered"))
             })
         } else {

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -170,7 +170,7 @@ pub(crate) async fn run_turn_lifecycle(
         return;
     };
 
-    let Some(agent) = server.agent_registry.get(&agent_name) else {
+    let Some(descriptor) = server.agent_registry.descriptor(&agent_name) else {
         let msg = format!("agent `{agent_name}` not found in registry");
         if let Err(e) = server.thread_manager.add_item(
             &thread_id,
@@ -194,6 +194,7 @@ pub(crate) async fn run_turn_lifecycle(
         .await;
         return;
     };
+    let agent = descriptor.code_agent();
 
     // RAII guard: ensures the adapter is deregistered when the turn scope exits,
     // even if the task is cancelled before reaching the end of this function.
@@ -209,10 +210,9 @@ pub(crate) async fn run_turn_lifecycle(
         }
     }
 
-    // Register adapter for this turn if one is configured for this agent name.
+    // Register adapter for this turn if one is configured for this descriptor.
     // Enables turn/steer and turn/respond_approval to reach the live process.
-    // Gracefully no-ops when no adapter is registered (adapter_registry is empty by default).
-    let _adapter_guard = server.adapter_registry.get(&agent_name).map(|adapter_arc| {
+    let _adapter_guard = descriptor.adapter().map(|adapter_arc| {
         server
             .thread_manager
             .register_active_adapter(&turn_id, adapter_arc.clone());

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -195,6 +195,7 @@ pub(crate) async fn run_turn_lifecycle(
         return;
     };
     let agent = descriptor.code_agent();
+    let adapter = descriptor.adapter();
 
     // RAII guard: ensures the adapter is deregistered when the turn scope exits,
     // even if the task is cancelled before reaching the end of this function.
@@ -210,73 +211,203 @@ pub(crate) async fn run_turn_lifecycle(
         }
     }
 
-    // Register adapter for this turn if one is configured for this descriptor.
-    // Enables turn/steer and turn/respond_approval to reach the live process.
-    let _adapter_guard = descriptor.adapter().map(|adapter_arc| {
-        server
-            .thread_manager
-            .register_active_adapter(&turn_id, adapter_arc.clone());
-        AdapterGuard {
-            server: server.clone(),
-            turn_id: turn_id.clone(),
-        }
-    });
-
     let req = AgentRequest {
-        prompt,
-        project_root,
+        prompt: prompt.clone(),
+        project_root: project_root.clone(),
         ..Default::default()
     };
 
+    let turn_req = harness_core::agent::TurnRequest {
+        prompt,
+        project_root,
+        model: None,
+        allowed_tools: Vec::new(),
+        context: Vec::new(),
+        timeout_secs: None,
+    };
+
     let stall_timeout = Duration::from_secs(server.config.concurrency.stall_timeout_secs);
-    let (stream_tx, mut stream_rx) = mpsc::channel(128);
-    let mut execution = std::pin::pin!(agent.execute_stream(req, stream_tx));
     let mut stream_closed = false;
     let mut execution_result: Option<harness_core::error::Result<()>> = None;
     let mut last_activity = Instant::now();
 
-    'outer: while execution_result.is_none() || !stream_closed {
-        tokio::select! {
-            result = &mut execution, if execution_result.is_none() => {
-                execution_result = Some(result);
-            }
-            incoming = stream_rx.recv(), if !stream_closed => {
-                match incoming {
-                    Some(item) => {
-                        last_activity = Instant::now();
-                        process_stream_item(
-                            &server,
-                            &thread_db,
-                            &notify_tx,
-                            &notification_tx,
-                            &thread_id,
-                            &turn_id,
-                            item,
-                        ).await;
-                    }
-                    None => {
-                        stream_closed = true;
+    if let Some(adapter_arc) = adapter {
+        server
+            .thread_manager
+            .register_active_adapter(&turn_id, adapter_arc.clone());
+        let _adapter_guard = AdapterGuard {
+            server: server.clone(),
+            turn_id: turn_id.clone(),
+        };
+
+        let (event_tx, mut event_rx) = mpsc::channel(128);
+        let mut execution = std::pin::pin!(adapter_arc.start_turn(turn_req, event_tx));
+
+        'outer: while execution_result.is_none() || !stream_closed {
+            tokio::select! {
+                result = &mut execution, if execution_result.is_none() => {
+                    execution_result = Some(result);
+                }
+                incoming = event_rx.recv(), if !stream_closed => {
+                    match incoming {
+                        Some(event) => {
+                            last_activity = Instant::now();
+                            match event {
+                                harness_core::agent::AgentEvent::TurnStarted => {}
+                                harness_core::agent::AgentEvent::ItemStarted { item_type } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::ItemStarted {
+                                            item: harness_core::types::Item::AgentReasoning {
+                                                content: format!("started: {item_type}"),
+                                            },
+                                        },
+                                    ).await;
+                                }
+                                harness_core::agent::AgentEvent::MessageDelta { text } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::MessageDelta { text },
+                                    ).await;
+                                }
+                                harness_core::agent::AgentEvent::ToolCall { name, input } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::ItemCompleted {
+                                            item: harness_core::types::Item::ToolCall {
+                                                name,
+                                                input,
+                                                output: None,
+                                            },
+                                        },
+                                    ).await;
+                                }
+                                harness_core::agent::AgentEvent::ApprovalRequest { id, command } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::ApprovalRequest { id, command },
+                                    ).await;
+                                }
+                                harness_core::agent::AgentEvent::ItemCompleted => {}
+                                harness_core::agent::AgentEvent::TurnCompleted { output } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::ItemCompleted {
+                                            item: harness_core::types::Item::AgentReasoning { content: output },
+                                        },
+                                    ).await;
+                                }
+                                harness_core::agent::AgentEvent::Error { message } => {
+                                    process_stream_item(
+                                        &server,
+                                        &thread_db,
+                                        &notify_tx,
+                                        &notification_tx,
+                                        &thread_id,
+                                        &turn_id,
+                                        StreamItem::Error { message },
+                                    ).await;
+                                }
+                            }
+                        }
+                        None => {
+                            stream_closed = true;
+                        }
                     }
                 }
-            }
-            _ = tokio::time::sleep_until(last_activity + stall_timeout) => {
-                let elapsed = last_activity.elapsed();
-                tracing::warn!(
-                    thread_id = %thread_id,
-                    turn_id = %turn_id,
-                    elapsed_secs = elapsed.as_secs(),
-                    "agent stream stall detected; no output for {}s",
-                    stall_timeout.as_secs()
-                );
-                // Store the stall reason as the execution result so the Err branch
-                // below appends a stall-specific Item::Error before marking failed.
-                execution_result = Some(Err(HarnessError::AgentExecution(format!(
-                    "Agent stream stalled: no output for {}s",
-                    stall_timeout.as_secs()
-                ))));
-                break 'outer;
+                _ = tokio::time::sleep_until(last_activity + stall_timeout) => {
+                    let elapsed = last_activity.elapsed();
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        turn_id = %turn_id,
+                        elapsed_secs = elapsed.as_secs(),
+                        "agent stream stall detected; no output for {}s",
+                        stall_timeout.as_secs()
+                    );
+                    execution_result = Some(Err(HarnessError::AgentExecution(format!(
+                        "Agent stream stalled: no output for {}s",
+                        stall_timeout.as_secs()
+                    ))));
+                    break 'outer;
+                }
             }
         }
+    } else {
+        let (stream_tx, mut stream_rx) = mpsc::channel(128);
+        let mut execution = std::pin::pin!(agent.execute_stream(req, stream_tx));
+
+        'outer: while execution_result.is_none() || !stream_closed {
+            tokio::select! {
+                result = &mut execution, if execution_result.is_none() => {
+                    execution_result = Some(result);
+                }
+                incoming = stream_rx.recv(), if !stream_closed => {
+                    match incoming {
+                        Some(item) => {
+                            last_activity = Instant::now();
+                            process_stream_item(
+                                &server,
+                                &thread_db,
+                                &notify_tx,
+                                &notification_tx,
+                                &thread_id,
+                                &turn_id,
+                                item,
+                            ).await;
+                        }
+                        None => {
+                            stream_closed = true;
+                        }
+                    }
+                }
+                _ = tokio::time::sleep_until(last_activity + stall_timeout) => {
+                    let elapsed = last_activity.elapsed();
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        turn_id = %turn_id,
+                        elapsed_secs = elapsed.as_secs(),
+                        "agent stream stall detected; no output for {}s",
+                        stall_timeout.as_secs()
+                    );
+                    // Store the stall reason as the execution result so the Err branch
+                    // below appends a stall-specific Item::Error before marking failed.
+                    execution_result = Some(Err(HarnessError::AgentExecution(format!(
+                        "Agent stream stalled: no output for {}s",
+                        stall_timeout.as_secs()
+                    ))));
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    if execution_result.is_none() {
+        execution_result = Some(Ok(()));
     }
 
     match execution_result.unwrap_or_else(|| {

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -330,8 +330,12 @@ pub(crate) async fn run_turn_lifecycle(
                                         &notification_tx,
                                         &thread_id,
                                         &turn_id,
-                                        StreamItem::Error { message },
+                                        StreamItem::Error {
+                                            message: message.clone(),
+                                        },
                                     ).await;
+                                    execution_result = Some(Err(HarnessError::AgentExecution(message)));
+                                    stream_closed = true;
                                 }
                             }
                         }

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -41,7 +41,47 @@ impl Drop for HomeGuard {
 
 use crate::{http::AppState, server::HarnessServer, thread_manager::ThreadManager};
 use harness_agents::registry::AgentRegistry;
-use harness_core::config::HarnessConfig;
+use harness_core::{
+    agent::{AgentAdapter, AgentEvent, TurnRequest},
+    config::HarnessConfig,
+};
+
+pub struct NoopTestAdapter {
+    name: String,
+}
+
+impl NoopTestAdapter {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for NoopTestAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        _tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn respond_approval(
+        &self,
+        _id: String,
+        _decision: harness_core::agent::ApprovalDecision,
+    ) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
 
 /// Create a temp directory under a writable base path without mutating
 /// global state (`HOME` env var).  Tries `$HOME` first; falls back to


### PR DESCRIPTION
## Summary
- unify execution agents and interactive adapters under one descriptor registry
- make server dispatch, default selection, and AgentList read the same registry source
- add lifecycle and routing tests for adapter-backed and execution-only descriptors

## Test Plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace