### PR TITLE
fix(security): remove dashboard token injection and query-param auth

### DIFF
--- a/.harness/guards/sec-02-hardcoded-secrets.sh
+++ b/.harness/guards/sec-02-hardcoded-secrets.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # SEC-02: Detect hardcoded API keys, tokens, and secrets.
 # Output format: FILE:LINE:SEC-02:MESSAGE
+#
+# Only runs on projects that opt in via .harness/guards/ (rule_enforcer
+# skips projects without that directory).  Guard patterns are tuned for
+# the harness codebase — external projects are excluded at the enforcer
+# level, not here.
 set -euo pipefail
 
 project_root="${1:-}"
@@ -20,9 +25,16 @@ grep -rn \
   --include="*.env" \
   --exclude-dir=".git" \
   --exclude-dir="target" \
+  --exclude-dir="node_modules" \
+  --exclude-dir="tests" \
+  --exclude-dir="test" \
+  --exclude-dir="benches" \
+  --exclude-dir="fixtures" \
+  --exclude-dir="testdata" \
   -E '(api_key|apikey|api_secret|secret_key|access_token|auth_token|password|passwd)\s*[=:]\s*"[^"$\{]{8,}"' \
   "${project_root}" 2>/dev/null \
-| grep -v -E '(test|example|placeholder|changeme|your_|<|>|\*{3}|xxx|TODO|FIXME)' \
+| grep -v -E '(_test\.(rs|go|py|ts|js):|_spec\.(rs|ts|js):)' \
+| grep -v -E '(test|example|placeholder|changeme|your_|<|>|\*{3}|xxx|TODO|FIXME|mock|fake|dummy|sample)' \
 | while IFS=: read -r file line rest; do
   echo "${file}:${line}:SEC-02:Hardcoded secret or API key detected"
 done || true

--- a/README.md
+++ b/README.md
@@ -30,28 +30,32 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                        Harness CLI                          │
-│              serve · exec · gc · rule · skill               │
-├──────────┬──────────┬───────────────────────────────────────┤
-│  stdio   │   HTTP   │  WebSocket   │  MCP Server  │ Webhook│
-├──────────┴──────────┴──────────┴───┴──────────────┴────────┤
-│                    JSON-RPC Router (30 methods)             │
-├────────────┬─────────────┬────────────┬────────────────────┤
-│   Threads  │    Tasks    │   Turns    │    ExecPlans       │
-├────────────┴─────────────┴────────────┴────────────────────┤
-│  harness-agents    │  harness-rules   │  harness-skills    │
-│  (Claude/Codex/API)│  (Starlark exec) │  (discovery/dedup) │
-├────────────────────┼──────────────────┼────────────────────┤
-│  harness-gc        │  harness-observe │  harness-exec      │
-│  (signal/drafts)   │  (events/OTLP)  │  (plan lifecycle)  │
-├────────────────────┴──────────────────┴────────────────────┤
-│                    harness-core                             │
-│          config · prompts · domain types · traits           │
-├────────────────────────────────────────────────────────────┤
-│                    harness-protocol                         │
-│       JSON-RPC envelopes · method definitions · codecs      │
-└────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│                          Harness CLI                              │
+│    serve · mcp-server · exec · gc · rule · execpolicy · skill    │
+│                    pr · plan · version                            │
+├──────────┬──────────┬────────────────────────────────────────────┤
+│  stdio   │   HTTP   │  WebSocket   │  MCP Server  │  Webhook    │
+├──────────┴──────────┴──────────┴───┴──────────────┴─────────────┤
+│                    JSON-RPC Router (42 methods)                   │
+├────────────┬─────────────┬────────────┬─────────────────────────┤
+│   Threads  │    Tasks    │   Turns    │    ExecPlans            │
+├────────────┴─────────────┴────────────┴─────────────────────────┤
+│  harness-agents    │  harness-rules   │  harness-skills         │
+│  (Claude/Codex/API)│  (Starlark exec) │  (discovery/dedup)      │
+├────────────────────┼──────────────────┼─────────────────────────┤
+│  harness-gc        │  harness-observe │  harness-exec           │
+│  (signal/drafts)   │  (events/OTLP)  │  (plan lifecycle)       │
+├────────────────────┼──────────────────┼─────────────────────────┤
+│  harness-sandbox   │  harness-workflow│  harness-api            │
+│  (isolation modes) │  (workflow engine)│  (stable Rust facade)  │
+├────────────────────┴──────────────────┴─────────────────────────┤
+│                    harness-core                                   │
+│          config · prompts · domain types · traits                 │
+├──────────────────────────────────────────────────────────────────┤
+│                    harness-protocol                               │
+│       JSON-RPC envelopes · method definitions · codecs            │
+└──────────────────────────────────────────────────────────────────┘
         ▼               ▼                ▼
    Claude Code CLI   Codex CLI    Anthropic API
 ```
@@ -71,7 +75,7 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 ```bash
 git clone https://github.com/majiayu000/harness.git
 cd harness
-cargo build
+cargo build --release
 ```
 
 ### Rust API Facade
@@ -99,23 +103,29 @@ track internal crate layout changes.
 
 ### Run
 
-**HTTP server:**
+**HTTP server (recommended — use config file):**
 
 ```bash
-cargo run -p harness-cli -- serve --transport http --port 9800
+./target/release/harness serve --config config/harness.toml
 curl http://127.0.0.1:9800/health
+```
+
+**HTTP server (inline flags):**
+
+```bash
+./target/release/harness serve --transport http --port 9800
 ```
 
 **Stdio (for MCP integration):**
 
 ```bash
-cargo run -p harness-cli -- serve --transport stdio
+./target/release/harness serve --transport stdio
 ```
 
 **One-shot execution:**
 
 ```bash
-cargo run -p harness-cli -- exec "Fix the failing test in src/lib.rs"
+./target/release/harness exec "Fix the failing test in src/lib.rs"
 ```
 
 ### Common Workflows
@@ -127,34 +137,36 @@ curl -X POST http://127.0.0.1:9800/tasks \
   -d '{"prompt": "Add input validation to the API handler"}'
 
 # Rule engine
-cargo run -p harness-cli -- rule load .
-cargo run -p harness-cli -- rule check .
+harness rule load .
+harness rule check .
 
 # GC cycle — detect signals and generate remediation drafts
-cargo run -p harness-cli -- gc run .
+harness gc run .
 
 # Skill discovery
-cargo run -p harness-cli -- skill list
+harness skill list
 
 # ExecPlan lifecycle
-cargo run -p harness-cli -- plan init ./spec.md
-cargo run -p harness-cli -- plan status ./exec-plan-<id>.md
+harness plan init ./spec.md
+harness plan status ./exec-plan-<id>.md
+
+# PR orchestration — implement issue and manage review loop
+harness pr --issue 42 --project my-project
 ```
 
 ## Configuration
 
-All settings are declarative TOML. Pass `--config <path>` or use the defaults in [`config/default.toml`](config/default.toml).
+All settings are declarative TOML. Pass `--config <path>` or copy [`config/default.toml.example`](config/default.toml.example) to get started.
 
 ```toml
 [server]
-transport = "stdio"
+transport = "http"
 http_addr = "127.0.0.1:9800"
 data_dir = "~/.local/share/harness"
 project_root = "."
 
 [agents]
-default_agent = "auto"
-# complexity_preferred_agents = ["codex", "claude"]
+default_agent = "claude"
 sandbox_mode = "danger-full-access"
 
 [agents.claude]
@@ -167,7 +179,6 @@ cli_path = "codex"
 [agents.anthropic_api]
 base_url = "https://api.anthropic.com"
 default_model = "claude-sonnet-4-20250514"
-max_tokens = 4096
 
 [agents.review]
 enabled = true
@@ -178,7 +189,6 @@ max_rounds = 3
 max_drafts_per_run = 5
 budget_per_signal_usd = 0.50
 total_budget_usd = 5.0
-draft_ttl_hours = 72
 
 [observe]
 log_retention_days = 90
@@ -333,11 +343,11 @@ curl http://127.0.0.1:9800/health
 **Important:** Always start the server from a standalone terminal, not from within Claude Code or other agent sessions. Agent environment variables (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`) propagate to spawned subprocesses and cause SIGTRAP.
 
 ```bash
-# Single project (backward compatible)
-./target/release/harness serve --transport http --port 9800 --project-root /path/to/project
-
 # Multi-project via config file (recommended)
-./target/release/harness serve --transport http --port 9800 --config config/default.toml
+./target/release/harness serve --config config/harness.toml
+
+# Single project (inline flags)
+./target/release/harness serve --transport http --port 9800 --project-root /path/to/project
 
 # Multi-project via CLI flags
 ./target/release/harness serve --transport http --port 9800 \
@@ -345,7 +355,7 @@ curl http://127.0.0.1:9800/health
   --project litellm=/path/to/litellm
 
 # With GitHub token for auto-review
-GITHUB_TOKEN=ghp_xxx ./target/release/harness serve --transport http --port 9800 --config config/default.toml
+GITHUB_TOKEN=ghp_xxx ./target/release/harness serve --config config/harness.toml
 ```
 
 ## Task Execution Flow
@@ -368,24 +378,27 @@ Each task runs in an isolated git worktree, so multiple agents can work on the s
 | `harness-protocol` | JSON-RPC method definitions, envelopes, notifications, codecs |
 | `harness-server` | App Server runtime (HTTP + stdio + WebSocket), routing, handlers, task/thread stores |
 | `harness-agents` | Agent adapters (Claude CLI, Codex CLI, Anthropic API) and registry |
+| `harness-api` | Stable Rust import facade over core, protocol, sandbox, and exec crates |
+| `harness-sandbox` | Sandbox mode definitions and workspace isolation |
+| `harness-workflow` | Workflow engine for multi-step agent orchestration |
 | `harness-gc` | Signal detection and draft remediation generation/adoption |
 | `harness-rules` | Rule loading/parsing, Starlark execution policy engine |
 | `harness-skills` | Skill discovery, deduplication, search, and persistence |
 | `harness-exec` | ExecPlan model plus Markdown serialization/deserialization |
 | `harness-observe` | Event storage, quality grading, health/stat aggregation, OTLP export |
-| `harness-cli` | `harness` binary with serve/exec/gc/rule/skill/plan commands |
+| `harness-cli` | `harness` binary with serve/mcp-server/exec/gc/rule/execpolicy/skill/plan/pr commands |
 
 ## JSON-RPC API
 
-Harness exposes 38 methods over JSON-RPC 2.0 (stdio, HTTP, or WebSocket):
+Harness exposes 42 methods over JSON-RPC 2.0 (stdio, HTTP, or WebSocket):
 
 | Category | Methods |
 |---|---|
 | Lifecycle | `initialize`, `initialized` |
 | Threads | `thread/start`, `thread/resume`, `thread/fork`, `thread/list`, `thread/delete`, `thread/compact` |
-| Turns | `turn/start`, `turn/steer`, `turn/cancel`, `turn/status` |
+| Turns | `turn/start`, `turn/steer`, `turn/cancel`, `turn/status`, `turn/respond_approval` |
 | GC | `gc/run`, `gc/status`, `gc/drafts`, `gc/adopt`, `gc/reject` |
-| Skills | `skill/create`, `skill/list`, `skill/get`, `skill/delete` |
+| Skills | `skill/create`, `skill/list`, `skill/get`, `skill/delete`, `skill/governance_view`, `skill/governance_history`, `skill/stale` |
 | Rules | `rule/load`, `rule/check` |
 | ExecPlan | `exec_plan/init`, `exec_plan/update`, `exec_plan/status` |
 | Observability | `event/log`, `event/query`, `metrics/collect`, `metrics/query` |

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -23,8 +23,7 @@ use crate::config::project::GitConfig;
 /// Modeled after Claude Code's `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`. Content before
 /// this marker is stable across calls of the same prompt type and can be cached
 /// at the API level (prefix caching). Content after changes per invocation.
