### PR TITLE
fix(prompts): remove stale worktree dir before git worktree add

### DIFF
--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -55,6 +55,7 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
             ```\n\
             git fetch origin {branch}\n\
             git worktree prune\n\
+            rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
             git worktree add /tmp/harness-pr-{pr_number} {branch}\n\
             ```\n\
          2. Read the PR diff and any review comments:\n\
@@ -362,6 +363,7 @@ pub fn review_prompt(
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
            git worktree prune\n\
+           rm -rf /tmp/harness-review-{pr} 2>/dev/null || true\n\
            git worktree add /tmp/harness-review-{pr} <branch>\n\
          Then do all editing, testing, and pushing from /tmp/harness-review-{pr},\n\
          and remove it when done: git worktree remove /tmp/harness-review-{pr}\n\

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -46,7 +46,7 @@ impl PromptParts {
 /// creating a duplicate PR, the agent checks out the existing branch, reads
 /// review feedback, continues the implementation, and pushes to the same branch.
 pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str) -> String {
-    let repo_slug = repo.replace('/', "-");
+    let repo_slug = repo.replace('/', "+");
     let worktree_path = format!("/tmp/harness-pr-{repo_slug}-{pr_number}");
     format!(
         "GitHub issue #{issue} already has an open PR #{pr_number} on branch `{branch}`.\n\n\
@@ -57,7 +57,7 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
             ```\n\
             git fetch origin {branch}\n\
             rm -rf {worktree_path} 2>/dev/null || true\n\
-            git worktree prune\n\
+            git worktree prune --expire now\n\
             git worktree add {worktree_path} {branch}\n\
             ```\n\
          2. Read the PR diff and any review comments:\n\
@@ -359,7 +359,7 @@ pub fn review_prompt(
         String::new()
     };
 
-    let repo_slug = repo.replace('/', "-");
+    let repo_slug = repo.replace('/', "+");
     let worktree_path = format!("/tmp/harness-review-{repo_slug}-{pr}");
     format!(
         "{context}\
@@ -367,7 +367,7 @@ pub fn review_prompt(
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
            rm -rf {worktree_path} 2>/dev/null || true\n\
-           git worktree prune\n\
+           git worktree prune --expire now\n\
            git worktree add {worktree_path} <branch>\n\
          Then do all editing, testing, and pushing from {worktree_path},\n\
          and remove it when done: git worktree remove {worktree_path}\n\
@@ -1107,8 +1107,8 @@ mod tests {
         assert!(p.contains("PR_URL=https://github.com/owner/repo/pull/50"));
         assert!(p.contains("repos/owner/repo/pulls/50/comments"));
         // Worktree isolation: must use worktree, must not bare-checkout in main repo
-        assert!(p.contains("worktree add /tmp/harness-pr-owner-repo-50"));
-        assert!(p.contains("worktree remove /tmp/harness-pr-owner-repo-50"));
+        assert!(p.contains("worktree add /tmp/harness-pr-owner+repo-50"));
+        assert!(p.contains("worktree remove /tmp/harness-pr-owner+repo-50"));
         assert!(!p.contains("git checkout fix/issue-29"));
     }
 
@@ -1222,7 +1222,7 @@ mod tests {
         assert!(p.contains("medium")); // round 2 includes medium
                                        // Worktree isolation: must prohibit git checkout in main repo
         assert!(p.contains("Never run `git checkout`"));
-        assert!(p.contains("worktree add /tmp/harness-review-owner-repo-10"));
+        assert!(p.contains("worktree add /tmp/harness-review-owner+repo-10"));
     }
 
     #[test]

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -46,6 +46,8 @@ impl PromptParts {
 /// creating a duplicate PR, the agent checks out the existing branch, reads
 /// review feedback, continues the implementation, and pushes to the same branch.
 pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str) -> String {
+    let repo_slug = repo.replace('/', "-");
+    let worktree_path = format!("/tmp/harness-pr-{repo_slug}-{pr_number}");
     format!(
         "GitHub issue #{issue} already has an open PR #{pr_number} on branch `{branch}`.\n\n\
          IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
@@ -54,9 +56,9 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
          1. Create an isolated worktree:\n\
             ```\n\
             git fetch origin {branch}\n\
+            rm -rf {worktree_path} 2>/dev/null || true\n\
             git worktree prune\n\
-            rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
-            git worktree add /tmp/harness-pr-{pr_number} {branch}\n\
+            git worktree add {worktree_path} {branch}\n\
             ```\n\
          2. Read the PR diff and any review comments:\n\
             - `gh pr diff {pr_number}`\n\
@@ -64,11 +66,11 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
             - `gh api repos/{repo}/pulls/{pr_number}/reviews`\n\
          3. Read the original issue requirements: `gh issue view {issue}`\n\
          4. Fix any unresolved review comments and continue the implementation if incomplete.\n\
-            All editing must happen inside `/tmp/harness-pr-{pr_number}`.\n\
-         5. Run `cd /tmp/harness-pr-{pr_number} && cargo check && cargo test`\n\
+            All editing must happen inside `{worktree_path}`.\n\
+         5. Run `cd {worktree_path} && cargo check && cargo test`\n\
          6. Commit and push from the worktree to the SAME branch `{branch}` — do NOT create a new PR:\n\
-            `cd /tmp/harness-pr-{pr_number} && git push origin {branch}`\n\
-         7. Clean up: `git worktree remove /tmp/harness-pr-{pr_number}`\n\n\
+            `cd {worktree_path} && git push origin {branch}`\n\
+         7. Clean up: `git worktree remove {worktree_path}`\n\n\
          On the last line of your output, print PR_URL=https://github.com/{repo}/pull/{pr_number}"
     )
 }
@@ -357,16 +359,18 @@ pub fn review_prompt(
         String::new()
     };
 
+    let repo_slug = repo.replace('/', "-");
+    let worktree_path = format!("/tmp/harness-review-{repo_slug}-{pr}");
     format!(
         "{context}\
          IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
+           rm -rf {worktree_path} 2>/dev/null || true\n\
            git worktree prune\n\
-           rm -rf /tmp/harness-review-{pr} 2>/dev/null || true\n\
-           git worktree add /tmp/harness-review-{pr} <branch>\n\
-         Then do all editing, testing, and pushing from /tmp/harness-review-{pr},\n\
-         and remove it when done: git worktree remove /tmp/harness-review-{pr}\n\
+           git worktree add {worktree_path} <branch>\n\
+         Then do all editing, testing, and pushing from {worktree_path},\n\
+         and remove it when done: git worktree remove {worktree_path}\n\
          (The branch name can be obtained with: gh pr view {pr} --json headRefName --jq .headRefName)\n\n\
          Steps:\n\
          1. Run `gh pr view {pr} --json statusCheckRollup` and parse the JSON. \
@@ -1103,8 +1107,8 @@ mod tests {
         assert!(p.contains("PR_URL=https://github.com/owner/repo/pull/50"));
         assert!(p.contains("repos/owner/repo/pulls/50/comments"));
         // Worktree isolation: must use worktree, must not bare-checkout in main repo
-        assert!(p.contains("worktree add /tmp/harness-pr-50"));
-        assert!(p.contains("worktree remove /tmp/harness-pr-50"));
+        assert!(p.contains("worktree add /tmp/harness-pr-owner-repo-50"));
+        assert!(p.contains("worktree remove /tmp/harness-pr-owner-repo-50"));
         assert!(!p.contains("git checkout fix/issue-29"));
     }
 
@@ -1218,7 +1222,7 @@ mod tests {
         assert!(p.contains("medium")); // round 2 includes medium
                                        // Worktree isolation: must prohibit git checkout in main repo
         assert!(p.contains("Never run `git checkout`"));
-        assert!(p.contains("worktree add /tmp/harness-review-10"));
+        assert!(p.contains("worktree add /tmp/harness-review-owner-repo-10"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `git worktree prune` only removes *registered* worktrees whose directories are gone; it cannot remove a stale directory left by a prior task that was SIGKILL'd after `mkdir` but before registration
- Add `rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true` before `git worktree add` in `continue_existing_pr()` to handle this case
- Apply the same fix for `/tmp/harness-review-{pr}` in `review_prompt()`

## Test plan
- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [ ] `cargo test --workspace` — all tests pass