### PR TITLE
fix: align SDK schema fields with server responses

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -46,6 +46,7 @@ for event in thread.run_stream("Diagnose failing tests"):
 Events are SDK-synthesized polling lifecycle events:
 `sdk:turn/started`, `sdk:turn/status`, `sdk:turn/completed`, `sdk:turn/timeout`.
 
+Timeout events use `event["params"]["timeout_seconds"]`.
 This SDK uses synchronous polling; calls block the current thread.
 
 ## Publish to PyPI

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -123,7 +123,10 @@ class HarnessSdkTests(unittest.TestCase):
         self.assertEqual(result.turn_id, "turn-2")
         self.assertEqual(result.status, "running")
         self.assertTrue(result.timed_out)
-        self.assertTrue(any(event["method"] == "sdk:turn/timeout" for event in result.events))
+        timeout_event = next(
+            event for event in result.events if event["method"] == "sdk:turn/timeout"
+        )
+        self.assertEqual(timeout_event["params"]["timeout_seconds"], 0.05)
 
     def test_extract_output_handles_multiple_item_shapes(self) -> None:
         turn = {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -48,6 +48,9 @@ for await (const event of thread.runStream("Diagnose failing tests")) {
 Events are SDK-synthesized polling lifecycle events:
 `sdk:turn/started`, `sdk:turn/status`, `sdk:turn/completed`, `sdk:turn/timeout`.
 
+Timeout events use `event.params.timeout_seconds`.
+Turn snapshots preserve server fields such as `approval_request.id`.
+
 ## Publish to npm
 
 ```bash

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -133,6 +133,7 @@ export class HarnessThread {
             params: {
               thread_id: this.id,
               turn_id: turnId,
+              timeout_ms: timeoutMs,
               timeout_seconds: timeoutMs / 1000,
               source: "sdk-poll",
               server_method: "turn/status",

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -133,7 +133,7 @@ export class HarnessThread {
             params: {
               thread_id: this.id,
               turn_id: turnId,
-              timeout_ms: timeoutMs,
+              timeout_seconds: timeoutMs / 1000,
               source: "sdk-poll",
               server_method: "turn/status",
             },
@@ -276,6 +276,7 @@ function parseTurnItem(value: unknown): TurnItem | undefined {
       return {
         type: "approval_request",
         action: value.action,
+        ...(typeof value.id === "string" || value.id === null ? { id: value.id } : {}),
         ...(typeof value.approved === "boolean" || value.approved === null
           ? { approved: value.approved }
           : {}),

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -97,6 +97,7 @@ export interface ToolCallItem {
 
 export interface ApprovalRequestItem {
   type: "approval_request";
+  id?: string | null;
   action: string;
   approved?: boolean | null;
 }
@@ -175,7 +176,7 @@ interface ThreadCompletedEventParams {
 interface ThreadTimeoutEventParams {
   thread_id: string;
   turn_id: string;
-  timeout_ms: number;
+  timeout_seconds: number;
   source: "sdk-poll";
   server_method: "turn/status";
 }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -176,6 +176,7 @@ interface ThreadCompletedEventParams {
 interface ThreadTimeoutEventParams {
   thread_id: string;
   turn_id: string;
+  timeout_ms: number;
   timeout_seconds: number;
   source: "sdk-poll";
   server_method: "turn/status";

--- a/sdk/typescript/tests/harness.test.ts
+++ b/sdk/typescript/tests/harness.test.ts
@@ -331,6 +331,7 @@ test("run handles timeout when turn never reaches terminal status", async () => 
   assert.equal(result.timedOut, true);
   const timeoutEvent = result.events.find((event) => event.method === SDK_TURN_TIMEOUT);
   assert.ok(timeoutEvent);
+  assert.equal(timeoutEvent.params.timeout_ms, 5);
   assert.equal(timeoutEvent.params.timeout_seconds, 0.005);
 });
 

--- a/sdk/typescript/tests/harness.test.ts
+++ b/sdk/typescript/tests/harness.test.ts
@@ -250,6 +250,51 @@ test("run preserves unknown turn item types in final snapshot", async () => {
   assert.equal(result.turn?.items[1]?.type, "future_item");
 });
 
+test("run preserves approval request ids in turn snapshots", async () => {
+  const mock = createMockFetch((method) => {
+    if (method === "thread/start") {
+      return { result: { thread_id: "thread-approval" } };
+    }
+    if (method === "turn/start") {
+      return { result: { turn_id: "turn-approval" } };
+    }
+    if (method === "turn/status") {
+      return {
+        result: {
+          id: "turn-approval",
+          thread_id: "thread-approval",
+          status: "completed",
+          items: [
+            {
+              type: "approval_request",
+              id: "approval-1",
+              action: "shell",
+              approved: null,
+            },
+          ],
+        },
+      };
+    }
+    return { result: {} };
+  });
+
+  const harness = new Harness({
+    fetch: mock.fetch,
+    defaultPollIntervalMs: 1,
+    defaultRunTimeoutMs: 500,
+  });
+  const thread = await harness.startThread({ cwd: "/repo" });
+  const result = await thread.run("Summarize");
+
+  assert.equal(result.status, "completed");
+  assert.deepEqual(result.turn?.items[0], {
+    type: "approval_request",
+    id: "approval-1",
+    action: "shell",
+    approved: null,
+  });
+});
+
 test("run handles timeout when turn never reaches terminal status", async () => {
   const mock = createMockFetch((method) => {
     if (method === "thread/start") {
@@ -284,7 +329,9 @@ test("run handles timeout when turn never reaches terminal status", async () => 
   assert.equal(result.turnId, "turn-4");
   assert.equal(result.status, "running");
   assert.equal(result.timedOut, true);
-  assert.ok(result.events.some((event) => event.method === SDK_TURN_TIMEOUT));
+  const timeoutEvent = result.events.find((event) => event.method === SDK_TURN_TIMEOUT);
+  assert.ok(timeoutEvent);
+  assert.equal(timeoutEvent.params.timeout_seconds, 0.005);
 });
 
 test("raises HarnessRpcError when server returns JSON-RPC error", async () => {


### PR DESCRIPTION
## Summary
- preserve `approval_request.id` in the TypeScript SDK turn snapshot parser and exported types
- align timeout event payloads on `timeout_seconds` across TypeScript and Python SDKs
- add regression coverage and README notes for the canonical SDK schema

## Test plan
- [x] cd sdk/typescript && pnpm test
- [x] cd sdk/typescript && npx tsc --noEmit
- [x] PYTHONPATH=sdk/python/src python3 sdk/python/tests/test_client.py
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace
- [x] cargo check