### PR TITLE
fix(periodic_review): add exponential backoff cooldown for failed auto-fix tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1005,10 +1005,23 @@ async fn run_review_tick(
                             match rs
                                 .recover_stale_pending_claims(3900, |tid| {
                                     let id = harness_core::types::TaskId(tid.to_string());
-                                    // task not in store → treat as done
-                                    tasks_snapshot
-                                        .get(&id)
-                                        .is_none_or(|t| t.status.is_terminal())
+                                    match tasks_snapshot.get(&id) {
+                                        // Task not in store: unknown outcome — release
+                                        // claim without penalty and let the next review
+                                        // cycle re-evaluate the finding.
+                                        None => Some(false),
+                                        Some(t) if matches!(
+                                            t.status,
+                                            crate::task_runner::TaskStatus::Done
+                                        ) => Some(false),
+                                        Some(t) if matches!(
+                                            t.status,
+                                            crate::task_runner::TaskStatus::Failed
+                                                | crate::task_runner::TaskStatus::Cancelled
+                                        ) => Some(true),
+                                        // Still in-flight — leave pending claim intact.
+                                        Some(_) => None,
+                                    }
                                 })
                                 .await
                             {

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1012,14 +1012,20 @@ async fn run_review_tick(
                             // DB-only after a server restart.  Using get_with_db_fallback
                             // ensures we correctly classify those tasks instead of
                             // misidentifying them as successful (None in-memory).
-                            let stale_ids = rs
+                            let stale_ids = match rs
                                 .list_stale_real_task_ids(&project_root_for_poll.to_string_lossy())
                                 .await
-                                .unwrap_or_default();
-                            let mut task_outcome_map: std::collections::HashMap<
-                                String,
-                                Option<bool>,
-                            > = std::collections::HashMap::new();
+                            {
+                                Ok(ids) => ids,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "scheduler: failed to list stale real task IDs, \
+                                         recovery may be incomplete: {e}"
+                                    );
+                                    vec![]
+                                }
+                            };
+                            let mut task_outcome_map = HashMap::new();
                             for tid in stale_ids {
                                 let task_id = harness_core::types::TaskId(tid.clone());
                                 let outcome = match tasks_snapshot

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1012,7 +1012,7 @@ async fn run_review_tick(
                             // DB-only after a server restart.  Using get_with_db_fallback
                             // ensures we correctly classify those tasks instead of
                             // misidentifying them as successful (None in-memory).
-                            let stale_ids = rs.list_stale_real_task_ids().await.unwrap_or_default();
+                            let stale_ids = rs.list_stale_real_task_ids(&project_root_for_poll.to_string_lossy()).await.unwrap_or_default();
                             let mut task_outcome_map: std::collections::HashMap<
                                 String,
                                 Option<bool>,
@@ -1038,7 +1038,7 @@ async fn run_review_tick(
                                 task_outcome_map.insert(tid, outcome);
                             }
                             match rs
-                                .recover_stale_pending_claims(3900, |tid| {
+                                .recover_stale_pending_claims(&project_root_for_poll.to_string_lossy(), 3900, |tid| {
                                     // Flatten Option<&Option<bool>> → Option<bool>.
                                     task_outcome_map.get(tid).copied().flatten()
                                 })

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1208,6 +1208,21 @@ async fn run_review_tick(
                                     );
                                 }
                             }
+                            // Reset cooldown counters for findings that were not
+                            // seen in this scan cycle (violation resolved).
+                            // This runs after the spawn loop so that resolution
+                            // and re-spawn cannot race within the same tick.
+                            match rs.reset_cooldowns_for_resolved(&final_task_id.0).await {
+                                Ok(0) => {}
+                                Ok(n) => tracing::debug!(
+                                    cleared = n,
+                                    "scheduler: reset cooldowns for resolved findings"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    "scheduler: reset_cooldowns_for_resolved failed \
+                                     (continuing): {e}"
+                                ),
+                            }
                         }
                         Err(e) => tracing::warn!("scheduler: failed to persist findings: {e}"),
                     }

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1084,7 +1084,11 @@ async fn run_review_tick(
                                         // if the claim succeeds do we enqueue a task,
                                         // preventing orphaned tasks on race loss.
                                         match rs
-                                            .try_claim_finding(&finding.rule_id, &finding.file)
+                                            .try_claim_finding(
+                                                &project_root_for_poll.to_string_lossy(),
+                                                &finding.rule_id,
+                                                &finding.file,
+                                            )
                                             .await
                                         {
                                             Ok(false) => {
@@ -1115,6 +1119,7 @@ async fn run_review_tick(
                                             Ok(fix_task_id) => {
                                                 match rs
                                                     .confirm_task_spawned(
+                                                        &project_root_for_poll.to_string_lossy(),
                                                         &finding.rule_id,
                                                         &finding.file,
                                                         &fix_task_id.0,
@@ -1142,6 +1147,8 @@ async fn run_review_tick(
                                                         // second attempt is safe.
                                                         if let Err(e2) = rs
                                                             .confirm_task_spawned(
+                                                                &project_root_for_poll
+                                                                    .to_string_lossy(),
                                                                 &finding.rule_id,
                                                                 &finding.file,
                                                                 &fix_task_id.0,
@@ -1221,7 +1228,11 @@ async fn run_review_tick(
                                             Err(e) => {
                                                 // Release the claim so the next cycle can retry.
                                                 if let Err(re) = rs
-                                                    .release_claim(&finding.rule_id, &finding.file)
+                                                    .release_claim(
+                                                        &project_root_for_poll.to_string_lossy(),
+                                                        &finding.rule_id,
+                                                        &finding.file,
+                                                    )
                                                     .await
                                                 {
                                                     tracing::warn!(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1190,6 +1190,8 @@ async fn run_review_tick(
                                                                     .await;
                                                                 match rs
                                                                     .record_real_task_id(
+                                                                        &project_root_for_poll
+                                                                            .to_string_lossy(),
                                                                         &finding.rule_id,
                                                                         &finding.file,
                                                                         &fix_task_id.0,

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1012,7 +1012,10 @@ async fn run_review_tick(
                             // DB-only after a server restart.  Using get_with_db_fallback
                             // ensures we correctly classify those tasks instead of
                             // misidentifying them as successful (None in-memory).
-                            let stale_ids = rs.list_stale_real_task_ids(&project_root_for_poll.to_string_lossy()).await.unwrap_or_default();
+                            let stale_ids = rs
+                                .list_stale_real_task_ids(&project_root_for_poll.to_string_lossy())
+                                .await
+                                .unwrap_or_default();
                             let mut task_outcome_map: std::collections::HashMap<
                                 String,
                                 Option<bool>,

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -977,7 +977,11 @@ async fn run_review_tick(
                 );
                 if let Some(ref rs) = review_store {
                     match rs
-                        .persist_findings(&final_task_id.0, &review.findings)
+                        .persist_findings(
+                            &project_root_for_poll.to_string_lossy(),
+                            &final_task_id.0,
+                            &review.findings,
+                        )
                         .await
                     {
                         Ok(n) => {
@@ -1002,26 +1006,41 @@ async fn run_review_tick(
                             //       premature recovery while any task spawned before the
                             //       upgrade may still be running.
                             let tasks_snapshot = state_for_synthesis.core.tasks.clone();
+                            // Pre-resolve task statuses for all stale real_task_ids.
+                            // The in-memory cache only contains active tasks; terminal
+                            // tasks (Failed, Cancelled) are evicted at startup and are
+                            // DB-only after a server restart.  Using get_with_db_fallback
+                            // ensures we correctly classify those tasks instead of
+                            // misidentifying them as successful (None in-memory).
+                            let stale_ids = rs.list_stale_real_task_ids().await.unwrap_or_default();
+                            let mut task_outcome_map: std::collections::HashMap<
+                                String,
+                                Option<bool>,
+                            > = std::collections::HashMap::new();
+                            for tid in stale_ids {
+                                let task_id = harness_core::types::TaskId(tid.clone());
+                                let outcome = match tasks_snapshot
+                                    .get_with_db_fallback(&task_id)
+                                    .await
+                                {
+                                    Ok(Some(t)) => match t.status {
+                                        crate::task_runner::TaskStatus::Done => Some(false),
+                                        crate::task_runner::TaskStatus::Failed
+                                        | crate::task_runner::TaskStatus::Cancelled => Some(true),
+                                        // Still in-flight — leave pending claim intact.
+                                        _ => None,
+                                    },
+                                    // Task unknown in both cache and DB, or DB error:
+                                    // leave the pending claim intact so Strategy 2
+                                    // (time-based fallback) can recover it later.
+                                    Ok(None) | Err(_) => None,
+                                };
+                                task_outcome_map.insert(tid, outcome);
+                            }
                             match rs
                                 .recover_stale_pending_claims(3900, |tid| {
-                                    let id = harness_core::types::TaskId(tid.to_string());
-                                    match tasks_snapshot.get(&id) {
-                                        // Task not in store: unknown outcome — release
-                                        // claim without penalty and let the next review
-                                        // cycle re-evaluate the finding.
-                                        None => Some(false),
-                                        Some(t) if matches!(
-                                            t.status,
-                                            crate::task_runner::TaskStatus::Done
-                                        ) => Some(false),
-                                        Some(t) if matches!(
-                                            t.status,
-                                            crate::task_runner::TaskStatus::Failed
-                                                | crate::task_runner::TaskStatus::Cancelled
-                                        ) => Some(true),
-                                        // Still in-flight — leave pending claim intact.
-                                        Some(_) => None,
-                                    }
+                                    // Flatten Option<&Option<bool>> → Option<bool>.
+                                    task_outcome_map.get(tid).copied().flatten()
                                 })
                                 .await
                             {
@@ -1225,7 +1244,13 @@ async fn run_review_tick(
                             // seen in this scan cycle (violation resolved).
                             // This runs after the spawn loop so that resolution
                             // and re-spawn cannot race within the same tick.
-                            match rs.reset_cooldowns_for_resolved(&final_task_id.0).await {
+                            match rs
+                                .reset_cooldowns_for_resolved(
+                                    &project_root_for_poll.to_string_lossy(),
+                                    &final_task_id.0,
+                                )
+                                .await
+                            {
                                 Ok(0) => {}
                                 Ok(n) => tracing::debug!(
                                     cleared = n,

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -172,10 +172,16 @@ impl ReviewStore {
             .await?;
         }
         // Partial index speeds up list_spawnable_findings which filters open rows
-        // by task_id IS NULL and cooldown_until on every scheduler tick.
+        // by review_id, task_id IS NULL and cooldown_until on every scheduler tick.
+        // Drop-and-recreate ensures the index is updated if the definition changed
+        // (CREATE INDEX IF NOT EXISTS is a no-op on an existing index, even with a
+        // different column list).
+        sqlx::query("DROP INDEX IF EXISTS idx_rf_spawnable")
+            .execute(&pool)
+            .await?;
         sqlx::query(
             "CREATE INDEX IF NOT EXISTS idx_rf_spawnable \
-             ON review_findings(task_id, cooldown_until) WHERE status = 'open'",
+             ON review_findings(review_id, task_id, cooldown_until) WHERE status = 'open'",
         )
         .execute(&pool)
         .await?;
@@ -371,7 +377,7 @@ impl ReviewStore {
     /// - `None`        — task is still in-flight; leave the claim intact.
     /// - `Some(true)`  — task failed or was cancelled; apply exponential backoff.
     /// - `Some(false)` — task completed successfully; release claim without penalty
-    ///                   so the next review cycle can re-evaluate the finding.
+    ///   so the next review cycle can re-evaluate the finding.
     ///
     /// Returns the number of findings recovered.
     pub async fn recover_stale_pending_claims(

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -241,6 +241,20 @@ impl ReviewStore {
         let mut tx = self.pool.begin().await?;
         let mut inserted = 0;
         for f in findings {
+            // Migrate legacy rows that have project_root='' to the current project_root
+            // before INSERT OR IGNORE so the dedup index (project_root, rule_id, file, status)
+            // correctly treats them as the same finding.  Without this, the INSERT would
+            // create a second row (different project_root key) and the subsequent UPDATE
+            // would try to rewrite both rows to the same unique key, violating the index.
+            sqlx::query(
+                "UPDATE review_findings SET project_root = ? \
+                 WHERE project_root = '' AND rule_id = ? AND file = ? AND status = 'open'",
+            )
+            .bind(project_root)
+            .bind(&f.rule_id)
+            .bind(&f.file)
+            .execute(&mut *tx)
+            .await?;
             let result = sqlx::query(
                 "INSERT OR IGNORE INTO review_findings \
                  (id, review_id, project_root, rule_id, priority, impact, confidence, effort, \
@@ -343,22 +357,29 @@ impl ReviewStore {
 
     /// Atomically claim a finding for auto-spawn by setting task_id to "pending".
     ///
-    /// Uses `(rule_id, file)` — the globally unique index columns — instead of
+    /// Uses `(project_root, rule_id, file)` — the unique index columns — instead of
     /// the non-globally-unique `id` field (PK is `(review_id, id)`, so two
     /// different reviews can share the same `id` value).  Filtering by `id`
     /// alone could stamp multiple unrelated findings with the same task_id.
     ///
     /// The `review_id` filter is intentionally absent: `persist_findings` may
     /// reassign the finding to a newer `review_id` between
-    /// `list_spawnable_findings` and this call; the unique `(rule_id, file)`
-    /// pair is stable regardless of which review_id the row carries.
+    /// `list_spawnable_findings` and this call; the unique `(project_root, rule_id, file)`
+    /// tuple is stable regardless of which review_id the row carries.
     ///
     /// Returns `true` if this caller won the claim, `false` if already claimed.
-    pub async fn try_claim_finding(&self, rule_id: &str, file: &str) -> anyhow::Result<bool> {
+    pub async fn try_claim_finding(
+        &self,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<bool> {
         let result = sqlx::query(
             "UPDATE review_findings SET task_id = 'pending', claimed_at = datetime('now') \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id IS NULL",
+             WHERE project_root = ? AND rule_id = ? AND file = ? AND status = 'open' \
+               AND task_id IS NULL",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -422,7 +443,9 @@ impl ReviewStore {
                     // The next review cycle will re-evaluate whether the finding is
                     // still present; treating a success as a failure would incorrectly
                     // increment failure_count and suppress respawn for an open finding.
-                    recovered += self.release_stale_claim_ok(&rule_id, &file).await?;
+                    recovered += self
+                        .release_stale_claim_ok(project_root, &rule_id, &file)
+                        .await?;
                 }
                 None => {
                     // Task still in-flight — leave the pending claim intact.
@@ -495,15 +518,18 @@ impl ReviewStore {
     /// real task_id after a successful enqueue.
     pub async fn confirm_task_spawned(
         &self,
+        project_root: &str,
         rule_id: &str,
         file: &str,
         task_id: &str,
     ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = ? \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? \
+               AND status = 'open' AND task_id = 'pending'",
         )
         .bind(task_id)
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -614,12 +640,19 @@ impl ReviewStore {
     /// Release a pending claim after the underlying task completed successfully,
     /// clearing task_id, claimed_at, and real_task_id without penalising
     /// failure_count or setting a cooldown.
-    async fn release_stale_claim_ok(&self, rule_id: &str, file: &str) -> anyhow::Result<u64> {
+    async fn release_stale_claim_ok(
+        &self,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<u64> {
         let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? \
+               AND status = 'open' AND task_id = 'pending'",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -627,11 +660,18 @@ impl ReviewStore {
         Ok(result.rows_affected())
     }
 
-    pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+    pub async fn release_claim(
+        &self,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = NULL \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? \
+               AND status = 'open' AND task_id = 'pending'",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -830,17 +870,17 @@ mod tests {
 
         // First claim wins.
         assert!(
-            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            store.try_claim_finding("", "RS-03", "src/lib.rs").await?,
             "first claim must succeed"
         );
         // Concurrent poller claim must lose (task_id is 'pending').
         assert!(
-            !store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            !store.try_claim_finding("", "RS-03", "src/lib.rs").await?,
             "duplicate claim must return false"
         );
         // Confirm with real task_id.
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-abc")
+            .confirm_task_spawned("", "RS-03", "src/lib.rs", "task-abc")
             .await?;
 
         let spawnable = store
@@ -861,12 +901,12 @@ mod tests {
         store.persist_findings("", "rev-1", &findings).await?;
 
         // Claim, then release (simulates enqueue failure).
-        assert!(store.try_claim_finding("RS-03", "src/lib.rs").await?);
-        store.release_claim("RS-03", "src/lib.rs").await?;
+        assert!(store.try_claim_finding("", "RS-03", "src/lib.rs").await?);
+        store.release_claim("", "RS-03", "src/lib.rs").await?;
 
         // Must be claimable again after release.
         assert!(
-            store.try_claim_finding("RS-03", "src/lib.rs").await?,
+            store.try_claim_finding("", "RS-03", "src/lib.rs").await?,
             "finding must be claimable after release"
         );
         Ok(())
@@ -904,8 +944,10 @@ mod tests {
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
         store.persist_findings("", "rev-1", &findings).await?;
-        store.try_claim_finding("R1", "a.rs").await?;
-        store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
+        store.try_claim_finding("", "R1", "a.rs").await?;
+        store
+            .confirm_task_spawned("", "R1", "a.rs", "task-111")
+            .await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -945,9 +987,9 @@ mod tests {
         store
             .persist_findings("", "rev-1", std::slice::from_ref(&finding))
             .await?;
-        store.try_claim_finding("RS-03", "src/lib.rs").await?;
+        store.try_claim_finding("", "RS-03", "src/lib.rs").await?;
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-orig")
+            .confirm_task_spawned("", "RS-03", "src/lib.rs", "task-orig")
             .await?;
 
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
@@ -987,10 +1029,10 @@ mod tests {
         store.persist_findings("", "rev-2", &[finding2]).await?;
 
         // try_claim_finding must succeed even though the row now has review_id="rev-2".
-        let claimed = store.try_claim_finding("RS-03", "src/lib.rs").await?;
+        let claimed = store.try_claim_finding("", "RS-03", "src/lib.rs").await?;
         assert!(claimed, "must succeed even after review_id changed");
         store
-            .confirm_task_spawned("RS-03", "src/lib.rs", "task-from-rev1-poller")
+            .confirm_task_spawned("", "RS-03", "src/lib.rs", "task-from-rev1-poller")
             .await?;
 
         // F1 must no longer appear in spawnable list for rev-2.

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -132,6 +132,35 @@ impl ReviewStore {
                 .execute(&pool)
                 .await?;
         }
+        // Migrate: add cooldown columns for exponential backoff on repeated failures
+        // (issue #770).  failure_count tracks how many times the auto-fix task failed;
+        // cooldown_until is an ISO-8601 datetime before which spawning is suppressed.
+        let has_failure_count = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "failure_count");
+        if !has_failure_count {
+            sqlx::query(
+                "ALTER TABLE review_findings ADD COLUMN failure_count INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(&pool)
+            .await?;
+        }
+        let has_cooldown_until = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "cooldown_until");
+        if !has_cooldown_until {
+            sqlx::query("ALTER TABLE review_findings ADD COLUMN cooldown_until TEXT")
+                .execute(&pool)
+                .await?;
+        }
+        // Partial index speeds up list_spawnable_findings which filters open rows
+        // by task_id IS NULL and cooldown_until on every scheduler tick.
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_rf_spawnable \
+             ON review_findings(task_id, cooldown_until) WHERE status = 'open'",
+        )
+        .execute(&pool)
+        .await?;
         // Remove duplicate (rule_id, file, status) rows that may exist from
         // before this unique index was introduced; keep the most recent row per group.
         sqlx::query(
@@ -260,7 +289,8 @@ impl ReviewStore {
                     file, line, title, description, action, task_id \
              FROM review_findings \
              WHERE review_id = ? AND priority IN ({placeholders}) \
-               AND status = 'open' AND task_id IS NULL"
+               AND status = 'open' AND task_id IS NULL \
+               AND (cooldown_until IS NULL OR cooldown_until <= datetime('now'))"
         );
         let mut query = sqlx::query_as::<_, FindingRow>(&sql).bind(review_id.to_owned());
         for p in priorities {
@@ -331,18 +361,10 @@ impl ReviewStore {
         let mut recovered = 0u64;
         for (rule_id, file, real_tid) in with_real_id {
             if is_task_done(&real_tid) {
-                let res = sqlx::query(
-                    "UPDATE review_findings \
-                     SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
-                     WHERE rule_id = ? AND file = ? AND status = 'open' \
-                       AND task_id = 'pending' AND real_task_id = ?",
-                )
-                .bind(&rule_id)
-                .bind(&file)
-                .bind(&real_tid)
-                .execute(&self.pool)
-                .await?;
-                recovered += res.rows_affected();
+                // The underlying task reached a terminal (failed/cancelled) state.
+                // Record the failure and apply exponential backoff so the same
+                // violation is not immediately re-attempted on the next tick.
+                recovered += self.mark_finding_failed(&rule_id, &file).await?;
             }
         }
 
@@ -401,6 +423,82 @@ impl ReviewStore {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Record a failed auto-fix attempt and apply exponential backoff cooldown.
+    ///
+    /// Atomically:
+    /// - Releases the pending claim (task_id = NULL)
+    /// - Increments failure_count
+    /// - Sets cooldown_until = now + min(3600 * 2^failure_count, 86400) seconds
+    ///   (1 h → 2 h → 4 h → 8 h → 16 h → 24 h cap)
+    ///
+    /// Uses the pre-increment failure_count to compute the delay so that the
+    /// first failure produces a 1-hour cooldown, the second 2 hours, etc.
+    /// The delay expression uses SQLite's `<<` (left shift) for 2^N arithmetic.
+    ///
+    /// Returns the number of rows updated (1 if found, 0 if not matching).
+    pub async fn mark_finding_failed(&self, rule_id: &str, file: &str) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE review_findings \
+             SET task_id = NULL, \
+                 claimed_at = NULL, \
+                 real_task_id = NULL, \
+                 failure_count = failure_count + 1, \
+                 cooldown_until = datetime('now', '+' || \
+                     cast(min(3600 * (1 << failure_count), 86400) as text) || ' seconds') \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Clear the backoff counters for a finding so it can be retried immediately.
+    ///
+    /// Called when the violation is no longer detected in the latest scan,
+    /// ensuring that if it reappears it starts with a fresh failure history.
+    pub async fn reset_finding_cooldown(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE review_findings \
+             SET failure_count = 0, cooldown_until = NULL \
+             WHERE rule_id = ? AND file = ? AND status = 'open'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Reset cooldown counters for open findings that did NOT appear in the
+    /// latest scan (identified by `current_review_id`).
+    ///
+    /// When `persist_findings` runs for a new scan, it updates `review_id` to
+    /// `current_review_id` for every finding that still exists.  Any open
+    /// finding whose `review_id` still points to an older scan was not seen in
+    /// this cycle, which means the violation was resolved (manually or via a
+    /// previously spawned fix task).  Clearing the counters ensures that if
+    /// the violation reappears it starts with a fresh failure history instead
+    /// of inheriting stale backoff state.
+    ///
+    /// Returns the number of rows whose cooldown was cleared.
+    pub async fn reset_cooldowns_for_resolved(
+        &self,
+        current_review_id: &str,
+    ) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE review_findings \
+             SET failure_count = 0, cooldown_until = NULL \
+             WHERE status = 'open' AND review_id != ? \
+               AND (failure_count > 0 OR cooldown_until IS NOT NULL)",
+        )
+        .bind(current_review_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Release a pending claim by resetting task_id to NULL.
@@ -815,6 +913,294 @@ mod tests {
         assert_eq!(open.len(), 1);
         assert_eq!(open[0].rule_id, "RS-03");
 
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Cooldown / backoff tests (issue #770)
+    // -------------------------------------------------------------------------
+
+    /// Helper: read (failure_count, cooldown_until) for an open finding.
+    async fn get_cooldown(store: &ReviewStore, rule_id: &str, file: &str) -> (i64, Option<String>) {
+        sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT failure_count, cooldown_until \
+             FROM review_findings WHERE rule_id = ? AND file = ? AND status = 'open'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .fetch_one(&store.pool)
+        .await
+        .unwrap()
+    }
+
+    /// Put a finding into pending state so mark_finding_failed can act on it.
+    async fn set_pending(store: &ReviewStore, rule_id: &str, file: &str) {
+        sqlx::query(
+            "UPDATE review_findings SET task_id = 'pending', claimed_at = datetime('now') \
+             WHERE rule_id = ? AND file = ? AND status = 'open'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mark_finding_failed_increments_count() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        for expected in 1u32..=3 {
+            set_pending(&store, "R1", "a.rs").await;
+            store.mark_finding_failed("R1", "a.rs").await?;
+            let (count, _) = get_cooldown(&store, "R1", "a.rs").await;
+            assert_eq!(
+                count as u32, expected,
+                "failure_count after {} calls",
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cooldown_until_is_future() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        set_pending(&store, "R1", "a.rs").await;
+        store.mark_finding_failed("R1", "a.rs").await?;
+
+        let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
+        let ts_str = cooldown_until.expect("cooldown_until must be set after failure");
+        // Parse the SQLite datetime string (format: "YYYY-MM-DD HH:MM:SS").
+        let dt = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%d %H:%M:%S")
+            .expect("cooldown_until must be a valid datetime");
+        let now = chrono::Utc::now().naive_utc();
+        assert!(dt > now, "cooldown_until must be in the future, got {dt}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_exponential_backoff_schedule() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Expected delays (seconds) for failure_count = 0..=5.
+        let expected_secs: &[i64] = &[3600, 7200, 14400, 28800, 57600, 86400];
+        for &expected in expected_secs {
+            set_pending(&store, "R1", "a.rs").await;
+            let before = chrono::Utc::now().naive_utc();
+            store.mark_finding_failed("R1", "a.rs").await?;
+            let after = chrono::Utc::now().naive_utc();
+
+            let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
+            let ts_str = cooldown_until.unwrap();
+            let dt = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%d %H:%M:%S").unwrap();
+
+            let lower = before + chrono::Duration::seconds(expected) - chrono::Duration::seconds(2);
+            let upper = after + chrono::Duration::seconds(expected) + chrono::Duration::seconds(2);
+            assert!(
+                dt >= lower && dt <= upper,
+                "cooldown_until {dt} not in expected window [{lower}, {upper}] \
+                 for delay {expected}s"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_spawnable_excludes_cooldown() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Set an active cooldown (far future).
+        sqlx::query(
+            "UPDATE review_findings \
+             SET cooldown_until = datetime('now', '+3600 seconds') \
+             WHERE rule_id = 'R1' AND file = 'a.rs' AND status = 'open'",
+        )
+        .execute(&store.pool)
+        .await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        assert!(
+            spawnable.is_empty(),
+            "finding with active cooldown must not appear in spawnable list"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_spawnable_includes_expired_cooldown() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Set an expired cooldown (past timestamp).
+        sqlx::query(
+            "UPDATE review_findings \
+             SET cooldown_until = datetime('now', '-1 seconds') \
+             WHERE rule_id = 'R1' AND file = 'a.rs' AND status = 'open'",
+        )
+        .execute(&store.pool)
+        .await?;
+
+        let spawnable = store
+            .list_spawnable_findings("rev-1", &["P1", "P2"])
+            .await?;
+        assert_eq!(
+            spawnable.len(),
+            1,
+            "finding with expired cooldown must appear in spawnable list"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reset_clears_cooldown() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Apply a failure to set counters.
+        set_pending(&store, "R1", "a.rs").await;
+        store.mark_finding_failed("R1", "a.rs").await?;
+        let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(count_before, 1);
+        assert!(cooldown_before.is_some());
+
+        store.reset_finding_cooldown("R1", "a.rs").await?;
+
+        let (count_after, cooldown_after) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(count_after, 0, "failure_count must be 0 after reset");
+        assert!(
+            cooldown_after.is_none(),
+            "cooldown_until must be NULL after reset"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_strategy1_recovery_triggers_backoff() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Simulate a confirmed-task pending row (real_task_id set).
+        sqlx::query(
+            "UPDATE review_findings \
+             SET task_id = 'pending', claimed_at = datetime('now'), real_task_id = 'task-xyz' \
+             WHERE rule_id = 'R1' AND file = 'a.rs' AND status = 'open'",
+        )
+        .execute(&store.pool)
+        .await?;
+
+        // Strategy-1 recovery: task is done → should trigger backoff.
+        let recovered = store
+            .recover_stale_pending_claims(3900, |_tid| true)
+            .await?;
+        assert_eq!(recovered, 1, "one row must be recovered");
+
+        let (count, cooldown) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(
+            count, 1,
+            "failure_count must be 1 after strategy-1 recovery"
+        );
+        assert!(
+            cooldown.is_some(),
+            "cooldown_until must be set after strategy-1 recovery"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_strategy2_timeout_no_backoff() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Simulate a stale mid-claim row (no real_task_id, old claimed_at).
+        sqlx::query(
+            "UPDATE review_findings \
+             SET task_id = 'pending', \
+                 claimed_at = datetime('now', '-4000 seconds'), \
+                 real_task_id = NULL \
+             WHERE rule_id = 'R1' AND file = 'a.rs' AND status = 'open'",
+        )
+        .execute(&store.pool)
+        .await?;
+
+        // Strategy-2 recovery via time threshold — must NOT apply backoff.
+        let recovered = store
+            .recover_stale_pending_claims(3900, |_tid| false)
+            .await?;
+        assert_eq!(recovered, 1, "one row must be recovered via timeout");
+
+        let (count, cooldown) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(
+            count, 0,
+            "failure_count must remain 0 for strategy-2 recovery"
+        );
+        assert!(
+            cooldown.is_none(),
+            "cooldown_until must stay NULL for strategy-2 recovery"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_resolution_clears_cooldown_state() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = ReviewStore::open(&dir.path().join("review.db")).await?;
+        store
+            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .await?;
+
+        // Apply some failures so counters are non-zero.
+        set_pending(&store, "R1", "a.rs").await;
+        store.mark_finding_failed("R1", "a.rs").await?;
+        set_pending(&store, "R1", "a.rs").await;
+        store.mark_finding_failed("R1", "a.rs").await?;
+
+        let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(count_before, 2);
+        assert!(cooldown_before.is_some());
+
+        // A new scan (rev-2) does not include this finding.  reset_cooldowns_for_resolved
+        // should clear the counters since the finding's review_id is still "rev-1".
+        let cleared = store.reset_cooldowns_for_resolved("rev-2").await?;
+        assert_eq!(cleared, 1, "one finding must have its cooldown cleared");
+
+        let (count_after, cooldown_after) = get_cooldown(&store, "R1", "a.rs").await;
+        assert_eq!(count_after, 0, "failure_count must be 0 after resolution");
+        assert!(
+            cooldown_after.is_none(),
+            "cooldown_until must be NULL after resolution"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -422,8 +422,7 @@ impl ReviewStore {
                     // The next review cycle will re-evaluate whether the finding is
                     // still present; treating a success as a failure would incorrectly
                     // increment failure_count and suppress respawn for an open finding.
-                    self.release_stale_claim_ok(&rule_id, &file).await?;
-                    recovered += 1;
+                    recovered += self.release_stale_claim_ok(&rule_id, &file).await?;
                 }
                 None => {
                     // Task still in-flight — leave the pending claim intact.
@@ -615,8 +614,8 @@ impl ReviewStore {
     /// Release a pending claim after the underlying task completed successfully,
     /// clearing task_id, claimed_at, and real_task_id without penalising
     /// failure_count or setting a cooldown.
-    async fn release_stale_claim_ok(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
-        sqlx::query(
+    async fn release_stale_claim_ok(&self, rule_id: &str, file: &str) -> anyhow::Result<u64> {
+        let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
              WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
@@ -625,7 +624,7 @@ impl ReviewStore {
         .bind(file)
         .execute(&self.pool)
         .await?;
-        Ok(())
+        Ok(result.rows_affected())
     }
 
     pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -332,8 +332,8 @@ impl ReviewStore {
     ///
     /// 1. **Known-task rows** (`real_task_id IS NOT NULL`): both `confirm_task_spawned`
     ///    attempts failed but `enqueue_task` succeeded.  We stored the real task id in
-    ///    `real_task_id` so recovery can call `is_task_done(real_task_id)` to verify
-    ///    the underlying task has reached a terminal state before resetting the claim.
+    ///    `real_task_id` so recovery can call `get_task_outcome(real_task_id)` to
+    ///    determine the terminal state before acting on the claim.
     ///    This is correct regardless of how many rounds the task ran or how long it
     ///    spent queued — no fixed time threshold is needed.
     ///
@@ -342,11 +342,17 @@ impl ReviewStore {
     ///    calls.  A time-based `stale_secs` threshold is appropriate here; this window
     ///    should never exceed a few seconds under normal operation.
     ///
+    /// The `get_task_outcome` closure returns:
+    /// - `None`        — task is still in-flight; leave the claim intact.
+    /// - `Some(true)`  — task failed or was cancelled; apply exponential backoff.
+    /// - `Some(false)` — task completed successfully; release claim without penalty
+    ///                   so the next review cycle can re-evaluate the finding.
+    ///
     /// Returns the number of findings recovered.
     pub async fn recover_stale_pending_claims(
         &self,
         stale_secs: i64,
-        is_task_done: impl Fn(&str) -> bool,
+        get_task_outcome: impl Fn(&str) -> Option<bool>,
     ) -> anyhow::Result<u64> {
         // Strategy 1: recover rows whose real underlying task has terminated.
         let with_real_id: Vec<(String, String, String)> = sqlx::query_as(
@@ -360,11 +366,23 @@ impl ReviewStore {
 
         let mut recovered = 0u64;
         for (rule_id, file, real_tid) in with_real_id {
-            if is_task_done(&real_tid) {
-                // The underlying task reached a terminal (failed/cancelled) state.
-                // Record the failure and apply exponential backoff so the same
-                // violation is not immediately re-attempted on the next tick.
-                recovered += self.mark_finding_failed(&rule_id, &file).await?;
+            match get_task_outcome(&real_tid) {
+                Some(true) => {
+                    // Task failed or was cancelled — apply exponential backoff so the
+                    // same violation is not immediately re-attempted on the next tick.
+                    recovered += self.mark_finding_failed(&rule_id, &file).await?;
+                }
+                Some(false) => {
+                    // Task completed successfully — release the claim without penalty.
+                    // The next review cycle will re-evaluate whether the finding is
+                    // still present; treating a success as a failure would incorrectly
+                    // increment failure_count and suppress respawn for an open finding.
+                    self.release_stale_claim_ok(&rule_id, &file).await?;
+                    recovered += 1;
+                }
+                None => {
+                    // Task still in-flight — leave the pending claim intact.
+                }
             }
         }
 
@@ -435,7 +453,13 @@ impl ReviewStore {
     ///
     /// Uses the pre-increment failure_count to compute the delay so that the
     /// first failure produces a 1-hour cooldown, the second 2 hours, etc.
-    /// The delay expression uses SQLite's `<<` (left shift) for 2^N arithmetic.
+    ///
+    /// The shift amount is capped at 24 before applying `<<` to avoid SQLite
+    /// integer overflow: `1 << 64` wraps to 0 (or goes negative) in SQLite's
+    /// 64-bit signed integers, which would collapse the cooldown to `now` after
+    /// enough failures and restart the every-tick respawn loop.  Capping at 24
+    /// gives `1 << 24 = 16_777_216`; multiplied by 3600 this far exceeds the
+    /// 86400-second cap, so the `min()` always fires first at failure_count ≥ 5.
     ///
     /// Returns the number of rows updated (1 if found, 0 if not matching).
     pub async fn mark_finding_failed(&self, rule_id: &str, file: &str) -> anyhow::Result<u64> {
@@ -446,7 +470,7 @@ impl ReviewStore {
                  real_task_id = NULL, \
                  failure_count = failure_count + 1, \
                  cooldown_until = datetime('now', '+' || \
-                     cast(min(3600 * (1 << failure_count), 86400) as text) || ' seconds') \
+                     cast(min(3600 * (1 << min(failure_count, 24)), 86400) as text) || ' seconds') \
              WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
         )
         .bind(rule_id)
@@ -505,6 +529,22 @@ impl ReviewStore {
     ///
     /// Called when task enqueue fails after a successful `try_claim_finding`,
     /// allowing the next poll cycle to retry spawning for this finding.
+    /// Release a pending claim after the underlying task completed successfully,
+    /// clearing task_id, claimed_at, and real_task_id without penalising
+    /// failure_count or setting a cooldown.
+    async fn release_stale_claim_ok(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE review_findings \
+             SET task_id = NULL, claimed_at = NULL, real_task_id = NULL \
+             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+        )
+        .bind(rule_id)
+        .bind(file)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn release_claim(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET task_id = NULL \
@@ -1117,9 +1157,9 @@ mod tests {
         .execute(&store.pool)
         .await?;
 
-        // Strategy-1 recovery: task is done → should trigger backoff.
+        // Strategy-1 recovery: task failed → should trigger backoff.
         let recovered = store
-            .recover_stale_pending_claims(3900, |_tid| true)
+            .recover_stale_pending_claims(3900, |_tid| Some(true))
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered");
 
@@ -1155,8 +1195,9 @@ mod tests {
         .await?;
 
         // Strategy-2 recovery via time threshold — must NOT apply backoff.
+        // real_task_id is NULL so the closure is never called; type must match.
         let recovered = store
-            .recover_stale_pending_claims(3900, |_tid| false)
+            .recover_stale_pending_claims(3900, |_tid| Some(false))
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered via timeout");
 

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -153,6 +153,24 @@ impl ReviewStore {
                 .execute(&pool)
                 .await?;
         }
+        // Migrate: add project_root column to enable per-project scoping of
+        // reset_cooldowns_for_resolved (issue #771).  Without this column the
+        // reset query clears cooldown state for all projects in a multi-project
+        // server when any single project finishes a scan.
+        // DEFAULT '' keeps existing rows selectable but they won't match any
+        // real project root query, effectively orphaning pre-migration cooldown
+        // state (acceptable; the next scan repopulates the correct value).
+        let has_project_root = columns
+            .iter()
+            .any(|(_, name, _, _, _, _)| name == "project_root");
+        if !has_project_root {
+            sqlx::query(
+                "ALTER TABLE review_findings \
+                 ADD COLUMN project_root TEXT NOT NULL DEFAULT ''",
+            )
+            .execute(&pool)
+            .await?;
+        }
         // Partial index speeds up list_spawnable_findings which filters open rows
         // by task_id IS NULL and cooldown_until on every scheduler tick.
         sqlx::query(
@@ -188,8 +206,12 @@ impl ReviewStore {
     /// returned as an error rather than silently dropped by INSERT OR IGNORE.
     /// Cross-review dedup (same rule_id+file already open) is handled atomically by
     /// INSERT OR IGNORE + conditional UPDATE, eliminating the TOCTOU race.
+    ///
+    /// `project_root` is stored on each row to enable per-project scoping of
+    /// `reset_cooldowns_for_resolved` in multi-project server deployments.
     pub async fn persist_findings(
         &self,
+        project_root: &str,
         review_id: &str,
         findings: &[ReviewFinding],
     ) -> anyhow::Result<usize> {
@@ -210,12 +232,13 @@ impl ReviewStore {
         for f in findings {
             let result = sqlx::query(
                 "INSERT OR IGNORE INTO review_findings \
-                 (id, review_id, rule_id, priority, impact, confidence, effort, \
+                 (id, review_id, project_root, rule_id, priority, impact, confidence, effort, \
                   file, line, title, description, action) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&f.id)
             .bind(review_id)
+            .bind(project_root)
             .bind(&f.rule_id)
             .bind(&f.priority)
             .bind(f.impact)
@@ -232,12 +255,14 @@ impl ReviewStore {
             if result.rows_affected() == 1 {
                 inserted += 1;
             } else {
-                // Existing open finding for the same rule_id+file — mark as recurring.
+                // Existing open finding for the same rule_id+file — mark as recurring
+                // and update project_root in case the row was created before migration.
                 sqlx::query(
-                    "UPDATE review_findings SET review_id = ? \
+                    "UPDATE review_findings SET review_id = ?, project_root = ? \
                      WHERE rule_id = ? AND file = ? AND status = 'open'",
                 )
                 .bind(review_id)
+                .bind(project_root)
                 .bind(&f.rule_id)
                 .bind(&f.file)
                 .execute(&mut *tx)
@@ -401,6 +426,25 @@ impl ReviewStore {
         Ok(recovered)
     }
 
+    /// Return the `real_task_id` values for all findings currently stuck in
+    /// `task_id='pending'` that have a confirmed real task ID.
+    ///
+    /// Used by callers to pre-resolve task statuses asynchronously (including
+    /// DB-fallback lookups) before passing results to `recover_stale_pending_claims`
+    /// via a synchronous closure.  The in-memory `TaskStore` cache only holds active
+    /// tasks; terminal tasks (Failed, Cancelled) are DB-only after a server restart,
+    /// so the caller must use `get_with_db_fallback` on each returned ID.
+    pub async fn list_stale_real_task_ids(&self) -> anyhow::Result<Vec<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT real_task_id FROM review_findings \
+             WHERE task_id = 'pending' AND status = 'open' \
+               AND claimed_at IS NOT NULL AND real_task_id IS NOT NULL",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Record the real task id for a finding stuck in `task_id='pending'` after
     /// both `confirm_task_spawned` attempts failed.  This enables task-status-based
     /// stale recovery via [`recover_stale_pending_claims`] without relying on a
@@ -508,17 +552,24 @@ impl ReviewStore {
     /// the violation reappears it starts with a fresh failure history instead
     /// of inheriting stale backoff state.
     ///
+    /// `project_root` scopes the reset to findings belonging to the same project.
+    /// In a multi-project server all projects share one DB; without this filter
+    /// a scan completion for project A would incorrectly clear cooldown state for
+    /// open findings from project B whose `review_id != current_review_id`.
+    ///
     /// Returns the number of rows whose cooldown was cleared.
     pub async fn reset_cooldowns_for_resolved(
         &self,
+        project_root: &str,
         current_review_id: &str,
     ) -> anyhow::Result<u64> {
         let result = sqlx::query(
             "UPDATE review_findings \
              SET failure_count = 0, cooldown_until = NULL \
-             WHERE status = 'open' AND review_id != ? \
+             WHERE status = 'open' AND project_root = ? AND review_id != ? \
                AND (failure_count > 0 OR cooldown_until IS NOT NULL)",
         )
+        .bind(project_root)
         .bind(current_review_id)
         .execute(&self.pool)
         .await?;
@@ -707,8 +758,8 @@ mod tests {
         let f2 = findings.clone();
 
         let (r1, r2) = tokio::join!(
-            store1.persist_findings("rev-1", &f1),
-            store2.persist_findings("rev-2", &f2),
+            store1.persist_findings("", "rev-1", &f1),
+            store2.persist_findings("", "rev-2", &f2),
         );
 
         // Both calls must succeed without constraint violation errors.
@@ -744,7 +795,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("", "rev-1", &findings).await?;
 
         // First claim wins.
         assert!(
@@ -776,7 +827,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F001", "RS-03", "src/lib.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("", "rev-1", &findings).await?;
 
         // Claim, then release (simulates enqueue failure).
         assert!(store.try_claim_finding("RS-03", "src/lib.rs").await?);
@@ -800,7 +851,7 @@ mod tests {
             make_finding("F2", "R2", "c.rs", "P2"),
             make_finding("F3", "R3", "d.rs", "P3"),
         ];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("", "rev-1", &findings).await?;
 
         let spawnable = store
             .list_spawnable_findings("rev-1", &["P1", "P2"])
@@ -821,7 +872,7 @@ mod tests {
             make_finding("F1", "R1", "a.rs", "P1"),
             make_finding("F2", "R2", "b.rs", "P2"),
         ];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("", "rev-1", &findings).await?;
         store.try_claim_finding("R1", "a.rs").await?;
         store.confirm_task_spawned("R1", "a.rs", "task-111").await?;
 
@@ -838,7 +889,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         let findings = vec![make_finding("F1", "R1", "a.rs", "P1")];
-        store.persist_findings("rev-1", &findings).await?;
+        store.persist_findings("", "rev-1", &findings).await?;
         sqlx::query("UPDATE review_findings SET status = 'resolved' WHERE id = 'F1'")
             .execute(&store.pool)
             .await?;
@@ -861,7 +912,7 @@ mod tests {
 
         // First review: persist, claim and confirm task.
         store
-            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .persist_findings("", "rev-1", std::slice::from_ref(&finding))
             .await?;
         store.try_claim_finding("RS-03", "src/lib.rs").await?;
         store
@@ -871,7 +922,7 @@ mod tests {
         // Second review: same rule_id+file triggers UPDATE (recurring finding),
         // review_id changes to rev-2 but task_id must be preserved.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
-        store.persist_findings("rev-2", &[finding2]).await?;
+        store.persist_findings("", "rev-2", &[finding2]).await?;
 
         // task_id IS NOT NULL so it must not appear in spawnable list.
         let spawnable = store
@@ -897,12 +948,12 @@ mod tests {
 
         // Simulate: list_spawnable_findings returned F1 under rev-1.
         store
-            .persist_findings("rev-1", std::slice::from_ref(&finding))
+            .persist_findings("", "rev-1", std::slice::from_ref(&finding))
             .await?;
 
         // Simulate race: persist_findings runs with rev-2 BEFORE try_claim_finding.
         let finding2 = make_finding("F1", "RS-03", "src/lib.rs", "P1");
-        store.persist_findings("rev-2", &[finding2]).await?;
+        store.persist_findings("", "rev-2", &[finding2]).await?;
 
         // try_claim_finding must succeed even though the row now has review_id="rev-2".
         let claimed = store.try_claim_finding("RS-03", "src/lib.rs").await?;
@@ -942,11 +993,11 @@ mod tests {
             task_id: None,
         }];
 
-        let inserted = store.persist_findings("rev-1", &findings).await?;
+        let inserted = store.persist_findings("", "rev-1", &findings).await?;
         assert_eq!(inserted, 1);
 
         // Same rule_id + file = dedup (recurring).
-        let inserted = store.persist_findings("rev-2", &findings).await?;
+        let inserted = store.persist_findings("", "rev-2", &findings).await?;
         assert_eq!(inserted, 0);
 
         let open = store.list_open().await?;
@@ -991,7 +1042,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         for expected in 1u32..=3 {
@@ -1012,7 +1063,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         set_pending(&store, "R1", "a.rs").await;
@@ -1033,7 +1084,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Expected delays (seconds) for failure_count = 0..=5.
@@ -1064,7 +1115,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Set an active cooldown (far future).
@@ -1091,7 +1142,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Set an expired cooldown (past timestamp).
@@ -1119,7 +1170,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Apply a failure to set counters.
@@ -1145,7 +1196,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Simulate a confirmed-task pending row (real_task_id set).
@@ -1180,7 +1231,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Simulate a stale mid-claim row (no real_task_id, old claimed_at).
@@ -1218,7 +1269,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let store = ReviewStore::open(&dir.path().join("review.db")).await?;
         store
-            .persist_findings("rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
+            .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
         // Apply some failures so counters are non-zero.
@@ -1233,7 +1284,7 @@ mod tests {
 
         // A new scan (rev-2) does not include this finding.  reset_cooldowns_for_resolved
         // should clear the counters since the finding's review_id is still "rev-1".
-        let cleared = store.reset_cooldowns_for_resolved("rev-2").await?;
+        let cleared = store.reset_cooldowns_for_resolved("", "rev-2").await?;
         assert_eq!(cleared, 1, "one finding must have its cooldown cleared");
 
         let (count_after, cooldown_after) = get_cooldown(&store, "R1", "a.rs").await;

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -496,17 +496,23 @@ impl ReviewStore {
     /// both `confirm_task_spawned` attempts failed.  This enables task-status-based
     /// stale recovery via [`recover_stale_pending_claims`] without relying on a
     /// fixed time threshold that may not bound actual task lifetime.
+    ///
+    /// Scoped by `project_root` to prevent cross-project contamination when two
+    /// projects share the same `rule_id` + `file` combination.
     pub async fn record_real_task_id(
         &self,
+        project_root: &str,
         rule_id: &str,
         file: &str,
         real_task_id: &str,
     ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings SET real_task_id = ? \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? \
+               AND status = 'open' AND task_id = 'pending'",
         )
         .bind(real_task_id)
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -585,12 +585,18 @@ impl ReviewStore {
     ///
     /// Called when the violation is no longer detected in the latest scan,
     /// ensuring that if it reappears it starts with a fresh failure history.
-    pub async fn reset_finding_cooldown(&self, rule_id: &str, file: &str) -> anyhow::Result<()> {
+    pub async fn reset_finding_cooldown(
+        &self,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE review_findings \
              SET failure_count = 0, cooldown_until = NULL \
-             WHERE rule_id = ? AND file = ? AND status = 'open'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? AND status = 'open'",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)
@@ -633,13 +639,12 @@ impl ReviewStore {
         Ok(result.rows_affected())
     }
 
-    /// Release a pending claim by resetting task_id to NULL.
-    ///
-    /// Called when task enqueue fails after a successful `try_claim_finding`,
-    /// allowing the next poll cycle to retry spawning for this finding.
     /// Release a pending claim after the underlying task completed successfully,
     /// clearing task_id, claimed_at, and real_task_id without penalising
     /// failure_count or setting a cooldown.
+    ///
+    /// Returns the number of rows updated (1 if found, 0 if the finding was
+    /// already in a different state when recovery ran).
     async fn release_stale_claim_ok(
         &self,
         project_root: &str,
@@ -660,6 +665,10 @@ impl ReviewStore {
         Ok(result.rows_affected())
     }
 
+    /// Release a pending claim by resetting task_id to NULL.
+    ///
+    /// Called when task enqueue fails after a successful `try_claim_finding`,
+    /// allowing the next poll cycle to retry spawning for this finding.
     pub async fn release_claim(
         &self,
         project_root: &str,
@@ -1085,11 +1094,18 @@ mod tests {
     // -------------------------------------------------------------------------
 
     /// Helper: read (failure_count, cooldown_until) for an open finding.
-    async fn get_cooldown(store: &ReviewStore, rule_id: &str, file: &str) -> (i64, Option<String>) {
+    async fn get_cooldown(
+        store: &ReviewStore,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> (i64, Option<String>) {
         sqlx::query_as::<_, (i64, Option<String>)>(
             "SELECT failure_count, cooldown_until \
-             FROM review_findings WHERE rule_id = ? AND file = ? AND status = 'open'",
+             FROM review_findings \
+             WHERE project_root = ? AND rule_id = ? AND file = ? AND status = 'open'",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .fetch_one(&store.pool)
@@ -1098,11 +1114,12 @@ mod tests {
     }
 
     /// Put a finding into pending state so mark_finding_failed can act on it.
-    async fn set_pending(store: &ReviewStore, rule_id: &str, file: &str) {
+    async fn set_pending(store: &ReviewStore, project_root: &str, rule_id: &str, file: &str) {
         sqlx::query(
             "UPDATE review_findings SET task_id = 'pending', claimed_at = datetime('now') \
-             WHERE rule_id = ? AND file = ? AND status = 'open'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? AND status = 'open'",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&store.pool)
@@ -1119,9 +1136,9 @@ mod tests {
             .await?;
 
         for expected in 1u32..=3 {
-            set_pending(&store, "R1", "a.rs").await;
+            set_pending(&store, "", "R1", "a.rs").await;
             store.mark_finding_failed("", "R1", "a.rs").await?;
-            let (count, _) = get_cooldown(&store, "R1", "a.rs").await;
+            let (count, _) = get_cooldown(&store, "", "R1", "a.rs").await;
             assert_eq!(
                 count as u32, expected,
                 "failure_count after {} calls",
@@ -1139,10 +1156,10 @@ mod tests {
             .persist_findings("", "rev-1", &[make_finding("F1", "R1", "a.rs", "P1")])
             .await?;
 
-        set_pending(&store, "R1", "a.rs").await;
+        set_pending(&store, "", "R1", "a.rs").await;
         store.mark_finding_failed("", "R1", "a.rs").await?;
 
-        let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
+        let (_, cooldown_until) = get_cooldown(&store, "", "R1", "a.rs").await;
         let ts_str = cooldown_until.expect("cooldown_until must be set after failure");
         // Parse the SQLite datetime string (format: "YYYY-MM-DD HH:MM:SS").
         let dt = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%d %H:%M:%S")
@@ -1163,12 +1180,12 @@ mod tests {
         // Expected delays (seconds) for failure_count = 0..=5.
         let expected_secs: &[i64] = &[3600, 7200, 14400, 28800, 57600, 86400];
         for &expected in expected_secs {
-            set_pending(&store, "R1", "a.rs").await;
+            set_pending(&store, "", "R1", "a.rs").await;
             let before = chrono::Utc::now().naive_utc();
             store.mark_finding_failed("", "R1", "a.rs").await?;
             let after = chrono::Utc::now().naive_utc();
 
-            let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
+            let (_, cooldown_until) = get_cooldown(&store, "", "R1", "a.rs").await;
             let ts_str = cooldown_until.unwrap();
             let dt = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%d %H:%M:%S").unwrap();
 
@@ -1247,15 +1264,15 @@ mod tests {
             .await?;
 
         // Apply a failure to set counters.
-        set_pending(&store, "R1", "a.rs").await;
+        set_pending(&store, "", "R1", "a.rs").await;
         store.mark_finding_failed("", "R1", "a.rs").await?;
-        let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count_before, cooldown_before) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(count_before, 1);
         assert!(cooldown_before.is_some());
 
-        store.reset_finding_cooldown("R1", "a.rs").await?;
+        store.reset_finding_cooldown("", "R1", "a.rs").await?;
 
-        let (count_after, cooldown_after) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count_after, cooldown_after) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(count_after, 0, "failure_count must be 0 after reset");
         assert!(
             cooldown_after.is_none(),
@@ -1287,7 +1304,7 @@ mod tests {
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered");
 
-        let (count, cooldown) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count, cooldown) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(
             count, 1,
             "failure_count must be 1 after strategy-1 recovery"
@@ -1325,7 +1342,7 @@ mod tests {
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered via timeout");
 
-        let (count, cooldown) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count, cooldown) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(
             count, 0,
             "failure_count must remain 0 for strategy-2 recovery"
@@ -1346,12 +1363,12 @@ mod tests {
             .await?;
 
         // Apply some failures so counters are non-zero.
-        set_pending(&store, "R1", "a.rs").await;
+        set_pending(&store, "", "R1", "a.rs").await;
         store.mark_finding_failed("", "R1", "a.rs").await?;
-        set_pending(&store, "R1", "a.rs").await;
+        set_pending(&store, "", "R1", "a.rs").await;
         store.mark_finding_failed("", "R1", "a.rs").await?;
 
-        let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count_before, cooldown_before) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(count_before, 2);
         assert!(cooldown_before.is_some());
 
@@ -1360,7 +1377,7 @@ mod tests {
         let cleared = store.reset_cooldowns_for_resolved("", "rev-2").await?;
         assert_eq!(cleared, 1, "one finding must have its cooldown cleared");
 
-        let (count_after, cooldown_after) = get_cooldown(&store, "R1", "a.rs").await;
+        let (count_after, cooldown_after) = get_cooldown(&store, "", "R1", "a.rs").await;
         assert_eq!(count_after, 0, "failure_count must be 0 after resolution");
         assert!(
             cooldown_after.is_none(),

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -413,7 +413,9 @@ impl ReviewStore {
                 Some(true) => {
                     // Task failed or was cancelled — apply exponential backoff so the
                     // same violation is not immediately re-attempted on the next tick.
-                    recovered += self.mark_finding_failed(project_root, &rule_id, &file).await?;
+                    recovered += self
+                        .mark_finding_failed(project_root, &rule_id, &file)
+                        .await?;
                 }
                 Some(false) => {
                     // Task completed successfully — release the claim without penalty.
@@ -453,7 +455,10 @@ impl ReviewStore {
     /// via a synchronous closure.  The in-memory `TaskStore` cache only holds active
     /// tasks; terminal tasks (Failed, Cancelled) are DB-only after a server restart,
     /// so the caller must use `get_with_db_fallback` on each returned ID.
-    pub async fn list_stale_real_task_ids(&self, project_root: &str) -> anyhow::Result<Vec<String>> {
+    pub async fn list_stale_real_task_ids(
+        &self,
+        project_root: &str,
+    ) -> anyhow::Result<Vec<String>> {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT real_task_id FROM review_findings \
              WHERE project_root = ? AND task_id = 'pending' AND status = 'open' \
@@ -526,7 +531,12 @@ impl ReviewStore {
     /// 86400-second cap, so the `min()` always fires first at failure_count ≥ 5.
     ///
     /// Returns the number of rows updated (1 if found, 0 if not matching).
-    pub async fn mark_finding_failed(&self, project_root: &str, rule_id: &str, file: &str) -> anyhow::Result<u64> {
+    pub async fn mark_finding_failed(
+        &self,
+        project_root: &str,
+        rule_id: &str,
+        file: &str,
+    ) -> anyhow::Result<u64> {
         let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = NULL, \
@@ -1069,7 +1079,7 @@ mod tests {
 
         for expected in 1u32..=3 {
             set_pending(&store, "R1", "a.rs").await;
-            store.mark_finding_failed("R1", "a.rs").await?;
+            store.mark_finding_failed("", "R1", "a.rs").await?;
             let (count, _) = get_cooldown(&store, "R1", "a.rs").await;
             assert_eq!(
                 count as u32, expected,
@@ -1089,7 +1099,7 @@ mod tests {
             .await?;
 
         set_pending(&store, "R1", "a.rs").await;
-        store.mark_finding_failed("R1", "a.rs").await?;
+        store.mark_finding_failed("", "R1", "a.rs").await?;
 
         let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
         let ts_str = cooldown_until.expect("cooldown_until must be set after failure");
@@ -1114,7 +1124,7 @@ mod tests {
         for &expected in expected_secs {
             set_pending(&store, "R1", "a.rs").await;
             let before = chrono::Utc::now().naive_utc();
-            store.mark_finding_failed("R1", "a.rs").await?;
+            store.mark_finding_failed("", "R1", "a.rs").await?;
             let after = chrono::Utc::now().naive_utc();
 
             let (_, cooldown_until) = get_cooldown(&store, "R1", "a.rs").await;
@@ -1197,7 +1207,7 @@ mod tests {
 
         // Apply a failure to set counters.
         set_pending(&store, "R1", "a.rs").await;
-        store.mark_finding_failed("R1", "a.rs").await?;
+        store.mark_finding_failed("", "R1", "a.rs").await?;
         let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
         assert_eq!(count_before, 1);
         assert!(cooldown_before.is_some());
@@ -1232,7 +1242,7 @@ mod tests {
 
         // Strategy-1 recovery: task failed → should trigger backoff.
         let recovered = store
-            .recover_stale_pending_claims(3900, |_tid| Some(true))
+            .recover_stale_pending_claims("", 3900, |_tid| Some(true))
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered");
 
@@ -1270,7 +1280,7 @@ mod tests {
         // Strategy-2 recovery via time threshold — must NOT apply backoff.
         // real_task_id is NULL so the closure is never called; type must match.
         let recovered = store
-            .recover_stale_pending_claims(3900, |_tid| Some(false))
+            .recover_stale_pending_claims("", 3900, |_tid| Some(false))
             .await?;
         assert_eq!(recovered, 1, "one row must be recovered via timeout");
 
@@ -1296,9 +1306,9 @@ mod tests {
 
         // Apply some failures so counters are non-zero.
         set_pending(&store, "R1", "a.rs").await;
-        store.mark_finding_failed("R1", "a.rs").await?;
+        store.mark_finding_failed("", "R1", "a.rs").await?;
         set_pending(&store, "R1", "a.rs").await;
-        store.mark_finding_failed("R1", "a.rs").await?;
+        store.mark_finding_failed("", "R1", "a.rs").await?;
 
         let (count_before, cooldown_before) = get_cooldown(&store, "R1", "a.rs").await;
         assert_eq!(count_before, 2);

--- a/crates/harness-server/src/review_store.rs
+++ b/crates/harness-server/src/review_store.rs
@@ -185,21 +185,26 @@ impl ReviewStore {
         )
         .execute(&pool)
         .await?;
-        // Remove duplicate (rule_id, file, status) rows that may exist from
-        // before this unique index was introduced; keep the most recent row per group.
+        // Remove duplicate (project_root, rule_id, file, status) rows that may exist
+        // from before this unique index was introduced; keep the most recent row per group.
         sqlx::query(
             "DELETE FROM review_findings \
              WHERE rowid NOT IN ( \
-                 SELECT MAX(rowid) FROM review_findings GROUP BY rule_id, file, status \
+                 SELECT MAX(rowid) FROM review_findings GROUP BY project_root, rule_id, file, status \
              )",
         )
         .execute(&pool)
         .await?;
+        // Migrate: rebuild the unique dedup index to include project_root so that
+        // findings from different projects with the same rule_id+file do not collide.
+        sqlx::query("DROP INDEX IF EXISTS idx_finding_dedup")
+            .execute(&pool)
+            .await?;
         // Unique index enables specific-conflict INSERT deduplication without a
         // TOCTOU race between a SELECT check and an INSERT.
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_finding_dedup \
-             ON review_findings(rule_id, file, status)",
+             ON review_findings(project_root, rule_id, file, status)",
         )
         .execute(&pool)
         .await?;
@@ -263,11 +268,16 @@ impl ReviewStore {
             } else {
                 // Existing open finding for the same rule_id+file — mark as recurring
                 // and update project_root in case the row was created before migration.
+                // The `(project_root = ? OR project_root = '')` condition ensures that
+                // pre-migration rows (project_root='') are correctly backfilled while
+                // new rows are matched precisely by project scope.
                 sqlx::query(
                     "UPDATE review_findings SET review_id = ?, project_root = ? \
-                     WHERE rule_id = ? AND file = ? AND status = 'open'",
+                     WHERE (project_root = ? OR project_root = '') \
+                       AND rule_id = ? AND file = ? AND status = 'open'",
                 )
                 .bind(review_id)
+                .bind(project_root)
                 .bind(project_root)
                 .bind(&f.rule_id)
                 .bind(&f.file)
@@ -382,6 +392,7 @@ impl ReviewStore {
     /// Returns the number of findings recovered.
     pub async fn recover_stale_pending_claims(
         &self,
+        project_root: &str,
         stale_secs: i64,
         get_task_outcome: impl Fn(&str) -> Option<bool>,
     ) -> anyhow::Result<u64> {
@@ -389,9 +400,10 @@ impl ReviewStore {
         let with_real_id: Vec<(String, String, String)> = sqlx::query_as(
             "SELECT rule_id, file, real_task_id \
              FROM review_findings \
-             WHERE task_id = 'pending' AND status = 'open' \
+             WHERE project_root = ? AND task_id = 'pending' AND status = 'open' \
                AND claimed_at IS NOT NULL AND real_task_id IS NOT NULL",
         )
+        .bind(project_root)
         .fetch_all(&self.pool)
         .await?;
 
@@ -401,7 +413,7 @@ impl ReviewStore {
                 Some(true) => {
                     // Task failed or was cancelled — apply exponential backoff so the
                     // same violation is not immediately re-attempted on the next tick.
-                    recovered += self.mark_finding_failed(&rule_id, &file).await?;
+                    recovered += self.mark_finding_failed(project_root, &rule_id, &file).await?;
                 }
                 Some(false) => {
                     // Task completed successfully — release the claim without penalty.
@@ -420,10 +432,11 @@ impl ReviewStore {
         // Strategy 2: recover mid-claim rows (no real task id yet) via time threshold.
         let result = sqlx::query(
             "UPDATE review_findings SET task_id = NULL, claimed_at = NULL \
-             WHERE task_id = 'pending' AND status = 'open' \
+             WHERE project_root = ? AND task_id = 'pending' AND status = 'open' \
                AND claimed_at IS NOT NULL AND real_task_id IS NULL \
                AND claimed_at < datetime('now', '-' || cast(? as text) || ' seconds')",
         )
+        .bind(project_root)
         .bind(stale_secs)
         .execute(&self.pool)
         .await?;
@@ -440,12 +453,13 @@ impl ReviewStore {
     /// via a synchronous closure.  The in-memory `TaskStore` cache only holds active
     /// tasks; terminal tasks (Failed, Cancelled) are DB-only after a server restart,
     /// so the caller must use `get_with_db_fallback` on each returned ID.
-    pub async fn list_stale_real_task_ids(&self) -> anyhow::Result<Vec<String>> {
+    pub async fn list_stale_real_task_ids(&self, project_root: &str) -> anyhow::Result<Vec<String>> {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT real_task_id FROM review_findings \
-             WHERE task_id = 'pending' AND status = 'open' \
+             WHERE project_root = ? AND task_id = 'pending' AND status = 'open' \
                AND claimed_at IS NOT NULL AND real_task_id IS NOT NULL",
         )
+        .bind(project_root)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
@@ -512,7 +526,7 @@ impl ReviewStore {
     /// 86400-second cap, so the `min()` always fires first at failure_count ≥ 5.
     ///
     /// Returns the number of rows updated (1 if found, 0 if not matching).
-    pub async fn mark_finding_failed(&self, rule_id: &str, file: &str) -> anyhow::Result<u64> {
+    pub async fn mark_finding_failed(&self, project_root: &str, rule_id: &str, file: &str) -> anyhow::Result<u64> {
         let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = NULL, \
@@ -521,8 +535,10 @@ impl ReviewStore {
                  failure_count = failure_count + 1, \
                  cooldown_until = datetime('now', '+' || \
                      cast(min(3600 * (1 << min(failure_count, 24)), 86400) as text) || ' seconds') \
-             WHERE rule_id = ? AND file = ? AND status = 'open' AND task_id = 'pending'",
+             WHERE project_root = ? AND rule_id = ? AND file = ? AND status = 'open' \
+               AND task_id IS NOT NULL",
         )
+        .bind(project_root)
         .bind(rule_id)
         .bind(file)
         .execute(&self.pool)


### PR DESCRIPTION
## Summary

- Adds `failure_count` and `cooldown_until` columns to `review_findings` via additive migration (no breaking schema change)
- After a confirmed auto-fix task failure, `mark_finding_failed()` atomically releases the pending claim and sets a cooldown: 1h → 2h → 4h → 8h → 16h → 24h cap (formula: `min(3600 * 2^failure_count, 86400)` seconds)
- `list_spawnable_findings()` now excludes findings whose `cooldown_until` is in the future — the storm-triggering re-spawn path is closed
- `recover_stale_pending_claims()` strategy-1 (confirmed terminal task) applies backoff; strategy-2 (ambiguous timeout) does not penalise the finding
- After the spawn loop each tick, `reset_cooldowns_for_resolved()` clears backoff state for violations no longer seen in the scan

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] 9 new tests covering: increment count, exponential schedule, future timestamp, cooldown exclusion, expired inclusion, reset, strategy-1 backoff, strategy-2 no-backoff, resolution clear — all pass
- [x] All existing harness-server tests pass

Closes #770