### PR TITLE
test(task_runner): add coverage for dependency scheduling (#634)

### DIFF
--- a/crates/harness-exec/src/markdown.rs
+++ b/crates/harness-exec/src/markdown.rs
@@ -115,20 +115,18 @@ pub fn from_markdown(content: &str) -> anyhow::Result<ExecPlan> {
             plan.project_root = PathBuf::from(p);
         } else {
             match section {
-                "progress" => {
-                    if line.starts_with("- [") {
-                        let completed = line.contains("[x]");
-                        let desc = line
-                            .trim_start_matches("- [x] ")
-                            .trim_start_matches("- [ ] ")
-                            .to_string();
-                        if !desc.is_empty() {
-                            plan.progress.push(Milestone {
-                                description: desc,
-                                completed,
-                                completed_at: None,
-                            });
-                        }
+                "progress" if line.starts_with("- [") => {
+                    let completed = line.contains("[x]");
+                    let desc = line
+                        .trim_start_matches("- [x] ")
+                        .trim_start_matches("- [ ] ")
+                        .to_string();
+                    if !desc.is_empty() {
+                        plan.progress.push(Milestone {
+                            description: desc,
+                            completed,
+                            completed_at: None,
+                        });
                     }
                 }
                 "steps" => {

--- a/crates/harness-observe/src/health.rs
+++ b/crates/harness-observe/src/health.rs
@@ -67,7 +67,7 @@ fn aggregate_violations(violations: &[Violation]) -> Vec<ViolationSummary> {
             severity,
         })
         .collect();
-    summaries.sort_by(|a, b| b.count.cmp(&a.count));
+    summaries.sort_by_key(|b| std::cmp::Reverse(b.count));
     summaries
 }
 
@@ -92,7 +92,7 @@ fn derive_signals(events: &[Event]) -> Vec<SignalSummary> {
             last_detected,
         })
         .collect();
-    summaries.sort_by(|a, b| b.count.cmp(&a.count));
+    summaries.sort_by_key(|b| std::cmp::Reverse(b.count));
     summaries
 }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -800,6 +800,15 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                                     "dep-watcher: failed to persist failed status: {pe}"
                                 );
                             }
+                            // Fire completion callback so intake sources (e.g. GitHub Issues
+                            // poller) remove this task from their `dispatched` map. Without
+                            // this the issue stays marked as dispatched forever and will never
+                            // be re-queued, causing a silent production deadlock.
+                            if let Some(cb) = &state.intake.completion_callback {
+                                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                    cb(final_state).await;
+                                }
+                            }
                             return;
                         }
 

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -688,12 +688,16 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                 // the intake poller never re-queues it.
                 if let Some(ref cb) = state.intake.completion_callback {
                     for task_id in &failed_ids {
-                        match state.core.tasks.get(task_id) {
-                            Some(task) => cb(task).await,
-                            None => tracing::warn!(
+                        if let Some(task) = state.core.tasks.get(task_id) {
+                            let cb = cb.clone();
+                            tokio::spawn(async move {
+                                cb(task).await;
+                            });
+                        } else {
+                            tracing::warn!(
                                 "dep-watcher: task {} not found after dep-failed transition",
                                 task_id.0
-                            ),
+                            );
                         }
                     }
                 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -759,6 +759,34 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                             settings.apply_to_req(&mut req);
                         }
 
+                        // Guard: prompt-only tasks store their prompt in memory only
+                        // (#[serde(skip)]). After a server restart the prompt field is
+                        // absent. If no issue/pr is present either, dispatching would
+                        // call implement_from_prompt("") — a silent mis-execution.
+                        // Fail the task explicitly so the caller can re-submit.
+                        if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
+                            let reason = "dep-watcher: prompt-only task has no persisted \
+                                prompt after server restart; please re-submit the task"
+                                .to_string();
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "dep-watcher: failed to persist failed status: {pe}"
+                                );
+                            }
+                            return;
+                        }
+
                         let permit = match state
                             .concurrency
                             .task_queue

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -681,6 +681,22 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
                         );
                     }
                 }