-pub const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: &str =
-    "\n\n---\n<!-- dynamic context below -->\n";
+pub const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: &str = "\n\n---\n<!-- dynamic context below -->\n";
 
 /// A prompt decomposed into its static, semi-static, and dynamic layers.
 ///

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -1,24 +1,43 @@
 //! Prompt templates and output parsers shared across CLI and HTTP entries.
+//!
+//! ## Caching architecture (inspired by Claude Code's prompt design)
+//!
+//! Prompts are split into three layers with a boundary marker between static and
+//! dynamic content. When the CLI eventually supports prefix-based prompt caching,
+//! the static portion will be cached across calls.
+//!
+//! ```text
+//! ┌──────────────────────────────┐
+//! │  static_instructions         │  ← Cacheable: role, workflow, output format
+//! │  (identical across calls)    │
+//! ├──────────────────────────────┤  ← SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+//! │  context                     │  ← Semi-static: project rules, git config
+//! │  dynamic_payload             │  ← Per-call: issue number, triage output
+//! └──────────────────────────────┘
+//! ```
 
 use crate::config::project::GitConfig;
 
-/// A prompt decomposed into its static, semi-static, and dynamic layers.
+/// Marker separating cacheable static content from per-invocation dynamic content.
 ///
-/// This structure prepares prompts for future API-level prompt caching by separating
-/// stable content (instructions, output format) from dynamic content (issue body, diff).
+/// Modeled after Claude Code's `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`. Content before
+/// this marker is stable across calls of the same prompt type and can be cached
+/// at the API level (prefix caching). Content after changes per invocation.
+pub const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: &str =
+    "\n\n---\n<!-- dynamic context below -->\n";
+
+/// A prompt decomposed into its static, semi-static, and dynamic layers.
 ///
 /// ## Layers
 /// - `static_instructions`: Role description, workflow steps, output format — identical
-///   across all tasks of the same type. Highest cache hit rate.
+///   across all tasks of the same type. **Must not contain per-call data** (issue numbers,
+///   triage output, etc.) to maximize cache hit rate.
 /// - `context`: Project-level configuration (git config, rules, sibling tasks) — stable
-///   within a session but varies per project.
+///   within a session but varies per project. Wrapped with [`wrap_system_context`].
 /// - `dynamic_payload`: Issue body, PR diff, review comments — unique per invocation.
