### PR TITLE
feat(dep-watcher): dispatch AwaitingDeps tasks when dependencies complete (#634)

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -92,6 +92,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pending_request: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -182,6 +183,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pending_request: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -205,6 +207,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pending_request: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -279,6 +282,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pending_request: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -344,6 +348,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pending_request: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -280,21 +280,103 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     .await?;
 
     // Spawn background watcher for AwaitingDeps tasks.
+    // When all dependencies of a task complete, the dep-watcher transitions it
+    // from AwaitingDeps → Pending, persists that state, then dispatches it.
     {
         let store = storage.tasks.clone();
+        let dw_agent_registry = server.agent_registry.clone();
+        let dw_server_config = Arc::new(server.config.clone());
+        let dw_skills = engines.skills.clone();
+        let dw_events = engines.events.clone();
+        let dw_interceptors = services.interceptors.clone();
+        let dw_workspace_mgr = registry.workspace_mgr.clone();
+        let dw_task_queue = intake.task_queue.clone();
+        let dw_completion_callback = intake.completion_callback.clone();
+        let dw_project_registry = registry.project_registry.clone();
+        let dw_allowed_roots = server.config.server.allowed_project_roots.clone();
+        let dw_review_config = server.config.agents.review.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
                 let (ready_ids, failed_ids) = crate::task_runner::check_awaiting_deps(&store).await;
-                for task_id in ready_ids.iter().chain(failed_ids.iter()) {
+                // Persist failed tasks (status already set to Failed by check_awaiting_deps).
+                for task_id in &failed_ids {
                     if let Err(e) = store.persist(task_id).await {
                         tracing::warn!(
-                            "dep-watcher: failed to persist {} after transition: {e}",
+                            "dep-watcher: failed to persist {} after dep-failure: {e}",
                             task_id.0
                         );
                     }
+                    store.close_task_stream(task_id);
+                }
+                // Dispatch each ready task.
+                for task_id in ready_ids {
+                    // Atomically take pending_request to prevent double-dispatch.
+                    let pending_req = store
+                        .cache
+                        .get_mut(&task_id)
+                        .and_then(|mut e| e.pending_request.take());
+                    let req = match pending_req {
+                        Some(r) => r,
+                        None => {
+                            tracing::warn!(
+                                task_id = %task_id.0,
+                                "dep-watcher: task ready but pending_request is None — skipping"
+                            );
+                            continue;
+                        }
+                    };
+                    // Persist Pending status (with pending_request_json cleared) so that
+                    // startup recovery can distinguish "mid-dispatch crash" from a normal
+                    // pending task. The pending_request_json column is now NULL because
+                    // pending_request was taken above.
+                    if let Err(e) = store.persist(&task_id).await {
+                        tracing::error!(
+                            task_id = %task_id.0,
+                            "dep-watcher: persist failed before dispatch: {e} — reverting to AwaitingDeps"
+                        );
+                        if let Some(mut entry) = store.cache.get_mut(&task_id) {
+                            if matches!(entry.status, crate::task_runner::TaskStatus::Pending) {
+                                entry.status = crate::task_runner::TaskStatus::AwaitingDeps;
+                                entry.pending_request = Some(req);
+                            }
+                        }
+                        continue;
+                    }
+                    // Dispatch in a separate task so the watcher loop is never blocked.
+                    let store2 = store.clone();
+                    let agent_registry2 = dw_agent_registry.clone();
+                    let server_config2 = dw_server_config.clone();
+                    let skills2 = dw_skills.clone();
+                    let events2 = dw_events.clone();
+                    let interceptors2 = dw_interceptors.clone();
+                    let workspace_mgr2 = dw_workspace_mgr.clone();
+                    let task_queue2 = dw_task_queue.clone();
+                    let completion_callback2 = dw_completion_callback.clone();
+                    let project_registry2 = dw_project_registry.clone();
+                    let allowed_roots2 = dw_allowed_roots.clone();
+                    let review_config2 = dw_review_config.clone();
+                    tokio::spawn(async move {
+                        dispatch_awaiting_task(
+                            task_id,
+                            req,
+                            store2,
+                            agent_registry2,
+                            server_config2,
+                            skills2,
+                            events2,
+                            interceptors2,
+                            workspace_mgr2,
+                            task_queue2,
+                            completion_callback2,
+                            Some(project_registry2),
+                            allowed_roots2,
+                            review_config2,
+                        )
+                        .await;
+                    });
                 }
             }
         });
