### PR TITLE
refactor: centralize task status semantics

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -536,10 +536,7 @@ pub(super) async fn cancel_task(
         }
     };
 
-    if matches!(
-        task.status,
-        TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
-    ) {
+    if task.status.is_terminal() {
         return (
             StatusCode::CONFLICT,
             Json(json!({ "error": "task already in terminal state" })),

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -444,7 +444,7 @@ async fn run_repo_sprint(
         let mut newly_done = Vec::new();
         for (&issue_num, task_id) in &running {
             if let Some(task) = state.core.tasks.get(task_id) {
-                if matches!(task.status, TaskStatus::Done | TaskStatus::Failed) {
+                if task.status.is_terminal() {
                     tracing::info!(
                         repo,
                         external_id = issue_num,
@@ -517,10 +517,10 @@ async fn poll_task_output(
         let Some(task) = store.get(task_id) else {
             continue;
         };
-        if !matches!(task.status, TaskStatus::Done | TaskStatus::Failed) {
+        if !task.status.is_terminal() {
             continue;
         }
-        if matches!(task.status, TaskStatus::Failed) {
+        if matches!(task.status, TaskStatus::Failed | TaskStatus::Cancelled) {
             tracing::error!(task_id = %task_id, error = ?task.error, "intake: task failed");
             return None;
         }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -999,14 +999,9 @@ async fn run_review_tick(
                                 .recover_stale_pending_claims(3900, |tid| {
                                     let id = harness_core::types::TaskId(tid.to_string());
                                     // task not in store → treat as done
-                                    tasks_snapshot.get(&id).is_none_or(|t| {
-                                        matches!(
-                                            t.status,
-                                            crate::task_runner::TaskStatus::Done
-                                                | crate::task_runner::TaskStatus::Failed
-                                                | crate::task_runner::TaskStatus::Cancelled
-                                        )
-                                    })
+                                    tasks_snapshot
+                                        .get(&id)
+                                        .is_none_or(|t| t.status.is_terminal())
                                 })
                                 .await
                             {

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -367,17 +367,21 @@ impl TaskDb {
         if let Some(status) = terminal_status {
             // Overwrite to terminal status; only touches tasks still in interrupted states
             // so we never downgrade a task that already reached Done/Failed in the DB.
-            sqlx::query(
+            let placeholders =
+                std::iter::repeat_n("?", TaskStatus::interrupted_for_recovery_statuses().len())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+            let sql = format!(
                 "UPDATE tasks SET status = ?, pr_url = COALESCE(?, pr_url), \
                  updated_at = datetime('now') \
                  WHERE id = ? \
-                 AND status IN ('implementing', 'agent_review', 'reviewing', 'waiting')",
-            )
-            .bind(status)
-            .bind(pr_url)
-            .bind(task_id)
-            .execute(&self.pool)
-            .await?;
+                 AND status IN ({placeholders})"
+            );
+            let mut query = sqlx::query(&sql).bind(status).bind(pr_url).bind(task_id);
+            for interrupted in TaskStatus::interrupted_for_recovery_statuses() {
+                query = query.bind(*interrupted);
+            }
+            query.execute(&self.pool).await?;
         } else if let Some(url) = pr_url {
             // Write pr_url back only when the DB row currently has no pr_url.
             sqlx::query(
@@ -413,15 +417,22 @@ impl TaskDb {
     /// Returns a [`RecoveryResult`] with counts for each outcome.
     pub async fn recover_in_progress(&self) -> anyhow::Result<RecoveryResult> {
         // Collect all interrupted tasks with their checkpoint data via LEFT JOIN.
-        let rows = sqlx::query_as::<_, RecoveryRow>(
+        let placeholders =
+            std::iter::repeat_n("?", TaskStatus::interrupted_for_recovery_statuses().len())
+                .collect::<Vec<_>>()
+                .join(", ");
+        let sql = format!(
             "SELECT t.id, t.status, t.turn, t.pr_url AS task_pr_url,
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url
              FROM tasks t
              LEFT JOIN task_checkpoints c ON t.id = c.task_id
-             WHERE t.status IN ('implementing', 'agent_review', 'reviewing', 'waiting')",
-        )
-        .fetch_all(&self.pool)
-        .await?;
+             WHERE t.status IN ({placeholders})"
+        );
+        let mut query = sqlx::query_as::<_, RecoveryRow>(&sql);
+        for interrupted in TaskStatus::interrupted_for_recovery_statuses() {
+            query = query.bind(*interrupted);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         let mut result = RecoveryResult::default();
 
@@ -604,9 +615,10 @@ impl TaskDb {
     /// to Done, which correctly reflects completion time rather than creation time.
     pub async fn latest_done_pr_url(&self) -> anyhow::Result<Option<String>> {
         let row: Option<(Option<String>,)> = sqlx::query_as(
-            "SELECT pr_url FROM tasks WHERE status = 'done' AND pr_url IS NOT NULL \
+            "SELECT pr_url FROM tasks WHERE status = ? AND pr_url IS NOT NULL \
              ORDER BY updated_at DESC LIMIT 1",
         )
+        .bind(TaskStatus::done_status())
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.and_then(|(pr_url,)| pr_url))
@@ -619,9 +631,10 @@ impl TaskDb {
     ) -> anyhow::Result<Option<String>> {
         let row: Option<(Option<String>,)> = sqlx::query_as(
             "SELECT pr_url FROM tasks \
-             WHERE status = 'done' AND pr_url IS NOT NULL AND project = ?1 \
+             WHERE status = ?1 AND pr_url IS NOT NULL AND project = ?2 \
              ORDER BY updated_at DESC LIMIT 1",
         )
+        .bind(TaskStatus::done_status())
         .bind(project)
         .fetch_optional(&self.pool)
         .await?;
@@ -638,9 +651,10 @@ impl TaskDb {
                SELECT project, pr_url, \
                       ROW_NUMBER() OVER (PARTITION BY project ORDER BY updated_at DESC) AS rn \
                FROM tasks \
-               WHERE status = 'done' AND pr_url IS NOT NULL AND project IS NOT NULL\
+               WHERE status = ? AND pr_url IS NOT NULL AND project IS NOT NULL\
              ) WHERE rn = 1",
         )
+        .bind(TaskStatus::done_status())
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().collect())
@@ -654,24 +668,41 @@ impl TaskDb {
     pub async fn count_done_failed_by_project(
         &self,
     ) -> anyhow::Result<(u64, u64, Vec<(String, u64, u64)>)> {
-        let global: (i64, i64) = sqlx::query_as(
-            "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
-             FROM tasks WHERE status IN ('done', 'failed')",
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let done = TaskStatus::done_status();
+        let failed = TaskStatus::failed_status();
+        let done_failed = TaskStatus::done_failed_statuses();
+        let placeholders = std::iter::repeat_n("?", done_failed.len())
+            .collect::<Vec<_>>()
+            .join(", ");
 
-        let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+        let global_sql = format!(
+            "SELECT COUNT(CASE WHEN status = ? THEN 1 END), \
+                    COUNT(CASE WHEN status = ? THEN 1 END) \
+             FROM tasks WHERE status IN ({placeholders})"
+        );
+        let mut global_query = sqlx::query_as::<_, (i64, i64)>(&global_sql)
+            .bind(done)
+            .bind(failed);
+        for status in done_failed {
+            global_query = global_query.bind(*status);
+        }
+        let global = global_query.fetch_one(&self.pool).await?;
+
+        let rows_sql = format!(
             "SELECT project, \
-                    COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+                    COUNT(CASE WHEN status = ? THEN 1 END), \
+                    COUNT(CASE WHEN status = ? THEN 1 END) \
              FROM tasks \
-             WHERE status IN ('done', 'failed') AND project IS NOT NULL \
-             GROUP BY project",
-        )
-        .fetch_all(&self.pool)
-        .await?;
+             WHERE status IN ({placeholders}) AND project IS NOT NULL \
+             GROUP BY project"
+        );
+        let mut rows_query = sqlx::query_as::<_, (String, i64, i64)>(&rows_sql)
+            .bind(done)
+            .bind(failed);
+        for status in done_failed {
+            rows_query = rows_query.bind(*status);
+        }
+        let rows = rows_query.fetch_all(&self.pool).await?;
 
         let by_project = rows
             .into_iter()
@@ -1618,8 +1649,305 @@ mod tests {
         let multi = db.list_by_status(&["pending", "done"]).await?;
         assert_eq!(multi.len(), 2);
 
-        let empty = db.list_by_status(&[]).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn replayed_state_only_updates_interrupted_statuses() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("impl", TaskStatus::Implementing))
+            .await?;
+        db.insert(&make_task("pending", TaskStatus::Pending))
+            .await?;
+        db.insert(&make_task("done", TaskStatus::Done)).await?;
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+
+        db.apply_replayed_state(
+            "impl",
+            Some("https://github.com/o/r/pull/1"),
+            Some("failed"),
+        )
+        .await?;
+        db.apply_replayed_state(
+            "pending",
+            Some("https://github.com/o/r/pull/2"),
+            Some("failed"),
+        )
+        .await?;
+        db.apply_replayed_state(
+            "done",
+            Some("https://github.com/o/r/pull/3"),
+            Some("failed"),
+        )
+        .await?;
+        db.apply_replayed_state(
+            "cancelled",
+            Some("https://github.com/o/r/pull/4"),
+            Some("failed"),
+        )
+        .await?;
+
+        assert!(matches!(
+            db.get("impl").await?.unwrap().status,
+            TaskStatus::Failed
+        ));
+        assert!(matches!(
+            db.get("pending").await?.unwrap().status,
+            TaskStatus::Pending
+        ));
+        assert!(matches!(
+            db.get("done").await?.unwrap().status,
+            TaskStatus::Done
+        ));
+        assert!(matches!(
+            db.get("cancelled").await?.unwrap().status,
+            TaskStatus::Cancelled
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn latest_done_queries_ignore_cancelled_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut cancelled = make_task("cancelled", TaskStatus::Cancelled);
+        cancelled.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        cancelled.pr_url = Some("https://github.com/o/r/pull/99".to_string());
+        db.insert(&cancelled).await?;
+
+        let mut done = make_task("done", TaskStatus::Done);
+        done.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        done.pr_url = Some("https://github.com/o/r/pull/42".to_string());
+        db.insert(&done).await?;
+
+        assert_eq!(
+            db.latest_done_pr_url().await?,
+            Some("https://github.com/o/r/pull/42".to_string())
+        );
+        assert_eq!(
+            db.latest_done_pr_url_by_project("/repo/a").await?,
+            Some("https://github.com/o/r/pull/42".to_string())
+        );
+        assert_eq!(
+            db.latest_done_pr_urls_all_projects().await?,
+            std::collections::HashMap::from([(
+                "/repo/a".to_string(),
+                "https://github.com/o/r/pull/42".to_string(),
+            )])
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn done_failed_counts_ignore_cancelled_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut done = make_task("done", TaskStatus::Done);
+        done.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&done).await?;
+
+        let mut failed = make_task("failed", TaskStatus::Failed);
+        failed.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&failed).await?;
+
+        let mut cancelled = make_task("cancelled", TaskStatus::Cancelled);
+        cancelled.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&cancelled).await?;
+
+        let (global_done, global_failed, by_project) = db.count_done_failed_by_project().await?;
+        assert_eq!((global_done, global_failed), (1, 1));
+        assert_eq!(by_project, vec![("/repo/a".to_string(), 1, 1)]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_by_status_accepts_centralized_status_sets() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("pending", TaskStatus::Pending))
+            .await?;
+        db.insert(&make_task("reviewing", TaskStatus::Reviewing))
+            .await?;
+        db.insert(&make_task("done", TaskStatus::Done)).await?;
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+
+        let active = db.list_by_status(TaskStatus::active_statuses()).await?;
+        let terminals = db
+            .list_ids_by_status(TaskStatus::terminal_statuses())
+            .await?;
+
+        assert_eq!(active.len(), 2);
+        assert_eq!(terminals.len(), 2);
+        assert!(terminals.iter().any(|id| id == "done"));
+        assert!(terminals.iter().any(|id| id == "cancelled"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn recover_in_progress_skips_cancelled_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+        db.insert(&make_task("implementing", TaskStatus::Implementing))
+            .await?;
+
+        let result = db.recover_in_progress().await?;
+        assert_eq!(result.failed, 1);
+        assert_eq!(result.resumed, 0);
+        assert!(matches!(
+            db.get("cancelled").await?.unwrap().status,
+            TaskStatus::Cancelled
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_ids_by_status_returns_matching_ids() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("task-a", TaskStatus::Pending)).await?;
+        db.insert(&make_task("task-b", TaskStatus::Done)).await?;
+
+        let ids = db.list_ids_by_status(&["done"]).await?;
+        assert_eq!(ids, vec!["task-b".to_string()]);
+
+        let empty = db.list_ids_by_status(&[]).await?;
         assert!(empty.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn latest_done_queries_return_none_for_cancelled_only() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut cancelled = make_task("cancelled", TaskStatus::Cancelled);
+        cancelled.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        cancelled.pr_url = Some("https://github.com/o/r/pull/99".to_string());
+        db.insert(&cancelled).await?;
+
+        assert_eq!(db.latest_done_pr_url().await?, None);
+        assert_eq!(db.latest_done_pr_url_by_project("/repo/a").await?, None);
+        assert!(db.latest_done_pr_urls_all_projects().await?.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn done_failed_counts_return_zero_for_cancelled_only() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut cancelled = make_task("cancelled", TaskStatus::Cancelled);
+        cancelled.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&cancelled).await?;
+
+        let (global_done, global_failed, by_project) = db.count_done_failed_by_project().await?;
+        assert_eq!((global_done, global_failed), (0, 0));
+        assert!(by_project.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn interrupted_statuses_exclude_pending_and_cancelled() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("pending", TaskStatus::Pending))
+            .await?;
+        db.insert(&make_task("implementing", TaskStatus::Implementing))
+            .await?;
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+
+        let ids = db
+            .list_ids_by_status(TaskStatus::interrupted_for_recovery_statuses())
+            .await?;
+        assert_eq!(ids, vec!["implementing".to_string()]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn terminal_statuses_include_cancelled() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("done", TaskStatus::Done)).await?;
+        db.insert(&make_task("failed", TaskStatus::Failed)).await?;
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+
+        let ids = db
+            .list_ids_by_status(TaskStatus::terminal_statuses())
+            .await?;
+        assert_eq!(ids.len(), 3);
+        assert!(ids.iter().any(|id| id == "cancelled"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn active_statuses_exclude_terminal_states() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("pending", TaskStatus::Pending))
+            .await?;
+        db.insert(&make_task("done", TaskStatus::Done)).await?;
+        db.insert(&make_task("failed", TaskStatus::Failed)).await?;
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+
+        let ids = db.list_ids_by_status(TaskStatus::active_statuses()).await?;
+        assert_eq!(ids, vec!["pending".to_string()]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancelled_roundtrips_in_db() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("cancelled", TaskStatus::Cancelled))
+            .await?;
+        let loaded = db.get("cancelled").await?.expect("task should exist");
+        assert!(matches!(loaded.status, TaskStatus::Cancelled));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn count_done_failed_ignores_pending_and_reviewing() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut pending = make_task("pending", TaskStatus::Pending);
+        pending.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&pending).await?;
+
+        let mut reviewing = make_task("reviewing", TaskStatus::Reviewing);
+        reviewing.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&reviewing).await?;
+
+        let (global_done, global_failed, by_project) = db.count_done_failed_by_project().await?;
+        assert_eq!((global_done, global_failed), (0, 0));
+        assert!(by_project.is_empty());
+
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -56,8 +56,44 @@ pub enum TaskStatus {
     Cancelled,
 }
 
-impl AsRef<str> for TaskStatus {
-    fn as_ref(&self) -> &str {
+impl TaskStatus {
+    pub const ACTIVE_STATUSES: &[&str] = &[
+        "pending",
+        "awaiting_deps",
+        "implementing",
+        "agent_review",
+        "waiting",
+        "reviewing",
+    ];
+
+    pub const TERMINAL_STATUSES: &[&str] = &["done", "failed", "cancelled"];
+
+    pub const DONE_FAILED_STATUSES: &[&str] = &["done", "failed"];
+
+    pub const INTERRUPTED_FOR_RECOVERY_STATUSES: &[&str] =
+        &["implementing", "agent_review", "waiting", "reviewing"];
+
+    pub const DONE_STATUS: &str = "done";
+
+    pub const FAILED_STATUS: &str = "failed";
+
+    pub const CANCELLED_STATUS: &str = "cancelled";
+
+    pub const PENDING_STATUS: &str = "pending";
+
+    pub const AWAITING_DEPS_STATUS: &str = "awaiting_deps";
+
+    pub const IMPLEMENTING_STATUS: &str = "implementing";
+
+    pub const AGENT_REVIEW_STATUS: &str = "agent_review";
+
+    pub const WAITING_STATUS: &str = "waiting";
+
+    pub const REVIEWING_STATUS: &str = "reviewing";
+
+    pub const DONE_ONLY_STATUSES: &[&str] = &[Self::DONE_STATUS];
+
+    pub fn as_str(&self) -> &str {
         match self {
             TaskStatus::Pending => "pending",
             TaskStatus::AwaitingDeps => "awaiting_deps",
@@ -69,6 +105,89 @@ impl AsRef<str> for TaskStatus {
             TaskStatus::Failed => "failed",
             TaskStatus::Cancelled => "cancelled",
         }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+        )
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.is_terminal()
+    }
+
+    pub fn is_interrupted_for_recovery(&self) -> bool {
+        matches!(
+            self,
+            TaskStatus::Implementing
+                | TaskStatus::AgentReview
+                | TaskStatus::Waiting
+                | TaskStatus::Reviewing
+        )
+    }
+
+    pub const fn active_statuses() -> &'static [&'static str] {
+        Self::ACTIVE_STATUSES
+    }
+
+    pub const fn terminal_statuses() -> &'static [&'static str] {
+        Self::TERMINAL_STATUSES
+    }
+
+    pub const fn done_failed_statuses() -> &'static [&'static str] {
+        Self::DONE_FAILED_STATUSES
+    }
+
+    pub const fn done_only_statuses() -> &'static [&'static str] {
+        Self::DONE_ONLY_STATUSES
+    }
+
+    pub const fn interrupted_for_recovery_statuses() -> &'static [&'static str] {
+        Self::INTERRUPTED_FOR_RECOVERY_STATUSES
+    }
+
+    pub const fn done_status() -> &'static str {
+        Self::DONE_STATUS
+    }
+
+    pub const fn failed_status() -> &'static str {
+        Self::FAILED_STATUS
+    }
+
+    pub const fn cancelled_status() -> &'static str {
+        Self::CANCELLED_STATUS
+    }
+
+    pub const fn pending_status() -> &'static str {
+        Self::PENDING_STATUS
+    }
+
+    pub const fn awaiting_deps_status() -> &'static str {
+        Self::AWAITING_DEPS_STATUS
+    }
+
+    pub const fn implementing_status() -> &'static str {
+        Self::IMPLEMENTING_STATUS
+    }
+
+    pub const fn agent_review_status() -> &'static str {
+        Self::AGENT_REVIEW_STATUS
+    }
+
+    pub const fn waiting_status() -> &'static str {
+        Self::WAITING_STATUS
+    }
+
+    pub const fn reviewing_status() -> &'static str {
+        Self::REVIEWING_STATUS
+    }
+}
+
+impl AsRef<str> for TaskStatus {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
@@ -659,15 +778,7 @@ impl TaskStore {
         let persist_locks = DashMap::new();
         // Only load active (non-terminal) tasks into the in-memory cache to prevent
         // unbounded memory growth from historical completed tasks.
-        let active_statuses = &[
-            "pending",
-            "awaiting_deps",
-            "implementing",
-            "agent_review",
-            "waiting",
-            "reviewing",
-        ];
-        for task in db.list_by_status(active_statuses).await? {
+        for task in db.list_by_status(TaskStatus::active_statuses()).await? {
             persist_locks.insert(task.id.clone(), Arc::new(Mutex::new(())));
             cache.insert(task.id.clone(), task);
         }
@@ -726,7 +837,7 @@ impl TaskStore {
     pub async fn list_terminal_ids_from_db(&self) -> anyhow::Result<Vec<TaskId>> {
         let ids = self
             .db
-            .list_ids_by_status(&["done", "failed", "cancelled"])
+            .list_ids_by_status(TaskStatus::terminal_statuses())
             .await?;
         Ok(ids.into_iter().map(harness_core::types::TaskId).collect())
     }
@@ -2102,6 +2213,61 @@ mod tests {
         assert!(state.project_root.is_none());
         assert!(state.issue.is_none());
         assert!(state.description.is_none());
+    }
+
+    #[test]
+    fn task_status_string_roundtrip_and_groups() -> anyhow::Result<()> {
+        let cases = [
+            (TaskStatus::Pending, "pending", false, true, false),
+            (
+                TaskStatus::AwaitingDeps,
+                "awaiting_deps",
+                false,
+                true,
+                false,
+            ),
+            (TaskStatus::Implementing, "implementing", false, true, true),
+            (TaskStatus::AgentReview, "agent_review", false, true, true),
+            (TaskStatus::Waiting, "waiting", false, true, true),
+            (TaskStatus::Reviewing, "reviewing", false, true, true),
+            (TaskStatus::Done, "done", true, false, false),
+            (TaskStatus::Failed, "failed", true, false, false),
+            (TaskStatus::Cancelled, "cancelled", true, false, false),
+        ];
+
+        for (status, expected, terminal, active, resumable) in cases {
+            assert_eq!(status.as_str(), expected);
+            assert_eq!(status.as_ref(), expected);
+            assert_eq!(expected.parse::<TaskStatus>()?.as_str(), expected);
+            assert_eq!(status.is_terminal(), terminal);
+            assert_eq!(status.is_active(), active);
+            assert_eq!(status.is_interrupted_for_recovery(), resumable);
+        }
+
+        Ok::<(), anyhow::Error>(())
+    }
+
+    #[test]
+    fn task_status_semantic_sets_match_expected_strings() {
+        assert_eq!(
+            TaskStatus::active_statuses(),
+            &[
+                "pending",
+                "awaiting_deps",
+                "implementing",
+                "agent_review",
+                "waiting",
+                "reviewing",
+            ]
+        );
+        assert_eq!(
+            TaskStatus::terminal_statuses(),
+            &["done", "failed", "cancelled"]
+        );
+        assert_eq!(
+            TaskStatus::interrupted_for_recovery_statuses(),
+            &["implementing", "agent_review", "waiting", "reviewing"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- centralize TaskStatus semantic groups for active, terminal, and interrupted-for-recovery states
- switch recovery, cancellation, intake, and periodic reviewer call sites to shared helpers
- keep Done-only queries and done/failed aggregates separate from terminal semantics

## Test plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace