### PR TITLE
feat: enforce squash-merge via GitHub ruleset (#758)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 - After creating a PR, wait for Gemini code review bot before merging
 - If Gemini leaves review comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
-- **Squash-merge only** — repo enforces squash merge to minimize cascade conflicts
+- **Squash-merge only** — enforced via GitHub ruleset (squash is the only allowed merge method; no bypass for anyone)
 - **Do NOT modify `Cargo.toml` version in feature/fix PRs** — version bumps happen only at release time (prevents merge conflicts across parallel PRs)
 - CI uses path-based change detection — only affected crate tests run on PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 - If Gemini leaves review comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
 - **Squash-merge only** — enforced via GitHub ruleset (squash is the only allowed merge method; no bypass for anyone)
+- **Required CI** — the `CI Result` status check must pass before merging (enforced via ruleset)
 - **Do NOT modify `Cargo.toml` version in feature/fix PRs** — version bumps happen only at release time (prevents merge conflicts across parallel PRs)
 - CI uses path-based change detection — only affected crate tests run on PRs
 


### PR DESCRIPTION
## Summary

- Created GitHub ruleset `main-branch-protection` (ID: 15055100) on `majiayu000/harness` targeting the default branch
- Ruleset enforces: deletion protection, non-fast-forward (force-push) protection, required linear history, squash-only merge (`allowed_merge_methods: ["squash"]`), and required `CI Result` status check
- No bypass for anyone (`current_user_can_bypass: "never"`)
- Updated `CLAUDE.md` to document that squash merge is now enforced via GitHub ruleset, not just convention

## Ruleset Details

| Rule | Value |
|------|-------|
| Deletion | Blocked |
| Force push | Blocked |
| Linear history | Required |
| Merge methods | squash only |
| Status check | `CI Result` (fan-in gate, always runs) |
| Bypass actors | None |

## Test plan

- [ ] Open a test PR; confirm only "Squash and merge" button is active
- [ ] Confirm PR checks UI shows "CI Result" as a required check
- [ ] `git push --force origin main` must be rejected with 403
- [ ] Ruleset shows "No bypass" in GitHub UI under Settings → Rules → Rulesets

Closes #758