### PR TITLE
fix(dedup): exclude closed PRs from terminal-task dedup (#791)

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -92,6 +92,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pr_state: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -182,6 +183,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pr_state: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -205,6 +207,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pr_state: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -279,6 +282,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pr_state: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -344,6 +348,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        pr_state: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -128,7 +128,12 @@ pub(crate) async fn build_services(
             tasks_for_recovery
                 .validate_recovered_tasks(cb_for_recovery)
                 .await;
-            tasks_for_recovery.validate_done_tasks_pr_state().await;
+            // Sweep at startup then every 5 minutes so tasks that complete during
+            // this server session get pr_state populated without waiting for a restart.
+            loop {
+                tasks_for_recovery.validate_done_tasks_pr_state().await;
+                tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+            }
         });
     }
 

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -128,6 +128,7 @@ pub(crate) async fn build_services(
             tasks_for_recovery
                 .validate_recovered_tasks(cb_for_recovery)
                 .await;
+            tasks_for_recovery.validate_done_tasks_pr_state().await;
         });
     }
 

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -137,6 +137,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pr_state: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -178,6 +179,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pr_state: None,
         };
         store.insert(&parent_state).await;
 
@@ -203,6 +205,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pr_state: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -16,7 +16,7 @@ const ARTIFACT_MAX_BYTES: usize = 65_536;
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings";
+const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings, pr_state";
 
 /// Versioned migrations for the tasks table.
 ///
@@ -130,6 +130,11 @@ static TASK_MIGRATIONS: &[Migration] = &[
         version: 16,
         description: "add request_settings column for execution limit recovery",
         sql: "ALTER TABLE tasks ADD COLUMN request_settings TEXT",
+    },
+    Migration {
+        version: 17,
+        description: "add pr_state column for dedup correctness on closed PRs",
+        sql: "ALTER TABLE tasks ADD COLUMN pr_state TEXT",
     },
 ];
 
@@ -248,6 +253,7 @@ impl TaskDb {
             "UPDATE tasks SET status = ?, turn = ?, pr_url = ?, rounds = ?, error = ?,
                     source = ?, external_id = ?, repo = ?, depends_on = ?, project = ?,
                     priority = ?, phase = ?, description = ?, request_settings = ?,
+                    pr_state = COALESCE(?, pr_state),
                     updated_at = datetime('now')
              WHERE id = ?",
         )
