### PR TITLE
feat(conflict): rebase-first strategy for conflicting PRs (#755)

### DIFF
--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -73,6 +73,47 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
     )
 }
 
+/// Build prompt: rebase a conflicting PR onto the current main branch.
+///
+/// Used when [`conflict_resolver::assess_pr_conflict`] classifies the PR as
+/// `Small` (≤3 files, <5 conflict regions). The agent performs the rebase
+/// inside an isolated worktree and force-pushes the result.
+pub fn rebase_conflicting_pr(pr_num: u64, branch: &str, repo: &str) -> String {
+    format!(
+        "PR #{pr_num} on branch `{branch}` in `{repo}` has a merge conflict that is small \
+         enough for automatic rebase.\n\n\
+         IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
+         All work must be done in an isolated worktree.\n\n\
+         Steps:\n\
+         1. Fetch and create an isolated worktree:\n\
+            ```\n\
+            git fetch origin\n\
+            git worktree remove /tmp/harness-rebase-{pr_num} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr_num} 2>/dev/null || true\n\
+            git worktree prune\n\
+            git worktree add /tmp/harness-rebase-{pr_num} {branch}\n\
+            ```\n\
+         2. Rebase onto origin/main inside the worktree:\n\
+            ```\n\
+            cd /tmp/harness-rebase-{pr_num}\n\
+            git rebase origin/main\n\
+            ```\n\
+         3. If rebase conflicts appear, resolve each file, then:\n\
+            ```\n\
+            git add <resolved-files>\n\
+            git rebase --continue\n\
+            ```\n\
+            Repeat until the rebase completes successfully.\n\
+         4. Force-push the rebased branch:\n\
+            ```\n\
+            git push --force-with-lease origin {branch}\n\
+            ```\n\
+         5. Clean up: `git worktree remove /tmp/harness-rebase-{pr_num}`\n\n\
+         On the last line of your output, print exactly one of:\n\
+         - `REBASE_OK` if the rebase and push succeeded.\n\
+         - `REBASE_FAILED` if you could not complete the rebase for any reason."
+    )
+}
+
 /// Build triage prompt: Tech Lead evaluates whether an issue is worth implementing.
 ///
 /// Outputs a triage decision on the last line:
