### PR TITLE
fix(task): deduplicate issue/PR submissions to prevent duplicate PRs

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -107,6 +107,13 @@ pub(crate) async fn enqueue_task(
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);
 
+    // Auto-populate external_id and check for duplicates before acquiring
+    // a concurrency permit (same dedup as enqueue_task_background).
+    populate_external_id(&mut req);
+    if let Some(existing_id) = check_duplicate(&state.core.tasks, &project_id, &req).await {
+        return Ok(existing_id);
+    }
+
     // Acquire concurrency permit before spawning. Blocks if all slots are
     // occupied; rejects immediately if the waiting queue is full.
     let permit = state

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -34,13 +34,34 @@ async fn resolve_project_from_registry(
     }
 }
 
-/// Auto-populate external_id from issue/pr for deduplication.
+/// Auto-populate and normalize external_id for deduplication.
+///
+/// Canonical format is `"issue:N"` / `"pr:N"`.  GitHub intake sets a raw
+/// numeric string (`"42"`) while API submissions leave it empty; this
+/// function normalizes both paths to the same canonical form so that
+/// verbatim comparison in `find_active_duplicate` matches correctly.
 fn populate_external_id(req: &mut task_runner::CreateTaskRequest) {
-    if req.external_id.is_none() {
-        if let Some(issue) = req.issue {
-            req.external_id = Some(format!("issue:{issue}"));
-        } else if let Some(pr) = req.pr {
-            req.external_id = Some(format!("pr:{pr}"));
+    match &req.external_id {
+        None => {
+            if let Some(issue) = req.issue {
+                req.external_id = Some(format!("issue:{issue}"));
+            } else if let Some(pr) = req.pr {
+                req.external_id = Some(format!("pr:{pr}"));
+            }
+        }
+        Some(id) => {
+            // Already canonical — nothing to do.
+            if id.starts_with("issue:") || id.starts_with("pr:") {
+                return;
+            }
+            // Raw numeric ID from intake — normalize to canonical form.
+            if id.chars().all(|c| c.is_ascii_digit()) && !id.is_empty() {
+                if req.issue.is_some() {
+                    req.external_id = Some(format!("issue:{id}"));
+                } else if req.pr.is_some() {
+                    req.external_id = Some(format!("pr:{id}"));
+                }
+            }
         }
     }
 }

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -34,6 +34,33 @@ async fn resolve_project_from_registry(
     }
 }
 
+/// Auto-populate external_id from issue/pr for deduplication.
+fn populate_external_id(req: &mut task_runner::CreateTaskRequest) {
+    if req.external_id.is_none() {
+        if let Some(issue) = req.issue {
+            req.external_id = Some(format!("issue:{issue}"));
+        } else if let Some(pr) = req.pr {
+            req.external_id = Some(format!("pr:{pr}"));
+        }
+    }
+}
+
+/// Return existing active TaskId if one matches project + external_id.
+async fn check_duplicate(
+    tasks: &Arc<crate::task_runner::TaskStore>,
+    project_id: &str,
+    req: &task_runner::CreateTaskRequest,
+) -> Option<task_runner::TaskId> {
+    let ext_id = req.external_id.as_deref()?;
+    let existing_id = tasks.find_active_duplicate(project_id, ext_id).await?;
+    tracing::info!(
+        existing_task = %existing_id.0,
+        external_id = %ext_id,
+        "dedup: returning existing active task instead of creating duplicate"
+    );
+    Some(existing_id)
+}
+
 pub(crate) async fn enqueue_task(
     state: &Arc<AppState>,
     mut req: task_runner::CreateTaskRequest,
@@ -280,6 +307,12 @@ async fn enqueue_task_background(
     let project_id = canonical_project.to_string_lossy().into_owned();
     req.project = Some(canonical_project);
     task_runner::fill_missing_repo_from_project(&mut req).await;
+
+    // Auto-populate external_id and check for duplicates.
+    populate_external_id(&mut req);
+    if let Some(existing_id) = check_duplicate(&state.core.tasks, &project_id, &req).await {
+        return Ok(existing_id);
+    }
 
     let server_config = std::sync::Arc::new(state.core.server.config.clone());
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -270,6 +270,24 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Find an active (non-terminal) task for the same project + external_id.
+    pub async fn find_active_duplicate(
+        &self,
+        project: &str,
+        external_id: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT id FROM tasks WHERE project = ? AND external_id = ? \
+             AND status IN ('pending', 'awaiting_deps', 'implementing', 'agent_review', 'waiting', 'reviewing') \
+             LIMIT 1",
+        )
+        .bind(project)
+        .bind(external_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
     /// Return all tasks as lightweight summaries, skipping the heavy `rounds` column.
     ///
     /// Used by the `/tasks` list endpoint to avoid deserializing large round histories
@@ -1620,6 +1638,71 @@ mod tests {
 
         let empty = db.list_by_status(&[]).await?;
         assert!(empty.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_returns_pending_task() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = make_task("task-issue-42", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        assert_eq!(dup, Some("task-issue-42".to_string()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_returns_implementing_task() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = make_task("task-impl-43", TaskStatus::Implementing);
+        task.external_id = Some("issue:43".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+        let dup = db.find_active_duplicate("/repo/foo", "issue:43").await?;
+        assert_eq!(dup, Some("task-impl-43".to_string()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_ignores_terminal_tasks() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = make_task("task-done-42", TaskStatus::Done);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        assert_eq!(dup, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_different_project_no_match() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = make_task("task-proj-a", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/a"));
+        db.insert(&task).await?;
+        let dup = db.find_active_duplicate("/repo/b", "issue:42").await?;
+        assert_eq!(dup, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_active_duplicate_different_external_id_no_match() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = make_task("task-issue-42", TaskStatus::Pending);
+        task.external_id = Some("issue:42".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
+        db.insert(&task).await?;
+        let dup = db.find_active_duplicate("/repo/foo", "issue:99").await?;
+        assert_eq!(dup, None);
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -735,6 +735,39 @@ impl TaskStore {
         self.cache.len()
     }
 
+    /// Check whether an active (non-terminal) task already exists for the same
+    /// project + external_id. Cache-first, DB fallback.
+    pub async fn find_active_duplicate(
+        &self,
+        project_id: &str,
+        external_id: &str,
+    ) -> Option<TaskId> {
+        for entry in self.cache.iter() {
+            let task = entry.value();
+            if task.external_id.as_deref() == Some(external_id)
+                && task
+                    .project_root
+                    .as_ref()
+                    .map(|p| p.to_string_lossy() == project_id)
+                    .unwrap_or(false)
+                && !matches!(
+                    task.status,
+                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+                )
+            {
+                return Some(task.id.clone());
+            }
+        }
+        match self.db.find_active_duplicate(project_id, external_id).await {
+            Ok(Some(id)) => Some(harness_core::types::TaskId(id)),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!("dedup: DB lookup failed: {e}");
+                None
+            }
+        }
+    }
+
     /// Return all tasks currently in the in-memory cache.
     ///
     /// **Semantic note**: since startup only loads active (non-terminal) tasks

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -742,21 +742,30 @@ impl TaskStore {
         project_id: &str,
         external_id: &str,
     ) -> Option<TaskId> {
+        let mut found_terminal_in_cache = false;
         for entry in self.cache.iter() {
             let task = entry.value();
-            if task.external_id.as_deref() == Some(external_id)
+            let same_key = task.external_id.as_deref() == Some(external_id)
                 && task
                     .project_root
                     .as_ref()
                     .map(|p| p.to_string_lossy() == project_id)
-                    .unwrap_or(false)
-                && !matches!(
-                    task.status,
-                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
-                )
-            {
+                    .unwrap_or(false);
+            if !same_key {
+                continue;
+            }
+            if !matches!(
+                task.status,
+                TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+            ) {
                 return Some(task.id.clone());
             }
+            // Cache has a terminal match — skip DB fallback since cache is
+            // more authoritative and the DB row may be stale.
+            found_terminal_in_cache = true;
+        }
+        if found_terminal_in_cache {
+            return None;
         }
         match self.db.find_active_duplicate(project_id, external_id).await {
             Ok(Some(id)) => Some(harness_core::types::TaskId(id)),


### PR DESCRIPTION
## Summary
- Submitting the same issue or PR number now returns the existing active task instead of creating a duplicate
- Fixes SQL status bug: was using non-existent `'running'`, now queries all 6 active statuses
- Extracted shared `populate_external_id()` and `check_duplicate()` helpers to eliminate duplication between `enqueue_task` and `enqueue_task_background`

## Changes
- `task_db.rs`: Add `find_active_duplicate()` with correct active status set + 5 tests
- `task_runner.rs`: Add `TaskStore::find_active_duplicate()` (cache-first, DB fallback)
- `task_routes.rs`: Add shared dedup helpers, wire into both enqueue paths

## Test plan
- [x] `cargo test --package harness-server` — 699 tests pass, 0 fail
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] CI green

## Known limitation
Dedup check runs before `task_queue.acquire` — concurrent requests can still race past dedup when the queue is saturated (P1 from original review). Fixing requires a reservation mechanism, out of scope.

Supersedes #680
Closes #680