@@ -270,6 +276,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
+        .bind(state.pr_state.as_deref())
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -335,6 +342,10 @@ impl TaskDb {
     ///
     /// Returns `(task_id, pr_url)` when found. Only matches `done` — failed/cancelled
     /// tasks are excluded so that retries after failure are always permitted.
+    ///
+    /// Rows where `pr_state = 'CLOSED'` are excluded: a closed-without-merge PR must
+    /// not block resubmission. NULL `pr_state` (legacy rows) still matches to preserve
+    /// backward compatibility until the startup sweep populates `pr_state`.
     pub async fn find_terminal_with_pr(
         &self,
         project: &str,
@@ -343,6 +354,7 @@ impl TaskDb {
         let row: Option<(String, String)> = sqlx::query_as(
             "SELECT id, pr_url FROM tasks \
              WHERE project = ? AND external_id = ? AND status = 'done' AND pr_url IS NOT NULL \
+             AND (pr_state IS NULL OR pr_state != 'CLOSED') \
              ORDER BY created_at DESC LIMIT 1",
         )
         .bind(project)
@@ -350,6 +362,34 @@ impl TaskDb {
         .fetch_optional(&self.pool)
         .await?;
         Ok(row)
+    }
+
+    /// Return `(task_id, pr_url)` for done tasks that have a PR URL but no `pr_state` set.
+    ///
+    /// Limited to tasks updated within the last 90 days to bound GitHub API call volume
+    /// during the startup sweep. Returns rows ordered by most-recently-updated first.
+    pub async fn list_done_tasks_needing_pr_state(&self) -> anyhow::Result<Vec<(String, String)>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, pr_url FROM tasks \
+             WHERE status = 'done' AND pr_url IS NOT NULL AND pr_state IS NULL \
+             AND updated_at >= datetime('now', '-90 days') \
+             ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Update the `pr_state` column for a single task row.
+    ///
+    /// Expected values: `"OPEN"`, `"MERGED"`, `"CLOSED"` (GitHub PR state strings).
+    pub async fn set_pr_state(&self, task_id: &str, state: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE tasks SET pr_state = ?, updated_at = datetime('now') WHERE id = ?")
+            .bind(state)
+            .bind(task_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     /// Back-fill `external_id` on a task that was created without one.
@@ -949,6 +989,7 @@ impl TaskDb {
             "SELECT t.id, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
                     t.external_id, t.parent_id, t.created_at, t.repo, t.depends_on, \
                     t.project, t.priority, t.phase, t.description, t.request_settings, \
+                    t.pr_state, \
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
                     c.last_phase, c.updated_at AS ck_updated_at \
              FROM tasks t \
@@ -981,6 +1022,7 @@ impl TaskDb {
                 phase: row.phase,
                 description: row.description,
                 request_settings: row.request_settings,
+                pr_state: row.pr_state,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,
@@ -1022,6 +1064,7 @@ struct TaskRow {
     phase: String,
     description: Option<String>,
     request_settings: Option<String>,
+    pr_state: Option<String>,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -1048,6 +1091,7 @@ struct PendingCheckpointRow {
     phase: String,
     description: Option<String>,
     request_settings: Option<String>,
+    pr_state: Option<String>,
     // Checkpoint columns (aliased)
     triage_output: Option<String>,
     plan_output: Option<String>,
@@ -1076,6 +1120,7 @@ impl TaskRow {
             phase,
             description,
             request_settings,
+            pr_state,
         } = self;
 
         let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
@@ -1125,6 +1170,7 @@ impl TaskRow {
             plan_output: None,
             repo,
             request_settings: decoded_request_settings,
+            pr_state,
         })
     }
 }
@@ -1209,6 +1255,7 @@ mod tests {
             phase: r#""implement""#.to_string(),
             description: None,
             request_settings: None,
+            pr_state: None,
         }
     }
 
@@ -1318,6 +1365,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pr_state: None,
         }
     }
 
@@ -2039,15 +2087,107 @@ mod tests {
             phase: String::new(),
             description: None,
             request_settings: None,
+            pr_state: None,
         };
 
         // Count must match — catches column added to constant but not struct (or vice versa).
         assert_eq!(
             columns.len(),
-            17, // bump this when adding a field
-            "TASK_ROW_COLUMNS has {} entries but expected 17 — update both the constant and this test",
+            18, // bump this when adding a field
+            "TASK_ROW_COLUMNS has {} entries but expected 18 — update both the constant and this test",
             columns.len()
         );
+    }
+
+    // --- find_terminal_with_pr pr_state tests ---
+
+    #[tokio::test]
+    async fn find_terminal_with_pr_returns_none_when_pr_closed() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-closed", TaskStatus::Done);
+        task.external_id = Some("issue:100".to_string());
+        task.pr_url = Some("https://github.com/org/repo/pull/10".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/x"));
+        db.insert(&task).await?;
+        db.set_pr_state("task-closed", "CLOSED").await?;
+
+        let result = db.find_terminal_with_pr("/repo/x", "issue:100").await?;
+        assert!(
+            result.is_none(),
+            "CLOSED pr_state must not block resubmission"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_terminal_with_pr_returns_row_when_pr_open() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-open", TaskStatus::Done);
+        task.external_id = Some("issue:101".to_string());
+        task.pr_url = Some("https://github.com/org/repo/pull/11".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/x"));
+        db.insert(&task).await?;
+        db.set_pr_state("task-open", "OPEN").await?;
+
+        let result = db.find_terminal_with_pr("/repo/x", "issue:101").await?;
+        assert!(result.is_some(), "OPEN pr_state must still dedup");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_terminal_with_pr_returns_row_when_pr_merged() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-merged", TaskStatus::Done);
+        task.external_id = Some("issue:102".to_string());
+        task.pr_url = Some("https://github.com/org/repo/pull/12".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/x"));
+        db.insert(&task).await?;
+        db.set_pr_state("task-merged", "MERGED").await?;
+
+        let result = db.find_terminal_with_pr("/repo/x", "issue:102").await?;
+        assert!(result.is_some(), "MERGED pr_state must still dedup");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_terminal_with_pr_returns_row_when_pr_state_null() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let mut task = make_task("task-null-state", TaskStatus::Done);
+        task.external_id = Some("issue:103".to_string());
+        task.pr_url = Some("https://github.com/org/repo/pull/13".to_string());
+        task.project_root = Some(std::path::PathBuf::from("/repo/x"));
+        db.insert(&task).await?;
+        // pr_state left NULL (legacy row — no set_pr_state call)
+
+        let result = db.find_terminal_with_pr("/repo/x", "issue:103").await?;
+        assert!(
+            result.is_some(),
+            "NULL pr_state must still dedup for backward compat"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_pr_state_updates_correctly() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        let task = make_task("task-set-state", TaskStatus::Done);
+        db.insert(&task).await?;
+
+        db.set_pr_state("task-set-state", "MERGED").await?;
+
+        let loaded = db.get("task-set-state").await?.expect("should exist");
+        assert_eq!(loaded.pr_state.as_deref(), Some("MERGED"));
+        Ok(())
     }
 
     /// Regression: list_by_status must map to TaskRow correctly (including priority).

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -344,8 +344,10 @@ impl TaskDb {
     /// tasks are excluded so that retries after failure are always permitted.
     ///
     /// Rows where `pr_state = 'CLOSED'` are excluded: a closed-without-merge PR must
-    /// not block resubmission. NULL `pr_state` (legacy rows) still matches to preserve
-    /// backward compatibility until the startup sweep populates `pr_state`.
+    /// not block resubmission. NULL `pr_state` is eligible only within the 90-day
+    /// backfill window (matching `list_done_tasks_needing_pr_state`). Rows older than
+    /// 90 days with NULL `pr_state` will never be backfilled and must not permanently
+    /// block resubmission.
     pub async fn find_terminal_with_pr(
         &self,
         project: &str,
@@ -355,6 +357,7 @@ impl TaskDb {
             "SELECT id, pr_url FROM tasks \
              WHERE project = ? AND external_id = ? AND status = 'done' AND pr_url IS NOT NULL \
              AND (pr_state IS NULL OR pr_state != 'CLOSED') \
+             AND (pr_state IS NOT NULL OR updated_at >= datetime('now', '-90 days')) \
              ORDER BY created_at DESC LIMIT 1",
         )
         .bind(project)

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -344,10 +344,10 @@ impl TaskDb {
     /// tasks are excluded so that retries after failure are always permitted.
     ///
     /// Rows where `pr_state = 'CLOSED'` are excluded: a closed-without-merge PR must
-    /// not block resubmission. NULL `pr_state` is eligible only within the 90-day
-    /// backfill window (matching `list_done_tasks_needing_pr_state`). Rows older than
-    /// 90 days with NULL `pr_state` will never be backfilled and must not permanently
-    /// block resubmission.
+    /// not block resubmission. Rows with NULL `pr_state` are included regardless of age
+    /// — we cannot know whether their PR is OPEN or MERGED, so we conservatively block
+    /// resubmission. The backfill sweep (`list_done_tasks_needing_pr_state`) has its own
+    /// 90-day limit for API efficiency; that limit must not carry over to dedup.
     pub async fn find_terminal_with_pr(
         &self,
         project: &str,
@@ -357,7 +357,6 @@ impl TaskDb {
             "SELECT id, pr_url FROM tasks \
              WHERE project = ? AND external_id = ? AND status = 'done' AND pr_url IS NOT NULL \
              AND (pr_state IS NULL OR pr_state != 'CLOSED') \
-             AND (pr_state IS NOT NULL OR updated_at >= datetime('now', '-90 days')) \
              ORDER BY created_at DESC LIMIT 1",
         )
         .bind(project)

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -202,6 +202,11 @@ pub struct TaskState {
     /// requested rather than silently falling back to server defaults.
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
+    /// GitHub PR state: `"OPEN"`, `"MERGED"`, or `"CLOSED"`. Persisted to the DB
+    /// so that dedup correctly skips done tasks whose PR was closed without merging.
+    /// `None` for tasks created before migration v17 until the startup sweep runs.
+    #[serde(skip)]
+    pub pr_state: Option<String>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -266,6 +271,7 @@ impl TaskState {
             plan_output: None,
             repo: None,
             request_settings: None,
+            pr_state: None,
         }
     }
 
@@ -939,6 +945,9 @@ impl TaskStore {
 
     /// Check whether a `done` task with a PR URL already exists for the same
     /// project + external_id. Cache-first, DB fallback. Fail-open on DB errors.
+    ///
+    /// Skips cache entries whose `pr_state` is `"CLOSED"` — a closed-without-merge
+    /// PR must not block resubmission (mirrors the SQL fix in `find_terminal_with_pr`).
     pub async fn find_terminal_pr_duplicate(
         &self,
         project_id: &str,
@@ -953,6 +962,9 @@ impl TaskStore {
                     .map(|p| p.to_string_lossy() == project_id)
                     .unwrap_or(false);
             if same_key && matches!(task.status, TaskStatus::Done) {
+                if task.pr_state.as_deref() == Some("CLOSED") {
+                    continue;
+                }
                 if let Some(ref url) = task.pr_url {
                     return Some((task.id.clone(), url.clone()));
                 }
@@ -1592,6 +1604,7 @@ impl TaskStore {
             if let Some(status) = new_status {
                 if let Some(mut entry) = self.cache.get_mut(&task_id) {
                     entry.status = status;
+                    entry.pr_state = Some(state.clone());
                 }
                 // Persist before invoking the callback. If persist fails the task
                 // remains `pending` in SQLite; firing the callback anyway would push
@@ -1624,6 +1637,91 @@ impl TaskStore {
                     "startup recovery: PR state {state} → leaving pending"
                 );
             }
+        }
+    }
+
+    /// Sweep done tasks that have a `pr_url` but no `pr_state` and backfill the column.
+    ///
+    /// Targets tasks created before migration v17 (or any task where `pr_state` was not
+    /// set at completion). Calls `gh pr view` for each candidate and writes
+    /// `OPEN` / `MERGED` / `CLOSED` to the DB. Limits to tasks updated within the last
+    /// 90 days to avoid hammering the GitHub API on large installs.
+    ///
+    /// This is the mechanism that lets `find_terminal_with_pr` correctly unblock
+    /// resubmission after a PR is closed: once `pr_state = 'CLOSED'` is written here,
+    /// the next dedup check will not match the old task.
+    pub async fn validate_done_tasks_pr_state(&self) {
+        let candidates: Vec<(String, String)> =
+            match self.db.list_done_tasks_needing_pr_state().await {
+                Ok(rows) => rows,
+                Err(e) => {
+                    tracing::warn!("validate_done_tasks_pr_state: DB query failed: {e}");
+                    return;
+                }
+            };
+
+        if candidates.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            "startup: backfilling pr_state for {} done task(s) with unset pr_state",
+            candidates.len()
+        );
+
+        for (task_id, pr_url) in candidates {
+            let Some((owner, repo, number)) = parse_pr_url(&pr_url) else {
+                tracing::warn!(
+                    task_id,
+                    pr_url,
+                    "validate_done_tasks_pr_state: could not parse PR URL; skipping"
+                );
+                continue;
+            };
+
+            let pr_ref = format!("{owner}/{repo}#{number}");
+            let mut cmd = tokio::process::Command::new("gh");
+            cmd.args(["pr", "view", &pr_ref, "--json", "state", "--jq", ".state"])
+                .kill_on_drop(true);
+            let gh_result =
+                tokio::time::timeout(std::time::Duration::from_secs(10), cmd.output()).await;
+
+            let output = match gh_result {
+                Err(_) => {
+                    tracing::warn!(task_id, pr_url, "gh pr view timed out; skipping");
+                    continue;
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(task_id, pr_url, "gh CLI error: {e}; skipping");
+                    continue;
+                }
+                Ok(Ok(out)) => out,
+            };
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(task_id, pr_url, "gh pr view failed: {stderr}; skipping");
+                continue;
+            }
+
+            let state = String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .to_uppercase();
+            if state.is_empty() {
+                continue;
+            }
+
+            if let Err(e) = self.db.set_pr_state(&task_id, &state).await {
+                tracing::warn!(
+                    task_id,
+                    "validate_done_tasks_pr_state: set_pr_state failed: {e}"
+                );
+            } else {
+                tracing::info!(task_id, pr_url, state, "startup: backfilled pr_state");
+            }
+
+            // Pace calls to avoid GitHub API rate limits.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         }
     }
 }
@@ -3629,6 +3727,30 @@ mod tests {
         assert!(
             !failed.contains(&task_id),
             "cancelled task must not be in failed_ids"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_terminal_pr_duplicate_skips_closed_in_cache() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let task_id = harness_core::types::TaskId("t-closed-cache".to_string());
+        let mut state = TaskState::new(task_id.clone());
+        state.status = TaskStatus::Done;
+        state.external_id = Some("issue:999".to_string());
+        state.project_root = Some(std::path::PathBuf::from("/repo/y"));
+        state.pr_url = Some("https://github.com/org/repo/pull/99".to_string());
+        state.pr_state = Some("CLOSED".to_string());
+        store.cache.insert(task_id, state);
+
+        let result = store
+            .find_terminal_pr_duplicate("/repo/y", "issue:999")
+            .await;
+        assert!(
+            result.is_none(),
+            "cache entry with pr_state=CLOSED must not block resubmission"
         );
         Ok(())
     }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1717,7 +1717,15 @@ impl TaskStore {
                     "validate_done_tasks_pr_state: set_pr_state failed: {e}"
                 );
             } else {
-                tracing::info!(task_id, pr_url, state, "startup: backfilled pr_state");
+                // Mirror the DB write into the in-memory cache so that
+                // `find_terminal_pr_duplicate` sees the updated state
+                // immediately — without this, a task that completes during
+                // the current server session retains pr_state=None in the
+                // cache and continues blocking resubmission until restart.
+                if let Some(mut entry) = self.cache.get_mut(&CoreTaskId(task_id.clone())) {
+                    entry.pr_state = Some(state.clone());
+                }
+                tracing::info!(task_id, pr_url, state, "backfilled pr_state");
             }
 
             // Pace calls to avoid GitHub API rate limits.

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -33,6 +33,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         plan_output: None,
         repo: None,
         request_settings: None,
+        pr_state: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `pr_state` column (migration v17) to track GitHub PR state on done tasks
- `find_terminal_with_pr` SQL now excludes rows where `pr_state = 'CLOSED'`, so resubmitting an issue whose previous PR was closed no longer silently returns the stale task
- In-memory dedup (`find_terminal_pr_duplicate`) mirrors the fix for same-session cache hits
- `validate_recovered_tasks` now writes `pr_state = MERGED/CLOSED` when it detects a terminal PR state at startup
- New `validate_done_tasks_pr_state` startup sweep backfills `pr_state` for legacy done tasks (90-day window, 200 ms pacing) — this is what unblocks resubmission for existing closed PRs without requiring a manual DB fixup
- 6 new unit tests: closed/open/merged/null pr_state SQL paths + set_pr_state helper + cache skip

## Test plan

- [ ] `cargo test --package harness-server` — all existing + 6 new tests pass
- [ ] Resubmit an issue whose previous done task has `pr_state = 'CLOSED'` → new task created
- [ ] Resubmit an issue whose previous done task has `pr_state = 'MERGED'` → still deduped (no regression)
- [ ] Resubmit while a PR is open → still deduped via Layer 1 active-task check (no regression)