+                // Invoke completion_callback for dep-failed tasks so intake
+                // sources (e.g. github_issues) can unmark them from the
+                // dispatched map and allow retries on the next poll cycle.
+                // Without this the issue stays permanently "dispatched" and
+                // the intake poller never re-queues it.
+                if let Some(ref cb) = state.intake.completion_callback {
+                    for task_id in &failed_ids {
+                        match state.core.tasks.get(task_id) {
+                            Some(task) => cb(task).await,
+                            None => tracing::warn!(
+                                "dep-watcher: task {} not found after dep-failed transition",
+                                task_id.0
+                            ),
+                        }
+                    }
+                }
                 // Spawn an agent for each task whose deps are now satisfied.
                 for task_id in ready_ids {
                     let state = state.clone();

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -2293,13 +2293,20 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>
                     break; // fail-fast — no need to inspect remaining deps
                 }
                 Some(TaskStatus::Cancelled) => {
-                    failed_dep_id = Some((dep_id.clone(), "cancelled"));
-                    break; // cancelled dep is also terminal — dependents cannot proceed
+                    // A cancelled dependency does NOT unblock or hard-fail its
+                    // dependents — this matches the intake DAG contract in
+                    // intake/mod.rs where `status_unblocks_dependents` only
+                    // returns true for Done | Failed, and cancelled tasks are
+                    // tracked in a separate `cancelled_sprint` set.  Keeping
+                    // the dependent in AwaitingDeps allows the cancelled parent
+                    // to be re-queued later; if it eventually reaches Done the
+                    // dependent will be released normally.
+                    all_done = false;
                 }
                 Some(TaskStatus::Done) => {} // this dep is satisfied
                 _ => {
                     // Pending, Implementing, or unknown — not ready yet.
-                    // Keep scanning in case a later dep is Failed or Cancelled.
+                    // Keep scanning in case a later dep is Failed.
                     all_done = false;
                 }
             }
@@ -3558,8 +3565,12 @@ mod tests {
         Ok(())
     }
 
+    /// A cancelled dependency must NOT hard-fail its dependents — they stay
+    /// in AwaitingDeps so that the parent can be re-queued later.  This
+    /// matches the intake DAG contract in intake/mod.rs where
+    /// `status_unblocks_dependents` only returns true for Done | Failed.
     #[tokio::test]
