### PR TITLE
fix: persist task phase and description to tasks DB (#681)

### DIFF
--- a/crates/harness-core/src/error.rs
+++ b/crates/harness-core/src/error.rs
@@ -100,6 +100,12 @@ pub enum TaskDbDecodeError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("failed to deserialize phase for task `{task_id}`")]
+    PhaseDeserialize {
+        task_id: String,
+        #[source]
+        source: serde_json::Error,
+    },
 }
 
 pub type Error = HarnessError;

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -16,7 +16,7 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority";
+const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description";
 
 /// Versioned migrations for the tasks table.
 ///
@@ -27,6 +27,8 @@ const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source,
 /// v10 – add composite index on (project, status, updated_at).
 /// v11 – add task_checkpoints table for phase recovery.
 /// v12 – add priority column for priority-based task scheduling.
+/// v13 – add phase column for consistent phase persistence across cache/DB paths.
+/// v14 – add description column for task observability after restart.
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -107,6 +109,16 @@ static TASK_MIGRATIONS: &[Migration] = &[
         description: "add priority column for task scheduling",
         sql: "ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
     },
+    Migration {
+        version: 13,
+        description: "add phase column for consistent phase persistence",
+        sql: r#"ALTER TABLE tasks ADD COLUMN phase TEXT NOT NULL DEFAULT '"implement"'"#,
+    },
+    Migration {
+        version: 14,
+        description: "add description column for task observability",
+        sql: "ALTER TABLE tasks ADD COLUMN description TEXT",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -176,9 +188,10 @@ impl TaskDb {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
+        let phase_json = serde_json::to_string(&state.phase)?;
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -194,6 +207,8 @@ impl TaskDb {
         .bind(&depends_on_json)
         .bind(state.project_root.as_ref().map(|p| p.to_string_lossy().into_owned()))
         .bind(state.priority as i64)
+        .bind(&phase_json)
+        .bind(state.description.as_deref())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -202,11 +217,12 @@ impl TaskDb {
     pub async fn update(&self, state: &TaskState) -> anyhow::Result<()> {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
+        let phase_json = serde_json::to_string(&state.phase)?;
         let status = state.status.as_ref();
         sqlx::query(
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
                     source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
-                    priority = ?, updated_at = datetime('now')
+                    priority = ?, phase = ?, description = ?, updated_at = datetime('now')
              WHERE id = ?",
         )
         .bind(status)
@@ -225,6 +241,8 @@ impl TaskDb {
                 .map(|p| p.to_string_lossy().into_owned()),
         )
         .bind(state.priority as i64)
+        .bind(&phase_json)
+        .bind(state.description.as_deref())
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -295,7 +313,7 @@ impl TaskDb {
     pub async fn list_summaries(&self) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
         let rows = sqlx::query_as::<_, TaskSummaryRow>(
             "SELECT id, status, turn, pr_url, error, source, external_id, parent_id, \
-             created_at, repo, depends_on, project \
+             created_at, repo, depends_on, project, phase, description \
              FROM tasks ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)
@@ -778,6 +796,8 @@ struct TaskRow {
     depends_on: String,
     project: Option<String>,
     priority: i64,
+    phase: String,
+    description: Option<String>,
 }
 
 impl TaskRow {
@@ -797,6 +817,8 @@ impl TaskRow {
             depends_on,
             project,
             priority,
+            phase,
+            description,
         } = self;
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
@@ -811,6 +833,13 @@ impl TaskRow {
                 source,
             }
         })?;
+        let decoded_phase =
+            serde_json::from_str::<crate::task_runner::TaskPhase>(&phase).map_err(|source| {
+                TaskDbDecodeError::PhaseDeserialize {
+                    task_id: id.clone(),
+                    source,
+                }
+            })?;
 
         Ok(TaskState {
             id: harness_core::types::TaskId(id),
@@ -826,10 +855,10 @@ impl TaskRow {
             subtask_ids: Vec::new(),
             project_root: project.map(PathBuf::from),
             issue: None,
-            description: None,
+            description,
             created_at,
             priority: priority.clamp(0, 255) as u8,
-            phase: crate::task_runner::TaskPhase::default(),
+            phase: decoded_phase,
             triage_output: None,
             plan_output: None,
             repo,
@@ -852,6 +881,8 @@ struct TaskSummaryRow {
     repo: Option<String>,
     depends_on: String,
     project: Option<String>,
+    phase: String,
+    description: Option<String>,
 }
 
 impl TaskSummaryRow {
@@ -863,6 +894,13 @@ impl TaskSummaryRow {
                 source,
             }
         })?;
+        let decoded_phase = serde_json::from_str::<crate::task_runner::TaskPhase>(&self.phase)
+            .map_err(
+                |source| harness_core::error::TaskDbDecodeError::PhaseDeserialize {
+                    task_id: self.id.clone(),
+                    source,
+                },
+            )?;
         Ok(crate::task_runner::TaskSummary {
             id: TaskId(self.id),
             status: self.status.parse::<crate::task_runner::TaskStatus>()?,
@@ -873,9 +911,9 @@ impl TaskSummaryRow {
             parent_id: self.parent_id.map(TaskId),
             external_id: self.external_id,
             repo: self.repo,
-            description: None,
+            description: self.description,
             created_at: self.created_at,
-            phase: crate::task_runner::TaskPhase::default(),
+            phase: decoded_phase,
             depends_on,
             subtask_ids: Vec::new(),
             project: self.project,
@@ -905,6 +943,8 @@ mod tests {
             depends_on: depends_on.to_string(),
             project: None,
             priority: 0,
+            phase: r#""implement""#.to_string(),
+            description: None,
         }
     }
 
@@ -1602,13 +1642,15 @@ mod tests {
             depends_on: String::new(),
             project: None,
             priority: 0,
+            phase: String::new(),
+            description: None,
         };
 
         // Count must match — catches column added to constant but not struct (or vice versa).
         assert_eq!(
             columns.len(),
-            14, // bump this when adding a field
-            "TASK_ROW_COLUMNS has {} entries but expected 14 — update both the constant and this test",
+            16, // bump this when adding a field
+            "TASK_ROW_COLUMNS has {} entries but expected 16 — update both the constant and this test",
             columns.len()
         );
     }
@@ -1703,6 +1745,93 @@ mod tests {
         db.insert(&task).await?;
         let dup = db.find_active_duplicate("/repo/foo", "issue:99").await?;
         assert_eq!(dup, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn phase_round_trips_through_db() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-phase-rt", TaskStatus::Implementing);
+        task.phase = crate::task_runner::TaskPhase::Review;
+        db.insert(&task).await?;
+
+        let loaded = db
+            .get("task-phase-rt")
+            .await?
+            .expect("inserted task should exist");
+        assert_eq!(loaded.phase, crate::task_runner::TaskPhase::Review);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn description_round_trips_through_db() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-desc-rt", TaskStatus::Pending);
+        task.description = Some("fix: crash on empty input".to_string());
+        db.insert(&task).await?;
+
+        let loaded = db
+            .get("task-desc-rt")
+            .await?
+            .expect("inserted task should exist");
+        assert_eq!(
+            loaded.description.as_deref(),
+            Some("fix: crash on empty input")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_summaries_includes_phase_and_description() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-summary-pd", TaskStatus::Pending);
+        task.phase = crate::task_runner::TaskPhase::Plan;
+        task.description = Some("architect PR #5".to_string());
+        db.insert(&task).await?;
+
+        let summaries = db.list_summaries().await?;
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].phase, crate::task_runner::TaskPhase::Plan);
+        assert_eq!(summaries[0].description.as_deref(), Some("architect PR #5"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn phase_defaults_for_legacy_rows() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        // Insert a row without supplying phase/description — SQLite uses column defaults.
+        sqlx::query(
+            "INSERT INTO tasks (id, status, turn, rounds, depends_on) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("task-legacy")
+        .bind("pending")
+        .bind(0_i64)
+        .bind("[]")
+        .bind("[]")
+        .execute(&db.pool)
+        .await?;
+
+        let loaded = db
+            .get("task-legacy")
+            .await?
+            .expect("legacy task should exist");
+        assert_eq!(
+            loaded.phase,
+            crate::task_runner::TaskPhase::default(),
+            "phase should default to Implement for legacy rows"
+        );
+        assert!(
+            loaded.description.is_none(),
+            "description should be None for legacy rows"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -337,17 +337,17 @@ impl Default for CreateTaskRequest {
 }
 
 fn summarize_request_description(req: &CreateTaskRequest) -> Option<String> {
-    req.issue.map(|n| format!("issue #{n}")).or_else(|| {
-        req.prompt.as_ref().map(|p| {
-            let s = p.trim();
-            let cutoff = s.char_indices().nth(80).map(|(i, _)| i).unwrap_or(s.len());
-            if cutoff < s.len() {
-                format!("{}...", &s[..cutoff])
-            } else {
-                s.to_string()
-            }
-        })
-    })
+    // Only persist structured safe labels (issue/PR IDs).
+    // Prompt text is deliberately excluded: it may contain credentials or customer
+    // data that must not be durably stored or exposed cross-task via the dashboard
+    // or sibling-awareness prompts.
+    if let Some(n) = req.issue {
+        return Some(format!("issue #{n}"));
+    }
+    if let Some(n) = req.pr {
+        return Some(format!("PR #{n}"));
+    }
+    None
 }
 
 pub(crate) async fn fill_missing_repo_from_project(req: &mut CreateTaskRequest) {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -135,8 +135,8 @@ pub struct TaskState {
     pub issue: Option<u64>,
     /// Repository slug (e.g. "owner/repo"). Persisted for traceability.
     pub repo: Option<String>,
-    /// Short description derived from the task prompt or issue number. Set at spawn time; not persisted.
-    #[serde(skip)]
+    /// Short description derived from the task prompt or issue number.
+    #[serde(default)]
     pub description: Option<String>,
     /// ISO 8601 creation timestamp. Set at spawn time and persisted to the tasks DB.
     #[serde(default)]

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -337,15 +337,20 @@ impl Default for CreateTaskRequest {
 }
 
 fn summarize_request_description(req: &CreateTaskRequest) -> Option<String> {
-    // Only persist structured safe labels (issue/PR IDs).
-    // Prompt text is deliberately excluded: it may contain credentials or customer
-    // data that must not be durably stored or exposed cross-task via the dashboard
-    // or sibling-awareness prompts.
+    // Only persist structured safe labels — never raw prompt text, which may contain
+    // credentials or customer data.
     if let Some(n) = req.issue {
         return Some(format!("issue #{n}"));
     }
     if let Some(n) = req.pr {
         return Some(format!("PR #{n}"));
+    }
+    // Prompt-only tasks: store a generic label so that:
+    //   (a) sibling-awareness can include them (prevents parallel agents stomping the same files),
+    //   (b) operators can identify crashed tasks in the DB/dashboard after a restart.
+    // The prompt itself is deliberately not stored.
+    if req.prompt.is_some() {
+        return Some("prompt task".to_string());
     }
     None
 }


### PR DESCRIPTION
## Summary

- `TaskState.phase` and `.description` were not persisted to the tasks DB, causing cache-hit and DB-fallback paths to return different values after restart
- Adds migrations v13/v14 (`phase TEXT NOT NULL DEFAULT '"implement"'`, `description TEXT`) 
- Updates all INSERT/UPDATE/SELECT queries, `TaskRow`, `TaskSummaryRow`, and both converters
- Removes `#[serde(skip)]` from `description` (replaced with `#[serde(default)]`) so it round-trips through JSON checkpoints
- Adds `PhaseDeserialize` error variant to `TaskDbDecodeError` for consistent error handling

## Test plan

- [x] 4 new regression tests: `phase_round_trips_through_db`, `description_round_trips_through_db`, `list_summaries_includes_phase_and_description`, `phase_defaults_for_legacy_rows`
- [x] All 32 task_db tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean

Closes #681