### PR TITLE
refactor: migrate handlers to service layer (#686)

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -29,11 +29,11 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         global_done,
         global_failed,
         by_project: project_counts,
-    } = state.core.tasks.count_for_dashboard().await;
+    } = state.task_svc.count_for_dashboard().await;
 
     // Most recent completed task with a PR URL, queried from the DB which is
     // ordered by updated_at DESC — reflects completion time, not creation time.
-    let latest_pr: Option<String> = state.core.tasks.latest_done_pr_url().await;
+    let latest_pr: Option<String> = state.task_svc.latest_done_pr_url().await;
 
     // Grade from the global quality event store.
     // Derive violation_count from the most recent rule_scan session so we don't
@@ -66,41 +66,38 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     };
 
     // Fetch latest PR URLs for all projects in one bulk query to avoid N+1.
-    let project_pr_urls = state.core.tasks.latest_done_pr_urls_all_projects().await;
+    let project_pr_urls = state.task_svc.latest_done_pr_urls_all_projects().await;
 
     // Build per-project entries from the registry.
-    let projects: Vec<Value> = match state.core.project_registry.as_ref() {
-        None => vec![],
-        Some(registry) => match registry.list().await {
-            Err(e) => {
-                tracing::warn!("dashboard: failed to list projects: {e}");
-                vec![]
+    let projects: Vec<Value> = match state.project_svc.list().await {
+        Err(e) => {
+            tracing::warn!("dashboard: failed to list projects: {e}");
+            vec![]
+        }
+        Ok(projects) => {
+            let mut entries = Vec::with_capacity(projects.len());
+            for p in projects {
+                // Task queue keys are canonical project root paths as strings.
+                let key = p.root.to_string_lossy().into_owned();
+                let qs = tq.project_stats(&key);
+                let counts = project_counts.get(&key);
+                let done = counts.map_or(0, |c| c.done);
+                let failed = counts.map_or(0, |c| c.failed);
+                let latest_pr = project_pr_urls.get(&key);
+                entries.push(json!({
+                    "id": p.id,
+                    "root": p.root,
+                    "tasks": {
+                        "running": qs.running,
+                        "queued": qs.queued,
+                        "done": done,
+                        "failed": failed,
+                    },
+                    "latest_pr": latest_pr,
+                }));
             }
-            Ok(projects) => {
-                let mut entries = Vec::with_capacity(projects.len());
-                for p in projects {
-                    // Task queue keys are canonical project root paths as strings.
-                    let key = p.root.to_string_lossy().into_owned();
-                    let qs = tq.project_stats(&key);
-                    let counts = project_counts.get(&key);
-                    let done = counts.map_or(0, |c| c.done);
-                    let failed = counts.map_or(0, |c| c.failed);
-                    let latest_pr = project_pr_urls.get(&key);
-                    entries.push(json!({
-                        "id": p.id,
-                        "root": p.root,
-                        "tasks": {
-                            "running": qs.running,
-                            "queued": qs.queued,
-                            "done": done,
-                            "failed": failed,
-                        },
-                        "latest_pr": latest_pr,
-                    }));
-                }
-                entries
-            }
-        },
+            entries
+        }
     };
 
     let runtime_hosts: Vec<Value> = state

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -24,13 +24,6 @@ pub async fn register_project(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RegisterProjectRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(registry) = state.core.project_registry.as_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "project registry not initialized"})),
-        );
-    };
-
     let root = match req.root.canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -71,7 +64,7 @@ pub async fn register_project(
         created_at: chrono::Utc::now().to_rfc3339(),
     };
 
