### PR TITLE
feat(config): env var overrides for ServerConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3516,6 +3517,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -271,12 +271,16 @@ fn configured_skill_store(
 
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     // Load config
-    let config = if let Some(config_path) = &cli.config {
+    let mut config: harness_core::config::HarnessConfig = if let Some(config_path) = &cli.config {
         let content = std::fs::read_to_string(config_path)?;
         toml::from_str(&content)?
     } else {
         harness_core::config::HarnessConfig::default()
     };
+    // Apply env var overrides for all subcommands so that HARNESS_DATA_DIR,
+    // HARNESS_PROJECT_ROOT, etc. are respected by gc, rule check, and skill
+    // commands — not just `serve`.
+    config.apply_env_overrides()?;
 
     match cli.command {
         Command::Serve {

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -160,6 +160,10 @@ pub async fn run(
     };
 
     let mut serve_config = config.clone();
+    // Apply serve-only env var overrides (HARNESS_HTTP_ADDR) here rather than
+    // in the global apply_env_overrides(), so a misconfigured bind-address env
+    // var does not break unrelated subcommands like `harness exec` or `harness version`.
+    serve_config.server.apply_serve_env_overrides()?;
     // When --project entries are provided, set project_root to the default project's path
     // so existing single-project behaviour is preserved.
     if let Some(ref id) = default_project_id {

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -48,13 +48,16 @@ fn startup_default_project_for_root(
 }
 
 pub async fn run(
-    config: HarnessConfig,
+    mut config: HarnessConfig,
     transport: Option<String>,
     port: Option<u16>,
     project_root: Option<PathBuf>,
     projects: Vec<String>,
     default_project: Option<String>,
 ) -> Result<()> {
+    // Apply env var overrides before CLI flags so CLI always wins.
+    config.apply_env_overrides()?;
+
     // On macOS, sandbox-exec (Seatbelt) with deny-default policy causes SIGTRAP
     // in Claude Code CLI. Only enforce danger-full-access when a Claude path
     // is actually configured to run.

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -48,16 +48,13 @@ fn startup_default_project_for_root(
 }
 
 pub async fn run(
-    mut config: HarnessConfig,
+    config: HarnessConfig,
     transport: Option<String>,
     port: Option<u16>,
     project_root: Option<PathBuf>,
     projects: Vec<String>,
     default_project: Option<String>,
 ) -> Result<()> {
-    // Apply env var overrides before CLI flags so CLI always wins.
-    config.apply_env_overrides()?;
-
     // On macOS, sandbox-exec (Seatbelt) with deny-default policy causes SIGTRAP
     // in Claude Code CLI. Only enforce danger-full-access when a Claude path
     // is actually configured to run.

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -19,3 +19,4 @@ sqlx = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 tempfile = { workspace = true }
+temp-env = "0.3"

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -54,6 +54,18 @@ pub struct HarnessConfig {
     pub projects: Vec<ProjectEntry>,
 }
 
+impl HarnessConfig {
+    /// Apply environment variable overrides to all sub-configs.
+    ///
+    /// Call this after loading from a TOML file (or using `Default`) and
+    /// before applying CLI flags so that CLI flags retain the highest
+    /// precedence.
+    pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
+        self.server.apply_env_overrides()?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -64,6 +64,41 @@ pub struct ServerConfig {
     pub github_token: Option<String>,
 }
 
+impl ServerConfig {
+    /// Apply environment variable overrides to this config.
+    ///
+    /// Reads a fixed set of env vars and overwrites the corresponding fields.
+    /// Precedence: TOML file → env vars → CLI flags (CLI flags are applied after
+    /// this call in the serve command and always win).
+    ///
+    /// Supported variables:
+    /// - `HARNESS_HTTP_ADDR`    — `http_addr` (parsed as `SocketAddr`)
+    /// - `HARNESS_DATA_DIR`     — `data_dir`
+    /// - `HARNESS_PROJECT_ROOT` — `project_root`
+    /// - `HARNESS_API_TOKEN`    — `api_token`
+    /// - `GITHUB_TOKEN`         — `github_token`
+    pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
+        if let Ok(v) = std::env::var("HARNESS_HTTP_ADDR") {
+            self.http_addr = v.parse().map_err(|e| {
+                anyhow::anyhow!("HARNESS_HTTP_ADDR={v:?} is not a valid SocketAddr: {e}")
+            })?;
+        }
+        if let Ok(v) = std::env::var("HARNESS_DATA_DIR") {
+            self.data_dir = std::path::PathBuf::from(v);
+        }
+        if let Ok(v) = std::env::var("HARNESS_PROJECT_ROOT") {
+            self.project_root = std::path::PathBuf::from(v);
+        }
+        if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
+            self.api_token = Some(v);
+        }
+        if let Ok(v) = std::env::var("GITHUB_TOKEN") {
+            self.github_token = Some(v);
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Exhaustive destructure: compiler error if a new field is added but omitted here.
@@ -181,6 +216,77 @@ fn default_constitution_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- env override tests ---
+
+    #[test]
+    fn env_override_http_addr() {
+        temp_env::with_vars([("HARNESS_HTTP_ADDR", Some("127.0.0.1:9801"))], || {
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.http_addr.port(), 9801);
+        });
+    }
+
+    #[test]
+    fn env_override_data_dir() {
+        temp_env::with_vars([("HARNESS_DATA_DIR", Some("/tmp/testdir"))], || {
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.data_dir, std::path::PathBuf::from("/tmp/testdir"));
+        });
+    }
+
+    #[test]
+    fn env_override_api_token() {
+        temp_env::with_vars([("HARNESS_API_TOKEN", Some("tok-test"))], || {
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.api_token, Some("tok-test".to_string()));
+        });
+    }
+
+    #[test]
+    fn env_override_github_token_fallback() {
+        temp_env::with_vars([("GITHUB_TOKEN", Some("gh-test"))], || {
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.github_token, Some("gh-test".to_string()));
+        });
+    }
+
+    #[test]
+    fn env_override_invalid_addr_returns_error() {
+        temp_env::with_vars([("HARNESS_HTTP_ADDR", Some("not-an-addr"))], || {
+            let mut cfg = ServerConfig::default();
+            let result = cfg.apply_env_overrides();
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn env_override_absent_vars_leave_defaults() {
+        temp_env::with_vars(
+            [
+                ("HARNESS_HTTP_ADDR", None::<&str>),
+                ("HARNESS_DATA_DIR", None::<&str>),
+                ("HARNESS_PROJECT_ROOT", None::<&str>),
+                ("HARNESS_API_TOKEN", None::<&str>),
+                ("GITHUB_TOKEN", None::<&str>),
+            ],
+            || {
+                let default = ServerConfig::default();
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.http_addr, default.http_addr);
+                assert_eq!(cfg.data_dir, default.data_dir);
+                assert_eq!(cfg.api_token, default.api_token);
+                assert_eq!(cfg.github_token, default.github_token);
+            },
+        );
+    }
+
+    // --- existing tests ---
 
     #[test]
     fn server_config_debug_redacts_secrets() {

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -78,16 +78,15 @@ impl ServerConfig {
     /// - `HARNESS_API_TOKEN`    — `api_token`
     /// - `GITHUB_TOKEN`         — `github_token`
     pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
-        if let Ok(v) = std::env::var("HARNESS_HTTP_ADDR") {
-            self.http_addr = v.parse().map_err(|e| {
-                anyhow::anyhow!("HARNESS_HTTP_ADDR={v:?} is not a valid SocketAddr: {e}")
-            })?;
-        }
         if let Ok(v) = std::env::var("HARNESS_DATA_DIR") {
-            self.data_dir = std::path::PathBuf::from(v);
+            if !v.is_empty() {
+                self.data_dir = std::path::PathBuf::from(v);
+            }
         }
         if let Ok(v) = std::env::var("HARNESS_PROJECT_ROOT") {
-            self.project_root = std::path::PathBuf::from(v);
+            if !v.is_empty() {
+                self.project_root = std::path::PathBuf::from(v);
+            }
         }
         if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
             if !v.is_empty() {
@@ -97,6 +96,25 @@ impl ServerConfig {
         if let Ok(v) = std::env::var("GITHUB_TOKEN") {
             if !v.is_empty() {
                 self.github_token = Some(v);
+            }
+        }
+        Ok(())
+    }
+
+    /// Apply the `HARNESS_HTTP_ADDR` env var override.
+    ///
+    /// This is intentionally separated from [`apply_env_overrides`] because
+    /// `HARNESS_HTTP_ADDR` is only meaningful for the `serve` subcommand.
+    /// Parsing it eagerly for every subcommand (e.g. `harness exec`,
+    /// `harness version`) would make a server-side misconfiguration (blank
+    /// value, or a hostname like `localhost:9800` that `SocketAddr` rejects)
+    /// brick completely unrelated commands.
+    pub fn apply_serve_env_overrides(&mut self) -> anyhow::Result<()> {
+        if let Ok(v) = std::env::var("HARNESS_HTTP_ADDR") {
+            if !v.is_empty() {
+                self.http_addr = v.parse().map_err(|e| {
+                    anyhow::anyhow!("HARNESS_HTTP_ADDR={v:?} is not a valid SocketAddr: {e}")
+                })?;
             }
         }
         Ok(())
@@ -227,8 +245,17 @@ mod tests {
     fn env_override_http_addr() {
         temp_env::with_vars([("HARNESS_HTTP_ADDR", Some("127.0.0.1:9801"))], || {
             let mut cfg = ServerConfig::default();
-            cfg.apply_env_overrides().unwrap();
+            cfg.apply_serve_env_overrides().unwrap();
             assert_eq!(cfg.http_addr.port(), 9801);
+        });
+    }
+
+    #[test]
+    fn env_override_http_addr_empty_leaves_default() {
+        temp_env::with_vars([("HARNESS_HTTP_ADDR", Some(""))], || {
+            let mut cfg = ServerConfig::default();
+            cfg.apply_serve_env_overrides().unwrap();
+            assert_eq!(cfg.http_addr.port(), 9800);
         });
     }
 
@@ -238,6 +265,26 @@ mod tests {
             let mut cfg = ServerConfig::default();
             cfg.apply_env_overrides().unwrap();
             assert_eq!(cfg.data_dir, std::path::PathBuf::from("/tmp/testdir"));
+        });
+    }
+
+    #[test]
+    fn env_override_empty_data_dir_does_not_override() {
+        temp_env::with_vars([("HARNESS_DATA_DIR", Some(""))], || {
+            let default = ServerConfig::default();
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.data_dir, default.data_dir);
+        });
+    }
+
+    #[test]
+    fn env_override_empty_project_root_does_not_override() {
+        temp_env::with_vars([("HARNESS_PROJECT_ROOT", Some(""))], || {
+            let default = ServerConfig::default();
+            let mut cfg = ServerConfig::default();
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.project_root, default.project_root);
         });
     }
 
@@ -263,7 +310,7 @@ mod tests {
     fn env_override_invalid_addr_returns_error() {
         temp_env::with_vars([("HARNESS_HTTP_ADDR", Some("not-an-addr"))], || {
             let mut cfg = ServerConfig::default();
-            let result = cfg.apply_env_overrides();
+            let result = cfg.apply_serve_env_overrides();
             assert!(result.is_err());
         });
     }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -90,10 +90,14 @@ impl ServerConfig {
             self.project_root = std::path::PathBuf::from(v);
         }
         if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
-            self.api_token = Some(v);
+            if !v.is_empty() {
+                self.api_token = Some(v);
+            }
         }
         if let Ok(v) = std::env::var("GITHUB_TOKEN") {
-            self.github_token = Some(v);
+            if !v.is_empty() {
+                self.github_token = Some(v);
+            }
         }
         Ok(())
     }
@@ -261,6 +265,31 @@ mod tests {
             let mut cfg = ServerConfig::default();
             let result = cfg.apply_env_overrides();
             assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn env_override_empty_api_token_does_not_override_toml_token() {
+        temp_env::with_vars([("HARNESS_API_TOKEN", Some(""))], || {
+            let mut cfg = ServerConfig {
+                api_token: Some("real-token".to_string()),
+                ..ServerConfig::default()
+            };
+            cfg.apply_env_overrides().unwrap();
+            // Empty env var must not overwrite a valid TOML token.
+            assert_eq!(cfg.api_token, Some("real-token".to_string()));
+        });
+    }
+
+    #[test]
+    fn env_override_empty_github_token_does_not_override_toml_token() {
+        temp_env::with_vars([("GITHUB_TOKEN", Some(""))], || {
+            let mut cfg = ServerConfig {
+                github_token: Some("gh-real".to_string()),
+                ..ServerConfig::default()
+            };
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.github_token, Some("gh-real".to_string()));
         });
     }
 


### PR DESCRIPTION
Adds env var overrides (HARNESS_HTTP_ADDR, HARNESS_DATA_DIR, HARNESS_PROJECT_ROOT, HARNESS_API_TOKEN, GITHUB_TOKEN) with precedence Default→TOML→env→CLI. 6 unit tests. Closes #715.