### PR TITLE
refactor(task_executor): split 2762-line monolith into 4 pipeline submodules

### DIFF
--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -186,6 +186,11 @@ pub struct AgentReviewConfig {
     /// GitHub login of the review bot (used for freshness checks in review loop).
     #[serde(default = "default_reviewer_name")]
     pub reviewer_name: String,
+    /// When true, the agent review loop runs `cargo check --workspace` and
+    /// `cargo test --package <pkg>` between rounds and includes the output
+    /// in the reviewer prompt. Default false for safe incremental rollout.
+    #[serde(default)]
+    pub enable_compilation_gate: bool,
 }
 
 impl Default for AgentReviewConfig {
@@ -197,6 +202,7 @@ impl Default for AgentReviewConfig {
             review_bot_command: default_review_bot_command(),
             review_bot_auto_trigger: default_review_bot_auto_trigger(),
             reviewer_name: default_reviewer_name(),
+            enable_compilation_gate: false,
         }
     }
 }

--- a/crates/harness-core/src/prompts.rs
+++ b/crates/harness-core/src/prompts.rs
@@ -2151,6 +2151,68 @@ pub fn evaluator_prompt(contract_yaml: &str, impl_output: &str, round: u32) -> P
     }
 }
 
+// ─── Pipeline prompt templates (Part 2 of issue #772) ───────────────────────
+// These functions extract inline prompt strings from the pipeline modules into
+// testable, named templates. Callers in pipeline modules replace inline
+// `format!()` literals with calls to these functions.
+
+/// Prompt used in `run_plan_for_prompt` to ask the agent for an implementation
+/// plan before writing code (prompt-only tasks that hit the complexity gate).
+pub fn plan_for_task_prompt(task_description: &str) -> String {
+    format!(
+        "Before implementing, produce a concise implementation plan for the following task.\n\
+         List the files to change, the approach, and any non-obvious design decisions.\n\
+         Do NOT write code yet — planning only.\n\n\
+         Task:\n{task_description}"
+    )
+}
+
+/// Formats the validation-retry context injected into the implementation prompt
+/// when a post-execution interceptor returns an error.
+///
+/// `base_prompt` is the original (first) implementation prompt.
+/// `error` is the truncated validation error string.
+/// `attempt` and `max_attempts` are the current retry counter values.
+pub fn validation_retry_error_context(
+    base_prompt: &str,
+    error: &str,
+    attempt: u32,
+    max_attempts: u32,
+) -> String {
+    format!(
+        "{base_prompt}\n\nPost-execution validation failed (attempt {attempt}/{max_attempts}).\n\
+         Errors are prefixed with [COMPILE ERROR], [TEST FAILURE], [LINT ERROR], or \
+         [VALIDATION ERROR] for classified failures, or with an interceptor name \
+         (e.g. [hook_name]) for hook/policy violations — focus your fix on the indicated \
+         error type:\n{error}"
+    )
+}
+
+/// Prepends test-gate failure context to the base review prompt when the
+/// previous LGTM was rejected because the project's tests failed.
+///
+/// `gate_output` is the captured stdout/stderr from the failing test command.
+/// `base_prompt` is the normal review prompt for this round.
+pub fn test_gate_failure_context(gate_output: &str, base_prompt: &str) -> String {
+    format!(
+        "IMPORTANT: The previous LGTM was rejected because the project's tests failed. \
+         Fix the test failures before declaring LGTM again.\n\n\
+         Test output:\n```\n{gate_output}\n```\n\n{base_prompt}"
+    )
+}
+
+/// Capability restriction note injected into the reviewer prompt so the agent
+/// knows which tools are permitted in review mode.
+///
+/// This is the primary enforcement mechanism now that `--allowedTools` is no
+/// longer passed to the CLI (issue #483).
+pub fn reviewer_capability_note() -> &'static str {
+    "Tool restriction: you are operating in review mode. \
+     Only Read, Grep, Glob, and Bash are permitted. \
+     Use Bash ONLY for read-only commands like `gh pr diff`. \
+     Do NOT call Write, Edit, or any other tool."
+}
+
 #[cfg(test)]
 mod contract_prompt_tests {
     use super::*;

--- a/crates/harness-server/src/task_executor.rs
+++ b/crates/harness-server/src/task_executor.rs
@@ -1,22 +1,22 @@
+pub(crate) mod agent_review;
 pub(crate) mod helpers;
+pub(crate) mod implement_pipeline;
 pub(crate) mod pr_detection;
+pub(crate) mod review_loop;
+pub(crate) mod triage_pipeline;
 
-use crate::task_runner::{
-    mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskStatus, TaskStore,
-};
+use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskStatus, TaskStore};
 use anyhow::Context;
 use harness_core::agent::{
     AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
 };
-use harness_core::config::agents::CapabilityProfile;
+use harness_core::config::agents::{AgentReviewConfig, CapabilityProfile};
 use harness_core::error::HarnessError;
-use harness_core::interceptor::ToolUseEvent;
-use harness_core::tool_isolation::validate_tool_usage;
-use harness_core::types::{
-    ContextItem, Decision, Event, ExecutionPhase, Item, SessionId, ThreadId, TokenUsage, TurnId,
-    TurnStatus,
+use harness_core::types::{Item, ThreadId, TokenUsage, TurnId, TurnStatus};
+use harness_core::{
+    config::project::{load_project_config, ProjectConfig},
+    lang_detect, prompts,
 };
-use harness_core::{config::project::load_project_config, lang_detect, prompts};
 use harness_protocol::{notifications::Notification, notifications::RpcNotification};
 use std::collections::{HashMap, HashSet};
 
@@ -32,17 +32,17 @@ fn restricted_tools(profile: CapabilityProfile) -> anyhow::Result<Vec<String>> {
         )
     })
 }
+#[cfg(test)]
+use helpers::truncate_validation_error;
 use helpers::{
-    collect_context_items, detect_modified_files, emit_runtime_notification,
-    inject_skills_into_prompt, mark_turn_failed, matched_skills_for_prompt, persist_runtime_thread,
-    process_stream_item, run_on_error, run_post_execute, run_post_tool_use, run_pre_execute,
-    truncate_validation_error, update_status,
+    emit_runtime_notification, mark_turn_failed, persist_runtime_thread, process_stream_item,
+    update_status,
 };
+use pr_detection::detect_repo_slug;
 #[cfg(test)]
 use pr_detection::{
     build_fix_ci_prompt, parse_harness_mention_command, HarnessMentionCommand, PromptBuilder,
 };
-use pr_detection::{detect_repo_slug, find_existing_pr_for_issue};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
@@ -65,7 +65,7 @@ impl Drop for TaskTargetDir {
     }
 }
 use tokio::process::Command as TokioCommand;
-use tokio::time::{sleep, timeout, Duration, Instant};
+use tokio::time::{timeout, Duration, Instant};
 
 /// Run the project's test commands as a hard gate before accepting LGTM.
 ///
@@ -707,189 +707,31 @@ fn prepend_constitution(prompt: String, enabled: bool) -> String {
     }
 }
 
-/// Run a plan step for a complex prompt-only task when the planning gate has
-/// forced `TaskPhase::Plan`.
+/// Shared task execution context passed to all pipeline phase modules.
 ///
-/// This gives the planning gate real effect: instead of silently skipping
-/// to Implement, the agent produces a plan first, which is then threaded into
-/// the implementation prompt just like issue-based plans.
-async fn run_plan_for_prompt(
-    agent: &dyn CodeAgent,
-    store: &TaskStore,
-    task_id: &TaskId,
-    cargo_env: &HashMap<String, String>,
-    project: &Path,
-    req: &CreateTaskRequest,
-) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
-    use crate::task_runner::TaskPhase;
-
-    let prompt_text = req.prompt.as_deref().unwrap_or_default();
-    tracing::info!(task_id = %task_id, "pipeline: starting plan phase for prompt-only task");
-
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Plan;
-    })
-    .await?;
-
-    let plan_prompt = format!(
-        "Before implementing, produce a concise implementation plan for the following task.\n\
-         List the files to change, the approach, and any non-obvious design decisions.\n\
-         Do NOT write code yet — planning only.\n\n\
-         Task:\n{prompt_text}"
-    );
-
-    let plan_req = AgentRequest {
-        prompt: plan_prompt,
-        project_root: project.to_path_buf(),
-        env_vars: cargo_env.clone(),
-        execution_phase: Some(ExecutionPhase::Planning),
-        ..Default::default()
-    };
-
-    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
-    // Use agent.execute() directly — NOT run_agent_streaming — to avoid the
-    // state side-effects that run_agent_streaming performs: PR_URL extraction,
-    // turn counter mutations, and status updates.  Those side-effects would
-    // corrupt the subsequent implement phase (e.g. consuming call #0 from a
-    // mock/real agent that sets pr_url before the real implementation turn).
-    let plan_resp = tokio::time::timeout(turn_timeout, agent.execute(plan_req))
-        .await
-        .map_err(|_| anyhow::anyhow!("plan phase timed out after {}s", req.turn_timeout_secs))?
-        .map_err(|e| anyhow::anyhow!("plan phase agent error: {e}"))?;
-
-    let plan_text = plan_resp.output.clone();
-    mutate_and_persist(store, task_id, |state| {
-        state.plan_output = Some(plan_text.clone());
-        state.phase = TaskPhase::Implement;
-    })
-    .await?;
-
-    tracing::info!(task_id = %task_id, plan_len = plan_text.len(), "plan phase complete (prompt-only)");
-    Ok((Some(plan_text), prompts::TriageComplexity::Medium, 1))
-}
-
-/// Run triage → plan pipeline for a fresh issue-based task.
-///
-/// Returns `Some(plan_text)` if the triage decided a plan is needed and the plan
-/// phase completed. Returns `None` only when triage says PROCEED (trivial issue,
-/// skip planning). All failures propagate as errors — no silent fallbacks.
-async fn run_triage_plan_pipeline(
-    agent: &dyn CodeAgent,
-    store: &TaskStore,
-    task_id: &TaskId,
-    issue: u64,
-    cargo_env: &HashMap<String, String>,
-    project: &Path,
-    req: &CreateTaskRequest,
-) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
-    use crate::task_runner::TaskPhase;
-
-    // --- Phase 1: Triage ---
-    tracing::info!(task_id = %task_id, issue, "pipeline: starting triage phase");
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Triage;
-    })
-    .await?;
-
-    let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
-    let triage_req = AgentRequest {
-        prompt: triage_prompt,
-        project_root: project.to_path_buf(),
-        env_vars: cargo_env.clone(),
-        execution_phase: Some(ExecutionPhase::Planning),
-        ..Default::default()
-    };
-
-    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
-    let (triage_resp, _) = tokio::time::timeout(
-        turn_timeout,
-        run_agent_streaming(agent, triage_req, task_id, store, 0),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("triage phase timed out after {}s", req.turn_timeout_secs))?
-    .map_err(|e| anyhow::anyhow!("triage phase agent error: {e}"))?;
-
-    let triage_text = triage_resp.output.clone();
-    mutate_and_persist(store, task_id, |state| {
-        state.triage_output = Some(triage_text.clone());
-    })
-    .await?;
-    if let Err(e) = store
-        .write_checkpoint(task_id, Some(&triage_text), None, None, "triage_done")
-        .await
-    {
-        tracing::warn!(task_id = %task_id, "failed to write triage checkpoint: {e}");
-    }
-
-    let decision = prompts::parse_triage(&triage_resp.output).ok_or_else(|| {
-        anyhow::anyhow!("triage output unparseable — agent did not produce TRIAGE=<decision>")
-    })?;
-    let complexity = prompts::parse_complexity(&triage_resp.output);
-    tracing::info!(task_id = %task_id, ?decision, ?complexity, "triage decision");
-
-    match decision {
-        prompts::TriageDecision::Skip => {
-            mutate_and_persist(store, task_id, |state| {
-                state.status = crate::task_runner::TaskStatus::Done;
-                state.phase = TaskPhase::Terminal;
-                state.error = Some("Triage: skipped — not worth implementing".to_string());
-            })
-            .await?;
-            anyhow::bail!("triage decided to skip issue #{issue}");
-        }
-        prompts::TriageDecision::NeedsClarification => {
-            // Treat as ProceedWithPlan — let the planner figure out ambiguities
-            // instead of failing the task outright.
-            tracing::info!(task_id = %task_id, "triage: NEEDS_CLARIFICATION → treating as PROCEED_WITH_PLAN");
-        }
-        prompts::TriageDecision::Proceed => {
-            tracing::info!(task_id = %task_id, "triage: PROCEED — skipping plan phase");
-            return Ok((None, complexity, 1));
-        }
-        prompts::TriageDecision::ProceedWithPlan => {
-            // Fall through to plan phase.
-        }
-    }
-
-    // --- Phase 2: Plan ---
-    tracing::info!(task_id = %task_id, issue, "pipeline: starting plan phase");
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Plan;
-    })
-    .await?;
-
-    let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
-    let plan_req = AgentRequest {
-        prompt: plan_prompt,
-        project_root: project.to_path_buf(),
-        env_vars: cargo_env.clone(),
-        execution_phase: Some(ExecutionPhase::Planning),
-        ..Default::default()
-    };
-
-    let (plan_resp, _) = tokio::time::timeout(
-        turn_timeout,
-        run_agent_streaming(agent, plan_req, task_id, store, 0),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("plan phase timed out after {}s", req.turn_timeout_secs))?
-    .map_err(|e| anyhow::anyhow!("plan phase agent error: {e}"))?;
-
-    let plan_text = plan_resp.output.clone();
-    mutate_and_persist(store, task_id, |state| {
-        state.plan_output = Some(plan_text.clone());
-        state.phase = TaskPhase::Implement;
-    })
-    .await?;
-    if let Err(e) = store
-        .write_checkpoint(task_id, None, Some(&plan_text), None, "plan_done")
-        .await
-    {
-        tracing::warn!(task_id = %task_id, "failed to write plan checkpoint: {e}");
-    }
-
-    tracing::info!(task_id = %task_id, plan_len = plan_text.len(), "plan phase complete");
-    Ok((Some(plan_text), complexity, 2))
+/// Built once in `run_task` and passed by reference to each phase, eliminating
+/// the need to thread individual parameters through every pipeline call.
+pub(crate) struct TaskContext<'a> {
+    pub store: &'a TaskStore,
+    pub task_id: &'a TaskId,
+    pub agent: &'a dyn CodeAgent,
+    pub reviewer: Option<&'a dyn CodeAgent>,
+    pub skills: std::sync::Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
+    pub events: std::sync::Arc<harness_observe::event_store::EventStore>,
+    pub interceptors:
+        std::sync::Arc<Vec<std::sync::Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
+    pub req: &'a CreateTaskRequest,
+    pub project: std::path::PathBuf,
+    pub server_config: &'a harness_core::config::HarnessConfig,
+    pub cargo_env: std::collections::HashMap<String, String>,
+    pub project_config: ProjectConfig,
+    pub review_config: AgentReviewConfig,
+    pub repo_slug: String,
+    pub turn_timeout: tokio::time::Duration,
+    pub jaccard_threshold: f64,
+    pub task_start: tokio::time::Instant,
+    pub resolved_review_wait_secs: Option<u64>,
+    pub resolved_review_max_rounds: Option<u32>,
 }
 
 pub(crate) async fn run_task(
@@ -916,8 +758,6 @@ pub(crate) async fn run_task(
 
     // Set CARGO_TARGET_DIR to a per-task temp path so parallel agents running
     // cargo check/test simultaneously do not contend on the same build directory.
-    // A per-project path caused `.cargo-lock` contention and build failures when
-    // two tasks targeted the same project concurrently (issue #488).
     let task_target = std::env::temp_dir()
         .join("harness-cargo-targets")
         .join(task_id.as_str());
@@ -938,8 +778,6 @@ pub(crate) async fn run_task(
         )
     })?;
     let resolved = harness_core::config::resolve::resolve_config(server_config, &project_config);
-    let review_config = &resolved.review;
-    let git = Some(&project_config.git);
     let repo_slug = detect_repo_slug(&project)
         .await
         .unwrap_or_else(|| "{owner}/{repo}".to_string());