@@ -379,6 +461,155 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         task_svc: services.task_svc,
         execution_svc: services.execution_svc,
     })
+}
+
+/// Dispatch a task that was waiting for dependencies and is now ready.
+///
+/// Handles project resolution, agent selection, allowed-roots enforcement,
+/// concurrency-permit acquisition, and spawning `spawn_preregistered_task`.
+/// On any error, the task is failed and its stream is closed.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_awaiting_task(
+    task_id: crate::task_runner::TaskId,
+    mut req: crate::task_runner::CreateTaskRequest,
+    store: std::sync::Arc<crate::task_runner::TaskStore>,
+    agent_registry: std::sync::Arc<harness_agents::registry::AgentRegistry>,
+    server_config: std::sync::Arc<harness_core::config::HarnessConfig>,
+    skills: std::sync::Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
+    events: std::sync::Arc<harness_observe::event_store::EventStore>,
+    interceptors: Vec<std::sync::Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    workspace_mgr: Option<std::sync::Arc<crate::workspace::WorkspaceManager>>,
+    task_queue: std::sync::Arc<crate::task_queue::TaskQueue>,
+    completion_callback: Option<crate::task_runner::CompletionCallback>,
+    project_registry: Option<std::sync::Arc<crate::project_registry::ProjectRegistry>>,
+    allowed_roots: Vec<std::path::PathBuf>,
+    review_config: harness_core::config::agents::AgentReviewConfig,
+) {
+    // Resolve project path through registry if needed.
+    if let (Some(registry), Some(ref project_path)) = (&project_registry, &req.project) {
+        if !project_path.is_dir() {
+            let id = project_path.to_string_lossy();
+            match registry.resolve_path(&id).await {
+                Ok(Some(resolved)) => req.project = Some(resolved),
+                Ok(None) => {
+                    fail_task(
+                        &store,
+                        &task_id,
+                        &format!("dep-watcher: project '{id}' not found in registry"),
+                        &completion_callback,
+                    )
+                    .await;
+                    return;
+                }
+                Err(e) => {
+                    fail_task(
+                        &store,
+                        &task_id,
+                        &format!("dep-watcher: registry lookup failed: {e}"),
+                        &completion_callback,
+                    )
+                    .await;
+                    return;
+                }
+            }
+        }
+    }
+
+    let canonical = match crate::task_runner::resolve_canonical_project(req.project.clone()).await {
+        Ok(c) => c,
+        Err(e) => {
+            fail_task(
+                &store,
+                &task_id,
+                &format!("dep-watcher: failed to resolve project path: {e}"),
+                &completion_callback,
+            )
+            .await;
+            return;
+        }
+    };
+
+    if let Err(e) = crate::project_registry::check_allowed_roots(&canonical, &allowed_roots) {
+        fail_task(
+            &store,
+            &task_id,
+            &format!("dep-watcher: project not in allowed_project_roots: {e}"),
+            &completion_callback,
+        )
+        .await;
+        return;
+    }
+
+    let project_id = canonical.to_string_lossy().into_owned();
+    req.project = Some(canonical);
+
+    let agent = match crate::http::task_routes::select_agent(&req, &agent_registry, None) {
+        Ok(a) => a,
+        Err(e) => {
+            fail_task(
+                &store,
+                &task_id,
+                &format!("dep-watcher: failed to select agent: {e}"),
+                &completion_callback,
+            )
+            .await;
+            return;
+        }
+    };
+    let (reviewer, _) =
+        crate::http::resolve_reviewer(&agent_registry, &review_config, agent.name());
+
+    let permit = match task_queue.acquire(&project_id, req.priority).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                task_id = %task_id.0,
+                "dep-watcher: failed to acquire concurrency permit: {e} — task stays Pending for retry"
+            );
+            return;
+        }
+    };
+
+    crate::task_runner::spawn_preregistered_task(
+        task_id,
+        store,
+        agent,
+        reviewer,
+        server_config,
+        skills,
+        events,
+        interceptors,
+        req,
+        workspace_mgr,
+        permit,
+        completion_callback,
+        None,
+    )
+    .await;
+}
+
+/// Mark a task as Failed, persist, close its stream, and fire the completion callback.
+async fn fail_task(
+    store: &std::sync::Arc<crate::task_runner::TaskStore>,
+    task_id: &crate::task_runner::TaskId,
+    reason: &str,
+    completion_callback: &Option<crate::task_runner::CompletionCallback>,
+) {
+    tracing::error!(task_id = %task_id.0, "{reason}");
+    let persist_ok = crate::task_runner::mutate_and_persist(store, task_id, |s| {
+        s.status = crate::task_runner::TaskStatus::Failed;
+        s.error = Some(reason.to_string());
+    })
+    .await
+    .is_ok();
+    store.close_task_stream(task_id);
+    if persist_ok {
+        if let Some(cb) = completion_callback {
+            if let Some(final_state) = store.get(task_id) {
+                cb(final_state).await;
+            }
+        }
+    }
 }
 
 pub(crate) fn build_completion_callback(
@@ -916,6 +1147,59 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         permit,
                         state.intake.completion_callback.clone(),
                         None,
+                    )
+                    .await;
+                });
+            }
+        }
+    }
+
+    // Re-dispatch dep-watcher tasks that were in mid-dispatch (Pending with pending_request set).
+    {
+        let recovered_dep: Vec<_> = state
+            .core
+            .tasks
+            .list_all()
+            .into_iter()
+            .filter(|t| {
+                matches!(t.status, task_runner::TaskStatus::Pending)
+                    && t.pending_request.is_some()
+                    && t.pr_url.is_none()
+            })
+            .collect();
+        if !recovered_dep.is_empty() {
+            tracing::info!(
+                count = recovered_dep.len(),
+                "startup: re-dispatching dep-watcher pending task(s) with stored requests"
+            );
+            for task in recovered_dep {
+                let req = match task.pending_request {
+                    Some(r) => r,
+                    None => continue,
+                };
+                let state2 = state.clone();
+                tokio::spawn(async move {
+                    dispatch_awaiting_task(
+                        task.id,
+                        req,
+                        state2.core.tasks.clone(),
+                        state2.core.server.agent_registry.clone(),
+                        Arc::new(state2.core.server.config.clone()),
+                        state2.engines.skills.clone(),
+                        state2.observability.events.clone(),
+                        state2.interceptors.clone(),
+                        state2.concurrency.workspace_mgr.clone(),
+                        state2.concurrency.task_queue.clone(),
+                        state2.intake.completion_callback.clone(),
+                        state2.core.project_registry.clone(),
+                        state2
+                            .core
+                            .server
+                            .config
+                            .server
+                            .allowed_project_roots
+                            .clone(),
+                        state2.core.server.config.agents.review.clone(),
                     )
                     .await;
                 });

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -137,6 +137,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pending_request: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -178,6 +179,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pending_request: None,
         };
         store.insert(&parent_state).await;
 
@@ -203,6 +205,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pending_request: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -16,7 +16,7 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings";
+const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings, pending_request_json";
 
 /// Versioned migrations for the tasks table.
 ///
@@ -131,6 +131,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         description: "add request_settings column for execution limit recovery",
         sql: "ALTER TABLE tasks ADD COLUMN request_settings TEXT",
     },
+    Migration {
+        version: 17,
+        description: "add pending_request_json column for dep-watcher crash-safe dispatch",
+        sql: "ALTER TABLE tasks ADD COLUMN pending_request_json TEXT",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -209,9 +214,13 @@ impl TaskDb {
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
+        let pending_request_json = state
+            .pending_request
+            .as_ref()
+            .and_then(|r| serde_json::to_string(r).ok());
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings, pending_request_json)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&state.id.0)
         .bind(status)
@@ -230,6 +239,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
+        .bind(pending_request_json.as_deref())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -244,11 +254,15 @@ impl TaskDb {
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
+        let pending_request_json = state
+            .pending_request
+            .as_ref()
+            .and_then(|r| serde_json::to_string(r).ok());
         sqlx::query(
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
                     source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
                     priority = ?, phase = ?, description = ?, request_settings = ?,
-                    updated_at = datetime('now')
+                    pending_request_json = ?, updated_at = datetime('now')
              WHERE id = ?",
         )
         .bind(status)
@@ -270,6 +284,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
+        .bind(pending_request_json.as_deref())
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -981,6 +996,7 @@ impl TaskDb {
                 phase: row.phase,
                 description: row.description,
                 request_settings: row.request_settings,
+                pending_request_json: None,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,
@@ -1022,6 +1038,7 @@ struct TaskRow {
     phase: String,
     description: Option<String>,
     request_settings: Option<String>,
+    pending_request_json: Option<String>,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -1076,10 +1093,16 @@ impl TaskRow {
             phase,
             description,
             request_settings,
+            pending_request_json,
         } = self;
 
         let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
             request_settings
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok());
+
+        let decoded_pending_request: Option<crate::task_runner::CreateTaskRequest> =
+            pending_request_json
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok());
 
@@ -1125,6 +1148,7 @@ impl TaskRow {
             plan_output: None,
             repo,
             request_settings: decoded_request_settings,
+            pending_request: decoded_pending_request,
         })
     }
 }
@@ -1209,6 +1233,7 @@ mod tests {
             phase: r#""implement""#.to_string(),
             description: None,
             request_settings: None,
+            pending_request_json: None,
         }
     }
 
@@ -1318,6 +1343,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pending_request: None,
         }
     }
 
@@ -2039,13 +2065,14 @@ mod tests {
             phase: String::new(),
             description: None,
             request_settings: None,
+            pending_request_json: None,
         };
 
         // Count must match — catches column added to constant but not struct (or vice versa).
         assert_eq!(
             columns.len(),
-            17, // bump this when adding a field
-            "TASK_ROW_COLUMNS has {} entries but expected 17 — update both the constant and this test",
+            18, // bump this when adding a field
+            "TASK_ROW_COLUMNS has {} entries but expected 18 — update both the constant and this test",
             columns.len()
         );
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -202,6 +202,14 @@ pub struct TaskState {
     /// requested rather than silently falling back to server defaults.
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
+    /// Original request stored for AwaitingDeps tasks so the dep-watcher can
+    /// dispatch the task once all dependencies complete.  Cleared from cache
+    /// after the first dispatch attempt.
+    ///
+    /// Not persisted via serde — `task_db` serializes it as `pending_request_json`
+    /// so it survives a server restart (crash-safe dispatch).
+    #[serde(skip)]
+    pub pending_request: Option<CreateTaskRequest>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -266,6 +274,7 @@ impl TaskState {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pending_request: None,
         }
     }
 
