### PR TITLE
fix(task_db): stop writing error field for resumed tasks on recovery

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -539,11 +539,10 @@ impl TaskDb {
 
                 if needs_pr_url_writeback {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', pr_url = ?, error = ?, \
+                        "UPDATE tasks SET status = 'pending', pr_url = ?, \
                          updated_at = datetime('now') WHERE id = ?",
                     )
                     .bind(effective_pr_url)
-                    .bind(&reason)
                     .bind(&row.id)
                     .execute(&self.pool)
                     .await?;
@@ -555,10 +554,9 @@ impl TaskDb {
                     );
                 } else {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', error = ?, updated_at = datetime('now') \
+                        "UPDATE tasks SET status = 'pending', updated_at = datetime('now') \
                          WHERE id = ?",
                     )
-                    .bind(&reason)
                     .bind(&row.id)
                     .execute(&self.pool)
                     .await?;
@@ -1471,12 +1469,11 @@ mod tests {
             impl_pr.pr_url.as_deref() == Some("https://github.com/owner/repo/pull/42"),
             "pr_url should be preserved"
         );
-        let err = impl_pr.error.as_deref().unwrap_or("");
         assert!(
-            err.contains("resumed after restart"),
-            "error should note resumption"
+            impl_pr.error.is_none(),
+            "resumed task must not have error set, got {:?}",
+            impl_pr.error
         );
-        assert!(err.contains("pull/42"), "should reference PR URL");
 
         // Verify: agent_review with PR → pending (resumed)
         let review = db
@@ -1525,11 +1522,9 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("t-impl-plan should exist"))?;
         assert!(matches!(task.status, TaskStatus::Pending));
         assert!(
+            task.error.is_none(),
+            "resumed task must not have error set, got {:?}",
             task.error
-                .as_deref()
-                .unwrap_or("")
-                .contains("plan checkpoint"),
-            "error should mention plan checkpoint"
         );
 
         Ok(())

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -539,7 +539,7 @@ impl TaskDb {
 
                 if needs_pr_url_writeback {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', pr_url = ?, \
+                        "UPDATE tasks SET status = 'pending', error = NULL, pr_url = ?, \
                          updated_at = datetime('now') WHERE id = ?",
                     )
                     .bind(effective_pr_url)
@@ -554,8 +554,8 @@ impl TaskDb {
                     );
                 } else {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', updated_at = datetime('now') \
-                         WHERE id = ?",
+                        "UPDATE tasks SET status = 'pending', error = NULL, \
+                         updated_at = datetime('now') WHERE id = ?",
                     )
                     .bind(&row.id)
                     .execute(&self.pool)

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -146,14 +146,10 @@ async fn restart_with_pr_url_resumes_task() -> anyhow::Result<()> {
         Some("https://github.com/owner/repo/pull/42"),
         "pr_url must be preserved after resume"
     );
-    let err = task.error.as_deref().unwrap_or("");
     assert!(
-        err.contains("resumed after restart"),
-        "error should note resumption, got: {err:?}"
-    );
-    assert!(
-        err.contains("pull/42"),
-        "error should reference the PR URL, got: {err:?}"
+        task.error.is_none(),
+        "resumed task must not have error set, got {:?}",
+        task.error
     );
 
     Ok(())
@@ -185,10 +181,10 @@ async fn restart_with_checkpoint_pr_url_resumes_task() -> anyhow::Result<()> {
         "task with checkpoint PR URL should resume, got {:?}",
         task.status
     );
-    let err = task.error.as_deref().unwrap_or("");
     assert!(
-        err.contains("resumed after restart"),
-        "error should note resumption, got: {err:?}"
+        task.error.is_none(),
+        "resumed task must not have error set, got {:?}",
+        task.error
     );
 
     Ok(())
@@ -220,10 +216,10 @@ async fn restart_with_plan_checkpoint_resumes_task() -> anyhow::Result<()> {
         "task with plan checkpoint should resume, got {:?}",
         task.status
     );
-    let err = task.error.as_deref().unwrap_or("");
     assert!(
-        err.contains("plan checkpoint"),
-        "error should mention plan checkpoint, got: {err:?}"
+        task.error.is_none(),
+        "resumed task must not have error set, got {:?}",
+        task.error
     );
 
     Ok(())
@@ -255,10 +251,10 @@ async fn restart_with_triage_checkpoint_resumes_task() -> anyhow::Result<()> {
         "task with triage checkpoint should resume, got {:?}",
         task.status
     );
-    let err = task.error.as_deref().unwrap_or("");
     assert!(
-        err.contains("triage checkpoint"),
-        "error should mention triage checkpoint, got: {err:?}"
+        task.error.is_none(),
+        "resumed task must not have error set, got {:?}",
+        task.error
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Remove `error = ?` from both resume-path `UPDATE` queries in `recover_in_progress()` so tasks resumed from restart checkpoints no longer appear as failures in the dashboard
- The diagnostic reason string is preserved in `tracing::info!` — no observability lost
- True failure paths (`status = 'failed'`) are unaffected

## Test plan

- [ ] `restart_with_pr_url_resumes_task`: asserts `task.error.is_none()` and `status == Pending`, `pr_url` preserved
- [ ] `restart_with_checkpoint_pr_url_resumes_task`: asserts `task.error.is_none()` and `status == Pending`
- [ ] `restart_with_plan_checkpoint_resumes_task`: asserts `task.error.is_none()` and `status == Pending`
- [ ] `restart_with_triage_checkpoint_resumes_task`: asserts `task.error.is_none()` and `status == Pending`
- [ ] `restart_no_checkpoint_fails_interrupted_tasks`: unchanged — failed tasks still get `error = "recovered after restart …"`
- [ ] `restart_transient_retry_task_fails`: unchanged — transient error detection unaffected
- [ ] `restart_mixed_recovery_counts`: count assertions unchanged
- [ ] Inline unit test in `task_db.rs`: `error.is_none()` for resumed tasks

All 7 integration tests + inline unit tests pass: `cargo test --package harness-server --test checkpoint_recovery`

Closes #696