### PR TITLE
fix(server): only set last_backfilled_issue guard on successful DB write

### DIFF
--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -599,17 +599,19 @@ async fn run_agent_streaming(
                                                 .overwrite_external_id_auto_fix(task_id, &eid)
                                                 .await
                                             {
-                                                Ok(()) => tracing::info!(
-                                                    task_id = %task_id,
-                                                    external_id = %eid,
-                                                    "streaming: backfilled external_id for auto-fix task"
-                                                ),
+                                                Ok(()) => {
+                                                    tracing::info!(
+                                                        task_id = %task_id,
+                                                        external_id = %eid,
+                                                        "streaming: backfilled external_id for auto-fix task"
+                                                    );
+                                                    last_backfilled_issue = Some(issue_num);
+                                                }
                                                 Err(e) => tracing::warn!(
                                                     task_id = %task_id,
                                                     "streaming: failed to backfill external_id: {e}"
                                                 ),
                                             }
-                                            last_backfilled_issue = Some(issue_num);
                                         }
                                     }
                                 }
@@ -640,17 +642,19 @@ async fn run_agent_streaming(
                                                 .overwrite_external_id_auto_fix(task_id, &eid)
                                                 .await
                                             {
-                                                Ok(()) => tracing::info!(
-                                                    task_id = %task_id,
-                                                    external_id = %eid,
-                                                    "streaming: backfilled external_id for auto-fix task"
-                                                ),
+                                                Ok(()) => {
+                                                    tracing::info!(
+                                                        task_id = %task_id,
+                                                        external_id = %eid,
+                                                        "streaming: backfilled external_id for auto-fix task"
+                                                    );
+                                                    last_backfilled_issue = Some(issue_num);
+                                                }
                                                 Err(e) => tracing::warn!(
                                                     task_id = %task_id,
                                                     "streaming: failed to backfill external_id: {e}"
                                                 ),
                                             }
-                                            last_backfilled_issue = Some(issue_num);
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

- Move `last_backfilled_issue = Some(issue_num)` inside the `Ok(())` arm for both backfill sites in `run_agent_streaming()` (MessageDelta path and AgentReasoning ItemCompleted path)
- Previously the guard was updated unconditionally even on DB write failure, suppressing all retry attempts for the remainder of the stream
- This left `external_id` unset in the DB, reopening the dedup-layer webhook race that PR #769 was meant to close

## Root Cause

When `overwrite_external_id_auto_fix` returns `Err` (transient SQLite lock, disk error, etc.), `last_backfilled_issue` was being set to `Some(issue_num)` regardless. Subsequent streaming deltas with the same issue number then skipped the write because the guard matched.

## Fix

Condition the guard update on write success — failed writes leave the guard unchanged so the next delta retries the DB write.

Fixes #782.

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] On transient DB write failure, the same `CREATED_ISSUE=N` sentinel in the next delta will retry the `overwrite_external_id_auto_fix` call