### PR TITLE
feat(config): auto-discover config file from XDG/OS-standard paths

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -277,7 +277,11 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             "config loaded from --config flag: {}",
             config_path.display()
         );
-        toml::from_str(&content)?
+        let mut cfg: harness_core::config::HarnessConfig = toml::from_str(&content)?;
+        if let Some(dir) = config_path.parent() {
+            cfg.rebase_relative_paths(dir);
+        }
+        cfg
     } else if let Some(discovered) = harness_core::config::dirs::find_config_file() {
         let content = std::fs::read_to_string(&discovered)?;
         tracing::info!("config loaded from {}", discovered.display());

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -273,8 +273,17 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
     // Load config
     let mut config: harness_core::config::HarnessConfig = if let Some(config_path) = &cli.config {
         let content = std::fs::read_to_string(config_path)?;
+        tracing::info!(
+            "config loaded from --config flag: {}",
+            config_path.display()
+        );
+        toml::from_str(&content)?
+    } else if let Some(discovered) = harness_core::config::dirs::find_config_file() {
+        let content = std::fs::read_to_string(&discovered)?;
+        tracing::info!("config loaded from {}", discovered.display());
         toml::from_str(&content)?
     } else {
+        tracing::warn!("no config file found, using built-in defaults");
         harness_core::config::HarnessConfig::default()
     };
     // Apply env var overrides for all subcommands so that HARNESS_DATA_DIR,

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -281,7 +281,14 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
     } else if let Some(discovered) = harness_core::config::dirs::find_config_file() {
         let content = std::fs::read_to_string(&discovered)?;
         tracing::info!("config loaded from {}", discovered.display());
-        toml::from_str(&content)?
+        let mut cfg: harness_core::config::HarnessConfig = toml::from_str(&content)?;
+        // Rebase relative paths against the config file's directory so that a
+        // global config like `project_root = "."` resolves relative to the
+        // config file rather than the operator's working directory.
+        if let Some(dir) = discovered.parent() {
+            cfg.rebase_relative_paths(dir);
+        }
+        cfg
     } else {
         tracing::warn!("no config file found, using built-in defaults");
         harness_core::config::HarnessConfig::default()

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -64,6 +64,28 @@ impl HarnessConfig {
         self.server.apply_env_overrides()?;
         Ok(())
     }
+
+    /// Rebase all relative `PathBuf` fields against `base`.
+    ///
+    /// Call this immediately after loading a config from a discovered file so
+    /// that relative paths (e.g. `project_root = "."`) resolve against the
+    /// config file's parent directory rather than the process working directory.
+    /// Paths that are already absolute are left unchanged.
+    pub fn rebase_relative_paths(&mut self, base: &std::path::Path) {
+        fn rebase(path: &mut PathBuf, base: &std::path::Path) {
+            if path.is_relative() {
+                *path = base.join(&*path);
+            }
+        }
+        rebase(&mut self.server.data_dir, base);
+        rebase(&mut self.server.project_root, base);
+        for p in &mut self.server.allowed_project_roots {
+            rebase(p, base);
+        }
+        for entry in &mut self.projects {
+            rebase(&mut entry.root, base);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -524,6 +546,49 @@ mod tests {
     fn invalid_toml_returns_parse_error() {
         let result = toml::from_str::<HarnessConfig>("not valid toml {{{}}}");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn rebase_relative_paths_resolves_against_base() {
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = PathBuf::from("data");
+        config.server.project_root = PathBuf::from("repo");
+        config.server.allowed_project_roots = vec![PathBuf::from("allowed")];
+        config.projects = vec![ProjectEntry {
+            name: "p".into(),
+            root: PathBuf::from("projects/p"),
+            default: false,
+            default_agent: None,
+            max_concurrent: None,
+        }];
+
+        config.rebase_relative_paths(std::path::Path::new("/etc/harness"));
+
+        assert_eq!(config.server.data_dir, PathBuf::from("/etc/harness/data"));
+        assert_eq!(
+            config.server.project_root,
+            PathBuf::from("/etc/harness/repo")
+        );
+        assert_eq!(
+            config.server.allowed_project_roots,
+            vec![PathBuf::from("/etc/harness/allowed")]
+        );
+        assert_eq!(
+            config.projects[0].root,
+            PathBuf::from("/etc/harness/projects/p")
+        );
+    }
+
+    #[test]
+    fn rebase_relative_paths_leaves_absolute_paths_unchanged() {
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = PathBuf::from("/absolute/data");
+        config.server.project_root = PathBuf::from("/absolute/repo");
+
+        config.rebase_relative_paths(std::path::Path::new("/etc/harness"));
+
+        assert_eq!(config.server.data_dir, PathBuf::from("/absolute/data"));
+        assert_eq!(config.server.project_root, PathBuf::from("/absolute/repo"));
     }
 
     #[test]

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -77,6 +77,13 @@ impl HarnessConfig {
                 *path = base.join(&*path);
             }
         }
+        fn rebase_opt(path: &mut Option<PathBuf>, base: &std::path::Path) {
+            if let Some(p) = path {
+                if p.is_relative() {
+                    *p = base.join(&*p);
+                }
+            }
+        }
         rebase(&mut self.server.data_dir, base);
         rebase(&mut self.server.project_root, base);
         for p in &mut self.server.allowed_project_roots {
@@ -85,6 +92,15 @@ impl HarnessConfig {
         for entry in &mut self.projects {
             rebase(&mut entry.root, base);
         }
+        for p in &mut self.rules.discovery_paths {
+            rebase(p, base);
+        }
+        rebase_opt(&mut self.rules.builtin_path, base);
+        for p in &mut self.rules.exec_policy_paths {
+            rebase(p, base);
+        }
+        rebase_opt(&mut self.rules.requirements_path, base);
+        rebase(&mut self.workspace.root, base);
     }
 }
 

--- a/crates/harness-core/src/config/dirs.rs
+++ b/crates/harness-core/src/config/dirs.rs
@@ -43,6 +43,59 @@ pub fn default_db_path(dir: &Path, name: &str) -> PathBuf {
     dir.join(format!("{name}.db"))
 }
 
+/// Probe OS-standard config locations and return the first that exists as a file.
+///
+/// Search order:
+/// 1. `$XDG_CONFIG_HOME/harness/config.toml` (or `~/.config/harness/config.toml`)
+/// 2. macOS: `$HOME/Library/Application Support/harness/config.toml`
+/// 3. Windows: `%APPDATA%\harness\config.toml`
+///
+/// Returns `None` if none of the candidates exist as a regular file.
+pub fn find_config_file() -> Option<PathBuf> {
+    for candidate in config_candidates() {
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn config_candidates() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // 1. $XDG_CONFIG_HOME/harness/config.toml
+    if let Some(xdg) = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".config"))
+        })
+    {
+        candidates.push(xdg.join("harness").join("config.toml"));
+    }
+
+    // 2. macOS: $HOME/Library/Application Support/harness/config.toml
+    #[cfg(target_os = "macos")]
+    if let Ok(home) = std::env::var("HOME") {
+        candidates.push(
+            PathBuf::from(home)
+                .join("Library/Application Support")
+                .join("harness")
+                .join("config.toml"),
+        );
+    }
+
+    // 3. Windows: %APPDATA%\harness\config.toml
+    #[cfg(target_os = "windows")]
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        candidates.push(PathBuf::from(appdata).join("harness").join("config.toml"));
+    }
+
+    candidates
+}
+
 fn data_local_dir() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
@@ -74,6 +127,7 @@ fn data_local_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     /// `dirs_data_dir()` must never return `"."` and must never panic,
     /// even when platform env vars (HOME / LOCALAPPDATA) are absent.
@@ -89,5 +143,94 @@ mod tests {
             PathBuf::from("."),
             "dirs_data_dir must not fall back to \".\""
         );
+    }
+
+    // Serialize env-var tests to prevent races when cargo runs tests in parallel.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env_vars<F: FnOnce()>(vars: &[(&str, &str)], f: F) {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // Save originals.
+        let saved: Vec<(&str, Option<String>)> = vars
+            .iter()
+            .map(|(k, _)| (*k, std::env::var(k).ok()))
+            .collect();
+        for (k, v) in vars {
+            // SAFETY: test-only, serialized by ENV_MUTEX.
+            unsafe { std::env::set_var(k, v) };
+        }
+        f();
+        // Restore.
+        for (k, orig) in &saved {
+            match orig {
+                Some(v) => unsafe { std::env::set_var(k, v) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+
+    /// When no config paths exist, `find_config_file` returns `None`.
+    #[test]
+    fn find_config_file_returns_none_when_nothing_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_str = dir.path().to_str().unwrap().to_owned();
+        with_env_vars(&[("XDG_CONFIG_HOME", &dir_str), ("HOME", &dir_str)], || {
+            assert!(find_config_file().is_none());
+        });
+    }
+
+    /// When `$XDG_CONFIG_HOME/harness/config.toml` exists, it is returned.
+    #[test]
+    fn find_config_file_finds_xdg_config_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("harness").join("config.toml");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, "").unwrap();
+        let dir_str = dir.path().to_str().unwrap().to_owned();
+        with_env_vars(&[("XDG_CONFIG_HOME", &dir_str), ("HOME", &dir_str)], || {
+            let found = find_config_file();
+            assert_eq!(found.as_deref(), Some(config_path.as_path()));
+        });
+    }
+
+    /// XDG path is preferred over the `~/.config` fallback.
+    #[test]
+    fn find_config_file_prefers_xdg_over_home() {
+        let xdg_dir = tempfile::tempdir().unwrap();
+        let home_dir = tempfile::tempdir().unwrap();
+
+        let xdg_config = xdg_dir.path().join("harness").join("config.toml");
+        fs::create_dir_all(xdg_config.parent().unwrap()).unwrap();
+        fs::write(&xdg_config, "# xdg").unwrap();
+
+        let home_config = home_dir
+            .path()
+            .join(".config")
+            .join("harness")
+            .join("config.toml");
+        fs::create_dir_all(home_config.parent().unwrap()).unwrap();
+        fs::write(&home_config, "# home").unwrap();
+
+        let xdg_str = xdg_dir.path().to_str().unwrap().to_owned();
+        let home_str = home_dir.path().to_str().unwrap().to_owned();
+        with_env_vars(
+            &[("XDG_CONFIG_HOME", &xdg_str), ("HOME", &home_str)],
+            || {
+                let found = find_config_file();
+                assert_eq!(found.as_deref(), Some(xdg_config.as_path()));
+            },
+        );
+    }
+
+    /// A directory at the candidate path must be skipped (not treated as a file).
+    #[test]
+    fn find_config_file_skips_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("harness").join("config.toml");
+        fs::create_dir_all(&config_dir).unwrap();
+        let dir_str = dir.path().to_str().unwrap().to_owned();
+        with_env_vars(&[("XDG_CONFIG_HOME", &dir_str), ("HOME", &dir_str)], || {
+            assert!(find_config_file().is_none());
+        });
     }
 }

--- a/crates/harness-core/src/config/dirs.rs
+++ b/crates/harness-core/src/config/dirs.rs
@@ -63,40 +63,46 @@ pub fn find_config_file() -> Option<PathBuf> {
 fn config_candidates() -> Vec<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
+    // Reject relative env-var values: accepting them would make harness probe
+    // paths relative to the process CWD, turning any directory an operator
+    // starts harness from into a config boundary and potentially loading
+    // attacker-controlled or accidental local config files.
+    let abs_home: Option<PathBuf> = std::env::var("HOME")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute());
+
     // 1. $XDG_CONFIG_HOME/harness/config.toml
     //    Per the XDG Base Directory Specification, XDG_CONFIG_HOME MUST be an
-    //    absolute path. Relative values are silently discarded: accepting them
-    //    would make harness probe paths relative to the process CWD, turning any
-    //    directory an operator starts harness from into a config boundary and
-    //    potentially loading attacker-controlled or accidental local config files.
+    //    absolute path. Relative values are silently discarded.
     if let Some(xdg) = std::env::var("XDG_CONFIG_HOME")
         .ok()
         .map(PathBuf::from)
         .filter(|p| p.is_absolute())
-        .or_else(|| {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| PathBuf::from(h).join(".config"))
-        })
+        .or_else(|| abs_home.as_ref().map(|h| h.join(".config")))
     {
         candidates.push(xdg.join("harness").join("config.toml"));
     }
 
     // 2. macOS: $HOME/Library/Application Support/harness/config.toml
     #[cfg(target_os = "macos")]
