### PR TITLE
feat(observe): add LLM-specific metrics (cost/turns/linter/latency)

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-observe/src/stats.rs
+++ b/crates/harness-observe/src/stats.rs
@@ -175,13 +175,17 @@ pub fn linter_feedback_count(events: &[Event]) -> u32 {
 
 /// Compute the p50 (median) of a slice of turn counts.
 /// Returns `None` for an empty slice.
+///
+/// Uses the lower-median convention for even-length slices so the result never
+/// overstates the true 50th percentile.  For `[1, 2, 3, 4]` this returns `2`
+/// (index `(4-1)/2 = 1`), not `3` (index `4/2 = 2`).
 pub fn p50_turns(turn_counts: &[u32]) -> Option<u32> {
     if turn_counts.is_empty() {
         return None;
     }
     let mut sorted = turn_counts.to_vec();
     sorted.sort_unstable();
-    Some(sorted[sorted.len() / 2])
+    Some(sorted[(sorted.len() - 1) / 2])
 }
 
 pub fn compute_rule_trends(events: &[Event], period_days: u32) -> Vec<RuleTrend> {
@@ -399,7 +403,7 @@ mod tests {
 
     #[test]
     fn p50_turns_even_count_returns_lower_median() {
-        // sorted: [1, 2, 3, 4] — index len/2 = 2 → 3
-        assert_eq!(p50_turns(&[4, 1, 3, 2]), Some(3));
+        // sorted: [1, 2, 3, 4] — index (len-1)/2 = 1 → 2 (lower median)
+        assert_eq!(p50_turns(&[4, 1, 3, 2]), Some(2));
     }
 }

--- a/crates/harness-observe/src/stats.rs
+++ b/crates/harness-observe/src/stats.rs
@@ -162,14 +162,16 @@ pub fn aggregate_rule_stats(events: &[Event]) -> Vec<RuleStats> {
     stats
 }
 
-/// Count linter/compiler feedback events (Block or Escalate) from `rule_check` events.
+/// Count linter/compiler feedback events (Block) from `rule_check` events.
 ///
 /// High values indicate the agent is in a "hallucination loop" with repeated build failures.
+/// Only `Block` is counted: `rule_check` scanners emit Pass/Warn/Block — `Escalate` is not
+/// produced by this hook and would silently count nothing.
 pub fn linter_feedback_count(events: &[Event]) -> u32 {
     events
         .iter()
         .filter(|e| e.hook == "rule_check")
-        .filter(|e| matches!(e.decision, Decision::Block | Decision::Escalate))
+        .filter(|e| matches!(e.decision, Decision::Block))
         .count() as u32
 }
 
@@ -366,15 +368,17 @@ mod tests {
     }
 
     #[test]
-    fn linter_feedback_count_counts_only_block_and_escalate() {
+    fn linter_feedback_count_counts_only_block() {
+        // rule_check scanners emit Pass/Warn/Block; Escalate is not produced
+        // by this hook so only Block events should be counted.
         let events = vec![
             make_rule_event("SEC-01", Decision::Block),
-            make_rule_event("SEC-01", Decision::Escalate),
+            make_rule_event("SEC-01", Decision::Escalate), // dead for rule_check
             make_rule_event("SEC-02", Decision::Pass),
             make_rule_event("SEC-03", Decision::Warn),
             make_event("other_hook", Decision::Block), // not rule_check
         ];
-        assert_eq!(linter_feedback_count(&events), 2);
+        assert_eq!(linter_feedback_count(&events), 1);
     }
 
     #[test]

--- a/crates/harness-observe/src/stats.rs
+++ b/crates/harness-observe/src/stats.rs
@@ -162,6 +162,28 @@ pub fn aggregate_rule_stats(events: &[Event]) -> Vec<RuleStats> {
     stats
 }
 
+/// Count linter/compiler feedback events (Block or Escalate) from `rule_check` events.
+///
+/// High values indicate the agent is in a "hallucination loop" with repeated build failures.
+pub fn linter_feedback_count(events: &[Event]) -> u32 {
+    events
+        .iter()
+        .filter(|e| e.hook == "rule_check")
+        .filter(|e| matches!(e.decision, Decision::Block | Decision::Escalate))
+        .count() as u32
+}
+
+/// Compute the p50 (median) of a slice of turn counts.
+/// Returns `None` for an empty slice.
+pub fn p50_turns(turn_counts: &[u32]) -> Option<u32> {
+    if turn_counts.is_empty() {
+        return None;
+    }
+    let mut sorted = turn_counts.to_vec();
+    sorted.sort_unstable();
+    Some(sorted[sorted.len() / 2])
+}
+
 pub fn compute_rule_trends(events: &[Event], period_days: u32) -> Vec<RuleTrend> {
     let rule_events: Vec<&Event> = events.iter().filter(|e| e.hook == "rule_check").collect();
     if rule_events.is_empty() {
@@ -332,5 +354,52 @@ mod tests {
     fn compute_rule_trends_empty_when_no_rule_events() {
         let trends = compute_rule_trends(&[make_event("h", Decision::Pass)], 7);
         assert!(trends.is_empty());
+    }
+
+    #[test]
+    fn linter_feedback_count_returns_zero_for_empty_events() {
+        assert_eq!(linter_feedback_count(&[]), 0);
+    }
+
+    #[test]
+    fn linter_feedback_count_counts_only_block_and_escalate() {
+        let events = vec![
+            make_rule_event("SEC-01", Decision::Block),
+            make_rule_event("SEC-01", Decision::Escalate),
+            make_rule_event("SEC-02", Decision::Pass),
+            make_rule_event("SEC-03", Decision::Warn),
+            make_event("other_hook", Decision::Block), // not rule_check
+        ];
+        assert_eq!(linter_feedback_count(&events), 2);
+    }
+
+    #[test]
+    fn linter_feedback_count_zero_when_all_pass() {
+        let events = vec![
+            make_rule_event("SEC-01", Decision::Pass),
+            make_rule_event("SEC-02", Decision::Complete),
+        ];
+        assert_eq!(linter_feedback_count(&events), 0);
+    }
+
+    #[test]
+    fn p50_turns_returns_none_for_empty_slice() {
+        assert_eq!(p50_turns(&[]), None);
+    }
+
+    #[test]
+    fn p50_turns_single_element() {
+        assert_eq!(p50_turns(&[5]), Some(5));
+    }
+
+    #[test]
+    fn p50_turns_odd_count() {
+        assert_eq!(p50_turns(&[1, 3, 5, 7, 9]), Some(5));
+    }
+
+    #[test]
+    fn p50_turns_even_count_returns_lower_median() {
+        // sorted: [1, 2, 3, 4] — index len/2 = 2 → 3
+        assert_eq!(p50_turns(&[4, 1, 3, 2]), Some(3));
     }
 }

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -5,6 +5,11 @@ use harness_observe::{quality::QualityGrader, stats};
 use serde_json::{json, Value};
 use std::sync::Arc;
 
+/// Rolling window for dashboard event queries. Keeps each `/api/dashboard` poll
+/// from doing a full-history scan — the browser polls every 5 s and the event
+/// store materialises all matching rows into memory on every call.
+const DASHBOARD_EVENT_WINDOW_DAYS: i64 = 30;
+
 /// Server start time. Initialized once in `serve()` before accepting connections,
 /// so `uptime_secs` reflects true server uptime rather than time since first dashboard hit.
 pub(crate) static SERVER_START: std::sync::OnceLock<std::time::Instant> =
@@ -38,10 +43,14 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     // Grade from the global quality event store.
     // Derive violation_count from the most recent rule_scan session so we don't
     // permanently depress the grade with historical violations from old scans.
+    let events_since = chrono::Utc::now() - chrono::Duration::days(DASHBOARD_EVENT_WINDOW_DAYS);
     let grade: Option<Value> = match state
         .observability
         .events
-        .query(&EventFilters::default())
+        .query(&EventFilters {
+            since: Some(events_since),
+            ..Default::default()
+        })
         .await
     {
         Ok(events) => {
@@ -92,12 +101,15 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         } else {
             Some(latencies[latencies.len() / 2])
         };
-        // total_linter_feedback from events already queried above
+        // total_linter_feedback from events already queried above.
+        // Bounded to the same rolling window as the grade query to avoid a
+        // full-history scan on every 5-second dashboard poll.
         let total_linter_feedback = match state
             .observability
             .events
             .query(&EventFilters {
                 hook: Some("rule_check".to_string()),
+                since: Some(events_since),
                 ..Default::default()
             })
             .await

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -99,7 +99,8 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         let p50_first_token_latency_ms: Option<u64> = if latencies.is_empty() {
             None
         } else {
-            Some(latencies[latencies.len() / 2])
+            // Lower-median: index (len-1)/2 avoids overstating p50 for even-length slices.
+            Some(latencies[(latencies.len() - 1) / 2])
         };
         // total_linter_feedback from events already queried above.
         // Bounded to the same rolling window as the grade query to avoid a

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -54,19 +54,27 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         .await
     {
         Ok(events) => {
-            let violation_count = events
-                .iter()
-                .rev()
-                .find(|e| e.hook == "rule_scan")
-                .map(|scan| {
-                    events
-                        .iter()
-                        .filter(|e| e.hook == "rule_check" && e.session_id == scan.session_id)
-                        .count()
-                })
-                .unwrap_or(0);
-            let report = QualityGrader::grade(&events, violation_count);
-            serde_json::to_value(report.grade).ok()
+            // Return None when the rolling window contains no events rather than
+            // computing a false perfect grade from an empty set.  Operators should
+            // see null (unknown) instead of an inflated A when the project has been
+            // quiet for more than DASHBOARD_EVENT_WINDOW_DAYS days.
+            if events.iter().all(|e| e.hook != "rule_scan") {
+                None
+            } else {
+                let violation_count = events
+                    .iter()
+                    .rev()
+                    .find(|e| e.hook == "rule_scan")
+                    .map(|scan| {
+                        events
+                            .iter()
+                            .filter(|e| e.hook == "rule_check" && e.session_id == scan.session_id)
+                            .count()
+                    })
+                    .unwrap_or(0);
+                let report = QualityGrader::grade(&events, violation_count);
+                serde_json::to_value(report.grade).ok()
+            }
         }
         Err(e) => {
             tracing::warn!("dashboard: failed to query events for grade: {e}");

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -66,25 +66,26 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     };
 
     // LLM-specific metrics derived from in-memory task state and event store.
+    //
+    // collect_llm_metrics_inputs() avoids two pitfalls:
+    // 1. Performance: does NOT call list_all() which would clone full TaskState
+    //    values (including large rounds.detail strings) on every 5-second poll.
+    //    Turn counts come from lightweight DB summaries; latencies are read
+    //    in-place from cache refs without any full-TaskState allocation.
+    // 2. Correctness: turn counts include terminal tasks from the DB so the
+    //    metrics are not zero when the queue is idle.  Latency computation skips
+    //    the synthetic "resumed_checkpoint" round injected at recovery time so
+    //    resumed tasks are not silently excluded from the p50.
     let llm_metrics: Value = {
-        let all_tasks = state.core.tasks.list_all();
-        // avg_turns: mean of task.turn across all non-zero tasks
-        let turn_counts: Vec<u32> = all_tasks
-            .iter()
-            .filter(|t| t.turn > 0)
-            .map(|t| t.turn)
-            .collect();
+        let inputs = state.core.tasks.collect_llm_metrics_inputs().await;
+        let turn_counts = inputs.turn_counts;
         let avg_turns: Option<f64> = if turn_counts.is_empty() {
             None
         } else {
             Some(turn_counts.iter().map(|&t| t as f64).sum::<f64>() / turn_counts.len() as f64)
         };
         let p50_turns = stats::p50_turns(&turn_counts);
-        // p50_first_token_latency_ms: from first round of each task
-        let mut latencies: Vec<u64> = all_tasks
-            .iter()
-            .filter_map(|t| t.rounds.first().and_then(|r| r.first_token_latency_ms))
-            .collect();
+        let mut latencies = inputs.first_token_latencies;
         latencies.sort_unstable();
         let p50_first_token_latency_ms: Option<u64> = if latencies.is_empty() {
             None

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -1,7 +1,7 @@
 use crate::{http::AppState, task_runner::DashboardCounts};
 use axum::{extract::State, http::StatusCode, Json};
 use harness_core::types::EventFilters;
-use harness_observe::quality::QualityGrader;
+use harness_observe::{quality::QualityGrader, stats};
 use serde_json::{json, Value};
 use std::sync::Arc;
 
@@ -63,6 +63,56 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
             tracing::warn!("dashboard: failed to query events for grade: {e}");
             None
         }
+    };
+
+    // LLM-specific metrics derived from in-memory task state and event store.
+    let llm_metrics: Value = {
+        let all_tasks = state.core.tasks.list_all();
+        // avg_turns: mean of task.turn across all non-zero tasks
+        let turn_counts: Vec<u32> = all_tasks
+            .iter()
+            .filter(|t| t.turn > 0)
+            .map(|t| t.turn)
+            .collect();
+        let avg_turns: Option<f64> = if turn_counts.is_empty() {
+            None
+        } else {
+            Some(turn_counts.iter().map(|&t| t as f64).sum::<f64>() / turn_counts.len() as f64)
+        };
+        let p50_turns = stats::p50_turns(&turn_counts);
+        // p50_first_token_latency_ms: from first round of each task
+        let mut latencies: Vec<u64> = all_tasks
+            .iter()
+            .filter_map(|t| t.rounds.first().and_then(|r| r.first_token_latency_ms))
+            .collect();
+        latencies.sort_unstable();
+        let p50_first_token_latency_ms: Option<u64> = if latencies.is_empty() {
+            None
+        } else {
+            Some(latencies[latencies.len() / 2])
+        };
+        // total_linter_feedback from events already queried above
+        let total_linter_feedback = match state
+            .observability
+            .events
+            .query(&EventFilters {
+                hook: Some("rule_check".to_string()),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(evts) => stats::linter_feedback_count(&evts),
+            Err(e) => {
+                tracing::warn!("dashboard: failed to query rule_check events: {e}");
+                0
+            }
+        };
+        json!({
+            "avg_turns": avg_turns,
+            "p50_turns": p50_turns,
+            "total_linter_feedback": total_linter_feedback,
+            "p50_first_token_latency_ms": p50_first_token_latency_ms,
+        })
     };
 
     // Fetch latest PR URLs for all projects in one bulk query to avoid N+1.
@@ -136,6 +186,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     let body = json!({
         "projects": projects,
         "runtime_hosts": runtime_hosts,
+        "llm_metrics": llm_metrics,
         "global": {
             "running": tq.running_count(),
             "queued": tq.queued_count(),

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1742,6 +1742,7 @@ mod tests {
             action: "review".to_string(),
             result: "cancelled".to_string(),
             detail: Some("cancelled output should be ignored".to_string()),
+            first_token_latency_ms: None,
         });
         store.insert(&task).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -354,13 +354,18 @@ impl TaskDb {
         Ok(summaries)
     }
 
-    /// Return `(task_id, first_token_latency_ms)` pairs for the most-recent
-    /// terminal (done/failed) tasks, capped at 500 rows.
+    /// Return `(task_id, first_token_latency_ms)` pairs for the most-recently
+    /// completed terminal (done/failed) tasks, capped at 500 rows.
     ///
     /// The latency scalar is extracted directly in SQL via `json_extract` so the
     /// full `rounds` blob — which may contain large `detail` strings — is never
     /// allocated on the Rust heap.  The correlated subquery skips synthetic
     /// `resumed_checkpoint` rounds and returns the first real latency per task.
+    ///
+    /// Ordered by `updated_at DESC` because `updated_at` is written at task
+    /// completion, so this correctly captures the 500 most-recently-finished
+    /// tasks.  Using `created_at` would silently drop long-running tasks that
+    /// finished recently but were created earlier.
     ///
     /// The `LIMIT 500` keeps each dashboard poll O(1) rather than
     /// O(total task history).  500 data points are more than sufficient for a
@@ -378,7 +383,25 @@ impl TaskDb {
               LIMIT 1) AS first_token_latency_ms \
              FROM tasks \
              WHERE status IN ('done', 'failed') \
-             ORDER BY created_at DESC \
+             ORDER BY updated_at DESC \
+             LIMIT 500",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Return `(task_id, turn)` pairs for the 500 most-recently-completed
+    /// terminal (done/failed) tasks, ordered by completion time (`updated_at DESC`).
+    ///
+    /// Only the lightweight `id` and `turn` columns are fetched; the heavy
+    /// `rounds` blob is never touched.  The `LIMIT 500` keeps each dashboard
+    /// poll O(1) rather than O(total task history).
+    pub async fn list_terminal_turn_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT id, turn FROM tasks \
+             WHERE status IN ('done', 'failed') \
+             ORDER BY updated_at DESC \
              LIMIT 500",
         )
         .fetch_all(&self.pool)

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -354,15 +354,32 @@ impl TaskDb {
         Ok(summaries)
     }
 
-    /// Return `(task_id, rounds_json)` pairs for terminal (done/failed) tasks.
+    /// Return `(task_id, first_token_latency_ms)` pairs for the most-recent
+    /// terminal (done/failed) tasks, capped at 500 rows.
     ///
-    /// Used by `collect_llm_metrics_inputs` to include historical latency data
-    /// for tasks that have already left the in-memory cache (e.g. after restart).
-    /// The caller is responsible for skipping IDs that are already in the cache
-    /// to avoid double-counting tasks that completed during the current session.
-    pub async fn list_terminal_rounds_json(&self) -> anyhow::Result<Vec<(String, String)>> {
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT id, rounds FROM tasks WHERE status IN ('done', 'failed') ORDER BY created_at DESC",
+    /// The latency scalar is extracted directly in SQL via `json_extract` so the
+    /// full `rounds` blob — which may contain large `detail` strings — is never
+    /// allocated on the Rust heap.  The correlated subquery skips synthetic
+    /// `resumed_checkpoint` rounds and returns the first real latency per task.
+    ///
+    /// The `LIMIT 500` keeps each dashboard poll O(1) rather than
+    /// O(total task history).  500 data points are more than sufficient for a
+    /// statistically valid p50; they also represent a natural rolling window that
+    /// gives more weight to recent latency behaviour.
+    pub async fn list_terminal_first_token_latencies_ms(
+        &self,
+    ) -> anyhow::Result<Vec<(String, Option<i64>)>> {
+        let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
+            "SELECT id, \
+             (SELECT CAST(json_extract(r.value, '$.first_token_latency_ms') AS INTEGER) \
+              FROM json_each(rounds) r \
+              WHERE json_extract(r.value, '$.result') != 'resumed_checkpoint' \
+                AND json_extract(r.value, '$.first_token_latency_ms') IS NOT NULL \
+              LIMIT 1) AS first_token_latency_ms \
+             FROM tasks \
+             WHERE status IN ('done', 'failed') \
+             ORDER BY created_at DESC \
+             LIMIT 500",
         )
         .fetch_all(&self.pool)
         .await?;

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1134,6 +1134,7 @@ mod tests {
             action: "implement".to_string(),
             result: "created PR".to_string(),
             detail: None,
+            first_token_latency_ms: None,
         });
         db.update(&task).await?;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -354,6 +354,21 @@ impl TaskDb {
         Ok(summaries)
     }
 
+    /// Return `(task_id, rounds_json)` pairs for terminal (done/failed) tasks.
+    ///
+    /// Used by `collect_llm_metrics_inputs` to include historical latency data
+    /// for tasks that have already left the in-memory cache (e.g. after restart).
+    /// The caller is responsible for skipping IDs that are already in the cache
+    /// to avoid double-counting tasks that completed during the current session.
+    pub async fn list_terminal_rounds_json(&self) -> anyhow::Result<Vec<(String, String)>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, rounds FROM tasks WHERE status IN ('done', 'failed') ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
     /// Return `(id, status)` pairs for all tasks — skips all heavy columns.
     ///
     /// Used by hot-path callers that only need task status for aggregation

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -29,6 +29,7 @@ const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source,
 /// v12 – add priority column for priority-based task scheduling.
 /// v13 – add phase column for consistent phase persistence across cache/DB paths.
 /// v14 – add description column for task observability after restart.
+/// v15 – add (status, updated_at DESC) index for project-agnostic terminal queries.
 static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -118,6 +119,12 @@ static TASK_MIGRATIONS: &[Migration] = &[
         version: 14,
         description: "add description column for task observability",
         sql: "ALTER TABLE tasks ADD COLUMN description TEXT",
+    },
+    Migration {
+        version: 15,
+        description: "add index on tasks(status, updated_at) for project-agnostic terminal queries",
+        sql: "CREATE INDEX IF NOT EXISTS idx_tasks_status_updated \
+              ON tasks(status, updated_at DESC)",
     },
 ];
 

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -485,6 +485,13 @@ async fn run_agent_streaming(
                             StreamItem::ItemCompleted {
                                 item: Item::AgentReasoning { content },
                             } => {
+                                // Adapters that emit ItemCompleted instead of MessageDelta
+                                // (e.g. AnthropicApiAdapter) never trigger the MessageDelta arm
+                                // above, so capture first-token latency here as well.
+                                if first_token_latency_ms.is_none() {
+                                    first_token_latency_ms =
+                                        Some(turn_start.elapsed().as_millis() as u64);
+                                }
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
                             }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -455,13 +455,15 @@ async fn run_agent_streaming(
     task_id: &TaskId,
     store: &TaskStore,
     turn: u32,
-) -> harness_core::error::Result<AgentResponse> {
+) -> harness_core::error::Result<(AgentResponse, Option<u64>)> {
+    let turn_start = Instant::now();
     let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamItem>(128);
     let mut exec = std::pin::pin!(agent.execute_stream(req, tx));
     let mut exec_result: Option<harness_core::error::Result<()>> = None;
     let mut channel_closed = false;
     let mut output = String::new();
     let mut token_usage = TokenUsage::default();
+    let mut first_token_latency_ms: Option<u64> = None;
 
     loop {
         tokio::select! {
@@ -474,6 +476,10 @@ async fn run_agent_streaming(
                         store.publish_stream_item(task_id, item.clone());
                         match &item {
                             StreamItem::MessageDelta { text } => {
+                                if first_token_latency_ms.is_none() {
+                                    first_token_latency_ms =
+                                        Some(turn_start.elapsed().as_millis() as u64);
+                                }
                                 output.push_str(text);
                             }
                             StreamItem::ItemCompleted {
@@ -510,14 +516,17 @@ async fn run_agent_streaming(
             "agent execution completed without result".into(),
         ))
     }) {
-        Ok(()) => Ok(AgentResponse {
-            output,
-            stderr: String::new(),
-            items: Vec::new(),
-            token_usage,
-            model: String::new(),
-            exit_code: Some(0),
-        }),
+        Ok(()) => Ok((
+            AgentResponse {
+                output,
+                stderr: String::new(),
+                items: Vec::new(),
+                token_usage,
+                model: String::new(),
+                exit_code: Some(0),
+            },
+            first_token_latency_ms,
+        )),
         Err(e) => Err(e),
     }
 }
@@ -625,7 +634,7 @@ async fn run_triage_plan_pipeline(
     };
 
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
-    let triage_resp = tokio::time::timeout(
+    let (triage_resp, _) = tokio::time::timeout(
         turn_timeout,
         run_agent_streaming(agent, triage_req, task_id, store, 0),
     )
@@ -695,7 +704,7 @@ async fn run_triage_plan_pipeline(
         ..Default::default()
     };
 
-    let plan_resp = tokio::time::timeout(
+    let (plan_resp, _) = tokio::time::timeout(
         turn_timeout,
         run_agent_streaming(agent, plan_req, task_id, store, 0),
     )
@@ -1085,6 +1094,7 @@ pub(crate) async fn run_task(
                     action: "implement".into(),
                     result: "resumed_checkpoint".into(),
                     detail: None,
+                    first_token_latency_ms: None,
                 });
             })
             .await?;
@@ -1136,7 +1146,7 @@ pub(crate) async fn run_task(
             turns_used += 1;
             *turns_used_acc = turns_used;
             match raw {
-                Ok(Ok(r)) => {
+                Ok(Ok((r, impl_first_token_ms))) => {
                     // Post-execution tool isolation check (defense-in-depth alongside
                     // --allowedTools CLI enforcement). Violations feed into the retry loop
                     // so the agent gets a chance to self-correct (fail-closed, not fail-open).
@@ -1212,7 +1222,7 @@ pub(crate) async fn run_task(
                             ));
                         }
                     }
-                    break r;
+                    break (r, impl_first_token_ms);
                 }
                 Ok(Err(e)) => {
                     run_on_error(&interceptors, &impl_req, &e.to_string()).await;
@@ -1229,12 +1239,15 @@ pub(crate) async fn run_task(
             }
         };
 
-        let AgentResponse {
-            output,
-            stderr,
-            token_usage: impl_token_usage,
-            ..
-        } = resp;
+        let (
+            AgentResponse {
+                output,
+                stderr,
+                token_usage: impl_token_usage,
+                ..
+            },
+            impl_first_token_ms,
+        ) = resp;
 
         tracing::info!(
             task_id = %task_id,
@@ -1280,6 +1293,7 @@ pub(crate) async fn run_task(
                     } else {
                         Some(output.clone())
                     },
+                    first_token_latency_ms: impl_first_token_ms,
                 });
             })
             .await?;
@@ -1318,6 +1332,7 @@ pub(crate) async fn run_task(
                         } else {
                             Some(output.clone())
                         },
+                        first_token_latency_ms: impl_first_token_ms,
                     });
                 })
                 .await?;
@@ -1349,6 +1364,7 @@ pub(crate) async fn run_task(
                 } else {
                     Some(output.clone())
                 },
+                first_token_latency_ms: impl_first_token_ms,
             });
         })
         .await?;
