### PR TITLE
fix(redispatch): re-dispatch plan/triage checkpoint tasks on startup (#698)

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -91,6 +91,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        request_settings: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -180,6 +181,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        request_settings: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -202,6 +204,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        request_settings: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -275,6 +278,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        request_settings: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -339,6 +343,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         phase: crate::task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
+        request_settings: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -917,6 +917,11 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                                 "startup recovery: failed to persist failed status: {e}"
                             );
                         }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
                         return;
                     }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -848,6 +848,164 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         }
     }
 
+    // Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
+    // Source A (above) handles tasks with `pr_url` set.  Source B (below) picks up
+    // remaining pending tasks that have a plan or triage checkpoint — these are
+    // issue/prompt tasks interrupted during planning that need to continue execution.
+    // If the DB query fails, log a warning and skip (startup must not abort).
+    {
+        let checkpoint_tasks = match state.core.tasks.pending_tasks_with_checkpoint().await {
+            Ok(pairs) => pairs,
+            Err(e) => {
+                tracing::warn!(
+                    "startup: failed to query checkpoint tasks, \
+                         skipping plan/triage redispatch: {e}"
+                );
+                vec![]
+            }
+        };
+        if !checkpoint_tasks.is_empty() {
+            tracing::info!(
+                count = checkpoint_tasks.len(),
+                "startup: re-dispatching recovered pending task(s) with plan/triage checkpoints"
+            );
+            for (task, _checkpoint) in checkpoint_tasks {
+                let state = state.clone();
+                tokio::spawn(async move {
+                    // Reconstruct request type from the persisted description.
+                    // Description format: "issue #N" → issue task; other → prompt task.
+                    // PR tasks are handled by Source A and never appear here.
+                    let issue_num = task
+                        .description
+                        .as_deref()
+                        .and_then(|d| d.strip_prefix("issue #"))
+                        .and_then(|s| s.split_whitespace().next())
+                        .and_then(|s| s.parse::<u64>().ok());
+
+                    if issue_num.is_none() && task.description.is_none() {
+                        tracing::warn!(
+                            task_id = ?task.id,
+                            "startup recovery: checkpoint task has no issue or description — skipping"
+                        );
+                        return;
+                    }
+
+                    let project_path = match task.repo.as_deref() {
+                        Some(repo) => {
+                            if let Some(registry) = state.core.project_registry.as_deref() {
+                                match registry.resolve_path(repo).await {
+                                    Ok(Some(p)) => Some(p),
+                                    Ok(None) => Some(std::path::PathBuf::from(repo)),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            task_id = ?task.id,
+                                            repo,
+                                            "startup recovery: registry lookup failed: \
+                                             {e}, using repo as path"
+                                        );
+                                        Some(std::path::PathBuf::from(repo))
+                                    }
+                                }
+                            } else {
+                                Some(std::path::PathBuf::from(repo))
+                            }
+                        }
+                        None => None,
+                    };
+
+                    let canonical = match task_runner::resolve_canonical_project(project_path).await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to resolve project path: {e}"
+                            );
+                            return;
+                        }
+                    };
+                    let project_id = canonical.to_string_lossy().into_owned();
+
+                    let permit = match state
+                        .concurrency
+                        .task_queue
+                        .acquire(&project_id, task.priority)
+                        .await
+                    {
+                        Ok(p) => p,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to acquire permit: {e}"
+                            );
+                            return;
+                        }
+                    };
+
+                    let req = if let Some(issue) = issue_num {
+                        task_runner::CreateTaskRequest {
+                            issue: Some(issue),
+                            project: Some(canonical),
+                            repo: task.repo.clone(),
+                            source: task.source.clone(),
+                            external_id: task.external_id.clone(),
+                            priority: task.priority,
+                            ..Default::default()
+                        }
+                    } else {
+                        task_runner::CreateTaskRequest {
+                            prompt: task.description.clone(),
+                            project: Some(canonical),
+                            repo: task.repo.clone(),
+                            source: task.source.clone(),
+                            external_id: task.external_id.clone(),
+                            priority: task.priority,
+                            ..Default::default()
+                        }
+                    };
+
+                    let classification = crate::complexity_router::classify(
+                        req.prompt.as_deref().unwrap_or(""),
+                        req.issue,
+                        req.pr,
+                    );
+                    let agent = match state.core.server.agent_registry.dispatch(&classification) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to dispatch agent: {e}"
+                            );
+                            return;
+                        }
+                    };
+                    let (reviewer, _) = resolve_reviewer(
+                        &state.core.server.agent_registry,
+                        &state.core.server.config.agents.review,
+                        agent.name(),
+                    );
+                    state.core.tasks.register_task_stream(&task.id);
+                    task_runner::spawn_preregistered_task(
+                        task.id,
+                        state.core.tasks.clone(),
+                        agent,
+                        reviewer,
+                        Arc::new(state.core.server.config.clone()),
+                        state.engines.skills.clone(),
+                        state.observability.events.clone(),
+                        state.interceptors.clone(),
+                        req,
+                        state.concurrency.workspace_mgr.clone(),
+                        permit,
+                        state.intake.completion_callback.clone(),
+                        None,
+                    )
+                    .await;
+                });
+            }
+        }
+    }
+
     let initial_grade = {
         let events = state
             .observability

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -815,13 +815,20 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     if let Some(ref settings) = task.request_settings {
                         settings.apply_to_req(&mut req);
                     }
-                    let classification = crate::complexity_router::classify("", None, Some(pr_num));
-                    let agent = match state.core.server.agent_registry.dispatch(&classification) {
+                    // Use the three-tier select_agent() so that an explicit agent
+                    // pin stored in request_settings (Tier 1) and project-level
+                    // defaults (Tier 2a) are honoured, not bypassed by a raw
+                    // complexity dispatch.
+                    let agent = match task_routes::select_agent(
+                        &req,
+                        &state.core.server.agent_registry,
+                        None,
+                    ) {
                         Ok(a) => a,
                         Err(e) => {
                             tracing::error!(
                                 task_id = ?task.id,
-                                "startup recovery: failed to dispatch agent: {e}"
+                                "startup recovery: failed to select agent: {e}"
                             );
                             return;
                         }
@@ -940,10 +947,29 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     {
                         Ok(c) => c,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to resolve project path: {e}"
-                            );
+                            let reason =
+                                format!("startup recovery: failed to resolve project path: {e}");
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };
@@ -957,10 +983,30 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     {
                         Ok(p) => p,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to acquire permit: {e}"
+                            let reason = format!(
+                                "startup recovery: failed to acquire concurrency permit: {e}"
                             );
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };
@@ -976,24 +1022,46 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         priority: task.priority,
                         ..Default::default()
                     };
-                    // Restore persisted execution limits so the recovered task resumes
-                    // with the same budget / timeout guardrails as originally requested.
+                    // Restore persisted execution limits and any additional prompt
+                    // context so the recovered task resumes with the same settings
+                    // and caller-supplied context as originally requested.
                     if let Some(ref settings) = task.request_settings {
                         settings.apply_to_req(&mut req);
                     }
 
-                    let classification = crate::complexity_router::classify(
-                        req.prompt.as_deref().unwrap_or(""),
-                        req.issue,
-                        req.pr,
-                    );
-                    let agent = match state.core.server.agent_registry.dispatch(&classification) {
+                    // Use the three-tier select_agent() so that an explicit agent
+                    // pin stored in request_settings (Tier 1) and project-level
+                    // defaults (Tier 2a) are honoured, not bypassed by a raw
+                    // complexity dispatch.
+                    let agent = match task_routes::select_agent(
+                        &req,
+                        &state.core.server.agent_registry,
+                        None,
+                    ) {
                         Ok(a) => a,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to dispatch agent: {e}"
-                            );
+                            let reason = format!("startup recovery: failed to select agent: {e}");
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -802,7 +802,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         }
                     };
 
