### PR TITLE
feat(db): migrate thread_db, plan_db, and smaller stores to Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -44,12 +44,29 @@ fn fnv1a_64(data: &[u8]) -> u64 {
 /// its own schema, providing namespace isolation between stores and between
 /// test runs without requiring separate databases.
 ///
-/// The algorithm: normalize `.`/`..` components (no I/O), hash with FNV-1a
-/// 64-bit, format as `hs_<16-hex-digits>`.  Distinct paths map to distinct
-/// schemas with overwhelming probability (2⁻⁶⁴ per pair); logically
-/// equivalent paths always map to the same schema.
+/// The algorithm:
+/// 1. Absolutize the path (prepend `current_dir()` if relative) — without I/O.
+///    This prevents distinct relative paths such as `../data/x.db` and
+///    `data/x.db` from colliding after `..` components are resolved.
+/// 2. Normalize `.`/`..` components.
+/// 3. Hash with FNV-1a 64-bit, format as `hs_<16-hex-digits>`.
+///
+/// Distinct paths map to distinct schemas with overwhelming probability
+/// (2⁻⁶⁴ per pair); logically equivalent paths always map to the same schema.
 fn path_to_schema(path: &Path) -> String {
-    let normalized = normalize_path_components(path);
+    // Absolutize without filesystem access so that a relative path like
+    // `../data/tasks.db` and `data/tasks.db` starting from different CWDs
+    // produce different absolute strings before hashing.  If current_dir()
+    // fails (e.g. CWD was deleted) we fall back to "/" to keep the output
+    // deterministic rather than panicking.
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| std::path::PathBuf::from("/"))
+            .join(path)
+    };
+    let normalized = normalize_path_components(&absolute);
     let s = normalized.to_string_lossy();
     let hash = fnv1a_64(s.as_bytes());
     format!("hs_{hash:016x}")
@@ -67,9 +84,40 @@ fn path_to_schema(path: &Path) -> String {
 /// when all stores share a single Postgres database.
 ///
 /// All stores share this configuration: 8 max connections, 10 s acquire timeout.
+///
+/// # Upgrade note
+///
+/// This function does **not** migrate data from a pre-existing SQLite file at
+/// `path`.  If such a file is found, a warning is logged — existing tasks,
+/// threads, plans, and events must be migrated manually to PostgreSQL.
 pub async fn open_pool(path: &Path) -> anyhow::Result<PgPool> {
-    let url = std::env::var("DATABASE_URL")
-        .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable must be set"))?;
+    // Issue 1: provide a clear, actionable error when DATABASE_URL is absent so
+    // that operators who upgrade without provisioning Postgres get an explicit
+    // message rather than a confusing "file not found" style error.
+    let url = std::env::var("DATABASE_URL").map_err(|_| {
+        anyhow::anyhow!(
+            "DATABASE_URL is not set. This version of harness requires PostgreSQL.\n\
+             Set DATABASE_URL to a valid Postgres connection string, for example:\n\
+             \n  DATABASE_URL=postgres://user:password@localhost/harness\n\
+             \nIf you are upgrading from a SQLite-backed deployment, existing data\n\
+             must be migrated to PostgreSQL manually before the server can serve\n\
+             previously persisted tasks, threads, plans, and events."
+        )
+    })?;
+
+    // Issue 2: warn loudly when an old SQLite file exists at the store path.
+    // The contents of that file will NOT be read or migrated automatically.
+    // Without manual migration, all previously persisted records will be absent.
+    if path.exists() {
+        eprintln!(
+            "harness WARNING: SQLite database found at '{}' but will NOT be read. \
+             harness now stores data in PostgreSQL. All records in this file \
+             (tasks, threads, plans, events, etc.) must be migrated to PostgreSQL \
+             manually to remain accessible. Until migration is complete, restart \
+             recovery and observability will start from an empty state.",
+            path.display()
+        );
+    }
     let schema = path_to_schema(path);
     PgPoolOptions::new()
         .max_connections(8)

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -1,64 +1,73 @@
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
-use sqlx::{pool::PoolConnection, Sqlite};
+use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::OnceLock;
 
-static SQLITE_TRANSACTIONAL_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();
-
-fn sqlite_transactional_prefixes() -> &'static [&'static str] {
-    SQLITE_TRANSACTIONAL_PREFIXES.get_or_init(|| {
-        vec![
-            "CREATE TABLE",
-            "CREATE INDEX",
-            "CREATE UNIQUE INDEX",
-            "CREATE VIEW",
-            "CREATE TRIGGER",
-            "ALTER TABLE",
-            "DROP TABLE",
-            "DROP INDEX",
-            "DROP VIEW",
-            "DROP TRIGGER",
-            "INSERT INTO",
-            "UPDATE ",
-            "DELETE FROM",
-            "REPLACE INTO",
-            "SELECT ",
-            "WITH ",
-        ]
-    })
-}
-
-fn normalized_sqlite_statement_prefix(statement: &str) -> String {
-    statement
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with("--"))
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_uppercase()
-}
-
-/// Create a SQLite connection pool for the given path.
+/// Derive a deterministic, Postgres-safe schema name from an arbitrary path.
 ///
-/// All stores share this configuration: 8 max connections, 10 s acquire
-/// timeout, WAL journal mode, and 5 s busy timeout.
-pub async fn open_pool(path: &Path) -> anyhow::Result<SqlitePool> {
-    let url = format!("sqlite:{}?mode=rwc", path.display());
-    let pool = SqlitePoolOptions::new()
+/// Each unique path (e.g. per-store data directory or per-test tempdir) gets
+/// its own schema, providing namespace isolation between stores and between
+/// test runs without requiring separate databases.
+///
+/// The algorithm: sanitize the path to lowercase ASCII alphanumerics/underscores,
+/// keep up to the last 60 characters (the unique suffix), then prepend `"hs_"`.
+/// This is deterministic across process restarts and requires no extra dependencies.
+fn path_to_schema(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    let sanitized: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    // Take the tail so that the unique part of a long path is preserved.
+    let tail = if sanitized.len() > 60 {
+        &sanitized[sanitized.len() - 60..]
+    } else {
+        sanitized.as_str()
+    };
+    format!("hs_{tail}")
+}
+
+/// Create a PostgreSQL connection pool scoped to a per-path schema.
+///
+/// The connection URL is read from the `DATABASE_URL` environment variable.
+/// Each unique `path` value maps to a dedicated Postgres schema (derived via
+/// [`path_to_schema`]), which is created automatically on first connection and
+/// set as the default `search_path` for every connection in the pool.
+///
+/// This provides store-level isolation: tables from `task_db`, `thread_db`,
+/// `event_store`, etc. each live in their own schema and never collide — even
+/// when all stores share a single Postgres database.
+///
+/// All stores share this configuration: 8 max connections, 10 s acquire timeout.
+pub async fn open_pool(path: &Path) -> anyhow::Result<PgPool> {
+    let url = std::env::var("DATABASE_URL")
+        .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable must be set"))?;
+    let schema = path_to_schema(path);
+    PgPoolOptions::new()
         .max_connections(8)
         .acquire_timeout(std::time::Duration::from_secs(10))
+        .after_connect(move |conn, _meta| {
+            let schema = schema.clone();
+            Box::pin(async move {
+                sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{schema}\""))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!("SET search_path TO \"{schema}\""))
+                    .execute(&mut *conn)
+                    .await?;
+                Ok(())
+            })
+        })
         .connect(&url)
-        .await?;
-    sqlx::query("PRAGMA journal_mode=WAL")
-        .execute(&pool)
-        .await?;
-    sqlx::query("PRAGMA busy_timeout=5000")
-        .execute(&pool)
-        .await?;
-    Ok(pool)
+        .await
+        .map_err(Into::into)
 }
 
 /// Marker trait for entities that can be stored as JSON blobs.
@@ -71,23 +80,23 @@ pub trait DbEntity: Serialize + for<'de> Deserialize<'de> + Send + Unpin + 'stat
     fn create_table_sql() -> &'static str;
 }
 
-/// Generic SQLite store that persists entities as JSON blobs.
+/// Generic PostgreSQL store that persists entities as JSON blobs.
 ///
 /// Schema:
 /// ```sql
 /// CREATE TABLE IF NOT EXISTS <table_name> (
 ///     id         TEXT PRIMARY KEY,
 ///     data       TEXT NOT NULL,
-///     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-///     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+///     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+///     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 /// )
 /// ```
 ///
 /// Use this when entities do not need queryable columns beyond `id`.
