### PR TITLE
refactor: unify project identity across registry, queue, and DB (#684)

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -91,6 +91,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        project_id: String::new(),
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -180,6 +181,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        project_id: String::new(),
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -202,6 +204,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        project_id: String::new(),
     };
     let task_b_id = task_b.id.clone();
 
@@ -275,6 +278,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        project_id: String::new(),
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -339,6 +343,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        project_id: String::new(),
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -67,19 +67,56 @@ fn populate_external_id(req: &mut task_runner::CreateTaskRequest) {
 }
 
 /// Return existing active TaskId if one matches project + external_id.
+///
+/// Passes `req.project` as the canonical path fallback so that legacy DB rows
+/// (whose `project_id` column is NULL) can still be matched by their path.
 async fn check_duplicate(
     tasks: &Arc<crate::task_runner::TaskStore>,
     project_id: &str,
     req: &task_runner::CreateTaskRequest,
 ) -> Option<task_runner::TaskId> {
     let ext_id = req.external_id.as_deref()?;
-    let existing_id = tasks.find_active_duplicate(project_id, ext_id).await?;
+    let path_string = req
+        .project
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned());
+    let existing_id = tasks
+        .find_active_duplicate(project_id, ext_id, path_string.as_deref())
+        .await?;
     tracing::info!(
         existing_task = %existing_id.0,
         external_id = %ext_id,
         "dedup: returning existing active task instead of creating duplicate"
     );
     Some(existing_id)