-    async fn check_awaiting_cancelled_dep_transitions_to_failed() -> anyhow::Result<()> {
+    async fn check_awaiting_cancelled_dep_stays_blocked() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
 
@@ -3575,22 +3586,17 @@ mod tests {
         store.insert(&task).await;
 
         let (ready, failed) = check_awaiting_deps(&store).await;
-        assert!(ready.is_empty(), "expected no ready tasks");
+        assert!(ready.is_empty(), "cancelled dep must not unblock dependent");
         assert!(
-            failed.contains(&task_id),
-            "expected task in failed_ids when dep is Cancelled"
+            failed.is_empty(),
+            "cancelled dep must not hard-fail dependent (DAG contract)"
         );
 
         let state = store.get(&task_id).expect("task should still be in store");
         assert!(
-            matches!(state.status, TaskStatus::Failed),
-            "expected Failed after dep cancelled, got {:?}",
+            matches!(state.status, TaskStatus::AwaitingDeps),
+            "dependent must remain AwaitingDeps when dep is Cancelled, got {:?}",
             state.status
-        );
-        assert!(
-            state.error.as_deref().unwrap_or("").contains("cancelled"),
-            "error message should mention 'cancelled', got: {:?}",
-            state.error
         );
         Ok(())
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -2294,15 +2294,14 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>
                     break; // fail-fast — no need to inspect remaining deps
                 }
                 Some(TaskStatus::Cancelled) => {
-                    // A cancelled dependency does NOT unblock or hard-fail its
-                    // dependents — this matches the intake DAG contract in
-                    // intake/mod.rs where `status_unblocks_dependents` only
-                    // returns true for Done | Failed, and cancelled tasks are
-                    // tracked in a separate `cancelled_sprint` set.  Keeping
-                    // the dependent in AwaitingDeps allows the cancelled parent
-                    // to be re-queued later; if it eventually reaches Done the
-                    // dependent will be released normally.
-                    all_done = false;
+                    // A cancelled dependency hard-fails its dependents. When a
+                    // task is re-queued it always receives a new TaskId, so the
+                    // original (now-cancelled) TaskId in `depends_on` can never
+                    // transition to Done. Leaving the dependent in AwaitingDeps
+                    // would block it indefinitely; failing it immediately lets
+                    // the caller re-submit with correct dependency IDs.
+                    failed_dep_id = Some((dep_id.clone(), "cancelled"));
+                    break; // fail-fast — no need to inspect remaining deps
                 }
                 Some(TaskStatus::Done) => {} // this dep is satisfied
                 _ => {
@@ -3566,12 +3565,11 @@ mod tests {
         Ok(())
     }
 
-    /// A cancelled dependency must NOT hard-fail its dependents — they stay
-    /// in AwaitingDeps so that the parent can be re-queued later.  This
-    /// matches the intake DAG contract in intake/mod.rs where
-    /// `status_unblocks_dependents` only returns true for Done | Failed.
+    /// A cancelled dependency hard-fails its dependents. Re-queued tasks always
+    /// get new TaskIds, so the old cancelled ID would never resolve — leaving the
+    /// dependent in AwaitingDeps would block it indefinitely.
     #[tokio::test]
-    async fn check_awaiting_cancelled_dep_stays_blocked() -> anyhow::Result<()> {
+    async fn check_awaiting_cancelled_dep_hard_fails_dependent() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
 
@@ -3589,14 +3587,14 @@ mod tests {
         let (ready, failed) = check_awaiting_deps(&store).await;
         assert!(ready.is_empty(), "cancelled dep must not unblock dependent");
         assert!(
-            failed.is_empty(),
-            "cancelled dep must not hard-fail dependent (DAG contract)"
+            failed.contains(&task_id),
+            "cancelled dep must hard-fail its dependent"
         );
 
         let state = store.get(&task_id).expect("task should still be in store");
         assert!(
-            matches!(state.status, TaskStatus::AwaitingDeps),
-            "dependent must remain AwaitingDeps when dep is Cancelled, got {:?}",
+            matches!(state.status, TaskStatus::Failed),
+            "dependent must be Failed when dep is Cancelled, got {:?}",
             state.status
         );
         Ok(())

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -2264,7 +2264,8 @@ pub async fn spawn_task_awaiting_deps(
 /// the caller so that status transitions survive a process restart.
 pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>) {
     let mut ready = Vec::new();
-    let mut failed_deps: Vec<(TaskId, TaskId)> = Vec::new();
+    // (task_id, dep_id, dep_terminal_status_label) — label is "failed" or "cancelled".
+    let mut failed_deps: Vec<(TaskId, TaskId, &'static str)> = Vec::new();
 
     // Snapshot AwaitingDeps tasks from cache before async work.
     let awaiting: Vec<(TaskId, Vec<TaskId>)> = store
@@ -2283,24 +2284,28 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>
     for (task_id, depends_on) in awaiting {
         // Single pass: one DB lookup per dep (cache-first, then lightweight
         // `SELECT status` — no `rounds` JSON decode).
-        let mut failed_dep_id = None;
+        let mut failed_dep_id: Option<(TaskId, &'static str)> = None;
         let mut all_done = true;
         for dep_id in &depends_on {
             match store.dep_status(dep_id).await {
                 Some(TaskStatus::Failed) => {
-                    failed_dep_id = Some(dep_id.clone());
+                    failed_dep_id = Some((dep_id.clone(), "failed"));
                     break; // fail-fast — no need to inspect remaining deps
+                }
+                Some(TaskStatus::Cancelled) => {
+                    failed_dep_id = Some((dep_id.clone(), "cancelled"));
+                    break; // cancelled dep is also terminal — dependents cannot proceed
                 }
                 Some(TaskStatus::Done) => {} // this dep is satisfied
                 _ => {
                     // Pending, Implementing, or unknown — not ready yet.
-                    // Keep scanning in case a later dep is Failed.
+                    // Keep scanning in case a later dep is Failed or Cancelled.
                     all_done = false;
                 }
             }
         }
-        if let Some(fd) = failed_dep_id {
-            failed_deps.push((task_id, fd));
+        if let Some((fd, label)) = failed_dep_id {
+            failed_deps.push((task_id, fd, label));
             continue;
         }
         if all_done {
@@ -2309,13 +2314,13 @@ pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>
     }
 
     let mut newly_failed: Vec<TaskId> = Vec::new();
-    for (task_id, failed_dep_id) in &failed_deps {
+    for (task_id, failed_dep_id, label) in &failed_deps {
         if let Some(mut entry) = store.cache.get_mut(task_id) {
             // Only overwrite if the task is still AwaitingDeps — a concurrent
             // cancel or status transition must not be clobbered.
             if matches!(entry.status, TaskStatus::AwaitingDeps) {
                 entry.status = TaskStatus::Failed;
-                entry.error = Some(format!("dependency {} failed", failed_dep_id.0));
+                entry.error = Some(format!("dependency {} {}", failed_dep_id.0, label));
                 newly_failed.push(task_id.clone());
             }
         }
@@ -3549,6 +3554,43 @@ mod tests {
             matches!(state.status, TaskStatus::AwaitingDeps),
             "expected AwaitingDeps with partial deps, got {:?}",
             state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_cancelled_dep_transitions_to_failed() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-cancelled");
+        let mut dep = TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Cancelled;
+        store.insert(&dep).await;
+
+        let task_id = tid("awaiting-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::AwaitingDeps;
+        task.depends_on = vec![dep_id.clone()];
+        store.insert(&task).await;
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(ready.is_empty(), "expected no ready tasks");
+        assert!(
+            failed.contains(&task_id),
+            "expected task in failed_ids when dep is Cancelled"
+        );
+
+        let state = store.get(&task_id).expect("task should still be in store");
+        assert!(
+            matches!(state.status, TaskStatus::Failed),
+            "expected Failed after dep cancelled, got {:?}",
+            state.status
+        );
+        assert!(
+            state.error.as_deref().unwrap_or("").contains("cancelled"),
+            "error message should mention 'cancelled', got: {:?}",
+            state.error
         );
         Ok(())
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -394,8 +394,9 @@ pub struct PersistedRequestSettings {
     /// Intentionally NOT serialised to the database: prompts may contain
     /// credentials or sensitive data and must not be written at rest.
     /// LIMITATION: after a server restart the prompt will be absent; prompt-only
-    /// `AwaitingDeps` tasks will be dispatched without the caller's original
-    /// prompt text and will remain stuck in `AwaitingDeps` with no prompt to replay.
+    /// `AwaitingDeps` tasks will transition to `Pending` once their dependencies
+    /// resolve, then fail immediately in the dep-watcher dispatch path because
+    /// no prompt is available to replay.
     #[serde(skip)]
     pub prompt: Option<String>,
 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -393,8 +393,9 @@ pub struct PersistedRequestSettings {
     /// request when their dependencies resolve within the same server session.
     /// Intentionally NOT serialised to the database: prompts may contain
     /// credentials or sensitive data and must not be written at rest.
-    /// After a server restart the prompt will be absent; the task will still
-    /// be dispatched but without the caller's original prompt text.
+    /// LIMITATION: after a server restart the prompt will be absent; prompt-only
+    /// `AwaitingDeps` tasks will be dispatched without the caller's original
+    /// prompt text and will remain stuck in `AwaitingDeps` with no prompt to replay.
     #[serde(skip)]
     pub prompt: Option<String>,
 }
@@ -3345,6 +3346,243 @@ mod tests {
         let key = root.to_string_lossy().into_owned();
         assert_eq!(counts.by_project[&key].done, 1);
         assert_eq!(counts.by_project[&key].failed, 1);
+        Ok(())
+    }
+
+    // --- dependency scheduling tests ---
+
+    fn tid(s: &str) -> harness_core::types::TaskId {
+        harness_core::types::TaskId(s.to_string())
+    }
+
+    #[tokio::test]
+    async fn spawn_awaiting_all_deps_done_creates_pending() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-done");
+        let mut dep = TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Done;
+        store.insert(&dep).await;
+
+        let req = CreateTaskRequest {
+            prompt: Some("task with done dep".into()),
+            depends_on: vec![dep_id],
+            ..Default::default()
+        };
+
+        let task_id = spawn_task_awaiting_deps(store.clone(), req).await?;
+        let state = store.get(&task_id).expect("task should be in store");
+        assert!(
+            matches!(state.status, TaskStatus::Pending),
+            "expected Pending when all deps Done, got {:?}",
+            state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spawn_awaiting_unresolved_dep_creates_awaiting() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-pending");
+        let dep = TaskState::new(dep_id.clone()); // Pending by default
+        store.insert(&dep).await;
+
+        let req = CreateTaskRequest {
+            prompt: Some("task with pending dep".into()),
+            depends_on: vec![dep_id],
+            ..Default::default()
+        };
+
+        let task_id = spawn_task_awaiting_deps(store.clone(), req).await?;
+        let state = store.get(&task_id).expect("task should be in store");
+        assert!(
+            matches!(state.status, TaskStatus::AwaitingDeps),
+            "expected AwaitingDeps when dep not Done, got {:?}",
+            state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spawn_awaiting_detects_direct_cycle() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        // Chain: new → A → new  (A's depends_on contains new_id)
+        let new_id = tid("new-task");
+        let a_id = tid("task-a");
+
+        let mut task_a = TaskState::new(a_id.clone());
+        task_a.depends_on = vec![new_id.clone()];
+        store.insert(&task_a).await;
+
+        assert!(
+            detect_cycle(&store, &new_id, &[a_id]),
+            "expected direct cycle to be detected"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spawn_awaiting_detects_transitive_cycle() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        // Chain: new → A → B → new
+        let new_id = tid("new-task");
+        let a_id = tid("task-a");
+        let b_id = tid("task-b");
+
+        let mut task_b = TaskState::new(b_id.clone());
+        task_b.depends_on = vec![new_id.clone()];
+        store.insert(&task_b).await;
+
+        let mut task_a = TaskState::new(a_id.clone());
+        task_a.depends_on = vec![b_id];
+        store.insert(&task_a).await;
+
+        assert!(
+            detect_cycle(&store, &new_id, &[a_id]),
+            "expected transitive cycle to be detected"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_no_tasks_returns_empty() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(ready.is_empty(), "expected no ready tasks");
+        assert!(failed.is_empty(), "expected no failed tasks");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_ready_transitions_to_pending() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-done");
+        let mut dep = TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Done;
+        store.insert(&dep).await;
+
+        let task_id = tid("awaiting-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::AwaitingDeps;
+        task.depends_on = vec![dep_id];
+        store.insert(&task).await;
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(ready.contains(&task_id), "expected task in ready_ids");
+        assert!(failed.is_empty(), "expected no failed tasks");
+
+        let state = store.get(&task_id).expect("task should still be in store");
+        assert!(
+            matches!(state.status, TaskStatus::Pending),
+            "expected Pending after transition, got {:?}",
+            state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_failed_dep_transitions_to_failed() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-failed");
+        let mut dep = TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Failed;
+        store.insert(&dep).await;
+
+        let task_id = tid("awaiting-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::AwaitingDeps;
+        task.depends_on = vec![dep_id];
+        store.insert(&task).await;
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(ready.is_empty(), "expected no ready tasks");
+        assert!(failed.contains(&task_id), "expected task in failed_ids");
+
+        let state = store.get(&task_id).expect("task should still be in store");
+        assert!(
+            matches!(state.status, TaskStatus::Failed),
+            "expected Failed after dep failure, got {:?}",
+            state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_partial_deps_stays_awaiting() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_done_id = tid("dep-done");
+        let mut dep_done = TaskState::new(dep_done_id.clone());
+        dep_done.status = TaskStatus::Done;
+        store.insert(&dep_done).await;
+
+        let dep_pending_id = tid("dep-pending");
+        let dep_pending = TaskState::new(dep_pending_id.clone()); // Pending by default
+        store.insert(&dep_pending).await;
+
+        let task_id = tid("awaiting-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::AwaitingDeps;
+        task.depends_on = vec![dep_done_id, dep_pending_id];
+        store.insert(&task).await;
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(!ready.contains(&task_id), "task must not be in ready_ids");
+        assert!(!failed.contains(&task_id), "task must not be in failed_ids");
+
+        let state = store.get(&task_id).expect("task should still be in store");
+        assert!(
+            matches!(state.status, TaskStatus::AwaitingDeps),
+            "expected AwaitingDeps with partial deps, got {:?}",
+            state.status
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn check_awaiting_concurrent_cancel_excluded() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let dep_id = tid("dep-done");
+        let mut dep = TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Done;
+        store.insert(&dep).await;
+
+        let task_id = tid("awaiting-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::AwaitingDeps;
+        task.depends_on = vec![dep_id];
+        store.insert(&task).await;
+
+        // Simulate concurrent cancel: flip status before check_awaiting_deps runs.
+        if let Some(mut entry) = store.cache.get_mut(&task_id) {
+            entry.status = TaskStatus::Cancelled;
+        }
+
+        let (ready, failed) = check_awaiting_deps(&store).await;
+        assert!(
+            !ready.contains(&task_id),
+            "cancelled task must not be in ready_ids"
+        );
+        assert!(
+            !failed.contains(&task_id),
+            "cancelled task must not be in failed_ids"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add 9 unit tests for `spawn_task_awaiting_deps` and `check_awaiting_deps` covering all scheduler-visible paths: Pending bypass (all deps Done), AwaitingDeps creation (unresolved dep), direct and transitive cycle detection, ready→Pending transition, failed dep propagation, partial deps hold, and concurrent-cancel exclusion
- Document the prompt-persistence `LIMITATION` on `PersistedRequestSettings::prompt`: after a server restart, prompt-only `AwaitingDeps` tasks cannot recover their original prompt text

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --package harness-server awaiting` — 9/9 new tests pass
- [x] `cargo test --workspace` — no failures

Closes #634