### PR TITLE
fix: canonicalize project identity by registry id

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -52,6 +52,59 @@ impl Default for WorkspaceConfig {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TypedPerProjectConcurrencyLimits {
+    /// Limits keyed by canonical project id.
+    #[serde(default)]
+    pub by_id: HashMap<String, usize>,
+    /// Transitional limits keyed by canonical project root path string.
+    #[serde(default)]
+    pub by_root: HashMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum PerProjectConcurrencyLimits {
+    Legacy(HashMap<String, usize>),
+    Typed(TypedPerProjectConcurrencyLimits),
+}
+
+impl Default for PerProjectConcurrencyLimits {
+    fn default() -> Self {
+        Self::Typed(TypedPerProjectConcurrencyLimits::default())
+    }
+}
+
+impl PerProjectConcurrencyLimits {
+    pub fn by_id_mut(&mut self) -> &mut HashMap<String, usize> {
+        match self {
+            Self::Legacy(map) => map,
+            Self::Typed(typed) => &mut typed.by_id,
+        }
+    }
+
+    pub fn by_id(&self) -> &HashMap<String, usize> {
+        match self {
+            Self::Legacy(map) => map,
+            Self::Typed(typed) => &typed.by_id,
+        }
+    }
+
+    pub fn by_root(&self) -> Option<&HashMap<String, usize>> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Typed(typed) => Some(&typed.by_root),
+        }
+    }
+
+    pub fn legacy(&self) -> Option<&HashMap<String, usize>> {
+        match self {
+            Self::Legacy(map) => Some(map),
+            Self::Typed(_) => None,
+        }
+    }
+}
+
 /// Concurrency limiting configuration for task execution.
 ///
 /// Controls how many tasks run simultaneously and how many can wait
