### PR TITLE
feat(ci): include changed job in ci-result fan-in gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,18 @@ jobs:
     name: CI Result
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, check, clippy, test, audit]
+    needs: [changed, fmt, check, clippy, test, audit]
     steps:
       - name: Check all jobs
         run: |
-          results=("${{ needs.fmt.result }}" "${{ needs.check.result }}" "${{ needs.clippy.result }}" "${{ needs.test.result }}" "${{ needs.audit.result }}")
+          results=(
+            "${{ needs.changed.result }}"
+            "${{ needs.fmt.result }}"
+            "${{ needs.check.result }}"
+            "${{ needs.clippy.result }}"
+            "${{ needs.test.result }}"
+            "${{ needs.audit.result }}"
+          )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
               echo "Job failed or cancelled: $r"


### PR DESCRIPTION
## Summary

- Add `changed` (Detect Changes) to `ci-result`'s `needs` list so a failure in path-based change detection propagates as a CI failure rather than silently letting all downstream jobs be skipped and `ci-result` pass
- Expand the results array to one entry per line for readability

The `ci-result` aggregation job and the `CI Result` branch-protection requirement were already in place (added in `7625fc5`). This PR improves the robustness of that job and formally closes the tracking issue.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all 42 tests pass
- [ ] CI workflow syntax verified via GitHub Actions on this PR

Closes #759