### PR TITLE
fix(triage): keep TRIAGE=SKIP token parseable in duplicate-PR instruction

### DIFF
--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -86,7 +86,7 @@ pub fn triage_prompt(issue: u64) -> PromptParts {
             "You are a Tech Lead evaluating GitHub issue #{issue} before any code is written.\n\n\
              **Step 1 — duplicate PR check:**\n\
              Run: `gh pr list --search \"{issue}\" --state open --json number,title`\n\
-             If an open PR targets this issue, mention the PR number in your assessment, then follow the mandatory output format below with TRIAGE=SKIP.\n\n\
+             If an open PR targets this issue, mention the PR number in your response, then follow the mandatory output format below with TRIAGE=SKIP.\n\n\
              **Step 2 — assess the issue (if no duplicate PR):**\n\
              Read the issue. Assess complexity and clarity briefly (2-3 sentences).\n\n\
              **Step 3 — choose ONE recommendation:**\n\

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -86,7 +86,7 @@ pub fn triage_prompt(issue: u64) -> PromptParts {
             "You are a Tech Lead evaluating GitHub issue #{issue} before any code is written.\n\n\
              **Step 1 — duplicate PR check:**\n\
              Run: `gh pr list --search \"{issue}\" --state open --json number,title`\n\
-             If an open PR targets this issue, output TRIAGE=SKIP with the PR number.\n\n\
+             If an open PR targets this issue, mention the PR number in your assessment, then follow the mandatory output format below with TRIAGE=SKIP.\n\n\
              **Step 2 — assess the issue (if no duplicate PR):**\n\
              Read the issue. Assess complexity and clarity briefly (2-3 sentences).\n\n\
              **Step 3 — choose ONE recommendation:**\n\


### PR DESCRIPTION
## Summary
Addresses review feedback from Gemini and Codex on PR #774: the instruction
"output TRIAGE=SKIP with the PR number" causes agents to append PR numbers
to the TRIAGE line (`TRIAGE=SKIP #123`), which `parse_triage()` rejects.

Reworded to: "mention the PR number in your assessment, then follow the
mandatory output format below with TRIAGE=SKIP."

## Test plan
- [x] `cargo check --workspace --all-targets`