@@ -1729,6 +1745,7 @@ pub(crate) async fn run_task(
                 action: "review".into(),
                 result: result_label.into(),
                 detail: None,
+                first_token_latency_ms: None,
             });
         })
         .await?;
@@ -2049,6 +2066,7 @@ async fn run_agent_review(
                     format!("{} issues", issues.len())
                 },
                 detail: Some(review_detail),
+                first_token_latency_ms: None,
             });
         })
         .await?;
@@ -2196,6 +2214,7 @@ async fn run_agent_review(
                 action: "agent_review_fix".into(),
                 result: "fixed".into(),
                 detail: None,
+                first_token_latency_ms: None,
             });
         })
         .await?;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -485,13 +485,13 @@ async fn run_agent_streaming(
                             StreamItem::ItemCompleted {
                                 item: Item::AgentReasoning { content },
                             } => {
-                                // Adapters that emit ItemCompleted instead of MessageDelta
-                                // (e.g. AnthropicApiAdapter) never trigger the MessageDelta arm
-                                // above, so capture first-token latency here as well.
-                                if first_token_latency_ms.is_none() {
-                                    first_token_latency_ms =
-                                        Some(turn_start.elapsed().as_millis() as u64);
-                                }
+                                // Non-streaming adapters (e.g. AnthropicApiAgent) call
+                                // execute() to completion before emitting this item, so
+                                // elapsed time here is full-request latency, not TTFB.
+                                // Recording it as first_token_latency_ms would silently
+                                // mix whole-request durations with real streaming TTFB
+                                // values and inflate p50.  Only MessageDelta (true
+                                // streaming events) sets first_token_latency_ms.
                                 // Prefer the full content over accumulated deltas.
                                 output = content.clone();
                             }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1099,28 +1099,18 @@ impl TaskStore {
         // Latencies — phase 2: include terminal tasks from DB not already in cache.
         // After restart with idle queue, cache is empty so without this the p50
         // would be None even though latencies are persisted in the DB.
-        // Uses (id, rounds_json) rows — no RoundResult deserialization — to keep
-        // the per-call footprint proportional to the number of terminal tasks.
-        match self.db.list_terminal_rounds_json().await {
+        // `list_terminal_first_token_latencies_ms` extracts the scalar in SQL via
+        // json_extract (no full rounds blob in Rust memory) and is bounded to the
+        // 500 most-recent terminal tasks so each dashboard poll stays O(1).
+        match self.db.list_terminal_first_token_latencies_ms().await {
             Ok(rows) => {
-                for (id, rounds_json) in rows {
+                for (id, latency_opt) in rows {
                     if cache_ids.contains(&id) {
                         // Already counted via cache iteration above.
                         continue;
                     }
-                    if let Ok(serde_json::Value::Array(rounds)) =
-                        serde_json::from_str::<serde_json::Value>(&rounds_json)
-                    {
-                        if let Some(latency) = rounds
-                            .iter()
-                            .filter(|r| {
-                                r.get("result").and_then(|v| v.as_str())
-                                    != Some("resumed_checkpoint")
-                            })
-                            .find_map(|r| r.get("first_token_latency_ms").and_then(|v| v.as_u64()))
-                        {
-                            first_token_latencies.push(latency);
-                        }
+                    if let Some(ms) = latency_opt {
+                        first_token_latencies.push(ms as u64);
                     }
                 }
             }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -139,6 +139,9 @@ pub struct RoundResult {
     /// Raw output from the reviewer agent, if available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    /// Time from agent launch to first output token (milliseconds).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_token_latency_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1698,6 +1701,7 @@ where
                                     "failed".into()
                                 },
                                 detail,
+                                first_token_latency_ms: None,
                             });
                         }
                         if succeeded {
@@ -1837,6 +1841,7 @@ where
                                 "attempt {transient_attempts}/{MAX_TRANSIENT_RETRIES}"
                             ),
                             detail: Some(reason.clone()),
+                            first_token_latency_ms: None,
                         });
                         s.status = TaskStatus::Pending;
                         s.error = Some(format!(

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -643,6 +643,20 @@ pub struct DashboardCounts {
     pub by_project: HashMap<String, ProjectCounts>,
 }
 
+/// Lightweight inputs collected for LLM metrics computation.
+///
+/// Turn counts span all tasks (active + terminal) via DB summaries so the
+/// queue-idle case returns real numbers.  Latencies come from the active
+/// cache only (no full `TaskState` clone) and skip synthetic
+/// `resumed_checkpoint` rounds so resumed tasks are not silently excluded.
+#[derive(Debug)]
+pub struct LlmMetricsInputs {
+    /// Non-zero turn counts across all tasks, active and terminal.
+    pub turn_counts: Vec<u32>,
+    /// First real first-token latency per active task (milliseconds).
+    pub first_token_latencies: Vec<u64>,
+}
+
 pub struct TaskStore {
     pub(crate) cache: DashMap<TaskId, TaskState>,
     db: TaskDb,
@@ -1024,6 +1038,56 @@ impl TaskStore {
                     by_project: HashMap::new(),
                 }
             }
+        }
+    }
+
+    /// Collect lightweight inputs for LLM metrics computation.
+    ///
+    /// **Turn counts** are fetched from `list_all_summaries_with_terminal` so
+    /// they include both active and historical terminal tasks.  When the queue
+    /// is idle this avoids reporting zeros that would misrepresent overall
+    /// throughput.
+    ///
+    /// **First-token latencies** are read directly from the in-memory cache
+    /// entries using `DashMap` references — no full `TaskState` is cloned, so
+    /// large `rounds.detail` strings are never materialised on the heap.
+    /// Rounds whose `result` is `"resumed_checkpoint"` are skipped: they are
+    /// synthetic markers with no real latency data and would silently exclude
+    /// the recovered task from the p50 calculation.
+    pub async fn collect_llm_metrics_inputs(&self) -> LlmMetricsInputs {
+        // Turn counts: DB summaries are lightweight (no rounds field) and cover
+        // terminal tasks that have already left the in-memory cache.
+        let turn_counts = match self.list_all_summaries_with_terminal().await {
+            Ok(summaries) => summaries
+                .into_iter()
+                .filter(|s| s.turn > 0)
+                .map(|s| s.turn)
+                .collect(),
+            Err(e) => {
+                tracing::warn!("collect_llm_metrics_inputs: summaries query failed: {e}");
+                vec![]
+            }
+        };
+
+        // Latencies: iterate cache refs in-place; never clone full TaskState.
+        // Find the first round that is not the synthetic resume marker and take
+        // its latency — that is the real "cold-start" latency for the task.
+        let mut first_token_latencies: Vec<u64> = Vec::new();
+        for entry in self.cache.iter() {
+            let task = entry.value();
+            if let Some(latency) = task
+                .rounds
+                .iter()
+                .find(|r| r.result != "resumed_checkpoint")
+                .and_then(|r| r.first_token_latency_ms)
+            {
+                first_token_latencies.push(latency);
+            }
+        }
+
+        LlmMetricsInputs {
+            turn_counts,
+            first_token_latencies,
         }
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -645,15 +645,13 @@ pub struct DashboardCounts {
 
 /// Lightweight inputs collected for LLM metrics computation.
 ///
-/// Turn counts span all tasks (active + terminal) via DB summaries so the
-/// queue-idle case returns real numbers.  Latencies come from the active
-/// cache only (no full `TaskState` clone) and skip synthetic
-/// `resumed_checkpoint` rounds so resumed tasks are not silently excluded.
+/// Bounded inputs for LLM metrics computation, collected in two O(1) phases:
+/// cache iteration (active tasks) then bounded SQL queries (terminal tasks).
 #[derive(Debug)]
 pub struct LlmMetricsInputs {
-    /// Non-zero turn counts across all tasks, active and terminal.
+    /// Non-zero turn counts from both active (cache) and terminal (DB) tasks.
     pub turn_counts: Vec<u32>,
-    /// First real first-token latency per active task (milliseconds).
+    /// First real first-token latency per task (milliseconds), from cache and DB.
     pub first_token_latencies: Vec<u64>,
 }
 
@@ -1043,43 +1041,34 @@ impl TaskStore {
 
     /// Collect lightweight inputs for LLM metrics computation.
     ///
-    /// **Turn counts** are fetched from `list_all_summaries_with_terminal` so
-    /// they include both active and historical terminal tasks.  When the queue
-    /// is idle this avoids reporting zeros that would misrepresent overall
-    /// throughput.
+    /// Both **turn counts** and **first-token latencies** are collected in two
+    /// bounded phases so the dashboard poll remains O(1) regardless of total
+    /// task history size:
     ///
-    /// **First-token latencies** are collected from two sources:
-    /// 1. The in-memory cache (active tasks + tasks completed this session):
-    ///    iterated via `DashMap` refs — no full `TaskState` clone.
-    /// 2. Terminal (done/failed) tasks in the DB that are no longer in the
-    ///    cache — needed so p50 is non-null after a restart with idle queue.
-    ///    Only `id` and `rounds` columns are fetched; latency is extracted
-    ///    with lightweight `serde_json::Value` parsing (no `RoundResult` alloc).
+    /// 1. **Cache phase** — iterate `DashMap` refs in-place (no full `TaskState`
+    ///    clone).  Records the IDs seen so phase 2 can deduplicate.
+    /// 2. **DB phase** — bounded SQL queries (`LIMIT 500`, `ORDER BY updated_at DESC`)
+    ///    return only scalar columns (`turn`, `first_token_latency_ms`) for the
+    ///    500 most-recently-completed terminal tasks not already counted from cache.
+    ///    This covers the idle-queue restart case without an unbounded table scan.
     ///
     /// Rounds whose `result` is `"resumed_checkpoint"` are skipped in both
     /// sources: they are synthetic markers with no real latency data.
     pub async fn collect_llm_metrics_inputs(&self) -> LlmMetricsInputs {
-        // Turn counts: DB summaries are lightweight (no rounds field) and cover
-        // terminal tasks that have already left the in-memory cache.
-        let turn_counts = match self.list_all_summaries_with_terminal().await {
-            Ok(summaries) => summaries
-                .into_iter()
-                .filter(|s| s.turn > 0)
-                .map(|s| s.turn)
-                .collect(),
-            Err(e) => {
-                tracing::warn!("collect_llm_metrics_inputs: summaries query failed: {e}");
-                vec![]
-            }
-        };
-
-        // Latencies — phase 1: iterate cache refs in-place; never clone full TaskState.
-        // Track IDs seen in cache so we can skip them in the DB query below.
+        // Phase 1: iterate cache refs in-place; never clone full TaskState.
+        // Collect both turn counts and latencies in a single pass, and track
+        // IDs seen so we can deduplicate against the DB queries in phase 2.
         let mut cache_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut turn_counts: Vec<u32> = Vec::new();
         let mut first_token_latencies: Vec<u64> = Vec::new();
         for entry in self.cache.iter() {
             let task = entry.value();
             cache_ids.insert(entry.key().0.clone());
+
+            if task.turn > 0 {
+                turn_counts.push(task.turn);
+            }
+
             // Skip the synthetic resumed_checkpoint round injected at recovery time,
             // then find the first round that actually received a response token.
             // Using find_map (instead of find + and_then) means transient_retry rounds
@@ -1096,12 +1085,28 @@ impl TaskStore {
             }
         }
 
-        // Latencies — phase 2: include terminal tasks from DB not already in cache.
-        // After restart with idle queue, cache is empty so without this the p50
-        // would be None even though latencies are persisted in the DB.
+        // Phase 2a: bounded DB query for terminal turn counts not in cache.
+        // After restart with idle queue the cache is empty; without this, turn
+        // counts would be zero even though history is persisted in the DB.
+        // `list_terminal_turn_counts` fetches only `id` and `turn` (no rounds
+        // blob) and is bounded to 500 rows ordered by updated_at DESC.
+        match self.db.list_terminal_turn_counts().await {
+            Ok(rows) => {
+                for (id, turn) in rows {
+                    if !cache_ids.contains(&id) && turn > 0 {
+                        turn_counts.push(turn as u32);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("collect_llm_metrics_inputs: DB turn counts query failed: {e}");
+            }
+        }
+
+        // Phase 2b: bounded DB query for terminal latencies not in cache.
         // `list_terminal_first_token_latencies_ms` extracts the scalar in SQL via
         // json_extract (no full rounds blob in Rust memory) and is bounded to the
-        // 500 most-recent terminal tasks so each dashboard poll stays O(1).
+        // 500 most-recently-completed terminal tasks so each dashboard poll stays O(1).
         match self.db.list_terminal_first_token_latencies_ms().await {
             Ok(rows) => {
                 for (id, latency_opt) in rows {

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1075,11 +1075,17 @@ impl TaskStore {
         let mut first_token_latencies: Vec<u64> = Vec::new();
         for entry in self.cache.iter() {
             let task = entry.value();
+            // Skip the synthetic resumed_checkpoint round injected at recovery time,
+            // then find the first round that actually received a response token.
+            // Using find_map (instead of find + and_then) means transient_retry rounds
+            // whose first_token_latency_ms is None are also skipped, so a task with
+            // one or more transient failures before a successful round is still included
+            // in p50 using the latency of that successful round.
             if let Some(latency) = task
                 .rounds
                 .iter()
-                .find(|r| r.result != "resumed_checkpoint")
-                .and_then(|r| r.first_token_latency_ms)
+                .filter(|r| r.result != "resumed_checkpoint")
+                .find_map(|r| r.first_token_latency_ms)
             {
                 first_token_latencies.push(latency);
             }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1048,12 +1048,16 @@ impl TaskStore {
     /// is idle this avoids reporting zeros that would misrepresent overall
     /// throughput.
     ///
-    /// **First-token latencies** are read directly from the in-memory cache
-    /// entries using `DashMap` references — no full `TaskState` is cloned, so
-    /// large `rounds.detail` strings are never materialised on the heap.
-    /// Rounds whose `result` is `"resumed_checkpoint"` are skipped: they are
-    /// synthetic markers with no real latency data and would silently exclude
-    /// the recovered task from the p50 calculation.
+    /// **First-token latencies** are collected from two sources:
+    /// 1. The in-memory cache (active tasks + tasks completed this session):
+    ///    iterated via `DashMap` refs — no full `TaskState` clone.
+    /// 2. Terminal (done/failed) tasks in the DB that are no longer in the
+    ///    cache — needed so p50 is non-null after a restart with idle queue.
+    ///    Only `id` and `rounds` columns are fetched; latency is extracted
+    ///    with lightweight `serde_json::Value` parsing (no `RoundResult` alloc).
+    ///
+    /// Rounds whose `result` is `"resumed_checkpoint"` are skipped in both
+    /// sources: they are synthetic markers with no real latency data.
     pub async fn collect_llm_metrics_inputs(&self) -> LlmMetricsInputs {
         // Turn counts: DB summaries are lightweight (no rounds field) and cover
         // terminal tasks that have already left the in-memory cache.
@@ -1069,12 +1073,13 @@ impl TaskStore {
             }
         };
 
-        // Latencies: iterate cache refs in-place; never clone full TaskState.
-        // Find the first round that is not the synthetic resume marker and take
-        // its latency — that is the real "cold-start" latency for the task.
+        // Latencies — phase 1: iterate cache refs in-place; never clone full TaskState.
+        // Track IDs seen in cache so we can skip them in the DB query below.
+        let mut cache_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut first_token_latencies: Vec<u64> = Vec::new();
         for entry in self.cache.iter() {
             let task = entry.value();
+            cache_ids.insert(entry.key().0.clone());
             // Skip the synthetic resumed_checkpoint round injected at recovery time,
             // then find the first round that actually received a response token.
             // Using find_map (instead of find + and_then) means transient_retry rounds
@@ -1088,6 +1093,39 @@ impl TaskStore {
                 .find_map(|r| r.first_token_latency_ms)
             {
                 first_token_latencies.push(latency);
+            }
+        }
+
+        // Latencies — phase 2: include terminal tasks from DB not already in cache.
+        // After restart with idle queue, cache is empty so without this the p50
+        // would be None even though latencies are persisted in the DB.
+        // Uses (id, rounds_json) rows — no RoundResult deserialization — to keep
+        // the per-call footprint proportional to the number of terminal tasks.
+        match self.db.list_terminal_rounds_json().await {
+            Ok(rows) => {
+                for (id, rounds_json) in rows {
+                    if cache_ids.contains(&id) {
+                        // Already counted via cache iteration above.
+                        continue;
+                    }
+                    if let Ok(serde_json::Value::Array(rounds)) =
+                        serde_json::from_str::<serde_json::Value>(&rounds_json)
+                    {
+                        if let Some(latency) = rounds
+                            .iter()
+                            .filter(|r| {
+                                r.get("result").and_then(|v| v.as_str())
+                                    != Some("resumed_checkpoint")
+                            })
+                            .find_map(|r| r.get("first_token_latency_ms").and_then(|v| v.as_u64()))
+                        {
+                            first_token_latencies.push(latency);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("collect_llm_metrics_inputs: DB terminal latency query failed: {e}");
             }
         }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1058,12 +1058,23 @@ impl TaskStore {
         // Phase 1: iterate cache refs in-place; never clone full TaskState.
         // Collect both turn counts and latencies in a single pass, and track
         // IDs seen so we can deduplicate against the DB queries in phase 2.
+        //
+        // Only terminal (done/failed) tasks are counted so the cache phase matches
+        // DB phase semantics: both sources use the same status set.  Non-terminal
+        // task IDs are still inserted into `cache_ids` so the DB deduplication
+        // logic remains correct (we never double-count a task that transitions to
+        // terminal while the DB query is in-flight).
         let mut cache_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut turn_counts: Vec<u32> = Vec::new();
         let mut first_token_latencies: Vec<u64> = Vec::new();
         for entry in self.cache.iter() {
             let task = entry.value();
             cache_ids.insert(entry.key().0.clone());
+
+            // Skip non-terminal tasks to match the DB phase (done/failed only).
+            if !matches!(task.status, TaskStatus::Done | TaskStatus::Failed) {
+                continue;
+            }
 
             if task.turn > 0 {
                 turn_counts.push(task.turn);


### PR DESCRIPTION
## Summary

Implements [#624](https://github.com/majiayu000/harness/issues/624) — LLM-specific observability metrics for the harness agent orchestration layer.

- **`linter_feedback_count`** — counts `Block`/`Escalate` rule_check events per session; high values signal the agent is stuck in a build-failure loop
- **`p50_turns`** — median turns-per-task derived from in-memory `TaskSummary.turn` (zero new DB calls)
- **`first_token_latency_ms`** — SSE first-token latency tracked inside `run_agent_streaming` using `Instant`, stored in `RoundResult.first_token_latency_ms: Option<u64>`
- **`GET /api/dashboard`** extended with a `llm_metrics` block: `{ avg_turns, p50_turns, total_linter_feedback, p50_first_token_latency_ms }`

## Test plan

- [ ] `cargo test --package harness-observe` — 8 new unit tests for `linter_feedback_count` and `p50_turns`
- [ ] `cargo test --workspace` — all 695+ existing tests still pass
- [ ] `GET /api/dashboard` response includes `llm_metrics` key with correct schema
- [ ] `RoundResult` deserialization backward-compatible (`first_token_latency_ms` defaults to `None`)