-                    let req = task_runner::CreateTaskRequest {
+                    let mut req = task_runner::CreateTaskRequest {
                         pr: Some(pr_num),
                         project: Some(canonical),
                         repo: task.repo.clone(),
@@ -810,6 +810,11 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         external_id: task.external_id.clone(),
                         ..Default::default()
                     };
+                    // Restore persisted execution limits so the recovered task resumes
+                    // with the same budget / timeout guardrails as originally requested.
+                    if let Some(ref settings) = task.request_settings {
+                        settings.apply_to_req(&mut req);
+                    }
                     let classification = crate::complexity_router::classify("", None, Some(pr_num));
                     let agent = match state.core.server.agent_registry.dispatch(&classification) {
                         Ok(a) => a,
@@ -882,11 +887,29 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         .and_then(|s| s.split_whitespace().next())
                         .and_then(|s| s.parse::<u64>().ok());
 
-                    if issue_num.is_none() && task.description.is_none() {
-                        tracing::warn!(
-                            task_id = ?task.id,
-                            "startup recovery: checkpoint task has no issue or description — skipping"
-                        );
+                    if issue_num.is_none() {
+                        // Prompt tasks store the placeholder "prompt task" in description
+                        // by design — the original prompt text is never persisted for
+                        // privacy.  Re-dispatching with that placeholder would execute
+                        // against the wrong prompt, so mark the task failed instead to
+                        // prevent the same broken recovery on every subsequent restart.
+                        let reason = if task.description.as_deref() == Some("prompt task") {
+                            "prompt task cannot be recovered after restart: \
+                             original prompt text is not persisted"
+                        } else {
+                            "checkpoint task has no parseable issue number — skipping"
+                        };
+                        tracing::warn!(task_id = ?task.id, "{reason}");
+                        let mut failed = task.clone();
+                        failed.status = task_runner::TaskStatus::Failed;
+                        failed.error = Some(reason.to_string());
+                        state.core.tasks.cache.insert(failed.id.clone(), failed);
+                        if let Err(e) = state.core.tasks.persist(&task.id).await {
+                            tracing::warn!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {e}"
+                            );
+                        }
                         return;
                     }
 
@@ -942,27 +965,22 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         }
                     };
 