@@ -947,7 +785,7 @@ pub(crate) async fn run_task(
     // --- Checkpoint-based resume detection ---
     // Load checkpoint and task state to determine if we can skip phases.
     // This is the duplicate-PR prevention gate: if the task already has a PR,
-    // we skip triage/plan/implement and jump directly to agent review.
+    // we skip triage/plan/implement and jump directly to review.
     //
     // Check task store for an existing pr_url first — this survives checkpoint
     // read failures (e.g. transient SQLite contention) and lets us safely
@@ -957,8 +795,6 @@ pub(crate) async fn run_task(
         Ok(cp) => cp,
         Err(e) => {
             if task_pr_url.is_some() {
-                // Task state already records a pr_url — safe to resume review
-                // without the checkpoint; log the failure for observability.
                 tracing::warn!(
                     task_id = %task_id,
                     error = %e,
@@ -966,7 +802,6 @@ pub(crate) async fn run_task(
                 );
                 None
             } else {
-                // No pr_url in task state — fail closed to prevent duplicate PR.
                 return Err(e).with_context(|| {
                     format!(
                         "failed to load checkpoint for task {}; aborting to prevent duplicate PR",
@@ -980,67 +815,55 @@ pub(crate) async fn run_task(
         task_pr_url.or_else(|| checkpoint.as_ref().and_then(|c| c.pr_url.clone()));
     let resumed_plan: Option<String> = checkpoint.and_then(|c| c.plan_output);
 
-    // --- Pipeline: Triage → Plan → Implement ---
-    // For issue-based tasks without an existing PR, run triage first.
-    // Triage decides whether to skip planning or go through a plan phase.
-    // Checkpoint overrides: if a plan was saved, skip the pipeline entirely.
-    let (plan_output, triage_complexity, pipeline_turns) = if resumed_pr_url.is_some() {
-        // PR already exists — skip triage/plan entirely.
-        (None, prompts::TriageComplexity::Medium, 0u32)
-    } else if let Some(plan) = resumed_plan {
-        // Plan checkpoint found — use saved plan, skip triage/plan pipeline.
-        tracing::info!(task_id = %task_id, "checkpoint resume: using saved plan, skipping triage/plan");
-        (Some(plan), prompts::TriageComplexity::Medium, 0u32)
-    } else if let Some(issue) = req.issue {
-        // Only triage fresh issues (no existing PR to continue).
-        let has_existing_pr = find_existing_pr_for_issue(&project, issue)
-            .await
-            .ok()
-            .flatten()
-            .is_some();
-        if !has_existing_pr {
-            run_triage_plan_pipeline(agent, store, task_id, issue, &cargo_env, &project, req)
-                .await?
-        } else {
-            (None, prompts::TriageComplexity::Medium, 0u32)
-        }
-    } else {
-        // Planning gate (task_runner) may have forced TaskPhase::Plan for a
-        // complex prompt-only task.  Check the stored phase so the gate has
-        // real effect rather than silently falling through to Implement.
-        let forced_plan = store
-            .get(task_id)
-            .map(|s| s.phase == crate::task_runner::TaskPhase::Plan)
-            .unwrap_or(false);
-        if forced_plan && req.issue.is_none() && req.pr.is_none() {
-            // Set to Implementing BEFORE the plan phase so that a crash during planning
-            // leaves the task in 'implementing' status. The startup recovery code will catch
-            // it and fail-close it (no pr_url → mark failed), rather than leaving it stuck
-            // as a plain 'pending' that is never re-dispatched.
-            update_status(store, task_id, TaskStatus::Implementing, 1).await?;
-            run_plan_for_prompt(agent, store, task_id, &cargo_env, &project, req).await?
-        } else {
-            (None, prompts::TriageComplexity::Medium, 0u32)
-        }
+    // --- Build shared TaskContext ---
+    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
+    let jaccard_threshold = server_config.concurrency.loop_jaccard_threshold;
+    let ctx = TaskContext {
+        store,
+        task_id,
+        agent,
+        reviewer,
+        skills,
+        events,
+        interceptors,
+        req,
+        project: project.clone(),
+        server_config,
+        cargo_env,
+        project_config: project_config.clone(),
+        review_config: resolved.review.clone(),
+        repo_slug,
+        turn_timeout,
+        jaccard_threshold,
+        task_start,
+        resolved_review_wait_secs: resolved.review_wait_secs,
+        resolved_review_max_rounds: resolved.review_max_rounds,
+    };
+
+    // --- Triage → Plan pipeline ---
+    let triage_outcome =
+        triage_pipeline::run(&ctx, resumed_pr_url.as_deref(), resumed_plan).await?;
+    let (plan_output, triage_complexity, pipeline_turns) = match triage_outcome {
+        triage_pipeline::TriageOutcome::Skip => return Ok(()),
+        triage_pipeline::TriageOutcome::Proceed {
+            plan,
+            complexity,
+            pipeline_turns,
+        } => (plan, complexity, pipeline_turns),
     };
 
     // Derive dynamic parameters from triage complexity.
-    // Triage provides a DEFAULT only — caller's explicit max_rounds always wins (Fix #2).
-    // Low complexity no longer skips agent review to preserve the review gate (Fix #1).
+    // Triage provides a DEFAULT only — caller's explicit max_rounds always wins.
+    // Low complexity no longer skips agent review to preserve the review gate.
     let (triage_default_rounds, skip_agent_review) = match triage_complexity {
         prompts::TriageComplexity::Low => (2u32, false),
         prompts::TriageComplexity::Medium => (8u32, false),
         prompts::TriageComplexity::High => (8u32, false),
     };
     let effective_max_rounds = req.max_rounds.unwrap_or(triage_default_rounds);
-    // max_turns: per-request override wins; global config is the fallback.
-    // Counts every agent API call (impl + validation retries + review rounds).
     let effective_max_turns: Option<u32> = req.max_turns.or(server_config.concurrency.max_turns);
-    // Start from accumulated turns (prior transient-retry attempts + pipeline phases)
-    // so the budget is global across the full task lifecycle.
     let mut turns_used: u32 = *turns_used_acc + pipeline_turns;
     *turns_used_acc = turns_used;
-    let jaccard_threshold = server_config.concurrency.loop_jaccard_threshold;
     tracing::info!(
         task_id = %task_id,
         ?triage_complexity,
@@ -1050,612 +873,52 @@ pub(crate) async fn run_task(
         "triage complexity applied"
     );
 
-    // Resume normal flow — update status to Implementing for the main turn.
+    // --- Implementation phase ---
     update_status(store, task_id, TaskStatus::Implementing, 1).await?;
+    let impl_outcome = implement_pipeline::run(
+        &ctx,
+        plan_output,
+        resumed_pr_url,
+        effective_max_turns,
+        &mut turns_used,
+    )
+    .await?;
+    *turns_used_acc = turns_used;
 
-    let first_prompt = if let Some(issue) = req.issue {
-        let base = match find_existing_pr_for_issue(&project, issue).await {
-            Ok(Some((pr_num, branch, pr_url))) => {
-                tracing::info!(
-                    "reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}"
-                );
-                let slug = prompts::repo_slug_from_pr_url(Some(&pr_url));
-                prompts::continue_existing_pr(issue, pr_num, &branch, &slug)
-            }
-            Ok(None) => {
-                prompts::implement_from_issue(issue, git, plan_output.as_deref()).to_prompt_string()
-            }
-            Err(e) => {
-                tracing::warn!("failed to check for existing PR for issue #{issue}: {e}");
-                prompts::implement_from_issue(issue, git, plan_output.as_deref()).to_prompt_string()
-            }
-        };
-        // If the caller also supplied a description alongside the issue number, include it
-        // as additional context. Without this, batch tasks that set both `description` and
-        // `issue` would silently discard the description.
-        if let Some(hint) = req.prompt.as_deref().filter(|s| !s.is_empty()) {
-            format!(
-                "{base}\n\nAdditional context from caller:\n{}",
-                prompts::wrap_external_data(hint)
-            )
-        } else {
-            base
-        }
-    } else if let Some(pr) = req.pr {
-        prompts::check_existing_pr(
-            pr,
-            &review_config.review_bot_command,
-            &repo_slug,
-            &review_config.reviewer_name,
-            false,
+    let (pr_url, pr_num, context_items, mut agent_pushed_commit) = match impl_outcome {
+        implement_pipeline::ImplementOutcome::Handled => return Ok(()),
+        implement_pipeline::ImplementOutcome::PrReady {
+            pr_url,
+            pr_num,
+            context_items,
+            agent_pushed_commit,
+        } => (pr_url, pr_num, context_items, agent_pushed_commit),
+    };
+
+    // --- Agent review phase (if enabled) ---
+    if ctx.review_config.enabled && !skip_agent_review {
+        let outcome = agent_review::run(
+            &ctx,
+            pr_url.as_deref().unwrap_or(""),
+            &context_items,
+            effective_max_turns,
+            &mut turns_used,
         )
-    } else if matches!(
-        req.source.as_deref(),
-        Some("periodic_review") | Some("sprint_planner")
-    ) {
-        // Review/planner tasks use their prompt as-is — no "create PR" wrapper.
-        req.prompt.clone().unwrap_or_default()
-    } else {
-        prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default(), git)
-    };
-
-    // Inject language-detected validation instructions into the prompt when no
-    // explicit validation config is set. This delegates validation to the agent
-    // instead of running external commands that may not be installed.
-    let first_prompt = if project_config.validation.pre_commit.is_empty()
-        && project_config.validation.pre_push.is_empty()
-    {
-        let lang = lang_detect::detect_language(&project);
-        let instructions = lang_detect::validation_prompt_instructions(lang, &project);
-        if instructions.is_empty() {
-            first_prompt
-        } else {
-            format!("{first_prompt}\n\n{instructions}")
-        }
-    } else {
-        first_prompt
-    };
-
-    // Inject sibling-awareness context when other agents are working on the same project.
-    // This prevents parallel agents from over-scoping their changes into each other's files.
-    //
-    // `project` may be a per-task worktree path when workspace isolation is active, but the
-    // sibling cache stores the canonical source repo path (set at spawn time before the worktree
-    // is created). Look up the canonical root from the task's own cache entry so that
-    // list_siblings() path comparison works correctly in the isolated-worktree case.
-    let first_prompt = {
-        let canonical_project = store
-            .get(task_id)
-            .and_then(|s| s.project_root)
-            .unwrap_or_else(|| project.clone());
-        let siblings = store.list_siblings(&canonical_project, task_id);
-        if siblings.is_empty() {
-            first_prompt
-        } else {
-            let sibling_tasks: Vec<prompts::SiblingTask> = siblings
-                .into_iter()
-                .filter_map(|s| {
-                    s.description.and_then(|description| {
-                        if description.is_empty() {
-                            None
-                        } else {
-                            Some(prompts::SiblingTask {
-                                issue: s.issue,
-                                description,
-                            })
-                        }
-                    })
-                })
-                .collect();
-            let ctx = prompts::sibling_task_context(&sibling_tasks);
-            format!("{first_prompt}\n\n{ctx}")
-        }
-    };
-
-    // Prepend the Golden Principles constitution when enabled.
-    let first_prompt =
-        prepend_constitution(first_prompt, server_config.server.constitution_enabled);
-
-    // Inject skill content directly into the prompt text.
-    // Since harness uses single-turn `claude -p`, context items are not visible
-    // to the agent — we must embed skill content in the prompt string itself.
-    // Also records usage for any matched skills via record_use().
-    let matched_skills = matched_skills_for_prompt(&skills, &first_prompt).await;
-    let skill_additions = inject_skills_into_prompt(&skills, &first_prompt).await;
-    let first_prompt = if skill_additions.is_empty() {
-        first_prompt
-    } else {
-        first_prompt + &skill_additions
-    };
-    for (skill_id, skill_name) in matched_skills {
-        let mut skill_event = Event::new(
-            SessionId::new(),
-            "skill_used",
-            "task_runner",
-            Decision::Pass,
-        );
-        skill_event.reason = Some(skill_name);
-        skill_event.detail = Some(format!(
-            "task_id={} skill_id={}",
-            task_id.as_str(),
-            skill_id.as_str()
-        ));
-        if let Err(err) = events.log(&skill_event).await {
-            tracing::warn!(error = %err, "failed to log skill_used event");
-        }
-    }
-
-    let context_items = collect_context_items(&skills, &project, &first_prompt).await;
-
-    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
-
-    // Periodic review tasks need Bash to run guard check commands but should
-    // not have unrestricted write access — use Standard profile. All other
-    // tasks (implementation) keep Full (None → --dangerously-skip-permissions).
-    //
-    // Some(tools) causes claude.rs to pass --allowedTools to the CLI (hard
-    // enforcement). None → --dangerously-skip-permissions (full access).
-    let (initial_allowed_tools, capability_prompt_note): (Option<Vec<String>>, _) = if matches!(
-        req.source.as_deref(),
-        Some("periodic_review") | Some("sprint_planner")
-    ) {
-        (
-            Some(restricted_tools(CapabilityProfile::Standard)?),
-            CapabilityProfile::Standard.prompt_note(),
-        )
-    } else {
-        (None, None)
-    };
-
-    // Prepend capability restriction note so the agent knows which tools are
-    // permitted. This is the primary enforcement path now that --allowedTools
-    // is not passed to the CLI.
-    let first_prompt = if let Some(note) = capability_prompt_note {
-        format!("{note}\n\n{first_prompt}")
-    } else {
-        first_prompt
-    };
-
-    tracing::info!(
-        task_id = %task_id,
-        prompt_len = first_prompt.len(),
-        prompt_empty = first_prompt.is_empty(),
-        source = ?req.source,
-        "run_task: prompt constructed"
-    );
-    if first_prompt.is_empty() {
-        tracing::error!(task_id = %task_id, "run_task: prompt is empty — agent will fail");
-    }
-
-    // Duplicate-PR prevention guard: if checkpoint shows PR already created, skip the
-    // implement agent entirely to avoid opening a second PR on resume.
-    let (pr_url, pr_num): (Option<String>, u64) = 'implement: {
-        if let Some(pr_str) = resumed_pr_url {
-            tracing::info!(
-                task_id = %task_id,
-                pr_url = %pr_str,
-                "checkpoint resume: PR exists, skipping implement phase"
-            );
-            let Some(n) = prompts::extract_pr_number(&pr_str) else {
-                tracing::error!(
-                    task_id = %task_id,
-                    pr_url = %pr_str,
-                    "checkpoint resume: cannot parse PR number, marking failed"
-                );
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.turn = 1;
-                    s.error = Some(format!("checkpoint resume: no PR number in {pr_str}"));
-                })
-                .await?;
-                return Ok(());
-            };
-            mutate_and_persist(store, task_id, |s| {
-                s.pr_url = Some(pr_str.clone());
-                s.rounds.push(RoundResult {
-                    turn: 1,
-                    action: "implement".into(),
-                    result: "resumed_checkpoint".into(),
-                    detail: None,
-                    first_token_latency_ms: None,
-                });
-            })
-            .await?;
-            break 'implement (Some(pr_str), n);
-        }
-
-        let impl_phase_start = Instant::now();
-
-        let initial_req = AgentRequest {
-            prompt: first_prompt,
-            project_root: project.clone(),
-            context: context_items.clone(),
-            max_budget_usd: req.max_budget_usd,
-            execution_phase: Some(ExecutionPhase::Planning),
-            allowed_tools: initial_allowed_tools,
-            env_vars: cargo_env.clone(),
-            ..Default::default()
-        };
-
-        // Run pre_execute interceptors; Block aborts the task.
-        let first_req = run_pre_execute(&interceptors, initial_req).await?;
-
-        // Execute implementation turn with post-execution validation and auto-retry.
-        // Use the largest max_retries declared by any interceptor.
-        // A single interceptor returning 0 should not suppress retries for others.
-        let max_validation_retries: u32 = interceptors
-            .iter()
-            .filter_map(|i| i.max_validation_retries())
-            .max()
-            .unwrap_or(2);
-        let mut validation_attempt = 0u32;
-        let mut impl_req = first_req.clone();
-
-        let resp = loop {
-            if let Some(max) = effective_max_turns {
-                if turns_used >= max {
-                    return Err(anyhow::anyhow!(
-                        "Turn budget exhausted: used {} of {} allowed turns",
-                        turns_used,
-                        max
-                    ));
-                }
-            }
-            let raw = tokio::time::timeout(
-                turn_timeout,
-                run_agent_streaming(agent, impl_req.clone(), task_id, store, 1),
-            )
-            .await;
-            turns_used += 1;
-            *turns_used_acc = turns_used;
-            match raw {
-                Ok(Ok((r, impl_first_token_ms))) => {
-                    // Post-execution tool isolation check (defense-in-depth alongside
-                    // --allowedTools CLI enforcement). Violations feed into the retry loop
-                    // so the agent gets a chance to self-correct (fail-closed, not fail-open).
-                    let impl_tools = impl_req.allowed_tools.as_deref().unwrap_or(&[]);
-                    let tool_violations = validate_tool_usage(&r.output, impl_tools);
-                    let violation_err: Option<String> = if !tool_violations.is_empty() {
-                        let msg = format!(
-                        "[VALIDATION ERROR] Tool isolation violation: agent used disallowed tools: [{}]. Only [{}] are permitted.",
-                        tool_violations.join(", "),
-                        impl_tools.join(", ")
-                    );
-                        tracing::warn!(
-                            ?tool_violations,
-                            "implementation turn: agent used tools outside allowed list"
-                        );
-                        Some(msg)
-                    } else {
-                        None
-                    };
-                    // PreToolUse / PostToolUse hook injection point:
-                    // detect files written during this turn and fire post_tool_use hooks.
-                    let hook_err = {
-                        let modified = detect_modified_files(&project).await;
-                        if modified.is_empty() {
-                            None
-                        } else {
-                            let hook_event = ToolUseEvent {
-                                tool_name: "file_write".to_string(),
-                                affected_files: modified,
-                                session_id: None,
-                            };
-                            run_post_tool_use(&interceptors, &hook_event, &project).await
-                        }
-                    };
-                    let post_err = run_post_execute(&interceptors, &impl_req, &r).await;
-                    let combined_err = violation_err.or(hook_err).or(post_err);
-                    if let Some(err) = combined_err {
-                        if validation_attempt < max_validation_retries {
-                            validation_attempt += 1;
-                            let backoff_ms = compute_backoff_ms(
-                                req.retry_base_backoff_ms,
-                                req.retry_max_backoff_ms,
-                                validation_attempt,
-                            );
-                            tracing::warn!(
-                                attempt = validation_attempt,
-                                max = max_validation_retries,
-                                backoff_ms,
-                                error = %err,
-                                "post-execution validation failed; backing off before retry"
-                            );
-                            let truncated = truncate_validation_error(&err, 2000);
-                            impl_req.prompt = format!(
-                                "{}\n\nPost-execution validation failed (attempt {}/{}).\nErrors are prefixed with [COMPILE ERROR], [TEST FAILURE], [LINT ERROR], or [VALIDATION ERROR] for classified failures, or with an interceptor name (e.g. [hook_name]) for hook/policy violations — focus your fix on the indicated error type:\n{}",
-                                first_req.prompt,
-                                validation_attempt,
-                                max_validation_retries,
-                                truncated
-                            );
-                            sleep(Duration::from_millis(backoff_ms)).await;
-                            continue;
-                        } else {
-                            tracing::error!(
-                                max = max_validation_retries,
-                                error = %err,
-                                "post-execution validation failed after max retries; aborting task"
-                            );
-                            run_on_error(&interceptors, &impl_req, &err).await;
-                            return Err(anyhow::anyhow!(
-                                "Post-execution validation failed after {} attempts: {}",
-                                max_validation_retries,
-                                err
-                            ));
-                        }
-                    }
-                    break (r, impl_first_token_ms);
-                }
-                Ok(Err(e)) => {
-                    run_on_error(&interceptors, &impl_req, &e.to_string()).await;
-                    return Err(e.into());
-                }
-                Err(_) => {
-                    let msg = format!(
-                        "Implementation turn timed out after {}s",
-                        turn_timeout.as_secs()
-                    );
-                    run_on_error(&interceptors, &impl_req, &msg).await;
-                    return Err(anyhow::anyhow!("{msg}"));
-                }
-            }
-        };
-
-        let (
-            AgentResponse {
-                output,
-                stderr,
-                token_usage: impl_token_usage,
-                ..
-            },
-            impl_first_token_ms,
-        ) = resp;
-
-        tracing::info!(
-            task_id = %task_id,
-            phase = "implementing",
-            elapsed_secs = impl_phase_start.elapsed().as_secs(),
-            "phase_completed"
-        );
-        {
-            let preview: String = output.chars().take(200).collect();
-            tracing::info!(
-                task_id = %task_id,
-                output_chars = output.len(),
-                preview = %preview,
-                input_tokens = impl_token_usage.input_tokens,
-                output_tokens = impl_token_usage.output_tokens,
-                "agent_output_summary"
-            );
-        }
-
-        if !stderr.is_empty() {
-            tracing::warn!(stderr = %stderr, "agent stderr during implementation");
-        }
-
-        // Review-only tasks produce a report, not a PR.
-        // Persist the output and return immediately — no PR parsing or review loop.
-        let is_review_task = store.get(task_id).is_some_and(|s| {
-            matches!(
-                s.source.as_deref(),
-                Some("periodic_review") | Some("sprint_planner")
-            )
-        });
-
-        if is_review_task {
-            mutate_and_persist(store, task_id, |s| {
-                s.status = TaskStatus::Done;
-                s.turn = 1;
-                s.rounds.push(RoundResult {
-                    turn: 1,
-                    action: "review".into(),
-                    result: "completed".into(),
-                    detail: if output.is_empty() {
-                        None
-                    } else {
-                        Some(output.clone())
-                    },
-                    first_token_latency_ms: impl_first_token_ms,
-                });
-            })
-            .await?;
-            store.log_event(crate::event_replay::TaskEvent::Completed {
-                task_id: task_id.0.clone(),
-                ts: crate::event_replay::now_ts(),
-            });
-            tracing::info!(
-                task_id = %task_id,
-                status = "done",
-                turns = 1,
-                pr_url = tracing::field::Empty,
-                total_elapsed_secs = task_start.elapsed().as_secs(),
-                "task_completed"
-            );
-            return Ok(());
-        }
-
-        let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
-            ImplementationOutcome::PlanIssue(plan_issue) => {
-                tracing::error!(
-                    task_id = %task_id,
-                    plan_issue = %plan_issue,
-                    "implementation returned PLAN_ISSUE; marking task failed"
-                );
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.turn = 2;
-                    s.error = Some(plan_issue.clone());
-                    s.rounds.push(RoundResult {
-                        turn: 1,
-                        action: "implement".into(),
-                        result: "plan_issue".into(),
-                        detail: if output.is_empty() {
-                            None
-                        } else {
-                            Some(output.clone())
-                        },
-                        first_token_latency_ms: impl_first_token_ms,
-                    });
-                })
-                .await?;
-                tracing::info!(
-                    task_id = %task_id,
-                    status = "failed",
-                    turns = 2,
-                    pr_url = tracing::field::Empty,
-                    total_elapsed_secs = task_start.elapsed().as_secs(),
-                    "task_completed"
-                );
-                return Ok(());
-            }
-            ImplementationOutcome::ParsedPr {
-                pr_url,
-                pr_num,
-                created_issue_num,
-            } => (pr_url, pr_num, created_issue_num),
-        };
-
-        mutate_and_persist(store, task_id, |s| {
-            s.pr_url = pr_url.clone();
-            s.rounds.push(RoundResult {
-                turn: 1,
-                action: "implement".into(),
-                result: if pr_num.is_some() {
-                    "pr_created".into()
-                } else {
-                    "no_pr".into()
-                },
-                detail: if output.is_empty() {
-                    None
-                } else {
-                    Some(output.clone())
-                },
-                first_token_latency_ms: impl_first_token_ms,
-            });
-        })
         .await?;
-
-        // Back-fill (or correct) external_id for auto-fix tasks that created a
-        // GitHub issue.  Dedup layers 1-3 match on external_id; without this,
-        // intake re-creates a duplicate task when it receives the webhook for the
-        // newly created issue.
-        //
-        // We compare against the current in-memory value rather than checking
-        // IS NULL so that a post-run self-correction (agent emitted CREATED_ISSUE=20
-        // after an earlier CREATED_ISSUE=10) is always written even when the
-        // streaming path already stored the stale value.
-        if let Some(issue_num) = created_issue_num {
-            let final_eid = format!("issue:{issue_num}");
-            let needs_backfill = store.get(task_id).is_some_and(|s| {
-                s.source.as_deref() == Some("auto-fix")
-                    && s.external_id.as_deref() != Some(&final_eid)
-            });
-            if needs_backfill {
-                if let Err(e) = store
-                    .overwrite_external_id_auto_fix(task_id, &final_eid)
-                    .await
-                {
-                    tracing::warn!(task_id = %task_id, "failed to back-fill external_id: {e}");
-                } else {
-                    tracing::info!(task_id = %task_id, external_id = %final_eid, "back-filled external_id for auto-fix task");
+        *turns_used_acc = turns_used;
+        match outcome {
+            agent_review::AgentReviewOutcome::Handled => return Ok(()),
+            agent_review::AgentReviewOutcome::ReviewComplete { pushed_commit } => {
+                if pushed_commit {
+                    agent_pushed_commit = true;
                 }
             }
-        }
-
-        // Emit PrDetected event so crash recovery can reconstruct pr_url.
-        if let Some(pr_url_str) = pr_url.as_deref() {
-            store.log_event(crate::event_replay::TaskEvent::PrDetected {
-                task_id: task_id.0.clone(),
-                ts: crate::event_replay::now_ts(),
-                pr_url: pr_url_str.to_string(),
-            });
-        }
-
-        // Write PR checkpoint immediately after pr_url is persisted.
-        // This is the most critical checkpoint — it prevents duplicate PR creation on resume.
-        if let Some(pr_url_str) = pr_url.as_deref() {
-            if let Err(e) = store
-                .write_checkpoint(task_id, None, None, Some(pr_url_str), "pr_created")
-                .await
-            {
-                tracing::warn!(task_id = %task_id, "failed to write pr checkpoint: {e}");
-            }
-        }
-
-        // Log implementation event
-        let mut ev = Event::new(
-            SessionId::new(),
-            "task_implement",
-            "task_runner",
-            harness_core::types::Decision::Complete,
-        );
-        ev.detail = pr_num.map(|n| format!("pr={n}"));
-        if let Err(e) = events.log(&ev).await {
-            tracing::warn!("failed to log task_implement event: {e}");
-        }
-
-        let Some(pr_num) = pr_num else {
-            tracing::warn!("no PR number found in agent output; skipping review");
-            mutate_and_persist(store, task_id, |s| {
-                s.status = TaskStatus::Done;
-                s.turn = 2;
-            })
-            .await?;
-            store.log_event(crate::event_replay::TaskEvent::Completed {
-                task_id: task_id.0.clone(),
-                ts: crate::event_replay::now_ts(),
-            });
-            tracing::info!(
-                task_id = %task_id,
-                status = "done",
-                turns = 2,
-                pr_url = tracing::field::Empty,
-                total_elapsed_secs = task_start.elapsed().as_secs(),
-                "task_completed"
-            );
-            return Ok(());
-        };
-
-        (pr_url, pr_num)
-    }; // end 'implement
-
-    // Agent review loop (if enabled and reviewer available, and not skipped by triage complexity)
-    let mut agent_pushed_commit = false;
-    if review_config.enabled && !skip_agent_review {
-        if let Some(reviewer) = reviewer {
-            tracing::info!(pr_url = %pr_url.as_deref().unwrap_or(""), "starting agent review");
-            let (review_ok, pushed) = run_agent_review(
-                store,
-                task_id,
-                agent,
-                reviewer,
-                review_config,
-                &context_items,
-                &project,
-                &interceptors,
-                turn_timeout,
-                pr_url.as_deref().unwrap_or(""),
-                project_config.review_type.as_str(),
-                &events,
-                &cargo_env,
-                effective_max_turns,
-                &mut turns_used,
-            )
-            .await?;
-            *turns_used_acc = turns_used;
-            if !review_ok {
-                return Ok(());
-            }
-            agent_pushed_commit = pushed;
-        } else {
-            tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
         }
     }
 
     // Skip external review bot wait when auto-trigger is disabled — there is
     // no bot to wait for, so the loop would always exhaust all rounds and fail.
-    if !review_config.review_bot_auto_trigger {
+    if !ctx.review_config.review_bot_auto_trigger {
         tracing::info!("review_bot_auto_trigger disabled; skipping external review wait");
         mutate_and_persist(store, task_id, |s| {
             s.status = TaskStatus::Done;
@@ -1677,416 +940,20 @@ pub(crate) async fn run_task(
         return Ok(());
     }
 
-    // Wait for external review bot.
-    // Use a local counter instead of querying the store to derive waiting_count —
-    // task execution is sequential within a single tokio task, so a plain u32 suffices.
-    let mut waiting_count: u32 = 0;
-    waiting_count += 1;
-    update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
+    // --- External review bot wait loop ---
+    review_loop::run(
+        &ctx,
+        pr_url,
+        pr_num,
+        context_items,
+        effective_max_rounds,
+        effective_max_turns,
+        agent_pushed_commit,
+        &mut turns_used,
+    )
+    .await?;
+    *turns_used_acc = turns_used;
 
-    let wait_secs = resolved.review_wait_secs.unwrap_or(req.wait_secs);
-    // Project-level override takes precedence over triage-derived rounds so that
-    // per-repo caps (review_max_rounds in harness.toml) are never silently bypassed.
-    let max_rounds = resolved.review_max_rounds.unwrap_or(effective_max_rounds);
-    tracing::info!("waiting {wait_secs}s for review bot on PR #{pr_num}");
-    sleep(Duration::from_secs(wait_secs)).await;
-
-    let review_phase_start = Instant::now();
-
-    // `prev_fixed` tracks whether a commit was pushed that hasn't been re-reviewed yet.
-    // Starts true if the implementation phase pushed a commit, and is set to true again
-    // whenever a review round produces FIXED (agent commits + pushes). This drives the
-    // freshness check in every round after a fix commit, not just round 1.
-    let mut prev_fixed = agent_pushed_commit;
-    let repo_slug = prompts::repo_slug_from_pr_url(pr_url.as_deref());
-
-    // Convergence tracking: detect when issue count stops decreasing.
-    let mut issue_counts: Vec<Option<u32>> = Vec::new();
-    let mut impasse = false;
-
-    // Carries test gate failure output from a rejected LGTM into the next review round.
-    let mut pending_test_failure: Option<String> = None;
-    // Issue 2 fix: track whether any LGTM was ever rejected by the test gate
-    // without a subsequent clean LGTM+pass. `pending_test_failure.take()` clears
-    // the Option at the start of each round (to avoid re-showing the same output),
-    // but the graduation check must still know a test gate rejection occurred.
-    let mut lgtm_test_gate_rejected = false;
-
-    // Tracks the most recent non-waiting review output for Jaccard loop detection.
-    let mut prev_review_output: Option<String> = None;
-
-    // Review loop.
-    // Use an explicit counter so WAITING responses don't consume a round — `continue`
-    // inside a `for` loop would silently advance the iterator even without a real review.
-    let mut round: u32 = 1;
-    while round <= max_rounds {
-        update_status(store, task_id, TaskStatus::Reviewing, round).await?;
-
-        let base_prompt = prompts::review_prompt(
-            req.issue,
-            pr_num,
-            round,
-            prev_fixed,
-            &review_config.review_bot_command,
-            &review_config.reviewer_name,
-            &repo_slug,
-            impasse,
-        );
-        // If the previous LGTM was rejected by the test gate, prepend the failure
-        // output so the agent has context for why re-work is needed.
-        let round_prompt = if let Some(failure) = pending_test_failure.take() {
-            format!(
-                "IMPORTANT: The previous LGTM was rejected because the project's tests failed. \
-                 Fix the test failures before declaring LGTM again.\n\n\
-                 Test output:\n```\n{failure}\n```\n\n{base_prompt}"
-            )
-        } else {
-            base_prompt
-        };
-
-        let check_req = AgentRequest {
-            prompt: round_prompt,
-            project_root: project.clone(),
-            context: context_items.clone(),
-            execution_phase: Some(ExecutionPhase::Execution),
-            env_vars: cargo_env.clone(),
-            ..Default::default()
-        };
-        let check_req = run_pre_execute(&interceptors, check_req).await?;
-
-        if let Some(max) = effective_max_turns {
-            if turns_used >= max {
-                let msg = format!(
-                    "Turn budget exhausted: used {} of {} allowed turns",
-                    turns_used, max
-                );
-                tracing::warn!(task_id = %task_id, turns_used, max, "turn budget exhausted in review loop");
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.error = Some(msg.clone());
-                })
-                .await?;
-                return Ok(());
-            }
-        }
-        let resp = tokio::time::timeout(turn_timeout, agent.execute(check_req.clone())).await;
-        turns_used += 1;
-        *turns_used_acc = turns_used;
-        let resp = match resp {
-            Ok(Ok(r)) => {
-                let tool_violations = validate_tool_usage(
-                    &r.output,
-                    check_req.allowed_tools.as_deref().unwrap_or(&[]),
-                );
-                if !tool_violations.is_empty() {
-                    let msg = format!(
-                        "Tool isolation violation in review check round {round}: agent used disallowed tools: [{}]",
-                        tool_violations.join(", ")
-                    );
-                    tracing::warn!(
-                        round,
-                        ?tool_violations,
-                        "review check: agent used tools outside allowed list"
-                    );
-                    run_on_error(&interceptors, &check_req, &msg).await;
-                    return Err(anyhow::anyhow!("{msg}"));
-                }
-                if let Some(val_err) = run_post_execute(&interceptors, &check_req, &r).await {
-                    tracing::error!(
-                        round,
-                        error = %val_err,
-                        "post-execute validation failed in review check; will re-enter review"
-                    );
-                    pending_test_failure =
-                        Some(format!("Post-execution validation failed:\n{val_err}"));
-                }
-                r
-            }
-            Ok(Err(e)) => {
-                // Quota exhausted is not retryable — break immediately instead of
-                // burning remaining review rounds on repeated 402 errors.
-                if matches!(e, HarnessError::QuotaExhausted(_)) {
-                    tracing::error!(round, error = %e, "quota exhausted during review — aborting review loop");
-                    run_on_error(&interceptors, &check_req, &e.to_string()).await;
-                    mutate_and_persist(store, task_id, |s| {
-                        s.status = TaskStatus::Failed;
-                        s.error = Some(e.to_string());
-                    })
-                    .await?;
-                    return Ok(());
-                }
-                run_on_error(&interceptors, &check_req, &e.to_string()).await;
-                return Err(e.into());
-            }
-            Err(_) => {
-                let msg = format!(
-                    "Review check round {round} timed out after {}s",
-                    turn_timeout.as_secs()
-                );
-                run_on_error(&interceptors, &check_req, &msg).await;
-                return Err(anyhow::anyhow!("{msg}"));
-            }
-        };
-
-        let AgentResponse { output, stderr, .. } = resp;
-
-        if !stderr.is_empty() {
-            tracing::warn!(round, stderr = %stderr, "agent stderr during review check");
-        }
-
-        let raw_lgtm = prompts::is_lgtm(&output);
-        let waiting = prompts::is_waiting(&output);
-        // If post-execute validation failed this round, block LGTM acceptance even
-        // if the reviewer approved — the local validator caught an issue that must be
-        // fixed before the PR can be marked done.
-        let lgtm = raw_lgtm && pending_test_failure.is_none();
-        let fixed = !lgtm && !waiting;
-
-        // Parse issue count before the Jaccard check so loop detection can distinguish
-        // genuine forward progress (decreasing issue count) from true stuck loops.
-        let current_issues = prompts::parse_issue_count(&output);
-
-        // Jaccard loop detection: two consecutive non-waiting, non-LGTM outputs that are
-        // too similar indicate the reviewer is stuck repeating itself without making progress.
-        // Skip when the raw output is an approval: repeated LGTM is legitimate convergence
-        // (e.g., reviewer approves again after a test-gate previously blocked acceptance).
-        if !waiting && !raw_lgtm {
-            if let Some(ref prev) = prev_review_output {
-                let score = jaccard_word_similarity(prev, &output);
-                if score >= jaccard_threshold {
-                    // If the issue count decreased since the previous round, the agent is making
-                    // genuine progress despite similar output structure (e.g., one fix per round
-                    // with a consistent report format). Only abort on true stagnation.
-                    let last_count = issue_counts.last().and_then(|x| *x);
-                    let progressing = matches!(
-                        (last_count, current_issues),
-                        (Some(prev_n), Some(curr_n)) if curr_n < prev_n
-                    );
-                    if !progressing {
-                        let msg = format!(
-                            "review loop detected: output similarity {score:.2} >= threshold {jaccard_threshold:.2}"
-                        );
-                        tracing::warn!(task_id = %task_id, round, score, jaccard_threshold, "jaccard loop detected in review");
-                        mutate_and_persist(store, task_id, |s| {
-                            s.status = TaskStatus::Failed;
-                            s.error = Some(msg.clone());
-                        })
-                        .await?;
-                        return Ok(());
-                    }
-                }
-            }
-            prev_review_output = Some(output.clone());
-        } else if raw_lgtm {
-            // A test-gate-rejected LGTM still resets the comparison baseline so the
-            // next genuine non-LGTM review is not incorrectly compared against a
-            // pre-LGTM review and falsely flagged as a loop.
-            prev_review_output = None;
-        }
-
-        if !waiting {
-            issue_counts.push(current_issues);
-        }
-
-        // Convergence check: if the last 3 rounds all reported issues and the
-        // count is not decreasing, enter impasse mode (critical-only fixes).
-        if issue_counts.len() >= 3 && !impasse {
-            let tail = &issue_counts[issue_counts.len() - 3..];
-            if let [Some(a), Some(b), Some(c)] = tail {
-                if c >= a && c >= b {
-                    impasse = true;
-                    tracing::warn!(
-                        task_id = %task_id,
-                        round,
-                        issues = %format_args!("[{a}, {b}, {c}]"),
-                        "review loop impasse detected: issue count not decreasing"
-                    );
-                }
-            }
-        }
-
-        // WAITING means review bot hasn't posted yet (e.g., quota exhausted).
-        // Don't consume a round — just sleep and retry without incrementing.
-        // Cap consecutive waits to prevent infinite loops when the bot never responds.
-        const MAX_CONSECUTIVE_WAITS: u32 = 10;
-        if waiting {
-            if waiting_count >= MAX_CONSECUTIVE_WAITS {
-                tracing::warn!(
-                    round,
-                    waiting_count,
-                    "PR #{pr_num} review bot has not responded after {MAX_CONSECUTIVE_WAITS} waits; \
-                     consuming a round to prevent infinite loop"
-                );
-                round += 1;
-                waiting_count = 0;
-            } else {
-                tracing::info!(
-                    round,
-                    waiting_count,
-                    "PR #{pr_num} review bot has not responded yet; sleeping without consuming round"
-                );
-                waiting_count += 1;
-                update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
-                sleep(Duration::from_secs(wait_secs)).await;
-                continue;
-            }
-        }
-
-        let result_label = if lgtm { "lgtm" } else { "fixed" };
-        mutate_and_persist(store, task_id, |s| {
-            s.rounds.push(RoundResult {
-                turn: round,
-                action: "review".into(),
-                result: result_label.into(),
-                detail: None,
-                first_token_latency_ms: None,
-            });
-        })
-        .await?;
-
-        // Emit RoundCompleted for crash recovery.
-        store.log_event(crate::event_replay::TaskEvent::RoundCompleted {
-            task_id: task_id.0.clone(),
-            ts: crate::event_replay::now_ts(),
-            round,
-            result: result_label.to_string(),
-        });
-
-        // Log pr_review event for observability and GC signal detection.
-        let mut ev = Event::new(
-            SessionId::new(),
-            "pr_review",
-            "task_runner",
-            if lgtm {
-                harness_core::types::Decision::Complete
-            } else {
-                harness_core::types::Decision::Warn
-            },
-        );
-        ev.detail = Some(format!("pr={pr_num}"));
-        let result_label = if lgtm { "lgtm" } else { "fixed" };
-        ev.reason = Some(format!("round {round}: {result_label}"));
-        if let Err(e) = events.log(&ev).await {
-            tracing::warn!("failed to log pr_review event: {e}");
-        }
-
-        if lgtm {
-            // Hard gate: run the project's tests before accepting LGTM.
-            // This prevents agents from gaming the review by manipulating tests
-            // rather than fixing code (OpenAI "Monitoring Reasoning Models", 2026).
-            match run_test_gate(
-                &project,
-                &project_config.validation.pre_push,
-                project_config.validation.test_gate_timeout_secs,
-                &cargo_env,
-            )
-            .await
-            {
-                Ok(()) => {
-                    tracing::info!("PR #{pr_num} approved at round {round}");
-                    mutate_and_persist(store, task_id, |s| {
-                        s.status = TaskStatus::Done;
-                        s.turn = round.saturating_add(1);
-                    })
-                    .await?;
-                    store.log_event(crate::event_replay::TaskEvent::Completed {
-                        task_id: task_id.0.clone(),
-                        ts: crate::event_replay::now_ts(),
-                    });
-                    tracing::info!(
-                        task_id = %task_id,
-                        phase = "reviewing",
-                        elapsed_secs = review_phase_start.elapsed().as_secs(),
-                        "phase_completed"
-                    );
-                    tracing::info!(
-                        task_id = %task_id,
-                        status = "done",
-                        turns = round.saturating_add(1),
-                        pr_url = pr_url.as_deref().unwrap_or(""),
-                        total_elapsed_secs = task_start.elapsed().as_secs(),
-                        "task_completed"
-                    );
-                    return Ok(());
-                }
-                Err(output) => {
-                    tracing::warn!(
-                        task_id = %task_id,
-                        round,
-                        "LGTM rejected: tests failed in test gate, re-entering review round {}",
-                        round.saturating_add(1)
-                    );
-                    lgtm_test_gate_rejected = true;
-                    pending_test_failure = Some(output);
-                }
-            }
-        }
-
-        // Track whether this round produced a fix so the next round enforces
-        // freshness checks against new reviewer feedback.
-        // Also treat a test gate rejection as a "fixed" round — the agent needs
-        // to push a fix and get a fresh review before LGTM can be accepted.
-        prev_fixed = fixed || pending_test_failure.is_some();
-        tracing::info!("PR #{pr_num} fixed at round {round}; waiting for bot re-review");
-        if round < max_rounds {
-            waiting_count += 1;
-            update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
-            sleep(Duration::from_secs(wait_secs)).await;
-        }
-        round += 1;
-    }
-
-    // Graduated exit: if the last round had few issues remaining, mark as done
-    // with a warning instead of outright failure — the PR is likely mergeable.
-    // But never graduate when the test gate was still failing on the last round:
-    // a PR whose tests consistently fail must not be approved.
-    let last_issue_count = issue_counts.iter().rev().find_map(|c| *c);
-    // Never graduate when a LGTM was rejected by the test gate — the pending_test_failure
-    // Option was already cleared by take() at round start, so we track rejection separately.
-    let graduated = last_issue_count.is_some_and(|n| n <= 2) && !lgtm_test_gate_rejected;
-
-    if graduated {
-        tracing::info!(
-            task_id = %task_id,
-            remaining_issues = last_issue_count.unwrap_or(0),
-            "review loop exhausted but few issues remain — marking done with warning"
-        );
-        mutate_and_persist(store, task_id, |s| {
-            s.status = TaskStatus::Done;
-            s.turn = max_rounds.saturating_add(1);
-            s.error = Some(format!(
-                "Graduated: LGTM not received after {} rounds but only {} issues remain.",
-                max_rounds,
-                last_issue_count.unwrap_or(0),
-            ));
-        })
-        .await?;
-    } else {
-        mutate_and_persist(store, task_id, |s| {
-            s.status = TaskStatus::Failed;
-            s.turn = max_rounds.saturating_add(1);
-            s.error = Some(format!(
-                "Task did not receive LGTM after {} review rounds (last issues: {}).",
-                max_rounds,
-                last_issue_count.map_or("unknown".to_string(), |n| n.to_string()),
-            ));
-        })
-        .await?;
-    }
-    tracing::info!(
-        task_id = %task_id,
-        phase = "reviewing",
-        elapsed_secs = review_phase_start.elapsed().as_secs(),
-        "phase_completed"
-    );
-    tracing::info!(
-        task_id = %task_id,
-        status = if graduated { "done" } else { "failed" },
-        turns = max_rounds.saturating_add(1),
-        pr_url = pr_url.as_deref().unwrap_or(""),
-        total_elapsed_secs = task_start.elapsed().as_secs(),
-        "task_completed"
-    );
     Ok(())
 }
 
@@ -2126,297 +993,7 @@ fn normalize_issues(issues: &[String]) -> Vec<String> {
     sorted.into_iter().cloned().collect()
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn run_agent_review(
-    store: &TaskStore,
-    task_id: &TaskId,
-    agent: &dyn CodeAgent,
-    reviewer: &dyn CodeAgent,
-    review_config: &harness_core::config::agents::AgentReviewConfig,
-    context_items: &[ContextItem],
-    project: &Path,
-    interceptors: &[Arc<dyn harness_core::interceptor::TurnInterceptor>],
-    turn_timeout: Duration,
-    pr_url: &str,
-    project_type: &str,
-    events: &harness_observe::event_store::EventStore,
-    cargo_env: &HashMap<String, String>,
-    effective_max_turns: Option<u32>,
-    turns_used: &mut u32,
-) -> anyhow::Result<(bool, bool)> {
-    let max_rounds = review_config.max_rounds;
-    // (normalized_issues, consecutive_count): tracks how many consecutive rounds produced identical issues.
-    let mut impasse_tracker: Option<(Vec<String>, u32)> = None;
-    // Whether the last action in this loop pushed a new commit (fix or intervention).
-    let mut pushed_commit = false;
-    for agent_round in 1..=max_rounds {
-        update_status(store, task_id, TaskStatus::AgentReview, agent_round).await?;
-
-        // Reviewer evaluates the PR diff — read-only except Bash for `gh pr diff`.
-        let review_req = AgentRequest {
-            prompt: {
-                let base = prompts::agent_review_prompt(pr_url, agent_round, project_type);
-                // Inject capability note — primary enforcement now that --allowedTools
-                // is not passed to the CLI (issue #483).
-                let note = "Tool restriction: you are operating in review mode. \
-                     Only Read, Grep, Glob, and Bash are permitted. \
-                     Use Bash ONLY for read-only commands like `gh pr diff`. \
-                     Do NOT call Write, Edit, or any other tool.";
-                format!("{note}\n\n{base}")
-            },
-            project_root: project.to_path_buf(),
-            context: context_items.to_vec(),
-            execution_phase: Some(ExecutionPhase::Validation),
-            allowed_tools: Some(vec![
-                "Read".to_string(),
-                "Grep".to_string(),
-                "Glob".to_string(),
-                "Bash".to_string(),
-            ]),
-            env_vars: cargo_env.clone(),
-            ..Default::default()
-        };
-        let review_req = run_pre_execute(interceptors, review_req).await?;
-
-        if let Some(max) = effective_max_turns {
-            if *turns_used >= max {
-                return Err(anyhow::anyhow!(
-                    "Turn budget exhausted before agent review round {agent_round}: used {} of {} allowed turns",
-                    turns_used, max
-                ));
-            }
-        }
-        let resp = tokio::time::timeout(turn_timeout, reviewer.execute(review_req.clone())).await;
-        *turns_used += 1;
-        let resp = match resp {
-            Ok(Ok(r)) => {
-                let tool_violations = validate_tool_usage(
-                    &r.output,
-                    review_req.allowed_tools.as_deref().unwrap_or(&[]),
-                );
-                if !tool_violations.is_empty() {
-                    let msg = format!(
-                        "Tool isolation violation in agent review round {agent_round}: agent used disallowed tools: [{}]",
-                        tool_violations.join(", ")
-                    );
-                    tracing::warn!(
-                        agent_round,
-                        ?tool_violations,
-                        "agent review: agent used tools outside allowed list"
-                    );
-                    run_on_error(interceptors, &review_req, &msg).await;
-                    return Err(anyhow::anyhow!("{msg}"));
-                }
-                if let Some(val_err) = run_post_execute(interceptors, &review_req, &r).await {
-                    tracing::warn!(
-                        agent_round,
-                        error = %val_err,
-                        "post-execute validation failed in agent review; continuing"
-                    );
-                }
-                r
-            }
-            Ok(Err(e)) => {
-                if matches!(e, HarnessError::QuotaExhausted(_)) {
-                    tracing::error!(agent_round, error = %e, "quota exhausted during agent review — aborting");
-                    run_on_error(interceptors, &review_req, &e.to_string()).await;
-                    mutate_and_persist(store, task_id, |s| {
-                        s.status = TaskStatus::Failed;
-                        s.error = Some(e.to_string());
-                    })
-                    .await?;
-                    return Ok((false, false));
-                }
-                run_on_error(interceptors, &review_req, &e.to_string()).await;
-                return Err(e.into());
-            }
-            Err(_) => {
-                let msg = format!(
-                    "Agent review round {agent_round} timed out after {}s",
-                    turn_timeout.as_secs()
-                );
-                run_on_error(interceptors, &review_req, &msg).await;
-                return Err(anyhow::anyhow!("{msg}"));
-            }
-        };
-
-        let AgentResponse { output, stderr, .. } = resp;
-
-        if !stderr.is_empty() {
-            tracing::warn!(agent_round, stderr = %stderr, "agent reviewer stderr");
-        }
-
-        let approved = prompts::is_approved(&output);
-        let issues = prompts::extract_review_issues(&output);
-        let review_detail = output;
-
-        mutate_and_persist(store, task_id, |s| {
-            s.rounds.push(RoundResult {
-                turn: 0, // agent review rounds use turn 0
-                action: "agent_review".into(),
-                result: if approved {
-                    "approved".into()
-                } else {
-                    format!("{} issues", issues.len())
-                },
-                detail: Some(review_detail),
-                first_token_latency_ms: None,
-            });
-        })
-        .await?;
-
-        // Log agent_review event
-        let mut ev = Event::new(
-            SessionId::new(),
-            "agent_review",
-            "task_runner",
-            if approved {
-                harness_core::types::Decision::Complete
-            } else {
-                harness_core::types::Decision::Warn
-            },
-        );
-        ev.detail = Some(format!("pr={pr_url}"));
-        ev.reason = Some(if approved {
-            format!("round {agent_round}: approved")
-        } else {
-            format!("round {agent_round}: {} issues", issues.len())
-        });
-        if let Err(e) = events.log(&ev).await {
-            tracing::warn!("failed to log agent_review event: {e}");
-        }
-
-        if approved {
-            tracing::info!("agent review approved at round {agent_round}");
-            break;
-        }
-
-        // Malformed reviewer output: neither APPROVED nor any ISSUE: lines.
-        // Sending an empty fix prompt would produce arbitrary or no-op commits,
-        // so treat this as a reviewer protocol failure and abort the review loop.
-        if issues.is_empty() {
-            tracing::warn!(
-                agent_round,
-                "agent reviewer output contained neither APPROVED nor ISSUE: lines; \
-                 treating as protocol failure and skipping fix round"
-            );
-            break;
-        }
-
-        // Detect impasse: track how many consecutive rounds produced identical issues.
-        // Must happen before the max_rounds break so thresholds are reachable at the last round.
-        // Compare normalized issue lists directly to avoid false positives from hash collisions.
-        let normalized = normalize_issues(&issues);
-        let consecutive_count = match &impasse_tracker {
-            Some((prev, c)) if *prev == normalized => c + 1,
-            _ => 1,
-        };
-        impasse_tracker = Some((normalized, consecutive_count));
-
-        // 5 consecutive rounds with identical issues → mark task as Failed immediately.
-        if consecutive_count >= 5 {
-            tracing::warn!(
-                agent_round,
-                consecutive_count,
-                "agent review impasse: same issues repeated 5 times — marking task as failed"
-            );
-            mutate_and_persist(store, task_id, |s| {
-                s.status = TaskStatus::Failed;
-                s.error = Some(format!(
-                    "Impasse detected: identical issues repeated {consecutive_count} consecutive rounds."
-                ));
-            })
-            .await?;
-            return Ok((false, false));
-        }
-
-        // 3+ consecutive rounds with identical issues → use the intervention prompt.
-        let is_impasse = consecutive_count >= 3;
-        if is_impasse {
-            tracing::warn!(
-                agent_round,
-                consecutive_count,
-                "agent review impasse detected — same issues repeated, using intervention prompt"
-            );
-        }
-
-        // Skip the fix round only when rounds are exhausted and there is no impasse.
-        // When impasse is detected at the last round, we still apply the intervention prompt
-        // to give the agent one final attempt to break the cycle before GitHub review.
-        if agent_round == max_rounds && !is_impasse {
-            tracing::info!(
-                "agent review exhausted {max_rounds} rounds, proceeding to GitHub review"
-            );
-            break;
-        }
-
-        // Implementor fixes the issues
-        let fix_req = AgentRequest {
-            prompt: {
-                let prompt_fn = if is_impasse {
-                    prompts::agent_review_intervention_prompt
-                } else {
-                    prompts::agent_review_fix_prompt
-                };
-                prompt_fn(pr_url, &issues, agent_round, project_type)
-            },
-            project_root: project.to_path_buf(),
-            context: context_items.to_vec(),
-            execution_phase: Some(ExecutionPhase::Execution),
-            env_vars: cargo_env.clone(),
-            ..Default::default()
-        };
-        let fix_req = run_pre_execute(interceptors, fix_req).await?;
-
-        if let Some(max) = effective_max_turns {
-            if *turns_used >= max {
-                return Err(anyhow::anyhow!(
-                    "Turn budget exhausted before agent review fix round {agent_round}: used {} of {} allowed turns",
-                    turns_used, max
-                ));
-            }
-        }
-        let fix_resp = tokio::time::timeout(turn_timeout, agent.execute(fix_req.clone())).await;
-        *turns_used += 1;
-        match fix_resp {
-            Ok(Ok(r)) => {
-                if let Some(val_err) = run_post_execute(interceptors, &fix_req, &r).await {
-                    tracing::warn!(
-                        agent_round,
-                        error = %val_err,
-                        "post-execute validation failed in agent review fix; continuing"
-                    );
-                }
-            }
-            Ok(Err(e)) => {
-                run_on_error(interceptors, &fix_req, &e.to_string()).await;
-                return Err(e.into());
-            }
-            Err(_) => {
-                let msg = format!(
-                    "Agent review fix round {agent_round} timed out after {}s",
-                    turn_timeout.as_secs()
-                );
-                run_on_error(interceptors, &fix_req, &msg).await;
-                return Err(anyhow::anyhow!("{msg}"));
-            }
-        }
-
-        mutate_and_persist(store, task_id, |s| {
-            s.rounds.push(RoundResult {
-                turn: 0,
-                action: "agent_review_fix".into(),
-                result: "fixed".into(),
-                detail: None,
-                first_token_latency_ms: None,
-            });
-        })
-        .await?;
-        pushed_commit = true;
-    }
-
-    Ok((true, pushed_commit))
-}
+// run_agent_review removed — replaced by agent_review::run (issue #772)
 
 #[cfg(test)]
 mod tests {

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -1,0 +1,475 @@
+/// Agent review phase module.
+///
+/// Runs the internal AI reviewer against the PR diff, cycling through rounds
+/// of review + fix until the reviewer approves or the round budget is exhausted.
+///
+/// Part 3 adds an optional compilation gate (`enable_compilation_gate`):
+/// when enabled, `cargo check --workspace` and `cargo test` are run between
+/// review rounds and the output is included in the reviewer prompt context.
+/// The gate is off by default to preserve existing behavior.
+///
+/// **Note:** `cargo check`/`cargo test` calls in this module are harness-level
+/// orchestration, NOT agent-side. They are not gh/git calls and do not violate
+/// the CLAUDE.md ban on `gh`/`git` inside harness crates.
+use crate::task_runner::{mutate_and_persist, RoundResult, TaskStatus};
+use harness_core::agent::{AgentRequest, AgentResponse};
+use harness_core::error::HarnessError;
+use harness_core::prompts;
+use harness_core::tool_isolation::validate_tool_usage;
+use harness_core::types::{ContextItem, Decision, Event, ExecutionPhase, SessionId};
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::process::Command as TokioCommand;
+use tokio::time::{timeout, Duration};
+
+use super::helpers::{run_on_error, run_post_execute, run_pre_execute, update_status};
+use super::TaskContext;
+
+/// Outcome returned by the agent review phase to the orchestrator.
+pub(crate) enum AgentReviewOutcome {
+    /// Review determined the task is done or failed (quota exhausted, fatal
+    /// impasse). The orchestrator should return `Ok(())` immediately.
+    Handled,
+    /// Agent review completed (approved or exhausted rounds). The orchestrator
+    /// proceeds to the external review bot loop.
+    ReviewComplete {
+        /// Whether the agent pushed a new commit during any review round.
+        pushed_commit: bool,
+    },
+}
+
+/// Output from a `cargo check` run.
+pub(crate) struct CompileOutput {
+    pub success: bool,
+    pub stderr: String,
+}
+
+/// Output from a `cargo test` run.
+pub(crate) struct TestOutput {
+    pub success: bool,
+    pub output: String,
+}
+
+/// Run `cargo check --workspace` and capture the result.
+///
+/// Uses the per-task `CARGO_TARGET_DIR` from `cargo_env` so parallel agents
+/// don't contend on the same build directory (issue #488).
+pub(crate) async fn run_compile_check(
+    workspace: &Path,
+    cargo_env: &HashMap<String, String>,
+) -> CompileOutput {
+    let result = TokioCommand::new("cargo")
+        .args(["check", "--workspace"])
+        .current_dir(workspace)
+        .envs(cargo_env)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn();
+
+    let child = match result {
+        Ok(c) => c,
+        Err(e) => {
+            return CompileOutput {
+                success: false,
+                stderr: format!("failed to spawn cargo check: {e}"),
+            }
+        }
+    };
+
+    match timeout(Duration::from_secs(300), child.wait_with_output()).await {
+        Ok(Ok(out)) => CompileOutput {
+            success: out.status.success(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        },
+        Ok(Err(e)) => CompileOutput {
+            success: false,
+            stderr: format!("cargo check wait error: {e}"),
+        },
+        Err(_) => CompileOutput {
+            success: false,
+            stderr: "cargo check timed out after 300s".to_string(),
+        },
+    }
+}
+
+/// Run `cargo test --package <package>` and capture the result.
+///
+/// If `package` is empty, runs `cargo test --workspace`.
+pub(crate) async fn run_test_suite(
+    package: &str,
+    workspace: &Path,
+    cargo_env: &HashMap<String, String>,
+) -> TestOutput {
+    let args: Vec<&str> = if package.is_empty() {
+        vec!["test", "--workspace"]
+    } else {
+        vec!["test", "--package", package]
+    };
+
+    let result = TokioCommand::new("cargo")
+        .args(&args)
+        .current_dir(workspace)
+        .envs(cargo_env)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn();
+
+    let child = match result {
+        Ok(c) => c,
+        Err(e) => {
+            return TestOutput {
+                success: false,
+                output: format!("failed to spawn cargo test: {e}"),
+            }
+        }
+    };
+
+    match timeout(Duration::from_secs(600), child.wait_with_output()).await {
+        Ok(Ok(out)) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            TestOutput {
+                success: out.status.success(),
+                output: format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
+            }
+        }
+        Ok(Err(e)) => TestOutput {
+            success: false,
+            output: format!("cargo test wait error: {e}"),
+        },
+        Err(_) => TestOutput {
+            success: false,
+            output: "cargo test timed out after 600s".to_string(),
+        },
+    }
+}
+
+/// Run the agent review loop.
+///
+/// If `ctx.review_config.enable_compilation_gate` is true, runs
+/// `cargo check --workspace` and `cargo test` between rounds and includes the
+/// output in the reviewer prompt.
+pub(crate) async fn run(
+    ctx: &TaskContext<'_>,
+    pr_url: &str,
+    context_items: &[ContextItem],
+    effective_max_turns: Option<u32>,
+    turns_used: &mut u32,
+) -> anyhow::Result<AgentReviewOutcome> {
+    let reviewer = match ctx.reviewer {
+        Some(r) => r,
+        None => {
+            tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
+            return Ok(AgentReviewOutcome::ReviewComplete {
+                pushed_commit: false,
+            });
+        }
+    };
+
+    let max_rounds = ctx.review_config.max_rounds;
+    let project_type = ctx.project_config.review_type.as_str();
+    let mut impasse_tracker: Option<(Vec<String>, u32)> = None;
+    let mut pushed_commit = false;
+    // Carry compile/test failure output into the next review round when the
+    // compilation gate is enabled and a check failed.
+    let mut pending_gate_failure: Option<String> = None;
+
+    for agent_round in 1..=max_rounds {
+        update_status(ctx.store, ctx.task_id, TaskStatus::AgentReview, agent_round).await?;
+
+        // Reviewer evaluates the PR diff — read-only except Bash for `gh pr diff`.
+        let base_review_prompt = prompts::agent_review_prompt(pr_url, agent_round, project_type);
+        let note = prompts::reviewer_capability_note();
+        let review_prompt = if let Some(gate_fail) = pending_gate_failure.take() {
+            format!(
+                "{note}\n\n\
+                 IMPORTANT: The previous round's compilation/test gate failed. \
+                 Fix the issues before re-reviewing.\n\n\
+                 Gate output:\n```\n{gate_fail}\n```\n\n{base_review_prompt}"
+            )
+        } else {
+            format!("{note}\n\n{base_review_prompt}")
+        };
+
+        let review_req = AgentRequest {
+            prompt: review_prompt,
+            project_root: ctx.project.clone(),
+            context: context_items.to_vec(),
+            execution_phase: Some(ExecutionPhase::Validation),
+            allowed_tools: Some(vec![
+                "Read".to_string(),
+                "Grep".to_string(),
+                "Glob".to_string(),
+                "Bash".to_string(),
+            ]),
+            env_vars: ctx.cargo_env.clone(),
+            ..Default::default()
+        };
+        let review_req = run_pre_execute(&ctx.interceptors, review_req).await?;
+
+        if let Some(max) = effective_max_turns {
+            if *turns_used >= max {
+                return Err(anyhow::anyhow!(
+                    "Turn budget exhausted before agent review round {agent_round}: \
+                     used {} of {} allowed turns",
+                    turns_used,
+                    max
+                ));
+            }
+        }
+        let resp = timeout(ctx.turn_timeout, reviewer.execute(review_req.clone())).await;
+        *turns_used += 1;
+        let resp = match resp {
+            Ok(Ok(r)) => {
+                let tool_violations = validate_tool_usage(
+                    &r.output,
+                    review_req.allowed_tools.as_deref().unwrap_or(&[]),
+                );
+                if !tool_violations.is_empty() {
+                    let msg = format!(
+                        "Tool isolation violation in agent review round {agent_round}: \
+                         agent used disallowed tools: [{}]",
+                        tool_violations.join(", ")
+                    );
+                    tracing::warn!(
+                        agent_round,
+                        ?tool_violations,
+                        "agent review: agent used tools outside allowed list"
+                    );
+                    run_on_error(&ctx.interceptors, &review_req, &msg).await;
+                    return Err(anyhow::anyhow!("{msg}"));
+                }
+                if let Some(val_err) = run_post_execute(&ctx.interceptors, &review_req, &r).await {
+                    tracing::warn!(
+                        agent_round,
+                        error = %val_err,
+                        "post-execute validation failed in agent review; continuing"
+                    );
+                }
+                r
+            }
+            Ok(Err(e)) => {
+                if matches!(e, HarnessError::QuotaExhausted(_)) {
+                    tracing::error!(
+                        agent_round,
+                        error = %e,
+                        "quota exhausted during agent review — aborting"
+                    );
+                    run_on_error(&ctx.interceptors, &review_req, &e.to_string()).await;
+                    mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.error = Some(e.to_string());
+                    })
+                    .await?;
+                    return Ok(AgentReviewOutcome::Handled);
+                }
+                run_on_error(&ctx.interceptors, &review_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Agent review round {agent_round} timed out after {}s",
+                    ctx.turn_timeout.as_secs()
+                );
+                run_on_error(&ctx.interceptors, &review_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        };
+
+        let AgentResponse { output, stderr, .. } = resp;
+
+        if !stderr.is_empty() {
+            tracing::warn!(agent_round, stderr = %stderr, "agent reviewer stderr");
+        }
+
+        let approved = prompts::is_approved(&output);
+        let issues = prompts::extract_review_issues(&output);
+        let review_detail = output;
+
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: 0,
+                action: "agent_review".into(),
+                result: if approved {
+                    "approved".into()
+                } else {
+                    format!("{} issues", issues.len())
+                },
+                detail: Some(review_detail.clone()),
+                first_token_latency_ms: None,
+            });
+        })
+        .await?;
+
+        let mut ev = Event::new(
+            SessionId::new(),
+            "agent_review",
+            "task_runner",
+            if approved {
+                Decision::Complete
+            } else {
+                Decision::Warn
+            },
+        );
+        ev.detail = Some(format!("pr={pr_url}"));
+        ev.reason = Some(if approved {
+            format!("round {agent_round}: approved")
+        } else {
+            format!("round {agent_round}: {} issues", issues.len())
+        });
+        if let Err(e) = ctx.events.log(&ev).await {
+            tracing::warn!("failed to log agent_review event: {e}");
+        }
+
+        if approved {
+            // Compilation gate (Part 3): verify the code actually compiles and
+            // tests pass before accepting the agent's approval.
+            if ctx.review_config.enable_compilation_gate {
+                let compile = run_compile_check(&ctx.project, &ctx.cargo_env).await;
+                if !compile.success {
+                    tracing::warn!(
+                        agent_round,
+                        "compilation gate failed; re-entering review loop"
+                    );
+                    pending_gate_failure = Some(format!("Compilation failed:\n{}", compile.stderr));
+                    continue;
+                }
+                let pkg = ctx.project_config.review_type.as_str();
+                let tests = run_test_suite(pkg, &ctx.project, &ctx.cargo_env).await;
+                if !tests.success {
+                    tracing::warn!(
+                        agent_round,
+                        "test gate failed in agent review; re-entering review loop"
+                    );
+                    pending_gate_failure = Some(format!("Tests failed:\n{}", tests.output));
+                    continue;
+                }
+            }
+            tracing::info!("agent review approved at round {agent_round}");
+            break;
+        }
+
+        // Malformed reviewer output: neither APPROVED nor any ISSUE: lines.
+        if issues.is_empty() {
+            tracing::warn!(
+                agent_round,
+                "agent reviewer output contained neither APPROVED nor ISSUE: lines; \
+                 treating as protocol failure and skipping fix round"
+            );
+            break;
+        }
+
+        // Detect impasse: track how many consecutive rounds produced identical issues.
+        let normalized = super::normalize_issues(&issues);
+        let consecutive_count = match &impasse_tracker {
+            Some((prev, c)) if *prev == normalized => c + 1,
+            _ => 1,
+        };
+        impasse_tracker = Some((normalized, consecutive_count));
+
+        if consecutive_count >= 5 {
+            tracing::warn!(
+                agent_round,
+                consecutive_count,
+                "agent review impasse: same issues repeated 5 times — marking task as failed"
+            );
+            mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                s.status = TaskStatus::Failed;
+                s.error = Some(format!(
+                    "Impasse detected: identical issues repeated {consecutive_count} \
+                     consecutive rounds."
+                ));
+            })
+            .await?;
+            return Ok(AgentReviewOutcome::Handled);
+        }
+
+        let is_impasse = consecutive_count >= 3;
+        if is_impasse {
+            tracing::warn!(
+                agent_round,
+                consecutive_count,
+                "agent review impasse detected — same issues repeated, using intervention prompt"
+            );
+        }
+
+        if agent_round == max_rounds && !is_impasse {
+            tracing::info!(
+                "agent review exhausted {max_rounds} rounds, proceeding to GitHub review"
+            );
+            break;
+        }
+
+        // Implementor fixes the issues.
+        let fix_req = AgentRequest {
+            prompt: {
+                let prompt_fn = if is_impasse {
+                    prompts::agent_review_intervention_prompt
+                } else {
+                    prompts::agent_review_fix_prompt
+                };
+                prompt_fn(pr_url, &issues, agent_round, project_type)
+            },
+            project_root: ctx.project.clone(),
+            context: context_items.to_vec(),
+            execution_phase: Some(ExecutionPhase::Execution),
+            env_vars: ctx.cargo_env.clone(),
+            ..Default::default()
+        };
+        let fix_req = run_pre_execute(&ctx.interceptors, fix_req).await?;
+
+        if let Some(max) = effective_max_turns {
+            if *turns_used >= max {
+                return Err(anyhow::anyhow!(
+                    "Turn budget exhausted before agent review fix round {agent_round}: \
+                     used {} of {} allowed turns",
+                    turns_used,
+                    max
+                ));
+            }
+        }
+        let fix_resp = timeout(ctx.turn_timeout, ctx.agent.execute(fix_req.clone())).await;
+        *turns_used += 1;
+        match fix_resp {
+            Ok(Ok(r)) => {
+                if let Some(val_err) = run_post_execute(&ctx.interceptors, &fix_req, &r).await {
+                    tracing::warn!(
+                        agent_round,
+                        error = %val_err,
+                        "post-execute validation failed in agent review fix; continuing"
+                    );
+                }
+            }
+            Ok(Err(e)) => {
+                run_on_error(&ctx.interceptors, &fix_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Agent review fix round {agent_round} timed out after {}s",
+                    ctx.turn_timeout.as_secs()
+                );
+                run_on_error(&ctx.interceptors, &fix_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        }
+
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: 0,
+                action: "agent_review_fix".into(),
+                result: "fixed".into(),
+                detail: None,
+                first_token_latency_ms: None,
+            });
+        })
+        .await?;
+        pushed_commit = true;
+    }
+
+    Ok(AgentReviewOutcome::ReviewComplete { pushed_commit })
+}

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -1,0 +1,616 @@
+/// Implementation phase pipeline module.
+///
+/// Builds the implementation prompt, executes the agent with post-execution
+/// validation and auto-retry, and returns the resulting PR URL and number.
+///
+/// **Note:** `cargo check` / `cargo test` are agent-side operations driven by
+/// harness prompts — this module spawns no Cargo subprocesses directly.
+use crate::task_runner::{mutate_and_persist, RoundResult, TaskStatus};
+use harness_core::agent::{AgentRequest, AgentResponse};
+use harness_core::interceptor::ToolUseEvent;
+use harness_core::tool_isolation::validate_tool_usage;
+use harness_core::types::{ContextItem, Decision, Event, ExecutionPhase, SessionId};
+use harness_core::{lang_detect, prompts};
+use tokio::time::{sleep, timeout, Duration, Instant};
+
+use super::helpers::{
+    collect_context_items, detect_modified_files, inject_skills_into_prompt,
+    matched_skills_for_prompt, run_on_error, run_post_execute, run_post_tool_use, run_pre_execute,
+    truncate_validation_error,
+};
+use super::pr_detection::find_existing_pr_for_issue;
+use super::{
+    compute_backoff_ms, parse_implementation_outcome, prepend_constitution, restricted_tools,
+    run_agent_streaming, ImplementationOutcome, TaskContext,
+};
+use harness_core::config::agents::CapabilityProfile;
+
+/// Outcome returned by the implementation pipeline to the orchestrator.
+pub(crate) enum ImplementOutcome {
+    /// Task was handled internally (marked Done or Failed). The orchestrator
+    /// should return `Ok(())` immediately.
+    Handled,
+    /// A PR is ready for review.
+    PrReady {
+        pr_url: Option<String>,
+        pr_num: u64,
+        /// Context items collected from skills / project; passed to review phases.
+        context_items: Vec<ContextItem>,
+        /// Whether the agent committed code during this phase (used to set
+        /// `prev_fixed` for the external review bot loop).
+        agent_pushed_commit: bool,
+    },
+}
+
+/// Run the implementation phase.
+///
+/// * `plan_output` — optional plan text from the triage pipeline.
+/// * `resumed_pr_url` — if `Some`, skip the agent entirely and return the
+///   existing PR URL directly (checkpoint resume).
+/// * `effective_max_turns` — optional turn budget.
+/// * `turns_used` — accumulated turn counter; updated in-place.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run(
+    ctx: &TaskContext<'_>,
+    plan_output: Option<String>,
+    resumed_pr_url: Option<String>,
+    effective_max_turns: Option<u32>,
+    turns_used: &mut u32,
+) -> anyhow::Result<ImplementOutcome> {
+    // --- Checkpoint resume: PR already exists, skip agent entirely ---
+    if let Some(pr_str) = resumed_pr_url {
+        tracing::info!(
+            task_id = %ctx.task_id,
+            pr_url = %pr_str,
+            "checkpoint resume: PR exists, skipping implement phase"
+        );
+        let Some(pr_num) = prompts::extract_pr_number(&pr_str) else {
+            tracing::error!(
+                task_id = %ctx.task_id,
+                pr_url = %pr_str,
+                "checkpoint resume: cannot parse PR number, marking failed"
+            );
+            mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                s.status = TaskStatus::Failed;
+                s.turn = 1;
+                s.error = Some(format!("checkpoint resume: no PR number in {pr_str}"));
+            })
+            .await?;
+            return Ok(ImplementOutcome::Handled);
+        };
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.pr_url = Some(pr_str.clone());
+            s.rounds.push(RoundResult {
+                turn: 1,
+                action: "implement".into(),
+                result: "resumed_checkpoint".into(),
+                detail: None,
+                first_token_latency_ms: None,
+            });
+        })
+        .await?;
+        // context_items not needed for checkpoint-resumed tasks (review loop
+        // uses them but the checkpoint case already had them in a prior run).
+        // Pass an empty vec; the review phases will re-collect as needed.
+        return Ok(ImplementOutcome::PrReady {
+            pr_url: Some(pr_str),
+            pr_num,
+            context_items: Vec::new(),
+            agent_pushed_commit: false,
+        });
+    }
+
+    // --- Build implementation prompt ---
+    let git = Some(&ctx.project_config.git);
+    let first_prompt = build_first_prompt(ctx, plan_output.as_deref(), git).await?;
+
+    // Inject language-detected validation instructions when no explicit
+    // validation config is set.
+    let first_prompt = if ctx.project_config.validation.pre_commit.is_empty()
+        && ctx.project_config.validation.pre_push.is_empty()
+    {
+        let lang = lang_detect::detect_language(&ctx.project);
+        let instructions = lang_detect::validation_prompt_instructions(lang, &ctx.project);
+        if instructions.is_empty() {
+            first_prompt
+        } else {
+            format!("{first_prompt}\n\n{instructions}")
+        }
+    } else {
+        first_prompt
+    };
+
+    // Inject sibling-awareness context when other agents are working on the same project.
+    let first_prompt = {
+        let canonical_project = ctx
+            .store
+            .get(ctx.task_id)
+            .and_then(|s| s.project_root)
+            .unwrap_or_else(|| ctx.project.clone());
+        let siblings = ctx.store.list_siblings(&canonical_project, ctx.task_id);
+        if siblings.is_empty() {
+            first_prompt
+        } else {
+            let sibling_tasks: Vec<prompts::SiblingTask> = siblings
+                .into_iter()
+                .filter_map(|s| {
+                    s.description.and_then(|description| {
+                        if description.is_empty() {
+                            None
+                        } else {
+                            Some(prompts::SiblingTask {
+                                issue: s.issue,
+                                description,
+                            })
+                        }
+                    })
+                })
+                .collect();
+            let sibling_ctx = prompts::sibling_task_context(&sibling_tasks);
+            format!("{first_prompt}\n\n{sibling_ctx}")
+        }
+    };
+
+    // Prepend the Golden Principles constitution when enabled.
+    let first_prompt =
+        prepend_constitution(first_prompt, ctx.server_config.server.constitution_enabled);
+
+    // Inject skill content directly into the prompt text.
+    let matched_skills = matched_skills_for_prompt(&ctx.skills, &first_prompt).await;
+    let skill_additions = inject_skills_into_prompt(&ctx.skills, &first_prompt).await;
+    let first_prompt = if skill_additions.is_empty() {
+        first_prompt
+    } else {
+        first_prompt + &skill_additions
+    };
+    for (skill_id, skill_name) in matched_skills {
+        let mut skill_event = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        skill_event.reason = Some(skill_name);
+        skill_event.detail = Some(format!(
+            "task_id={} skill_id={}",
+            ctx.task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = ctx.events.log(&skill_event).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
+
+    let context_items = collect_context_items(&ctx.skills, &ctx.project, &first_prompt).await;
+
+    tracing::info!(
+        task_id = %ctx.task_id,
+        prompt_len = first_prompt.len(),
+        prompt_empty = first_prompt.is_empty(),
+        source = ?ctx.req.source,
+        "run_task: prompt constructed"
+    );
+    if first_prompt.is_empty() {
+        tracing::error!(task_id = %ctx.task_id, "run_task: prompt is empty — agent will fail");
+    }
+
+    // Periodic review tasks need Bash but not unrestricted write access.
+    let (initial_allowed_tools, capability_prompt_note) = if matches!(
+        ctx.req.source.as_deref(),
+        Some("periodic_review") | Some("sprint_planner")
+    ) {
+        (
+            Some(restricted_tools(CapabilityProfile::Standard)?),
+            CapabilityProfile::Standard.prompt_note(),
+        )
+    } else {
+        (None, None)
+    };
+
+    // Prepend capability restriction note.
+    let first_prompt = if let Some(note) = capability_prompt_note {
+        format!("{note}\n\n{first_prompt}")
+    } else {
+        first_prompt
+    };
+
+    let impl_phase_start = Instant::now();
+
+    let initial_req = AgentRequest {
+        prompt: first_prompt,
+        project_root: ctx.project.clone(),
+        context: context_items.clone(),
+        max_budget_usd: ctx.req.max_budget_usd,
+        execution_phase: Some(ExecutionPhase::Planning),
+        allowed_tools: initial_allowed_tools,
+        env_vars: ctx.cargo_env.clone(),
+        ..Default::default()
+    };
+
+    let first_req = run_pre_execute(&ctx.interceptors, initial_req).await?;
+
+    // Execute implementation turn with post-execution validation and auto-retry.
+    let max_validation_retries: u32 = ctx
+        .interceptors
+        .iter()
+        .filter_map(|i| i.max_validation_retries())
+        .max()
+        .unwrap_or(2);
+    let mut validation_attempt = 0u32;
+    let mut impl_req = first_req.clone();
+
+    let resp = loop {
+        if let Some(max) = effective_max_turns {
+            if *turns_used >= max {
+                return Err(anyhow::anyhow!(
+                    "Turn budget exhausted: used {} of {} allowed turns",
+                    turns_used,
+                    max
+                ));
+            }
+        }
+        let raw = timeout(
+            ctx.turn_timeout,
+            run_agent_streaming(ctx.agent, impl_req.clone(), ctx.task_id, ctx.store, 1),
+        )
+        .await;
+        *turns_used += 1;
+        match raw {
+            Ok(Ok((r, impl_first_token_ms))) => {
+                let impl_tools = impl_req.allowed_tools.as_deref().unwrap_or(&[]);
+                let tool_violations = validate_tool_usage(&r.output, impl_tools);
+                let violation_err: Option<String> = if !tool_violations.is_empty() {
+                    let msg = format!(
+                        "[VALIDATION ERROR] Tool isolation violation: agent used disallowed tools: [{}]. Only [{}] are permitted.",
+                        tool_violations.join(", "),
+                        impl_tools.join(", ")
+                    );
+                    tracing::warn!(
+                        ?tool_violations,
+                        "implementation turn: agent used tools outside allowed list"
+                    );
+                    Some(msg)
+                } else {
+                    None
+                };
+                let hook_err = {
+                    let modified = detect_modified_files(&ctx.project).await;
+                    if modified.is_empty() {
+                        None
+                    } else {
+                        let hook_event = ToolUseEvent {
+                            tool_name: "file_write".to_string(),
+                            affected_files: modified,
+                            session_id: None,
+                        };
+                        run_post_tool_use(&ctx.interceptors, &hook_event, &ctx.project).await
+                    }
+                };
+                let post_err = run_post_execute(&ctx.interceptors, &impl_req, &r).await;
+                let combined_err = violation_err.or(hook_err).or(post_err);
+                if let Some(err) = combined_err {
+                    if validation_attempt < max_validation_retries {
+                        validation_attempt += 1;
+                        let backoff_ms = compute_backoff_ms(
+                            ctx.req.retry_base_backoff_ms,
+                            ctx.req.retry_max_backoff_ms,
+                            validation_attempt,
+                        );
+                        tracing::warn!(
+                            attempt = validation_attempt,
+                            max = max_validation_retries,
+                            backoff_ms,
+                            error = %err,
+                            "post-execution validation failed; backing off before retry"
+                        );
+                        let truncated = truncate_validation_error(&err, 2000);
+                        impl_req.prompt = prompts::validation_retry_error_context(
+                            &first_req.prompt,
+                            &truncated,
+                            validation_attempt,
+                            max_validation_retries,
+                        );
+                        sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    } else {
+                        tracing::error!(
+                            max = max_validation_retries,
+                            error = %err,
+                            "post-execution validation failed after max retries; aborting task"
+                        );
+                        run_on_error(&ctx.interceptors, &impl_req, &err).await;
+                        return Err(anyhow::anyhow!(
+                            "Post-execution validation failed after {} attempts: {}",
+                            max_validation_retries,
+                            err
+                        ));
+                    }
+                }
+                break (r, impl_first_token_ms);
+            }
+            Ok(Err(e)) => {
+                run_on_error(&ctx.interceptors, &impl_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Implementation turn timed out after {}s",
+                    ctx.turn_timeout.as_secs()
+                );
+                run_on_error(&ctx.interceptors, &impl_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        }
+    };
+
+    let (
+        AgentResponse {
+            output,
+            stderr,
+            token_usage: impl_token_usage,
+            ..
+        },
+        impl_first_token_ms,
+    ) = resp;
+
+    tracing::info!(
+        task_id = %ctx.task_id,
+        phase = "implementing",
+        elapsed_secs = impl_phase_start.elapsed().as_secs(),
+        "phase_completed"
+    );
+    {
+        let preview: String = output.chars().take(200).collect();
+        tracing::info!(
+            task_id = %ctx.task_id,
+            output_chars = output.len(),
+            preview = %preview,
+            input_tokens = impl_token_usage.input_tokens,
+            output_tokens = impl_token_usage.output_tokens,
+            "agent_output_summary"
+        );
+    }
+
+    if !stderr.is_empty() {
+        tracing::warn!(stderr = %stderr, "agent stderr during implementation");
+    }
+
+    // Review-only tasks produce a report, not a PR.
+    let is_review_task = ctx.store.get(ctx.task_id).is_some_and(|s| {
+        matches!(
+            s.source.as_deref(),
+            Some("periodic_review") | Some("sprint_planner")
+        )
+    });
+
+    if is_review_task {
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.status = TaskStatus::Done;
+            s.turn = 1;
+            s.rounds.push(RoundResult {
+                turn: 1,
+                action: "review".into(),
+                result: "completed".into(),
+                detail: if output.is_empty() {
+                    None
+                } else {
+                    Some(output.clone())
+                },
+                first_token_latency_ms: impl_first_token_ms,
+            });
+        })
+        .await?;
+        ctx.store
+            .log_event(crate::event_replay::TaskEvent::Completed {
+                task_id: ctx.task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+            });
+        tracing::info!(
+            task_id = %ctx.task_id,
+            status = "done",
+            turns = 1,
+            pr_url = tracing::field::Empty,
+            total_elapsed_secs = ctx.task_start.elapsed().as_secs(),
+            "task_completed"
+        );
+        return Ok(ImplementOutcome::Handled);
+    }
+
+    let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
+        ImplementationOutcome::PlanIssue(plan_issue) => {
+            tracing::error!(
+                task_id = %ctx.task_id,
+                plan_issue = %plan_issue,
+                "implementation returned PLAN_ISSUE; marking task failed"
+            );
+            mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                s.status = TaskStatus::Failed;
+                s.turn = 2;
+                s.error = Some(plan_issue.clone());
+                s.rounds.push(RoundResult {
+                    turn: 1,
+                    action: "implement".into(),
+                    result: "plan_issue".into(),
+                    detail: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.clone())
+                    },
+                    first_token_latency_ms: impl_first_token_ms,
+                });
+            })
+            .await?;
+            tracing::info!(
+                task_id = %ctx.task_id,
+                status = "failed",
+                turns = 2,
+                pr_url = tracing::field::Empty,
+                total_elapsed_secs = ctx.task_start.elapsed().as_secs(),
+                "task_completed"
+            );
+            return Ok(ImplementOutcome::Handled);
+        }
+        ImplementationOutcome::ParsedPr {
+            pr_url,
+            pr_num,
+            created_issue_num,
+        } => (pr_url, pr_num, created_issue_num),
+    };
+
+    mutate_and_persist(ctx.store, ctx.task_id, |s| {
+        s.pr_url = pr_url.clone();
+        s.rounds.push(RoundResult {
+            turn: 1,
+            action: "implement".into(),
+            result: if pr_num.is_some() {
+                "pr_created".into()
+            } else {
+                "no_pr".into()
+            },
+            detail: if output.is_empty() {
+                None
+            } else {
+                Some(output.clone())
+            },
+            first_token_latency_ms: impl_first_token_ms,
+        });
+    })
+    .await?;
+
+    // Back-fill external_id for auto-fix tasks that created a GitHub issue.
+    if let Some(issue_num) = created_issue_num {
+        let final_eid = format!("issue:{issue_num}");
+        let needs_backfill = ctx.store.get(ctx.task_id).is_some_and(|s| {
+            s.source.as_deref() == Some("auto-fix") && s.external_id.as_deref() != Some(&final_eid)
+        });
+        if needs_backfill {
+            if let Err(e) = ctx
+                .store
+                .overwrite_external_id_auto_fix(ctx.task_id, &final_eid)
+                .await
+            {
+                tracing::warn!(task_id = %ctx.task_id, "failed to back-fill external_id: {e}");
+            } else {
+                tracing::info!(
+                    task_id = %ctx.task_id,
+                    external_id = %final_eid,
+                    "back-filled external_id for auto-fix task"
+                );
+            }
+        }
+    }
+
+    // Emit PrDetected event so crash recovery can reconstruct pr_url.
+    if let Some(pr_url_str) = pr_url.as_deref() {
+        ctx.store
+            .log_event(crate::event_replay::TaskEvent::PrDetected {
+                task_id: ctx.task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+                pr_url: pr_url_str.to_string(),
+            });
+    }
+
+    // Write PR checkpoint — prevents duplicate PR creation on resume.
+    if let Some(pr_url_str) = pr_url.as_deref() {
+        if let Err(e) = ctx
+            .store
+            .write_checkpoint(ctx.task_id, None, None, Some(pr_url_str), "pr_created")
+            .await
+        {
+            tracing::warn!(task_id = %ctx.task_id, "failed to write pr checkpoint: {e}");
+        }
+    }
+
+    // Log implementation event.
+    let mut ev = Event::new(
+        SessionId::new(),
+        "task_implement",
+        "task_runner",
+        harness_core::types::Decision::Complete,
+    );
+    ev.detail = pr_num.map(|n| format!("pr={n}"));
+    if let Err(e) = ctx.events.log(&ev).await {
+        tracing::warn!("failed to log task_implement event: {e}");
+    }
+
+    let Some(pr_num) = pr_num else {
+        tracing::warn!("no PR number found in agent output; skipping review");
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.status = TaskStatus::Done;
+            s.turn = 2;
+        })
+        .await?;
+        ctx.store
+            .log_event(crate::event_replay::TaskEvent::Completed {
+                task_id: ctx.task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+            });
+        tracing::info!(
+            task_id = %ctx.task_id,
+            status = "done",
+            turns = 2,
+            pr_url = tracing::field::Empty,
+            total_elapsed_secs = ctx.task_start.elapsed().as_secs(),
+            "task_completed"
+        );
+        return Ok(ImplementOutcome::Handled);
+    };
+
+    Ok(ImplementOutcome::PrReady {
+        pr_url,
+        pr_num,
+        context_items,
+        agent_pushed_commit: false,
+    })
+}
+
+/// Build the base first-turn prompt before skill injection and constitution prepend.
+async fn build_first_prompt(
+    ctx: &TaskContext<'_>,
+    plan_output: Option<&str>,
+    git: Option<&harness_core::config::project::GitConfig>,
+) -> anyhow::Result<String> {
+    if let Some(issue) = ctx.req.issue {
+        let base = match find_existing_pr_for_issue(&ctx.project, issue).await {
+            Ok(Some((pr_num, branch, pr_url))) => {
+                tracing::info!(
+                    "reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}"
+                );
+                let slug = prompts::repo_slug_from_pr_url(Some(&pr_url));
+                prompts::continue_existing_pr(issue, pr_num, &branch, &slug)
+            }
+            Ok(None) => prompts::implement_from_issue(issue, git, plan_output).to_prompt_string(),
+            Err(e) => {
+                tracing::warn!("failed to check for existing PR for issue #{issue}: {e}");
+                prompts::implement_from_issue(issue, git, plan_output).to_prompt_string()
+            }
+        };
+        let prompt = if let Some(hint) = ctx.req.prompt.as_deref().filter(|s| !s.is_empty()) {
+            format!(
+                "{base}\n\nAdditional context from caller:\n{}",
+                prompts::wrap_external_data(hint)
+            )
+        } else {
+            base
+        };
+        Ok(prompt)
+    } else if let Some(pr) = ctx.req.pr {
+        Ok(prompts::check_existing_pr(
+            pr,
+            &ctx.review_config.review_bot_command,
+            &ctx.repo_slug,
+            &ctx.review_config.reviewer_name,
+            false,
+        ))
+    } else if matches!(
+        ctx.req.source.as_deref(),
+        Some("periodic_review") | Some("sprint_planner")
+    ) {
+        Ok(ctx.req.prompt.clone().unwrap_or_default())
+    } else {
+        Ok(prompts::implement_from_prompt(
+            ctx.req.prompt.as_deref().unwrap_or_default(),
+            git,
+        ))
+    }
+}