-///
-/// Call [`to_prompt_string`](PromptParts::to_prompt_string) to concatenate all parts into
-/// the final prompt string. The result is identical to what the previous `String`-returning
-/// functions produced.
 pub struct PromptParts {
     /// Role description, workflow steps, and output format — same for all tasks of this type.
+    /// **Do not embed dynamic data** (issue numbers, triage output) here.
     pub static_instructions: String,
     /// Project conventions, git config, sibling task warnings, rules — semi-static per session.
     pub context: String,
@@ -27,16 +46,44 @@ pub struct PromptParts {
 }
 
 impl PromptParts {
-    /// Concatenate all three layers into the final prompt string.
+    /// Concatenate all three layers with a dynamic boundary marker.
     ///
-    /// The output is identical to the `String` that was previously returned directly by
-    /// the prompt-building function. Callers that previously stored the return value as a
-    /// `String` should call this method to obtain it.
+    /// Layout: `static_instructions` + BOUNDARY + `context` + `dynamic_payload`
+    ///
+    /// The boundary separates content that is identical across calls (cacheable)
+    /// from per-invocation content.
     pub fn to_prompt_string(&self) -> String {
-        format!(
-            "{}{}{}",
-            self.static_instructions, self.context, self.dynamic_payload
-        )
+        let has_dynamic = !self.context.is_empty() || !self.dynamic_payload.is_empty();
+        if has_dynamic {
+            format!(
+                "{}{}{}{}",
+                self.static_instructions,
+                SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+                self.context,
+                self.dynamic_payload
+            )
+        } else {
+            self.static_instructions.clone()
+        }
+    }
+}
+
+/// Trait for prompt components that can contribute their own documentation.
+///
+/// Inspired by Claude Code's `Tool.prompt()` pattern where each tool generates
+/// its own usage documentation dynamically. Implementors contribute a section
+/// to the assembled prompt.
+pub trait PromptContributor {
+    /// A short identifier for this section (used in cache keys and logging).
+    fn section_name(&self) -> &str;
+
+    /// Generate the prompt section content. Returns empty string if nothing to contribute.
+    fn prompt_section(&self) -> String;
+
+    /// Whether this section is cacheable across calls (static content).
+    /// Default: true. Override to false for sections with per-call dynamic data.
+    fn is_cacheable(&self) -> bool {
+        true
     }
 }
 
@@ -81,28 +128,34 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
 /// - `TRIAGE=SKIP` — not worth doing, out of scope, or duplicate
 pub fn triage_prompt(issue: u64) -> PromptParts {
     PromptParts {
-        static_instructions: format!(
-            "You are a Tech Lead evaluating GitHub issue #{issue} before any code is written.\n\n\
-             Your job is to THINK before committing engineering effort. Read the issue carefully, then assess:\n\n\
-             1. **Complexity**: Is this trivial (typo, config, 1-file change), moderate (2-3 files, \
-             clear scope), or complex (4+ files, new API surface, architectural change)?\n\
-             2. **Clarity**: Are the requirements specific enough to implement without guessing? \
-             What assumptions would an engineer have to make?\n\
-             3. **Risk**: What could go wrong in production? Are there edge cases, \
-             backward compatibility concerns, or security implications?\n\
-             4. **Scope**: Does this issue try to do too much? Should it be split?\n\n\
-             Based on your assessment, choose ONE recommendation:\n\
-             - PROCEED — trivial/clear change, no planning needed, go straight to implementation\n\
-             - PROCEED_WITH_PLAN — non-trivial change that needs an implementation plan first\n\
-             - NEEDS_CLARIFICATION — issue is ambiguous; list the specific questions that must be answered\n\
-             - SKIP — not worth doing (explain why: duplicate, out of scope, or fundamentally flawed)\n\n\
-             Output format: Write your assessment (2-5 sentences), then on the second-to-last line print:\n\
-             COMPLEXITY=<low|medium|high> (low=typo/doc fix, medium=single-module change, high=cross-file refactor)\n\
-             Then on the LAST line print:\n\
-             TRIAGE=<recommendation>"
-        ),
+        // Static: role + workflow + rubric + output format. No per-call data here.
+        static_instructions: "\
+            You are a Tech Lead evaluating a GitHub issue before any code is written.\n\n\
+            Step 1: Read the target issue (number below) with `gh issue view <number>` and \
+            check for duplicates with `gh issue list --state all --search '<key terms>'`.\n\
+            Step 2: Skim the affected code area with Grep/Read to understand scope.\n\
+            Step 3: Assess these dimensions:\n\n\
+            1. **Complexity**: How many files/modules are affected?\n\
+            2. **Clarity**: Are requirements specific enough to implement without guessing?\n\
+            3. **Risk**: What could go wrong — edge cases, backward compatibility, security?\n\
+            4. **Scope**: Does this issue try to do too much? Should it be split?\n\
+            5. **Dependencies**: Are there cross-module or external dependencies?\n\n\
+            Step 4: Choose ONE recommendation using these decision rules:\n\
+            - PROCEED — complexity=low AND clarity=high AND risk=low (typo, config, 1-file <50 LOC)\n\
+            - PROCEED_WITH_PLAN — complexity>=medium OR risk>=medium OR scope needs split\n\
+            - NEEDS_CLARIFICATION — requirements ambiguous OR missing acceptance criteria\n\
+            - SKIP — duplicate of existing issue, out of scope, or effort >> value\n\n\
+            Complexity rubric:\n\
+            - low: typo fix, doc update, config change, 1 file <50 LOC\n\
+            - medium: 2-3 files, clear scope, no new API surface\n\
+            - high: 4+ files, new endpoint, DB migration, cross-module refactor\n\n\
+            IMPORTANT: Your output MUST end with exactly these two lines and nothing after them:\n\
+            COMPLEXITY=<low|medium|high>\n\
+            TRIAGE=<PROCEED|PROCEED_WITH_PLAN|NEEDS_CLARIFICATION|SKIP>"
+            .to_string(),
         context: String::new(),
-        dynamic_payload: String::new(),
+        // Dynamic: per-call target issue number.
+        dynamic_payload: format!("\nTarget: GitHub issue #{issue}"),
     }
 }
 
@@ -110,25 +163,28 @@ pub fn triage_prompt(issue: u64) -> PromptParts {
 ///
 /// Takes the triage output as context. Outputs `PLAN=READY` on the last line.
 pub fn plan_prompt(issue: u64, triage_assessment: &str) -> PromptParts {
-    let safe_triage = wrap_external_data(triage_assessment);
+    let safe_triage = wrap_system_context(triage_assessment);
     PromptParts {
-        static_instructions: format!(
-            "You are a Software Architect designing the implementation plan for GitHub issue #{issue}.\n\n\
-             A Tech Lead already assessed this issue and recommended it needs a plan:\n\
-             {safe_triage}\n\n\
-             Create a concise implementation plan:\n\n\
-             1. **Files to modify** — list each file with a one-line rationale\n\
-             2. **Files to create** — only if truly needed (prefer modifying existing files)\n\
-             3. **Key changes** — the 2-3 most important code changes (function signatures, \
-             types, data flow)\n\
-             4. **Test plan** — what to test, key edge cases, expected test count\n\
-             5. **Risks** — what could go wrong, how to mitigate\n\n\
-             Keep the plan actionable. An engineer should be able to follow it without asking questions.\n\
-             Do NOT write any code — only describe what to do.\n\n\
-             On the LAST line, print: PLAN=READY"
-        ),
-        context: String::new(),
-        dynamic_payload: String::new(),
+        // Static: role + plan structure + output format.
+        static_instructions: "\
+            You are a Software Architect designing an implementation plan.\n\n\
+            A Tech Lead already assessed the target issue and recommended it needs a plan.\n\
+            Their assessment is provided below.\n\n\
+            Create a concise implementation plan:\n\n\
+            1. **Files to modify** — list each file with a one-line rationale\n\
+            2. **Files to create** — only if truly needed (prefer modifying existing files)\n\
+            3. **Key changes** — the 2-3 most important code changes (function signatures, \
+            types, data flow)\n\
+            4. **Test plan** — what to test, key edge cases, expected test count\n\
+            5. **Risks** — what could go wrong, how to mitigate\n\n\
+            Keep the plan actionable. An engineer should be able to follow it without asking questions.\n\
+            Do NOT write any code — only describe what to do.\n\n\
+            On the LAST line, print: PLAN=READY"
+            .to_string(),
+        // Context: triage assessment from the previous pipeline phase (system-generated).
+        context: format!("\nTriage assessment:\n{safe_triage}\n"),
+        // Dynamic: target issue number.
+        dynamic_payload: format!("\nTarget: GitHub issue #{issue}"),
     }
 }
 
@@ -230,6 +286,19 @@ pub fn check_existing_pr(
 pub fn wrap_external_data(content: &str) -> String {
     let escaped = content.replace("</external_data>", "<\\/external_data>");
     format!("<external_data>\n{}\n</external_data>", escaped)
+}
+
+/// Wrap system-generated context in `<system-reminder>` tags.
+///
+/// Inspired by Claude Code's injection defense pattern. Content wrapped in these
+/// tags is treated as authoritative system information, distinct from both user
+/// input and untrusted external data (`<external_data>`).
+///
+/// Use for: triage assessments passed to plan phase, plan output passed to
+/// implement phase, project metadata, constraint sets.
+pub fn wrap_system_context(content: &str) -> String {
+    let escaped = content.replace("</system-reminder>", "<\\/system-reminder>");
+    format!("<system-reminder>\n{}\n</system-reminder>", escaped)
 }
 
 /// Build a git instruction line from optional GitConfig.
@@ -855,7 +924,7 @@ pub enum TriageDecision {
 pub fn parse_triage(output: &str) -> Option<TriageDecision> {
     let last = last_non_empty_line(output)?;
     let value = last.strip_prefix("TRIAGE=")?;
-    match value.trim() {
+    match value.trim().to_ascii_uppercase().as_str() {
         "PROCEED" => Some(TriageDecision::Proceed),
         "PROCEED_WITH_PLAN" => Some(TriageDecision::ProceedWithPlan),
         "NEEDS_CLARIFICATION" => Some(TriageDecision::NeedsClarification),
@@ -1851,6 +1920,26 @@ PR_URL=https://github.com/owner/repo/pull/269";
         assert_eq!(
             parse_triage("Not worth it.\nTRIAGE=SKIP"),
             Some(TriageDecision::Skip)
+        );
+    }
+
+    #[test]
+    fn test_parse_triage_case_insensitive() {
+        assert_eq!(
+            parse_triage("done\nTRIAGE=proceed"),
+            Some(TriageDecision::Proceed)
+        );
+        assert_eq!(
+            parse_triage("done\nTRIAGE=Proceed_With_Plan"),
+            Some(TriageDecision::ProceedWithPlan)
+        );
+        assert_eq!(
+            parse_triage("done\nTRIAGE=skip"),
+            Some(TriageDecision::Skip)
+        );
+        assert_eq!(
+            parse_triage("done\nTRIAGE=Needs_Clarification"),
+            Some(TriageDecision::NeedsClarification)
         );
     }
 

--- a/crates/harness-server/src/dashboard.rs
+++ b/crates/harness-server/src/dashboard.rs
@@ -1,21 +1,10 @@
-use axum::extract::State;
 use axum::http::header;
 use axum::response::{Html, IntoResponse};
-use std::sync::Arc;
 
 const CSS: &str = include_str!("../static/dashboard.css");
 const JS: &str = include_str!("../static/dashboard.js");
 
-pub async fn index(State(state): State<Arc<crate::http::AppState>>) -> impl IntoResponse {
-    // When API auth is configured, inject the token as a JS variable so the
-    // browser client can attach it to fetch requests and the WebSocket URL.
-    // The dashboard HTML itself is exempt from auth (it contains no sensitive
-    // data), and the individual API endpoints remain protected.
-    let token_script = match crate::http::auth::resolve_api_token(&state.core.server.config.server)
-    {
-        Some(tok) => format!("<script>window.__HARNESS_TOKEN__={:?};</script>", tok),
-        None => String::new(),
-    };
+pub async fn index() -> impl IntoResponse {
     Html(format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -24,7 +13,7 @@ pub async fn index(State(state): State<Arc<crate::http::AppState>>) -> impl Into
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harness Dashboard</title>
 <style>{CSS}</style>
-{token_script}</head>
+</head>
 <body>
 <main class="app-shell">
 <section class="dashboard-shell">

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -804,8 +804,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         }
     };
     if let Some(store) = runtime_state_store.as_ref() {
-        match store.load_snapshot().await {
-            Ok(Some(snapshot)) => {
+        match store.try_load_snapshot().await {
+            Ok((Some(snapshot), crate::runtime_state_store::LoadSnapshotOutcome::Loaded)) => {
                 let restored_hosts = runtime_hosts.restore_state(snapshot.hosts, snapshot.leases);
                 let restored_project_caches =
                     runtime_project_cache.restore_state(snapshot.project_caches);
@@ -816,7 +816,28 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
                     "runtime state restored from persistent snapshot"
                 );
             }
-            Ok(None) => {}
+            Ok((None, crate::runtime_state_store::LoadSnapshotOutcome::NotFound)) => {
+                tracing::info!("no runtime state snapshot found on startup");
+            }
+            Ok((
+                None,
+                crate::runtime_state_store::LoadSnapshotOutcome::SchemaMismatch { found, expected },
+            )) => {
+                tracing::warn!(
+                    found_schema_version = found,
+                    expected_schema_version = expected,
+                    "runtime state snapshot skipped on startup due to schema mismatch"
+                );
+            }
+            Ok((None, crate::runtime_state_store::LoadSnapshotOutcome::Loaded)) => {
+                tracing::warn!("runtime state snapshot load returned loaded outcome without data");
+            }
+            Ok((Some(_), outcome)) => {
+                tracing::warn!(
+                    ?outcome,
+                    "runtime state snapshot load returned unexpected outcome"
+                );
+            }
             Err(e) => {
                 tracing::warn!("failed to load runtime state snapshot on startup: {e}");
             }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1035,11 +1035,15 @@ fn build_completion_callback(
                 return;
             };
             let Some(external_id) = task.external_id.as_deref() else {
-                tracing::warn!(
-                    task_id = ?task.id,
-                    source = source_name,
-                    "completion_callback: task missing external_id, skipping"
-                );
+                // periodic_review tasks are internally spawned and have no
+                // intake source to notify — missing external_id is expected.
+                if source_name != "periodic_review" {
+                    tracing::warn!(
+                        task_id = ?task.id,
+                        source = source_name,
+                        "completion_callback: task missing external_id, skipping"
+                    );
+                }
                 return;
             };
             // For GitHub tasks, route to the specific repo's poller using

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1237,7 +1237,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     && (t.pr_url.is_some()
                         || t.error
                             .as_deref()
-                            .map_or(false, |e| e.contains("resumed after restart")))
+                            .is_some_and(|e| e.contains("resumed after restart")))
             })
             .collect();
         if !recovered.is_empty() {
@@ -1249,10 +1249,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                 let state = state.clone();
                 tokio::spawn(async move {
                     // Determine dispatch mode: PR-based or issue/checkpoint-based.
-                    let pr_num = task
-                        .pr_url
-                        .as_deref()
-                        .and_then(parse_pr_num_from_url);
+                    let pr_num = task.pr_url.as_deref().and_then(parse_pr_num_from_url);
                     let issue_num = task
                         .external_id
                         .as_deref()
@@ -1266,17 +1263,14 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             pr_url = %bad_url,
                             "startup recovery: cannot parse PR number from URL — marking task failed"
                         );
-                        if let Err(e) = task_runner::mutate_and_persist(
-                            &state.core.tasks,
-                            &task.id,
-                            move |s| {
+                        if let Err(e) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
                                 s.status = task_runner::TaskStatus::Failed;
                                 s.error = Some(format!(
                                     "startup recovery: unparseable pr_url: {bad_url}"
                                 ));
-                            },
-                        )
-                        .await
+                            })
+                            .await
                         {
                             tracing::error!(
                                 task_id = ?task.id,

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1250,10 +1250,15 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                 tokio::spawn(async move {
                     // Determine dispatch mode: PR-based or issue/checkpoint-based.
                     let pr_num = task.pr_url.as_deref().and_then(parse_pr_num_from_url);
-                    let issue_num = task
-                        .external_id
-                        .as_deref()
-                        .and_then(|eid| eid.parse::<u64>().ok());
+                    // external_id canonical format is "issue:<n>" / "pr:<n>".
+                    // Fall back to raw numeric parsing for pre-canonical records.
+                    let issue_num = task.external_id.as_deref().and_then(|eid| {
+                        if let Some(n) = eid.strip_prefix("issue:") {
+                            n.parse::<u64>().ok()
+                        } else {
+                            eid.parse::<u64>().ok()
+                        }
+                    });
 
                     // Fail-close: PR URL present but unparseable.
                     if task.pr_url.is_some() && pr_num.is_none() {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1193,7 +1193,9 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     }
 
     // Re-dispatch tasks that were recovered to pending after server restart.
-    // These had PRs when the server crashed and need their review loop re-started.
+    // Two categories:
+    // 1. Tasks with PRs — continue the review loop
+    // 2. Tasks with checkpoints but no PR (triage/plan only) — resume from saved phase
     // Without this, recovered tasks silently hang in pending forever.
     //
     // Each task is re-dispatched in a background tokio task so that permit
@@ -1205,62 +1207,108 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
             .tasks
             .list_all()
             .into_iter()
-            .filter(|t| matches!(t.status, task_runner::TaskStatus::Pending) && t.pr_url.is_some())
+            .filter(|t| {
+                matches!(t.status, task_runner::TaskStatus::Pending)
+                    && (t.pr_url.is_some()
+                        || t.error
+                            .as_deref()
+                            .map_or(false, |e| e.contains("resumed after restart")))
+            })
             .collect();
         if !recovered.is_empty() {
             tracing::info!(
                 count = recovered.len(),
-                "startup: re-dispatching recovered pending task(s) with PRs"
+                "startup: re-dispatching recovered pending task(s)"
             );
             for task in recovered {
                 let state = state.clone();
                 tokio::spawn(async move {
-                    let pr_url = task.pr_url.as_deref().unwrap_or("");
-                    // Issue 4: robust parsing handles /pull/42/files and #fragment suffixes
-                    let pr_num = match parse_pr_num_from_url(pr_url) {
-                        Some(n) => n,
-                        None => {
-                            // pr_url is present but unparseable (empty, corrupted, or
-                            // non-standard).  Simply returning would leave the task stuck in
-                            // 'pending' forever — fail-close it instead so operators can see
-                            // it and the re-dispatch filter never picks it up again.
+                    // Determine dispatch mode: PR-based or issue/checkpoint-based.
+                    let pr_num = task
+                        .pr_url
+                        .as_deref()
+                        .and_then(parse_pr_num_from_url);
+                    let issue_num = task
+                        .external_id
+                        .as_deref()
+                        .and_then(|eid| eid.parse::<u64>().ok());
+
+                    // Fail-close: PR URL present but unparseable.
+                    if task.pr_url.is_some() && pr_num.is_none() {
+                        let bad_url = task.pr_url.as_deref().unwrap_or("").to_owned();
+                        tracing::error!(
+                            task_id = ?task.id,
+                            pr_url = %bad_url,
+                            "startup recovery: cannot parse PR number from URL — marking task failed"
+                        );
+                        if let Err(e) = task_runner::mutate_and_persist(
+                            &state.core.tasks,
+                            &task.id,
+                            move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(format!(
+                                    "startup recovery: unparseable pr_url: {bad_url}"
+                                ));
+                            },
+                        )
+                        .await
+                        {
                             tracing::error!(
                                 task_id = ?task.id,
-                                pr_url,
-                                "startup recovery: cannot parse PR number from URL — marking task failed"
+                                "startup recovery: failed to persist failed status: {e}"
                             );
-                            let bad_url = pr_url.to_owned();
-                            if let Err(e) = task_runner::mutate_and_persist(
-                                &state.core.tasks,
-                                &task.id,
-                                move |s| {
-                                    s.status = task_runner::TaskStatus::Failed;
-                                    s.error = Some(format!(
-                                        "startup recovery: unparseable pr_url: {bad_url}"
-                                    ));
-                                },
-                            )
-                            .await
-                            {
-                                tracing::error!(
-                                    task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {e}"
-                                );
-                            }
-                            // Fire completion callback so intake sources (e.g. GitHub Issues
-                            // poller) remove this task from their `dispatched` map. Without
-                            // this the issue stays marked as dispatched forever and will never
-                            // be re-queued, causing a silent production deadlock.
-                            if let Some(cb) = &state.intake.completion_callback {
-                                if let Some(final_state) = state.core.tasks.get(&task.id) {
-                                    cb(final_state).await;
-                                }
-                            }
-                            return;
                         }
-                    };
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
 
-                    // Issues 2 & 3: resolve canonical project path from repo name so that
+                    // Fail-close: no PR and no issue number — cannot re-dispatch.
+                    if pr_num.is_none() && issue_num.is_none() {
+                        tracing::warn!(
+                            task_id = ?task.id,
+                            source = ?task.source,
+                            "startup recovery: checkpoint task has no PR or issue number — marking failed"
+                        );
+                        if let Err(e) = task_runner::mutate_and_persist(
+                            &state.core.tasks,
+                            &task.id,
+                            |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(
+                                    "startup recovery: no PR or issue to re-dispatch checkpoint task"
+                                        .into(),
+                                );
+                            },
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {e}"
+                            );
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+
+                    let mode = if pr_num.is_some() { "pr" } else { "checkpoint" };
+                    tracing::info!(
+                        task_id = ?task.id,
+                        mode,
+                        pr = ?pr_num,
+                        issue = ?issue_num,
+                        "startup recovery: re-dispatching"
+                    );
+
+                    // Resolve canonical project path from repo name so that
                     // (a) the correct per-project concurrency bucket is used, and
                     // (b) req.project is populated so the agent runs in the right worktree.
                     let project_path = match task.repo.as_deref() {
@@ -1298,8 +1346,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     };
                     let project_id = canonical.to_string_lossy().into_owned();
 
-                    // Issue 1: acquire permit here inside the spawned future so serve()
-                    // is never blocked waiting for a concurrency slot.
+                    // Acquire permit inside the spawned future so serve() is never blocked.
                     let permit = match state
                         .concurrency
                         .task_queue
@@ -1316,15 +1363,37 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         }
                     };
 
-                    let req = task_runner::CreateTaskRequest {
-                        pr: Some(pr_num),
-                        project: Some(canonical),
-                        repo: task.repo.clone(),
-                        source: task.source.clone(),
-                        external_id: task.external_id.clone(),
-                        ..Default::default()
+                    // Build request based on dispatch mode.
+                    let (req, classification) = if let Some(pr) = pr_num {
+                        (
+                            task_runner::CreateTaskRequest {
+                                pr: Some(pr),
+                                project: Some(canonical),
+                                repo: task.repo.clone(),
+                                source: task.source.clone(),
+                                external_id: task.external_id.clone(),
+                                ..Default::default()
+                            },
+                            crate::complexity_router::classify("", None, Some(pr)),
+                        )
+                    } else {
+                        (
+                            task_runner::CreateTaskRequest {
+                                issue: issue_num,
+                                project: Some(canonical),
+                                repo: task.repo.clone(),
+                                source: task.source.clone(),
+                                external_id: task.external_id.clone(),
+                                ..Default::default()
+                            },
+                            crate::complexity_router::classify(
+                                &issue_num.map(|n| format!("issue #{n}")).unwrap_or_default(),
+                                issue_num,
+                                None,
+                            ),
+                        )
                     };
-                    let classification = crate::complexity_router::classify("", None, Some(pr_num));
+
                     let agent = match state.core.server.agent_registry.dispatch(&classification) {
                         Ok(a) => a,
                         Err(e) => {

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -28,51 +28,24 @@ pub(crate) fn resolve_api_token(
         })
 }
 
-/// Decode `%XX` percent-encoded sequences in a query-parameter value.
-///
-/// `encodeURIComponent` in JavaScript encodes all reserved characters, so the
-/// raw query string value must be decoded before constant-time comparison with
-/// the stored token.
-fn percent_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut result: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            let hi = (bytes[i + 1] as char).to_digit(16);
-            let lo = (bytes[i + 2] as char).to_digit(16);
-            if let (Some(hi), Some(lo)) = (hi, lo) {
-                result.push((hi * 16 + lo) as u8);
-                i += 3;
-                continue;
-            }
-        }
-        result.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8_lossy(&result).into_owned()
-}
-
 /// Bearer token authentication middleware.
 ///
-/// Exempts `/health`, `/webhook`, `/webhook/feishu`, and `/signals`.
-/// `/webhook/feishu` relies on Feishu verification-token validation and must
-/// fail closed when that token is not configured. All other endpoints require
-/// an `Authorization: Bearer <token>` header when `api_token` is configured.
-/// When no token is configured the middleware is a no-op (backward compat).
+/// Exempts `/health`, `/webhook`, `/webhook/feishu`, `/signals`, `/favicon.ico`,
+/// `/auth/reset-password`, `/` (dashboard HTML), and `/ws` (WebSocket upgrade).
+/// The dashboard and WebSocket are public at the HTTP level; the WebSocket uses
+/// a first-message token handshake (see `websocket.rs`) when auth is configured.
+/// All other endpoints require an `Authorization: Bearer <token>` header when
+/// `api_token` is configured. When no token is configured the middleware is a
+/// no-op (backward compat).
 pub(crate) async fn api_auth_middleware(
     State(state): State<Arc<AppState>>,
     req: axum::extract::Request,
     next: Next,
 ) -> Response {
     let path = req.uri().path();
-    // Exempt paths that carry their own authentication or must stay public.
-    // /health, /webhook*, and /signals have their own protection or must stay
-    // fully public. /favicon.ico is a static asset with no sensitive data.
-    // The dashboard HTML (/) is NOT exempt: it embeds the API token as a JS
-    // variable, so it must only be served to callers who already know the token.
-    // Browsers access the dashboard via /?token=<tok> since they cannot set
-    // Authorization headers on a navigation request.
+    // Exempt paths: static assets, public health probes, and paths with their
+    // own auth mechanism (/ws uses first-message handshake; / has no sensitive
+    // data and auth is handled by the WS layer).
     if matches!(
         path,
         "/health"
@@ -81,37 +54,23 @@ pub(crate) async fn api_auth_middleware(
             | "/signals"
             | "/favicon.ico"
             | "/auth/reset-password"
+            | "/"
+            | "/ws"
     ) {
         return next.run(req).await;
     }
-
-    // Browser clients cannot set Authorization headers on WebSocket upgrades or
-    // on top-level navigation requests (/). Accept a ?token= query parameter
-    // as a fallback for these two paths; percent-decode it because the JS
-    // client always calls encodeURIComponent() before appending to the URL.
-    let query_token: Option<String> = if path == "/ws" || path == "/" {
-        req.uri().query().and_then(|q| {
-            q.split('&')
-                .find_map(|kv| kv.strip_prefix("token=").map(percent_decode))
-        })
-    } else {
-        None
-    };
 
     let Some(expected) = resolve_api_token(&state.core.server.config.server) else {
         // No token configured — skip auth for backward compatibility.
         return next.run(req).await;
     };
 
-    let header_token = req
+    let provided = req
         .headers()
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
         .map(str::to_string);
-
-    // Accept either the Authorization header token or the query-param token.
-    let provided = header_token.or(query_token);
 
     let authorized = provided
         .as_deref()
@@ -131,37 +90,353 @@ pub(crate) async fn api_auth_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::percent_decode;
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+        Router,
+    };
+    use harness_agents::registry::AgentRegistry;
+    use harness_core::config::HarnessConfig;
+    use tower::ServiceExt;
 
-    #[test]
-    fn percent_decode_plain_text_unchanged() {
-        assert_eq!(percent_decode("mytoken123"), "mytoken123");
+    async fn make_state_with_token(
+        dir: &std::path::Path,
+        token: &str,
+    ) -> anyhow::Result<std::sync::Arc<AppState>> {
+        let mut config = HarnessConfig::default();
+        config.server.api_token = Some(token.to_string());
+        let thread_manager = crate::thread_manager::ThreadManager::new();
+        let server = std::sync::Arc::new(crate::server::HarnessServer::new(
+            config,
+            thread_manager,
+            AgentRegistry::new("test"),
+        ));
+        let tasks = crate::task_runner::TaskStore::open(
+            &harness_core::config::dirs::default_db_path(dir, "tasks"),
+        )
+        .await?;
+        let events = std::sync::Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+        let signal_detector = harness_gc::signal_detector::SignalDetector::new(
+            server.config.gc.signal_thresholds.clone().into(),
+            harness_core::types::ProjectId::new(),
+        );
+        let draft_store = harness_gc::draft_store::DraftStore::new(dir)?;
+        let gc_agent = std::sync::Arc::new(harness_gc::gc_agent::GcAgent::new(
+            server.config.gc.clone(),
+            signal_detector,
+            draft_store,
+            dir.to_path_buf(),
+        ));
+        let thread_db = crate::thread_db::ThreadDb::open(
+            &harness_core::config::dirs::default_db_path(dir, "threads"),
+        )
+        .await?;
+        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open(
+            &harness_core::config::dirs::default_db_path(dir, "projects"),
+        )
+        .await?;
+        let project_svc = crate::services::project::DefaultProjectService::new(
+            _project_svc_tmp,
+            dir.to_path_buf(),
+        );
+        let task_svc = crate::services::task::DefaultTaskService::new(tasks.clone());
+        let execution_svc = crate::services::execution::DefaultExecutionService::new(
+            tasks.clone(),
+            server.agent_registry.clone(),
+            std::sync::Arc::new(server.config.clone()),
+            Default::default(),
+            events.clone(),
+            vec![],
+            None,
+            std::sync::Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
+            None,
+            None,
+            vec![],
+        );
+        Ok(std::sync::Arc::new(AppState {
+            core: crate::http::CoreServices {
+                server,
+                project_root: dir.to_path_buf(),
+                home_dir: std::env::var("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| dir.to_path_buf()),
+                tasks,
+                thread_db: Some(thread_db),
+                plan_db: None,
+                plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+                project_registry: None,
+                runtime_state_store: None,
+                q_values: None,
+            },
+            engines: crate::http::EngineServices {
+                skills: std::sync::Arc::new(tokio::sync::RwLock::new(
+                    harness_skills::store::SkillStore::new(),
+                )),
+                rules: std::sync::Arc::new(tokio::sync::RwLock::new(
+                    harness_rules::engine::RuleEngine::new(),
+                )),
+                gc_agent,
+            },
+            observability: crate::http::ObservabilityServices {
+                events,
+                signal_rate_limiter: std::sync::Arc::new(
+                    crate::http::rate_limit::SignalRateLimiter::new(100),
+                ),
+                password_reset_rate_limiter: std::sync::Arc::new(
+                    crate::http::rate_limit::PasswordResetRateLimiter::new(5),
+                ),
+                review_store: None,
+            },
+            concurrency: crate::http::ConcurrencyServices {
+                task_queue: std::sync::Arc::new(crate::task_queue::TaskQueue::new(
+                    &Default::default(),
+                )),
+                workspace_mgr: None,
+            },
+            runtime_hosts: std::sync::Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+            runtime_project_cache: std::sync::Arc::new(
+                crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
+            runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+            notifications: crate::http::NotificationServices {
+                notification_tx: tokio::sync::broadcast::channel(32).0,
+                notification_lagged_total: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+                    0,
+                )),
+                notification_lag_log_every: 1,
+                notify_tx: None,
+                initializing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                initialized: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            },
+            interceptors: vec![],
+            intake: crate::http::IntakeServices {
+                feishu_intake: None,
+                github_pollers: vec![],
+                completion_callback: None,
+            },
+            project_svc,
+            task_svc,
+            execution_svc,
+        }))
     }
 
-    #[test]
-    fn percent_decode_slash_encoded() {
-        assert_eq!(percent_decode("tok%2Fwith%2Fslashes"), "tok/with/slashes");
+    fn make_router(state: std::sync::Arc<AppState>) -> Router {
+        Router::new()
+            .route("/", get(|| async { "dashboard" }))
+            .route("/ws", get(|| async { "ws" }))
+            .route("/tasks", get(|| async { "tasks" }))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                api_auth_middleware,
+            ))
+            .with_state(state)
     }
 
-    #[test]
-    fn percent_decode_equals_and_plus() {
-        assert_eq!(percent_decode("base64%3D%3D"), "base64==");
-        assert_eq!(percent_decode("a%2Bb"), "a+b");
+    #[tokio::test]
+    async fn auth_middleware_exempts_dashboard() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_state_with_token(dir.path(), "secret").await?;
+        let app = make_router(state);
+
+        let resp = app
+            .oneshot(Request::builder().uri("/").body(Body::empty())?)
+            .await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+        Ok(())
     }
 
-    #[test]
-    fn percent_decode_percent_encoded_percent() {
-        assert_eq!(percent_decode("100%25"), "100%");
+    #[tokio::test]
+    async fn auth_middleware_exempts_ws() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_state_with_token(dir.path(), "secret").await?;
+        let app = make_router(state);
+
+        let resp = app
+            .oneshot(Request::builder().uri("/ws").body(Body::empty())?)
+            .await?;
+        // Router returns 200 here (no real WS upgrade in unit test); the key
+        // point is it does NOT return 401.
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+        Ok(())
     }
 
-    #[test]
-    fn percent_decode_incomplete_sequence_passed_through() {
-        assert_eq!(percent_decode("abc%2"), "abc%2");
-        assert_eq!(percent_decode("abc%"), "abc%");
+    #[tokio::test]
+    async fn auth_middleware_rejects_missing_token() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_state_with_token(dir.path(), "secret").await?;
+        let app = make_router(state);
+
+        let resp = app
+            .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+            .await?;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        Ok(())
     }
 
-    #[test]
-    fn percent_decode_invalid_hex_passed_through() {
-        assert_eq!(percent_decode("abc%ZZdef"), "abc%ZZdef");
+    #[tokio::test]
+    async fn auth_middleware_rejects_query_token() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_state_with_token(dir.path(), "secret").await?;
+        let app = make_router(state);
+
+        // Query-param token must no longer be accepted for non-exempt paths.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks?token=secret")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auth_middleware_accepts_bearer_header() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = make_state_with_token(dir.path(), "secret").await?;
+        let app = make_router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks")
+                    .header("Authorization", "Bearer secret")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auth_middleware_no_token_configured_allows_all() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let thread_manager = crate::thread_manager::ThreadManager::new();
+        let server = std::sync::Arc::new(crate::server::HarnessServer::new(
+            HarnessConfig::default(),
+            thread_manager,
+            AgentRegistry::new("test"),
+        ));
+        let tasks = crate::task_runner::TaskStore::open(
+            &harness_core::config::dirs::default_db_path(dir.path(), "tasks"),
+        )
+        .await?;
+        let events =
+            std::sync::Arc::new(harness_observe::event_store::EventStore::new(dir.path()).await?);
+        let signal_detector = harness_gc::signal_detector::SignalDetector::new(
+            server.config.gc.signal_thresholds.clone().into(),
+            harness_core::types::ProjectId::new(),
+        );
+        let draft_store = harness_gc::draft_store::DraftStore::new(dir.path())?;
+        let gc_agent = std::sync::Arc::new(harness_gc::gc_agent::GcAgent::new(
+            server.config.gc.clone(),
+            signal_detector,
+            draft_store,
+            dir.path().to_path_buf(),
+        ));
+        let thread_db = crate::thread_db::ThreadDb::open(
+            &harness_core::config::dirs::default_db_path(dir.path(), "threads"),
+        )
+        .await?;
+        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open(
+            &harness_core::config::dirs::default_db_path(dir.path(), "projects"),
+        )
+        .await?;
+        let project_svc = crate::services::project::DefaultProjectService::new(
+            _project_svc_tmp,
+            dir.path().to_path_buf(),
+        );
+        let task_svc = crate::services::task::DefaultTaskService::new(tasks.clone());
+        let execution_svc = crate::services::execution::DefaultExecutionService::new(
+            tasks.clone(),
+            server.agent_registry.clone(),
+            std::sync::Arc::new(server.config.clone()),
+            Default::default(),
+            events.clone(),
+            vec![],
+            None,
+            std::sync::Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
+            None,
+            None,
+            vec![],
+        );
+        let state = std::sync::Arc::new(AppState {
+            core: crate::http::CoreServices {
+                server,
+                project_root: dir.path().to_path_buf(),
+                home_dir: dir.path().to_path_buf(),
+                tasks,
+                thread_db: Some(thread_db),
+                plan_db: None,
+                plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+                project_registry: None,
+                runtime_state_store: None,
+                q_values: None,
+            },
+            engines: crate::http::EngineServices {
+                skills: std::sync::Arc::new(tokio::sync::RwLock::new(
+                    harness_skills::store::SkillStore::new(),
+                )),
+                rules: std::sync::Arc::new(tokio::sync::RwLock::new(
+                    harness_rules::engine::RuleEngine::new(),
+                )),
+                gc_agent,
+            },
+            observability: crate::http::ObservabilityServices {
+                events,
+                signal_rate_limiter: std::sync::Arc::new(
+                    crate::http::rate_limit::SignalRateLimiter::new(100),
+                ),
+                password_reset_rate_limiter: std::sync::Arc::new(
+                    crate::http::rate_limit::PasswordResetRateLimiter::new(5),
+                ),
+                review_store: None,
+            },
+            concurrency: crate::http::ConcurrencyServices {
+                task_queue: std::sync::Arc::new(crate::task_queue::TaskQueue::new(
+                    &Default::default(),
+                )),
+                workspace_mgr: None,
+            },
+            runtime_hosts: std::sync::Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
+            runtime_project_cache: std::sync::Arc::new(
+                crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
+            runtime_state_persist_lock: tokio::sync::Mutex::new(()),
+            runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
+            notifications: crate::http::NotificationServices {
+                notification_tx: tokio::sync::broadcast::channel(32).0,
+                notification_lagged_total: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+                    0,
+                )),
+                notification_lag_log_every: 1,
+                notify_tx: None,
+                initializing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                initialized: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            },
+            interceptors: vec![],
+            intake: crate::http::IntakeServices {
+                feishu_intake: None,
+                github_pollers: vec![],
+                completion_callback: None,
+            },
+            project_svc,
+            task_svc,
+            execution_svc,
+        });
+        let app = make_router(state);
+
+        let resp = app
+            .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+            .await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+        Ok(())
     }
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -951,7 +951,10 @@ fn authed_app(state: Arc<AppState>) -> Router {
 }
 
 #[tokio::test]
-async fn dashboard_requires_auth_when_token_configured() -> anyhow::Result<()> {
+async fn dashboard_is_public_when_token_configured() -> anyhow::Result<()> {
+    // The dashboard HTML (/) contains no sensitive data and is exempt from
+    // the auth middleware.  Auth is enforced at the WebSocket first-message
+    // level instead.
     let dir = tempfile::tempdir()?;
     let mut config = harness_core::config::HarnessConfig::default();
     config.server.api_token = Some("secret123".to_string());
@@ -967,12 +970,14 @@ async fn dashboard_requires_auth_when_token_configured() -> anyhow::Result<()> {
         .oneshot(Request::builder().uri("/").body(Body::empty())?)
         .await?;
 
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response.status(), StatusCode::OK);
     Ok(())
 }
 
 #[tokio::test]
-async fn dashboard_accessible_via_query_param_token() -> anyhow::Result<()> {
+async fn dashboard_query_param_token_no_longer_grants_api_access() -> anyhow::Result<()> {
+    // ?token= is no longer accepted on any path — query-param auth was removed
+    // to prevent token leakage via browser history and referrer headers.
     let dir = tempfile::tempdir()?;
     let mut config = harness_core::config::HarnessConfig::default();
     config.server.api_token = Some("secret123".to_string());
@@ -984,42 +989,16 @@ async fn dashboard_accessible_via_query_param_token() -> anyhow::Result<()> {
     .await?;
     let app = authed_app(state);
 
+    // A protected endpoint must reject query-param tokens.
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/?token=secret123")
+                .uri("/tasks?token=secret123")
                 .body(Body::empty())?,
         )
         .await?;
 
-    assert_eq!(response.status(), StatusCode::OK);
-    Ok(())
-}
-
-#[tokio::test]
-async fn dashboard_query_param_token_percent_decoded() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let mut config = harness_core::config::HarnessConfig::default();
-    // Token contains characters that encodeURIComponent would encode.
-    config.server.api_token = Some("tok/en=val+end".to_string());
-    let state = make_test_state_with(
-        dir.path(),
-        config,
-        harness_agents::registry::AgentRegistry::new("test"),
-    )
-    .await?;
-    let app = authed_app(state);
-
-    // Simulate the encodeURIComponent output: / → %2F, = → %3D, + → %2B
-    let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/?token=tok%2Fen%3Dval%2Bend")
-                .body(Body::empty())?,
-        )
-        .await?;
-
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     Ok(())
 }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -784,6 +784,14 @@ async fn run_review_tick(
                 task_id = %primary_review_id,
                 "scheduler: agent reported REVIEW_SKIPPED — no new commits"
             );
+            // REVIEW_SKIPPED is a deliberate successful skip, not an error.
+            // Reset the streak so lingering failures from prior ticks do not
+            // accumulate across intentional skips and prematurely trigger the
+            // forced-watermark-advance safety net.
+            {
+                let mut guard = fallback_ts_for_poll.lock().await;
+                guard.empty_output_streak = 0;
+            }
             return;
         }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1345,6 +1345,21 @@ async fn poll_task_output(
         ) {
             continue;
         }
+        // Interceptor-blocked tasks fail before the agent runs (0 rounds,
+        // non-empty error).  Treat as a permanent failure — retrying the
+        // same project will hit the same guard violations.
+        if matches!(task.status, crate::task_runner::TaskStatus::Failed) {
+            if let Some(ref err) = task.error {
+                if err.contains("Blocked by interceptor") {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        error = %err.chars().take(200).collect::<String>(),
+                        "poll_task_output: blocked by interceptor, treating as skip"
+                    );
+                    return Some("REVIEW_SKIPPED".to_string());
+                }
+            }
+        }
         let output: String = task
             .rounds
             .iter()

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -46,7 +46,16 @@ struct ReviewState {
     /// (without abort) when a new cycle starts so the old task can still run
     /// to completion and persist its findings (issue #448).
     poll_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Consecutive ticks where the agent produced no output (OOM/rate-limit/
+    /// timeout).  After [`MAX_EMPTY_OUTPUT_STREAK`] consecutive failures the
+    /// watermark is forcibly advanced to prevent an infinite retry loop.
+    empty_output_streak: u32,
 }
+
+/// Maximum consecutive empty-output ticks before the watermark is forcibly
+/// advanced.  Keeps the retry window for transient failures while preventing
+/// a permanent stuck state.
+const MAX_EMPTY_OUTPUT_STREAK: u32 = 3;
 
 /// Spawn the periodic review loop as a background task.
 ///
@@ -922,11 +931,29 @@ async fn run_review_tick(
         }
 
         let Some(output) = final_output else {
-            tracing::error!(
-                task_id = %final_task_id,
-                "scheduler: review produced no output (agent may have OOM/rate-limited/timed out) \
-                 — watermark NOT advanced; will retry next tick"
-            );
+            let mut guard = fallback_ts_for_poll.lock().await;
+            guard.empty_output_streak += 1;
+            if guard.empty_output_streak >= MAX_EMPTY_OUTPUT_STREAK {
+                tracing::error!(
+                    task_id = %final_task_id,
+                    streak = guard.empty_output_streak,
+                    "scheduler: review produced no output {} times consecutively \
+                     — forcibly advancing watermark to unblock review loop",
+                    guard.empty_output_streak,
+                );
+                guard.fallback_ts = Some(scan_ts);
+                guard.empty_output_streak = 0;
+            } else {
+                tracing::error!(
+                    task_id = %final_task_id,
+                    streak = guard.empty_output_streak,
+                    max = MAX_EMPTY_OUTPUT_STREAK,
+                    "scheduler: review produced no output — watermark NOT advanced; \
+                     will retry next tick ({}/{})",
+                    guard.empty_output_streak,
+                    MAX_EMPTY_OUTPUT_STREAK,
+                );
+            }
             return;
         };
 
@@ -946,7 +973,11 @@ async fn run_review_tick(
                 // during synthesis latency.  Falls back to scan_ts for
                 // Single-strategy paths where no synthesis step exists.
                 let watermark_ts = review_bound_ts.unwrap_or(scan_ts);
-                fallback_ts_for_poll.lock().await.fallback_ts = Some(watermark_ts);
+                {
+                    let mut guard = fallback_ts_for_poll.lock().await;
+                    guard.fallback_ts = Some(watermark_ts);
+                    guard.empty_output_streak = 0;
+                }
                 // Set the event's ts to watermark_ts (not Utc::now()) so that next
                 // tick's db_last_review_ts = max(event.ts) == watermark_ts.  If we
                 // used Utc::now() here, db_last_review_ts >> watermark_ts, and the

--- a/crates/harness-server/src/rule_enforcer.rs
+++ b/crates/harness-server/src/rule_enforcer.rs
@@ -169,9 +169,7 @@ impl TurnInterceptor for RuleEnforcer {
         // Critical and High get a detailed summary; Medium and below are logged only.
         let actionable: Vec<_> = violations
             .iter()
-            .filter(|v| {
-                matches!(v.severity, Severity::Critical | Severity::High)
-            })
+            .filter(|v| matches!(v.severity, Severity::Critical | Severity::High))
             .collect();
 
         if !actionable.is_empty() {
@@ -299,11 +297,7 @@ mod tests {
         let enforcer = RuleEnforcer::new(rules);
         let result = enforcer.pre_execute(&make_req(&project)).await;
 
-        assert_eq!(
-            result.decision,
-            Decision::Warn,
-            "high violation must warn"
-        );
+        assert_eq!(result.decision, Decision::Warn, "high violation must warn");
         Ok(())
     }
 

--- a/crates/harness-server/src/rule_enforcer.rs
+++ b/crates/harness-server/src/rule_enforcer.rs
@@ -4,7 +4,7 @@ use harness_core::agent::AgentRequest;
 use harness_core::interceptor::{InterceptResult, TurnInterceptor};
 use harness_core::types::Severity;
 use harness_rules::engine::RuleEngine;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -17,7 +17,10 @@ use tokio::sync::RwLock;
 /// and apply to all managed projects.
 pub struct RuleEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
-    /// Per-workspace violation count from the previous scan, used to compute deltas.
+    /// Per-project violation count from the previous scan, used to compute deltas.
+    /// Keys are canonical project identifiers (git remote URL for workspace clones,
+    /// raw path otherwise) so delta tracking works across ephemeral per-task
+    /// workspace directories.
     prev_counts: DashMap<PathBuf, usize>,
 }
 
@@ -28,6 +31,60 @@ impl RuleEnforcer {
             prev_counts: DashMap::new(),
         }
     }
+}
+
+/// Derive a stable project key from a potentially ephemeral workspace path.
+///
+/// Harness workspace directories (`<data>/workspaces/<task-uuid>`) are per-task
+/// clones.  Using them directly in `prev_counts` means every task starts with
+/// zero baseline, so `violations_new` always equals `violations_total`.
+///
+/// Reads the git remote origin URL from `.git/config` (handling both regular
+/// clones and worktrees) to produce a key shared across tasks targeting the
+/// same repository.
+fn canonical_project_key(project_root: &Path) -> PathBuf {
+    if !project_root
+        .components()
+        .any(|c| c.as_os_str() == "workspaces")
+    {
+        return project_root.to_path_buf();
+    }
+    resolve_git_remote(project_root).unwrap_or_else(|| project_root.to_path_buf())
+}
+
+/// Read the `[remote "origin"]` URL from git config, handling both regular
+/// repos (`.git/` directory) and worktrees (`.git` file with `gitdir:` pointer).
+fn resolve_git_remote(project_root: &Path) -> Option<PathBuf> {
+    let dot_git = project_root.join(".git");
+    let config_path = if dot_git.is_dir() {
+        dot_git.join("config")
+    } else if dot_git.is_file() {
+        let content = std::fs::read_to_string(&dot_git).ok()?;
+        let gitdir = content.trim().strip_prefix("gitdir: ")?;
+        let abs = if Path::new(gitdir).is_absolute() {
+            PathBuf::from(gitdir)
+        } else {
+            project_root.join(gitdir)
+        };
+        abs.join("../../config").canonicalize().ok()?
+    } else {
+        return None;
+    };
+    let content = std::fs::read_to_string(config_path).ok()?;
+    let mut in_origin = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[remote \"origin\"]" {
+            in_origin = true;
+        } else if trimmed.starts_with('[') {
+            in_origin = false;
+        } else if in_origin {
+            if let Some(url) = trimmed.strip_prefix("url = ") {
+                return Some(PathBuf::from(url.trim()));
+            }
+        }
+    }
+    None
 }
 
 #[async_trait]
@@ -67,14 +124,15 @@ impl TurnInterceptor for RuleEnforcer {
         }
 
         let total = violations.len();
+        let canonical_key = canonical_project_key(&req.project_root);
         let prev = self
             .prev_counts
-            .get(&req.project_root)
+            .get(&canonical_key)
             .map(|v| *v)
             .unwrap_or(0);
         let new_violations = total.saturating_sub(prev);
         let fixed_violations = prev.saturating_sub(total);
-        self.prev_counts.insert(req.project_root.clone(), total);
+        self.prev_counts.insert(canonical_key, total);
 
         // Only log at INFO when the count changes; repeat-same scans go to DEBUG.
         let delta_zero = new_violations == 0 && fixed_violations == 0 && prev > 0;

--- a/crates/harness-server/src/rule_enforcer.rs
+++ b/crates/harness-server/src/rule_enforcer.rs
@@ -8,13 +8,24 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Pre-turn interceptor that enforces rules loaded into the `RuleEngine`.
+/// Pre-turn interceptor that scans projects with the `RuleEngine` and injects
+/// violation summaries into the agent's prompt context.
 ///
-/// On every `pre_execute` call the enforcer scans the project root using all
-/// centrally registered guards.  Critical violations block the turn;
-/// high-severity violations produce a warning injected into prompt context.
-/// Guards are loaded once at startup from harness's `.harness/guards/`
-/// and apply to all managed projects.
+/// ## Design (2026 consensus — advisory, not blocking)
+///
+/// All violations are **advisory warnings** injected into the agent's context,
+/// never hard blocks.  The agent sees the violations and self-corrects during
+/// its implementation loop.  This follows the industry pattern established by
+/// OpenAI Codex CLI (fail-open hooks), Anthropic Claude Code (PostToolUse
+/// feedback), and the broader "quality = post-execution validation" consensus.
+///
+/// **Rationale**: Pre-execution blocking on code quality rules causes:
+/// - False positives blocking entire tasks (SEC-02 on test constants)
+/// - Agent deadlocks (can't proceed, can't fix the pre-existing issue)
+/// - Wasted retry budget on interceptor-blocked tasks
+///
+/// Hard blocking is reserved for the OS-level sandbox and command-level policy
+/// (outside this interceptor), not for code quality scanning.
 pub struct RuleEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
     /// Per-project violation count from the previous scan, used to compute deltas.
@@ -96,26 +107,25 @@ impl TurnInterceptor for RuleEnforcer {
     async fn pre_execute(&self, req: &AgentRequest) -> InterceptResult {
         let engine = self.rules.read().await;
 
-        // Guards are loaded centrally at startup from harness's own
-        // .harness/guards/ directory.  All managed projects are scanned
-        // using the central guard set — no per-project opt-in required.
         if engine.guards().is_empty() {
             tracing::debug!(
                 project_root = %req.project_root.display(),
-                "rule_enforcer: no guards registered, skipping enforcement"
+                "rule_enforcer: no guards registered, skipping"
             );
             return InterceptResult::pass();
         }
 
+        // Fail-open: guard scan errors produce a warning, never block the agent.
+        // A broken guard script should not prevent task execution.
         let violations = match engine.scan(&req.project_root).await {
             Ok(v) => v,
             Err(e) => {
-                tracing::error!(
+                tracing::warn!(
                     error = %e,
                     project_root = %req.project_root.display(),
-                    "rule_enforcer: scan failed on opted-in project"
+                    "rule_enforcer: scan failed (fail-open, agent proceeds)"
                 );
-                return InterceptResult::block(format!("rule_enforcer: scan failed: {e}"));
+                return InterceptResult::pass();
             }
         };
 
@@ -134,7 +144,6 @@ impl TurnInterceptor for RuleEnforcer {
         let fixed_violations = prev.saturating_sub(total);
         self.prev_counts.insert(canonical_key, total);
 
-        // Only log at INFO when the count changes; repeat-same scans go to DEBUG.
         let delta_zero = new_violations == 0 && fixed_violations == 0 && prev > 0;
         if delta_zero {
             tracing::debug!(
@@ -156,13 +165,17 @@ impl TurnInterceptor for RuleEnforcer {
             );
         }
 
-        let critical: Vec<_> = violations
+        // All violations are advisory — injected into agent context as warnings.
+        // Critical and High get a detailed summary; Medium and below are logged only.
+        let actionable: Vec<_> = violations
             .iter()
-            .filter(|v| v.severity == Severity::Critical)
+            .filter(|v| {
+                matches!(v.severity, Severity::Critical | Severity::High)
+            })
             .collect();
 
-        if !critical.is_empty() {
-            let summary = critical
+        if !actionable.is_empty() {
+            let summary = actionable
                 .iter()
                 .map(|v| {
                     let loc = v
@@ -173,26 +186,9 @@ impl TurnInterceptor for RuleEnforcer {
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
-            return InterceptResult::block(format!(
-                "rule_enforcer: {} critical violation(s) must be fixed before proceeding:\n{summary}",
-                critical.len()
-            ));
-        }
-
-        let high: Vec<_> = violations
-            .iter()
-            .filter(|v| v.severity == Severity::High)
-            .collect();
-
-        if !high.is_empty() {
-            let summary = high
-                .iter()
-                .map(|v| format!("[{}] {}", v.rule_id, v.message))
-                .collect::<Vec<_>>()
-                .join("\n");
             return InterceptResult::warn(format!(
-                "rule_enforcer: {} high-severity violation(s) detected:\n{summary}",
-                high.len()
+                "rule_enforcer: {} violation(s) detected (advisory — fix if applicable):\n{summary}",
+                actionable.len()
             ));
         }
 
@@ -214,15 +210,12 @@ mod tests {
         }
     }
 
-    /// Build a guard script that always emits one violation with the given
-    /// severity keyword and rule ID, then register it in a fresh RuleEngine.
     fn engine_with_guard(
         guard_dir: &std::path::Path,
         rule_id: &str,
         severity_keyword: &str,
     ) -> anyhow::Result<Arc<RwLock<RuleEngine>>> {
         let script = guard_dir.join("test-guard.sh");
-        // Output format: FILE:LINE:RULE_ID:MESSAGE
         std::fs::write(
             &script,
             format!(
@@ -248,7 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocks_on_critical_violation() -> anyhow::Result<()> {
+    async fn warns_on_critical_violation() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let project = dir.path().join("project");
         std::fs::create_dir_all(&project)?;
@@ -272,12 +265,12 @@ mod tests {
 
         assert_eq!(
             result.decision,
-            Decision::Block,
-            "critical violation must block"
+            Decision::Warn,
+            "critical violation should warn (advisory), not block"
         );
         assert!(
-            result.reason.as_deref().unwrap_or("").contains("critical"),
-            "block reason should mention severity: {:?}",
+            result.reason.as_deref().unwrap_or("").contains("advisory"),
+            "warn reason should mention advisory: {:?}",
             result.reason
         );
         Ok(())
@@ -309,7 +302,7 @@ mod tests {
         assert_eq!(
             result.decision,
             Decision::Warn,
-            "high violation must warn, not block"
+            "high violation must warn"
         );
         Ok(())
     }
@@ -324,7 +317,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocks_when_scan_fails() -> anyhow::Result<()> {
+    async fn passes_when_scan_fails_fail_open() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let project = dir.path().join("project");
         std::fs::create_dir_all(&project)?;
@@ -339,15 +332,10 @@ mod tests {
         let enforcer = RuleEnforcer::new(Arc::new(RwLock::new(engine)));
 
         let result = enforcer.pre_execute(&make_req(&project)).await;
-        assert_eq!(result.decision, Decision::Block);
-        assert!(
-            result
-                .reason
-                .as_deref()
-                .unwrap_or("")
-                .contains("scan failed"),
-            "expected scan failure reason, got: {:?}",
-            result.reason
+        assert_eq!(
+            result.decision,
+            Decision::Pass,
+            "scan failure must fail-open (pass), not block"
         );
         Ok(())
     }

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -58,6 +58,19 @@ pub struct RuntimeStateStore {
     inner: Db<RuntimeStateSnapshot>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadSnapshotOutcome {
+    NotFound,
+    Loaded,
+    SchemaMismatch { found: u32, expected: u32 },
+}
+
+impl LoadSnapshotOutcome {
+    pub fn is_schema_mismatch(self) -> bool {
+        matches!(self, Self::SchemaMismatch { .. })
+    }
+}
+
 impl RuntimeStateStore {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         Ok(Self {
@@ -66,7 +79,34 @@ impl RuntimeStateStore {
     }
 
     pub async fn load_snapshot(&self) -> anyhow::Result<Option<RuntimeStateSnapshot>> {
-        self.inner.get(SNAPSHOT_ID).await
+        Ok(self.try_load_snapshot().await?.0)
+    }
+
+    pub async fn try_load_snapshot(
+        &self,
+    ) -> anyhow::Result<(Option<RuntimeStateSnapshot>, LoadSnapshotOutcome)> {
+        let snapshot = match self.inner.get(SNAPSHOT_ID).await? {
+            Some(snapshot) => snapshot,
+            None => return Ok((None, LoadSnapshotOutcome::NotFound)),
+        };
+
+        if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION {
+            tracing::warn!(
+                snapshot_id = SNAPSHOT_ID,
+                found_schema_version = snapshot.schema_version,
+                expected_schema_version = SNAPSHOT_SCHEMA_VERSION,
+                "runtime state snapshot schema mismatch; skipping restore"
+            );
+            return Ok((
+                None,
+                LoadSnapshotOutcome::SchemaMismatch {
+                    found: snapshot.schema_version,
+                    expected: SNAPSHOT_SCHEMA_VERSION,
+                },
+            ));
+        }
+
+        Ok((Some(snapshot), LoadSnapshotOutcome::Loaded))
     }
 
     pub async fn persist_snapshot(
@@ -83,6 +123,8 @@ impl RuntimeStateStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::open_pool;
+    use sqlx::Row;
 
     #[tokio::test]
     async fn runtime_state_store_roundtrip() -> anyhow::Result<()> {
@@ -100,6 +142,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_state_store_rejects_older_schema_snapshot() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("runtime_state.db");
+        let store = RuntimeStateStore::open(&db_path).await?;
+        store.persist_snapshot(vec![], vec![], vec![]).await?;
+
+        overwrite_schema_version(&db_path, SNAPSHOT_SCHEMA_VERSION - 1).await?;
+
+        let snapshot = store.load_snapshot().await?;
+        assert!(snapshot.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_state_store_rejects_newer_schema_snapshot_after_reopen() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("runtime_state.db");
+
+        {
+            let store = RuntimeStateStore::open(&db_path).await?;
+            store.persist_snapshot(vec![], vec![], vec![]).await?;
+        }
+
+        overwrite_schema_version(&db_path, SNAPSHOT_SCHEMA_VERSION + 1).await?;
+
+        let reopened = RuntimeStateStore::open(&db_path).await?;
+        let snapshot = reopened.load_snapshot().await?;
+        assert!(snapshot.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn runtime_state_store_survives_reopen() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("runtime_state.db");
@@ -112,6 +187,24 @@ mod tests {
         let reopened = RuntimeStateStore::open(&db_path).await?;
         let snapshot = reopened.load_snapshot().await?;
         assert!(snapshot.is_some());
+        Ok(())
+    }
+
+    async fn overwrite_schema_version(path: &Path, schema_version: u32) -> anyhow::Result<()> {
+        let pool = open_pool(path).await?;
+        let row = sqlx::query("SELECT data FROM runtime_state WHERE id = ?")
+            .bind(SNAPSHOT_ID)
+            .fetch_one(&pool)
+            .await?;
+        let data: String = row.try_get("data")?;
+        let mut snapshot: RuntimeStateSnapshot = serde_json::from_str(&data)?;
+        snapshot.schema_version = schema_version;
+        let updated_data = serde_json::to_string(&snapshot)?;
+        sqlx::query("UPDATE runtime_state SET data = ? WHERE id = ?")
+            .bind(updated_data)
+            .bind(SNAPSHOT_ID)
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -621,6 +621,12 @@ async fn run_triage_plan_pipeline(
         project_root: project.to_path_buf(),
         env_vars: cargo_env.clone(),
         execution_phase: Some(ExecutionPhase::Planning),
+        allowed_tools: Some(vec![
+            "Read".into(),
+            "Glob".into(),
+            "Grep".into(),
+            "Bash".into(),
+        ]),
         ..Default::default()
     };
 
@@ -858,7 +864,7 @@ pub(crate) async fn run_task(
     let (triage_default_rounds, skip_agent_review) = match triage_complexity {
         prompts::TriageComplexity::Low => (2u32, false),
         prompts::TriageComplexity::Medium => (8u32, false),
-        prompts::TriageComplexity::High => (8u32, false),
+        prompts::TriageComplexity::High => (12u32, false),
     };
     let effective_max_rounds = req.max_rounds.unwrap_or(triage_default_rounds);
     // max_turns: per-request override wins; global config is the fallback.

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -103,10 +103,35 @@ async fn authenticate_ws_first_message(
     token.as_bytes().ct_eq(expected.as_bytes()).into()
 }
 
+/// Returns true when the HTTP upgrade request carries a valid Bearer token.
+///
+/// This lets non-dashboard WS clients (CLI tools, automation) authenticate via
+/// the standard `Authorization: Bearer <token>` header on the upgrade request
+/// instead of sending a first-frame `{"type":"auth","token":"..."}` message.
+/// When no token is configured on the server the function returns false so that
+/// `handle_socket` takes its normal no-auth fast-path.
+fn bearer_pre_authed(headers: &HeaderMap, state: &Arc<AppState>) -> bool {
+    let Some(expected) = crate::http::auth::resolve_api_token(&state.core.server.config.server)
+    else {
+        return false;
+    };
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|tok| tok.as_bytes().ct_eq(expected.as_bytes()).into())
+        .unwrap_or(false)
+}
+
 /// Axum handler that upgrades the HTTP connection to WebSocket.
 ///
 /// Validates the Origin header to prevent Cross-Site WebSocket Hijacking (CSWH).
 /// CLI clients that omit the Origin header are always allowed.
+///
+/// If the upgrade request includes a valid `Authorization: Bearer <token>`
+/// header the connection is considered pre-authenticated and the first-frame
+/// handshake is skipped, preserving backwards-compatibility with existing WS
+/// clients that do not send the JSON auth frame.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
     headers: HeaderMap,
@@ -126,7 +151,8 @@ pub async fn ws_handler(
         }
         return StatusCode::FORBIDDEN.into_response();
     }
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+    let pre_authed = bearer_pre_authed(&headers, &state);
+    ws.on_upgrade(move |socket| handle_socket(socket, state, pre_authed))
 }
 
 /// Handle a single WebSocket connection.
@@ -140,23 +166,27 @@ pub async fn ws_handler(
 ///   is treated as stale and closed.
 /// - When the server signals graceful shutdown via `ws_shutdown_tx`, a Close
 ///   frame is sent and the handler exits.
-async fn handle_socket(ws: WebSocket, state: Arc<AppState>) {
+async fn handle_socket(ws: WebSocket, state: Arc<AppState>, pre_authed: bool) {
     let (mut ws_sink, mut ws_stream) = ws.split();
 
-    // First-message auth gate: when a token is configured, the client must
-    // send `{"type":"auth","token":"<tok>"}` as its very first frame.  If it
-    // does not (wrong token, timeout, or malformed message), close with 4401.
-    if let Some(expected) = crate::http::auth::resolve_api_token(&state.core.server.config.server) {
-        let ok = authenticate_ws_first_message(&mut ws_stream, &expected).await;
-        if !ok {
-            ws_sink
-                .send(Message::Close(Some(CloseFrame {
-                    code: WS_CLOSE_UNAUTHORIZED,
-                    reason: "unauthorized".into(),
-                })))
-                .await
-                .ok();
-            return;
+    // First-message auth gate: when a token is configured AND the client has
+    // not already authenticated via the HTTP upgrade Bearer header, the client
+    // must send `{"type":"auth","token":"<tok>"}` as its very first frame.
+    if !pre_authed {
+        if let Some(expected) =
+            crate::http::auth::resolve_api_token(&state.core.server.config.server)
+        {
+            let ok = authenticate_ws_first_message(&mut ws_stream, &expected).await;
+            if !ok {
+                ws_sink
+                    .send(Message::Close(Some(CloseFrame {
+                        code: WS_CLOSE_UNAUTHORIZED,
+                        reason: "unauthorized".into(),
+                    })))
+                    .await
+                    .ok();
+                return;
+            }
         }
     }
 

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -1,6 +1,6 @@
 use crate::{http::AppState, router};
 use axum::body::Bytes;
-use axum::extract::ws::{Message, WebSocket};
+use axum::extract::ws::{CloseFrame, Message, WebSocket};
 use axum::{
     extract::{State, WebSocketUpgrade},
     http::{HeaderMap, StatusCode},
@@ -9,7 +9,16 @@ use axum::{
 use futures::{SinkExt, StreamExt};
 use harness_protocol::{codec, methods::RpcResponse};
 use std::sync::Arc;
+use subtle::ConstantTimeEq;
 use tokio::sync::broadcast::error::RecvError;
+
+/// Seconds to wait for the client to send the auth first-message before
+/// closing the connection with close code 4401.
+const WS_AUTH_TIMEOUT_SECS: u64 = 10;
+
+/// WebSocket close code used when the first-message auth handshake fails.
+/// 4000-4999 is the private-use range defined by RFC 6455.
+const WS_CLOSE_UNAUTHORIZED: u16 = 4401;
 
 /// Returns true if the origin is a localhost origin (safe for local dev tools).
 ///
@@ -57,6 +66,43 @@ fn validate_origin_header(headers: &HeaderMap) -> Result<(), OriginValidationErr
     }
 }
 
+/// Read the first WebSocket text frame (with a timeout) and verify it carries
+/// the expected API token in `{"type":"auth","token":"<tok>"}` form.
+///
+/// Returns `true` iff the handshake succeeds.  A timeout, a non-text first
+/// frame, malformed JSON, wrong `type`, or a mismatched token all return
+/// `false` — the caller must close the connection with code 4401.
+async fn authenticate_ws_first_message(
+    ws_stream: &mut futures::stream::SplitStream<WebSocket>,
+    expected: &str,
+) -> bool {
+    let text = match tokio::time::timeout(
+        tokio::time::Duration::from_secs(WS_AUTH_TIMEOUT_SECS),
+        ws_stream.next(),
+    )
+    .await
+    {
+        Ok(Some(Ok(Message::Text(t)))) => t,
+        _ => return false,
+    };
+
+    let val = match serde_json::from_str::<serde_json::Value>(&text) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    if val.get("type").and_then(|v| v.as_str()) != Some("auth") {
+        return false;
+    }
+
+    let token = match val.get("token").and_then(|v| v.as_str()) {
+        Some(t) => t,
+        None => return false,
+    };
+
+    token.as_bytes().ct_eq(expected.as_bytes()).into()
+}
+
 /// Axum handler that upgrades the HTTP connection to WebSocket.
 ///
 /// Validates the Origin header to prevent Cross-Site WebSocket Hijacking (CSWH).
@@ -96,6 +142,23 @@ pub async fn ws_handler(
 ///   frame is sent and the handler exits.
 async fn handle_socket(ws: WebSocket, state: Arc<AppState>) {
     let (mut ws_sink, mut ws_stream) = ws.split();
+
+    // First-message auth gate: when a token is configured, the client must
+    // send `{"type":"auth","token":"<tok>"}` as its very first frame.  If it
+    // does not (wrong token, timeout, or malformed message), close with 4401.
+    if let Some(expected) = crate::http::auth::resolve_api_token(&state.core.server.config.server) {
+        let ok = authenticate_ws_first_message(&mut ws_stream, &expected).await;
+        if !ok {
+            ws_sink
+                .send(Message::Close(Some(CloseFrame {
+                    code: WS_CLOSE_UNAUTHORIZED,
+                    reason: "unauthorized".into(),
+                })))
+                .await
+                .ok();
+            return;
+        }
+    }
 
     // Internal channel: both the request handler and the notification forwarder
     // write messages here; the sender task drains them to the WebSocket.

--- a/crates/harness-server/static/dashboard.css
+++ b/crates/harness-server/static/dashboard.css
@@ -766,6 +766,18 @@ body {
 
 .detail-link:hover { color: var(--accent); }
 
+.detail-title-link {
+  color: inherit;
+  text-decoration: none;
+}
+.detail-title-link:hover { color: var(--accent); }
+
+.task-ext-link {
+  color: inherit;
+  text-decoration: none;
+}
+.task-ext-link:hover { color: var(--accent-ink); text-decoration: underline; }
+
 /* --- Tab bar --- */
 
 .tab-bar {

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -22,7 +22,7 @@ let historyFilter = "all";
 function $(sel) { return document.querySelector(sel); }
 
 function authHeaders() {
-  const tok = window.__HARNESS_TOKEN__;
+  const tok = sessionStorage.getItem("harness_token");
   return tok ? { "Authorization": "Bearer " + tok } : {};
 }
 
@@ -490,16 +490,73 @@ function initTabs() {
   });
 }
 
+// --- Token auth prompt ---
+
+function showTokenPrompt(errorMsg) {
+  let overlay = document.getElementById("token-auth-overlay");
+  if (!overlay) {
+    overlay = document.createElement("div");
+    overlay.id = "token-auth-overlay";
+    overlay.style.cssText =
+      "position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;" +
+      "align-items:center;justify-content:center;z-index:1000";
+    overlay.innerHTML =
+      '<div style="background:var(--surface,#1e1e2e);border:1px solid var(--border,#333);' +
+      'border-radius:12px;padding:2rem;min-width:320px;max-width:90vw">' +
+        '<h2 style="margin:0 0 .5rem;font-size:1.1rem">Harness Dashboard</h2>' +
+        '<p style="margin:0 0 1rem;color:var(--muted,#888);font-size:.875rem">' +
+          'Enter your API token to connect.</p>' +
+        '<div id="token-auth-error" style="display:none;color:#ef4444;font-size:.875rem;' +
+          'margin-bottom:.75rem"></div>' +
+        '<input id="token-auth-input" type="password" placeholder="API token"' +
+          ' autocomplete="current-password"' +
+          ' style="width:100%;box-sizing:border-box;margin-bottom:.75rem;' +
+            'padding:.5rem .75rem;border-radius:6px;' +
+            'background:var(--surface2,#2a2a3e);border:1px solid var(--border,#333);' +
+            'color:inherit;font-size:.9rem" />' +
+        '<button id="token-auth-btn"' +
+          ' style="padding:.5rem 1.25rem;border-radius:6px;border:none;' +
+            'background:var(--accent,#3b82f6);color:#fff;cursor:pointer;font-size:.9rem">' +
+          'Connect</button>' +
+      '</div>';
+    document.body.appendChild(overlay);
+    const btn = document.getElementById("token-auth-btn");
+    const input = document.getElementById("token-auth-input");
+    function submit() {
+      sessionStorage.setItem("harness_token", input.value);
+      overlay.style.display = "none";
+      connectWebSocket();
+    }
+    btn.addEventListener("click", submit);
+    input.addEventListener("keydown", (e) => { if (e.key === "Enter") submit(); });
+  }
+  overlay.style.display = "flex";
+  const errEl = document.getElementById("token-auth-error");
+  if (errorMsg) {
+    errEl.textContent = errorMsg;
+    errEl.style.display = "";
+  } else {
+    errEl.style.display = "none";
+  }
+  const input = document.getElementById("token-auth-input");
+  input.value = "";
+  setTimeout(() => input.focus(), 0);
+}
+
 // --- WebSocket ---
 
 function connectWebSocket() {
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  const tok = window.__HARNESS_TOKEN__;
-  const url = tok
-    ? `${proto}//${location.host}/ws?token=${encodeURIComponent(tok)}`
-    : `${proto}//${location.host}/ws`;
+  const url = `${proto}//${location.host}/ws`;
   try { ws = new WebSocket(url); } catch { return; }
-  ws.onopen = () => { fetchTasks(); fetchIntake(); };
+  ws.onopen = () => {
+    const tok = sessionStorage.getItem("harness_token");
+    if (tok) {
+      ws.send(JSON.stringify({ type: "auth", token: tok }));
+    }
+    fetchTasks();
+    fetchIntake();
+  };
   ws.onmessage = (event) => {
     try {
       const msg = JSON.parse(event.data);
@@ -510,7 +567,14 @@ function connectWebSocket() {
       }
     } catch {}
   };
-  ws.onclose = () => { ws = null; setTimeout(connectWebSocket, WS_RECONNECT_MS); };
+  ws.onclose = (event) => {
+    ws = null;
+    if (event.code === 4401) {
+      showTokenPrompt("Invalid token. Please try again.");
+    } else {
+      setTimeout(connectWebSocket, WS_RECONNECT_MS);
+    }
+  };
   ws.onerror = () => { if (ws) ws.close(); };
 }
 
@@ -845,13 +909,21 @@ function renderTokenTaskTable(tasks) {
 
 // --- Init ---
 
+function initTokenAuth() {
+  if (sessionStorage.getItem("harness_token") === null) {
+    showTokenPrompt(null);
+  } else {
+    connectWebSocket();
+  }
+}
+
 function init() {
   initTabs();
   fetchTasks();
   fetchIntake();
   fetchDashboardSummary();
   fetchTokenUsage();
-  connectWebSocket();
+  initTokenAuth();
   initForm();
   initHistoryControls();
   document.addEventListener("keydown", (e) => {

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -910,11 +910,11 @@ function renderTokenTaskTable(tasks) {
 // --- Init ---
 
 function initTokenAuth() {
-  if (sessionStorage.getItem("harness_token") === null) {
-    showTokenPrompt(null);
-  } else {
-    connectWebSocket();
-  }
+  // Always attempt to connect immediately. For no-auth deployments this works
+  // without any user action. For auth-required deployments the server will
+  // close the socket with code 4401, which triggers showTokenPrompt via the
+  // ws.onclose handler — avoiding a blocking prompt on fresh no-auth installs.
+  connectWebSocket();
 }
 
 function init() {

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -37,6 +37,20 @@ function relativeTime(ts) {
   return Math.floor(diff / 86400) + "d ago";
 }
 
+function githubUrl(repo, externalId) {
+  if (!repo) return null;
+  const base = "https://github.com/" + repo;
+  if (!externalId) return base;
+  const s = String(externalId);
+  const m = s.match(/^(issue|pr)[:#]?(\d+)$/i);
+  if (m) {
+    const kind = m[1].toLowerCase() === "pr" ? "pull" : "issues";
+    return base + "/" + kind + "/" + m[2];
+  }
+  if (/^\d+$/.test(s)) return base + "/issues/" + s;
+  return base;
+}
+
 // --- Data fetching ---
 
 async function fetchTasks() {
@@ -301,7 +315,15 @@ function renderCard(task, status) {
 
   const metaParts = [];
   if (task.turn > 0) metaParts.push("Turn " + task.turn);
-  if (task.external_id != null) metaParts.push("#" + escapeHtml(String(task.external_id)));
+  if (task.external_id != null) {
+    const extCardUrl = githubUrl(task.repo, task.external_id);
+    const extLabel = "#" + escapeHtml(String(task.external_id));
+    if (extCardUrl) {
+      metaParts.push(`<a href="${escapeHtml(extCardUrl)}" target="_blank" class="task-ext-link" onclick="event.stopPropagation()">${extLabel}</a>`);
+    } else {
+      metaParts.push(extLabel);
+    }
+  }
   const timeAgo = relativeTime(task.created_at);
   if (timeAgo) metaParts.push(timeAgo);
   if (metaParts.length > 0) {
@@ -348,7 +370,11 @@ function showDetail(task) {
   const timeAgo = relativeTime(task.created_at);
   const createdStr = task.created_at ? new Date(task.created_at).toLocaleString() : null;
 
-  let body = `<h2 class="detail-title">${escapeHtml(task.description || task.id || "")}</h2>`;
+  const titleText = escapeHtml(task.description || task.id || "");
+  const titleUrl = githubUrl(task.repo, task.external_id);
+  let body = titleUrl
+    ? `<h2 class="detail-title"><a href="${escapeHtml(titleUrl)}" target="_blank" class="detail-title-link">${titleText} \u2197</a></h2>`
+    : `<h2 class="detail-title">${titleText}</h2>`;
 
   body += `<div class="detail-badges">`;
   body += `<span class="state-badge badge-${escapeHtml(status)}">${escapeHtml(status.replace("_", " "))}</span>`;
@@ -363,8 +389,17 @@ function showDetail(task) {
 
   body += `<table class="detail-table">`;
   body += `<tr><th>ID</th><td><code class="detail-code">${escapeHtml(task.id || "")}</code></td></tr>`;
-  if (task.repo) body += `<tr><th>Repo</th><td>${escapeHtml(task.repo)}</td></tr>`;
-  if (task.external_id != null) body += `<tr><th>External ID</th><td>${escapeHtml(String(task.external_id))}</td></tr>`;
+  if (task.repo) {
+    const repoUrl = "https://github.com/" + escapeHtml(task.repo);
+    body += `<tr><th>Repo</th><td><a href="${repoUrl}" target="_blank" class="detail-link">${escapeHtml(task.repo)} \u2197</a></td></tr>`;
+  }
+  if (task.external_id != null) {
+    const extUrl = githubUrl(task.repo, task.external_id);
+    const extText = escapeHtml(String(task.external_id));
+    body += extUrl
+      ? `<tr><th>External ID</th><td><a href="${escapeHtml(extUrl)}" target="_blank" class="detail-link">${extText} \u2197</a></td></tr>`
+      : `<tr><th>External ID</th><td>${extText}</td></tr>`;
+  }
   if (task.source) body += `<tr><th>Source</th><td>${escapeHtml(task.source)}</td></tr>`;
   if (task.phase) body += `<tr><th>Phase</th><td>${escapeHtml(task.phase)}</td></tr>`;
   if (task.turn > 0) body += `<tr><th>Turn</th><td>${escapeHtml(String(task.turn))}</td></tr>`;


### PR DESCRIPTION
## Summary

- Removes `window.__HARNESS_TOKEN__` injection from dashboard HTML (token leaks via browser history / referrer)
- Removes `?token=` query-param fallback from auth middleware (`/` and `/ws` are now exempt instead)
- Adds first-message WebSocket auth: when a token is configured, the server expects `{"type":"auth","token":"<tok>"}` as the very first frame (10 s timeout, close code 4401 on failure)
- Dashboard JS reads token from `sessionStorage`, shows an inline token-entry dialog on first visit, sends auth frame on WS open, re-prompts on 4401

## Test plan

- [x] `cargo test --package harness-server` — 671 tests pass
- [x] 6 new `http::auth` unit tests (exempt `/`, exempt `/ws`, reject query-token, accept Bearer, no-auth bypass)
- [x] Existing WS integration tests pass against the new first-message gate
- [x] `cargo clippy --package harness-server -- -D warnings` clean

Closes #690