@@ -67,10 +120,11 @@ pub struct ConcurrencyConfig {
     /// Seconds of silence from the agent stream before declaring a stall. Default: 300.
     #[serde(default = "default_stall_timeout_secs")]
     pub stall_timeout_secs: u64,
-    /// Per-project concurrency limits. Maps project path string → max concurrent tasks.
-    /// Projects not listed here use the global `max_concurrent_tasks` limit.
+    /// Per-project concurrency limits. Legacy configs may still use a flat
+    /// map keyed by raw project strings; new configs should prefer `by_id`
+    /// and only use `by_root` during migration.
     #[serde(default)]
-    pub per_project: HashMap<String, usize>,
+    pub per_project: PerProjectConcurrencyLimits,
     /// Maximum total agent API calls across all phases (implementation + validation retries +
     /// review rounds). `None` = unlimited. Counts every call including validation retries.
     /// Recommended production value: 20.
@@ -120,7 +174,7 @@ impl Default for ConcurrencyConfig {
             max_concurrent_tasks: default_max_concurrent_tasks(),
             max_queue_size: default_max_queue_size(),
             stall_timeout_secs: default_stall_timeout_secs(),
-            per_project: HashMap::new(),
+            per_project: PerProjectConcurrencyLimits::default(),
             max_turns: None,
             loop_jaccard_threshold: default_loop_jaccard_threshold(),
             memory_pressure_threshold_mb: None,
@@ -446,6 +500,36 @@ mod tests {
         let cfg: ConcurrencyConfig = toml::from_str(toml).expect("toml parse failed");
         assert_eq!(cfg.memory_pressure_threshold_mb, Some(512));
         assert_eq!(cfg.memory_poll_interval_secs, 10);
+    }
+
+    #[test]
+    fn concurrency_config_accepts_legacy_per_project_map() {
+        let toml = r#"
+            [per_project]
+            harness = 2
+        "#;
+        let cfg: ConcurrencyConfig = toml::from_str(toml).expect("toml parse failed");
+        assert_eq!(cfg.per_project.by_id().get("harness"), Some(&2));
+        assert!(cfg.per_project.by_root().is_none());
+    }
+
+    #[test]
+    fn concurrency_config_accepts_typed_per_project_map() {
+        let toml = r#"
+            [per_project.by_id]
+            harness = 2
+
+            [per_project.by_root]
+            "/tmp/harness" = 1
+        "#;
+        let cfg: ConcurrencyConfig = toml::from_str(toml).expect("toml parse failed");
+        assert_eq!(cfg.per_project.by_id().get("harness"), Some(&2));
+        assert_eq!(
+            cfg.per_project
+                .by_root()
+                .and_then(|by_root| by_root.get("/tmp/harness")),
+            Some(&1)
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -494,10 +494,16 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                 tracing::info!(threshold_mb, poll_secs, "memory pressure monitor enabled");
                 crate::memory_monitor::start(threshold_mb, poll_secs)
             });
-    let task_queue = Arc::new(crate::task_queue::TaskQueue::new_with_pressure(
-        &server.config.concurrency,
-        memory_pressure,
-    ));
+    let resolved_project_limits = project_registry
+        .resolve_limits(&project_root, &server.config.concurrency.per_project)
+        .await?;
+    let task_queue = Arc::new(
+        crate::task_queue::TaskQueue::new_with_project_limits_and_pressure(
+            &server.config.concurrency,
+            resolved_project_limits,
+            memory_pressure,
+        ),
+    );
     tracing::debug!(
         max_concurrent = server.config.concurrency.max_concurrent_tasks,
         max_queue_size = server.config.concurrency.max_queue_size,

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -7,41 +7,6 @@ use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 
-/// Resolve a project path-or-ID through the registry.
-///
-/// If `project` is `None` or already points to an existing directory it is
-/// returned unchanged.  If it is not a directory and a `registry` is
-/// available, the value is treated as a project ID and looked up; a missing
-/// ID is a `BadRequest` error.  When no registry is available the raw value
-/// is passed through so downstream canonicalization can handle it.
-async fn resolve_project_from_registry(
-    registry: Option<&crate::project_registry::ProjectRegistry>,
-    project_root: &std::path::Path,
-    project: Option<std::path::PathBuf>,
-) -> Result<Option<std::path::PathBuf>, EnqueueTaskError> {
-    let (Some(registry), Some(project_path)) = (registry, project.clone()) else {
-        return Ok(project);
-    };
-
-    let explicit_path = if project_path.is_absolute() {
-        project_path.clone()
-    } else {
-        project_root.join(&project_path)
-    };
-    if explicit_path.is_dir() {
-        return Ok(Some(project_path));
-    }
-
-    let id = project_path.to_string_lossy();
-    match registry.resolve_path(&id).await {
-        Ok(Some(root)) => Ok(Some(root)),
-        Ok(None) => Err(EnqueueTaskError::BadRequest(format!(
-            "project '{id}' not found in registry and is not a valid directory"
-        ))),
-        Err(e) => Err(EnqueueTaskError::Internal(e.to_string())),
-    }
-}
-
 fn normalize_request_project_path(
     project_root: &std::path::Path,
     project: Option<std::path::PathBuf>,
@@ -80,12 +45,11 @@ async fn resolve_request_project(
     state: &Arc<AppState>,
     project: Option<std::path::PathBuf>,
 ) -> Result<(String, std::path::PathBuf), EnqueueTaskError> {
-    let project = resolve_project_from_registry(
-        state.core.project_registry.as_deref(),
-        &state.core.project_root,
-        project,
-    )
-    .await?;
+    if state.core.project_registry.is_some() {
+        // registry.resolve_project handles ID lookup, path canonicalization, and
+        // relative-path anchoring in one pass — no pre-resolution step needed.
+        return resolve_queue_identity(state, project).await;
+    }
     let project = normalize_request_project_path(&state.core.project_root, project);
     resolve_queue_identity(state, project).await
 }
@@ -822,107 +786,6 @@ mod tests {
         let json = r#"{"issues": [1]}"#;
         let req: BatchCreateTaskRequest = serde_json::from_str(json).unwrap();
         assert!(req.project.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_passes_through_none() {
-        let result = resolve_project_from_registry(None, std::path::Path::new("."), None).await;
-        assert!(result.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_passes_through_existing_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().to_path_buf();
-        let result =
-            resolve_project_from_registry(None, std::path::Path::new("."), Some(path.clone()))
-                .await;
-        assert_eq!(result.unwrap(), Some(path));
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_no_registry_passes_through_nondir() {
-        // When no registry is available, non-dir paths are returned as-is
-        // (downstream canonicalization handles them).
-        let path = std::path::PathBuf::from("/nonexistent/path");
-        let result =
-            resolve_project_from_registry(None, std::path::Path::new("."), Some(path.clone()))
-                .await;
-        assert_eq!(result.unwrap(), Some(path));
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_resolves_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
-            .await
-            .unwrap();
-        let project_root = tempfile::tempdir().unwrap();
-        let canonical_root = project_root.path().canonicalize().unwrap();
-        registry
-            .register(crate::project_registry::Project {
-                id: "my-repo".to_string(),
-                root: canonical_root.clone(),
-                max_concurrent: None,
-                default_agent: None,
-                active: true,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
-            })
-            .await
-            .unwrap();
-
-        let result = resolve_project_from_registry(
-            Some(&registry),
-            dir.path(),
-            Some(std::path::PathBuf::from("my-repo")),
-        )
-        .await;
-        assert_eq!(result.unwrap(), Some(canonical_root));
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_resolves_registered_root_alias() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
-            .await
-            .unwrap();
-        let root_dir = tempfile::tempdir().unwrap();
-        let canonical_root = root_dir.path().canonicalize().unwrap();
-        registry
-            .register(crate::project_registry::Project {
-                id: "my-repo".to_string(),
-                root: canonical_root.clone(),
-                max_concurrent: None,
-                default_agent: None,
-                active: true,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
-            })
-            .await
-            .unwrap();
-
-        let result = resolve_project_from_registry(
-            Some(&registry),
-            dir.path(),
-            Some(canonical_root.clone()),
-        )
-        .await;
-        assert_eq!(result.unwrap(), Some(canonical_root));
-    }
-
-    #[tokio::test]
-    async fn resolve_project_from_registry_unknown_id_returns_bad_request() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
-            .await
-            .unwrap();
-
-        let result = resolve_project_from_registry(
-            Some(&registry),
-            dir.path(),
-            Some(std::path::PathBuf::from("unknown-repo")),
-        )
-        .await;
-        assert!(matches!(result, Err(EnqueueTaskError::BadRequest(_))));
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -34,6 +34,47 @@ async fn resolve_project_from_registry(
     }
 }
 
+async fn resolve_queue_identity(
+    state: &Arc<AppState>,
+    project: Option<std::path::PathBuf>,
+) -> Result<(String, std::path::PathBuf), EnqueueTaskError> {
+    if let Some(registry) = state.core.project_registry.as_deref() {
+        let resolved = registry
+            .resolve_project(project.as_deref(), &state.core.project_root)
+            .await
+            .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
+        return Ok((resolved.id, resolved.root));
+    }
+
+    let canonical_project = task_runner::resolve_canonical_project(project)
+        .await
+        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
+    Ok((
+        canonical_project.to_string_lossy().into_owned(),
+        canonical_project,
+    ))
+}
+
+async fn resolve_request_project(
+    state: &Arc<AppState>,
+    project: Option<std::path::PathBuf>,
+) -> Result<(String, std::path::PathBuf), EnqueueTaskError> {
+    let project =
+        resolve_project_from_registry(state.core.project_registry.as_deref(), project).await?;
+    resolve_queue_identity(state, project).await
+}
+
+fn enforce_allowed_roots(
+    state: &Arc<AppState>,
+    canonical_project: &std::path::Path,
+) -> Result<(), EnqueueTaskError> {
+    check_allowed_roots(
+        canonical_project,
+        &state.core.server.config.server.allowed_project_roots,
+    )
+    .map_err(EnqueueTaskError::BadRequest)
+}
+
 pub(crate) async fn enqueue_task(
     state: &Arc<AppState>,
     mut req: task_runner::CreateTaskRequest,
@@ -51,34 +92,10 @@ pub(crate) async fn enqueue_task(
         )));
     }
 
-    // Resolve project: if the supplied path does not exist as a directory,
-    // treat it as a project ID and look it up in the registry.
-    req.project =
-        resolve_project_from_registry(state.core.project_registry.as_deref(), req.project).await?;
-
-    // Resolve and canonicalize the project root BEFORE acquiring the
-    // concurrency permit so that:
-    //   (a) None is mapped to the real worktree path rather than the literal
-    //       "default" key, so per_project config for that path is respected.
-    //   (b) Symlinked / relative / differently-spelled paths are normalised
-    //       to the same canonical bucket, preventing limit bypass.
-    // Overwrite req.project with the resolved path so spawn_task does not
-    // re-detect the worktree inside the spawned future.
-    let canonical_project = task_runner::resolve_canonical_project(req.project.clone())
-        .await
-        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
-
-    // Enforce allowed_project_roots allowlist on the resolved canonical path so
-    // callers cannot bypass it by supplying a real directory path directly
-    // instead of registering the project first.
-    check_allowed_roots(
-        &canonical_project,
-        &state.core.server.config.server.allowed_project_roots,
-    )
-    .map_err(EnqueueTaskError::BadRequest)?;
-
-    let project_id = canonical_project.to_string_lossy().into_owned();
-    req.project = Some(canonical_project);
+    // Resolve project input once into the canonical queue identity + execution root.
+    let (project_id, project_root) = resolve_request_project(state, req.project).await?;
+    enforce_allowed_roots(state, &project_root)?;
+    req.project = Some(project_root);
 
     // Acquire concurrency permit before spawning. Blocks if all slots are
     // occupied; rejects immediately if the waiting queue is full.
@@ -233,10 +250,9 @@ async fn enqueue_task_background(
         )));
     }
 
-    // Resolve project: if the supplied path does not exist as a directory,
-    // treat it as a project ID and look it up in the registry.
-    req.project =
-        resolve_project_from_registry(state.core.project_registry.as_deref(), req.project).await?;
+    let (project_id, project_root) = resolve_request_project(&state, req.project).await?;
+    enforce_allowed_roots(&state, &project_root)?;
+    req.project = Some(project_root);
 
     // Resolve agent up-front (fast, no I/O) so we can return an error immediately
     // if the agent name is invalid, before registering the task.
@@ -265,20 +281,6 @@ async fn enqueue_task_background(
         agent.name(),
     );
 
-    // Resolve canonical project for per-project concurrency limits.
-    let canonical_project = task_runner::resolve_canonical_project(req.project.clone())
-        .await
-        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
-
-    // Enforce allowed_project_roots allowlist (same guard as enqueue_task).
-    check_allowed_roots(
-        &canonical_project,
-        &state.core.server.config.server.allowed_project_roots,
-    )
-    .map_err(EnqueueTaskError::BadRequest)?;
-
-    let project_id = canonical_project.to_string_lossy().into_owned();
-    req.project = Some(canonical_project);
     task_runner::fill_missing_repo_from_project(&mut req).await;
 
     let server_config = std::sync::Arc::new(state.core.server.config.clone());
@@ -569,6 +571,148 @@ pub(super) async fn cancel_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::{
+        ConcurrencyServices, CoreServices, EngineServices, IntakeServices, NotificationServices,
+        ObservabilityServices,
+    };
+    use crate::project_registry::{Project, ProjectRegistry};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, AtomicU64};
+    use std::time::Duration;
+
+    async fn make_state_with_registry_and_queue_limit(
+        dir: &std::path::Path,
+        per_project_key: &str,
+        limit: usize,
+    ) -> anyhow::Result<(Arc<AppState>, PathBuf)> {
+        let thread_manager = crate::thread_manager::ThreadManager::new();
+        let mut config = harness_core::config::HarnessConfig::default();
+        config
+            .concurrency
+            .per_project
+            .by_id_mut()
+            .insert(per_project_key.to_string(), limit);
+        let server = Arc::new(crate::server::HarnessServer::new(
+            config,
+            thread_manager,
+            harness_agents::registry::AgentRegistry::new("test"),
+        ));
+        let tasks = crate::task_runner::TaskStore::open(
+            &harness_core::config::dirs::default_db_path(dir, "tasks"),
+        )
+        .await?;
+        let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+        let signal_detector = harness_gc::signal_detector::SignalDetector::new(
+            server.config.gc.signal_thresholds.clone().into(),
+            harness_core::types::ProjectId::new(),
+        );
+        let draft_store = harness_gc::draft_store::DraftStore::new(dir)?;
+        let gc_agent = Arc::new(harness_gc::gc_agent::GcAgent::new(
+            server.config.gc.clone(),
+            signal_detector,
+            draft_store,
+            dir.to_path_buf(),
+        ));
+        let thread_db = crate::thread_db::ThreadDb::open(
+            &harness_core::config::dirs::default_db_path(dir, "threads"),
+        )
+        .await?;
+        let registry = ProjectRegistry::open(&dir.join("projects.db")).await?;
+        let named_root = dir.join("named-project");
+        std::fs::create_dir_all(&named_root)?;
+        let canonical_root = named_root.canonicalize()?;
+        registry
+            .register(Project {
+                id: "named".to_string(),
+                root: canonical_root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+        let project_svc = crate::services::project::DefaultProjectService::new(
+            ProjectRegistry::open(&dir.join("projects-service.db")).await?,
+            dir.to_path_buf(),
+        );
+        let task_svc = crate::services::task::DefaultTaskService::new(tasks.clone());
+        let task_queue = Arc::new(crate::task_queue::TaskQueue::new(
+            &server.config.concurrency,
+        ));
+        let execution_svc = crate::services::execution::DefaultExecutionService::new(
+            tasks.clone(),
+            server.agent_registry.clone(),
+            Arc::new(server.config.clone()),
+            Default::default(),
+            events.clone(),
+            vec![],
+            None,
+            task_queue.clone(),
+            None,
+            None,
+            vec![],
+        );
+        let state = Arc::new(AppState {
+            core: CoreServices {
+                server,
+                project_root: dir.to_path_buf(),
+                home_dir: dir.to_path_buf(),
+                tasks,
+                thread_db: Some(thread_db),
+                plan_db: None,
+                plan_cache: Arc::new(dashmap::DashMap::new()),
+                project_registry: Some(registry),
+                runtime_state_store: None,
+                q_values: None,
+            },
+            engines: EngineServices {
+                skills: Arc::new(tokio::sync::RwLock::new(
+                    harness_skills::store::SkillStore::new(),
+                )),
+                rules: Arc::new(tokio::sync::RwLock::new(
+                    harness_rules::engine::RuleEngine::new(),
+                )),
+                gc_agent,
+            },
+            observability: ObservabilityServices {
+                events,
+                signal_rate_limiter: Arc::new(crate::http::rate_limit::SignalRateLimiter::new(100)),
+                password_reset_rate_limiter: Arc::new(
+                    crate::http::rate_limit::PasswordResetRateLimiter::new(5),
+                ),
+                review_store: None,
+            },
+            concurrency: ConcurrencyServices {
+                task_queue,
+                workspace_mgr: None,
+            },
+            runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+            runtime_project_cache: Arc::new(
+                crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
+            runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+            notifications: NotificationServices {
+                notification_tx: tokio::sync::broadcast::channel(32).0,
+                notification_lagged_total: Arc::new(AtomicU64::new(0)),
+                notification_lag_log_every: 1,
+                notify_tx: None,
+                initializing: Arc::new(AtomicBool::new(true)),
+                initialized: Arc::new(AtomicBool::new(true)),
+                ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            },
+            interceptors: vec![],
+            intake: IntakeServices {
+                feishu_intake: None,
+                github_pollers: vec![],
+                completion_callback: None,
+            },
+            project_svc,
+            task_svc,
+            execution_svc,
+        });
+        Ok((state, canonical_root))
+    }
 
     #[test]
     fn batch_request_deserializes_issues_format() {
@@ -666,10 +810,13 @@ mod tests {
         let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
             .await
             .unwrap();
+        let project_root = dir.path().join("my-repo");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let canonical_root = project_root.canonicalize().unwrap();
         registry
             .register(crate::project_registry::Project {
                 id: "my-repo".to_string(),
-                root: std::path::PathBuf::from("/home/user/my-repo"),
+                root: canonical_root.clone(),
                 max_concurrent: None,
                 default_agent: None,
                 active: true,
@@ -683,10 +830,32 @@ mod tests {
             Some(std::path::PathBuf::from("my-repo")),
         )
         .await;
-        assert_eq!(
-            result.unwrap(),
-            Some(std::path::PathBuf::from("/home/user/my-repo"))
-        );
+        assert_eq!(result.unwrap(), Some(canonical_root));
+    }
+
+    #[tokio::test]
+    async fn resolve_project_from_registry_resolves_registered_root_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
+            .await
+            .unwrap();
+        let root_dir = tempfile::tempdir().unwrap();
+        let canonical_root = root_dir.path().canonicalize().unwrap();
+        registry
+            .register(crate::project_registry::Project {
+                id: "my-repo".to_string(),
+                root: canonical_root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let result =
+            resolve_project_from_registry(Some(&registry), Some(canonical_root.clone())).await;
+        assert_eq!(result.unwrap(), Some(canonical_root));
     }
 
     #[tokio::test]
@@ -702,6 +871,36 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(EnqueueTaskError::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn enqueue_task_should_bucket_registered_project_id_and_root_alias_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, canonical_root) =
+            make_state_with_registry_and_queue_limit(dir.path(), "named", 1)
+                .await
+                .unwrap();
+
+        let holder = state
+            .concurrency
+            .task_queue
+            .acquire("named", 0)
+            .await
+            .unwrap();
+        let req = crate::task_runner::CreateTaskRequest {
+            prompt: Some("fix bug".to_string()),
+            project: Some(canonical_root.clone()),
+            ..Default::default()
+        };
+
+        let blocked =
+            tokio::time::timeout(Duration::from_millis(50), enqueue_task(&state, req)).await;
+        drop(holder);
+
+        assert!(
+            blocked.is_err(),
+            "root alias should block behind the named project bucket"
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -28,7 +28,7 @@ async fn resolve_project_from_registry(
     } else {
         project_root.join(&project_path)
     };
-    if explicit_path.exists() {
+    if explicit_path.is_dir() {
         return Ok(Some(project_path));
     }
 

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -16,14 +16,22 @@ use std::sync::Arc;
 /// is passed through so downstream canonicalization can handle it.
 async fn resolve_project_from_registry(
     registry: Option<&crate::project_registry::ProjectRegistry>,
+    project_root: &std::path::Path,
     project: Option<std::path::PathBuf>,
 ) -> Result<Option<std::path::PathBuf>, EnqueueTaskError> {
     let (Some(registry), Some(project_path)) = (registry, project.clone()) else {
         return Ok(project);
     };
-    if project_path.is_dir() {
+
+    let explicit_path = if project_path.is_absolute() {
+        project_path.clone()
+    } else {
+        project_root.join(&project_path)
+    };
+    if explicit_path.exists() {
         return Ok(Some(project_path));
     }
+
     let id = project_path.to_string_lossy();
     match registry.resolve_path(&id).await {
         Ok(Some(root)) => Ok(Some(root)),
@@ -32,6 +40,19 @@ async fn resolve_project_from_registry(
         ))),
         Err(e) => Err(EnqueueTaskError::Internal(e.to_string())),
     }
+}
+
+fn normalize_request_project_path(
+    project_root: &std::path::Path,
+    project: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    project.map(|path| {
+        if path.is_absolute() {
+            path
+        } else {
+            project_root.join(path)
+        }
+    })
 }
 
 async fn resolve_queue_identity(
@@ -59,8 +80,13 @@ async fn resolve_request_project(
     state: &Arc<AppState>,
     project: Option<std::path::PathBuf>,
 ) -> Result<(String, std::path::PathBuf), EnqueueTaskError> {
-    let project =
-        resolve_project_from_registry(state.core.project_registry.as_deref(), project).await?;
+    let project = resolve_project_from_registry(
+        state.core.project_registry.as_deref(),
+        &state.core.project_root,
+        project,
+    )
+    .await?;
+    let project = normalize_request_project_path(&state.core.project_root, project);
     resolve_queue_identity(state, project).await
 }
 
@@ -714,6 +740,23 @@ mod tests {
         Ok((state, canonical_root))
     }
 
+    #[tokio::test]
+    async fn existing_relative_directory_is_not_rebound_to_registry_project() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let (state, _canonical_root) =
+            make_state_with_registry_and_queue_limit(dir.path(), "named", 1).await?;
+        let local_dir = dir.path().join("foo");
+        std::fs::create_dir_all(&local_dir)?;
+
+        let (project_id, project_root) =
+            resolve_request_project(&state, Some(PathBuf::from("foo"))).await?;
+
+        assert_eq!(project_root, local_dir.canonicalize()?);
+        assert_eq!(project_id, local_dir.canonicalize()?.to_string_lossy());
+        Ok(())
+    }
+
     #[test]
     fn batch_request_deserializes_issues_format() {
         let json = r#"{"issues": [300, 301, 302], "agent": "claude", "max_rounds": 3, "turn_timeout_secs": 600}"#;
@@ -783,7 +826,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_project_from_registry_passes_through_none() {
-        let result = resolve_project_from_registry(None, None).await;
+        let result = resolve_project_from_registry(None, std::path::Path::new("."), None).await;
         assert!(result.unwrap().is_none());
     }
 
@@ -791,7 +834,9 @@ mod tests {
     async fn resolve_project_from_registry_passes_through_existing_dir() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
-        let result = resolve_project_from_registry(None, Some(path.clone())).await;
+        let result =
+            resolve_project_from_registry(None, std::path::Path::new("."), Some(path.clone()))
+                .await;
         assert_eq!(result.unwrap(), Some(path));
     }
 
@@ -800,7 +845,9 @@ mod tests {
         // When no registry is available, non-dir paths are returned as-is
         // (downstream canonicalization handles them).
         let path = std::path::PathBuf::from("/nonexistent/path");
-        let result = resolve_project_from_registry(None, Some(path.clone())).await;
+        let result =
+            resolve_project_from_registry(None, std::path::Path::new("."), Some(path.clone()))
+                .await;
         assert_eq!(result.unwrap(), Some(path));
     }
 
@@ -810,9 +857,8 @@ mod tests {
         let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
             .await
             .unwrap();
-        let project_root = dir.path().join("my-repo");
-        std::fs::create_dir_all(&project_root).unwrap();
-        let canonical_root = project_root.canonicalize().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let canonical_root = project_root.path().canonicalize().unwrap();
         registry
             .register(crate::project_registry::Project {
                 id: "my-repo".to_string(),
@@ -827,6 +873,7 @@ mod tests {
 
         let result = resolve_project_from_registry(
             Some(&registry),
+            dir.path(),
             Some(std::path::PathBuf::from("my-repo")),
         )
         .await;
@@ -853,8 +900,12 @@ mod tests {
             .await
             .unwrap();
 
-        let result =
-            resolve_project_from_registry(Some(&registry), Some(canonical_root.clone())).await;
+        let result = resolve_project_from_registry(
+            Some(&registry),
+            dir.path(),
+            Some(canonical_root.clone()),
+        )
+        .await;
         assert_eq!(result.unwrap(), Some(canonical_root));
     }
 
@@ -867,6 +918,7 @@ mod tests {
 
         let result = resolve_project_from_registry(
             Some(&registry),
+            dir.path(),
             Some(std::path::PathBuf::from("unknown-repo")),
         )
         .await;

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -152,6 +152,12 @@ fn ensure_unique_identity(
                 &entry.id,
             ));
         }
+        // Inverse check: new project's ID must not equal an existing project's
+        // canonical root alias, or resolve_project_input would hijack path
+        // lookups for that existing project to the new one.
+        if project.id == canonical_root_alias(&entry.root) {
+            return Err(invalid_project_id(&project.id));
+        }
     }
 
     Ok(())
@@ -236,7 +242,17 @@ pub fn resolve_configured_project_limits(
     default_root: &Path,
     limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
 ) -> anyhow::Result<std::collections::HashMap<String, usize>> {
-    let mut resolved = limits.by_id().clone();
+    let mut resolved = std::collections::HashMap::new();
+
+    // For the Typed variant, by_id keys are already project IDs — copy directly
+    // without resolution.  Skip this for the Legacy variant because by_id() and
+    // legacy() return the *same* underlying map there; copying first and then
+    // resolving again in the legacy branch would leave raw path keys alongside
+    // their resolved counterparts.
+    if limits.legacy().is_none() {
+        resolved.extend(limits.by_id().iter().map(|(k, v)| (k.clone(), *v)));
+    }
+
     if let Some(legacy) = limits.legacy() {
         for (key, value) in legacy {
             let resolved_key = resolve_configured_limit_key(projects, default_root, key)?;
@@ -262,10 +278,19 @@ pub fn resolve_project_input(
     match requested {
         None => resolve_default_from_projects(projects, default_root),
         Some(path) => {
+            // Resolve relative paths against default_root, not the process CWD,
+            // so behaviour is deterministic regardless of where the binary was
+            // launched from.
+            let full_path: std::borrow::Cow<'_, Path> = if path.is_absolute() {
+                std::borrow::Cow::Borrowed(path)
+            } else {
+                std::borrow::Cow::Owned(default_root.join(path))
+            };
+
             // Only treat the literal string "default" as the default-project
             // sentinel when it is not an actual directory on disk.  A relative
             // directory named "default" must go through normal path resolution.
-            if path == Path::new(DEFAULT_PROJECT_ID) && !path.is_dir() {
+            if path == Path::new(DEFAULT_PROJECT_ID) && !full_path.is_dir() {
                 return resolve_default_from_projects(projects, default_root);
             }
 
@@ -274,7 +299,7 @@ pub fn resolve_project_input(
                 return Ok(ResolvedProject::from_project(clone_project_root(project)));
             }
 
-            let canonical_root = canonicalize_root(path)?;
+            let canonical_root = canonicalize_root(&full_path)?;
             if let Some(project) = find_exact_root_match(projects, &canonical_root) {
                 return Ok(ResolvedProject::from_project(clone_project_root(project)));
             }
@@ -343,7 +368,7 @@ impl ProjectRegistry {
         // unique constraint so that upgrading from an older DB that allowed
         // duplicate roots does not cause a startup outage.  Keep the row with
         // the lowest rowid (oldest entry) for each root value.
-        sqlx::query(
+        let delete_result = sqlx::query(
             "DELETE FROM projects WHERE rowid NOT IN (\
                 SELECT MIN(rowid) FROM projects \
                 GROUP BY json_extract(data, '$.root')\
@@ -351,6 +376,14 @@ impl ProjectRegistry {
         )
         .execute(self.db.pool())
         .await?;
+        let deleted = delete_result.rows_affected();
+        if deleted > 0 {
+            tracing::warn!(
+                deleted_rows = deleted,
+                "removed duplicate project rows during startup deduplication; \
+                 only the oldest row per canonical root was kept"
+            );
+        }
 
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_canonical_root \
@@ -1185,6 +1218,19 @@ mod tests {
 
     static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// RAII guard that restores the process working directory on drop.
+    struct CwdGuard(std::path::PathBuf);
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            if let Err(e) = std::env::set_current_dir(&self.0) {
+                eprintln!(
+                    "CwdGuard: failed to restore working directory to {}: {e}",
+                    self.0.display()
+                );
+            }
+        }
+    }
+
     fn test_project(root: PathBuf, id: &str) -> Project {
         Project {
             id: id.to_string(),
@@ -1506,33 +1552,32 @@ mod tests {
     #[tokio::test]
     async fn relative_directory_input_does_not_resolve_to_registered_suffix_alias(
     ) -> anyhow::Result<()> {
-        let _cwd_guard = CWD_LOCK.lock().unwrap();
-        let original_cwd = std::env::current_dir()?;
+        let _lock = CWD_LOCK.lock().unwrap();
+        let _cwd = CwdGuard(std::env::current_dir()?);
 
-        let result = (|| -> anyhow::Result<()> {
-            let project_root = tempfile::tempdir()?;
-            let canonical_project_root = project_root.path().canonicalize()?;
-            let nested = canonical_project_root.join("foo");
-            std::fs::create_dir(&nested)?;
-            std::env::set_current_dir(project_root.path())?;
+        let project_root = tempfile::tempdir()?;
+        let canonical_project_root = project_root.path().canonicalize()?;
+        let nested = canonical_project_root.join("foo");
+        std::fs::create_dir(&nested)?;
+        // Set CWD so that the test mirrors a realistic server launch context;
+        // resolve_project_input now anchors relative paths to default_root
+        // rather than CWD, so this does not affect the outcome.
+        std::env::set_current_dir(project_root.path())?;
 
-            let registered_root = tempfile::tempdir()?;
-            let registered_root = registered_root.path().join("parent").join("foo");
-            std::fs::create_dir_all(&registered_root)?;
-            let registered_root = registered_root.canonicalize()?;
+        let registered_root = tempfile::tempdir()?;
+        let registered_root = registered_root.path().join("parent").join("foo");
+        std::fs::create_dir_all(&registered_root)?;
+        let registered_root = registered_root.canonicalize()?;
 
-            let project = resolve_project_input(
-                &[test_project(registered_root, "registered")],
-                Some(Path::new("foo")),
-                project_root.path(),
-            )?;
+        let project = resolve_project_input(
+            &[test_project(registered_root, "registered")],
+            Some(Path::new("foo")),
+            project_root.path(),
+        )?;
 
-            assert_eq!(project.root, nested.canonicalize()?);
-            assert_eq!(project.id, nested.to_string_lossy());
-            Ok(())
-        })();
-
-        std::env::set_current_dir(original_cwd)?;
+        assert_eq!(project.root, nested.canonicalize()?);
+        assert_eq!(project.id, nested.to_string_lossy());
+        let result: anyhow::Result<()> = Ok(());
         result
     }
 

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -265,7 +265,7 @@ pub fn resolve_project_input(
             }
 
             Ok(ResolvedProject {
-                id: DEFAULT_PROJECT_ID.to_string(),
+                id: canonical_root_alias(&canonical_root),
                 root: canonical_root,
                 max_concurrent: None,
                 default_agent: None,
@@ -338,11 +338,7 @@ impl ProjectRegistry {
 
     /// List all registered projects ordered by creation time (newest first).
     pub async fn list(&self) -> anyhow::Result<Vec<Project>> {
-        let mut projects = self.db.list().await?;
-        for project in &mut projects {
-            project.root = canonicalize_root(&project.root)?;
-        }
-        Ok(projects)
+        self.db.list().await
     }
 
     /// Get a project by ID or canonical root alias.
@@ -1344,7 +1340,11 @@ mod tests {
         assert_eq!(implicit.id, DEFAULT_PROJECT_ID);
         assert_eq!(implicit.root, canonical_default_root);
         assert_eq!(default_id, implicit);
-        assert_eq!(default_alias, implicit);
+        assert_eq!(
+            default_alias.id,
+            canonical_root_alias(&canonical_default_root)
+        );
+        assert_eq!(default_alias.root, canonical_default_root);
         Ok(())
     }
 
@@ -1379,6 +1379,74 @@ mod tests {
             .resolve_limits(default_root.path(), &limits)
             .await?;
         assert_eq!(resolved.get("named"), Some(&2));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_registered_root_does_not_break_other_project_lookups() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let live_root = tempfile::tempdir()?;
+        let deleted_root = tempfile::tempdir()?;
+        let live_canonical_root = live_root.path().canonicalize()?;
+        let deleted_canonical_root = deleted_root.path().canonicalize()?;
+
+        registry
+            .register(test_project(live_canonical_root.clone(), "live-project"))
+            .await?;
+        registry
+            .register(test_project(deleted_canonical_root, "stale-project"))
+            .await?;
+        drop(deleted_root);
+
+        let loaded = registry
+            .get("live-project")
+            .await?
+            .expect("live project should still resolve");
+        assert_eq!(loaded.root, live_canonical_root);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unregistered_directory_keeps_its_own_canonical_queue_identity() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let default_root = tempfile::tempdir()?;
+        let repo_root = tempfile::tempdir()?;
+        let canonical_repo_root = repo_root.path().canonicalize()?;
+
+        let resolved = registry
+            .resolve_project(Some(canonical_repo_root.as_path()), default_root.path())
+            .await?;
+
+        assert_eq!(resolved.root, canonical_repo_root);
+        assert_eq!(resolved.id, canonical_repo_root.to_string_lossy());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_limits_maps_by_root_entries_for_registered_projects() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let default_root = tempfile::tempdir()?;
+        let project_root = tempfile::tempdir()?;
+        let canonical_project_root = project_root.path().canonicalize()?;
+
+        registry
+            .register(test_project(canonical_project_root.clone(), "named"))
+            .await?;
+
+        let mut limits = harness_core::config::misc::PerProjectConcurrencyLimits::default();
+        if let harness_core::config::misc::PerProjectConcurrencyLimits::Typed(typed) = &mut limits {
+            typed
+                .by_root
+                .insert(canonical_project_root.to_string_lossy().into_owned(), 3);
+        }
+
+        let resolved = registry
+            .resolve_limits(default_root.path(), &limits)
+            .await?;
+        assert_eq!(resolved.get("named"), Some(&3));
         Ok(())
     }
 }

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -262,7 +262,10 @@ pub fn resolve_project_input(
     match requested {
         None => resolve_default_from_projects(projects, default_root),
         Some(path) => {
-            if path == Path::new(DEFAULT_PROJECT_ID) {
+            // Only treat the literal string "default" as the default-project
+            // sentinel when it is not an actual directory on disk.  A relative
+            // directory named "default" must go through normal path resolution.
+            if path == Path::new(DEFAULT_PROJECT_ID) && !path.is_dir() {
                 return resolve_default_from_projects(projects, default_root);
             }
 
@@ -336,6 +339,19 @@ pub struct ProjectRegistry {
 
 impl ProjectRegistry {
     async fn ensure_indexes(&self) -> anyhow::Result<()> {
+        // Deduplicate rows with the same canonical root before enforcing the
+        // unique constraint so that upgrading from an older DB that allowed
+        // duplicate roots does not cause a startup outage.  Keep the row with
+        // the lowest rowid (oldest entry) for each root value.
+        sqlx::query(
+            "DELETE FROM projects WHERE rowid NOT IN (\
+                SELECT MIN(rowid) FROM projects \
+                GROUP BY json_extract(data, '$.root')\
+            )",
+        )
+        .execute(self.db.pool())
+        .await?;
+
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_canonical_root \
              ON projects(json_extract(data, '$.root'))",

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,7 +1,284 @@
+use anyhow::Context;
 use harness_core::db::{Db, DbEntity};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+pub const DEFAULT_PROJECT_ID: &str = "default";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedProject {
+    pub id: String,
+    pub root: PathBuf,
+    pub max_concurrent: Option<u32>,
+    pub default_agent: Option<String>,
+    pub active: bool,
+}
+
+impl ResolvedProject {
+    fn from_project(project: Project) -> Self {
+        Self {
+            id: project.id,
+            root: project.root,
+            max_concurrent: project.max_concurrent,
+            default_agent: project.default_agent,
+            active: project.active,
+        }
+    }
+}
+
+fn canonicalize_root(root: &Path) -> anyhow::Result<PathBuf> {
+    root.canonicalize()
+        .with_context(|| format!("failed to canonicalize project root '{}'", root.display()))
+}
+
+fn canonical_root_alias(root: &Path) -> String {
+    root.to_string_lossy().into_owned()
+}
+
+fn clone_project_root(project: &Project) -> Project {
+    Project {
+        id: project.id.clone(),
+        root: project.root.clone(),
+        max_concurrent: project.max_concurrent,
+        default_agent: project.default_agent.clone(),
+        active: project.active,
+        created_at: project.created_at.clone(),
+    }
+}
+
+fn matches_alias(project: &Project, alias: &Path) -> bool {
+    project.root == alias || project.root.ends_with(alias)
+}
+
+fn invalid_project_id(id: &str) -> anyhow::Error {
+    anyhow::anyhow!("project id '{id}' conflicts with a canonical root alias")
+}
+
+fn duplicate_root_error(id: &str, root: &Path, existing_id: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "project '{id}' reuses canonical root '{}' already registered to '{existing_id}'",
+        root.display()
+    )
+}
+
+fn ambiguous_alias_error(alias: &Path, first_id: &str, second_id: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "project alias '{}' is ambiguous between '{first_id}' and '{second_id}'",
+        alias.display()
+    )
+}
+
+fn duplicate_alias_error(id: &str, root: &Path, existing_id: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "project '{id}' root '{}' conflicts with registered id '{existing_id}'",
+        root.display()
+    )
+}
+
+fn find_alias_match<'a>(
+    projects: &'a [Project],
+    alias: &Path,
+) -> anyhow::Result<Option<&'a Project>> {
+    let mut matched: Option<&Project> = None;
+    for project in projects {
+        if matches_alias(project, alias) {
+            if let Some(existing) = matched {
+                return Err(ambiguous_alias_error(alias, &existing.id, &project.id));
+            }
+            matched = Some(project);
+        }
+    }
+    Ok(matched)
+}
+
+fn ensure_unique_identity(
+    existing: &[Project],
+    project: &Project,
+    canonical_root: &Path,
+) -> anyhow::Result<()> {
+    if existing
+        .iter()
+        .any(|entry| entry.id != project.id && entry.id == canonical_root_alias(canonical_root))
+    {
+        return Err(invalid_project_id(&project.id));
+    }
+
+    for entry in existing {
+        if entry.id == project.id {
+            continue;
+        }
+        if entry.root == canonical_root {
+            return Err(duplicate_root_error(&project.id, canonical_root, &entry.id));
+        }
+        if entry.id == canonical_root_alias(canonical_root) {
+            return Err(duplicate_alias_error(
+                &project.id,
+                canonical_root,
+                &entry.id,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_project(project: Project) -> anyhow::Result<Project> {
+    let canonical_root = canonicalize_root(&project.root)?;
+    if project.id == canonical_root_alias(&canonical_root) {
+        return Err(invalid_project_id(&project.id));
+    }
+    Ok(Project {
+        root: canonical_root,
+        ..project
+    })
+}
+
+fn resolve_from_projects(projects: &[Project], key: &str) -> anyhow::Result<Option<Project>> {
+    if let Some(project) = projects.iter().find(|project| project.id == key) {
+        return Ok(Some(clone_project_root(project)));
+    }
+
+    let alias_path = Path::new(key);
+    if alias_path.as_os_str().is_empty() {
+        return Ok(None);
+    }
+
+    find_alias_match(projects, alias_path).map(|project| project.map(clone_project_root))
+}
+
+fn resolve_default_from_projects(
+    projects: &[Project],
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    if let Some(project) = projects
+        .iter()
+        .find(|project| project.id == DEFAULT_PROJECT_ID)
+    {
+        return Ok(ResolvedProject::from_project(clone_project_root(project)));
+    }
+
+    if let Some(project) = find_alias_match(projects, default_root)? {
+        return Ok(ResolvedProject::from_project(clone_project_root(project)));
+    }
+
+    Ok(ResolvedProject {
+        id: DEFAULT_PROJECT_ID.to_string(),
+        root: canonicalize_root(default_root)?,
+        max_concurrent: None,
+        default_agent: None,
+        active: true,
+    })
+}
+
+pub fn canonical_project_key(id: &str) -> String {
+    id.to_string()
+}
+
+pub fn default_project_record(root: PathBuf) -> Project {
+    Project {
+        id: DEFAULT_PROJECT_ID.to_string(),
+        root,
+        max_concurrent: None,
+        default_agent: None,
+        active: true,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+pub fn startup_project_record(id: String, root: PathBuf) -> Project {
+    Project {
+        id,
+        root,
+        max_concurrent: None,
+        default_agent: None,
+        active: true,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+pub fn resolve_configured_project_limits(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    let mut resolved = limits.by_id().clone();
+    if let Some(legacy) = limits.legacy() {
+        for (key, value) in legacy {
+            let resolved_project = if key == DEFAULT_PROJECT_ID {
+                resolve_default_from_projects(projects, default_root)?
+            } else {
+                resolve_from_projects(projects, key)?
+                    .map(ResolvedProject::from_project)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "legacy per_project entry '{key}' does not resolve to a project"
+                        )
+                    })?
+            };
+            resolved.entry(resolved_project.id).or_insert(*value);
+        }
+    }
+
+    if let Some(by_root) = limits.by_root() {
+        for (key, value) in by_root {
+            let alias_path = Path::new(key);
+            let resolved_project = if alias_path == default_root {
+                resolve_default_from_projects(projects, default_root)?
+            } else {
+                resolve_from_projects(projects, key)?
+                    .map(ResolvedProject::from_project)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "per_project.by_root entry '{key}' does not resolve to a project"
+                        )
+                    })?
+            };
+            resolved.entry(resolved_project.id).or_insert(*value);
+        }
+    }
+
+    Ok(resolved)
+}
+
+pub fn resolve_project_input(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    match requested {
+        None => resolve_default_from_projects(projects, default_root),
+        Some(path) => {
+            if path == Path::new(DEFAULT_PROJECT_ID) {
+                return resolve_default_from_projects(projects, default_root);
+            }
+
+            if let Some(project) = resolve_from_projects(projects, &path.to_string_lossy())? {
+                return Ok(ResolvedProject::from_project(project));
+            }
+
+            let canonical_root = canonicalize_root(path)?;
+            if let Some(project) =
+                resolve_from_projects(projects, &canonical_root.to_string_lossy())?
+            {
+                return Ok(ResolvedProject::from_project(project));
+            }
+
+            Ok(ResolvedProject {
+                id: DEFAULT_PROJECT_ID.to_string(),
+                root: canonical_root,
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+            })
+        }
+    }
+}
+
+fn project_list_alias_guard(projects: &[Project], project: &Project) -> anyhow::Result<()> {
+    let canonical_root = canonicalize_root(&project.root)?;
+    ensure_unique_identity(projects, project, &canonical_root)
+}
 
 /// A registered project with its root path and optional config overrides.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,17 +330,25 @@ impl ProjectRegistry {
 
     /// Register or update a project.
     pub async fn register(&self, project: Project) -> anyhow::Result<()> {
+        let project = normalize_project(project)?;
+        let existing = self.db.list().await?;
+        project_list_alias_guard(&existing, &project)?;
         self.db.upsert(&project).await
     }
 
     /// List all registered projects ordered by creation time (newest first).
     pub async fn list(&self) -> anyhow::Result<Vec<Project>> {
-        self.db.list().await
+        let mut projects = self.db.list().await?;
+        for project in &mut projects {
+            project.root = canonicalize_root(&project.root)?;
+        }
+        Ok(projects)
     }
 
-    /// Get a project by ID.
+    /// Get a project by ID or canonical root alias.
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<Project>> {
-        self.db.get(id).await
+        let projects = self.list().await?;
+        resolve_from_projects(&projects, id)
     }
 
     /// Remove a project by ID. Returns `true` if it existed.
@@ -71,10 +356,742 @@ impl ProjectRegistry {
         self.db.delete(id).await
     }
 
-    /// Resolve a project ID to its root path. Returns `None` if not found.
+    /// Resolve a project ID or alias to its root path. Returns `None` if not found.
     pub async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
         Ok(self.get(id).await?.map(|p| p.root))
     }
+
+    pub async fn resolve_project(
+        &self,
+        requested: Option<&Path>,
+        default_root: &Path,
+    ) -> anyhow::Result<ResolvedProject> {
+        let projects = self.list().await?;
+        resolve_project_input(&projects, requested, default_root)
+    }
+
+    pub async fn resolve_limits(
+        &self,
+        default_root: &Path,
+        limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+    ) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+        let projects = self.list().await?;
+        resolve_configured_project_limits(&projects, default_root, limits)
+    }
+}
+
+impl Project {
+    pub fn resolved(&self) -> ResolvedProject {
+        ResolvedProject::from_project(self.clone())
+    }
+}
+
+impl ResolvedProject {
+    pub fn task_queue_key(&self) -> String {
+        canonical_project_key(&self.id)
+    }
+}
+
+pub fn resolve_project_with_registry(
+    registry: Option<&ProjectRegistry>,
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    match registry {
+        Some(_) => anyhow::bail!("async registry resolution required"),
+        None => resolve_project_input(&[], requested, default_root),
+    }
+}
+
+pub async fn resolve_project_with_optional_registry(
+    registry: Option<&ProjectRegistry>,
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    match registry {
+        Some(registry) => registry.resolve_project(requested, default_root).await,
+        None => resolve_project_input(&[], requested, default_root),
+    }
+}
+
+pub fn project_queue_overrides(
+    project: &ResolvedProject,
+    configured_limit: Option<usize>,
+) -> Option<usize> {
+    project
+        .max_concurrent
+        .map(|limit| limit as usize)
+        .or(configured_limit)
+}
+
+pub fn ensure_project_is_active(project: &ResolvedProject) -> anyhow::Result<()> {
+    if project.active {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("project '{}' is inactive", project.id))
+    }
+}
+
+pub fn resolve_project_default_agent(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn resolve_project_root_alias(project: &ResolvedProject) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn canonical_project_root(root: &Path) -> anyhow::Result<PathBuf> {
+    canonicalize_root(root)
+}
+
+pub fn canonical_project_root_string(root: &Path) -> anyhow::Result<String> {
+    Ok(canonical_root_alias(&canonicalize_root(root)?))
+}
+
+pub fn is_default_project_id(id: &str) -> bool {
+    id == DEFAULT_PROJECT_ID
+}
+
+pub fn default_project_id() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn normalize_project_record(project: Project) -> anyhow::Result<Project> {
+    normalize_project(project)
+}
+
+pub fn resolve_project_alias_in_memory(
+    projects: &[Project],
+    key: &str,
+) -> anyhow::Result<Option<Project>> {
+    resolve_from_projects(projects, key)
+}
+
+pub fn validate_project_identity_uniqueness(
+    existing: &[Project],
+    project: &Project,
+) -> anyhow::Result<()> {
+    let canonical_root = canonicalize_root(&project.root)?;
+    ensure_unique_identity(existing, project, &canonical_root)
+}
+
+pub fn resolve_default_project_in_memory(
+    projects: &[Project],
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_default_from_projects(projects, default_root)
+}
+
+pub fn queue_limit_overrides(
+    project: &ResolvedProject,
+    configured_limit: Option<usize>,
+) -> Option<usize> {
+    project_queue_overrides(project, configured_limit)
+}
+
+pub fn project_identity_alias(project: &Project) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn canonical_project_alias(root: &Path) -> String {
+    canonical_root_alias(root)
+}
+
+pub fn canonicalize_project_root(root: &Path) -> anyhow::Result<PathBuf> {
+    canonicalize_root(root)
+}
+
+pub fn resolved_project_from_project(project: Project) -> ResolvedProject {
+    ResolvedProject::from_project(project)
+}
+
+pub fn clone_project(project: &Project) -> Project {
+    clone_project_root(project)
+}
+
+pub fn project_matches_alias(project: &Project, alias: &Path) -> bool {
+    matches_alias(project, alias)
+}
+
+pub fn resolve_projects_configured_limits(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    resolve_configured_project_limits(projects, default_root, limits)
+}
+
+pub fn resolve_requested_project(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn default_project(root: PathBuf) -> Project {
+    default_project_record(root)
+}
+
+pub fn startup_project(id: String, root: PathBuf) -> Project {
+    startup_project_record(id, root)
+}
+
+pub fn validate_project_activity(project: &ResolvedProject) -> anyhow::Result<()> {
+    ensure_project_is_active(project)
+}
+
+pub fn project_default_agent(project: &ResolvedProject) -> Option<&str> {
+    resolve_project_default_agent(project)
+}
+
+pub fn project_queue_key(project: &ResolvedProject) -> String {
+    project.task_queue_key()
+}
+
+pub fn project_root_alias(project: &ResolvedProject) -> String {
+    resolve_project_root_alias(project)
+}
+
+pub fn canonical_root_key(root: &Path) -> anyhow::Result<String> {
+    canonical_project_root_string(root)
+}
+
+pub fn canonical_id_key(id: &str) -> String {
+    canonical_project_key(id)
+}
+
+pub fn project_id_conflicts_with_alias(id: &str, root: &Path) -> bool {
+    id == canonical_root_alias(root)
+}
+
+pub fn resolve_project_alias(
+    projects: &[Project],
+    alias: &Path,
+) -> anyhow::Result<Option<Project>> {
+    find_alias_match(projects, alias).map(|project| project.map(clone_project_root))
+}
+
+pub fn resolved_project_default_id() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn resolved_project_key(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn resolved_project_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn resolved_project_is_active(project: &ResolvedProject) -> bool {
+    project.active
+}
+
+pub fn resolved_project_limit(project: &ResolvedProject) -> Option<u32> {
+    project.max_concurrent
+}
+
+pub fn resolved_project_agent(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn projects_by_id(projects: &[Project]) -> std::collections::HashMap<String, Project> {
+    projects
+        .iter()
+        .cloned()
+        .map(|project| (project.id.clone(), project))
+        .collect()
+}
+
+pub fn project_aliases(projects: &[Project]) -> std::collections::HashMap<String, String> {
+    projects
+        .iter()
+        .map(|project| (canonical_root_alias(&project.root), project.id.clone()))
+        .collect()
+}
+
+pub fn resolved_project_for_queue(project: &ResolvedProject) -> (&str, &Path) {
+    (&project.id, &project.root)
+}
+
+pub fn active_project_or_error(project: ResolvedProject) -> anyhow::Result<ResolvedProject> {
+    ensure_project_is_active(&project)?;
+    Ok(project)
+}
+
+pub fn apply_project_overrides(
+    project: &ResolvedProject,
+    configured_limit: Option<usize>,
+) -> Option<usize> {
+    project_queue_overrides(project, configured_limit)
+}
+
+pub fn resolved_project_from_parts(
+    id: String,
+    root: PathBuf,
+    max_concurrent: Option<u32>,
+    default_agent: Option<String>,
+    active: bool,
+) -> ResolvedProject {
+    ResolvedProject {
+        id,
+        root,
+        max_concurrent,
+        default_agent,
+        active,
+    }
+}
+
+pub fn default_project_resolved(root: PathBuf) -> ResolvedProject {
+    ResolvedProject {
+        id: DEFAULT_PROJECT_ID.to_string(),
+        root,
+        max_concurrent: None,
+        default_agent: None,
+        active: true,
+    }
+}
+
+pub fn resolved_project_from_optional(
+    project: Option<Project>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    match project {
+        Some(project) => Ok(project.resolved()),
+        None => Ok(default_project_resolved(canonicalize_root(default_root)?)),
+    }
+}
+
+pub fn project_root_matches(project: &ResolvedProject, root: &Path) -> bool {
+    project.root == root
+}
+
+pub fn resolved_project_display_name(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn default_project_display_name() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn resolved_project_created_from_default(root: PathBuf) -> ResolvedProject {
+    default_project_resolved(root)
+}
+
+pub fn project_id_matches(project: &ResolvedProject, id: &str) -> bool {
+    project.id == id
+}
+
+pub fn resolved_project_to_project(project: &ResolvedProject, created_at: String) -> Project {
+    Project {
+        id: project.id.clone(),
+        root: project.root.clone(),
+        max_concurrent: project.max_concurrent,
+        default_agent: project.default_agent.clone(),
+        active: project.active,
+        created_at,
+    }
+}
+
+pub fn project_identity(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn project_execution_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn configured_project_default_agent(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn configured_project_max_concurrent(project: &ResolvedProject) -> Option<u32> {
+    project.max_concurrent
+}
+
+pub fn resolved_project_summary(project: &ResolvedProject) -> (&str, &Path, bool) {
+    (&project.id, &project.root, project.active)
+}
+
+pub fn project_key_for_logs(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn project_root_for_logs(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn resolve_project_or_default(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn configured_queue_key(id: &str) -> String {
+    canonical_project_key(id)
+}
+
+pub fn default_project_name() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn default_project_root_key(root: &Path) -> anyhow::Result<String> {
+    canonical_project_root_string(root)
+}
+
+pub fn resolved_project_limit_override(project: &ResolvedProject) -> Option<usize> {
+    project.max_concurrent.map(|value| value as usize)
+}
+
+pub fn canonical_root_alias_string(root: &Path) -> String {
+    canonical_root_alias(root)
+}
+
+pub fn project_root_alias_string(project: &Project) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn maybe_resolve_project(projects: &[Project], key: &str) -> anyhow::Result<Option<Project>> {
+    resolve_from_projects(projects, key)
+}
+
+pub fn maybe_resolve_requested_project(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn resolve_project_limit_map(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    resolve_configured_project_limits(projects, default_root, limits)
+}
+
+pub fn canonical_project_identifier(id: &str) -> String {
+    canonical_project_key(id)
+}
+
+pub fn resolved_project_identifier(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn resolved_project_canonical_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn resolved_project_default_agent_name(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn resolved_project_concurrency(project: &ResolvedProject) -> Option<u32> {
+    project.max_concurrent
+}
+
+pub fn resolved_project_active(project: &ResolvedProject) -> bool {
+    project.active
+}
+
+pub fn default_resolved_project(root: PathBuf) -> ResolvedProject {
+    default_project_resolved(root)
+}
+
+pub fn is_default_project(project: &ResolvedProject) -> bool {
+    project.id == DEFAULT_PROJECT_ID
+}
+
+pub fn resolve_project_id_or_alias(
+    projects: &[Project],
+    key: &str,
+) -> anyhow::Result<Option<Project>> {
+    resolve_from_projects(projects, key)
+}
+
+pub fn ensure_distinct_project_identity(
+    existing: &[Project],
+    project: &Project,
+) -> anyhow::Result<()> {
+    let canonical_root = canonicalize_root(&project.root)?;
+    ensure_unique_identity(existing, project, &canonical_root)
+}
+
+pub fn canonical_project_path(root: &Path) -> anyhow::Result<PathBuf> {
+    canonicalize_root(root)
+}
+
+pub fn canonical_project_path_string(root: &Path) -> anyhow::Result<String> {
+    canonical_project_root_string(root)
+}
+
+pub fn canonical_project_alias_string_for_project(project: &Project) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn resolve_registered_project(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn queue_identity(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn execution_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn registry_project(project: Project) -> ResolvedProject {
+    project.resolved()
+}
+
+pub fn registry_project_key(project: &ResolvedProject) -> String {
+    canonical_project_key(&project.id)
+}
+
+pub fn registry_project_root_alias(project: &ResolvedProject) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn registry_default_project(root: PathBuf) -> Project {
+    default_project_record(root)
+}
+
+pub fn registry_startup_project(id: String, root: PathBuf) -> Project {
+    startup_project_record(id, root)
+}
+
+pub fn resolved_project_active_or_err(project: &ResolvedProject) -> anyhow::Result<()> {
+    ensure_project_is_active(project)
+}
+
+pub fn resolved_project_limit_or_config(
+    project: &ResolvedProject,
+    configured_limit: Option<usize>,
+) -> Option<usize> {
+    project_queue_overrides(project, configured_limit)
+}
+
+pub fn configured_limit_map(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    resolve_configured_project_limits(projects, default_root, limits)
+}
+
+pub fn project_registry_default_id() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn project_registry_canonical_id(id: &str) -> String {
+    canonical_project_key(id)
+}
+
+pub fn project_registry_canonical_root(root: &Path) -> anyhow::Result<PathBuf> {
+    canonicalize_root(root)
+}
+
+pub fn project_registry_canonical_root_alias(root: &Path) -> String {
+    canonical_root_alias(root)
+}
+
+pub fn project_registry_resolved_project(project: Project) -> ResolvedProject {
+    project.resolved()
+}
+
+pub fn project_registry_default_project(root: PathBuf) -> Project {
+    default_project_record(root)
+}
+
+pub fn project_registry_startup_project(id: String, root: PathBuf) -> Project {
+    startup_project_record(id, root)
+}
+
+pub fn project_registry_resolve_project(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn project_registry_resolve_limits(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    resolve_configured_project_limits(projects, default_root, limits)
+}
+
+pub fn project_registry_validate_activity(project: &ResolvedProject) -> anyhow::Result<()> {
+    ensure_project_is_active(project)
+}
+
+pub fn project_registry_queue_key(project: &ResolvedProject) -> String {
+    canonical_project_key(&project.id)
+}
+
+pub fn project_registry_execution_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn project_registry_default_agent(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn project_registry_limit(project: &ResolvedProject) -> Option<u32> {
+    project.max_concurrent
+}
+
+pub fn project_registry_activity(project: &ResolvedProject) -> bool {
+    project.active
+}
+
+pub fn project_registry_root_alias(project: &ResolvedProject) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn project_registry_identity(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn project_registry_resolve_alias(
+    projects: &[Project],
+    alias: &Path,
+) -> anyhow::Result<Option<Project>> {
+    resolve_project_alias(projects, alias)
+}
+
+pub fn project_registry_validate_uniqueness(
+    existing: &[Project],
+    project: &Project,
+) -> anyhow::Result<()> {
+    validate_project_identity_uniqueness(existing, project)
+}
+
+pub fn project_registry_config_limits(
+    projects: &[Project],
+    default_root: &Path,
+    limits: &harness_core::config::misc::PerProjectConcurrencyLimits,
+) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+    resolve_configured_project_limits(projects, default_root, limits)
+}
+
+pub fn project_registry_default_resolved(root: PathBuf) -> ResolvedProject {
+    default_project_resolved(root)
+}
+
+pub fn project_registry_is_default(project: &ResolvedProject) -> bool {
+    project.id == DEFAULT_PROJECT_ID
+}
+
+pub fn project_registry_root_matches(project: &ResolvedProject, root: &Path) -> bool {
+    project.root == root
+}
+
+pub fn project_registry_id_matches(project: &ResolvedProject, id: &str) -> bool {
+    project.id == id
+}
+
+pub fn project_registry_resolve_or_default(
+    projects: &[Project],
+    requested: Option<&Path>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolve_project_input(projects, requested, default_root)
+}
+
+pub fn project_registry_queue_limit_override(
+    project: &ResolvedProject,
+    configured_limit: Option<usize>,
+) -> Option<usize> {
+    project_queue_overrides(project, configured_limit)
+}
+
+pub fn project_registry_display_name(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn project_registry_default_name() -> &'static str {
+    DEFAULT_PROJECT_ID
+}
+
+pub fn project_registry_resolved_key(project: &ResolvedProject) -> &str {
+    &project.id
+}
+
+pub fn project_registry_resolved_root(project: &ResolvedProject) -> &Path {
+    &project.root
+}
+
+pub fn project_registry_resolved_agent(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn project_registry_resolved_limit(project: &ResolvedProject) -> Option<u32> {
+    project.max_concurrent
+}
+
+pub fn project_registry_resolved_active(project: &ResolvedProject) -> bool {
+    project.active
+}
+
+pub fn project_registry_resolved_parts(project: &ResolvedProject) -> (&str, &Path, bool) {
+    (&project.id, &project.root, project.active)
+}
+
+pub fn project_registry_resolved_project_for_queue(project: &ResolvedProject) -> (&str, &Path) {
+    (&project.id, &project.root)
+}
+
+pub fn project_registry_resolved_from_optional(
+    project: Option<Project>,
+    default_root: &Path,
+) -> anyhow::Result<ResolvedProject> {
+    resolved_project_from_optional(project, default_root)
+}
+
+pub fn project_registry_resolved_from_parts(
+    id: String,
+    root: PathBuf,
+    max_concurrent: Option<u32>,
+    default_agent: Option<String>,
+    active: bool,
+) -> ResolvedProject {
+    resolved_project_from_parts(id, root, max_concurrent, default_agent, active)
+}
+
+pub fn project_registry_resolved_summary(project: &ResolvedProject) -> (&str, &Path, bool) {
+    (&project.id, &project.root, project.active)
+}
+
+pub fn project_registry_resolved_queue_key(project: &ResolvedProject) -> String {
+    canonical_project_key(&project.id)
+}
+
+pub fn project_registry_resolved_root_alias(project: &ResolvedProject) -> String {
+    canonical_root_alias(&project.root)
+}
+
+pub fn project_registry_resolved_default_agent_name(project: &ResolvedProject) -> Option<&str> {
+    project.default_agent.as_deref()
+}
+
+pub fn project_registry_resolved_limit_override(project: &ResolvedProject) -> Option<usize> {
+    project.max_concurrent.map(|value| value as usize)
+}
+
+pub fn project_registry_default_project_id() -> &'static str {
+    DEFAULT_PROJECT_ID
 }
 
 /// Check that `canonical_root` falls under at least one of the
@@ -119,19 +1136,25 @@ pub fn validate_project_root(root: &std::path::Path) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn register_and_get_roundtrip() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
-
-        let project = Project {
-            id: "my-project".to_string(),
-            root: PathBuf::from("/tmp/my-project"),
+    fn test_project(root: PathBuf, id: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            root,
             max_concurrent: None,
             default_agent: None,
             active: true,
             created_at: "2026-01-01T00:00:00Z".to_string(),
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn register_and_get_roundtrip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let project_root = tempfile::tempdir()?;
+        let canonical_root = project_root.path().canonicalize()?;
+
+        let project = test_project(canonical_root.clone(), "my-project");
         registry.register(project.clone()).await?;
 
         let loaded = registry
@@ -139,7 +1162,7 @@ mod tests {
             .await?
             .expect("project should exist");
         assert_eq!(loaded.id, "my-project");
-        assert_eq!(loaded.root, PathBuf::from("/tmp/my-project"));
+        assert_eq!(loaded.root, canonical_root);
         assert!(loaded.active);
         Ok(())
     }
@@ -148,17 +1171,16 @@ mod tests {
     async fn list_returns_all_projects() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let root_dirs: Vec<_> = (0..3)
+            .map(|_| tempfile::tempdir())
+            .collect::<Result<_, _>>()?;
 
-        for i in 0..3u32 {
+        for (i, root_dir) in root_dirs.iter().enumerate() {
             registry
-                .register(Project {
-                    id: format!("p{i}"),
-                    root: PathBuf::from(format!("/tmp/p{i}")),
-                    max_concurrent: None,
-                    default_agent: None,
-                    active: true,
-                    created_at: "2026-01-01T00:00:00Z".to_string(),
-                })
+                .register(test_project(
+                    root_dir.path().canonicalize()?,
+                    &format!("p{i}"),
+                ))
                 .await?;
         }
 
@@ -171,16 +1193,13 @@ mod tests {
     async fn remove_returns_true_when_found() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let project_root = tempfile::tempdir()?;
 
         registry
-            .register(Project {
-                id: "to-delete".to_string(),
-                root: PathBuf::from("/tmp/x"),
-                max_concurrent: None,
-                default_agent: None,
-                active: true,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
-            })
+            .register(test_project(
+                project_root.path().canonicalize()?,
+                "to-delete",
+            ))
             .await?;
 
         assert!(registry.remove("to-delete").await?);
@@ -200,11 +1219,59 @@ mod tests {
     async fn resolve_path_returns_root() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let project_root = tempfile::tempdir()?;
+        let canonical_root = project_root.path().canonicalize()?;
+
+        registry
+            .register(test_project(canonical_root.clone(), "harness"))
+            .await?;
+
+        let path = registry.resolve_path("harness").await?;
+        assert_eq!(path, Some(canonical_root));
+        assert!(registry.resolve_path("unknown").await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolving_by_root_alias_returns_registered_project() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let root_dir = tempfile::tempdir()?;
+        let canonical_root = root_dir.path().canonicalize()?;
 
         registry
             .register(Project {
                 id: "harness".to_string(),
-                root: PathBuf::from("/home/user/harness"),
+                root: canonical_root.clone(),
+                max_concurrent: Some(2),
+                default_agent: Some("claude".to_string()),
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        let loaded = registry
+            .get(&canonical_root.to_string_lossy())
+            .await?
+            .expect("root alias should resolve to project");
+        assert_eq!(loaded.id, "harness");
+        assert_eq!(loaded.root, canonical_root);
+        assert_eq!(loaded.max_concurrent, Some(2));
+        assert_eq!(loaded.default_agent.as_deref(), Some("claude"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn registering_duplicate_canonical_root_is_rejected() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let root_dir = tempfile::tempdir()?;
+        let canonical_root = root_dir.path().canonicalize()?;
+
+        registry
+            .register(Project {
+                id: "alpha".to_string(),
+                root: canonical_root.clone(),
                 max_concurrent: None,
                 default_agent: None,
                 active: true,
@@ -212,9 +1279,18 @@ mod tests {
             })
             .await?;
 
-        let path = registry.resolve_path("harness").await?;
-        assert_eq!(path, Some(PathBuf::from("/home/user/harness")));
-        assert!(registry.resolve_path("unknown").await?.is_none());
+        let err = registry
+            .register(Project {
+                id: "beta".to_string(),
+                root: canonical_root,
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await
+            .expect_err("duplicate root should be rejected");
+        assert!(err.to_string().contains("canonical root"));
         Ok(())
     }
 
@@ -222,13 +1298,15 @@ mod tests {
     async fn survives_reopen() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("projects.db");
+        let project_root = tempfile::tempdir()?;
+        let canonical_root = project_root.path().canonicalize()?;
 
         {
             let registry = ProjectRegistry::open(&db_path).await?;
             registry
                 .register(Project {
                     id: "persistent".to_string(),
-                    root: PathBuf::from("/tmp/persistent"),
+                    root: canonical_root.clone(),
                     max_concurrent: Some(2),
                     default_agent: Some("claude".to_string()),
                     active: true,
@@ -242,8 +1320,65 @@ mod tests {
             .get("persistent")
             .await?
             .expect("should survive reopen");
+        assert_eq!(loaded.root, canonical_root);
         assert_eq!(loaded.max_concurrent, Some(2));
         assert_eq!(loaded.default_agent.as_deref(), Some("claude"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_requested_project_supports_default_identity_aliases() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let default_root = tempfile::tempdir()?;
+        let canonical_default_root = default_root.path().canonicalize()?;
+
+        let implicit = registry.resolve_project(None, default_root.path()).await?;
+        let default_id = registry
+            .resolve_project(Some(Path::new(DEFAULT_PROJECT_ID)), default_root.path())
+            .await?;
+        let default_alias = registry
+            .resolve_project(Some(canonical_default_root.as_path()), default_root.path())
+            .await?;
+
+        assert_eq!(implicit.id, DEFAULT_PROJECT_ID);
+        assert_eq!(implicit.root, canonical_default_root);
+        assert_eq!(default_id, implicit);
+        assert_eq!(default_alias, implicit);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_limits_maps_root_aliases_to_project_ids() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let default_root = tempfile::tempdir()?;
+        let project_root = tempfile::tempdir()?;
+        let canonical_project_root = project_root.path().canonicalize()?;
+
+        registry
+            .register(Project {
+                id: "named".to_string(),
+                root: canonical_project_root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        let mut limits = harness_core::config::misc::PerProjectConcurrencyLimits::default();
+        limits.by_id_mut().insert("named".to_string(), 2);
+        if let harness_core::config::misc::PerProjectConcurrencyLimits::Typed(typed) = &mut limits {
+            typed
+                .by_root
+                .insert(canonical_project_root.to_string_lossy().into_owned(), 3);
+        }
+
+        let resolved = registry
+            .resolve_limits(default_root.path(), &limits)
+            .await?;
+        assert_eq!(resolved.get("named"), Some(&2));
         Ok(())
     }
 }

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -51,6 +51,40 @@ fn matches_alias(project: &Project, alias: &Path) -> bool {
     project.root == alias || project.root.ends_with(alias)
 }
 
+fn find_exact_root_match<'a>(projects: &'a [Project], root: &Path) -> Option<&'a Project> {
+    projects.iter().find(|project| project.root == root)
+}
+
+fn canonical_or_raw_root_key(path: &Path) -> String {
+    canonicalize_root(path)
+        .map(|root| canonical_root_alias(&root))
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned())
+}
+
+fn resolve_configured_limit_key(
+    projects: &[Project],
+    default_root: &Path,
+    key: &str,
+) -> anyhow::Result<String> {
+    if key == DEFAULT_PROJECT_ID {
+        return Ok(resolve_default_from_projects(projects, default_root)?.id);
+    }
+
+    if let Some(project) = resolve_from_projects(projects, key)? {
+        return Ok(project.id);
+    }
+
+    Ok(canonical_or_raw_root_key(Path::new(key)))
+}
+
+fn map_duplicate_root_conflict(existing: &[Project], project: &Project) -> anyhow::Error {
+    if let Some(existing_project) = existing.iter().find(|entry| entry.root == project.root) {
+        duplicate_root_error(&project.id, &project.root, &existing_project.id)
+    } else {
+        duplicate_root_error(&project.id, &project.root, "unknown")
+    }
+}
+
 fn invalid_project_id(id: &str) -> anyhow::Error {
     anyhow::anyhow!("project id '{id}' conflicts with a canonical root alias")
 }
@@ -205,36 +239,15 @@ pub fn resolve_configured_project_limits(
     let mut resolved = limits.by_id().clone();
     if let Some(legacy) = limits.legacy() {
         for (key, value) in legacy {
-            let resolved_project = if key == DEFAULT_PROJECT_ID {
-                resolve_default_from_projects(projects, default_root)?
-            } else {
-                resolve_from_projects(projects, key)?
-                    .map(ResolvedProject::from_project)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "legacy per_project entry '{key}' does not resolve to a project"
-                        )
-                    })?
-            };
-            resolved.entry(resolved_project.id).or_insert(*value);
+            let resolved_key = resolve_configured_limit_key(projects, default_root, key)?;
+            resolved.entry(resolved_key).or_insert(*value);
         }
     }
 
     if let Some(by_root) = limits.by_root() {
         for (key, value) in by_root {
-            let alias_path = Path::new(key);
-            let resolved_project = if alias_path == default_root {
-                resolve_default_from_projects(projects, default_root)?
-            } else {
-                resolve_from_projects(projects, key)?
-                    .map(ResolvedProject::from_project)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "per_project.by_root entry '{key}' does not resolve to a project"
-                        )
-                    })?
-            };
-            resolved.entry(resolved_project.id).or_insert(*value);
+            let resolved_key = resolve_configured_limit_key(projects, default_root, key)?;
+            resolved.entry(resolved_key).or_insert(*value);
         }
     }
 
@@ -253,15 +266,14 @@ pub fn resolve_project_input(
                 return resolve_default_from_projects(projects, default_root);
             }
 
-            if let Some(project) = resolve_from_projects(projects, &path.to_string_lossy())? {
-                return Ok(ResolvedProject::from_project(project));
+            let raw = path.to_string_lossy();
+            if let Some(project) = projects.iter().find(|project| project.id == raw) {
+                return Ok(ResolvedProject::from_project(clone_project_root(project)));
             }
 
             let canonical_root = canonicalize_root(path)?;
-            if let Some(project) =
-                resolve_from_projects(projects, &canonical_root.to_string_lossy())?
-            {
-                return Ok(ResolvedProject::from_project(project));
+            if let Some(project) = find_exact_root_match(projects, &canonical_root) {
+                return Ok(ResolvedProject::from_project(clone_project_root(project)));
             }
 
             Ok(ResolvedProject {
@@ -323,9 +335,21 @@ pub struct ProjectRegistry {
 }
 
 impl ProjectRegistry {
+    async fn ensure_indexes(&self) -> anyhow::Result<()> {
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_canonical_root \
+             ON projects(json_extract(data, '$.root'))",
+        )
+        .execute(self.db.pool())
+        .await?;
+        Ok(())
+    }
+
     pub async fn open(path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
         let db = Db::open(path).await?;
-        Ok(Arc::new(Self { db }))
+        let registry = Arc::new(Self { db });
+        registry.ensure_indexes().await?;
+        Ok(registry)
     }
 
     /// Register or update a project.
@@ -333,7 +357,18 @@ impl ProjectRegistry {
         let project = normalize_project(project)?;
         let existing = self.db.list().await?;
         project_list_alias_guard(&existing, &project)?;
-        self.db.upsert(&project).await
+        match self.db.upsert(&project).await {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                let message = error.to_string();
+                if message.contains("idx_projects_canonical_root")
+                    || message.contains("json_extract(data, '$.root')")
+                {
+                    return Err(map_duplicate_root_conflict(&existing, &project));
+                }
+                Err(error)
+            }
+        }
     }
 
     /// List all registered projects ordered by creation time (newest first).
@@ -1132,6 +1167,8 @@ pub fn validate_project_root(root: &std::path::Path) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn test_project(root: PathBuf, id: &str) -> Project {
         Project {
             id: id.to_string(),
@@ -1447,6 +1484,122 @@ mod tests {
             .resolve_limits(default_root.path(), &limits)
             .await?;
         assert_eq!(resolved.get("named"), Some(&3));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relative_directory_input_does_not_resolve_to_registered_suffix_alias(
+    ) -> anyhow::Result<()> {
+        let _cwd_guard = CWD_LOCK.lock().unwrap();
+        let original_cwd = std::env::current_dir()?;
+
+        let result = (|| -> anyhow::Result<()> {
+            let project_root = tempfile::tempdir()?;
+            let canonical_project_root = project_root.path().canonicalize()?;
+            let nested = canonical_project_root.join("foo");
+            std::fs::create_dir(&nested)?;
+            std::env::set_current_dir(project_root.path())?;
+
+            let registered_root = tempfile::tempdir()?;
+            let registered_root = registered_root.path().join("parent").join("foo");
+            std::fs::create_dir_all(&registered_root)?;
+            let registered_root = registered_root.canonicalize()?;
+
+            let project = resolve_project_input(
+                &[test_project(registered_root, "registered")],
+                Some(Path::new("foo")),
+                project_root.path(),
+            )?;
+
+            assert_eq!(project.root, nested.canonicalize()?);
+            assert_eq!(project.id, nested.to_string_lossy());
+            Ok(())
+        })();
+
+        std::env::set_current_dir(original_cwd)?;
+        result
+    }
+
+    #[tokio::test]
+    async fn resolve_limits_keeps_unregistered_raw_root_entries() -> anyhow::Result<()> {
+        let default_root = tempfile::tempdir()?;
+        let unregistered_root = tempfile::tempdir()?;
+        let canonical_unregistered_root = unregistered_root.path().canonicalize()?;
+        let projects = vec![test_project(
+            default_root.path().canonicalize()?,
+            DEFAULT_PROJECT_ID,
+        )];
+
+        let mut limits = harness_core::config::misc::PerProjectConcurrencyLimits::Legacy(
+            std::collections::HashMap::new(),
+        );
+        if let harness_core::config::misc::PerProjectConcurrencyLimits::Legacy(legacy) = &mut limits
+        {
+            legacy.insert(
+                canonical_unregistered_root.to_string_lossy().into_owned(),
+                4,
+            );
+        }
+
+        let resolved = resolve_configured_project_limits(&projects, default_root.path(), &limits)?;
+        assert_eq!(
+            resolved.get(&canonical_unregistered_root.to_string_lossy().into_owned()),
+            Some(&4)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_limits_keeps_unregistered_by_root_entries() -> anyhow::Result<()> {
+        let default_root = tempfile::tempdir()?;
+        let unregistered_root = tempfile::tempdir()?;
+        let canonical_unregistered_root = unregistered_root.path().canonicalize()?;
+        let projects = vec![test_project(
+            default_root.path().canonicalize()?,
+            DEFAULT_PROJECT_ID,
+        )];
+
+        let mut limits = harness_core::config::misc::PerProjectConcurrencyLimits::default();
+        if let harness_core::config::misc::PerProjectConcurrencyLimits::Typed(typed) = &mut limits {
+            typed.by_root.insert(
+                canonical_unregistered_root.to_string_lossy().into_owned(),
+                5,
+            );
+        }
+
+        let resolved = resolve_configured_project_limits(&projects, default_root.path(), &limits)?;
+        assert_eq!(
+            resolved.get(&canonical_unregistered_root.to_string_lossy().into_owned()),
+            Some(&5)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_rejects_duplicate_root_under_concurrency() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+        let root_dir = tempfile::tempdir()?;
+        let canonical_root = root_dir.path().canonicalize()?;
+
+        let first = registry.register(test_project(canonical_root.clone(), "alpha"));
+        let second = registry.register(test_project(canonical_root, "beta"));
+        let (first_result, second_result) = tokio::join!(first, second);
+
+        let success_count = [first_result.is_ok(), second_result.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(success_count, 1);
+
+        let failure = first_result
+            .err()
+            .or_else(|| second_result.err())
+            .expect("one registration must fail");
+        assert!(failure.to_string().contains("canonical root"));
+
+        let projects = registry.list().await?;
+        assert_eq!(projects.len(), 1);
         Ok(())
     }
 }

--- a/crates/harness-server/src/services/project.rs
+++ b/crates/harness-server/src/services/project.rs
@@ -136,12 +136,16 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
         let svc = DefaultProjectService::new(registry, dir.path().to_path_buf());
+        let project_root = dir.path().join("alpha-root");
+        std::fs::create_dir_all(&project_root)?;
+        let canonical_root = project_root.canonicalize()?;
 
-        svc.register(make_project("alpha", "/tmp/alpha")).await?;
+        svc.register(make_project("alpha", canonical_root.to_str().unwrap()))
+            .await?;
 
         let loaded = svc.get("alpha").await?.expect("should exist");
         assert_eq!(loaded.id, "alpha");
-        assert_eq!(loaded.root, PathBuf::from("/tmp/alpha"));
+        assert_eq!(loaded.root, canonical_root);
         Ok(())
     }
 
@@ -150,14 +154,14 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
         let svc = DefaultProjectService::new(registry, dir.path().to_path_buf());
+        let project_root = dir.path().join("beta-root");
+        std::fs::create_dir_all(&project_root)?;
+        let canonical_root = project_root.canonicalize()?;
 
-        svc.register(make_project("beta", "/home/user/beta"))
+        svc.register(make_project("beta", canonical_root.to_str().unwrap()))
             .await?;
 
-        assert_eq!(
-            svc.resolve_path("beta").await?,
-            Some(PathBuf::from("/home/user/beta"))
-        );
+        assert_eq!(svc.resolve_path("beta").await?, Some(canonical_root));
         assert_eq!(svc.resolve_path("missing").await?, None);
         Ok(())
     }
@@ -167,8 +171,12 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("p.db")).await?;
         let svc = DefaultProjectService::new(registry, dir.path().to_path_buf());
+        let project_root = dir.path().join("gamma-root");
+        std::fs::create_dir_all(&project_root)?;
+        let canonical_root = project_root.canonicalize()?;
 
-        svc.register(make_project("gamma", "/tmp/gamma")).await?;
+        svc.register(make_project("gamma", canonical_root.to_str().unwrap()))
+            .await?;
         assert!(svc.remove("gamma").await?);
         assert!(!svc.remove("gamma").await?);
         assert!(svc.get("gamma").await?.is_none());

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -408,7 +408,32 @@ pub struct TaskQueue {
 
 impl TaskQueue {
     pub fn new(config: &ConcurrencyConfig) -> Self {
-        Self::new_with_pressure(config, None)
+        let project_limits: DashMap<String, usize> = config
+            .per_project
+            .by_id()
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+        Self::new_with_limits(config, project_limits, None)
+    }
+
+    pub fn new_with_project_limits(
+        config: &ConcurrencyConfig,
+        project_limits: std::collections::HashMap<String, usize>,
+    ) -> Self {
+        Self::new_with_project_limits_and_pressure(config, project_limits, None)
+    }
+
+    pub fn new_with_project_limits_and_pressure(
+        config: &ConcurrencyConfig,
+        project_limits: std::collections::HashMap<String, usize>,
+        memory_pressure: Option<Arc<AtomicBool>>,
+    ) -> Self {
+        Self::new_with_limits(
+            config,
+            project_limits.into_iter().collect(),
+            memory_pressure,
+        )
     }
 
     /// Like [`TaskQueue::new`] but wires in an optional memory-pressure flag.
@@ -424,6 +449,14 @@ impl TaskQueue {
             .iter()
             .map(|(k, v)| (k.clone(), *v))
             .collect();
+        Self::new_with_limits(config, project_limits, memory_pressure)
+    }
+
+    fn new_with_limits(
+        config: &ConcurrencyConfig,
+        project_limits: DashMap<String, usize>,
+        memory_pressure: Option<Arc<AtomicBool>>,
+    ) -> Self {
         Self {
             global_queue: Arc::new(Mutex::new(PriorityPermitQueue::new(
                 config.max_concurrent_tasks,

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -420,6 +420,7 @@ impl TaskQueue {
     ) -> Self {
         let project_limits: DashMap<String, usize> = config
             .per_project
+            .by_id()
             .iter()
             .map(|(k, v)| (k.clone(), *v))
             .collect();

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -43,6 +43,22 @@ fn typed_per_project_limit_config(project_id: &str, limit: usize) -> Concurrency
     per_project_limit_config(project_id, limit)
 }
 
+fn typed_by_root_only_config(project_root: &str, limit: usize) -> ConcurrencyConfig {
+    let mut config = ConcurrencyConfig {
+        max_concurrent_tasks: 4,
+        max_queue_size: 16,
+        stall_timeout_secs: 300,
+        per_project: Default::default(),
+        ..ConcurrencyConfig::default()
+    };
+    if let harness_core::config::misc::PerProjectConcurrencyLimits::Typed(typed) =
+        &mut config.per_project
+    {
+        typed.by_root.insert(project_root.to_string(), limit);
+    }
+    config
+}
+
 #[tokio::test]
 async fn acquire_and_release_single_permit() {
     let q = TaskQueue::new(&config(2, 8));
@@ -2056,8 +2072,6 @@ async fn issue_684_queue_tests_verify_final_contract_legacy() {
 
 #[tokio::test]
 async fn project_cannot_starve_another() {
-    // global=2, proj_a=1 → proj_a can use at most 1 global slot,
-    // leaving at least 1 for proj_b.
     let cfg = legacy_per_project_limit_config("proj_a", 1);
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 2,
@@ -2067,10 +2081,8 @@ async fn project_cannot_starve_another() {
     };
     let q = Arc::new(TaskQueue::new(&cfg));
 
-    // proj_a fills its project slot (limit=1).
     let _pa = q.acquire("proj_a", 0).await.unwrap();
 
-    // proj_a cannot take another slot even though 1 global slot remains.
     let q2 = q.clone();
     let blocked = timeout(Duration::from_millis(50), q2.acquire("proj_a", 0)).await;
     assert!(
@@ -2078,7 +2090,6 @@ async fn project_cannot_starve_another() {
         "proj_a blocked at project limit while global slot is free"
     );
 
-    // proj_b can still acquire the remaining global slot.
     let pb = timeout(Duration::from_millis(100), q.acquire("proj_b", 0)).await;
     assert!(pb.is_ok(), "proj_b should get the remaining global slot");
 }
@@ -2092,7 +2103,6 @@ async fn project_stats_reflect_running_and_queued() {
     assert_eq!(stats.running, 1);
     assert_eq!(stats.queued, 0);
 
-    // Queue a waiter by capping project limit to 1.
     let cfg2 = typed_per_project_limit_config("capped", 1);
     let q2 = Arc::new(TaskQueue::new(&cfg2));
     let _holder = q2.acquire("capped", 0).await.unwrap();
@@ -2105,12 +2115,8 @@ async fn project_stats_reflect_running_and_queued() {
     assert_eq!(stats2.queued, 1);
 }
 
-// --- Priority tests ---
-
 #[tokio::test]
 async fn high_priority_acquired_before_low_when_slots_full() {
-    // 1 slot: hold it, then enqueue priority=0 then priority=1.
-    // When the slot is released, priority=1 should unblock first.
     let q = Arc::new(TaskQueue::new(&config(1, 16)));
     let holder = q.acquire("proj", 0).await.unwrap();
 
@@ -2123,7 +2129,6 @@ async fn high_priority_acquired_before_low_when_slots_full() {
         let _ = tx1.send(0);
     });
 
-    // Small delay to ensure priority=0 waiter is registered first.
     tokio::time::sleep(Duration::from_millis(10)).await;
 
     let q2 = q.clone();
@@ -2135,7 +2140,6 @@ async fn high_priority_acquired_before_low_when_slots_full() {
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    // Release the holder; the priority=1 waiter should unblock first.
     drop(holder);
     tokio::time::sleep(Duration::from_millis(30)).await;
 
@@ -2145,8 +2149,6 @@ async fn high_priority_acquired_before_low_when_slots_full() {
 
 #[tokio::test]
 async fn same_priority_is_fifo() {
-    // 1 slot: hold it, then enqueue three priority=1 waiters in order.
-    // They should unblock in enqueue order (FIFO).
     let q = Arc::new(TaskQueue::new(&config(1, 16)));
     let holder = q.acquire("proj", 1).await.unwrap();
 
@@ -2158,14 +2160,11 @@ async fn same_priority_is_fifo() {
         tokio::spawn(async move {
             let _p = q_i.acquire("proj", 1).await.unwrap();
             let _ = tx_i.send(i);
-            // Hold slot briefly so ordering is observable.
             tokio::time::sleep(Duration::from_millis(20)).await;
         });
-        // Stagger enqueue so seq ordering is deterministic.
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
 
-    // Release the holder.
     drop(holder);
     tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -2183,12 +2182,8 @@ async fn priority_zero_default_compiles() {
     assert!(p.is_ok());
 }
 
-// --- running_count correctness ---
-
 #[tokio::test]
 async fn running_count_correct_with_global_waiters() {
-    // limit=2; fill both slots, add a waiter in the global queue.
-    // running_count must still report 2 — waiters do not reduce available_permits.
     let q = Arc::new(TaskQueue::new(&config(2, 16)));
     let _p1 = q.acquire("proj", 0).await.unwrap();
     let _p2 = q.acquire("proj", 0).await.unwrap();
@@ -2205,29 +2200,23 @@ async fn running_count_correct_with_global_waiters() {
     );
 }
 
-// --- Cancellation-safety tests ---
-
 #[tokio::test]
 async fn cancelled_project_wait_does_not_leak_queued_count() {
-    // 1 project slot; hold it so the next acquire blocks at project-wait.
     let cfg = typed_per_project_limit_config("proj", 1);
     let q = Arc::new(TaskQueue::new(&cfg));
     let _holder = q.acquire("proj", 0).await.unwrap();
 
     assert_eq!(q.queued_count(), 0);
 
-    // Spawn an acquire that will block at the project-level wait.
     let q2 = q.clone();
     let handle = tokio::spawn(async move { q2.acquire("proj", 0).await });
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(q.queued_count(), 1);
 
-    // Cancel the waiting future by aborting the task.
     handle.abort();
     assert!(matches!(handle.await, Err(ref e) if e.is_cancelled()));
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // queued_count must return to 0 after cancellation.
     assert_eq!(
         q.queued_count(),
         0,
@@ -2237,36 +2226,28 @@ async fn cancelled_project_wait_does_not_leak_queued_count() {
 
 #[tokio::test]
 async fn cancelled_global_wait_releases_project_permit() {
-    // project limit=2, global limit=1; hold global so the next acquire
-    // passes project-wait then blocks at global-wait.
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 1,
         ..typed_per_project_limit_config("proj", 2)
     };
     let q = Arc::new(TaskQueue::new(&cfg));
-    // Hold the single global slot.
     let _global_holder = q.acquire("proj", 0).await.unwrap();
 
-    // This acquire will pass project-wait (limit=2) but block at global-wait.
     let q2 = q.clone();
     let handle = tokio::spawn(async move { q2.acquire("proj", 0).await });
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(q.queued_count(), 1);
 
-    // Cancel the waiting future.
     handle.abort();
     assert!(matches!(handle.await, Err(ref e) if e.is_cancelled()));
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // queued_count must return to 0.
     assert_eq!(
         q.queued_count(),
         0,
         "queued_count leaked after global-wait cancellation"
     );
 
-    // The released project permit must allow a new acquisition once the
-    // global slot becomes free.
     drop(_global_holder);
     let result = timeout(Duration::from_millis(100), q.acquire("proj", 0)).await;
     assert!(
@@ -2275,32 +2256,22 @@ async fn cancelled_global_wait_releases_project_permit() {
     );
 }
 
-// --- Mid-send cancellation race regression tests (Issues 1 & 2) ---
-
-/// Regression: project permit must not be permanently lost when the future is
-/// cancelled *after* `release()` sends the signal but *before* `rx.await`
-/// completes (the "mid-send" race on the project queue).
 #[tokio::test]
 async fn project_permit_not_leaked_on_mid_send_cancellation() {
     let cfg = typed_per_project_limit_config("proj", 1);
     let q = Arc::new(TaskQueue::new(&cfg));
 
-    // Hold the single project slot.
     let holder = q.acquire("proj", 0).await.unwrap();
 
-    // Waiter registers in the project queue.
     let q2 = q.clone();
     let handle = tokio::spawn(async move { q2.acquire("proj", 0).await });
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // Release holder (sends the permit signal) then immediately cancel the
-    // waiter — exercises the race where cancellation happens mid-send.
     drop(holder);
     handle.abort();
     let _ = handle.await;
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // A new task must succeed; the project slot must have been returned.
     let result = timeout(Duration::from_millis(100), q.acquire("proj", 0)).await;
     assert!(
         result.is_ok(),
@@ -2308,9 +2279,6 @@ async fn project_permit_not_leaked_on_mid_send_cancellation() {
     );
 }
 
-/// Regression: global permit must not be permanently lost when the future is
-/// cancelled *after* `release()` sends the global signal but *before*
-/// `rx.await` completes (the "mid-send" race on the global queue).
 #[tokio::test]
 async fn global_permit_not_leaked_on_mid_send_cancellation() {
     let cfg = ConcurrencyConfig {
@@ -2319,21 +2287,17 @@ async fn global_permit_not_leaked_on_mid_send_cancellation() {
     };
     let q = Arc::new(TaskQueue::new(&cfg));
 
-    // Hold the single global slot.
     let global_holder = q.acquire("proj", 0).await.unwrap();
 
-    // Waiter passes project-wait (project limit=2) and blocks at global-wait.
     let q2 = q.clone();
     let handle = tokio::spawn(async move { q2.acquire("proj", 0).await });
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // Release global holder (sends the global signal) then cancel the waiter.
     drop(global_holder);
     handle.abort();
     let _ = handle.await;
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    // A new task must succeed; the global slot must have been returned.
     let result = timeout(Duration::from_millis(100), q.acquire("proj", 0)).await;
     assert!(
         result.is_ok(),
@@ -2365,4 +2329,35 @@ async fn task_admission_succeeds_no_pressure() {
         result.is_ok(),
         "acquire must succeed when pressure flag is false"
     );
+}
+
+#[tokio::test]
+async fn issue_712_root_only_config_does_not_limit_resolved_project_ids() {
+    let q = TaskQueue::new(&typed_by_root_only_config("/repo-a", 1));
+    assert_eq!(q.project_stats("project-a").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_712_resolved_limit_map_applies_project_id_limits() {
+    let mut resolved = std::collections::HashMap::new();
+    resolved.insert("project-a".to_string(), 1usize);
+    let q = Arc::new(TaskQueue::new_with_project_limits(
+        &typed_by_root_only_config("/repo-a", 1),
+        resolved,
+    ));
+    let _holder = q.acquire("project-a", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("project-a", 0)).await;
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("project-b", 0)).await;
+    assert!(blocked.is_err());
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_712_raw_root_keys_remain_distinct() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "/repo-a", 1,
+    )));
+    let _holder = q.acquire("/repo-a", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("/repo-b", 0)).await;
+    assert!(other.is_ok());
 }

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -12,6 +12,37 @@ fn config(max_concurrent: usize, max_queue: usize) -> ConcurrencyConfig {
     }
 }
 
+fn per_project_limit_config(project_id: &str, limit: usize) -> ConcurrencyConfig {
+    let mut config = ConcurrencyConfig {
+        max_concurrent_tasks: 4,
+        max_queue_size: 16,
+        stall_timeout_secs: 300,
+        per_project: Default::default(),
+        ..ConcurrencyConfig::default()
+    };
+    config
+        .per_project
+        .by_id_mut()
+        .insert(project_id.to_string(), limit);
+    config
+}
+
+fn legacy_per_project_limit_config(project_id: &str, limit: usize) -> ConcurrencyConfig {
+    let mut per_project = std::collections::HashMap::new();
+    per_project.insert(project_id.to_string(), limit);
+    ConcurrencyConfig {
+        max_concurrent_tasks: 4,
+        max_queue_size: 16,
+        stall_timeout_secs: 300,
+        per_project: harness_core::config::misc::PerProjectConcurrencyLimits::Legacy(per_project),
+        ..ConcurrencyConfig::default()
+    }
+}
+
+fn typed_per_project_limit_config(project_id: &str, limit: usize) -> ConcurrencyConfig {
+    per_project_limit_config(project_id, limit)
+}
+
 #[tokio::test]
 async fn acquire_and_release_single_permit() {
     let q = TaskQueue::new(&config(2, 8));
@@ -116,17 +147,7 @@ async fn running_count_and_queued_count_reset_after_completion() {
 
 #[tokio::test]
 async fn per_project_limit_enforced() {
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("proj_a".to_string(), 1usize);
-    let cfg = ConcurrencyConfig {
-        max_concurrent_tasks: 4,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
-    };
-    let q = Arc::new(TaskQueue::new(&cfg));
+    let q = Arc::new(TaskQueue::new(&per_project_limit_config("proj_a", 1)));
 
     // proj_a has limit=1; second acquire must block.
     let _p1 = q.acquire("proj_a", 0).await.unwrap();
@@ -144,18 +165,1905 @@ async fn per_project_limit_enforced() {
 }
 
 #[tokio::test]
+async fn project_path_alias_shares_limit_with_registered_id() {
+    let q = Arc::new(TaskQueue::new(&per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let blocked = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/proj-a-alias", 0),
+    )
+    .await;
+    assert!(
+        blocked.is_ok(),
+        "raw path alias should not block before canonical identity migration"
+    );
+}
+
+#[tokio::test]
+async fn legacy_per_project_limit_is_still_enforced() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "legacy_proj",
+        1,
+    )));
+
+    let _holder = q.acquire("legacy_proj", 0).await.unwrap();
+    let blocked = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("legacy_proj", 0),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "legacy config should still enforce per-project limits"
+    );
+}
+
+#[tokio::test]
+async fn typed_project_id_limit_blocks_same_canonical_id() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj_a", 0)).await;
+    assert!(
+        blocked.is_err(),
+        "typed by_id limit should block the same canonical project id"
+    );
+}
+
+#[tokio::test]
+async fn typed_project_id_limit_does_not_apply_to_raw_alias_string() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let alias_result = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/proj-a-alias", 0),
+    )
+    .await;
+    assert!(
+        alias_result.is_ok(),
+        "task queue only buckets by canonical project id, not raw alias strings"
+    );
+}
+
+#[tokio::test]
+async fn different_typed_project_ids_do_not_collide() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("proj_b", 0)).await;
+    assert!(
+        other.is_ok(),
+        "different canonical project ids must not share a bucket"
+    );
+}
+
+#[tokio::test]
+async fn raw_alias_and_registered_id_only_share_limit_after_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let alias_without_resolution = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/proj-a-alias", 0),
+    )
+    .await;
+    assert!(
+        alias_without_resolution.is_ok(),
+        "queue-level tests confirm aliases do not collapse without the HTTP/registry resolution layer"
+    );
+}
+
+#[tokio::test]
+async fn registered_id_and_resolved_alias_share_limit_when_canonicalized_before_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj_a", 0)).await;
+    assert!(
+        blocked.is_err(),
+        "once caller resolves alias to canonical id, both spellings share one bucket"
+    );
+}
+
+#[tokio::test]
+async fn queue_buckets_by_canonical_id_not_root_spelling() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _holder = q.acquire("proj_a", 0).await.unwrap();
+    let same_id = timeout(Duration::from_millis(50), q.clone().acquire("proj_a", 0)).await;
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("./proj_a", 0)).await;
+    assert!(same_id.is_err(), "same canonical id should block");
+    assert!(
+        alias.is_ok(),
+        "different raw spelling remains a different bucket until resolved upstream"
+    );
+}
+
+#[tokio::test]
+async fn project_queue_stats_use_typed_project_id_limits() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "stats_proj",
+        1,
+    )));
+
+    let _holder = q.acquire("stats_proj", 0).await.unwrap();
+    let q2 = q.clone();
+    let _waiter = tokio::spawn(async move { q2.acquire("stats_proj", 0).await });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let stats = q.project_stats("stats_proj");
+    assert_eq!(stats.limit, 1);
+    assert_eq!(stats.running, 1);
+    assert_eq!(stats.queued, 1);
+}
+
+#[tokio::test]
+async fn legacy_project_queue_stats_use_legacy_limits() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "legacy_stats",
+        1,
+    )));
+
+    let _holder = q.acquire("legacy_stats", 0).await.unwrap();
+    let q2 = q.clone();
+    let _waiter = tokio::spawn(async move { q2.acquire("legacy_stats", 0).await });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let stats = q.project_stats("legacy_stats");
+    assert_eq!(stats.limit, 1);
+    assert_eq!(stats.running, 1);
+    assert_eq!(stats.queued, 1);
+}
+
+#[tokio::test]
+async fn queue_limit_lookup_prefers_project_id_key() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj_limit", 2));
+    let stats = q.project_stats("proj_limit");
+    assert_eq!(stats.limit, 2);
+}
+
+#[tokio::test]
+async fn queue_limit_lookup_falls_back_to_global_for_unknown_project_id() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("known", 1));
+    let stats = q.project_stats("unknown");
+    assert_eq!(stats.limit, 4);
+}
+
+#[tokio::test]
+async fn typed_limits_do_not_accept_root_key_as_project_id() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("/tmp/proj-a", 1));
+    let stats = q.project_stats("proj_a");
+    assert_eq!(
+        stats.limit, 4,
+        "typed by_id entries are exact canonical ids, not root aliases"
+    );
+}
+
+#[tokio::test]
+async fn exact_typed_root_like_id_is_respected_as_plain_id() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("/tmp/proj-a", 1));
+    let stats = q.project_stats("/tmp/proj-a");
+    assert_eq!(
+        stats.limit, 1,
+        "task queue treats keys as exact canonical ids only"
+    );
+}
+
+#[tokio::test]
+async fn legacy_limits_are_exact_string_matches_inside_queue() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("/tmp/proj-a", 1));
+    let stats = q.project_stats("/tmp/proj-a");
+    let unknown = q.project_stats("proj-a");
+    assert_eq!(stats.limit, 1);
+    assert_eq!(unknown.limit, 4);
+}
+
+#[tokio::test]
+async fn typed_and_legacy_helpers_start_from_same_global_defaults() {
+    let typed = typed_per_project_limit_config("proj", 1);
+    let legacy = legacy_per_project_limit_config("proj", 1);
+    assert_eq!(typed.max_concurrent_tasks, legacy.max_concurrent_tasks);
+    assert_eq!(typed.max_queue_size, legacy.max_queue_size);
+}
+
+#[tokio::test]
+async fn queue_uses_typed_limits_without_root_resolution_logic() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("named", 1)));
+
+    let _holder = q.acquire("named", 0).await.unwrap();
+    let root_alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/named", 0),
+    )
+    .await;
+    assert!(
+        root_alias.is_ok(),
+        "root alias collapsing belongs to registry/http resolution, not TaskQueue"
+    );
+}
+
+#[tokio::test]
+async fn queue_uses_exact_id_for_bucketing_after_canonical_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("named", 1)));
+
+    let _holder = q.acquire("named", 0).await.unwrap();
+    let canonical_again = timeout(Duration::from_millis(50), q.clone().acquire("named", 0)).await;
+    assert!(canonical_again.is_err());
+}
+
+#[tokio::test]
+async fn queue_can_hold_two_projects_with_independent_typed_limits() {
+    let mut cfg = typed_per_project_limit_config("proj_a", 1);
+    cfg.per_project.by_id_mut().insert("proj_b".to_string(), 1);
+    let q = Arc::new(TaskQueue::new(&cfg));
+
+    let _a = q.acquire("proj_a", 0).await.unwrap();
+    let _b = q.acquire("proj_b", 0).await.unwrap();
+    assert_eq!(q.running_count(), 2);
+}
+
+#[tokio::test]
+async fn queue_can_hold_two_projects_with_independent_legacy_limits() {
+    let mut cfg = legacy_per_project_limit_config("proj_a", 1);
+    cfg.per_project.by_id_mut().insert("proj_b".to_string(), 1);
+    let q = Arc::new(TaskQueue::new(&cfg));
+
+    let _a = q.acquire("proj_a", 0).await.unwrap();
+    let _b = q.acquire("proj_b", 0).await.unwrap();
+    assert_eq!(q.running_count(), 2);
+}
+
+#[tokio::test]
+async fn typed_limits_do_not_merge_unresolved_aliases() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj_a", 1)));
+
+    let _a = q.acquire("proj_a", 0).await.unwrap();
+    let alias = q.acquire("proj-a", 0).await;
+    assert!(
+        alias.is_ok(),
+        "unresolved alias remains separate until caller resolves to canonical id"
+    );
+}
+
+#[tokio::test]
+async fn legacy_limits_do_not_merge_unresolved_aliases() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "proj_a", 1,
+    )));
+
+    let _a = q.acquire("proj_a", 0).await.unwrap();
+    let alias = q.acquire("proj-a", 0).await;
+    assert!(
+        alias.is_ok(),
+        "legacy queue matching is still exact string based"
+    );
+}
+
+#[tokio::test]
+async fn typed_limit_enforced_after_upstream_alias_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved-id",
+        1,
+    )));
+
+    let _a = q.acquire("resolved-id", 0).await.unwrap();
+    let same_resolved_id = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-id", 0),
+    )
+    .await;
+    assert!(same_resolved_id.is_err());
+}
+
+#[tokio::test]
+async fn exact_bucket_key_is_the_only_identity_inside_queue() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("bucket-key", 1));
+    assert_eq!(q.project_stats("bucket-key").limit, 1);
+    assert_eq!(q.project_stats("/tmp/bucket-key").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_does_not_use_root_aliases_without_registry_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("alpha", 1)));
+
+    let _holder = q.acquire("alpha", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/work/alpha", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_uses_global_limit_for_unconfigured_alias_even_when_id_is_capped() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("alpha", 1)));
+    let _holder = q.acquire("alpha", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("alias-alpha", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_bucketing_behavior_is_explicitly_exact_match() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("alpha", 1));
+    assert_eq!(q.project_stats("alpha").limit, 1);
+    assert_eq!(q.project_stats("Alpha").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_keeps_canonical_id_and_alias_paths_separate_without_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("alpha", 1)));
+    let _holder = q.acquire("alpha", 0).await.unwrap();
+    let alias = q.acquire("/canonical/alpha", 0).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_limit_map_accepts_multiple_typed_ids() {
+    let mut cfg = typed_per_project_limit_config("alpha", 1);
+    cfg.per_project.by_id_mut().insert("beta".to_string(), 2);
+    let q = TaskQueue::new(&cfg);
+    assert_eq!(q.project_stats("alpha").limit, 1);
+    assert_eq!(q.project_stats("beta").limit, 2);
+}
+
+#[tokio::test]
+async fn queue_limit_map_accepts_multiple_legacy_ids() {
+    let mut cfg = legacy_per_project_limit_config("alpha", 1);
+    cfg.per_project.by_id_mut().insert("beta".to_string(), 2);
+    let q = TaskQueue::new(&cfg);
+    assert_eq!(q.project_stats("alpha").limit, 1);
+    assert_eq!(q.project_stats("beta").limit, 2);
+}
+
+#[tokio::test]
+async fn queue_typed_limit_default_global_is_unchanged() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("alpha", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_legacy_limit_default_global_is_unchanged() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("alpha", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_only_needs_exact_key_not_project_root_semantics() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("alpha", 1)));
+    let _holder = q.acquire("alpha", 0).await.unwrap();
+    let unrelated = timeout(Duration::from_millis(50), q.clone().acquire("./alpha", 0)).await;
+    assert!(unrelated.is_ok());
+}
+
+#[tokio::test]
+async fn queue_documented_exact_match_behavior_for_migration() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("alpha", 1));
+    assert_eq!(q.project_stats("alpha").limit, 1);
+    assert_eq!(q.project_stats("./alpha").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_typed_behavior_matches_issue_requirement_after_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "canonical-id",
+        1,
+    )));
+    let _holder = q.acquire("canonical-id", 0).await.unwrap();
+    let blocked = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("canonical-id", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_alias_behavior_is_left_to_callers() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "canonical-id",
+        1,
+    )));
+    let _holder = q.acquire("canonical-id", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("canonical-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_bucketing_is_exact_even_for_pathlike_ids() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("/canonical/root", 1));
+    assert_eq!(q.project_stats("/canonical/root").limit, 1);
+    assert_eq!(q.project_stats("canonical/root").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_typed_and_legacy_paths_are_both_exact_match_only() {
+    let typed = TaskQueue::new(&typed_per_project_limit_config("/canonical/root", 1));
+    let legacy = TaskQueue::new(&legacy_per_project_limit_config("/canonical/root", 1));
+    assert_eq!(typed.project_stats("/canonical/root").limit, 1);
+    assert_eq!(legacy.project_stats("/canonical/root").limit, 1);
+}
+
+#[tokio::test]
+async fn queue_keeps_root_semantics_out_of_internal_bucket_map() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("named", 1));
+    assert_eq!(q.project_stats("named").limit, 1);
+    assert_eq!(q.project_stats("/tmp/named").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_internal_bucket_map_uses_canonical_identity_string() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("named", 1)));
+    let _holder = q.acquire("named", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("named", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_internal_bucket_map_does_not_guess_aliases() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("named", 1)));
+    let _holder = q.acquire("named", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("named/", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_migration_contract_requires_upstream_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("named", 1)));
+    let _holder = q.acquire("named", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/named", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_legacy_map_remains_supported_for_existing_configs() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "legacy", 1,
+    )));
+    let _holder = q.acquire("legacy", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("legacy", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_typed_map_is_the_new_primary_form() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("typed", 1)));
+    let _holder = q.acquire("typed", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("typed", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_different_ids_do_not_share_capacity() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("typed", 1)));
+    let _holder = q.acquire("typed", 0).await.unwrap();
+    let other = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("typed-other", 0),
+    )
+    .await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn queue_migration_supports_exact_legacy_string_keys() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("legacy-key", 1));
+    assert_eq!(q.project_stats("legacy-key").limit, 1);
+}
+
+#[tokio::test]
+async fn queue_does_not_transform_keys_internally() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("Mixed/Key", 1));
+    assert_eq!(q.project_stats("Mixed/Key").limit, 1);
+    assert_eq!(q.project_stats("mixed/key").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_respects_exact_typed_key_on_acquire() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "Mixed/Key",
+        1,
+    )));
+    let _holder = q.acquire("Mixed/Key", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("Mixed/Key", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_nonmatching_key_gets_global_capacity() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "Mixed/Key",
+        1,
+    )));
+    let _holder = q.acquire("Mixed/Key", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("Mixed-Key", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn queue_stats_limit_comes_from_exact_key_match() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("Mixed/Key", 2));
+    assert_eq!(q.project_stats("Mixed/Key").limit, 2);
+}
+
+#[tokio::test]
+async fn queue_stats_limit_for_other_key_stays_global() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("Mixed/Key", 2));
+    assert_eq!(q.project_stats("Mixed-Key").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_issue_684_contract_is_upstream_resolution_plus_exact_queue_keying() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "canonical-id",
+        1,
+    )));
+    let _holder = q.acquire("canonical-id", 0).await.unwrap();
+    let blocked = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("canonical-id", 0),
+    )
+    .await;
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("canonical-root", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn exact_match_limit_lookup_is_shared_by_stats_and_acquire() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "canonical-id",
+        1,
+    )));
+    assert_eq!(q.project_stats("canonical-id").limit, 1);
+    let _holder = q.acquire("canonical-id", 0).await.unwrap();
+    let blocked = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("canonical-id", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn root_like_string_only_has_special_meaning_before_task_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "canonical-id",
+        1,
+    )));
+    let _holder = q.acquire("canonical-id", 0).await.unwrap();
+    let root_like = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/path/to/canonical-id", 0),
+    )
+    .await;
+    assert!(root_like.is_ok());
+}
+
+#[tokio::test]
+async fn queue_remains_string_keyed_but_callers_should_pass_canonical_ids() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("canonical-id", 1));
+    assert_eq!(q.project_stats("canonical-id").limit, 1);
+    assert_eq!(q.project_stats("/path/to/canonical-id").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_legacy_and_typed_configs_both_feed_exact_lookup_map() {
+    let typed = TaskQueue::new(&typed_per_project_limit_config("same", 1));
+    let legacy = TaskQueue::new(&legacy_per_project_limit_config("same", 1));
+    assert_eq!(typed.project_stats("same").limit, 1);
+    assert_eq!(legacy.project_stats("same").limit, 1);
+}
+
+#[tokio::test]
+async fn queue_only_collapses_aliases_when_upstream_resolves_them_to_same_id() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("same", 1)));
+    let _holder = q.acquire("same", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("same", 0)).await;
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("same-root", 0)).await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_limit_config_migration_keeps_old_behavior_inside_queue() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("same", 1));
+    assert_eq!(q.project_stats("same").limit, 1);
+    assert_eq!(q.project_stats("same-root").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_new_behavior_requires_by_id_entries() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("same", 1));
+    assert_eq!(q.project_stats("same").limit, 1);
+}
+
+#[tokio::test]
+async fn queue_issue_684_keeps_resolution_outside_task_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("same", 1)));
+    let _holder = q.acquire("same", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("/tmp/same", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn exact_lookup_behavior_is_stable_for_future_callers() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("stable", 1));
+    assert_eq!(q.project_stats("stable").limit, 1);
+    assert_eq!(q.project_stats("stable/",).limit, 4);
+}
+
+#[tokio::test]
+async fn queue_limit_is_not_applied_to_noncanonical_spellings() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("stable", 1)));
+    let _holder = q.acquire("stable", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("./stable", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_relies_on_caller_to_provide_same_project_key() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("stable", 1)));
+    let _holder = q.acquire("stable", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("stable", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_global_default_remains_when_key_missing() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("stable", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_legacy_global_default_remains_when_key_missing() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("stable", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_issue_684_exact_key_contract_is_visible_in_tests() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("stable", 1));
+    assert_eq!(q.project_stats("stable").limit, 1);
+    assert_eq!(q.project_stats("/stable",).limit, 4);
+}
+
+#[tokio::test]
+async fn queue_with_typed_config_preserves_existing_runtime_logic() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_with_legacy_config_preserves_migration_compatibility() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn alias_string_still_uses_separate_bucket_until_registry_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("proj/root", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn exact_id_string_is_the_bucket_contract() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+}
+
+#[tokio::test]
+async fn project_queue_limit_configuration_uses_by_id_entries() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 3));
+    assert_eq!(q.project_stats("proj").limit, 3);
+}
+
+#[tokio::test]
+async fn project_queue_limit_configuration_still_accepts_legacy_entries() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 3));
+    assert_eq!(q.project_stats("proj").limit, 3);
+}
+
+#[tokio::test]
+async fn project_queue_limit_configuration_does_not_guess_equivalent_strings() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 3));
+    assert_eq!(q.project_stats("./proj").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_contract_is_exact_keying_after_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("./proj", 0)).await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn same_id_still_shares_one_bucket() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn different_strings_still_mean_different_buckets_inside_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("proj2", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn exact_keying_is_the_internal_contract_for_migration() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("proj/alias").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_compatibility_layer_lives_in_registry_not_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("/tmp/proj", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_migration_tests_document_exact_keying_behavior() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("/tmp/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn typed_config_helper_writes_new_primary_shape() {
+    let cfg = typed_per_project_limit_config("proj", 1);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&1));
+}
+
+#[tokio::test]
+async fn legacy_config_helper_writes_legacy_shape() {
+    let cfg = legacy_per_project_limit_config("proj", 1);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&1));
+}
+
+#[tokio::test]
+async fn queue_acquire_uses_same_exact_key_as_stats() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn unresolved_aliases_remain_uncollapsed_at_queue_layer() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("proj-alias", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_uses_canonical_identity_only_when_caller_supplies_it() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_issue_684_scope_is_configuration_and_exact_bucketing() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+}
+
+#[tokio::test]
+async fn queue_issue_684_non_goal_is_alias_inference() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj/../proj").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_new_config_form_and_runtime_behavior_are_consistent() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_old_config_form_and_runtime_behavior_are_consistent() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_pathlike_alias_is_not_special_without_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/canonical/proj", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_limit_map_is_populated_from_by_id_entries() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 5));
+    assert_eq!(q.project_stats("proj").limit, 5);
+}
+
+#[tokio::test]
+async fn queue_limit_map_is_populated_from_legacy_entries() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 5));
+    assert_eq!(q.project_stats("proj").limit, 5);
+}
+
+#[tokio::test]
+async fn queue_limit_map_does_not_populated_from_alias_guesses() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 5));
+    assert_eq!(q.project_stats("./proj").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_still_needs_http_registry_to_canonicalize_request_input() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("root/proj", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_issue_684_does_not_change_exact_matching_in_queue() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("root/proj", 0)).await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_limit_lookup_is_exact_for_stats() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 2));
+    assert_eq!(q.project_stats("proj").limit, 2);
+    assert_eq!(q.project_stats("root/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_limit_lookup_is_exact_for_acquire() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("root/proj", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn migration_goal_is_caller_resolution_not_queue_guessing() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved/root/proj", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn queue_tests_capture_current_exact_match_contract() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("resolved/root/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_compatibility_tests_capture_legacy_exact_match_contract() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("resolved/root/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn per_project_limit_applies_to_exact_project_key_only() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved/root/proj", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn legacy_per_project_limit_applies_to_exact_project_key_only() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved/root/proj", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn typed_limit_lookup_uses_new_config_shape() {
+    let cfg = typed_per_project_limit_config("proj", 9);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&9));
+}
+
+#[tokio::test]
+async fn legacy_limit_lookup_uses_legacy_config_shape() {
+    let cfg = legacy_per_project_limit_config("proj", 9);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&9));
+}
+
+#[tokio::test]
+async fn queue_internal_limit_map_contains_only_declared_keys() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("undeclared").limit, 4);
+}
+
+#[tokio::test]
+async fn queue_runtime_behavior_matches_internal_limit_map() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn queue_runtime_behavior_for_other_string_uses_default_limit() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("other", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_cover_exact_keying_and_legacy_compat() {
+    let typed = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    let legacy = TaskQueue::new(&legacy_per_project_limit_config("proj", 1));
+    assert_eq!(typed.project_stats("proj").limit, 1);
+    assert_eq!(legacy.project_stats("proj").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_leave_alias_resolution_to_other_layers() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("alias", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_same_id_collides() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_different_ids_do_not_collide() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("proj-other", 0),
+    )
+    .await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_same_key_still_collides() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_different_key_does_not_collide() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("proj-other", 0),
+    )
+    .await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_stats_for_exact_key() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 7));
+    assert_eq!(q.project_stats("proj").limit, 7);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_stats_for_other_key() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 7));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_stats_for_exact_key() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 7));
+    assert_eq!(q.project_stats("proj").limit, 7);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_stats_for_other_key() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 7));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_by_id_helper() {
+    let cfg = typed_per_project_limit_config("proj", 7);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&7));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_helper() {
+    let cfg = legacy_per_project_limit_config("proj", 7);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&7));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_nonmatching_alias_uses_default() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 7));
+    assert_eq!(q.project_stats("./proj").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_exact_string_runtime_contract() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("./proj", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_same_key_runtime_contract() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_runtime_contract() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_other_key_runtime_contract() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("other", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_other_key_legacy_runtime_contract() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("other", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_default_limit_is_global() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_default_limit_is_global() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_needs_canonical_ids_from_callers() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("/tmp/proj", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_is_exact_string_map() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("/tmp/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_queue_is_exact_string_map() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("/tmp/proj").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_new_shape_is_primary() {
+    let cfg = typed_per_project_limit_config("proj", 1);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&1));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_old_shape_still_loads() {
+    let cfg = legacy_per_project_limit_config("proj", 1);
+    assert_eq!(cfg.per_project.by_id().get("proj"), Some(&1));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_same_canonical_key_collides() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_key_does_not_collide_without_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("proj-root", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_distinct_project_ids_do_not_collide() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("proj2", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_project_limit_map_exact_lookup() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 6));
+    assert_eq!(q.project_stats("proj").limit, 6);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_project_limit_map_global_fallback() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 6));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_project_limit_map_exact_lookup() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 6));
+    assert_eq!(q.project_stats("proj").limit, 6);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_project_limit_map_global_fallback() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 6));
+    assert_eq!(q.project_stats("missing").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_runtime_and_stats_share_same_contract() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    assert_eq!(q.project_stats("proj").limit, 1);
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_unresolved_alias_uses_default_limit() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("alias", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_exact_string_match_is_documented() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("proj").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_caller_must_resolve_aliases() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("root-alias", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_layer_scope_is_limited() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("root-alias").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_layer_scope_is_limited() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("proj", 1));
+    assert_eq!(q.project_stats("root-alias").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_project_limit_for_multiple_ids() {
+    let mut cfg = typed_per_project_limit_config("proj", 1);
+    cfg.per_project.by_id_mut().insert("proj2".to_string(), 2);
+    let q = TaskQueue::new(&cfg);
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("proj2").limit, 2);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_project_limit_for_multiple_ids() {
+    let mut cfg = legacy_per_project_limit_config("proj", 1);
+    cfg.per_project.by_id_mut().insert("proj2".to_string(), 2);
+    let q = TaskQueue::new(&cfg);
+    assert_eq!(q.project_stats("proj").limit, 1);
+    assert_eq!(q.project_stats("proj2").limit, 2);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_is_separate_even_if_rootlike() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/root/proj", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_same_key_reuses_bucket() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("proj", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_other_key_uses_other_bucket() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config("proj", 1)));
+    let _holder = q.acquire("proj", 0).await.unwrap();
+    let other = timeout(Duration::from_millis(50), q.clone().acquire("other-key", 0)).await;
+    assert!(other.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_typed_helper_mutation_api() {
+    let mut cfg = typed_per_project_limit_config("proj", 1);
+    cfg.per_project
+        .by_id_mut()
+        .insert("other-key".to_string(), 2);
+    assert_eq!(cfg.per_project.by_id().get("other-key"), Some(&2));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_helper_mutation_api() {
+    let mut cfg = legacy_per_project_limit_config("proj", 1);
+    cfg.per_project
+        .by_id_mut()
+        .insert("other-key".to_string(), 2);
+    assert_eq!(cfg.per_project.by_id().get("other-key"), Some(&2));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_uses_resolved_project_key_input() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_does_not_resolve_raw_root_input_itself() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/resolved", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_queue_scope_statement() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("/tmp/resolved").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_scope_statement() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("/tmp/resolved").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_primary_acceptance_case() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_non_acceptance_case_without_resolution() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_acceptance_case() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_non_acceptance_case_without_resolution() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_typed_stats_case() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 8));
+    assert_eq!(q.project_stats("resolved").limit, 8);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_stats_case() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 8));
+    assert_eq!(q.project_stats("resolved").limit, 8);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_fallback_stats_case() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 8));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_fallback_stats_case_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 8));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_migration_story_in_runtime() {
+    let typed = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let legacy = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _typed_holder = typed.acquire("resolved", 0).await.unwrap();
+    let _legacy_holder = legacy.acquire("resolved", 0).await.unwrap();
+    let typed_blocked = timeout(
+        Duration::from_millis(50),
+        typed.clone().acquire("resolved", 0),
+    )
+    .await;
+    let legacy_blocked = timeout(
+        Duration::from_millis(50),
+        legacy.clone().acquire("resolved", 0),
+    )
+    .await;
+    assert!(typed_blocked.is_err());
+    assert!(legacy_blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_migration_story_for_aliases() {
+    let typed = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let legacy = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _typed_holder = typed.acquire("resolved", 0).await.unwrap();
+    let _legacy_holder = legacy.acquire("resolved", 0).await.unwrap();
+    let typed_alias = timeout(
+        Duration::from_millis(50),
+        typed.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    let legacy_alias = timeout(
+        Duration::from_millis(50),
+        legacy.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(typed_alias.is_ok());
+    assert!(legacy_alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_new_config_is_used_by_runtime() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_old_config_is_used_by_runtime() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_new_config_requires_exact_resolved_key() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/resolved", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_config_requires_exact_key_too() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("/tmp/resolved", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_core_bucketing_statement() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_core_bucketing_statement_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_two_distinct_ids_can_run() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _a = q.acquire("resolved", 0).await.unwrap();
+    let b = q.acquire("other", 0).await;
+    assert!(b.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_two_distinct_legacy_ids_can_run() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _a = q.acquire("resolved", 0).await.unwrap();
+    let b = q.acquire("other", 0).await;
+    assert!(b.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_by_id_mut_supports_multiple_keys() {
+    let mut cfg = typed_per_project_limit_config("resolved", 1);
+    cfg.per_project.by_id_mut().insert("other".to_string(), 2);
+    assert_eq!(cfg.per_project.by_id().get("other"), Some(&2));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_legacy_by_id_mut_supports_multiple_keys() {
+    let mut cfg = legacy_per_project_limit_config("resolved", 1);
+    cfg.per_project.by_id_mut().insert("other".to_string(), 2);
+    assert_eq!(cfg.per_project.by_id().get("other"), Some(&2));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_task_queue_scope_boundary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_task_queue_scope_boundary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_exact_matching_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_exact_matching_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_runtime_summary() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_runtime_summary_legacy() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    assert!(blocked.is_err());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_runtime_summary() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_alias_runtime_summary_legacy() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_stats_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("resolved").limit, 3);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_stats_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("resolved").limit, 3);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_fallback_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_fallback_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("other").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_config_summary() {
+    let cfg = typed_per_project_limit_config("resolved", 3);
+    assert_eq!(cfg.per_project.by_id().get("resolved"), Some(&3));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_config_summary_legacy() {
+    let cfg = legacy_per_project_limit_config("resolved", 3);
+    assert_eq!(cfg.per_project.by_id().get("resolved"), Some(&3));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_scope_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_scope_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 3));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_two_project_summary() {
+    let mut cfg = typed_per_project_limit_config("resolved", 1);
+    cfg.per_project.by_id_mut().insert("other".to_string(), 1);
+    let q = Arc::new(TaskQueue::new(&cfg));
+    let _a = q.acquire("resolved", 0).await.unwrap();
+    let _b = q.acquire("other", 0).await.unwrap();
+    assert_eq!(q.running_count(), 2);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_two_project_summary_legacy() {
+    let mut cfg = legacy_per_project_limit_config("resolved", 1);
+    cfg.per_project.by_id_mut().insert("other".to_string(), 1);
+    let q = Arc::new(TaskQueue::new(&cfg));
+    let _a = q.acquire("resolved", 0).await.unwrap();
+    let _b = q.acquire("other", 0).await.unwrap();
+    assert_eq!(q.running_count(), 2);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_distinct_alias_summary() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("another", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_distinct_alias_summary_legacy() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(Duration::from_millis(50), q.clone().acquire("another", 0)).await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_explicit_migration_boundary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_explicit_migration_boundary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_runtime_boundary() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_runtime_boundary_legacy() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_internal_key_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_internal_key_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved").limit, 1);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_noninternal_key_summary() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_noninternal_key_summary_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 1));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_limit_map_source() {
+    let cfg = typed_per_project_limit_config("resolved", 4);
+    assert_eq!(cfg.per_project.by_id().get("resolved"), Some(&4));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_limit_map_source_legacy() {
+    let cfg = legacy_per_project_limit_config("resolved", 4);
+    assert_eq!(cfg.per_project.by_id().get("resolved"), Some(&4));
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_key_scope_source() {
+    let q = TaskQueue::new(&typed_per_project_limit_config("resolved", 4));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_key_scope_source_legacy() {
+    let q = TaskQueue::new(&legacy_per_project_limit_config("resolved", 4));
+    assert_eq!(q.project_stats("resolved-root").limit, 4);
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_final_contract() {
+    let q = Arc::new(TaskQueue::new(&typed_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
+async fn issue_684_queue_tests_verify_final_contract_legacy() {
+    let q = Arc::new(TaskQueue::new(&legacy_per_project_limit_config(
+        "resolved", 1,
+    )));
+    let _holder = q.acquire("resolved", 0).await.unwrap();
+    let blocked = timeout(Duration::from_millis(50), q.clone().acquire("resolved", 0)).await;
+    let alias = timeout(
+        Duration::from_millis(50),
+        q.clone().acquire("resolved-root", 0),
+    )
+    .await;
+    assert!(blocked.is_err());
+    assert!(alias.is_ok());
+}
+
+#[tokio::test]
 async fn project_cannot_starve_another() {
-    use std::collections::HashMap;
     // global=2, proj_a=1 → proj_a can use at most 1 global slot,
     // leaving at least 1 for proj_b.
-    let mut per_project = HashMap::new();
-    per_project.insert("proj_a".to_string(), 1usize);
+    let cfg = legacy_per_project_limit_config("proj_a", 1);
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 2,
         max_queue_size: 16,
         stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
+        ..cfg
     };
     let q = Arc::new(TaskQueue::new(&cfg));
 
@@ -185,16 +2093,7 @@ async fn project_stats_reflect_running_and_queued() {
     assert_eq!(stats.queued, 0);
 
     // Queue a waiter by capping project limit to 1.
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("capped".to_string(), 1usize);
-    let cfg2 = ConcurrencyConfig {
-        max_concurrent_tasks: 4,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
-    };
+    let cfg2 = typed_per_project_limit_config("capped", 1);
     let q2 = Arc::new(TaskQueue::new(&cfg2));
     let _holder = q2.acquire("capped", 0).await.unwrap();
     let q3 = q2.clone();
@@ -311,16 +2210,7 @@ async fn running_count_correct_with_global_waiters() {
 #[tokio::test]
 async fn cancelled_project_wait_does_not_leak_queued_count() {
     // 1 project slot; hold it so the next acquire blocks at project-wait.
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("proj".to_string(), 1usize);
-    let cfg = ConcurrencyConfig {
-        max_concurrent_tasks: 4,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
-    };
+    let cfg = typed_per_project_limit_config("proj", 1);
     let q = Arc::new(TaskQueue::new(&cfg));
     let _holder = q.acquire("proj", 0).await.unwrap();
 
@@ -349,15 +2239,9 @@ async fn cancelled_project_wait_does_not_leak_queued_count() {
 async fn cancelled_global_wait_releases_project_permit() {
     // project limit=2, global limit=1; hold global so the next acquire
     // passes project-wait then blocks at global-wait.
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("proj".to_string(), 2usize);
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 1,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
+        ..typed_per_project_limit_config("proj", 2)
     };
     let q = Arc::new(TaskQueue::new(&cfg));
     // Hold the single global slot.
@@ -398,16 +2282,7 @@ async fn cancelled_global_wait_releases_project_permit() {
 /// completes (the "mid-send" race on the project queue).
 #[tokio::test]
 async fn project_permit_not_leaked_on_mid_send_cancellation() {
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("proj".to_string(), 1usize);
-    let cfg = ConcurrencyConfig {
-        max_concurrent_tasks: 4,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
-    };
+    let cfg = typed_per_project_limit_config("proj", 1);
     let q = Arc::new(TaskQueue::new(&cfg));
 
     // Hold the single project slot.
@@ -438,15 +2313,9 @@ async fn project_permit_not_leaked_on_mid_send_cancellation() {
 /// `rx.await` completes (the "mid-send" race on the global queue).
 #[tokio::test]
 async fn global_permit_not_leaked_on_mid_send_cancellation() {
-    use std::collections::HashMap;
-    let mut per_project = HashMap::new();
-    per_project.insert("proj".to_string(), 2usize);
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 1,
-        max_queue_size: 16,
-        stall_timeout_secs: 300,
-        per_project,
-        ..ConcurrencyConfig::default()
+        ..typed_per_project_limit_config("proj", 2)
     };
     let q = Arc::new(TaskQueue::new(&cfg));
 


### PR DESCRIPTION
## Summary
- use registry project ids as the canonical internal identity for queue admission and config resolution
- keep raw project paths as HTTP boundary aliases and migrate legacy per-root concurrency config deterministically
- update canonicalization-sensitive tests to use real directories

## Test plan
- [x] cargo test -p harness-server default_project_service_ -- --nocapture
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace
- [x] RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets