### PR TITLE
fix(prompts): remove stale worktree dir before git worktree add (#730)

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -54,8 +54,8 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
          1. Create an isolated worktree:\n\
             ```\n\
             git fetch origin {branch}\n\
+            git worktree remove --force /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
             git worktree prune\n\
-            rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
             git worktree add /tmp/harness-pr-{pr_number} {branch}\n\
             ```\n\
          2. Read the PR diff and any review comments:\n\
@@ -369,8 +369,8 @@ pub fn review_prompt(
          IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
+           git worktree remove --force /tmp/harness-review-{pr} 2>/dev/null || true\n\
            git worktree prune\n\
-           rm -rf /tmp/harness-review-{pr} 2>/dev/null || true\n\
            git worktree add /tmp/harness-review-{pr} <branch>\n\
          Then do all editing, testing, and pushing from /tmp/harness-review-{pr},\n\
          and remove it when done: git worktree remove /tmp/harness-review-{pr}\n\

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -55,6 +55,7 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
             ```\n\
             git fetch origin {branch}\n\
             git worktree prune\n\
+            rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
             git worktree add /tmp/harness-pr-{pr_number} {branch}\n\
             ```\n\
          2. Read the PR diff and any review comments:\n\
@@ -369,6 +370,7 @@ pub fn review_prompt(
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
            git worktree prune\n\
+           rm -rf /tmp/harness-review-{pr} 2>/dev/null || true\n\
            git worktree add /tmp/harness-review-{pr} <branch>\n\
          Then do all editing, testing, and pushing from /tmp/harness-review-{pr},\n\
          and remove it when done: git worktree remove /tmp/harness-review-{pr}\n\

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -54,7 +54,7 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
          1. Create an isolated worktree:\n\
             ```\n\
             git fetch origin {branch}\n\
-            git worktree remove --force /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
+            git worktree remove /tmp/harness-pr-{pr_number} 2>/dev/null || rm -rf /tmp/harness-pr-{pr_number} 2>/dev/null || true\n\
             git worktree prune\n\
             git worktree add /tmp/harness-pr-{pr_number} {branch}\n\
             ```\n\
@@ -369,7 +369,7 @@ pub fn review_prompt(
          IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
          If you need to modify files, first create an isolated worktree:\n\
            git fetch origin <branch>\n\
-           git worktree remove --force /tmp/harness-review-{pr} 2>/dev/null || true\n\
+           git worktree remove /tmp/harness-review-{pr} 2>/dev/null || rm -rf /tmp/harness-review-{pr} 2>/dev/null || true\n\
            git worktree prune\n\
            git worktree add /tmp/harness-review-{pr} <branch>\n\
          Then do all editing, testing, and pushing from /tmp/harness-review-{pr},\n\


### PR DESCRIPTION
## Summary

- `git worktree prune` only removes registered worktrees whose directories no longer exist; it cannot remove a directory that exists but was never registered (e.g. leftover from a SIGKILL'd task)
- When such a stale directory exists, `git worktree add` fails with `fatal: '<path>' already exists`, leaving the agent with no recovery path
- Add `rm -rf <path> 2>/dev/null || true` before `git worktree add` in both `continue_existing_pr` and `review_prompt` to handle this case

## Test plan

- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Verified changed lines in `crates/harness-core/src/prompts.rs` at both prompt locations

Fixes #730