@@ -298,7 +307,7 @@ impl TaskState {
 /// `0` = normal (default), `1` = high, `2` = critical.
 pub const MAX_TASK_PRIORITY: u8 = 2;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTaskRequest {
     /// Free-text task description (prompt, issue URL, etc.).
     pub prompt: Option<String>,
@@ -2227,6 +2236,9 @@ pub async fn spawn_task_awaiting_deps(
 
     if !all_done && !state.depends_on.is_empty() {
         state.status = TaskStatus::AwaitingDeps;
+        // Store the full request so the dep-watcher can dispatch this task
+        // once all dependencies complete (crash-safe via pending_request_json in DB).
+        state.pending_request = Some(req.clone());
     }
 
     store.insert(&state).await;
@@ -3321,6 +3333,75 @@ mod tests {
         let key = root.to_string_lossy().into_owned();
         assert_eq!(counts.by_project[&key].done, 1);
         assert_eq!(counts.by_project[&key].failed, 1);
+        Ok(())
+    }
+
+    // --- dependency scheduling ---
+
+    #[tokio::test]
+    async fn spawn_task_awaiting_deps_stores_pending_request() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut upstream = TaskState::new(TaskId::new());
+        upstream.status = TaskStatus::Implementing;
+        store.insert(&upstream).await;
+
+        let req = CreateTaskRequest {
+            prompt: Some("downstream".into()),
+            depends_on: vec![upstream.id.clone()],
+            ..Default::default()
+        };
+        let task_id = spawn_task_awaiting_deps(store.clone(), req.clone()).await?;
+        let state = store.get(&task_id).expect("task must exist");
+
+        assert!(
+            matches!(state.status, TaskStatus::AwaitingDeps),
+            "expected AwaitingDeps, got {:?}",
+            state.status
+        );
+        let stored = state.pending_request.expect("pending_request must be Some");
+        assert_eq!(stored.prompt, req.prompt);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_deps_preserves_pending_request() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut t1 = TaskState::new(TaskId::new());
+        t1.status = TaskStatus::Implementing;
+        store.insert(&t1).await;
+
+        let t2_id = spawn_task_awaiting_deps(
+            store.clone(),
+            CreateTaskRequest {
+                prompt: Some("downstream".into()),
+                depends_on: vec![t1.id.clone()],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Mark t1 Done.
+        if let Some(mut e) = store.cache.get_mut(&t1.id) {
+            e.status = TaskStatus::Done;
+        }
+
+        let (ready, _failed) = check_awaiting_deps(&store).await;
+        assert_eq!(ready, vec![t2_id.clone()]);
+
+        let state = store.get(&t2_id).expect("T2 must exist");
+        assert!(
+            matches!(state.status, TaskStatus::Pending),
+            "expected Pending, got {:?}",
+            state.status
+        );
+        assert!(
+            state.pending_request.is_some(),
+            "pending_request must survive check_awaiting_deps"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -33,6 +33,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         plan_output: None,
         repo: None,
         request_settings: None,
+        pending_request: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Option A from issue #634: the dep-watcher now actually dispatches tasks when their dependencies complete, not just transitions their status.

- **`CreateTaskRequest`** derives `Serialize` so it can be stored as JSON
- **`TaskState.pending_request`** stores the original request when a task enters `AwaitingDeps`; cleared after first dispatch to prevent double-dispatch
- **DB migration v17** adds `pending_request_json TEXT` column — persisted in `insert`/`update`, deserialized in `try_into_task_state` for crash-safe recovery
- **Dep-watcher** (in `http.rs`) upgraded: failed deps are persisted + stream closed; ready tasks atomically take `pending_request`, persist `Pending`, then spawn `dispatch_awaiting_task`
- **`dispatch_awaiting_task`** helper: project resolution → allowed-roots check → agent selection → concurrency permit → `spawn_preregistered_task`
- **`fail_task`** helper: marks Failed, persists, closes stream, fires completion callback
- **Startup recovery**: Pending tasks with `pending_request.is_some() && pr_url.is_none()` are re-dispatched on server start (handles crash between persist and dispatch)

## Test plan

- [x] `spawn_task_awaiting_deps_stores_pending_request` — verifies `pending_request` is set when task enters AwaitingDeps
- [x] `check_awaiting_deps_preserves_pending_request` — transitions T1→Done, verifies T2 reaches Pending with `pending_request` intact
- [x] All 709 existing harness-server tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all` applied

Closes #634