--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -1,0 +1,414 @@
+/// External review bot loop module.
+///
+/// Waits for the external review bot (e.g. Gemini) to post review comments,
+/// dispatches fix agents when issues are found, and loops until LGTM is
+/// received, the round budget is exhausted, or a loop is detected.
+use crate::task_runner::{mutate_and_persist, RoundResult, TaskStatus};
+use harness_core::agent::AgentRequest;
+use harness_core::error::HarnessError;
+use harness_core::prompts;
+use harness_core::tool_isolation::validate_tool_usage;
+use harness_core::types::{ContextItem, Decision, Event, ExecutionPhase, SessionId};
+use tokio::time::{sleep, timeout, Duration, Instant};
+
+use super::helpers::{run_on_error, run_post_execute, run_pre_execute, update_status};
+use super::TaskContext;
+
+/// Run the external review bot wait loop.
+///
+/// Waits for the external review bot to post review feedback, dispatches fix
+/// agents when issues are found, and terminates when:
+/// - The bot posts LGTM and the test gate passes → task marked Done.
+/// - Round budget exhausted → task marked Done (graduated) or Failed.
+/// - Jaccard loop detected → task marked Failed.
+/// - Turn budget exhausted → task marked Failed.
+///
+/// `pr_url` and `pr_num` identify the PR being reviewed.
+/// `context_items` are passed to each fix agent for context.
+/// `effective_max_rounds` is the triage-derived (or caller-overridden) round cap.
+/// `prev_fixed` is true when the implementation or agent review pushed a commit.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run(
+    ctx: &TaskContext<'_>,
+    pr_url: Option<String>,
+    pr_num: u64,
+    context_items: Vec<ContextItem>,
+    effective_max_rounds: u32,
+    effective_max_turns: Option<u32>,
+    prev_fixed: bool,
+    turns_used: &mut u32,
+) -> anyhow::Result<()> {
+    let mut waiting_count: u32 = 1;
+    update_status(ctx.store, ctx.task_id, TaskStatus::Waiting, waiting_count).await?;
+
+    let wait_secs = ctx.resolved_review_wait_secs.unwrap_or(ctx.req.wait_secs);
+    let max_rounds = ctx
+        .resolved_review_max_rounds
+        .unwrap_or(effective_max_rounds);
+    tracing::info!("waiting {wait_secs}s for review bot on PR #{pr_num}");
+    sleep(Duration::from_secs(wait_secs)).await;
+
+    let review_phase_start = Instant::now();
+    let jaccard_threshold = ctx.jaccard_threshold;
+
+    let mut prev_fixed = prev_fixed;
+    let repo_slug = prompts::repo_slug_from_pr_url(pr_url.as_deref());
+
+    let mut issue_counts: Vec<Option<u32>> = Vec::new();
+    let mut impasse = false;
+    let mut pending_test_failure: Option<String> = None;
+    let mut lgtm_test_gate_rejected = false;
+    let mut prev_review_output: Option<String> = None;
+
+    let mut round: u32 = 1;
+    while round <= max_rounds {
+        update_status(ctx.store, ctx.task_id, TaskStatus::Reviewing, round).await?;
+
+        let base_prompt = prompts::review_prompt(
+            ctx.req.issue,
+            pr_num,
+            round,
+            prev_fixed,
+            &ctx.review_config.review_bot_command,
+            &ctx.review_config.reviewer_name,
+            &repo_slug,
+            impasse,
+        );
+        let round_prompt = if let Some(failure) = pending_test_failure.take() {
+            prompts::test_gate_failure_context(&failure, &base_prompt)
+        } else {
+            base_prompt
+        };
+
+        let check_req = AgentRequest {
+            prompt: round_prompt,
+            project_root: ctx.project.clone(),
+            context: context_items.clone(),
+            execution_phase: Some(ExecutionPhase::Execution),
+            env_vars: ctx.cargo_env.clone(),
+            ..Default::default()
+        };
+        let check_req = run_pre_execute(&ctx.interceptors, check_req).await?;
+
+        if let Some(max) = effective_max_turns {
+            if *turns_used >= max {
+                let msg = format!(
+                    "Turn budget exhausted: used {} of {} allowed turns",
+                    turns_used, max
+                );
+                tracing::warn!(
+                    task_id = %ctx.task_id,
+                    turns_used,
+                    max,
+                    "turn budget exhausted in review loop"
+                );
+                mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                    s.status = TaskStatus::Failed;
+                    s.error = Some(msg.clone());
+                })
+                .await?;
+                return Ok(());
+            }
+        }
+        let resp = timeout(ctx.turn_timeout, ctx.agent.execute(check_req.clone())).await;
+        *turns_used += 1;
+        let resp = match resp {
+            Ok(Ok(r)) => {
+                let tool_violations = validate_tool_usage(
+                    &r.output,
+                    check_req.allowed_tools.as_deref().unwrap_or(&[]),
+                );
+                if !tool_violations.is_empty() {
+                    let msg = format!(
+                        "Tool isolation violation in review check round {round}: \
+                         agent used disallowed tools: [{}]",
+                        tool_violations.join(", ")
+                    );
+                    tracing::warn!(
+                        round,
+                        ?tool_violations,
+                        "review check: agent used tools outside allowed list"
+                    );
+                    run_on_error(&ctx.interceptors, &check_req, &msg).await;
+                    return Err(anyhow::anyhow!("{msg}"));
+                }
+                if let Some(val_err) = run_post_execute(&ctx.interceptors, &check_req, &r).await {
+                    tracing::error!(
+                        round,
+                        error = %val_err,
+                        "post-execute validation failed in review check; will re-enter review"
+                    );
+                    pending_test_failure =
+                        Some(format!("Post-execution validation failed:\n{val_err}"));
+                }
+                r
+            }
+            Ok(Err(e)) => {
+                if matches!(e, HarnessError::QuotaExhausted(_)) {
+                    tracing::error!(
+                        round,
+                        error = %e,
+                        "quota exhausted during review — aborting review loop"
+                    );
+                    run_on_error(&ctx.interceptors, &check_req, &e.to_string()).await;
+                    mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.error = Some(e.to_string());
+                    })
+                    .await?;
+                    return Ok(());
+                }
+                run_on_error(&ctx.interceptors, &check_req, &e.to_string()).await;
+                return Err(e.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "Review check round {round} timed out after {}s",
+                    ctx.turn_timeout.as_secs()
+                );
+                run_on_error(&ctx.interceptors, &check_req, &msg).await;
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+        };
+
+        let harness_core::agent::AgentResponse { output, stderr, .. } = resp;
+
+        if !stderr.is_empty() {
+            tracing::warn!(round, stderr = %stderr, "agent stderr during review check");
+        }
+
+        let raw_lgtm = prompts::is_lgtm(&output);
+        let waiting = prompts::is_waiting(&output);
+        let lgtm = raw_lgtm && pending_test_failure.is_none();
+        let fixed = !lgtm && !waiting;
+
+        let current_issues = prompts::parse_issue_count(&output);
+
+        // Jaccard loop detection: two consecutive non-waiting, non-LGTM outputs
+        // that are too similar indicate the reviewer is stuck.
+        if !waiting && !raw_lgtm {
+            if let Some(ref prev) = prev_review_output {
+                let score = super::jaccard_word_similarity(prev, &output);
+                if score >= jaccard_threshold {
+                    let last_count = issue_counts.last().and_then(|x| *x);
+                    let progressing = matches!(
+                        (last_count, current_issues),
+                        (Some(prev_n), Some(curr_n)) if curr_n < prev_n
+                    );
+                    if !progressing {
+                        let msg = format!(
+                            "review loop detected: output similarity {score:.2} >= \
+                             threshold {jaccard_threshold:.2}"
+                        );
+                        tracing::warn!(
+                            task_id = %ctx.task_id,
+                            round,
+                            score,
+                            jaccard_threshold,
+                            "jaccard loop detected in review"
+                        );
+                        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                            s.status = TaskStatus::Failed;
+                            s.error = Some(msg.clone());
+                        })
+                        .await?;
+                        return Ok(());
+                    }
+                }
+            }
+            prev_review_output = Some(output.clone());
+        } else if raw_lgtm {
+            prev_review_output = None;
+        }
+
+        if !waiting {
+            issue_counts.push(current_issues);
+        }
+
+        // Convergence check: if the last 3 rounds all reported issues and the
+        // count is not decreasing, enter impasse mode.
+        if issue_counts.len() >= 3 && !impasse {
+            let tail = &issue_counts[issue_counts.len() - 3..];
+            if let [Some(a), Some(b), Some(c)] = tail {
+                if c >= a && c >= b {
+                    impasse = true;
+                    tracing::warn!(
+                        task_id = %ctx.task_id,
+                        round,
+                        issues = %format_args!("[{a}, {b}, {c}]"),
+                        "review loop impasse detected: issue count not decreasing"
+                    );
+                }
+            }
+        }
+
+        // WAITING: review bot hasn't posted yet.
+        const MAX_CONSECUTIVE_WAITS: u32 = 10;
+        if waiting {
+            if waiting_count >= MAX_CONSECUTIVE_WAITS {
+                tracing::warn!(
+                    round,
+                    waiting_count,
+                    "PR #{pr_num} review bot has not responded after \
+                     {MAX_CONSECUTIVE_WAITS} waits; consuming a round"
+                );
+                round += 1;
+                waiting_count = 0;
+            } else {
+                tracing::info!(
+                    round,
+                    waiting_count,
+                    "PR #{pr_num} review bot has not responded yet; sleeping"
+                );
+                waiting_count += 1;
+                update_status(ctx.store, ctx.task_id, TaskStatus::Waiting, waiting_count).await?;
+                sleep(Duration::from_secs(wait_secs)).await;
+                continue;
+            }
+        }
+
+        let result_label = if lgtm { "lgtm" } else { "fixed" };
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.rounds.push(RoundResult {
+                turn: round,
+                action: "review".into(),
+                result: result_label.into(),
+                detail: None,
+                first_token_latency_ms: None,
+            });
+        })
+        .await?;
+
+        ctx.store
+            .log_event(crate::event_replay::TaskEvent::RoundCompleted {
+                task_id: ctx.task_id.0.clone(),
+                ts: crate::event_replay::now_ts(),
+                round,
+                result: result_label.to_string(),
+            });
+
+        let mut ev = Event::new(
+            SessionId::new(),
+            "pr_review",
+            "task_runner",
+            if lgtm {
+                Decision::Complete
+            } else {
+                Decision::Warn
+            },
+        );
+        ev.detail = Some(format!("pr={pr_num}"));
+        ev.reason = Some(format!("round {round}: {result_label}"));
+        if let Err(e) = ctx.events.log(&ev).await {
+            tracing::warn!("failed to log pr_review event: {e}");
+        }
+
+        if lgtm {
+            // Hard gate: run the project's tests before accepting LGTM.
+            match super::run_test_gate(
+                &ctx.project,
+                &ctx.project_config.validation.pre_push,
+                ctx.project_config.validation.test_gate_timeout_secs,
+                &ctx.cargo_env,
+            )
+            .await
+            {
+                Ok(()) => {
+                    tracing::info!("PR #{pr_num} approved at round {round}");
+                    mutate_and_persist(ctx.store, ctx.task_id, |s| {
+                        s.status = TaskStatus::Done;
+                        s.turn = round.saturating_add(1);
+                    })
+                    .await?;
+                    ctx.store
+                        .log_event(crate::event_replay::TaskEvent::Completed {
+                            task_id: ctx.task_id.0.clone(),
+                            ts: crate::event_replay::now_ts(),
+                        });
+                    tracing::info!(
+                        task_id = %ctx.task_id,
+                        phase = "reviewing",
+                        elapsed_secs = review_phase_start.elapsed().as_secs(),
+                        "phase_completed"
+                    );
+                    tracing::info!(
+                        task_id = %ctx.task_id,
+                        status = "done",
+                        turns = round.saturating_add(1),
+                        pr_url = pr_url.as_deref().unwrap_or(""),
+                        total_elapsed_secs = ctx.task_start.elapsed().as_secs(),
+                        "task_completed"
+                    );
+                    return Ok(());
+                }
+                Err(gate_output) => {
+                    tracing::warn!(
+                        task_id = %ctx.task_id,
+                        round,
+                        "LGTM rejected: tests failed in test gate, re-entering review round {}",
+                        round.saturating_add(1)
+                    );
+                    lgtm_test_gate_rejected = true;
+                    pending_test_failure = Some(gate_output);
+                }
+            }
+        }
+
+        prev_fixed = fixed || pending_test_failure.is_some();
+        tracing::info!("PR #{pr_num} fixed at round {round}; waiting for bot re-review");
+        if round < max_rounds {
+            waiting_count += 1;
+            update_status(ctx.store, ctx.task_id, TaskStatus::Waiting, waiting_count).await?;
+            sleep(Duration::from_secs(wait_secs)).await;
+        }
+        round += 1;
+    }
+
+    // Graduated exit: if the last round had few issues remaining, mark as done.
+    let last_issue_count = issue_counts.iter().rev().find_map(|c| *c);
+    let graduated = last_issue_count.is_some_and(|n| n <= 2) && !lgtm_test_gate_rejected;
+
+    if graduated {
+        tracing::info!(
+            task_id = %ctx.task_id,
+            remaining_issues = last_issue_count.unwrap_or(0),
+            "review loop exhausted but few issues remain — marking done with warning"
+        );
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.status = TaskStatus::Done;
+            s.turn = max_rounds.saturating_add(1);
+            s.error = Some(format!(
+                "Graduated: LGTM not received after {} rounds but only {} issues remain.",
+                max_rounds,
+                last_issue_count.unwrap_or(0),
+            ));
+        })
+        .await?;
+    } else {
+        mutate_and_persist(ctx.store, ctx.task_id, |s| {
+            s.status = TaskStatus::Failed;
+            s.turn = max_rounds.saturating_add(1);
+            s.error = Some(format!(
+                "Task did not receive LGTM after {} review rounds (last issues: {}).",
+                max_rounds,
+                last_issue_count.map_or("unknown".to_string(), |n| n.to_string()),
+            ));
+        })
+        .await?;
+    }
+    tracing::info!(
+        task_id = %ctx.task_id,
+        phase = "reviewing",
+        elapsed_secs = review_phase_start.elapsed().as_secs(),
+        "phase_completed"
+    );
+    tracing::info!(
+        task_id = %ctx.task_id,
+        status = if graduated { "done" } else { "failed" },
+        turns = max_rounds.saturating_add(1),
+        pr_url = pr_url.as_deref().unwrap_or(""),
+        total_elapsed_secs = ctx.task_start.elapsed().as_secs(),
+        "task_completed"
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1,0 +1,293 @@
+/// Triage → Plan pipeline module.
+///
+/// Handles the initial classification phase for a new task:
+/// - If a checkpoint or existing PR is found, returns `Proceed` immediately
+///   with the saved plan so the orchestrator can skip triage/planning.
+/// - For fresh issue-based tasks: runs triage, then optionally the plan phase.
+/// - For complex prompt-only tasks (planning gate active): runs the plan phase.
+use crate::task_runner::{mutate_and_persist, TaskPhase, TaskStatus};
+use harness_core::agent::AgentRequest;
+use harness_core::prompts;
+use harness_core::types::ExecutionPhase;
+use tokio::time::timeout;
+
+use super::TaskContext;
+
+/// Outcome returned by the triage/plan pipeline to the orchestrator.
+pub(crate) enum TriageOutcome {
+    /// Triage decided to skip this issue — task is already marked Done.
+    Skip,
+    /// Proceed with implementation.
+    Proceed {
+        /// Optional plan text (Some when triage emitted PROCEED_WITH_PLAN, or when
+        /// a prompt-only task's complexity gate forced a plan phase).
+        plan: Option<String>,
+        /// Complexity classification for deriving default review round count.
+        complexity: prompts::TriageComplexity,
+        /// Number of agent turns consumed by this pipeline (0, 1, or 2).
+        pipeline_turns: u32,
+    },
+}
+
+/// Run the triage → plan pipeline.
+///
+/// Handles checkpoint resume, existing-PR detection, issue-based triage, and
+/// prompt-only planning. Returns `TriageOutcome::Skip` when the issue should be
+/// skipped; otherwise returns `TriageOutcome::Proceed` with an optional plan.
+pub(crate) async fn run(
+    ctx: &TaskContext<'_>,
+    resumed_pr_url: Option<&str>,
+    resumed_plan: Option<String>,
+) -> anyhow::Result<TriageOutcome> {
+    // PR already exists from a previous run — skip triage/plan entirely.
+    if resumed_pr_url.is_some() {
+        return Ok(TriageOutcome::Proceed {
+            plan: None,
+            complexity: prompts::TriageComplexity::Medium,
+            pipeline_turns: 0,
+        });
+    }
+
+    // Plan checkpoint found — use saved plan, skip triage/plan pipeline.
+    if let Some(plan) = resumed_plan {
+        tracing::info!(
+            task_id = %ctx.task_id,
+            "checkpoint resume: using saved plan, skipping triage/plan"
+        );
+        return Ok(TriageOutcome::Proceed {
+            plan: Some(plan),
+            complexity: prompts::TriageComplexity::Medium,
+            pipeline_turns: 0,
+        });
+    }
+
+    if let Some(issue) = ctx.req.issue {
+        // Only triage fresh issues (no existing PR to continue).
+        let has_existing_pr = super::pr_detection::find_existing_pr_for_issue(&ctx.project, issue)
+            .await
+            .ok()
+            .flatten()
+            .is_some();
+        if !has_existing_pr {
+            return run_triage_plan_pipeline(ctx, issue).await;
+        }
+        // Existing PR found — skip triage/plan.
+        return Ok(TriageOutcome::Proceed {
+            plan: None,
+            complexity: prompts::TriageComplexity::Medium,
+            pipeline_turns: 0,
+        });
+    }
+
+    // Planning gate (task_runner) may have forced TaskPhase::Plan for a complex
+    // prompt-only task. Check the stored phase so the gate has real effect.
+    let forced_plan = ctx
+        .store
+        .get(ctx.task_id)
+        .map(|s| s.phase == TaskPhase::Plan)
+        .unwrap_or(false);
+    if forced_plan && ctx.req.issue.is_none() && ctx.req.pr.is_none() {
+        // Set to Implementing BEFORE the plan phase so that a crash during planning
+        // leaves the task in 'implementing' status. The startup recovery code will
+        // catch it and fail-close it (no pr_url → mark failed), rather than leaving
+        // it stuck as a plain 'pending' that is never re-dispatched.
+        super::helpers::update_status(ctx.store, ctx.task_id, TaskStatus::Implementing, 1).await?;
+        return run_plan_for_prompt(ctx).await;
+    }
+
+    Ok(TriageOutcome::Proceed {
+        plan: None,
+        complexity: prompts::TriageComplexity::Medium,
+        pipeline_turns: 0,
+    })
+}
+
+/// Run a plan step for a complex prompt-only task when the planning gate has
+/// forced `TaskPhase::Plan`.
+async fn run_plan_for_prompt(ctx: &TaskContext<'_>) -> anyhow::Result<TriageOutcome> {
+    let prompt_text = ctx.req.prompt.as_deref().unwrap_or_default();
+    tracing::info!(
+        task_id = %ctx.task_id,
+        "pipeline: starting plan phase for prompt-only task"
+    );
+
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.phase = TaskPhase::Plan;
+    })
+    .await?;
+
+    let plan_prompt = prompts::plan_for_task_prompt(prompt_text);
+
+    let plan_req = AgentRequest {
+        prompt: plan_prompt,
+        project_root: ctx.project.clone(),
+        env_vars: ctx.cargo_env.clone(),
+        execution_phase: Some(ExecutionPhase::Planning),
+        ..Default::default()
+    };
+
+    // Use agent.execute() directly — NOT run_agent_streaming — to avoid the
+    // state side-effects that run_agent_streaming performs: PR_URL extraction,
+    // turn counter mutations, and status updates. Those side-effects would
+    // corrupt the subsequent implement phase.
+    let plan_resp = timeout(ctx.turn_timeout, ctx.agent.execute(plan_req))
+        .await
+        .map_err(|_| anyhow::anyhow!("plan phase timed out after {}s", ctx.req.turn_timeout_secs))?
+        .map_err(|e| anyhow::anyhow!("plan phase agent error: {e}"))?;
+
+    let plan_text = plan_resp.output.clone();
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.plan_output = Some(plan_text.clone());
+        state.phase = TaskPhase::Implement;
+    })
+    .await?;
+
+    tracing::info!(
+        task_id = %ctx.task_id,
+        plan_len = plan_text.len(),
+        "plan phase complete (prompt-only)"
+    );
+    Ok(TriageOutcome::Proceed {
+        plan: Some(plan_text),
+        complexity: prompts::TriageComplexity::Medium,
+        pipeline_turns: 1,
+    })
+}
+
+/// Run triage → plan pipeline for a fresh issue-based task.
+///
+/// Returns `TriageOutcome::Skip` if triage decides to skip the issue.
+/// Returns `TriageOutcome::Proceed` with an optional plan and complexity.
+/// All failures propagate as errors — no silent fallbacks.
+async fn run_triage_plan_pipeline(
+    ctx: &TaskContext<'_>,
+    issue: u64,
+) -> anyhow::Result<TriageOutcome> {
+    // --- Phase 1: Triage ---
+    tracing::info!(task_id = %ctx.task_id, issue, "pipeline: starting triage phase");
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.phase = TaskPhase::Triage;
+    })
+    .await?;
+
+    let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
+    let triage_req = AgentRequest {
+        prompt: triage_prompt,
+        project_root: ctx.project.clone(),
+        env_vars: ctx.cargo_env.clone(),
+        execution_phase: Some(ExecutionPhase::Planning),
+        ..Default::default()
+    };
+
+    let (triage_resp, _) = timeout(
+        ctx.turn_timeout,
+        super::run_agent_streaming(ctx.agent, triage_req, ctx.task_id, ctx.store, 0),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "triage phase timed out after {}s",
+            ctx.req.turn_timeout_secs
+        )
+    })?
+    .map_err(|e| anyhow::anyhow!("triage phase agent error: {e}"))?;
+
+    let triage_text = triage_resp.output.clone();
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.triage_output = Some(triage_text.clone());
+    })
+    .await?;
+    if let Err(e) = ctx
+        .store
+        .write_checkpoint(ctx.task_id, Some(&triage_text), None, None, "triage_done")
+        .await
+    {
+        tracing::warn!(task_id = %ctx.task_id, "failed to write triage checkpoint: {e}");
+    }
+
+    let decision = prompts::parse_triage(&triage_resp.output).ok_or_else(|| {
+        anyhow::anyhow!("triage output unparseable — agent did not produce TRIAGE=<decision>")
+    })?;
+    let complexity = prompts::parse_complexity(&triage_resp.output);
+    tracing::info!(task_id = %ctx.task_id, ?decision, ?complexity, "triage decision");
+
+    match decision {
+        prompts::TriageDecision::Skip => {
+            mutate_and_persist(ctx.store, ctx.task_id, |state| {
+                state.status = TaskStatus::Done;
+                state.phase = TaskPhase::Terminal;
+                state.error = Some("Triage: skipped — not worth implementing".to_string());
+            })
+            .await?;
+            return Ok(TriageOutcome::Skip);
+        }
+        prompts::TriageDecision::NeedsClarification => {
+            // Treat as ProceedWithPlan — let the planner figure out ambiguities
+            // instead of failing the task outright.
+            tracing::info!(
+                task_id = %ctx.task_id,
+                "triage: NEEDS_CLARIFICATION → treating as PROCEED_WITH_PLAN"
+            );
+        }
+        prompts::TriageDecision::Proceed => {
+            tracing::info!(task_id = %ctx.task_id, "triage: PROCEED — skipping plan phase");
+            return Ok(TriageOutcome::Proceed {
+                plan: None,
+                complexity,
+                pipeline_turns: 1,
+            });
+        }
+        prompts::TriageDecision::ProceedWithPlan => {
+            // Fall through to plan phase.
+        }
+    }
+
+    // --- Phase 2: Plan ---
+    tracing::info!(task_id = %ctx.task_id, issue, "pipeline: starting plan phase");
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.phase = TaskPhase::Plan;
+    })
+    .await?;
+
+    let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
+    let plan_req = AgentRequest {
+        prompt: plan_prompt,
+        project_root: ctx.project.clone(),
+        env_vars: ctx.cargo_env.clone(),
+        execution_phase: Some(ExecutionPhase::Planning),
+        ..Default::default()
+    };
+
+    let (plan_resp, _) = timeout(
+        ctx.turn_timeout,
+        super::run_agent_streaming(ctx.agent, plan_req, ctx.task_id, ctx.store, 0),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("plan phase timed out after {}s", ctx.req.turn_timeout_secs))?
+    .map_err(|e| anyhow::anyhow!("plan phase agent error: {e}"))?;
+
+    let plan_text = plan_resp.output.clone();
+    mutate_and_persist(ctx.store, ctx.task_id, |state| {
+        state.plan_output = Some(plan_text.clone());
+        state.phase = TaskPhase::Implement;
+    })
+    .await?;
+    if let Err(e) = ctx
+        .store
+        .write_checkpoint(ctx.task_id, None, Some(&plan_text), None, "plan_done")
+        .await
+    {
+        tracing::warn!(task_id = %ctx.task_id, "failed to write plan checkpoint: {e}");
+    }
+
+    tracing::info!(
+        task_id = %ctx.task_id,
+        plan_len = plan_text.len(),
+        "plan phase complete"
+    );
+    Ok(TriageOutcome::Proceed {
+        plan: Some(plan_text),
+        complexity,
+        pipeline_turns: 2,
+    })
+}


### PR DESCRIPTION
Closes #772

## Summary

- **Split** `task_executor.rs` (2762 lines) into 4 focused submodules under `src/task_executor/`:
  - `triage_pipeline.rs` — triage phase, returns `TriageOutcome`
  - `implement_pipeline.rs` — implementation phase, returns `ImplementOutcome`
  - `agent_review.rs` — internal AI reviewer loop, returns `AgentReviewOutcome`
  - `review_loop.rs` — external review bot wait loop
- **Add** `TaskContext<'a>` struct to share task state across pipeline phases without long argument lists
- **Reduce** `run_task` to a thin ~170-line orchestrator that delegates to submodules
- **Migrate** 4 inline prompt strings to named template functions in `prompts.rs` (Part 2):
  - `plan_for_task_prompt`, `validation_retry_error_context`, `test_gate_failure_context`, `reviewer_capability_note`
- **Add** `enable_compilation_gate: bool` to `AgentReviewConfig` (Part 3, off by default): when enabled, runs `cargo check --workspace` + `cargo test` between agent review rounds before accepting approval

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --all` — no diff
- [x] `cargo test --workspace` — all tests pass
- [x] Pre-commit hook (fmt + clippy + test) passed on commit