### PR TITLE
refactor: unify AgentRegistry and AdapterRegistry into descriptor registry (#687)

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -479,14 +479,8 @@ mod tests {
         let req_no_phase = AgentRequest::default();
 
         assert_eq!(agent.resolve_model(&req_planning), "claude-opus-4-6");
-        assert_eq!(
-            agent.resolve_model(&req_execution),
-            "claude-sonnet-4-6"
-        );
-        assert_eq!(
-            agent.resolve_model(&req_validation),
-            "claude-opus-4-6"
-        );
+        assert_eq!(agent.resolve_model(&req_execution), "claude-sonnet-4-6");
+        assert_eq!(agent.resolve_model(&req_validation), "claude-opus-4-6");
         // No phase → falls back to default_model
         assert_eq!(agent.resolve_model(&req_no_phase), "default-model");
     }

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -69,7 +69,10 @@ impl CodexAgent {
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
-            OsString::from(format!("model_reasoning_effort=\"{}\"", self.reasoning_effort)),
+            OsString::from(format!(
+                "model_reasoning_effort=\"{}\"",
+                self.reasoning_effort
+            )),
             OsString::from("-s"),
             OsString::from(codex_sandbox_mode(self.sandbox_mode)),
         ];

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -5,7 +5,8 @@ use harness_core::{
 use serde_json::json;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::ChildStdout;
 use tokio::sync::{mpsc, Mutex};
 use tracing;
 
@@ -19,9 +20,14 @@ pub struct CodexAdapter {
     state: Arc<Mutex<AdapterState>>,
 }
 
+/// Persistent stdout reader kept alive across turns.
+type StdoutLines = Lines<BufReader<ChildStdout>>;
+
 struct AdapterState {
     child: Option<tokio::process::Child>,
     stdin: Option<tokio::process::ChildStdin>,
+    /// Stdout reader persisted between turns so subsequent turns can read events.
+    stdout_lines: Option<StdoutLines>,
     next_id: u64,
 }
 
@@ -30,6 +36,7 @@ impl AdapterState {
         Self {
             child: None,
             stdin: None,
+            stdout_lines: None,
             next_id: 1,
         }
     }
@@ -161,9 +168,8 @@ impl AgentAdapter for CodexAdapter {
             // Initialize handshake
             Self::send_request(&mut state, "initialize", json!({})).await?;
 
-            // Read initialize response (blocking on first line)
-            let reader = tokio::io::BufReader::new(stdout);
-            let mut lines = reader.lines();
+            // Persist the stdout reader across turns so subsequent turns can read events.
+            let mut lines = BufReader::new(stdout).lines();
 
             // Read init response
             if let Ok(Some(line)) = lines.next_line().await {
@@ -173,49 +179,51 @@ impl AgentAdapter for CodexAdapter {
             // Send initialized notification
             Self::send_notification(&mut state, "initialized").await?;
 
-            // Send turn/start
-            Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
+            state.stdout_lines = Some(lines);
+        }
 
-            // Release lock before reading event stream
-            drop(state);
+        // Send turn/start for both first and subsequent turns.
+        Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
 
-            if tx.send(AgentEvent::TurnStarted).await.is_err() {
-                return Ok(());
+        // Take the persistent stdout reader out of state so we can read from it
+        // without holding the lock (which would block concurrent steer/interrupt calls).
+        let mut lines = state.stdout_lines.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex stdout reader not available".into(),
+            )
+        })?;
+
+        // Release state lock before blocking on stdout.
+        drop(state);
+
+        if tx.send(AgentEvent::TurnStarted).await.is_err() {
+            // Put reader back so future turns can still use it.
+            self.state.lock().await.stdout_lines = Some(lines);
+            return Ok(());
+        }
+
+        // Read event stream until the turn completes or the channel closes.
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
             }
 
-            // Read event stream until turn completes
-            let mut output_buf = String::new();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if line.trim().is_empty() {
-                    continue;
+            if let Some(event) = parse_codex_message(&line) {
+                let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
+                let is_error = matches!(event, AgentEvent::Error { .. });
+
+                if tx.send(event).await.is_err() {
+                    break;
                 }
 
-                if let Some(event) = parse_codex_message(&line) {
-                    if let AgentEvent::MessageDelta { ref text } = event {
-                        output_buf.push_str(text);
-                    }
-
-                    let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
-                    let is_error = matches!(event, AgentEvent::Error { .. });
-
-                    if tx.send(event).await.is_err() {
-                        break;
-                    }
-
-                    if is_turn_completed || is_error {
-                        break;
-                    }
+                if is_turn_completed || is_error {
+                    break;
                 }
-            }
-        } else {
-            // Already running — just send a new turn
-            Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
-            drop(state);
-
-            if let Err(e) = tx.send(AgentEvent::TurnStarted).await {
-                tracing::debug!("stream channel closed: {e}");
             }
         }
+
+        // Return the reader to state for the next turn.
+        self.state.lock().await.stdout_lines = Some(lines);
 
         Ok(())
     }

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -5,8 +5,17 @@ use harness_core::{
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Bundles an agent executor with an optional interactive adapter.
+///
+/// A descriptor is created with `adapter: None` on plain `register()` calls.
+/// Call `register_adapter()` to attach an adapter after the agent is registered.
+pub struct AgentDescriptor {
+    pub agent: Arc<dyn CodeAgent>,
+    pub adapter: Option<Arc<dyn AgentAdapter>>,
+}
+
 pub struct AgentRegistry {
-    agents: HashMap<String, Arc<dyn CodeAgent>>,
+    entries: HashMap<String, AgentDescriptor>,
     registration_order: Vec<String>,
     default_agent: String,
     complexity_preferred_agents: Vec<String>,
@@ -15,7 +24,7 @@ pub struct AgentRegistry {
 impl AgentRegistry {
     pub fn new(default_agent: impl Into<String>) -> Self {
         Self {
-            agents: HashMap::new(),
+            entries: HashMap::new(),
             registration_order: Vec::new(),
             default_agent: default_agent.into(),
             complexity_preferred_agents: Vec::new(),
@@ -32,27 +41,59 @@ impl AgentRegistry {
 
     pub fn register(&mut self, name: impl Into<String>, agent: Arc<dyn CodeAgent>) {
         let name = name.into();
-        if !self.agents.contains_key(&name) {
+        if !self.entries.contains_key(&name) {
             self.registration_order.push(name.clone());
         }
-        self.agents.insert(name, agent);
+        self.entries.insert(
+            name,
+            AgentDescriptor {
+                agent,
+                adapter: None,
+            },
+        );
+    }
+
+    /// Attach an adapter to an already-registered agent.
+    ///
+    /// Returns `Err(HarnessError::AgentNotFound)` if the agent name is unknown,
+    /// so misconfiguration fails loudly instead of silently (U-23).
+    pub fn register_adapter(
+        &mut self,
+        name: &str,
+        adapter: Arc<dyn AgentAdapter>,
+    ) -> harness_core::error::Result<()> {
+        match self.entries.get_mut(name) {
+            Some(descriptor) => {
+                descriptor.adapter = Some(adapter);
+                Ok(())
+            }
+            None => Err(HarnessError::AgentNotFound(format!(
+                "cannot register adapter: agent '{}' not found",
+                name
+            ))),
+        }
     }
 
     pub fn get(&self, name: &str) -> Option<Arc<dyn CodeAgent>> {
-        self.agents.get(name).cloned()
+        self.entries.get(name).map(|d| d.agent.clone())
+    }
+
+    /// Return the adapter registered for the given agent name, if any.
+    pub fn get_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
+        self.entries.get(name).and_then(|d| d.adapter.clone())
     }
 
     pub fn resolved_default_agent_name(&self) -> Option<&str> {
         let configured = self.default_agent.trim();
         if !configured.is_empty()
             && !configured.eq_ignore_ascii_case("auto")
-            && self.agents.contains_key(configured)
+            && self.entries.contains_key(configured)
         {
             return Some(configured);
         }
         self.registration_order
             .iter()
-            .find(|name| self.agents.contains_key(name.as_str()))
+            .find(|name| self.entries.contains_key(name.as_str()))
             .map(String::as_str)
     }
 
@@ -80,40 +121,6 @@ impl AgentRegistry {
 
     pub fn list(&self) -> Vec<&str> {
         self.registration_order.iter().map(|k| k.as_str()).collect()
-    }
-}
-
-/// Registry for streaming `AgentAdapter` implementations.
-///
-/// Coexists with `AgentRegistry` — when an adapter is available for a given
-/// agent name, the task executor prefers it over the legacy `CodeAgent` path.
-pub struct AdapterRegistry {
-    adapters: HashMap<String, Arc<dyn AgentAdapter>>,
-    default_adapter: String,
-}
-
-impl AdapterRegistry {
-    pub fn new(default_adapter: impl Into<String>) -> Self {
-        Self {
-            adapters: HashMap::new(),
-            default_adapter: default_adapter.into(),
-        }
-    }
-
-    pub fn register(&mut self, name: impl Into<String>, adapter: Arc<dyn AgentAdapter>) {
-        self.adapters.insert(name.into(), adapter);
-    }
-
-    pub fn get(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
-        self.adapters.get(name).cloned()
-    }
-
-    pub fn default_adapter(&self) -> Option<Arc<dyn AgentAdapter>> {
-        self.get(&self.default_adapter)
-    }
-
-    pub fn list(&self) -> Vec<&str> {
-        self.adapters.keys().map(|k| k.as_str()).collect()
     }
 }
 
@@ -328,49 +335,79 @@ mod tests {
     }
 
     #[test]
-    fn adapter_registry_register_and_get_roundtrip() {
-        let mut registry = AdapterRegistry::new("mock");
-        registry.register(
-            "mock",
-            Arc::new(StubAdapter {
-                adapter_name: "mock",
-            }),
-        );
+    fn register_adapter_and_get_roundtrip() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+            )
+            .unwrap();
 
-        let adapter = registry.get("mock");
+        let adapter = registry.get_adapter("mock");
         assert!(adapter.is_some());
         assert_eq!(adapter.unwrap().name(), "mock");
     }
 
     #[test]
-    fn adapter_registry_default_adapter_uses_configured_name() {
-        let mut registry = AdapterRegistry::new("mock");
-        registry.register(
-            "mock",
+    fn register_adapter_on_unknown_agent_returns_error() {
+        let mut registry = AgentRegistry::new("");
+        let result = registry.register_adapter(
+            "ghost",
             Arc::new(StubAdapter {
-                adapter_name: "mock",
+                adapter_name: "ghost",
             }),
         );
-
-        let adapter = registry.default_adapter();
-        assert!(adapter.is_some());
-        assert_eq!(adapter.unwrap().name(), "mock");
+        assert!(matches!(result, Err(HarnessError::AgentNotFound(_))));
     }
 
     #[test]
-    fn adapter_registry_default_adapter_missing_returns_none() {
-        let registry = AdapterRegistry::new("missing");
-        assert!(registry.default_adapter().is_none());
+    fn get_adapter_returns_none_when_not_registered() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+
+        assert!(registry.get_adapter("mock").is_none());
     }
 
     #[test]
-    fn adapter_registry_list_returns_registered_names() {
-        let mut registry = AdapterRegistry::new("a");
-        registry.register("a", Arc::new(StubAdapter { adapter_name: "a" }));
-        registry.register("b", Arc::new(StubAdapter { adapter_name: "b" }));
+    fn register_creates_descriptor_with_no_adapter() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
 
-        let mut names = registry.list();
-        names.sort_unstable();
+        assert!(registry.get_adapter("mock").is_none());
+        assert!(registry.get("mock").is_some());
+    }
+
+    #[test]
+    fn dispatch_regression_returns_descriptor_agent() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+            )
+            .unwrap();
+
+        // dispatch() must still return the CodeAgent, not the adapter
+        let agent = registry
+            .dispatch(&classification(TaskComplexity::Simple))
+            .unwrap();
+        assert_eq!(agent.name(), "mock");
+    }
+
+    #[test]
+    fn list_returns_registered_agent_names_in_order() {
+        let mut registry = AgentRegistry::new("a");
+        registry.register("a", Arc::new(StubAgent { agent_name: "a" }));
+        registry.register("b", Arc::new(StubAgent { agent_name: "b" }));
+
+        let names = registry.list();
         assert_eq!(names, vec!["a", "b"]);
     }
 }

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -41,6 +41,10 @@ impl AgentRegistry {
 
     pub fn register(&mut self, name: impl Into<String>, agent: Arc<dyn CodeAgent>) {
         let name = name.into();
+        // Preserve any previously attached adapter so that hot-reload cannot
+        // accidentally clear the adapter by re-registering the agent under the
+        // same name (the old split-registry design had this property naturally).
+        let existing_adapter = self.entries.get(&name).and_then(|d| d.adapter.clone());
         if !self.entries.contains_key(&name) {
             self.registration_order.push(name.clone());
         }
@@ -48,7 +52,7 @@ impl AgentRegistry {
             name,
             AgentDescriptor {
                 agent,
-                adapter: None,
+                adapter: existing_adapter,
             },
         );
     }
@@ -399,6 +403,37 @@ mod tests {
             .dispatch(&classification(TaskComplexity::Simple))
             .unwrap();
         assert_eq!(agent.name(), "mock");
+    }
+
+    #[test]
+    fn re_register_preserves_existing_adapter() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+            )
+            .unwrap();
+
+        // Re-registering with a new agent must not clear the adapter.
+        registry.register(
+            "mock",
+            Arc::new(StubAgent {
+                agent_name: "mock-v2",
+            }),
+        );
+
+        let adapter = registry.get_adapter("mock");
+        assert!(
+            adapter.is_some(),
+            "adapter must survive re-registration of the same agent name"
+        );
+        assert_eq!(adapter.unwrap().name(), "mock");
+        // The agent itself must be updated.
+        assert_eq!(registry.get("mock").unwrap().name(), "mock-v2");
     }
 
     #[test]

--- a/crates/harness-cli/src/cmd/mcp_server.rs
+++ b/crates/harness-cli/src/cmd/mcp_server.rs
@@ -1,5 +1,8 @@
 use anyhow::Context;
-use harness_agents::{claude::ClaudeCodeAgent, codex::CodexAgent, registry::AgentRegistry};
+use harness_agents::{
+    claude::ClaudeCodeAgent, claude_adapter::ClaudeAdapter, codex::CodexAgent,
+    codex_adapter::CodexAdapter, registry::AgentRegistry,
+};
 use harness_core::{agent::AgentRequest, config::HarnessConfig, prompts, types::ThreadId};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -497,6 +500,15 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
             .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
     );
+    agent_registry
+        .register_adapter(
+            "claude",
+            Arc::new(ClaudeAdapter::new(
+                config.agents.claude.cli_path.clone(),
+                config.agents.claude.default_model.clone(),
+            )),
+        )
+        .context("failed to attach claude adapter")?;
     agent_registry.register(
         "codex",
         Arc::new(
@@ -504,6 +516,12 @@ pub async fn run(config: HarnessConfig) -> anyhow::Result<()> {
                 .with_stream_timeout(config.agents.stream_timeout_secs),
         ),
     );
+    agent_registry
+        .register_adapter(
+            "codex",
+            Arc::new(CodexAdapter::new(config.agents.codex.cli_path.clone())),
+        )
+        .context("failed to attach codex adapter")?;
 
     let default_agent_name = agent_registry
         .resolved_default_agent_name()

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -197,6 +197,15 @@ pub async fn run(
     }
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
     agent_registry.register("claude", Arc::new(claude_agent));
+    agent_registry
+        .register_adapter(
+            "claude",
+            Arc::new(harness_agents::claude_adapter::ClaudeAdapter::new(
+                serve_config.agents.claude.cli_path.clone(),
+                serve_config.agents.claude.default_model.clone(),
+            )),
+        )
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     agent_registry.register(
         "codex",
         Arc::new(
@@ -207,6 +216,14 @@ pub async fn run(
             .with_stream_timeout(serve_config.agents.stream_timeout_secs),
         ),
     );
+    agent_registry
+        .register_adapter(
+            "codex",
+            Arc::new(harness_agents::codex_adapter::CodexAdapter::new(
+                serve_config.agents.codex.cli_path.clone(),
+            )),
+        )
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
         agent_registry.register(
             "anthropic-api",

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1,5 +1,5 @@
 use crate::thread_manager::ThreadManager;
-use harness_agents::registry::{AdapterRegistry, AgentRegistry};
+use harness_agents::registry::AgentRegistry;
 use harness_core::config::{HarnessConfig, ProjectEntry};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -8,7 +8,6 @@ pub struct HarnessServer {
     pub config: HarnessConfig,
     pub thread_manager: ThreadManager,
     pub agent_registry: Arc<AgentRegistry>,
-    pub adapter_registry: Arc<AdapterRegistry>,
     /// Projects to register in the project registry at startup.
     pub startup_projects: Vec<ProjectEntry>,
     /// The startup project selected as the effective default project root.
@@ -25,7 +24,6 @@ impl HarnessServer {
             config,
             thread_manager,
             agent_registry: Arc::new(agent_registry),
-            adapter_registry: Arc::new(AdapterRegistry::new("")),
             startup_projects: Vec::new(),
             startup_default_project: None,
         }

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -211,16 +211,19 @@ pub(crate) async fn run_turn_lifecycle(
 
     // Register adapter for this turn if one is configured for this agent name.
     // Enables turn/steer and turn/respond_approval to reach the live process.
-    // Gracefully no-ops when no adapter is registered (adapter_registry is empty by default).
-    let _adapter_guard = server.adapter_registry.get(&agent_name).map(|adapter_arc| {
-        server
-            .thread_manager
-            .register_active_adapter(&turn_id, adapter_arc.clone());
-        AdapterGuard {
-            server: server.clone(),
-            turn_id: turn_id.clone(),
-        }
-    });
+    // Gracefully no-ops when no adapter is registered for this agent.
+    let _adapter_guard = server
+        .agent_registry
+        .get_adapter(&agent_name)
+        .map(|adapter_arc| {
+            server
+                .thread_manager
+                .register_active_adapter(&turn_id, adapter_arc.clone());
+            AdapterGuard {
+                server: server.clone(),
+                turn_id: turn_id.clone(),
+            }
+        });
 
     let req = AgentRequest {
         prompt,

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -231,14 +231,18 @@ pub(crate) async fn run_turn_lifecycle(
     let stall_timeout = Duration::from_secs(server.config.concurrency.stall_timeout_secs);
     let (stream_tx, mut stream_rx) = mpsc::channel(128);
 
-    // When an adapter is registered, execute via adapter.start_turn() so that
-    // the adapter's stdin is initialized before any steer/respond_approval call
-    // arrives. CodexAgent::execute_stream uses stdin(Stdio::null()), which means
-    // the adapter state would always have stdin=None and steer/approval would
-    // fail with "codex stdin not available".
+    // Only Codex uses the adapter for turn execution (initializes stdin so that
+    // subsequent steer/respond_approval calls can find a live process).
+    // Other adapters (e.g., ClaudeAdapter) exist for interrupt/steer only and must
+    // not override the configured CodeAgent execution path — ClaudeCodeAgent carries
+    // config-level settings (model, sandbox) that ClaudeAdapter does not replicate.
+    let execution_adapter = adapter_opt
+        .as_ref()
+        .filter(|a| a.name() == "codex")
+        .cloned();
     let mut execution: std::pin::Pin<
         Box<dyn std::future::Future<Output = harness_core::error::Result<()>> + Send>,
-    > = if let Some(adapter_arc) = adapter_opt {
+    > = if let Some(adapter_arc) = execution_adapter {
         let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(128);
         // Move stream_tx into the bridge task so dropping it closes stream_rx.
         let bridge_tx = stream_tx;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -5,7 +5,9 @@ use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskStatus, TaskStore,
 };
 use anyhow::Context;
-use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
+use harness_core::agent::{
+    AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
+};
 use harness_core::config::agents::CapabilityProfile;
 use harness_core::error::HarnessError;
 use harness_core::interceptor::ToolUseEvent;
@@ -209,31 +211,86 @@ pub(crate) async fn run_turn_lifecycle(
         }
     }
 
-    // Register adapter for this turn if one is configured for this agent name.
-    // Enables turn/steer and turn/respond_approval to reach the live process.
-    // Gracefully no-ops when no adapter is registered for this agent.
-    let _adapter_guard = server
-        .agent_registry
-        .get_adapter(&agent_name)
-        .map(|adapter_arc| {
-            server
-                .thread_manager
-                .register_active_adapter(&turn_id, adapter_arc.clone());
-            AdapterGuard {
-                server: server.clone(),
-                turn_id: turn_id.clone(),
-            }
-        });
+    // Get the adapter for this agent, if any.
+    let adapter_opt = server.agent_registry.get_adapter(&agent_name);
 
-    let req = AgentRequest {
-        prompt,
-        project_root,
-        ..Default::default()
-    };
+    // Register as live adapter (RAII guard for cleanup on turn exit).
+    // When an adapter is available, execution goes through adapter.start_turn()
+    // (see below), so the adapter's stdin is initialized before any
+    // steer/respond_approval call arrives.
+    let _adapter_guard = adapter_opt.as_ref().map(|adapter_arc| {
+        server
+            .thread_manager
+            .register_active_adapter(&turn_id, adapter_arc.clone());
+        AdapterGuard {
+            server: server.clone(),
+            turn_id: turn_id.clone(),
+        }
+    });
 
     let stall_timeout = Duration::from_secs(server.config.concurrency.stall_timeout_secs);
     let (stream_tx, mut stream_rx) = mpsc::channel(128);
-    let mut execution = std::pin::pin!(agent.execute_stream(req, stream_tx));
+
+    // When an adapter is registered, execute via adapter.start_turn() so that
+    // the adapter's stdin is initialized before any steer/respond_approval call
+    // arrives. CodexAgent::execute_stream uses stdin(Stdio::null()), which means
+    // the adapter state would always have stdin=None and steer/approval would
+    // fail with "codex stdin not available".
+    let mut execution: std::pin::Pin<
+        Box<dyn std::future::Future<Output = harness_core::error::Result<()>> + Send>,
+    > = if let Some(adapter_arc) = adapter_opt {
+        let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(128);
+        // Move stream_tx into the bridge task so dropping it closes stream_rx.
+        let bridge_tx = stream_tx;
+        tokio::spawn(async move {
+            let mut output_buf = String::new();
+            while let Some(event) = event_rx.recv().await {
+                let maybe_item: Option<StreamItem> = match event {
+                    AgentEvent::MessageDelta { ref text } => {
+                        output_buf.push_str(text);
+                        Some(StreamItem::MessageDelta { text: text.clone() })
+                    }
+                    AgentEvent::ApprovalRequest { id, command } => {
+                        Some(StreamItem::ApprovalRequest { id, command })
+                    }
+                    AgentEvent::Error { message } => Some(StreamItem::Error { message }),
+                    AgentEvent::TurnCompleted { output } => {
+                        let content = if output.is_empty() {
+                            std::mem::take(&mut output_buf)
+                        } else {
+                            output
+                        };
+                        Some(StreamItem::ItemCompleted {
+                            item: harness_core::types::Item::AgentReasoning { content },
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some(item) = maybe_item {
+                    if bridge_tx.send(item).await.is_err() {
+                        return;
+                    }
+                }
+            }
+            // event_rx closed → adapter done; dropping bridge_tx closes stream_rx.
+        });
+        let turn_req = TurnRequest {
+            prompt,
+            project_root,
+            model: None,
+            allowed_tools: vec![],
+            context: vec![],
+            timeout_secs: None,
+        };
+        Box::pin(async move { adapter_arc.start_turn(turn_req, event_tx).await })
+    } else {
+        let req = AgentRequest {
+            prompt,
+            project_root,
+            ..Default::default()
+        };
+        Box::pin(agent.execute_stream(req, stream_tx))
+    };
     let mut stream_closed = false;
     let mut execution_result: Option<harness_core::error::Result<()>> = None;
     let mut last_activity = Instant::now();


### PR DESCRIPTION
## Summary

- Adds `AgentDescriptor { agent, adapter: Option<...> }` — one struct owns both the executor and optional interactive adapter
- Replaces dual `HashMap`s (`agents` + `AdapterRegistry::adapters`) with a single `entries: HashMap<String, AgentDescriptor>` in `AgentRegistry`
- Removes `AdapterRegistry` struct entirely and drops `HarnessServer::adapter_registry` field
- `register_adapter(name, adapter)` returns `Err(AgentNotFound)` if the agent is unknown — no silent fallback (U-23)
- `task_executor` adapter lookup redirected to `agent_registry.get_adapter()`
- Old `AdapterRegistry` unit tests migrated to cover the unified API; new regression test confirms `dispatch()` still returns the `CodeAgent`

Closes #687

## Test plan
- [ ] `cargo fmt --all` — clean
- [ ] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — 88 harness-agents tests pass (up from 82, +6 new adapter tests); all server integration tests pass