-    match registry.register(project.clone()).await {
+    match state.project_svc.register(project.clone()).await {
         Ok(()) => (StatusCode::CREATED, Json(json!(project))),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -83,14 +76,7 @@ pub async fn register_project(
 pub async fn list_projects(
     State(state): State<Arc<AppState>>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(registry) = state.core.project_registry.as_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "project registry not initialized"})),
-        );
-    };
-
-    match registry.list().await {
+    match state.project_svc.list().await {
         Ok(projects) => {
             let mut with_counts: Vec<serde_json::Value> = Vec::with_capacity(projects.len());
             for p in projects {
@@ -121,14 +107,7 @@ pub async fn get_project(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(registry) = state.core.project_registry.as_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "project registry not initialized"})),
-        );
-    };
-
-    match registry.get(&id).await {
+    match state.project_svc.get(&id).await {
         Ok(Some(project)) => (StatusCode::OK, Json(json!(project))),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -145,14 +124,7 @@ pub async fn delete_project(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(registry) = state.core.project_registry.as_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "project registry not initialized"})),
-        );
-    };
-
-    match registry.remove(&id).await {
+    match state.project_svc.remove(&id).await {
         Ok(true) => (StatusCode::OK, Json(json!({"deleted": id}))),
         Ok(false) => (
             StatusCode::NOT_FOUND,

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -1,8 +1,9 @@
 //! TaskService — task lifecycle, stream subscriptions, and task-project association.
 
-use crate::task_runner::{TaskId, TaskState, TaskStore};
+use crate::task_runner::{DashboardCounts, TaskId, TaskState, TaskStore};
 use async_trait::async_trait;
 use harness_core::agent::StreamItem;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -30,6 +31,13 @@ pub trait TaskService: Send + Sync {
     /// Subscribe to the real-time stream of a running task.
     /// Returns `None` when no stream channel is registered for the task.
     fn subscribe_stream(&self, id: &TaskId) -> Option<broadcast::Receiver<StreamItem>>;
+
+    /// Global and per-project done/failed counts for the dashboard.
+    async fn count_for_dashboard(&self) -> DashboardCounts;
+
+    /// Most recent completed-task PR URL keyed by canonical project root string,
+    /// for all projects. Used by the dashboard to show per-project latest PR.
+    async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String>;
 }
 
 /// Production implementation backed by [`TaskStore`].
@@ -73,6 +81,14 @@ impl TaskService for DefaultTaskService {
 
     fn subscribe_stream(&self, id: &TaskId) -> Option<broadcast::Receiver<StreamItem>> {
         self.store.subscribe_task_stream(id)
+    }
+
+    async fn count_for_dashboard(&self) -> DashboardCounts {
+        self.store.count_for_dashboard().await
+    }
+
+    async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String> {
+        self.store.latest_done_pr_urls_all_projects().await
     }
 }
 


### PR DESCRIPTION
## Summary

- Extends `TaskService` trait with two new methods: `count_for_dashboard()` and `latest_done_pr_urls_all_projects()`, delegating to `TaskStore` in `DefaultTaskService`
- Migrates `handlers/projects.rs`: all four handlers (`register_project`, `list_projects`, `get_project`, `delete_project`) now call `state.project_svc` instead of `state.core.project_registry`
- Migrates `handlers/dashboard.rs`: replaces `state.core.tasks.*` and `state.core.project_registry.*` calls with `state.task_svc.*` and `state.project_svc.list()`

Closes #686

## Note on task_routes.rs

The plan proposed collapsing `enqueue_task`/`enqueue_task_background` into `state.execution_svc` calls, but `DefaultExecutionService` is currently missing: (a) dedup checks (`populate_external_id`, `check_duplicate`, `check_pr_duplicate`), (b) three-tier agent selection (tier 2a from `.harness/config.toml`), and (c) `group_sem` for batch conflict-group serialization. Delegating to `execution_svc` as-is would silently drop these behaviors. That migration requires extending `DefaultExecutionService` first and is left for a follow-up.

## Test plan

- [x] `cargo check --workspace --all-targets` with `-Dwarnings` passes
- [x] `cargo test --package harness-server` — all tests pass
- [x] `cargo fmt --all` applied