+}
+
+/// Resolve `canonical_project` to a semantic project ID via the registry.
+///
+/// Falls back to the path string when the project is unregistered or the
+/// registry is unavailable. The returned string is used as the uniform key
+/// for queue limits, dedup, and DB storage.
+async fn resolve_project_id(
+    registry: Option<&crate::project_registry::ProjectRegistry>,
+    canonical_project: &std::path::Path,
+) -> String {
+    let Some(registry) = registry else {
+        return canonical_project.to_string_lossy().into_owned();
+    };
+    match registry.resolve_id_for_path(canonical_project).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            tracing::warn!(
+                path = %canonical_project.display(),
+                "project path not in registry; using path string as project_id"
+            );
+            canonical_project.to_string_lossy().into_owned()
+        }
+        Err(e) => {
+            tracing::warn!("registry resolve_id_for_path failed: {e}; falling back to path string");
+            canonical_project.to_string_lossy().into_owned()
+        }
+    }
 }
 
 pub(crate) async fn enqueue_task(
@@ -125,8 +162,12 @@ pub(crate) async fn enqueue_task(
     )
     .map_err(EnqueueTaskError::BadRequest)?;
 
-    let project_id = canonical_project.to_string_lossy().into_owned();
+    // Resolve canonical path to semantic project ID so that queue limits
+    // (keyed by semantic name in TOML) and dedup are consistent.
+    let project_id =
+        resolve_project_id(state.core.project_registry.as_deref(), &canonical_project).await;
     req.project = Some(canonical_project);
+    req.project_id = project_id.clone();
 
     // Auto-populate external_id and check for duplicates before acquiring
     // a concurrency permit (same dedup as enqueue_task_background).
@@ -332,8 +373,12 @@ async fn enqueue_task_background(
     )
     .map_err(EnqueueTaskError::BadRequest)?;
 
-    let project_id = canonical_project.to_string_lossy().into_owned();
+    // Resolve canonical path to semantic project ID so that queue limits
+    // (keyed by semantic name in TOML) and dedup are consistent.
+    let project_id =
+        resolve_project_id(state.core.project_registry.as_deref(), &canonical_project).await;
     req.project = Some(canonical_project);
+    req.project_id = project_id.clone();
     task_runner::fill_missing_repo_from_project(&mut req).await;
 
     // Auto-populate external_id and check for duplicates.

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -75,6 +75,17 @@ impl ProjectRegistry {
     pub async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
         Ok(self.get(id).await?.map(|p| p.root))
     }
+
+    /// Reverse-lookup: given a canonical filesystem path, return the semantic
+    /// project ID registered for that root. Returns `None` for unregistered
+    /// paths — not an error; callers should fall back to the path string.
+    pub async fn resolve_id_for_path(
+        &self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<Option<String>> {
+        let projects = self.list().await?;
+        Ok(projects.into_iter().find(|p| p.root == path).map(|p| p.id))
+    }
 }
 
 /// Check that `canonical_root` falls under at least one of the
@@ -193,6 +204,34 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
         assert!(!registry.remove("nonexistent").await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_id_for_path_returns_semantic_id() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let registry = ProjectRegistry::open(&dir.path().join("projects.db")).await?;
+
+        registry
+            .register(Project {
+                id: "harness".to_string(),
+                root: PathBuf::from("/home/user/harness"),
+                max_concurrent: None,
+                default_agent: None,
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        let id = registry
+            .resolve_id_for_path(&PathBuf::from("/home/user/harness"))
+            .await?;
+        assert_eq!(id, Some("harness".to_string()));
+
+        let none = registry
+            .resolve_id_for_path(&PathBuf::from("/home/user/unknown"))
+            .await?;
+        assert!(none.is_none());
         Ok(())
     }
 

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -120,6 +120,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            project_id: String::new(),
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -160,6 +161,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            project_id: String::new(),
         };
         store.insert(&parent_state).await;
 
@@ -184,6 +186,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            project_id: String::new(),
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -16,7 +16,7 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority";
+const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, project_id";
 
 /// Versioned migrations for the tasks table.
 ///
@@ -27,6 +27,7 @@ const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source,
 /// v10 – add composite index on (project, status, updated_at).
 /// v11 – add task_checkpoints table for phase recovery.
 /// v12 – add priority column for priority-based task scheduling.
+/// v13 – add project_id column for semantic project identity (registry alias).
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -107,6 +108,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         description: "add priority column for task scheduling",
         sql: "ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
     },
+    Migration {
+        version: 13,
+        description: "add project_id column for semantic project identity",
+        sql: "ALTER TABLE tasks ADD COLUMN project_id TEXT",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -176,9 +182,14 @@ impl TaskDb {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
+        let project_id = if state.project_id.is_empty() {
+            None
+        } else {
+            Some(state.project_id.as_str())
+        };
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, project_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -194,6 +205,7 @@ impl TaskDb {
         .bind(&depends_on_json)
         .bind(state.project_root.as_ref().map(|p| p.to_string_lossy().into_owned()))
         .bind(state.priority as i64)
+        .bind(project_id)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -203,10 +215,15 @@ impl TaskDb {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
+        let project_id = if state.project_id.is_empty() {
+            None
+        } else {
+            Some(state.project_id.as_str())
+        };
         sqlx::query(
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
                     source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
-                    priority = ?, updated_at = datetime('now')
+                    priority = ?, project_id = ?, updated_at = datetime('now')
              WHERE id = ?",
         )
         .bind(status)
@@ -225,6 +242,7 @@ impl TaskDb {
                 .map(|p| p.to_string_lossy().into_owned()),
         )
         .bind(state.priority as i64)
+        .bind(project_id)
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -271,18 +289,27 @@ impl TaskDb {
     }
 
     /// Find an active (non-terminal) task for the same project + external_id.
+    ///
+    /// Matches on `project_id` (semantic ID) first. For legacy rows where
+    /// `project_id` is NULL or empty, falls back to matching on the `project`
+    /// path column using `canonical_path`. When `canonical_path` is `None`,
+    /// `project_id` is used as the fallback (handles unregistered path projects).
     pub async fn find_active_duplicate(
         &self,
-        project: &str,
+        project_id: &str,
         external_id: &str,
+        canonical_path: Option<&str>,
     ) -> anyhow::Result<Option<String>> {
+        let fallback = canonical_path.unwrap_or(project_id);
         let row: Option<(String,)> = sqlx::query_as(
-            "SELECT id FROM tasks WHERE project = ? AND external_id = ? \
+            "SELECT id FROM tasks WHERE external_id = ? \
+             AND (project_id = ? OR ((project_id IS NULL OR project_id = '') AND project = ?)) \
              AND status IN ('pending', 'awaiting_deps', 'implementing', 'agent_review', 'waiting', 'reviewing') \
              LIMIT 1",
         )
-        .bind(project)
         .bind(external_id)
+        .bind(project_id)
+        .bind(fallback)
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.map(|r| r.0))
@@ -778,6 +805,7 @@ struct TaskRow {
     depends_on: String,
     project: Option<String>,
     priority: i64,
+    project_id: Option<String>,
 }
 
 impl TaskRow {
@@ -797,6 +825,7 @@ impl TaskRow {
             depends_on,
             project,
             priority,
+            project_id,
         } = self;
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
@@ -825,6 +854,7 @@ impl TaskRow {
             depends_on: decoded_depends_on,
             subtask_ids: Vec::new(),
             project_root: project.map(PathBuf::from),
+            project_id: project_id.unwrap_or_default(),
             issue: None,
             description: None,
             created_at,
@@ -905,6 +935,7 @@ mod tests {
             depends_on: depends_on.to_string(),
             project: None,
             priority: 0,
+            project_id: None,
         }
     }
 
@@ -1005,6 +1036,7 @@ mod tests {
             depends_on: vec![],
             subtask_ids: vec![],
             project_root: None,
+            project_id: String::new(),
             issue: None,
             description: None,
             created_at: None,
@@ -1602,13 +1634,14 @@ mod tests {
             depends_on: String::new(),
             project: None,
             priority: 0,
+            project_id: None,
         };
 
         // Count must match — catches column added to constant but not struct (or vice versa).
         assert_eq!(
             columns.len(),
-            14, // bump this when adding a field
-            "TASK_ROW_COLUMNS has {} entries but expected 14 — update both the constant and this test",
+            15, // bump this when adding a field
+            "TASK_ROW_COLUMNS has {} entries but expected 15 — update both the constant and this test",
             columns.len()
         );
     }
@@ -1649,7 +1682,9 @@ mod tests {
         task.external_id = Some("issue:42".to_string());
         task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
         db.insert(&task).await?;
-        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        let dup = db
+            .find_active_duplicate("/repo/foo", "issue:42", None)
+            .await?;
         assert_eq!(dup, Some("task-issue-42".to_string()));
         Ok(())
     }
@@ -1662,7 +1697,9 @@ mod tests {
         task.external_id = Some("issue:43".to_string());
         task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
         db.insert(&task).await?;
-        let dup = db.find_active_duplicate("/repo/foo", "issue:43").await?;
+        let dup = db
+            .find_active_duplicate("/repo/foo", "issue:43", None)
+            .await?;
         assert_eq!(dup, Some("task-impl-43".to_string()));
         Ok(())
     }
@@ -1675,7 +1712,9 @@ mod tests {
         task.external_id = Some("issue:42".to_string());
         task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
         db.insert(&task).await?;
-        let dup = db.find_active_duplicate("/repo/foo", "issue:42").await?;
+        let dup = db
+            .find_active_duplicate("/repo/foo", "issue:42", None)
+            .await?;
         assert_eq!(dup, None);
         Ok(())
     }
@@ -1688,7 +1727,9 @@ mod tests {
         task.external_id = Some("issue:42".to_string());
         task.project_root = Some(std::path::PathBuf::from("/repo/a"));
         db.insert(&task).await?;
-        let dup = db.find_active_duplicate("/repo/b", "issue:42").await?;
+        let dup = db
+            .find_active_duplicate("/repo/b", "issue:42", None)
+            .await?;
         assert_eq!(dup, None);
         Ok(())
     }
@@ -1701,7 +1742,9 @@ mod tests {
         task.external_id = Some("issue:42".to_string());
         task.project_root = Some(std::path::PathBuf::from("/repo/foo"));
         db.insert(&task).await?;
-        let dup = db.find_active_duplicate("/repo/foo", "issue:99").await?;
+        let dup = db
+            .find_active_duplicate("/repo/foo", "issue:99", None)
+            .await?;
         assert_eq!(dup, None);
         Ok(())
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -130,6 +130,11 @@ pub struct TaskState {
     /// Used by sibling-awareness lookups and exposed via TaskSummary for observability.
     #[serde(skip)]
     pub project_root: Option<PathBuf>,
+    /// Semantic project identifier (e.g. "harness", "vibeguard") from the project registry.
+    /// Used as the canonical key for queue limits and dedup. Falls back to the canonical
+    /// path string when the project is not in the registry. Empty on legacy DB rows.
+    #[serde(default)]
+    pub project_id: String,
     /// GitHub issue number if this is an issue-based task. Set at spawn time; not persisted.
     #[serde(skip)]
     pub issue: Option<u64>,
@@ -209,6 +214,7 @@ impl TaskState {
             depends_on: Vec::new(),
             subtask_ids: Vec::new(),
             project_root: None,
+            project_id: String::new(),
             issue: None,
             description: None,
             created_at: Some(chrono::Utc::now().to_rfc3339()),
@@ -308,6 +314,10 @@ pub struct CreateTaskRequest {
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
     pub priority: u8,
+    /// Resolved semantic project ID. Set internally by task_routes after registry
+    /// lookup; not part of the public JSON API.
+    #[serde(skip)]
+    pub project_id: String,
 }
 
 impl Default for CreateTaskRequest {
@@ -332,6 +342,7 @@ impl Default for CreateTaskRequest {
             parent_task_id: None,
             depends_on: Vec::new(),
             priority: 0,
+            project_id: String::new(),
         }
     }
 }
@@ -737,20 +748,33 @@ impl TaskStore {
 
     /// Check whether an active (non-terminal) task already exists for the same
     /// project + external_id. Cache-first, DB fallback.
+    ///
+    /// `project_id` is the canonical identity (semantic ID or path string).
+    /// `canonical_path` is the filesystem path string used as a fallback for
+    /// legacy DB rows whose `project_id` column is NULL or empty.
     pub async fn find_active_duplicate(
         &self,
         project_id: &str,
         external_id: &str,
+        canonical_path: Option<&str>,
     ) -> Option<TaskId> {
         let mut found_terminal_in_cache = false;
         for entry in self.cache.iter() {
             let task = entry.value();
-            let same_key = task.external_id.as_deref() == Some(external_id)
-                && task
-                    .project_root
+            // Match by semantic project_id for new tasks; fall back to
+            // project_root path comparison for legacy cache entries.
+            let project_matches = if !task.project_id.is_empty() {
+                task.project_id == project_id
+            } else {
+                task.project_root
                     .as_ref()
-                    .map(|p| p.to_string_lossy() == project_id)
-                    .unwrap_or(false);
+                    .map(|p| {
+                        let path_str = p.to_string_lossy();
+                        path_str == project_id || canonical_path.is_some_and(|cp| path_str == cp)
+                    })
+                    .unwrap_or(false)
+            };
+            let same_key = task.external_id.as_deref() == Some(external_id) && project_matches;
             if !same_key {
                 continue;
             }
@@ -767,7 +791,11 @@ impl TaskStore {
         if found_terminal_in_cache {
             return None;
         }
-        match self.db.find_active_duplicate(project_id, external_id).await {
+        match self
+            .db
+            .find_active_duplicate(project_id, external_id, canonical_path)
+            .await
+        {
             Ok(Some(id)) => Some(harness_core::types::TaskId(id)),
             Ok(None) => None,
             Err(e) => {
@@ -1388,6 +1416,7 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.parent_id = req.parent_task_id.clone();
     state.depends_on = req.depends_on.clone();
     state.priority = req.priority;
+    state.project_id = req.project_id.clone();
     state.issue = req.issue;
     state.description = summarize_request_description(req);
     store.insert(&state).await;
@@ -1464,6 +1493,7 @@ where
         state.external_id = req.external_id.clone();
         state.repo = req.repo.clone();
         state.priority = req.priority;
+        state.project_id = req.project_id.clone();
         store.insert(&state).await;
         // Register stream channel before spawning so SSE clients can subscribe immediately.
         store.register_task_stream(&task_id);

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -32,6 +32,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         triage_output: None,
         plan_output: None,
         repo: None,
+        project_id: String::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `ProjectRegistry::resolve_id_for_path` to reverse-look up a canonical path back to its semantic registry ID (e.g. `"harness"`)
- Introduce a single choke point in `enqueue_task` / `enqueue_task_background` that resolves the canonical path to a semantic `project_id`; queue limits, dedup, and DB storage all use this uniform key
- Add `project_id: String` field to `TaskState` with `#[serde(default)]` so legacy deserialized rows (empty string) round-trip cleanly
- DB migration v13: `ALTER TABLE tasks ADD COLUMN project_id TEXT`; INSERT writes semantic ID; dedup query matches on `project_id` with OR-fallback to `project` path column for legacy NULL rows
- Fix all `TaskState` literal constructors in tests to include `project_id`

Closes #684

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all pass
- [ ] Manual: submit task to registered project, verify `project_id` column in `tasks.db` equals semantic ID
- [ ] Manual: submit duplicate issue to same project, verify dedup returns existing task ID