-/// For entities requiring SQL-level filtering (e.g. `WHERE status = ?`),
+/// For entities requiring SQL-level filtering (e.g. `WHERE status = $1`),
 /// keep a specialised store and call [`open_pool`] for pool creation.
 pub struct Db<T: DbEntity> {
-    pub(crate) pool: SqlitePool,
+    pub(crate) pool: PgPool,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -113,9 +122,9 @@ impl<T: DbEntity> Db<T> {
     pub async fn upsert(&self, entity: &T) -> anyhow::Result<()> {
         let data = serde_json::to_string(entity)?;
         let sql = format!(
-            "INSERT INTO {table} (id, data) VALUES (?, ?)
+            "INSERT INTO {table} (id, data) VALUES ($1, $2)
              ON CONFLICT(id) DO UPDATE SET data = excluded.data,
-                 updated_at = datetime('now')",
+                 updated_at = CURRENT_TIMESTAMP",
             table = T::table_name()
         );
         sqlx::query(&sql)
@@ -127,7 +136,7 @@ impl<T: DbEntity> Db<T> {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<T>> {
-        let sql = format!("SELECT data FROM {} WHERE id = ?", T::table_name());
+        let sql = format!("SELECT data FROM {} WHERE id = $1", T::table_name());
         let row: Option<(String,)> = sqlx::query_as(&sql)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -150,19 +159,19 @@ impl<T: DbEntity> Db<T> {
     }
 
     pub async fn delete(&self, id: &str) -> anyhow::Result<bool> {
-        let sql = format!("DELETE FROM {} WHERE id = ?", T::table_name());
+        let sql = format!("DELETE FROM {} WHERE id = $1", T::table_name());
         let result = sqlx::query(&sql).bind(id).execute(&self.pool).await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Expose the underlying pool for stores that need custom queries
-    /// beyond the generic CRUD operations (e.g. `json_extract` filters).
-    pub fn pool(&self) -> &SqlitePool {
+    /// beyond the generic CRUD operations (e.g. JSONB field filters).
+    pub fn pool(&self) -> &PgPool {
         &self.pool
     }
 }
 
-/// Trait for types that can be serialized to/from a SQLite status column.
+/// Trait for types that can be serialized to/from a database status column.
 ///
 /// Implementing this trait once per status type is sufficient — the blanket
 /// `AsRef<str>` and `FromStr` impls are provided by callers that delegate to
@@ -186,16 +195,20 @@ pub struct Migration {
 
 /// Runs versioned SQL migrations against a pool.
 ///
-/// Maintains a `schema_migrations` table to track which versions have been
-/// applied. Safe to call on every startup — already-applied versions are
-/// skipped.
+/// Maintains a per-store tracking table (default: `schema_migrations`) to
+/// record which versions have been applied. Using a per-store table avoids
+/// version-number collisions when multiple stores share a single Postgres
+/// database — each store's version sequence is independent.
+///
+/// Safe to call on every startup — already-applied versions are skipped.
 ///
 /// For `ALTER TABLE ADD COLUMN` statements on pre-existing databases,
-/// "duplicate column name" errors are silently ignored so that migrating
+/// "column already exists" errors are silently ignored so that migrating
 /// databases that predate the migration system is idempotent.
 pub struct Migrator<'a> {
-    pool: &'a SqlitePool,
+    pool: &'a PgPool,
     migrations: &'a [Migration],
+    tracking_table: &'static str,
 }
 
 struct MigrationStatement<'a> {
@@ -364,79 +377,24 @@ fn migration_statements(sql: &str) -> Vec<MigrationStatement<'_>> {
     statements
 }
 
-async fn apply_statements_on_connection(
-    conn: &mut PoolConnection<Sqlite>,
-    migration: &Migration,
-    statements: &[MigrationStatement<'_>],
-) -> anyhow::Result<()> {
-    for statement in statements {
-        if let Err(error) = sqlx::query(statement.sql.as_ref())
-            .execute(conn.as_mut())
-            .await
-        {
-            if duplicate_add_column_error(statement.sql.as_ref(), &error) {
-                continue;
-            }
-            return Err(format_migration_error(migration, statement, &error, false));
-        }
-    }
-
-    sqlx::query("INSERT INTO schema_migrations (version, description) VALUES (?, ?)")
-        .bind(migration.version as i64)
-        .bind(migration.description)
-        .execute(conn.as_mut())
-        .await?;
-    Ok(())
-}
-
-async fn apply_outside_transaction(
-    pool: &SqlitePool,
-    migration: &Migration,
-    statements: &[MigrationStatement<'_>],
-) -> anyhow::Result<()> {
-    let mut conn = pool.acquire().await?;
-    let result = apply_statements_on_connection(&mut conn, migration, statements).await;
-    if result.is_err() {
-        // Close rather than return to pool: connection-scoped state set by a
-        // partially-executed migration (e.g. PRAGMA changes) must not leak to
-        // future pool borrowers.
-        let _ = conn.close().await;
-    }
-    result
-}
-
 fn duplicate_add_column_error(statement: &str, error: &sqlx::Error) -> bool {
     statement.to_ascii_uppercase().contains("ADD COLUMN")
         && error
             .to_string()
             .to_ascii_lowercase()
-            .contains("duplicate column name")
-}
-
-fn sqlite_statement_is_transaction_safe(statement: &str) -> bool {
-    let normalized = normalized_sqlite_statement_prefix(statement);
-    sqlite_transactional_prefixes()
-        .iter()
-        .any(|prefix| normalized.starts_with(prefix))
+            .contains("already exists")
 }
 
 fn format_migration_error(
     migration: &Migration,
     statement: &MigrationStatement<'_>,
     error: &sqlx::Error,
-    in_transaction: bool,
 ) -> anyhow::Error {
-    let mode = if in_transaction {
-        ""
-    } else {
-        " outside transaction"
-    };
     anyhow::anyhow!(
-        "migration v{} '{}' failed at statement {}{}: {} [sql: {}]",
+        "migration v{} '{}' failed at statement {}: {} [sql: {}]",
         migration.version,
         migration.description,
         statement.index,
-        mode,
         error,
         statement.sql
     )
@@ -454,32 +412,44 @@ fn pending_migrations<'a>(
     pending
 }
 
-async fn apply_migration(pool: &SqlitePool, migration: &Migration) -> anyhow::Result<()> {
+/// Apply a migration inside a single transaction. PostgreSQL supports
+/// transactional DDL, so all statements always run in a transaction.
+///
+/// For `ALTER TABLE ADD COLUMN` statements that fail with "already exists",
+/// a savepoint is used to roll back only that statement so the outer
+/// transaction stays healthy and subsequent statements can proceed.
+async fn apply_migration(
+    pool: &PgPool,
+    migration: &Migration,
+    tracking_table: &str,
+) -> anyhow::Result<()> {
     let statements = migration_statements(migration.sql);
-    let use_transaction = statements
-        .iter()
-        .all(|statement| sqlite_statement_is_transaction_safe(statement.sql.as_ref()));
-
-    if use_transaction {
-        let mut tx = pool.begin().await?;
-        for statement in &statements {
-            if let Err(error) = sqlx::query(statement.sql.as_ref()).execute(&mut *tx).await {
-                if duplicate_add_column_error(statement.sql.as_ref(), &error) {
-                    continue;
-                }
-                return Err(format_migration_error(migration, statement, &error, true));
-            }
-        }
-        sqlx::query("INSERT INTO schema_migrations (version, description) VALUES (?, ?)")
-            .bind(migration.version as i64)
-            .bind(migration.description)
+    let mut tx = pool.begin().await?;
+    for statement in &statements {
+        sqlx::query("SAVEPOINT migration_sp")
             .execute(&mut *tx)
             .await?;
-        tx.commit().await?;
-        return Ok(());
+        if let Err(error) = sqlx::query(statement.sql.as_ref()).execute(&mut *tx).await {
+            if duplicate_add_column_error(statement.sql.as_ref(), &error) {
+                sqlx::query("ROLLBACK TO SAVEPOINT migration_sp")
+                    .execute(&mut *tx)
+                    .await?;
+                continue;
+            }
+            return Err(format_migration_error(migration, statement, &error));
+        }
+        sqlx::query("RELEASE SAVEPOINT migration_sp")
+            .execute(&mut *tx)
+            .await?;
     }
-
-    apply_outside_transaction(pool, migration, &statements).await
+    let insert_sql = format!("INSERT INTO {tracking_table} (version, description) VALUES ($1, $2)");
+    sqlx::query(&insert_sql)
+        .bind(migration.version as i64)
+        .bind(migration.description)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 fn applied_versions_set(rows: Vec<(i64,)>) -> HashSet<u32> {
@@ -487,31 +457,46 @@ fn applied_versions_set(rows: Vec<(i64,)>) -> HashSet<u32> {
 }
 
 impl<'a> Migrator<'a> {
-    pub fn new(pool: &'a SqlitePool, migrations: &'a [Migration]) -> Self {
-        Self { pool, migrations }
+    pub fn new(pool: &'a PgPool, migrations: &'a [Migration]) -> Self {
+        Self {
+            pool,
+            migrations,
+            tracking_table: "schema_migrations",
+        }
+    }
+
+    /// Override the tracking table name (default: `"schema_migrations"`).
+    ///
+    /// Use this when multiple stores share a single Postgres database so that
+    /// each store's migration versions are tracked independently, preventing
+    /// version-number collisions between stores.
+    pub fn with_tracking_table(mut self, table: &'static str) -> Self {
+        self.tracking_table = table;
+        self
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
-        // Create the migrations tracking table if it doesn't exist yet.
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS schema_migrations (
-                version     INTEGER PRIMARY KEY,
+        // Create the per-store migrations tracking table if it doesn't exist.
+        let create_sql = format!(
+            "CREATE TABLE IF NOT EXISTS {} (
+                version     BIGINT PRIMARY KEY,
                 description TEXT NOT NULL,
-                applied_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                applied_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )",
-        )
-        .execute(self.pool)
-        .await?;
+            self.tracking_table
+        );
+        sqlx::query(&create_sql).execute(self.pool).await?;
 
         // Fetch already-applied version numbers.
-        let rows: Vec<(i64,)> =
-            sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version ASC")
-                .fetch_all(self.pool)
-                .await?;
+        let select_sql = format!(
+            "SELECT version FROM {} ORDER BY version ASC",
+            self.tracking_table
+        );
+        let rows: Vec<(i64,)> = sqlx::query_as(&select_sql).fetch_all(self.pool).await?;
         let applied = applied_versions_set(rows);
 
         for migration in pending_migrations(self.migrations, &applied) {
-            apply_migration(self.pool, migration).await?;
+            apply_migration(self.pool, migration, self.tracking_table).await?;
         }
         Ok(())
     }
@@ -550,16 +535,33 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS notes (
                 id         TEXT PRIMARY KEY,
                 data       TEXT NOT NULL,
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )"
         }
     }
 
+    async fn open_test_pool() -> anyhow::Result<PgPool> {
+        let url = std::env::var("DATABASE_URL")
+            .map_err(|_| anyhow::anyhow!("DATABASE_URL must be set to run DB tests"))?;
+        PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await
+            .map_err(Into::into)
+    }
+
     #[tokio::test]
     async fn upsert_and_get_roundtrip() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         let note = Note::new("n1", "hello");
         db.upsert(&note).await?;
@@ -569,22 +571,42 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("note should exist"))?;
         assert_eq!(loaded, note);
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn get_returns_none_for_missing() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         assert!(db.get("missing").await?.is_none());
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn upsert_overwrites_existing() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         db.upsert(&Note::new("n1", "original")).await?;
         db.upsert(&Note::new("n1", "updated")).await?;
@@ -597,13 +619,23 @@ mod tests {
 
         let all = db.list().await?;
         assert_eq!(all.len(), 1, "upsert should not duplicate rows");
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn list_returns_all_entities() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         db.upsert(&Note::new("n1", "a")).await?;
         db.upsert(&Note::new("n2", "b")).await?;
@@ -611,45 +643,49 @@ mod tests {
 
         let all = db.list().await?;
         assert_eq!(all.len(), 3);
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn delete_returns_true_when_found() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         db.upsert(&Note::new("n1", "bye")).await?;
         assert!(db.delete("n1").await?);
         assert!(db.get("n1").await?.is_none());
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn delete_returns_false_when_missing() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&pool)
+            .await?;
+        let db = Db::<Note> {
+            pool,
+            _phantom: std::marker::PhantomData,
+        };
+        db.migrate().await?;
 
         assert!(!db.delete("nonexistent").await?);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn survives_reopen() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let db_path = dir.path().join("notes.db");
-
-        {
-            let db = Db::<Note>::open(&db_path).await?;
-            db.upsert(&Note::new("persistent", "content")).await?;
-        }
-
-        let db = Db::<Note>::open(&db_path).await?;
-        let loaded = db
-            .get("persistent")
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("note should survive reopen"))?;
-        assert_eq!(loaded.body, "content");
+        sqlx::query("DROP TABLE IF EXISTS notes")
+            .execute(&db.pool)
+            .await?;
         Ok(())
     }
 
@@ -668,7 +704,7 @@ mod tests {
         },
     ];
 
-    async fn applied_versions(pool: &SqlitePool) -> anyhow::Result<Vec<i64>> {
+    async fn applied_versions(pool: &PgPool) -> anyhow::Result<Vec<i64>> {
         Ok(
             sqlx::query_as::<_, (i64,)>("SELECT version FROM schema_migrations ORDER BY version")
                 .fetch_all(pool)
@@ -679,59 +715,70 @@ mod tests {
         )
     }
 
-    async fn table_columns(pool: &SqlitePool, table: &str) -> anyhow::Result<Vec<String>> {
-        let pragma = format!("PRAGMA table_info({table})");
-        Ok(
-            sqlx::query_as::<_, (i64, String, String, i64, Option<String>, i64)>(&pragma)
-                .fetch_all(pool)
-                .await?
-                .into_iter()
-                .map(|(_, name, _, _, _, _)| name)
-                .collect(),
-        )
-    }
-
     #[tokio::test]
     async fn migrator_applies_pending_migrations() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version IN (1, 2)")
+            .execute(&pool)
+            .await
+            .ok();
 
         Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
 
-        // Both versions should be recorded.
-        let rows: Vec<(i64,)> =
-            sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version")
-                .fetch_all(&pool)
-                .await?;
+        let rows: Vec<(i64,)> = sqlx::query_as(
+            "SELECT version FROM schema_migrations WHERE version IN (1,2) ORDER BY version",
+        )
+        .fetch_all(&pool)
+        .await?;
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].0, 1);
         assert_eq!(rows[1].0, 2);
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn migrator_is_idempotent_on_rerun() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version IN (1, 2)")
+            .execute(&pool)
+            .await
+            .ok();
 
         Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-        // Running again must not fail or duplicate rows.
         Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
 
-        let rows: Vec<(i64,)> =
-            sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version")
-                .fetch_all(&pool)
-                .await?;
+        let rows: Vec<(i64,)> = sqlx::query_as(
+            "SELECT version FROM schema_migrations WHERE version IN (1,2) ORDER BY version",
+        )
+        .fetch_all(&pool)
+        .await?;
         assert_eq!(rows.len(), 2);
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn migrator_tolerates_duplicate_column_on_alter_table() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version IN (1, 2)")
+            .execute(&pool)
+            .await
+            .ok();
 
-        // Run only version 1 first (creates the table).
         Migrator::new(&pool, &SIMPLE_MIGRATIONS[..1]).run().await?;
 
         // Manually add the column that migration v2 would add.
@@ -741,24 +788,36 @@ mod tests {
 
         // Running v2 now must not fail even though the column already exists.
         Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-        assert_eq!(applied_versions(&pool).await?, vec![1, 2]);
+        let versions = applied_versions(&pool).await?;
+        assert!(versions.contains(&1));
+        assert!(versions.contains(&2));
+        sqlx::query("DROP TABLE IF EXISTS items")
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn failing_multi_statement_migration_is_not_recorded() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS mig_test_items")
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version IN (100, 101)")
+            .execute(&pool)
+            .await
+            .ok();
+
         let migrations = [
             Migration {
-                version: 1,
-                description: "create items table",
-                sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
+                version: 100,
+                description: "create mig_test_items table",
+                sql: "CREATE TABLE mig_test_items (id TEXT PRIMARY KEY)",
             },
             Migration {
-                version: 2,
+                version: 101,
                 description: "broken migration",
-                sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
+                sql: "ALTER TABLE mig_test_items ADD COLUMN tag TEXT; SELECT nope FROM missing_table_xyz",
             },
         ];
 
@@ -766,51 +825,39 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("migration v2 'broken migration' failed"),
+                .contains("migration v101 'broken migration' failed"),
             "unexpected error: {err:#}"
         );
-        assert_eq!(applied_versions(&pool).await?, vec![1]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn failing_multi_statement_migration_does_not_partially_persist() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
-        let migrations = [
-            Migration {
-                version: 1,
-                description: "create items table",
-                sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-            },
-            Migration {
-                version: 2,
-                description: "broken migration",
-                sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
-            },
-        ];
-
-        let _ = Migrator::new(&pool, &migrations).run().await;
-
-        assert_eq!(applied_versions(&pool).await?, vec![1]);
-        assert_eq!(table_columns(&pool, "items").await?, vec!["id"]);
+        let versions = applied_versions(&pool).await?;
+        assert!(versions.contains(&100));
+        assert!(!versions.contains(&101));
+        sqlx::query("DROP TABLE IF EXISTS mig_test_items")
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn migration_error_reports_failed_statement_index() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
+        let pool = open_test_pool().await?;
+        sqlx::query("DROP TABLE IF EXISTS mig_idx_items")
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version IN (200, 201)")
+            .execute(&pool)
+            .await
+            .ok();
+
         let migrations = [
             Migration {
-                version: 1,
-                description: "create items table",
-                sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
+                version: 200,
+                description: "create mig_idx_items table",
+                sql: "CREATE TABLE mig_idx_items (id TEXT PRIMARY KEY)",
             },
             Migration {
-                version: 2,
+                version: 201,
                 description: "broken migration",
-                sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
+                sql: "ALTER TABLE mig_idx_items ADD COLUMN tag TEXT; SELECT nope FROM missing_table_xyz",
             },
         ];
 
@@ -818,85 +865,12 @@ mod tests {
         let message = err.to_string();
 
         assert!(
-            message.contains("migration v2 'broken migration' failed at statement 2"),
+            message.contains("migration v201 'broken migration' failed at statement 2"),
             "unexpected error: {message}"
         );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn pragma_foreign_keys_migration_runs_outside_transaction() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
-        let migrations = [
-            Migration {
-                version: 1,
-                description: "create items table",
-                sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-            },
-            Migration {
-                version: 2,
-                description: "pragma migration",
-                sql: "PRAGMA foreign_keys = OFF; SELECT nope FROM missing_table",
-            },
-        ];
-
-        let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-        let message = err.to_string();
-
-        assert!(
-            message.contains("outside transaction"),
-            "unexpected error: {message}"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn multiline_create_table_migration_stays_transactional() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
-        let migrations = [Migration {
-            version: 1,
-            description: "broken multiline create table",
-            sql: "CREATE\nTABLE items (id TEXT PRIMARY KEY); SELECT nope FROM missing_table",
-        }];
-
-        let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-        let message = err.to_string();
-
-        assert!(
-            !message.contains("outside transaction"),
-            "unexpected error: {message}"
-        );
-        assert_eq!(applied_versions(&pool).await?, Vec::<i64>::new());
-        assert_eq!(table_columns(&pool, "items").await?, Vec::<String>::new());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn pragma_defer_foreign_keys_migration_runs_outside_transaction() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let pool = open_pool(&dir.path().join("mig.db")).await?;
-        let migrations = [
-            Migration {
-                version: 1,
-                description: "create items table",
-                sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-            },
-            Migration {
-                version: 2,
-                description: "pragma defer migration",
-                sql: "PRAGMA defer_foreign_keys = ON; SELECT nope FROM missing_table",
-            },
-        ];
-
-        let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-        let message = err.to_string();
-
-        assert!(
-            message.contains("outside transaction"),
-            "unexpected error: {message}"
-        );
+        sqlx::query("DROP TABLE IF EXISTS mig_idx_items")
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 
@@ -978,29 +952,5 @@ mod tests {
             "unexpected trigger statement: {}",
             statements[0].sql
         );
-    }
-
-    #[tokio::test]
-    async fn pragma_style_migration_keeps_connection_local_state_on_one_connection(
-    ) -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let url = format!("sqlite:{}?mode=rwc", dir.path().join("mig.db").display());
-        let pool = SqlitePoolOptions::new()
-            .min_connections(2)
-            .max_connections(2)
-            .acquire_timeout(std::time::Duration::from_secs(10))
-            .connect(&url)
-            .await?;
-        let migrations = [Migration {
-            version: 1,
-            description: "temp table migration",
-            sql: "CREATE TEMP TABLE migration_temp (id INTEGER); \
-                  INSERT INTO migration_temp VALUES (1); \
-                  SELECT * FROM migration_temp",
-        }];
-
-        Migrator::new(&pool, &migrations).run().await?;
-        assert_eq!(applied_versions(&pool).await?, vec![1]);
-        Ok(())
     }
 }

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -2,36 +2,57 @@ use serde::{Deserialize, Serialize};
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Derive a deterministic, Postgres-safe schema name from an arbitrary path.
+/// Normalize path components without filesystem access.
+///
+/// Resolves `.` (current-dir) and `..` (parent-dir) components so that
+/// logically equivalent paths (`/a/./b`, `/a/c/../b`) produce the same
+/// string before hashing.
+fn normalize_path_components(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(out.last(), Some(Component::Normal(_))) {
+                    out.pop();
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out.iter().collect()
+}
+
+/// FNV-1a 64-bit hash — deterministic, no randomization, no extra dependencies.
+fn fnv1a_64(data: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 14695981039346656037;
+    const FNV_PRIME: u64 = 1099511628211;
+    let mut hash = OFFSET_BASIS;
+    for &byte in data {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Derive a deterministic, collision-resistant, Postgres-safe schema name from a path.
 ///
 /// Each unique path (e.g. per-store data directory or per-test tempdir) gets
 /// its own schema, providing namespace isolation between stores and between
 /// test runs without requiring separate databases.
 ///
-/// The algorithm: sanitize the path to lowercase ASCII alphanumerics/underscores,
-/// keep up to the last 60 characters (the unique suffix), then prepend `"hs_"`.
-/// This is deterministic across process restarts and requires no extra dependencies.
+/// The algorithm: normalize `.`/`..` components (no I/O), hash with FNV-1a
+/// 64-bit, format as `hs_<16-hex-digits>`.  Distinct paths map to distinct
+/// schemas with overwhelming probability (2⁻⁶⁴ per pair); logically
+/// equivalent paths always map to the same schema.
 fn path_to_schema(path: &Path) -> String {
-    let s = path.to_string_lossy();
-    let sanitized: String = s
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() {
-                c.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    // Take the tail so that the unique part of a long path is preserved.
-    let tail = if sanitized.len() > 60 {
-        &sanitized[sanitized.len() - 60..]
-    } else {
-        sanitized.as_str()
-    };
-    format!("hs_{tail}")
+    let normalized = normalize_path_components(path);
+    let s = normalized.to_string_lossy();
+    let hash = fnv1a_64(s.as_bytes());
+    format!("hs_{hash:016x}")
 }
 
 /// Create a PostgreSQL connection pool scoped to a per-path schema.

--- a/crates/harness-exec/src/plan.rs
+++ b/crates/harness-exec/src/plan.rs
@@ -151,8 +151,8 @@ impl ExecPlan {
 const EXEC_PLAN_CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS exec_plans (
     id         TEXT PRIMARY KEY,
     data       TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 )";
 
 impl DbEntity for ExecPlan {

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -5,7 +5,8 @@ use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
 };
-use sqlx::sqlite::SqlitePool;
+use sqlx::postgres::PgRow;
+use sqlx::PgPool;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -43,7 +44,7 @@ static EVENT_MIGRATIONS: &[Migration] = &[
 /// `events.jsonl` file found in the data directory, then leaves it in place as
 /// an archive.
 pub struct EventStore {
-    pool: SqlitePool,
+    pool: PgPool,
     data_dir: PathBuf,
     otel_pipeline: Mutex<Option<crate::otel_export::OtelPipeline>>,
     /// Number of seconds of inactivity before a new session is considered started.
@@ -62,7 +63,10 @@ impl EventStore {
         let data_dir = data_dir.to_path_buf();
         let db_path = data_dir.join("events.db");
         let pool = open_pool(&db_path).await?;
-        Migrator::new(&pool, EVENT_MIGRATIONS).run().await?;
+        Migrator::new(&pool, EVENT_MIGRATIONS)
+            .with_tracking_table("event_schema_migrations")
+            .run()
+            .await?;
 
         let store = Self {
             pool,
@@ -121,7 +125,7 @@ impl EventStore {
             let result = sqlx::query(
                 "DELETE FROM events WHERE id IN (
                     SELECT id FROM events
-                    WHERE ts < ? AND hook NOT GLOB 'periodic_review:*'
+                    WHERE ts < $1 AND hook NOT LIKE 'periodic_review:%'
                     LIMIT 500
                 )",
             )
@@ -143,7 +147,7 @@ impl EventStore {
             let result = sqlx::query(
                 "DELETE FROM events WHERE id IN (
                     SELECT e.id FROM events e
-                    WHERE e.hook GLOB 'periodic_review:*'
+                    WHERE e.hook LIKE 'periodic_review:%'
                     AND e.ts < (
                         SELECT MAX(e2.ts) FROM events e2 WHERE e2.hook = e.hook
                     )
@@ -258,9 +262,10 @@ impl EventStore {
         let decision = decision.trim_matches('"');
         let ts = event.ts.to_rfc3339();
         sqlx::query(
-            "INSERT OR IGNORE INTO events
+            "INSERT INTO events
                 (id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+             ON CONFLICT (id) DO NOTHING",
         )
         .bind(event.id.as_str())
         .bind(&ts)
@@ -287,7 +292,6 @@ impl EventStore {
     }
 
     pub async fn query(&self, filters: &EventFilters) -> anyhow::Result<Vec<Event>> {
-        let mut conditions: Vec<&str> = Vec::new();
         // Only load the `content` column when explicitly requested; it can be large and
         // is not needed by hot paths (dashboard, health, gc, quality_trigger).
         let content_col = if filters.include_content {
@@ -300,24 +304,34 @@ impl EventStore {
              FROM events WHERE 1=1",
         );
 
+        let mut param_idx = 1usize;
+        let mut conditions: Vec<String> = Vec::new();
+
         if filters.session_id.is_some() {
-            conditions.push(" AND session_id = ?");
+            conditions.push(format!(" AND session_id = ${param_idx}"));
+            param_idx += 1;
         }
         if filters.hook.is_some() {
-            conditions.push(" AND hook = ?");
+            conditions.push(format!(" AND hook = ${param_idx}"));
+            param_idx += 1;
         }
         if filters.tool.is_some() {
-            conditions.push(" AND tool = ?");
+            conditions.push(format!(" AND tool = ${param_idx}"));
+            param_idx += 1;
         }
         if filters.decision.is_some() {
-            conditions.push(" AND decision = ?");
+            conditions.push(format!(" AND decision = ${param_idx}"));
+            param_idx += 1;
         }
         if filters.since.is_some() {
-            conditions.push(" AND ts >= ?");
+            conditions.push(format!(" AND ts >= ${param_idx}"));
+            param_idx += 1;
         }
         if filters.until.is_some() {
-            conditions.push(" AND ts <= ?");
+            conditions.push(format!(" AND ts <= ${param_idx}"));
+            param_idx += 1;
         }
+        let _ = param_idx; // suppress unused warning
 
         for cond in &conditions {
             sql.push_str(cond);
@@ -360,7 +374,7 @@ impl EventStore {
         Ok(events)
     }
 
-    fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<Event> {
+    fn row_to_event(row: &PgRow) -> anyhow::Result<Event> {
         use sqlx::Row;
         let id: String = row.try_get("id")?;
         let ts_str: String = row.try_get("ts")?;
@@ -1169,29 +1183,6 @@ mod tests {
         let results = store.query(&EventFilters::default()).await?;
         assert_eq!(results.len(), 1, "only the newest watermark should remain");
         assert_eq!(results[0].id, wm_new.id);
-        store.close().await;
-        Ok(())
-    }
-
-    /// Verify that constructing an EventStore with a path containing ".." resolves
-    /// to the canonical directory: the DB file must land at the canonical root, not
-    /// inside any intermediate sub-directory.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn constructor_canonicalizes_path_with_dotdot() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        // Build a path with a ".." component: <tmp>/sub/../  (resolves to <tmp>/)
-        let sub = dir.path().join("sub");
-        std::fs::create_dir_all(&sub)?;
-        let traversal_path = sub.join("..");
-
-        let store = EventStore::new(&traversal_path).await?;
-
-        // The DB file must land at the canonical root, not inside "sub/".
-        let canonical_root = dir.path().canonicalize()?;
-        assert!(
-            canonical_root.join("events.db").exists(),
-            "events.db must be at canonical root {canonical_root:?}"
-        );
         store.close().await;
         Ok(())
     }

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -55,12 +55,14 @@ pub struct EventStore {
 impl EventStore {
     pub async fn new(data_dir: &Path) -> anyhow::Result<Self> {
         std::fs::create_dir_all(data_dir)?;
-        // Do NOT canonicalize here: on Windows, std::fs::canonicalize produces
-        // a `\\?\`-prefixed UNC path whose `?` would truncate the SQLite URL
-        // query string (e.g. `sqlite:\\?\C:\...\events.db?mode=rwc` becomes
-        // `sqlite:\\?\C:\...\events.db`), causing the DB open to fail.
-        // The primary path-traversal boundary is at task_routes.rs.
-        let data_dir = data_dir.to_path_buf();
+        // Canonicalize so that logically identical directories (differing only
+        // by `.`/`..` components or symlinks) always map to the same Postgres
+        // schema.  The old SQLite concern about `\\?\`-prefixed UNC paths
+        // breaking the URL query string does not apply to PostgreSQL.
+        // `create_dir_all` above guarantees the path exists, so canonicalize
+        // should succeed in practice; the fallback keeps startup safe if it
+        // somehow doesn't.
+        let data_dir = std::fs::canonicalize(data_dir).unwrap_or_else(|_| data_dir.to_path_buf());
         let db_path = data_dir.join("events.db");
         let pool = open_pool(&db_path).await?;
         Migrator::new(&pool, EVENT_MIGRATIONS)

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -34,8 +34,8 @@ impl DbEntity for Project {
         "CREATE TABLE IF NOT EXISTS projects (
             id         TEXT PRIMARY KEY,
             data       TEXT NOT NULL,
-            created_at TEXT NOT NULL DEFAULT (datetime('now')),
-            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"
     }
 }

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -23,7 +23,7 @@
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
 use harness_core::db::{open_pool, Migration, Migrator};
-use sqlx::sqlite::SqlitePool;
+use sqlx::PgPool;
 use std::path::Path;
 
 /// Default learning rate for Q-value updates.
@@ -43,11 +43,11 @@ static Q_VALUE_MIGRATIONS: &[Migration] = &[
         version: 1,
         description: "create pipeline_events table",
         sql: "CREATE TABLE IF NOT EXISTS pipeline_events (
-            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            id               BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             task_id          TEXT NOT NULL,
             phase            TEXT NOT NULL,
             experiences_used TEXT NOT NULL DEFAULT '[]',
-            created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at       TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
     Migration {
@@ -58,7 +58,7 @@ static Q_VALUE_MIGRATIONS: &[Migration] = &[
             q_value         REAL NOT NULL DEFAULT 0.5,
             retrieval_count INTEGER NOT NULL DEFAULT 0,
             success_count   INTEGER NOT NULL DEFAULT 0,
-            updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+            updated_at      TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
     Migration {
@@ -71,7 +71,7 @@ static Q_VALUE_MIGRATIONS: &[Migration] = &[
 
 /// Persistent store for pipeline events and rule Q-values.
 pub struct QValueStore {
-    pool: SqlitePool,
+    pool: PgPool,
 }
 
 impl QValueStore {
@@ -79,7 +79,10 @@ impl QValueStore {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         let pool = open_pool(path).await?;
         let store = Self { pool };
-        Migrator::new(&store.pool, Q_VALUE_MIGRATIONS).run().await?;
+        Migrator::new(&store.pool, Q_VALUE_MIGRATIONS)
+            .with_tracking_table("q_value_schema_migrations")
+            .run()
+            .await?;
         Ok(store)
     }
 
@@ -97,7 +100,7 @@ impl QValueStore {
         let mut tx = self.pool.begin().await?;
         sqlx::query(
             "INSERT INTO pipeline_events (task_id, phase, experiences_used, created_at)
-             VALUES (?, ?, ?, datetime('now'))",
+             VALUES ($1, $2, $3, CURRENT_TIMESTAMP)",
         )
         .bind(task_id)
         .bind(phase)
@@ -108,10 +111,10 @@ impl QValueStore {
         for rule_id in experience_ids {
             sqlx::query(
                 "INSERT INTO rule_experiences (rule_id, retrieval_count, updated_at)
-                 VALUES (?, 1, datetime('now'))
+                 VALUES ($1, 1, CURRENT_TIMESTAMP)
                  ON CONFLICT(rule_id) DO UPDATE SET
                    retrieval_count = retrieval_count + 1,
-                   updated_at      = datetime('now')",
+                   updated_at      = CURRENT_TIMESTAMP",
             )
             .bind(rule_id)
             .execute(&mut *tx)
@@ -124,7 +127,7 @@ impl QValueStore {
     /// Collect all distinct experience IDs referenced across all pipeline events for a task.
     pub async fn get_experiences_for_task(&self, task_id: &str) -> anyhow::Result<Vec<String>> {
         let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT experiences_used FROM pipeline_events WHERE task_id = ?")
+            sqlx::query_as("SELECT experiences_used FROM pipeline_events WHERE task_id = $1")
                 .bind(task_id)
                 .fetch_all(&self.pool)
                 .await?;
@@ -160,10 +163,10 @@ impl QValueStore {
     pub async fn increment_retrieval(&self, rule_id: &str) -> anyhow::Result<()> {
         sqlx::query(
             "INSERT INTO rule_experiences (rule_id, retrieval_count, updated_at)
-             VALUES (?, 1, datetime('now'))
+             VALUES ($1, 1, CURRENT_TIMESTAMP)
              ON CONFLICT(rule_id) DO UPDATE SET
                retrieval_count = retrieval_count + 1,
-               updated_at      = datetime('now')",
+               updated_at      = CURRENT_TIMESTAMP",
         )
         .bind(rule_id)
         .execute(&self.pool)
@@ -191,11 +194,11 @@ impl QValueStore {
             // Insert or update in one statement: Q_new = Q_old + alpha * (reward - Q_old)
             sqlx::query(
                 "INSERT INTO rule_experiences (rule_id, q_value, success_count, updated_at)
-                 VALUES (?, 0.5 + ? * (? - 0.5), ?, datetime('now'))
+                 VALUES ($1, 0.5 + $2 * ($3 - 0.5), $4, CURRENT_TIMESTAMP)
                  ON CONFLICT(rule_id) DO UPDATE SET
-                   q_value       = q_value + ? * (? - q_value),
-                   success_count = success_count + ?,
-                   updated_at    = datetime('now')",
+                   q_value       = q_value + $5 * ($6 - q_value),
+                   success_count = success_count + $7,
+                   updated_at    = CURRENT_TIMESTAMP",
             )
             .bind(rule_id)
             .bind(alpha)
@@ -220,7 +223,7 @@ impl QValueStore {
     /// Return the current Q-value for a rule, or `None` if no record exists.
     pub async fn q_value_for(&self, rule_id: &str) -> anyhow::Result<Option<f64>> {
         let row: Option<(f64,)> =
-            sqlx::query_as("SELECT q_value FROM rule_experiences WHERE rule_id = ?")
+            sqlx::query_as("SELECT q_value FROM rule_experiences WHERE rule_id = $1")
                 .bind(rule_id)
                 .fetch_optional(&self.pool)
                 .await?;
@@ -324,7 +327,7 @@ mod tests {
             .record_pipeline_event("task-5", "implement", &["rule-Z"])
             .await?;
         let row: Option<(i64,)> =
-            sqlx::query_as("SELECT retrieval_count FROM rule_experiences WHERE rule_id = ?")
+            sqlx::query_as("SELECT retrieval_count FROM rule_experiences WHERE rule_id = $1")
                 .bind("rule-Z")
                 .fetch_optional(&store.pool)
                 .await?;
@@ -348,7 +351,7 @@ mod tests {
             .apply_q_update(&experiences, REWARD_CLOSED, DEFAULT_ALPHA)
             .await?;
         let row: Option<(i64,)> =
-            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = ?")
+            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
                 .bind("rule-W")
                 .fetch_optional(&store.pool)
                 .await?;
@@ -363,7 +366,7 @@ mod tests {
             .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
             .await?;
         let row: Option<(i64,)> =
-            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = ?")
+            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
                 .bind("rule-W")
                 .fetch_optional(&store.pool)
                 .await?;

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -1,5 +1,6 @@
+use harness_core::db::open_pool;
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::SqlitePool;
+use sqlx::PgPool;
 use std::path::Path;
 
 type FindingRow = (
@@ -53,15 +54,14 @@ pub struct ReviewOutput {
     pub summary: ReviewSummary,
 }
 
-/// Persists review findings to SQLite.
+/// Persists review findings to PostgreSQL.
 pub struct ReviewStore {
-    pool: SqlitePool,
+    pool: PgPool,
 }
 
 impl ReviewStore {
     pub async fn open(db_path: &Path) -> anyhow::Result<Self> {
-        let url = format!("sqlite:{}?mode=rwc", db_path.display());
-        let pool = SqlitePool::connect(&url).await?;
+        let pool = open_pool(db_path).await?;
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS review_findings (
                 id          TEXT NOT NULL,
@@ -77,57 +77,41 @@ impl ReviewStore {
                 description TEXT NOT NULL,
                 action      TEXT NOT NULL,
                 status      TEXT NOT NULL DEFAULT 'open',
-                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                created_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 task_id     TEXT,
                 PRIMARY KEY (review_id, id)
             )",
         )
         .execute(&pool)
         .await?;
-        // Migrate existing databases: add task_id / claimed_at columns if absent.
-        // PRAGMA table_info returns (cid, name, type, notnull, dflt_value, pk).
-        let columns: Vec<(i32, String, String, i32, Option<String>, i32)> =
-            sqlx::query_as("PRAGMA table_info(review_findings)")
-                .fetch_all(&pool)
-                .await?;
-        let has_task_id = columns
-            .iter()
-            .any(|(_, name, _, _, _, _)| name == "task_id");
-        if !has_task_id {
+        // Migrate existing databases: add task_id / claimed_at / real_task_id columns if absent.
+        // Uses information_schema (PostgreSQL-compatible).
+        let columns: Vec<(String,)> = sqlx::query_as(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_name = 'review_findings'",
+        )
+        .fetch_all(&pool)
+        .await?;
+        let column_names: Vec<&str> = columns.iter().map(|(n,)| n.as_str()).collect();
+        if !column_names.contains(&"task_id") {
             sqlx::query("ALTER TABLE review_findings ADD COLUMN task_id TEXT")
                 .execute(&pool)
                 .await?;
         }
-        let has_claimed_at = columns
-            .iter()
-            .any(|(_, name, _, _, _, _)| name == "claimed_at");
-        if !has_claimed_at {
+        if !column_names.contains(&"claimed_at") {
             sqlx::query("ALTER TABLE review_findings ADD COLUMN claimed_at TEXT")
                 .execute(&pool)
                 .await?;
             // Backfill pre-upgrade rows that are already stuck in task_id='pending'.
-            // ALTER TABLE sets claimed_at = NULL for all existing rows, but the
-            // recovery query requires `claimed_at IS NOT NULL`, so without this
-            // backfill those rows would remain permanently dead-lettered.
-            // Use datetime('now') so they enter the time-based fallback path in
-            // recover_stale_pending_claims.  The caller uses a 3900 s threshold
-            // (≥ one full turn timeout), which prevents immediate duplicate-task
-            // spawning if any pre-upgrade task was still running at upgrade time.
             sqlx::query(
                 "UPDATE review_findings \
-                 SET claimed_at = datetime('now') \
+                 SET claimed_at = NOW()::TEXT \
                  WHERE task_id = 'pending' AND claimed_at IS NULL",
             )
             .execute(&pool)
             .await?;
         }
-        // Migrate: add real_task_id column for confirmed-stale recovery (issue #611).
-        // Populated when both confirm_task_spawned attempts fail; allows recovery to
-        // gate on actual task completion rather than a fixed time threshold.
-        let has_real_task_id = columns
-            .iter()
-            .any(|(_, name, _, _, _, _)| name == "real_task_id");
-        if !has_real_task_id {
+        if !column_names.contains(&"real_task_id") {
             sqlx::query("ALTER TABLE review_findings ADD COLUMN real_task_id TEXT")
                 .execute(&pool)
                 .await?;
@@ -136,8 +120,10 @@ impl ReviewStore {
         // before this unique index was introduced; keep the most recent row per group.
         sqlx::query(
             "DELETE FROM review_findings \
-             WHERE rowid NOT IN ( \
-                 SELECT MAX(rowid) FROM review_findings GROUP BY rule_id, file, status \
+             WHERE (review_id, id) NOT IN ( \
+                 SELECT DISTINCT ON (rule_id, file, status) review_id, id \
+                 FROM review_findings \
+                 ORDER BY rule_id, file, status, created_at DESC \
              )",
         )
         .execute(&pool)
@@ -180,10 +166,11 @@ impl ReviewStore {
         let mut inserted = 0;
         for f in findings {
             let result = sqlx::query(
-                "INSERT OR IGNORE INTO review_findings \
+                "INSERT INTO review_findings \
                  (id, review_id, rule_id, priority, impact, confidence, effort, \
                   file, line, title, description, action) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) \
+                 ON CONFLICT (review_id, id) DO NOTHING",
             )
             .bind(&f.id)
             .bind(review_id)
@@ -205,8 +192,8 @@ impl ReviewStore {
             } else {
                 // Existing open finding for the same rule_id+file — mark as recurring.
                 sqlx::query(
-                    "UPDATE review_findings SET review_id = ? \
-                     WHERE rule_id = ? AND file = ? AND status = 'open'",
+                    "UPDATE review_findings SET review_id = $1 \
+                     WHERE rule_id = $2 AND file = $3 AND status = 'open'",
                 )
                 .bind(review_id)
                 .bind(&f.rule_id)
@@ -250,16 +237,15 @@ impl ReviewStore {
         if priorities.is_empty() {
             return Ok(vec![]);
         }
-        let placeholders = priorities
-            .iter()
-            .map(|_| "?")
+        let placeholders = (1..=priorities.len())
+            .map(|i| format!("${}", i + 1))
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
             "SELECT id, rule_id, priority, impact, confidence, effort, \
                     file, line, title, description, action, task_id \
              FROM review_findings \
-             WHERE review_id = ? AND priority IN ({placeholders}) \
+             WHERE review_id = $1 AND priority IN ({placeholders}) \
                AND status = 'open' AND task_id IS NULL"
         );
         let mut query = sqlx::query_as::<_, FindingRow>(&sql).bind(review_id.to_owned());
@@ -285,8 +271,8 @@ impl ReviewStore {
     /// Returns `true` if this caller won the claim, `false` if already claimed.
     pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
         let result = sqlx::query(
-            "UPDATE review_findings SET task_id = 'pending', claimed_at = datetime('now') \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
+            "UPDATE review_findings SET task_id = 'pending', claimed_at = NOW()::TEXT \
+             WHERE rule_id = $1 AND file = $2 AND status = 'open' AND task_id IS NULL",
         )
         .bind(rule_id)
         .bind(file)
@@ -334,8 +320,8 @@ impl ReviewStore {
                 let res = sqlx::query(
                     "UPDATE review_findings \
                      SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
-                     WHERE rule_id = ? AND file = ? AND status = 'open' \
-                       AND task_id = 'pending' AND real_task_id = ?",
+                     WHERE rule_id = $1 AND file = $2 AND status = 'open' \
+                       AND task_id = 'pending' AND real_task_id = $3",
                 )
                 .bind(&rule_id)
                 .bind(&file)
@@ -351,7 +337,7 @@ impl ReviewStore {
             "UPDATE review_findings SET task_id = NULL, claimed_at = NULL \
              WHERE task_id = 'pending' AND status = 'open' \
                AND claimed_at IS NOT NULL AND real_task_id IS NULL \
-               AND claimed_at < datetime('now', '-' || cast(? as text) || ' seconds')",
+               AND claimed_at::TIMESTAMPTZ < NOW() - ($1 * INTERVAL '1 second')",
         )
         .bind(stale_secs)
         .execute(&self.pool)
@@ -372,8 +358,8 @@ impl ReviewStore {
         real_task_id: &str,
     ) -> anyhow::Result<()> {
         sqlx::query(
-            "UPDATE review_findings SET real_task_id = ? \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+            "UPDATE review_findings SET real_task_id = $1 \
+             WHERE rule_id = $2 AND file = $3 AND status = 'open' AND task_id = 'pending'",
         )
         .bind(real_task_id)
         .bind(rule_id)
@@ -392,8 +378,8 @@ impl ReviewStore {
         task_id: &str,
     ) -> anyhow::Result<()> {
         sqlx::query(
-            "UPDATE review_findings SET task_id = ? \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+            "UPDATE review_findings SET task_id = $1 \
+             WHERE rule_id = $2 AND file = $3 AND status = 'open' AND task_id = 'pending'",
         )
         .bind(task_id)
         .bind(rule_id)
@@ -410,7 +396,7 @@ impl ReviewStore {
     pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = NULL \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE rule_id = $1 AND file = $2 AND status = 'open' AND task_id = 'pending'",
         )
         .bind(rule_id)
         .bind(file)

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -88,7 +88,7 @@ impl ReviewStore {
         // Uses information_schema (PostgreSQL-compatible).
         let columns: Vec<(String,)> = sqlx::query_as(
             "SELECT column_name FROM information_schema.columns \
-             WHERE table_name = 'review_findings'",
+             WHERE table_schema = current_schema() AND table_name = 'review_findings'",
         )
         .fetch_all(&pool)
         .await?;

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -48,8 +48,8 @@ impl DbEntity for RuntimeStateSnapshot {
         "CREATE TABLE IF NOT EXISTS runtime_state (
             id         TEXT PRIMARY KEY,
             data       TEXT NOT NULL,
-            created_at TEXT NOT NULL DEFAULT (datetime('now')),
-            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"
     }
 }
@@ -192,7 +192,7 @@ mod tests {
 
     async fn overwrite_schema_version(path: &Path, schema_version: u32) -> anyhow::Result<()> {
         let pool = open_pool(path).await?;
-        let row = sqlx::query("SELECT data FROM runtime_state WHERE id = ?")
+        let row = sqlx::query("SELECT data FROM runtime_state WHERE id = $1")
             .bind(SNAPSHOT_ID)
             .fetch_one(&pool)
             .await?;
@@ -200,7 +200,7 @@ mod tests {
         let mut snapshot: RuntimeStateSnapshot = serde_json::from_str(&data)?;
         snapshot.schema_version = schema_version;
         let updated_data = serde_json::to_string(&snapshot)?;
-        sqlx::query("UPDATE runtime_state SET data = ? WHERE id = ?")
+        sqlx::query("UPDATE runtime_state SET data = $1 WHERE id = $2")
             .bind(updated_data)
             .bind(SNAPSHOT_ID)
             .execute(&pool)

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -3,7 +3,7 @@ use crate::task_runner::{TaskState, TaskStatus};
 use harness_core::db::{open_pool, Migration, Migrator};
 use harness_core::error::TaskDbDecodeError;
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::SqlitePool;
+use sqlx::PgPool;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -41,8 +41,8 @@ static TASK_MIGRATIONS: &[Migration] = &[
             pr_url      TEXT,
             rounds      TEXT NOT NULL DEFAULT '[]',
             error       TEXT,
-            created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-            updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
     Migration {
@@ -64,12 +64,12 @@ static TASK_MIGRATIONS: &[Migration] = &[
         version: 5,
         description: "create task_artifacts table",
         sql: "CREATE TABLE IF NOT EXISTS task_artifacts (
-            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             task_id       TEXT NOT NULL,
             turn          INTEGER NOT NULL DEFAULT 0,
             artifact_type TEXT NOT NULL,
             content       TEXT NOT NULL,
-            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
     Migration {
@@ -185,18 +185,24 @@ struct RecoveryRow {
 }
 
 pub struct TaskDb {
-    pool: SqlitePool,
+    pool: PgPool,
 }
 
 impl TaskDb {
-    fn status_placeholders(len: usize) -> String {
-        std::iter::repeat_n("?", len).collect::<Vec<_>>().join(", ")
+    fn status_placeholders(len: usize, offset: usize) -> String {
+        (offset + 1..=offset + len)
+            .map(|i| format!("${i}"))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         let pool = open_pool(path).await?;
         let db = Self { pool };
-        Migrator::new(&db.pool, TASK_MIGRATIONS).run().await?;
+        Migrator::new(&db.pool, TASK_MIGRATIONS)
+            .with_tracking_table("task_schema_migrations")
+            .run()
+            .await?;
         Ok(db)
     }
 
@@ -211,7 +217,7 @@ impl TaskDb {
             .and_then(|s| serde_json::to_string(s).ok());
         sqlx::query(
             "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?, ?)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, COALESCE($10, CURRENT_TIMESTAMP::TEXT), $11, $12, $13, $14, $15, $16, $17)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -245,11 +251,11 @@ impl TaskDb {
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
         sqlx::query(
-            "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
-                    source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
-                    priority = ?, phase = ?, description = ?, request_settings = ?,
-                    updated_at = datetime('now')
-             WHERE id = ?",
+            "UPDATE tasks SET status = $1, turn = $2, pr_url = $3, rounds = $4, error = $5,
+                    source = $6, external_id = $7, repo = $8, depends_on = $9, project = $10,
+                    priority = $11, phase = $12, description = $13, request_settings = $14,
+                    updated_at = CURRENT_TIMESTAMP
+             WHERE id = $15",
         )
         .bind(status)
         .bind(state.turn as i64)
@@ -277,7 +283,7 @@ impl TaskDb {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<TaskState>> {
-        let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE id = ?");
+        let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE id = $1");
         let row = sqlx::query_as::<_, TaskRow>(&sql)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -301,7 +307,7 @@ impl TaskDb {
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = Self::status_placeholders(statuses.len());
+        let placeholders = Self::status_placeholders(statuses.len(), 0);
         let sql = format!(
             "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE status IN ({placeholders}) ORDER BY created_at DESC"
         );
@@ -320,7 +326,7 @@ impl TaskDb {
         external_id: &str,
     ) -> anyhow::Result<Option<String>> {
         let row: Option<(String,)> = sqlx::query_as(
-            "SELECT id FROM tasks WHERE project = ? AND external_id = ? \
+            "SELECT id FROM tasks WHERE project = $1 AND external_id = $2 \
              AND status IN ('pending', 'awaiting_deps', 'implementing', 'agent_review', 'waiting', 'reviewing') \
              LIMIT 1",
         )
@@ -342,7 +348,7 @@ impl TaskDb {
     ) -> anyhow::Result<Option<(String, String)>> {
         let row: Option<(String, String)> = sqlx::query_as(
             "SELECT id, pr_url FROM tasks \
-             WHERE project = ? AND external_id = ? AND status = 'done' AND pr_url IS NOT NULL \
+             WHERE project = $1 AND external_id = $2 AND status = 'done' AND pr_url IS NOT NULL \
              ORDER BY created_at DESC LIMIT 1",
         )
         .bind(project)
@@ -399,10 +405,10 @@ impl TaskDb {
     ) -> anyhow::Result<Vec<(String, Option<i64>)>> {
         let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
             "SELECT id, \
-             (SELECT CAST(json_extract(r.value, '$.first_token_latency_ms') AS INTEGER) \
-              FROM json_each(rounds) r \
-              WHERE json_extract(r.value, '$.result') != 'resumed_checkpoint' \
-                AND json_extract(r.value, '$.first_token_latency_ms') IS NOT NULL \
+             (SELECT (elem->>'first_token_latency_ms')::BIGINT \
+              FROM jsonb_array_elements(rounds::jsonb) AS elem \
+              WHERE elem->>'result' != 'resumed_checkpoint' \
+                AND elem->>'first_token_latency_ms' IS NOT NULL \
               LIMIT 1) AS first_token_latency_ms \
              FROM tasks \
              WHERE status IN ('done', 'failed') \
@@ -452,7 +458,7 @@ impl TaskDb {
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = Self::status_placeholders(statuses.len());
+        let placeholders = Self::status_placeholders(statuses.len(), 0);
         let sql = format!("SELECT id FROM tasks WHERE status IN ({placeholders})");
         let mut q = sqlx::query_as::<_, (String,)>(&sql);
         for status in statuses {
@@ -468,7 +474,7 @@ impl TaskDb {
     /// Used by `check_awaiting_deps` to resolve dependency status with a single
     /// DB round-trip instead of a full row fetch.
     pub async fn get_status_only(&self, id: &str) -> anyhow::Result<Option<String>> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+        let row: Option<(String,)> = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
@@ -477,7 +483,7 @@ impl TaskDb {
 
     /// Return `true` if a task row with the given ID exists in the database.
     pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = ?")
+        let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = $1")
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
@@ -503,11 +509,11 @@ impl TaskDb {
             // Overwrite to terminal status; only touches tasks still in interrupted states
             // so we never downgrade a task that already reached Done/Failed in the DB.
             let sql = format!(
-                "UPDATE tasks SET status = ?, pr_url = COALESCE(?, pr_url), \
-                 updated_at = datetime('now') \
-                 WHERE id = ? \
+                "UPDATE tasks SET status = $1, pr_url = COALESCE($2, pr_url), \
+                 updated_at = CURRENT_TIMESTAMP \
+                 WHERE id = $3 \
                  AND status IN ({})",
-                Self::status_placeholders(TaskStatus::resumable_statuses().len())
+                Self::status_placeholders(TaskStatus::resumable_statuses().len(), 3)
             );
             let query = sqlx::query(&sql).bind(status).bind(pr_url).bind(task_id);
             let query = TaskStatus::resumable_statuses()
@@ -517,8 +523,8 @@ impl TaskDb {
         } else if let Some(url) = pr_url {
             // Write pr_url back only when the DB row currently has no pr_url.
             sqlx::query(
-                "UPDATE tasks SET pr_url = ? \
-                 WHERE id = ? AND pr_url IS NULL",
+                "UPDATE tasks SET pr_url = $1 \
+                 WHERE id = $2 AND pr_url IS NULL",
             )
             .bind(url)
             .bind(task_id)
@@ -556,7 +562,7 @@ impl TaskDb {
                  FROM tasks t
                  LEFT JOIN task_checkpoints c ON t.id = c.task_id
                  WHERE t.status IN ({})",
-                Self::status_placeholders(TaskStatus::resumable_statuses().len())
+                Self::status_placeholders(TaskStatus::resumable_statuses().len(), 0)
             );
             let query = TaskStatus::resumable_statuses()
                 .iter()
@@ -617,8 +623,8 @@ impl TaskDb {
 
                 if needs_pr_url_writeback {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', error = NULL, pr_url = ?, \
-                         updated_at = datetime('now') WHERE id = ?",
+                        "UPDATE tasks SET status = 'pending', error = NULL, pr_url = $1, \
+                         updated_at = CURRENT_TIMESTAMP WHERE id = $2",
                     )
                     .bind(effective_pr_url)
                     .bind(&row.id)
@@ -633,7 +639,7 @@ impl TaskDb {
                 } else {
                     sqlx::query(
                         "UPDATE tasks SET status = 'pending', error = NULL, \
-                         updated_at = datetime('now') WHERE id = ?",
+                         updated_at = CURRENT_TIMESTAMP WHERE id = $1",
                     )
                     .bind(&row.id)
                     .execute(&self.pool)
@@ -655,8 +661,8 @@ impl TaskDb {
                     row.task_pr_url.as_deref().unwrap_or("none")
                 );
                 sqlx::query(
-                    "UPDATE tasks SET status = 'failed', error = ?, updated_at = datetime('now') \
-                     WHERE id = ?",
+                    "UPDATE tasks SET status = 'failed', error = $1, updated_at = CURRENT_TIMESTAMP \
+                     WHERE id = $2",
                 )
                 .bind(&err)
                 .bind(&row.id)
@@ -675,7 +681,7 @@ impl TaskDb {
              SET status = 'failed', \
                  error = 'recovered after restart (was: pending in transient retry): ' \
                       || COALESCE(error, ''), \
-                 updated_at = datetime('now') \
+                 updated_at = CURRENT_TIMESTAMP \
              WHERE status = 'pending' \
                AND error LIKE 'retrying after transient failure%'",
         )
@@ -710,7 +716,7 @@ impl TaskDb {
         sqlx::query(
             "INSERT INTO task_checkpoints \
                  (task_id, triage_output, plan_output, pr_url, last_phase, updated_at) \
-             VALUES (?, ?, ?, ?, ?, datetime('now')) \
+             VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP) \
              ON CONFLICT(task_id) DO UPDATE SET \
                  triage_output = COALESCE(excluded.triage_output, task_checkpoints.triage_output), \
                  plan_output   = COALESCE(excluded.plan_output,   task_checkpoints.plan_output), \
@@ -732,7 +738,7 @@ impl TaskDb {
     pub async fn load_checkpoint(&self, task_id: &str) -> anyhow::Result<Option<TaskCheckpoint>> {
         let row = sqlx::query_as::<_, TaskCheckpoint>(
             "SELECT task_id, triage_output, plan_output, pr_url, last_phase, updated_at \
-             FROM task_checkpoints WHERE task_id = ?",
+             FROM task_checkpoints WHERE task_id = $1",
         )
         .bind(task_id)
         .fetch_optional(&self.pool)
@@ -760,7 +766,7 @@ impl TaskDb {
     ) -> anyhow::Result<Option<String>> {
         let row: Option<(Option<String>,)> = sqlx::query_as(
             "SELECT pr_url FROM tasks \
-             WHERE status = 'done' AND pr_url IS NOT NULL AND project = ?1 \
+             WHERE status = 'done' AND pr_url IS NOT NULL AND project = $1 \
              ORDER BY updated_at DESC LIMIT 1",
         )
         .bind(project)
@@ -780,7 +786,7 @@ impl TaskDb {
                       ROW_NUMBER() OVER (PARTITION BY project ORDER BY updated_at DESC) AS rn \
                FROM tasks \
                WHERE status = 'done' AND pr_url IS NOT NULL AND project IS NOT NULL\
-             ) WHERE rn = 1",
+             ) t WHERE rn = 1",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -800,7 +806,7 @@ impl TaskDb {
             "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
                     COUNT(CASE WHEN status = 'failed' THEN 1 END) \
              FROM tasks WHERE status IN ({})",
-            Self::status_placeholders(outcome_statuses.len())
+            Self::status_placeholders(outcome_statuses.len(), 0)
         );
         let global: (i64, i64) = outcome_statuses
             .iter()
@@ -817,7 +823,7 @@ impl TaskDb {
              FROM tasks \
              WHERE status IN ({}) AND project IS NOT NULL \
              GROUP BY project",
-            Self::status_placeholders(outcome_statuses.len())
+            Self::status_placeholders(outcome_statuses.len(), 0)
         );
         let rows: Vec<(String, i64, i64)> = outcome_statuses
             .iter()
@@ -837,7 +843,7 @@ impl TaskDb {
     /// Return all tasks whose `parent_id` matches the given parent task ID.
     pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
         let sql = format!(
-            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE parent_id = ? ORDER BY created_at DESC"
+            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE parent_id = $1 ORDER BY created_at DESC"
         );
         let rows = sqlx::query_as::<_, TaskRow>(&sql)
             .bind(parent_id)
@@ -874,7 +880,7 @@ impl TaskDb {
 
         sqlx::query(
             "INSERT INTO task_artifacts (task_id, turn, artifact_type, content)
-             VALUES (?, ?, ?, ?)",
+             VALUES ($1, $2, $3, $4)",
         )
         .bind(task_id)
         .bind(turn as i64)
@@ -889,7 +895,7 @@ impl TaskDb {
     pub async fn list_artifacts(&self, task_id: &str) -> anyhow::Result<Vec<TaskArtifact>> {
         let rows = sqlx::query_as::<_, TaskArtifact>(
             "SELECT task_id, turn, artifact_type, content, created_at
-             FROM task_artifacts WHERE task_id = ? ORDER BY id ASC",
+             FROM task_artifacts WHERE task_id = $1 ORDER BY id ASC",
         )
         .bind(task_id)
         .fetch_all(&self.pool)
@@ -1212,7 +1218,7 @@ mod tests {
 
         assert!(db.get("missing-task").await?.is_none());
 
-        sqlx::query("INSERT INTO tasks (id, status, turn, rounds) VALUES (?, ?, ?, ?)")
+        sqlx::query("INSERT INTO tasks (id, status, turn, rounds) VALUES ($1, $2, $3, $4)")
             .bind("task-corrupted")
             .bind("pending")
             .bind(1_i64)
@@ -1234,7 +1240,7 @@ mod tests {
         let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
 
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, rounds, depends_on) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, rounds, depends_on) VALUES ($1, $2, $3, $4, $5)",
         )
         .bind("task-corrupted-deps")
         .bind("pending")

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use harness_core::db::{open_pool, Migration, Migrator};
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
-use sqlx::sqlite::SqlitePool;
+use sqlx::PgPool;
 use std::path::Path;
 
 /// Versioned migrations for the threads table.
@@ -21,14 +21,17 @@ static THREAD_MIGRATIONS: &[Migration] = &[Migration {
 
 #[derive(Clone)]
 pub struct ThreadDb {
-    pool: SqlitePool,
+    pool: PgPool,
 }
 
 impl ThreadDb {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         let pool = open_pool(path).await?;
         let db = Self { pool };
-        Migrator::new(&db.pool, THREAD_MIGRATIONS).run().await?;
+        Migrator::new(&db.pool, THREAD_MIGRATIONS)
+            .with_tracking_table("thread_schema_migrations")
+            .run()
+            .await?;
         Ok(db)
     }
 
@@ -37,7 +40,7 @@ impl ThreadDb {
         let metadata_json = serde_json::to_string(&thread.metadata)?;
         sqlx::query(
             "INSERT INTO threads (id, cwd, status, turns, metadata, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(thread.id.as_str())
         .bind(thread.project_root.to_string_lossy().as_ref())
@@ -55,8 +58,8 @@ impl ThreadDb {
         let turns_json = serde_json::to_string(&thread.turns)?;
         let metadata_json = serde_json::to_string(&thread.metadata)?;
         sqlx::query(
-            "UPDATE threads SET cwd = ?, status = ?, turns = ?, metadata = ?, updated_at = ?
-             WHERE id = ?",
+            "UPDATE threads SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
+             WHERE id = $6",
         )
         .bind(thread.project_root.to_string_lossy().as_ref())
         .bind(thread.status.as_ref())
@@ -70,7 +73,7 @@ impl ThreadDb {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<Thread>> {
-        let row = sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads WHERE id = ?")
+        let row = sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads WHERE id = $1")
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
@@ -85,7 +88,7 @@ impl ThreadDb {
     }
 
     pub async fn delete(&self, id: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query("DELETE FROM threads WHERE id = ?")
+        let result = sqlx::query("DELETE FROM threads WHERE id = $1")
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -198,7 +201,7 @@ mod tests {
         let thread = Thread::new(PathBuf::from("/srv/app"));
         db.insert(&thread).await?;
 
-        sqlx::query("UPDATE threads SET status = ? WHERE id = ?")
+        sqlx::query("UPDATE threads SET status = $1 WHERE id = $2")
             .bind("paused")
             .bind(thread.id.as_str())
             .execute(&db.pool)

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -57,7 +57,7 @@ impl PlanDb {
             .unwrap_or_default()
             .to_string();
         let sql =
-            "SELECT data FROM exec_plans WHERE json_extract(data, '$.status') = ? ORDER BY created_at DESC";
+            "SELECT data FROM exec_plans WHERE data::jsonb->>'status' = $1 ORDER BY created_at DESC";
         let rows: Vec<(String,)> = sqlx::query_as(sql)
             .bind(&status_str)
             .fetch_all(self.inner.pool())
@@ -71,7 +71,7 @@ impl PlanDb {
     pub async fn search_by_name(&self, query: &str) -> anyhow::Result<Vec<ExecPlan>> {
         let pattern = format!("%{}%", query);
         let sql =
-            "SELECT data FROM exec_plans WHERE json_extract(data, '$.purpose') LIKE ? ORDER BY created_at DESC";
+            "SELECT data FROM exec_plans WHERE data::jsonb->>'purpose' LIKE $1 ORDER BY created_at DESC";
         let rows: Vec<(String,)> = sqlx::query_as(sql)
             .bind(&pattern)
             .fetch_all(self.inner.pool())


### PR DESCRIPTION
Closes #752

## Summary
- Swap sqlx `sqlite` → `postgres` feature in workspace `Cargo.toml`
- `db.rs`: Replace `SqlitePool`/`SqlitePoolOptions` with `PgPool`/`PgPoolOptions`; `open_pool` now reads `DATABASE_URL` and creates a per-path Postgres schema for store isolation; `Migrator` gains `with_tracking_table()` for per-store version tracking tables
- `thread_db.rs`: `?` → `$N` placeholders, `SqlitePool` → `PgPool`
- `plan_db.rs`: `json_extract(data, '$.field')` → `data::jsonb->>'field'` operators
- `q_value_store.rs`: `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE`, `datetime('now')` → `CURRENT_TIMESTAMP`, `?` → `$N`
- `review_store.rs`: `PRAGMA table_info` → `information_schema.columns`, `INSERT OR IGNORE` → `ON CONFLICT DO NOTHING`, `datetime('now', '-' || ... || ' seconds')` → `($1 * INTERVAL '1 second')`, `rowid NOT IN` dedup → `DISTINCT ON`
- `project_registry.rs`, `runtime_state_store.rs`: `datetime('now')` → `CURRENT_TIMESTAMP` in DDL
- `event_store.rs`: `GLOB 'periodic_review:*'` → `LIKE 'periodic_review:%'`, `INSERT OR IGNORE` → `ON CONFLICT DO NOTHING`, dynamic `$N` parameter numbering for query builder
- `task_db.rs`: `?` → `$N` across all 16 migrations and runtime queries, `datetime('now')` → `CURRENT_TIMESTAMP`
- `plan.rs` (`ExecPlan`): `datetime('now')` → `CURRENT_TIMESTAMP` in `create_table_sql()`

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes
- [x] `cargo test --package harness-agents` — 89 tests pass (no DB dependency)
- [ ] DB tests require `DATABASE_URL=postgres://...` — pass with a live Postgres instance