@@ -1084,6 +1125,22 @@ fn last_non_empty_line(output: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rebase_prompt_contains_force_push() {
+        let p = rebase_conflicting_pr(42, "feat/my-branch", "owner/repo");
+        assert!(
+            p.contains("--force-with-lease"),
+            "prompt must instruct force-with-lease push"
+        );
+    }
+
+    #[test]
+    fn rebase_prompt_contains_pr_branch() {
+        let branch = "fix/issue-123";
+        let p = rebase_conflicting_pr(123, branch, "owner/repo");
+        assert!(p.contains(branch), "prompt must reference the PR branch");
+    }
 
     #[test]
     fn test_gc_adopt_prompt() {

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -90,7 +90,7 @@ pub fn rebase_conflicting_pr(pr_num: u64, branch: &str, repo: &str) -> String {
             git fetch origin\n\
             git worktree remove /tmp/harness-rebase-{pr_num} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr_num} 2>/dev/null || true\n\
             git worktree prune\n\
-            git worktree add /tmp/harness-rebase-{pr_num} {branch}\n\
+            git worktree add /tmp/harness-rebase-{pr_num} '{branch}'\n\
             ```\n\
          2. Rebase onto origin/main inside the worktree:\n\
             ```\n\
@@ -105,7 +105,7 @@ pub fn rebase_conflicting_pr(pr_num: u64, branch: &str, repo: &str) -> String {
             Repeat until the rebase completes successfully.\n\
          4. Force-push the rebased branch:\n\
             ```\n\
-            git push --force-with-lease origin {branch}\n\
+            git push --force-with-lease origin '{branch}'\n\
             ```\n\
          5. Clean up: `git worktree remove /tmp/harness-rebase-{pr_num}`\n\n\
          On the last line of your output, print exactly one of:\n\

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1,3 +1,4 @@
+pub(crate) mod conflict_resolver;
 pub(crate) mod helpers;
 pub(crate) mod pr_detection;
 
@@ -892,6 +893,78 @@ async fn run_triage_plan_pipeline(
     Ok((Some(plan_text), complexity, 2))
 }
 
+/// Fire a single agent turn to rebase a conflicting PR onto `origin/main`.
+///
+/// Logs the outcome (`REBASE_OK` / `REBASE_FAILED`) but does not propagate
+/// errors — a rebase failure is not fatal; the review loop will handle the PR.
+async fn run_rebase_turn(
+    agent: &dyn CodeAgent,
+    pr_num: u64,
+    project: &std::path::Path,
+    repo: &str,
+    turn_timeout: Duration,
+    cargo_env: &HashMap<String, String>,
+) {
+    // Fetch the branch name from GitHub so the prompt has an exact ref.
+    let branch = {
+        let out = tokio::process::Command::new("gh")
+            .current_dir(project)
+            .args([
+                "pr",
+                "view",
+                &pr_num.to_string(),
+                "--json",
+                "headRefName",
+                "--jq",
+                ".headRefName",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .await;
+        match out {
+            Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .trim_matches('"')
+                .to_string(),
+            _ => {
+                tracing::warn!(
+                    pr = pr_num,
+                    "run_rebase_turn: could not fetch branch name; skipping"
+                );
+                return;
+            }
+        }
+    };
+
+    let prompt = harness_core::prompts::rebase_conflicting_pr(pr_num, &branch, repo);
+    let req = AgentRequest {
+        prompt,
+        project_root: project.to_path_buf(),
+        env_vars: cargo_env.clone(),
+        execution_phase: Some(harness_core::types::ExecutionPhase::Planning),
+        ..Default::default()
+    };
+
+    match tokio::time::timeout(turn_timeout, agent.execute(req)).await {
+        Ok(Ok(resp)) => {
+            let last = resp.output.lines().next_back().unwrap_or("").trim();
+            if last.contains("REBASE_OK") {
+                tracing::info!(pr = pr_num, "rebase turn: REBASE_OK");
+            } else {
+                tracing::warn!(
+                    pr = pr_num,
+                    last_line = last,
+                    "rebase turn: REBASE_FAILED or unexpected output"
+                );
+            }
+        }
+        Ok(Err(e)) => tracing::warn!(pr = pr_num, error = %e, "rebase turn: agent error"),
+        Err(_) => tracing::warn!(pr = pr_num, "rebase turn: timed out"),
+    }
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
@@ -978,6 +1051,8 @@ pub(crate) async fn run_task(
     };
     let resumed_pr_url: Option<String> =
         task_pr_url.or_else(|| checkpoint.as_ref().and_then(|c| c.pr_url.clone()));
+    // Capture before `resumed_pr_url` is moved into the `'implement` block.
+    let was_resumed_pr = resumed_pr_url.is_some();
     let resumed_plan: Option<String> = checkpoint.and_then(|c| c.plan_output);
 
     // --- Pipeline: Triage → Plan → Implement ---
@@ -1619,6 +1694,47 @@ pub(crate) async fn run_task(
 
         (pr_url, pr_num)
     }; // end 'implement
+
+    // Conflict resolution gate: intercept CONFLICTING PRs before the review loop.
+    // Only runs on the resume/recovery path — fresh PRs cannot be conflicting yet.
+    if was_resumed_pr {
+        use conflict_resolver::{assess_pr_conflict, PrConflictSize};
+        let conflict_size = assess_pr_conflict(pr_num, &project).await;
+        match conflict_size {
+            PrConflictSize::Small {
+                file_count,
+                region_count,
+            } => {
+                tracing::info!(
+                    pr = pr_num,
+                    file_count,
+                    region_count,
+                    "conflict: small — attempting auto-rebase"
+                );
+                run_rebase_turn(
+                    agent,
+                    pr_num,
+                    &project,
+                    &repo_slug,
+                    turn_timeout,
+                    &cargo_env,
+                )
+                .await;
+            }
+            PrConflictSize::Large {
+                file_count,
+                region_count,
+            } => {
+                tracing::warn!(
+                    pr = pr_num,
+                    file_count,
+                    region_count,
+                    "conflict: too large for auto-rebase — deferring to review agent"
+                );
+            }
+            PrConflictSize::Clean | PrConflictSize::Unknown(_) => {}
+        }
+    }
 
     // Agent review loop (if enabled and reviewer available, and not skipped by triage complexity)
     let mut agent_pushed_commit = false;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -895,8 +895,9 @@ async fn run_triage_plan_pipeline(
 
 /// Fire a single agent turn to rebase a conflicting PR onto `origin/main`.
 ///
-/// Logs the outcome (`REBASE_OK` / `REBASE_FAILED`) but does not propagate
-/// errors — a rebase failure is not fatal; the review loop will handle the PR.
+/// Returns `true` if the agent reported `REBASE_OK` (i.e. a new commit was
+/// force-pushed), `false` in every other case.  Errors are not propagated —
+/// a rebase failure is not fatal; the review loop will handle the PR.
 async fn run_rebase_turn(
     agent: &dyn CodeAgent,
     pr_num: u64,
@@ -904,7 +905,7 @@ async fn run_rebase_turn(
     repo: &str,
     turn_timeout: Duration,
     cargo_env: &HashMap<String, String>,
-) {
+) -> bool {
     // Fetch the branch name from GitHub so the prompt has an exact ref.
     let branch = {
         let out = tokio::process::Command::new("gh")
@@ -933,10 +934,25 @@ async fn run_rebase_turn(
                     pr = pr_num,
                     "run_rebase_turn: could not fetch branch name; skipping"
                 );
-                return;
+                return false;
             }
         }
     };
+
+    // Reject branch names that contain shell metacharacters.  The branch
+    // name is embedded inside single-quoted shell commands in the agent
+    // prompt; a single-quote in the name would break out of the quoting.
+    if !branch
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '/' | '-' | '_' | '.' | '@' | '~' | '+' | ':'))
+    {
+        tracing::warn!(
+            pr = pr_num,
+            branch = %branch,
+            "run_rebase_turn: branch name contains unsafe characters; skipping"
+        );
+        return false;
+    }
 
     let prompt = harness_core::prompts::rebase_conflicting_pr(pr_num, &branch, repo);
     let req = AgentRequest {
@@ -952,16 +968,24 @@ async fn run_rebase_turn(
             let last = resp.output.lines().next_back().unwrap_or("").trim();
             if last.contains("REBASE_OK") {
                 tracing::info!(pr = pr_num, "rebase turn: REBASE_OK");
+                true
             } else {
                 tracing::warn!(
                     pr = pr_num,
                     last_line = last,
                     "rebase turn: REBASE_FAILED or unexpected output"
                 );
+                false
             }
         }
-        Ok(Err(e)) => tracing::warn!(pr = pr_num, error = %e, "rebase turn: agent error"),
-        Err(_) => tracing::warn!(pr = pr_num, "rebase turn: timed out"),
+        Ok(Err(e)) => {
+            tracing::warn!(pr = pr_num, error = %e, "rebase turn: agent error");
+            false
+        }
+        Err(_) => {
+            tracing::warn!(pr = pr_num, "rebase turn: timed out");
+            false
+        }
     }
 }
 
@@ -1697,6 +1721,7 @@ pub(crate) async fn run_task(
 
     // Conflict resolution gate: intercept CONFLICTING PRs before the review loop.
     // Only runs on the resume/recovery path — fresh PRs cannot be conflicting yet.
+    let mut rebase_pushed = false;
     if was_resumed_pr {
         use conflict_resolver::{assess_pr_conflict, PrConflictSize};
         let conflict_size = assess_pr_conflict(pr_num, &project).await;
@@ -1711,7 +1736,7 @@ pub(crate) async fn run_task(
                     region_count,
                     "conflict: small — attempting auto-rebase"
                 );
-                run_rebase_turn(
+                rebase_pushed = run_rebase_turn(
                     agent,
                     pr_num,
                     &project,
@@ -1813,7 +1838,7 @@ pub(crate) async fn run_task(
     // Starts true if the implementation phase pushed a commit, and is set to true again
     // whenever a review round produces FIXED (agent commits + pushes). This drives the
     // freshness check in every round after a fix commit, not just round 1.
-    let mut prev_fixed = agent_pushed_commit;
+    let mut prev_fixed = agent_pushed_commit || rebase_pushed;
     let repo_slug = prompts::repo_slug_from_pr_url(pr_url.as_deref());
 
     // Convergence tracking: detect when issue count stops decreasing.

--- a/crates/harness-server/src/task_executor/conflict_resolver.rs
+++ b/crates/harness-server/src/task_executor/conflict_resolver.rs
@@ -1,0 +1,217 @@
+//! Assess the size of a PR conflict without modifying any repository state.
+//!
+//! All operations here are read-only `gh` queries. Write operations (rebase,
+//! force-push) are delegated to the agent via the prompt returned by
+//! [`harness_core::prompts::rebase_conflicting_pr`].
+
+use std::path::Path;
+use tokio::process::Command;
+
+/// Classification of how large a PR's merge conflict is.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PrConflictSize {
+    /// The PR is not in a conflicting state.
+    Clean,
+    /// The PR is conflicting and small enough for auto-rebase:
+    /// at most 3 files and fewer than 5 conflict regions.
+    Small {
+        file_count: usize,
+        region_count: usize,
+    },
+    /// The PR is conflicting but too large for auto-rebase:
+    /// more than 3 files OR 5 or more conflict regions.
+    Large {
+        file_count: usize,
+        region_count: usize,
+    },
+    /// A `gh` invocation failed; the error message is included.
+    Unknown(String),
+}
+
+/// Assess the conflict size of a GitHub PR without touching the working tree.
+///
+/// Returns:
+/// - [`PrConflictSize::Clean`] when the PR is not conflicting.
+/// - [`PrConflictSize::Small`] when conflicts are resolvable by auto-rebase.
+/// - [`PrConflictSize::Large`] when conflicts require manual intervention.
+/// - [`PrConflictSize::Unknown`] when a `gh` call fails.
+pub(crate) async fn assess_pr_conflict(pr_num: u64, project: &Path) -> PrConflictSize {
+    // Step 1: check mergeability — 10 s timeout for the status query.
+    let mergeable = match gh_mergeable(pr_num, project).await {
+        Ok(s) => s,
+        Err(e) => return PrConflictSize::Unknown(e),
+    };
+    if mergeable != "CONFLICTING" {
+        return PrConflictSize::Clean;
+    }
+
+    // Step 2: count conflicting files.
+    let file_count = match gh_conflict_file_count(pr_num, project).await {
+        Ok(n) => n,
+        Err(e) => return PrConflictSize::Unknown(e),
+    };
+
+    // Early exit: if already over the file threshold, skip the more expensive
+    // diff parse and go directly to Large.
+    if file_count > 3 {
+        return PrConflictSize::Large {
+            file_count,
+            region_count: 0,
+        };
+    }
+
+    // Step 3: count conflict marker regions.
+    let region_count = match gh_conflict_region_count(pr_num, project).await {
+        Ok(n) => n,
+        Err(e) => return PrConflictSize::Unknown(e),
+    };
+
+    if file_count <= 3 && region_count < 5 {
+        PrConflictSize::Small {
+            file_count,
+            region_count,
+        }
+    } else {
+        PrConflictSize::Large {
+            file_count,
+            region_count,
+        }
+    }
+}
+
+/// Run `gh pr view <pr_num> --json mergeable --jq .mergeable` with a 10 s timeout.
+/// Returns the raw string value (e.g. `"CONFLICTING"`, `"MERGEABLE"`, `"UNKNOWN"`).
+async fn gh_mergeable(pr_num: u64, project: &Path) -> Result<String, String> {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        Command::new("gh")
+            .current_dir(project)
+            .args([
+                "pr",
+                "view",
+                &pr_num.to_string(),
+                "--json",
+                "mergeable",
+                "--jq",
+                ".mergeable",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("gh pr view #{pr_num} --json mergeable timed out"))?
+    .map_err(|e| format!("gh pr view #{pr_num}: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!("gh pr view #{pr_num} failed: {stderr}"));
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // gh --jq returns a JSON string with surrounding quotes; strip them.
+    Ok(value.trim_matches('"').to_string())
+}
+
+/// Run `gh pr diff <pr_num> --name-only` and return the count of distinct files.
+async fn gh_conflict_file_count(pr_num: u64, project: &Path) -> Result<usize, String> {
+    let output = Command::new("gh")
+        .current_dir(project)
+        .args(["pr", "diff", &pr_num.to_string(), "--name-only"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| format!("gh pr diff --name-only #{pr_num}: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!("gh pr diff --name-only #{pr_num} failed: {stderr}"));
+    }
+
+    let count = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .count();
+    Ok(count)
+}
+
+/// Run `gh pr diff <pr_num>` and return the number of conflict-marker lines (`<<<<<<<`).
+async fn gh_conflict_region_count(pr_num: u64, project: &Path) -> Result<usize, String> {
+    let output = Command::new("gh")
+        .current_dir(project)
+        .args(["pr", "diff", &pr_num.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| format!("gh pr diff #{pr_num}: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!("gh pr diff #{pr_num} failed: {stderr}"));
+    }
+
+    let count = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| l.starts_with("+<<<<<<<") || l.starts_with("-<<<<<<<"))
+        .count();
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Unit tests for the threshold logic — does not invoke `gh`.
+
+    fn small(f: usize, r: usize) -> PrConflictSize {
+        PrConflictSize::Small {
+            file_count: f,
+            region_count: r,
+        }
+    }
+
+    fn large(f: usize, r: usize) -> PrConflictSize {
+        PrConflictSize::Large {
+            file_count: f,
+            region_count: r,
+        }
+    }
+
+    fn classify(file_count: usize, region_count: usize) -> PrConflictSize {
+        if file_count <= 3 && region_count < 5 {
+            small(file_count, region_count)
+        } else {
+            large(file_count, region_count)
+        }
+    }
+
+    #[test]
+    fn conflicting_small_pr() {
+        assert_eq!(classify(2, 3), small(2, 3));
+    }
+
+    #[test]
+    fn conflicting_large_by_files() {
+        assert_eq!(classify(4, 2), large(4, 2));
+    }
+
+    #[test]
+    fn conflicting_large_by_regions() {
+        assert_eq!(classify(2, 6), large(2, 6));
+    }
+
+    #[test]
+    fn boundary_exactly_3_files_4_regions_is_small() {
+        assert_eq!(classify(3, 4), small(3, 4));
+    }
+
+    #[test]
+    fn boundary_exactly_5_regions_is_large() {
+        assert_eq!(classify(1, 5), large(1, 5));
+    }
+}

--- a/crates/harness-server/src/task_executor/conflict_resolver.rs
+++ b/crates/harness-server/src/task_executor/conflict_resolver.rs
@@ -1,8 +1,11 @@
 //! Assess the size of a PR conflict without modifying any repository state.
 //!
-//! All operations here are read-only `gh` queries. Write operations (rebase,
-//! force-push) are delegated to the agent via the prompt returned by
-//! [`harness_core::prompts::rebase_conflicting_pr`].
+//! Mergeability is checked via read-only `gh` queries.  Conflict region
+//! counting uses `git merge-tree` (a dry-run three-way merge that writes
+//! nothing to the working tree or index) so that `<<<<<<<` markers reflect
+//! the actual merge result against `origin/main`, not the PR's own diff.
+//! Write operations (rebase, force-push) are delegated to the agent via the
+//! prompt returned by [`harness_core::prompts::rebase_conflicting_pr`].
 
 use std::path::Path;
 use tokio::process::Command;
@@ -45,26 +48,19 @@ pub(crate) async fn assess_pr_conflict(pr_num: u64, project: &Path) -> PrConflic
         return PrConflictSize::Clean;
     }
 
-    // Step 2: count conflicting files.
-    let file_count = match gh_conflict_file_count(pr_num, project).await {
-        Ok(n) => n,
+    // Step 2: measure the actual conflict size using a dry-run merge.
+    let (file_count, region_count) = match git_conflict_counts(pr_num, project).await {
+        Ok(pair) => pair,
         Err(e) => return PrConflictSize::Unknown(e),
     };
 
-    // Early exit: if already over the file threshold, skip the more expensive
-    // diff parse and go directly to Large.
+    // Early exit: if already over the file threshold, skip region check.
     if file_count > 3 {
         return PrConflictSize::Large {
             file_count,
-            region_count: 0,
+            region_count,
         };
     }
-
-    // Step 3: count conflict marker regions.
-    let region_count = match gh_conflict_region_count(pr_num, project).await {
-        Ok(n) => n,
-        Err(e) => return PrConflictSize::Unknown(e),
-    };
 
     if file_count <= 3 && region_count < 5 {
         PrConflictSize::Small {
@@ -114,52 +110,141 @@ async fn gh_mergeable(pr_num: u64, project: &Path) -> Result<String, String> {
     Ok(value.trim_matches('"').to_string())
 }
 
-/// Run `gh pr diff <pr_num> --name-only` and return the count of distinct files.
-async fn gh_conflict_file_count(pr_num: u64, project: &Path) -> Result<usize, String> {
-    let output = Command::new("gh")
-        .current_dir(project)
-        .args(["pr", "diff", &pr_num.to_string(), "--name-only"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .await
-        .map_err(|e| format!("gh pr diff --name-only #{pr_num}: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(format!("gh pr diff --name-only #{pr_num} failed: {stderr}"));
-    }
-
-    let count = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .count();
-    Ok(count)
+/// Returns `true` if `name` contains only characters that are safe to embed
+/// inside single-quoted shell strings (i.e. no single-quote or NUL).
+fn is_safe_ref(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|c| {
+            c.is_alphanumeric() || matches!(c, '/' | '-' | '_' | '.' | '@' | '~' | '+' | ':')
+        })
 }
 
-/// Run `gh pr diff <pr_num>` and return the number of conflict-marker lines (`<<<<<<<`).
-async fn gh_conflict_region_count(pr_num: u64, project: &Path) -> Result<usize, String> {
-    let output = Command::new("gh")
-        .current_dir(project)
-        .args(["pr", "diff", &pr_num.to_string()])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .await
-        .map_err(|e| format!("gh pr diff #{pr_num}: {e}"))?;
+/// Fetch the `headRefName` of a PR from the GitHub API.
+async fn gh_head_ref_name(pr_num: u64, project: &Path) -> Result<String, String> {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        Command::new("gh")
+            .current_dir(project)
+            .args([
+                "pr",
+                "view",
+                &pr_num.to_string(),
+                "--json",
+                "headRefName",
+                "--jq",
+                ".headRefName",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("gh pr view #{pr_num} --json headRefName timed out"))?
+    .map_err(|e| format!("gh pr view #{pr_num}: {e}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(format!("gh pr diff #{pr_num} failed: {stderr}"));
+        return Err(format!("gh pr view #{pr_num} failed: {stderr}"));
     }
 
-    let count = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|l| l.starts_with("+<<<<<<<") || l.starts_with("-<<<<<<<"))
-        .count();
-    Ok(count)
+    let name = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .trim_matches('"')
+        .to_string();
+    Ok(name)
+}
+
+/// Perform a read-only three-way merge via `git merge-tree` and return
+/// `(conflicting_file_count, conflict_region_count)`.
+///
+/// `git merge-tree <base> origin/main origin/<branch>` outputs the synthetic
+/// merge result — including `<<<<<<<` / `=======` / `>>>>>>>` markers for
+/// unresolved sections — without touching the working tree or index.  Each
+/// `<<<<<<< ` line is one conflict region; each `changed in both` header is
+/// one conflicting file.
+async fn git_conflict_counts(pr_num: u64, project: &Path) -> Result<(usize, usize), String> {
+    let branch = gh_head_ref_name(pr_num, project).await?;
+    if !is_safe_ref(&branch) {
+        return Err(format!(
+            "PR #{pr_num}: branch name `{branch}` contains unsafe characters"
+        ));
+    }
+
+    // Fetch to ensure origin/main and origin/<branch> are current.
+    // Best-effort: a stale fetch is not fatal — merge-tree will still run
+    // on whatever refs are already present.
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        Command::new("git")
+            .current_dir(project)
+            .args(["fetch", "origin", "--quiet"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) if !o.status.success() => {
+            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            tracing::warn!(pr = pr_num, stderr = %stderr, "git fetch origin failed; proceeding with cached refs");
+        }
+        Err(_) => tracing::warn!(
+            pr = pr_num,
+            "git fetch origin timed out; proceeding with cached refs"
+        ),
+        _ => {}
+    }
+
+    // Compute the merge base between origin/main and origin/<branch>.
+    let base_out = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        Command::new("git")
+            .current_dir(project)
+            .args(["merge-base", "origin/main", &format!("origin/{branch}")])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("git merge-base timed out for PR #{pr_num}"))?
+    .map_err(|e| format!("git merge-base for PR #{pr_num}: {e}"))?;
+
+    if !base_out.status.success() {
+        let stderr = String::from_utf8_lossy(&base_out.stderr).trim().to_string();
+        return Err(format!("git merge-base for PR #{pr_num} failed: {stderr}"));
+    }
+    let base_sha = String::from_utf8_lossy(&base_out.stdout).trim().to_string();
+
+    // Dry-run three-way merge: outputs file content with conflict markers but
+    // does not write to the working tree or index.
+    let merge_out = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        Command::new("git")
+            .current_dir(project)
+            .args([
+                "merge-tree",
+                &base_sha,
+                "origin/main",
+                &format!("origin/{branch}"),
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("git merge-tree timed out for PR #{pr_num}"))?
+    .map_err(|e| format!("git merge-tree for PR #{pr_num}: {e}"))?;
+
+    let text = String::from_utf8_lossy(&merge_out.stdout);
+    // "changed in both" appears once per file that has conflicting edits.
+    let file_count = text.lines().filter(|l| *l == "changed in both").count();
+    // Each "<<<<<<< " line opens one conflict region.
+    let region_count = text.lines().filter(|l| l.starts_with("<<<<<<<")).count();
+    Ok((file_count, region_count))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `conflict_resolver` submodule with `assess_pr_conflict`: reads `gh pr view` (mergeability) and `gh pr diff` (file/region counts) to classify conflicts as `Clean`, `Small` (≤3 files, <5 regions), `Large`, or `Unknown`
- Add `prompts::rebase_conflicting_pr`: instructs the agent to fetch, create an isolated worktree, rebase onto `origin/main`, resolve conflicts, and `--force-with-lease` push; outputs `REBASE_OK` or `REBASE_FAILED`
- Add `run_rebase_turn` helper in `task_executor`: fires one non-fatal agent turn for small conflicts on the resume path; large conflicts fall through to the existing review loop

## Test plan

- [ ] `cargo test --package harness-server conflict` — 5 threshold unit tests pass
- [ ] `cargo test --package harness-core rebase_prompt` — 2 prompt content tests pass
- [ ] Full `cargo test --workspace` — all existing tests pass
- [ ] CI `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean

Closes #755