-                    let req = if let Some(issue) = issue_num {
-                        task_runner::CreateTaskRequest {
-                            issue: Some(issue),
-                            project: Some(canonical),
-                            repo: task.repo.clone(),
-                            source: task.source.clone(),
-                            external_id: task.external_id.clone(),
-                            priority: task.priority,
-                            ..Default::default()
-                        }
-                    } else {
-                        task_runner::CreateTaskRequest {
-                            prompt: task.description.clone(),
-                            project: Some(canonical),
-                            repo: task.repo.clone(),
-                            source: task.source.clone(),
-                            external_id: task.external_id.clone(),
-                            priority: task.priority,
-                            ..Default::default()
-                        }
+                    // issue_num is always Some here — the None branch returned above.
+                    let issue = issue_num.expect("checked above");
+                    let mut req = task_runner::CreateTaskRequest {
+                        issue: Some(issue),
+                        project: Some(canonical),
+                        repo: task.repo.clone(),
+                        source: task.source.clone(),
+                        external_id: task.external_id.clone(),
+                        priority: task.priority,
+                        ..Default::default()
                     };
+                    // Restore persisted execution limits so the recovered task resumes
+                    // with the same budget / timeout guardrails as originally requested.
+                    if let Some(ref settings) = task.request_settings {
+                        settings.apply_to_req(&mut req);
+                    }
 
                     let classification = crate::complexity_router::classify(
                         req.prompt.as_deref().unwrap_or(""),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -114,7 +114,7 @@ async fn check_pr_duplicate(
 ///
 /// Calling this helper from both enqueue paths ensures the three tiers are
 /// enforced identically and cannot drift apart.
-fn select_agent(
+pub(crate) fn select_agent(
     req: &task_runner::CreateTaskRequest,
     registry: &harness_agents::registry::AgentRegistry,
     registry_agent: Option<&str>,

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -136,6 +136,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            request_settings: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -176,6 +177,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            request_settings: None,
         };
         store.insert(&parent_state).await;
 
@@ -200,6 +202,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            request_settings: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -16,7 +16,7 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description";
+const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings";
 
 /// Versioned migrations for the tasks table.
 ///
@@ -126,6 +126,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_tasks_status_updated \
               ON tasks(status, updated_at DESC)",
     },
+    Migration {
+        version: 16,
+        description: "add request_settings column for execution limit recovery",
+        sql: "ALTER TABLE tasks ADD COLUMN request_settings TEXT",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -200,9 +205,13 @@ impl TaskDb {
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
         let phase_json = serde_json::to_string(&state.phase)?;
+        let settings_json = state
+            .request_settings
+            .as_ref()
+            .and_then(|s| serde_json::to_string(s).ok());
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -220,6 +229,7 @@ impl TaskDb {
         .bind(state.priority as i64)
         .bind(&phase_json)
         .bind(state.description.as_deref())
+        .bind(settings_json.as_deref())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -230,10 +240,15 @@ impl TaskDb {
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let phase_json = serde_json::to_string(&state.phase)?;
         let status = state.status.as_ref();
+        let settings_json = state
+            .request_settings
+            .as_ref()
+            .and_then(|s| serde_json::to_string(s).ok());
         sqlx::query(
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
                     source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
-                    priority = ?, phase = ?, description = ?, updated_at = datetime('now')
+                    priority = ?, phase = ?, description = ?, request_settings = ?,
+                    updated_at = datetime('now')
              WHERE id = ?",
         )
         .bind(status)
@@ -254,6 +269,7 @@ impl TaskDb {
         .bind(state.priority as i64)
         .bind(&phase_json)
         .bind(state.description.as_deref())
+        .bind(settings_json.as_deref())
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -895,7 +911,7 @@ impl TaskDb {
         let rows = sqlx::query_as::<_, PendingCheckpointRow>(
             "SELECT t.id, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
                     t.external_id, t.parent_id, t.created_at, t.repo, t.depends_on, \
-                    t.project, t.priority, t.phase, t.description, \
+                    t.project, t.priority, t.phase, t.description, t.request_settings, \
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
                     c.last_phase, c.updated_at AS ck_updated_at \
              FROM tasks t \
@@ -927,6 +943,7 @@ impl TaskDb {
                 priority: row.priority,
                 phase: row.phase,
                 description: row.description,
+                request_settings: row.request_settings,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,
@@ -967,6 +984,7 @@ struct TaskRow {
     priority: i64,
     phase: String,
     description: Option<String>,
+    request_settings: Option<String>,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -992,6 +1010,7 @@ struct PendingCheckpointRow {
     priority: i64,
     phase: String,
     description: Option<String>,
+    request_settings: Option<String>,
     // Checkpoint columns (aliased)
     triage_output: Option<String>,
     plan_output: Option<String>,
@@ -1019,7 +1038,13 @@ impl TaskRow {
             priority,
             phase,
             description,
+            request_settings,
         } = self;
+
+        let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
+            request_settings
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok());
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
             TaskDbDecodeError::RoundsDeserialize {
@@ -1062,6 +1087,7 @@ impl TaskRow {
             triage_output: None,
             plan_output: None,
             repo,
+            request_settings: decoded_request_settings,
         })
     }
 }
@@ -1145,6 +1171,7 @@ mod tests {
             priority: 0,
             phase: r#""implement""#.to_string(),
             description: None,
+            request_settings: None,
         }
     }
 
@@ -1253,6 +1280,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             repo: None,
+            request_settings: None,
         }
     }
 
@@ -1896,13 +1924,14 @@ mod tests {
             priority: 0,
             phase: String::new(),
             description: None,
+            request_settings: None,
         };
 
         // Count must match — catches column added to constant but not struct (or vice versa).
         assert_eq!(
             columns.len(),
-            16, // bump this when adding a field
-            "TASK_ROW_COLUMNS has {} entries but expected 16 — update both the constant and this test",
+            17, // bump this when adding a field
+            "TASK_ROW_COLUMNS has {} entries but expected 17 — update both the constant and this test",
             columns.len()
         );
     }

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -880,6 +880,73 @@ impl TaskDb {
         .await?;
         Ok(rows)
     }
+
+    /// Return all `pending` tasks that have a plan or triage checkpoint but no `pr_url`.
+    ///
+    /// Used at startup to re-dispatch tasks that were recovered from plan/triage checkpoints
+    /// but were not picked up by the PR-based redispatch path (which only catches tasks with
+    /// `pr_url` set).
+    ///
+    /// Excludes tasks that already have `tasks.pr_url` set — those are handled by the
+    /// existing PR-based redispatch path in `http.rs`.
+    pub async fn pending_tasks_with_checkpoint(
+        &self,
+    ) -> anyhow::Result<Vec<(TaskState, TaskCheckpoint)>> {
+        let rows = sqlx::query_as::<_, PendingCheckpointRow>(
+            "SELECT t.id, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
+                    t.external_id, t.parent_id, t.created_at, t.repo, t.depends_on, \
+                    t.project, t.priority, t.phase, t.description, \
+                    c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
+                    c.last_phase, c.updated_at AS ck_updated_at \
+             FROM tasks t \
+             JOIN task_checkpoints c ON c.task_id = t.id \
+             WHERE t.status = 'pending' \
+               AND t.pr_url IS NULL \
+               AND (c.plan_output IS NOT NULL OR c.triage_output IS NOT NULL)",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut pairs = Vec::with_capacity(rows.len());
+        for row in rows {
+            let task_id = row.id.clone();
+            let task_row = TaskRow {
+                id: row.id,
+                status: row.status,
+                turn: row.turn,
+                pr_url: row.pr_url,
+                rounds: row.rounds,
+                error: row.error,
+                source: row.source,
+                external_id: row.external_id,
+                parent_id: row.parent_id,
+                created_at: row.created_at,
+                repo: row.repo,
+                depends_on: row.depends_on,
+                project: row.project,
+                priority: row.priority,
+                phase: row.phase,
+                description: row.description,
+            };
+            let task_state = match task_row.try_into_task_state() {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(task_id = %task_id, "skipping malformed pending checkpoint task: {e}");
+                    continue;
+                }
+            };
+            let checkpoint = TaskCheckpoint {
+                task_id,
+                triage_output: row.triage_output,
+                plan_output: row.plan_output,
+                pr_url: row.ck_pr_url,
+                last_phase: row.last_phase,
+                updated_at: row.ck_updated_at,
+            };
+            pairs.push((task_state, checkpoint));
+        }
+        Ok(pairs)
+    }
 }
 
 #[derive(sqlx::FromRow)]
@@ -900,6 +967,37 @@ struct TaskRow {
     priority: i64,
     phase: String,
     description: Option<String>,
+}
+
+/// Combined row for the pending-tasks-with-checkpoint JOIN query.
+///
+/// Aliases checkpoint columns to avoid collision with task columns:
+/// `c.pr_url` → `ck_pr_url`, `c.updated_at` → `ck_updated_at`.
+#[derive(sqlx::FromRow)]
+struct PendingCheckpointRow {
+    // Task columns
+    id: String,
+    status: String,
+    turn: i64,
+    pr_url: Option<String>,
+    rounds: String,
+    error: Option<String>,
+    source: Option<String>,
+    external_id: Option<String>,
+    parent_id: Option<String>,
+    created_at: Option<String>,
+    repo: Option<String>,
+    depends_on: String,
+    project: Option<String>,
+    priority: i64,
+    phase: String,
+    description: Option<String>,
+    // Checkpoint columns (aliased)
+    triage_output: Option<String>,
+    plan_output: Option<String>,
+    ck_pr_url: Option<String>,
+    last_phase: String,
+    ck_updated_at: String,
 }
 
 impl TaskRow {
@@ -1986,6 +2084,125 @@ mod tests {
             loaded.description.is_none(),
             "description should be None for legacy rows"
         );
+        Ok(())
+    }
+
+    // --- pending_tasks_with_checkpoint tests ---
+
+    #[tokio::test]
+    async fn pending_with_triage_checkpoint_is_returned() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("t-triage", TaskStatus::Pending);
+        task.description = Some("issue #10".to_string());
+        db.insert(&task).await?;
+        db.write_checkpoint("t-triage", Some("triage output"), None, None, "triage_done")
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert_eq!(pairs.len(), 1);
+        let (t, ck) = &pairs[0];
+        assert_eq!(t.id.0, "t-triage");
+        assert_eq!(ck.triage_output.as_deref(), Some("triage output"));
+        assert!(ck.plan_output.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_with_plan_checkpoint_is_returned() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("t-plan", TaskStatus::Pending);
+        task.description = Some("issue #20".to_string());
+        db.insert(&task).await?;
+        db.write_checkpoint("t-plan", None, Some("plan text"), None, "plan_done")
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert_eq!(pairs.len(), 1);
+        let (t, ck) = &pairs[0];
+        assert_eq!(t.id.0, "t-plan");
+        assert_eq!(ck.plan_output.as_deref(), Some("plan text"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_with_pr_url_excluded_from_checkpoint_query() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        // Task with pr_url set — handled by PR-based redispatch, not checkpoint path.
+        let mut task_pr = make_task("t-pr", TaskStatus::Pending);
+        task_pr.pr_url = Some("https://github.com/o/r/pull/42".to_string());
+        db.insert(&task_pr).await?;
+        db.write_checkpoint("t-pr", None, Some("plan"), None, "plan_done")
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert!(
+            pairs.is_empty(),
+            "task with pr_url should be excluded from checkpoint query"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_without_checkpoint_not_returned() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("t-no-ck", TaskStatus::Pending))
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert!(
+            pairs.is_empty(),
+            "task with no checkpoint should not be returned"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_pending_with_checkpoint_not_returned() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        // Implementing status — should NOT be returned (status filter)
+        db.insert(&make_task("t-impl", TaskStatus::Implementing))
+            .await?;
+        db.write_checkpoint("t-impl", None, Some("plan"), None, "plan_done")
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert!(pairs.is_empty(), "non-pending task should not be returned");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn checkpoint_query_returns_task_state_fields() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("t-fields", TaskStatus::Pending);
+        task.description = Some("issue #99".to_string());
+        task.repo = Some("owner/repo".to_string());
+        task.source = Some("github".to_string());
+        task.external_id = Some("ext-1".to_string());
+        task.priority = 1;
+        db.insert(&task).await?;
+        db.write_checkpoint("t-fields", Some("triage out"), None, None, "triage_done")
+            .await?;
+
+        let pairs = db.pending_tasks_with_checkpoint().await?;
+        assert_eq!(pairs.len(), 1);
+        let (t, _) = &pairs[0];
+        assert_eq!(t.description.as_deref(), Some("issue #99"));
+        assert_eq!(t.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(t.source.as_deref(), Some("github"));
+        assert_eq!(t.external_id.as_deref(), Some("ext-1"));
+        assert_eq!(t.priority, 1);
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1339,6 +1339,16 @@ impl TaskStore {
         self.db.load_checkpoint(task_id.as_str()).await
     }
 
+    /// Return pending tasks that have a plan or triage checkpoint but no `pr_url`.
+    ///
+    /// Used at startup to re-dispatch tasks recovered from plan/triage checkpoints
+    /// that were not caught by the PR-based redispatch path.
+    pub(crate) async fn pending_tasks_with_checkpoint(
+        &self,
+    ) -> anyhow::Result<Vec<(TaskState, crate::task_db::TaskCheckpoint)>> {
+        self.db.pending_tasks_with_checkpoint().await
+    }
+
     pub(crate) async fn persist(&self, id: &TaskId) -> anyhow::Result<()> {
         let lock = self
             .persist_locks

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1732,6 +1732,7 @@ where
         state.external_id = req.external_id.clone();
         state.repo = req.repo.clone();
         state.priority = req.priority;
+        state.request_settings = Some(PersistedRequestSettings::from_req(&req));
         store.insert(&state).await;
         // Register stream channel before spawning so SSE clients can subscribe immediately.
         store.register_task_stream(&task_id);

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -197,6 +197,11 @@ pub struct TaskState {
     /// Output from the Plan phase (Architect plan). Not persisted to DB.
     #[serde(skip)]
     pub plan_output: Option<String>,
+    /// Caller-specified execution limits. Persisted to the DB so that recovered
+    /// tasks resume with the same budget / timeout guardrails as originally
+    /// requested rather than silently falling back to server defaults.
+    #[serde(skip)]
+    pub request_settings: Option<PersistedRequestSettings>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -260,6 +265,7 @@ impl TaskState {
             triage_output: None,
             plan_output: None,
             repo: None,
+            request_settings: None,
         }
     }
 
@@ -351,6 +357,56 @@ pub struct CreateTaskRequest {
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
     pub priority: u8,
+}
+
+/// Execution limits that survive a server restart.
+///
+/// Serialised as a JSON blob in `tasks.request_settings`. Restored at startup
+/// redispatch so recovered tasks honour the original budget / timeout
+/// guardrails instead of silently falling back to server-wide defaults.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PersistedRequestSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rounds: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_budget_usd: Option<f64>,
+    pub wait_secs: u64,
+    pub retry_base_backoff_ms: u64,
+    pub retry_max_backoff_ms: u64,
+    pub stall_timeout_secs: u64,
+    pub turn_timeout_secs: u64,
+}
+
+impl PersistedRequestSettings {
+    pub(crate) fn from_req(req: &CreateTaskRequest) -> Self {
+        Self {
+            agent: req.agent.clone(),
+            max_rounds: req.max_rounds,
+            max_turns: req.max_turns,
+            max_budget_usd: req.max_budget_usd,
+            wait_secs: req.wait_secs,
+            retry_base_backoff_ms: req.retry_base_backoff_ms,
+            retry_max_backoff_ms: req.retry_max_backoff_ms,
+            stall_timeout_secs: req.stall_timeout_secs,
+            turn_timeout_secs: req.turn_timeout_secs,
+        }
+    }
+
+    pub(crate) fn apply_to_req(&self, req: &mut CreateTaskRequest) {
+        req.agent = self.agent.clone();
+        req.max_rounds = self.max_rounds;
+        req.max_turns = self.max_turns;
+        req.max_budget_usd = self.max_budget_usd;
+        req.wait_secs = self.wait_secs;
+        req.retry_base_backoff_ms = self.retry_base_backoff_ms;
+        req.retry_max_backoff_ms = self.retry_max_backoff_ms;
+        req.stall_timeout_secs = self.stall_timeout_secs;
+        req.turn_timeout_secs = self.turn_timeout_secs;
+    }
 }
 
 impl Default for CreateTaskRequest {
@@ -1580,6 +1636,7 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.priority = req.priority;
     state.issue = req.issue;
     state.description = summarize_request_description(req);
+    state.request_settings = Some(PersistedRequestSettings::from_req(req));
     store.insert(&state).await;
     // Register stream channel now so SSE clients can subscribe before execution begins.
     store.register_task_stream(&task_id);

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -379,6 +379,14 @@ pub struct PersistedRequestSettings {
     pub retry_max_backoff_ms: u64,
     pub stall_timeout_secs: u64,
     pub turn_timeout_secs: u64,
+    /// Additional caller-supplied prompt context for issue tasks.
+    ///
+    /// Callers may submit `{ issue: N, prompt: "extra context" }` to augment
+    /// issue resolution.  The prompt is not stored in `description` (privacy),
+    /// so we persist it here for issue tasks only to survive a server restart.
+    /// Pure prompt tasks and PR tasks leave this `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_prompt: Option<String>,
 }
 
 impl PersistedRequestSettings {
@@ -393,6 +401,15 @@ impl PersistedRequestSettings {
             retry_max_backoff_ms: req.retry_max_backoff_ms,
             stall_timeout_secs: req.stall_timeout_secs,
             turn_timeout_secs: req.turn_timeout_secs,
+            // Only persist the caller's prompt for issue tasks — it serves as
+            // additional context that is safe to store (unlike pure prompt
+            // tasks which may contain credentials).  PR and prompt-only tasks
+            // leave this None.
+            additional_prompt: if req.issue.is_some() {
+                req.prompt.clone()
+            } else {
+                None
+            },
         }
     }
 
@@ -406,6 +423,10 @@ impl PersistedRequestSettings {
         req.retry_max_backoff_ms = self.retry_max_backoff_ms;
         req.stall_timeout_secs = self.stall_timeout_secs;
         req.turn_timeout_secs = self.turn_timeout_secs;
+        // Restore the additional prompt context for recovered issue tasks.
+        if self.additional_prompt.is_some() {
+            req.prompt = self.additional_prompt.clone();
+        }
     }
 }
 

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -32,6 +32,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         triage_output: None,
         plan_output: None,
         repo: None,
+        request_settings: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Startup redispatch previously only picked up pending tasks with pr_url set, leaving tasks recovered from plan/triage checkpoints stuck in pending forever
- Add pending_tasks_with_checkpoint() to TaskDb/TaskStore — JOINs tasks + task_checkpoints returning pending tasks with plan or triage checkpoints but no pr_url
- Add Source B redispatch block in http.rs that reconstructs CreateTaskRequest from the persisted description (parses issue #N -> req.issue, else falls back to prompt); DB failure is non-fatal

## Test plan

- pending_with_triage_checkpoint_is_returned
- pending_with_plan_checkpoint_is_returned
- pending_with_pr_url_excluded_from_checkpoint_query
- pending_without_checkpoint_not_returned
- non_pending_with_checkpoint_not_returned
- checkpoint_query_returns_task_state_fields
- All 701 existing harness-server tests pass

Closes #698