### PR TITLE
fix(triage): use ExecutionPhase::Rebase in run_rebase_turn

### DIFF
--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -256,7 +256,7 @@ pub(crate) async fn run_rebase_turn(
         prompt,
         project_root: project.to_path_buf(),
         env_vars: cargo_env.clone(),
-        execution_phase: Some(harness_core::types::ExecutionPhase::Planning),
+        execution_phase: Some(harness_core::types::ExecutionPhase::Rebase),
         ..Default::default()
     };
 

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -256,7 +256,7 @@ pub(crate) async fn run_rebase_turn(
         prompt,
         project_root: project.to_path_buf(),
         env_vars: cargo_env.clone(),
-        execution_phase: Some(harness_core::types::ExecutionPhase::Rebase),
+        execution_phase: Some(ExecutionPhase::Rebase),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary
- `run_rebase_turn` was using `ExecutionPhase::Planning` (max thinking / xhigh model tier) instead of `ExecutionPhase::Rebase`
- `ExecutionPhase::Rebase` was introduced in PR #778 for this exact purpose: lightweight git rebase operations using the Medium budget tier (haiku model)
- Single one-line fix at `crates/harness-server/src/task_executor/triage_pipeline.rs:259`

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass

Closes #788