### PR TITLE
fix(agents): increase stream idle timeout from 30min to 60min

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -32,7 +32,7 @@ impl ClaudeCodeAgent {
             default_model,
             sandbox_mode,
             reasoning_budget: None,
-            stream_timeout_secs: Some(1800),
+            stream_timeout_secs: Some(3600),
         }
     }
 

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -40,7 +40,7 @@ impl CodexAgent {
             reasoning_effort: "high".to_string(),
             cloud,
             sandbox_mode,
-            stream_timeout_secs: Some(1800),
+            stream_timeout_secs: Some(3600),
         }
     }
 

--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -113,7 +113,7 @@ pub struct AgentsConfig {
     pub allowed_tools: Option<Vec<String>>,
     /// Maximum seconds of silence on a stream before declaring a zombie and
     /// killing the subprocess. Set to `0` to disable the per-line idle timeout.
-    /// Default: 1800 (30 minutes).
+    /// Default: 3600 (60 minutes).
     #[serde(
         default = "default_stream_timeout_secs",
         deserialize_with = "deserialize_stream_timeout_secs"
@@ -122,7 +122,7 @@ pub struct AgentsConfig {
 }
 
 fn default_stream_timeout_secs() -> Option<u64> {
-    Some(1800)
+    Some(3600)
 }
 
 /// Deserializer for `stream_timeout_secs`: TOML integer `0` maps to `None`


### PR DESCRIPTION
## Summary
- Increase default stream idle timeout from 1800s to 3600s across all agent types
- Large refactoring tasks (e.g. issue #772, splitting 2300-line files) cause Opus to think >30min during planning phase without stdout, triggering zombie detection

## Test plan
- [x] `cargo check --workspace --all-targets` — clean