-    if let Ok(home) = std::env::var("HOME") {
+    if let Some(home) = &abs_home {
         candidates.push(
-            PathBuf::from(home)
-                .join("Library/Application Support")
+            home.join("Library/Application Support")
                 .join("harness")
                 .join("config.toml"),
         );
     }
 
     // 3. Windows: %APPDATA%\harness\config.toml
+    //    APPDATA must be absolute for the same reason as XDG_CONFIG_HOME.
     #[cfg(target_os = "windows")]
-    if let Ok(appdata) = std::env::var("APPDATA") {
-        candidates.push(PathBuf::from(appdata).join("harness").join("config.toml"));
+    if let Some(appdata) = std::env::var("APPDATA")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+    {
+        candidates.push(appdata.join("harness").join("config.toml"));
     }
 
     candidates

--- a/crates/harness-core/src/config/dirs.rs
+++ b/crates/harness-core/src/config/dirs.rs
@@ -52,12 +52,9 @@ pub fn default_db_path(dir: &Path, name: &str) -> PathBuf {
 ///
 /// Returns `None` if none of the candidates exist as a regular file.
 pub fn find_config_file() -> Option<PathBuf> {
-    for candidate in config_candidates() {
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+    config_candidates()
+        .into_iter()
+        .find(|candidate| candidate.is_file())
 }
 
 fn config_candidates() -> Vec<PathBuf> {

--- a/crates/harness-core/src/config/dirs.rs
+++ b/crates/harness-core/src/config/dirs.rs
@@ -64,9 +64,15 @@ fn config_candidates() -> Vec<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
     // 1. $XDG_CONFIG_HOME/harness/config.toml
+    //    Per the XDG Base Directory Specification, XDG_CONFIG_HOME MUST be an
+    //    absolute path. Relative values are silently discarded: accepting them
+    //    would make harness probe paths relative to the process CWD, turning any
+    //    directory an operator starts harness from into a config boundary and
+    //    potentially loading attacker-controlled or accidental local config files.
     if let Some(xdg) = std::env::var("XDG_CONFIG_HOME")
         .ok()
         .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
         .or_else(|| {
             std::env::var("HOME")
                 .ok()
@@ -218,6 +224,21 @@ mod tests {
             || {
                 let found = find_config_file();
                 assert_eq!(found.as_deref(), Some(xdg_config.as_path()));
+            },
+        );
+    }
+
+    /// Relative XDG_CONFIG_HOME values must be rejected (XDG spec requires absolute paths).
+    #[test]
+    fn find_config_file_rejects_relative_xdg_config_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let home_str = dir.path().to_str().unwrap().to_owned();
+        // XDG_CONFIG_HOME is relative ("relative/path") — must be ignored and fall
+        // through to HOME-based ~/.config which does not exist in this temp dir.
+        with_env_vars(
+            &[("XDG_CONFIG_HOME", "relative/path"), ("HOME", &home_str)],
+            || {
+                assert!(find_config_file().is_none());
             },
         );
     }


### PR DESCRIPTION
## Summary

- Add `find_config_file()` to `harness-core/src/config/dirs.rs` that probes XDG/OS-standard paths in priority order (`$XDG_CONFIG_HOME`, `~/.config`, macOS `Application Support`, Windows `%APPDATA%`) and returns the first that exists as a file
- Update config-loading block in `commands.rs` to call discovery when `--config` is not supplied, with INFO log on success and WARN log when falling back to defaults
- 4 new unit tests covering: no-file, XDG found, XDG-over-HOME preference, directory-skipped

## Test plan

- [ ] `cargo test --package harness-core` — 4 new `find_config_file_*` tests pass
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] Startup without config file emits: `WARN no config file found, using built-in defaults`
- [ ] Startup with `~/.config/harness/config.toml` present emits: `INFO config loaded from <path>`
- [ ] `--config <path>` flag still works and emits: `INFO config loaded from --config flag: <path>`

Closes #691