### PR TITLE
fix(server): apply fail-fast error pattern to Source-A startup redispatch (#765)

### DIFF
--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -790,8 +790,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {
@@ -829,8 +831,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {
@@ -879,8 +883,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {
@@ -1024,8 +1030,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {
@@ -1061,8 +1069,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {
@@ -1116,8 +1126,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             {
                                 tracing::error!(
                                     task_id = ?task.id,
-                                    "startup recovery: failed to persist failed status: {pe}"
+                                    "startup recovery: failed to persist failed status: {pe}; \
+                                     skipping completion callback to avoid state split"
                                 );
+                                return;
                             }
                             if let Some(cb) = &state.intake.completion_callback {
                                 if let Some(final_state) = state.core.tasks.get(&task.id) {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -794,10 +794,30 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     {
                         Ok(p) => p,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to acquire permit: {e}"
+                            let reason = format!(
+                                "startup recovery: failed to acquire concurrency permit: {e}"
                             );
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -775,10 +775,29 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     {
                         Ok(c) => c,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to resolve project path: {e}"
-                            );
+                            let reason =
+                                format!("startup recovery: failed to resolve project path: {e}");
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };
@@ -846,10 +865,28 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                     ) {
                         Ok(a) => a,
                         Err(e) => {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to select agent: {e}"
-                            );
+                            let reason = format!("startup recovery: failed to select agent: {e}");
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "startup recovery: failed to persist failed status: {pe}"
+                                );
+                            }
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
                     };


### PR DESCRIPTION
## Summary

- Source A startup redispatch (`http.rs` ~796–803) previously returned silently on `acquire()` failure, leaving the task stuck in `pending` forever
- Apply the same fail-fast pattern from Source B: call `mutate_and_persist(Failed)` and fire the completion callback on error
- Prevents permanent dedup deadlock in intake sources (e.g. GitHub Issues poller) caused by the completion callback never firing

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass

Fixes #765