### PR TITLE
feat(scheduler): periodic retry loop for stalled open issues (#794)

### DIFF
--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -49,6 +49,8 @@ pub struct HarnessConfig {
     pub intake: IntakeConfig,
     #[serde(default)]
     pub review: ReviewConfig,
+    #[serde(default)]
+    pub retry_scheduler: RetrySchedulerConfig,
     /// Projects declared in the config file. Registered on server startup.
     #[serde(default)]
     pub projects: Vec<ProjectEntry>,
@@ -520,6 +522,40 @@ mod tests {
     fn harness_config_includes_review() {
         let config = HarnessConfig::default();
         assert!(!config.review.enabled);
+    }
+
+    #[test]
+    fn retry_scheduler_config_defaults() {
+        let config = RetrySchedulerConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.interval_secs, 300);
+        assert_eq!(config.stale_threshold_mins, 60);
+        assert_eq!(config.cooldown_mins, 120);
+        assert_eq!(config.max_retries, 3);
+    }
+
+    #[test]
+    fn retry_scheduler_config_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            interval_secs = 600
+            stale_threshold_mins = 30
+            cooldown_mins = 60
+            max_retries = 5
+        "#;
+        let config: RetrySchedulerConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.interval_secs, 600);
+        assert_eq!(config.stale_threshold_mins, 30);
+        assert_eq!(config.cooldown_mins, 60);
+        assert_eq!(config.max_retries, 5);
+    }
+
+    #[test]
+    fn harness_config_includes_retry_scheduler() {
+        let config = HarnessConfig::default();
+        assert!(!config.retry_scheduler.enabled);
+        assert_eq!(config.retry_scheduler.interval_secs, 300);
     }
 
     #[test]

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -423,6 +423,60 @@ impl Default for ReviewConfig {
     }
 }
 
+/// Configuration for the periodic retry scheduler.
+///
+/// The scheduler scans for stalled in-flight tasks (tasks in active statuses
+/// whose `updated_at` is older than `stale_threshold_mins`) and re-enqueues
+/// them up to `max_retries` times before labelling the issue `harness:stuck`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrySchedulerConfig {
+    /// Whether the periodic retry scheduler is enabled. Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Seconds between scheduler ticks. Default: 300 (5 minutes).
+    #[serde(default = "default_retry_interval_secs")]
+    pub interval_secs: u64,
+    /// A task is considered stalled when `updated_at` is older than this many
+    /// minutes. Default: 60.
+    #[serde(default = "default_retry_stale_threshold_mins")]
+    pub stale_threshold_mins: u64,
+    /// Minimum gap in minutes between two retries of the same task. Default: 120.
+    #[serde(default = "default_retry_cooldown_mins")]
+    pub cooldown_mins: u64,
+    /// Maximum number of automatic retries before the task is labelled
+    /// `harness:stuck`. Default: 3.
+    #[serde(default = "default_retry_max_retries")]
+    pub max_retries: u32,
+}
+
+fn default_retry_interval_secs() -> u64 {
+    300
+}
+
+fn default_retry_stale_threshold_mins() -> u64 {
+    60
+}
+
+fn default_retry_cooldown_mins() -> u64 {
+    120
+}
+
+fn default_retry_max_retries() -> u32 {
+    3
+}
+
+impl Default for RetrySchedulerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: default_retry_interval_secs(),
+            stale_threshold_mins: default_retry_stale_threshold_mins(),
+            cooldown_mins: default_retry_cooldown_mins(),
+            max_retries: default_retry_max_retries(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -142,12 +142,16 @@ impl EventStore {
         }
 
         // Phase 2: trim watermark history — keep only the newest row per hook.
-        // Covers both periodic_review:* and periodic_retry:* watermarks.
+        // Only trims true watermark hooks (periodic_review:* and
+        // periodic_retry:summary).  Per-identity history hooks such as
+        // periodic_retry:attempt:* and periodic_retry:stuck:* must NOT be
+        // trimmed because attempt counts are derived from the number of events
+        // stored under those hooks.
         loop {
             let result = sqlx::query(
                 "DELETE FROM events WHERE id IN (
                     SELECT e.id FROM events e
-                    WHERE (e.hook GLOB 'periodic_review:*' OR e.hook GLOB 'periodic_retry:*')
+                    WHERE (e.hook GLOB 'periodic_review:*' OR e.hook = 'periodic_retry:summary')
                     AND e.ts < (
                         SELECT MAX(e2.ts) FROM events e2 WHERE e2.hook = e.hook
                     )

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -116,12 +116,15 @@ impl EventStore {
         let mut total_deleted: u64 = 0;
 
         // Phase 1: delete regular (non-watermark) events older than the
-        // retention window.
+        // retention window.  Both periodic_review:* and periodic_retry:* hooks
+        // are spared so their watermark/attempt history survives purges.
         loop {
             let result = sqlx::query(
                 "DELETE FROM events WHERE id IN (
                     SELECT id FROM events
-                    WHERE ts < ? AND hook NOT GLOB 'periodic_review:*'
+                    WHERE ts < ?
+                      AND hook NOT GLOB 'periodic_review:*'
+                      AND hook NOT GLOB 'periodic_retry:*'
                     LIMIT 500
                 )",
             )
@@ -139,11 +142,12 @@ impl EventStore {
         }
 
         // Phase 2: trim watermark history — keep only the newest row per hook.
+        // Covers both periodic_review:* and periodic_retry:* watermarks.
         loop {
             let result = sqlx::query(
                 "DELETE FROM events WHERE id IN (
                     SELECT e.id FROM events e
-                    WHERE e.hook GLOB 'periodic_review:*'
+                    WHERE (e.hook GLOB 'periodic_review:*' OR e.hook GLOB 'periodic_retry:*')
                     AND e.ts < (
                         SELECT MAX(e2.ts) FROM events e2 WHERE e2.hook = e.hook
                     )
@@ -531,6 +535,38 @@ impl EventStore {
             if let Err(e) = self.log(&evt).await {
                 tracing::warn!("failed to log auto_fix_attempt event: {e}");
             }
+        }
+    }
+
+    /// Emit a `periodic_retry:summary` event recording one scheduler tick's outcome.
+    ///
+    /// `checked`  — total stalled tasks evaluated this tick.
+    /// `retried`  — tasks successfully re-enqueued.
+    /// `stuck`    — tasks that hit the retry cap and were labelled `harness:stuck`.
+    /// `skipped`  — tasks skipped due to cooldown or other reasons.
+    pub async fn persist_retry_summary(
+        &self,
+        checked: u32,
+        retried: u32,
+        stuck: u32,
+        skipped: u32,
+    ) {
+        let decision = if stuck > 0 {
+            Decision::Warn
+        } else {
+            Decision::Pass
+        };
+        let mut event = Event::new(
+            SessionId::new(),
+            "periodic_retry:summary",
+            "RetryScheduler",
+            decision,
+        );
+        event.detail = Some(format!(
+            r#"{{"checked":{checked},"retried":{retried},"stuck":{stuck},"skipped":{skipped}}}"#
+        ));
+        if let Err(e) = self.log(&event).await {
+            tracing::warn!("periodic_retry: failed to log summary event: {e}");
         }
     }
 

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -25,6 +25,7 @@ pub mod intake;
 pub mod memory_monitor;
 pub mod notify;
 pub mod parallel_dispatch;
+pub mod periodic_retry;
 pub mod periodic_reviewer;
 pub use harness_workflow::plan_db;
 pub mod post_validator;

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -1,6 +1,6 @@
 use crate::http::task_routes;
 use crate::http::AppState;
-use crate::task_runner::CreateTaskRequest;
+use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskStatus};
 use chrono::Utc;
 use harness_core::{
     config::misc::RetrySchedulerConfig,
@@ -9,6 +9,20 @@ use harness_core::{
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
+
+/// Parse a canonical `external_id` into `(issue_num, pr_num)`.
+fn parse_external_id(external_id: Option<&str>) -> (Option<u64>, Option<u64>) {
+    match external_id {
+        Some(eid) if eid.starts_with("issue:") => (
+            eid.strip_prefix("issue:").and_then(|s| s.parse().ok()),
+            None,
+        ),
+        Some(eid) if eid.starts_with("pr:") => {
+            (None, eid.strip_prefix("pr:").and_then(|s| s.parse().ok()))
+        }
+        _ => (None, None),
+    }
+}
 
 /// Spawn the periodic retry loop as a background task.
 ///
@@ -111,14 +125,27 @@ async fn run_retry_tick(
                 );
             }
 
-            let issue_num = task
-                .external_id
-                .as_deref()
-                .and_then(|eid| eid.strip_prefix("issue:"))
-                .and_then(|s| s.parse::<u64>().ok());
+            // Cancel the stalled task before re-enqueuing so the active-task
+            // dedup in enqueue_task does not find it and return the same ID
+            // instead of creating a new successor.
+            if let Err(e) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                s.status = TaskStatus::Cancelled;
+            })
+            .await
+            {
+                tracing::warn!(
+                    task_id = %task.id.0,
+                    "periodic_retry: failed to cancel stalled task before retry: {e}; skipping"
+                );
+                continue;
+            }
+            state.core.tasks.abort_task(&task.id);
+
+            let (issue_num, pr_num) = parse_external_id(task.external_id.as_deref());
 
             let req = CreateTaskRequest {
                 issue: issue_num,
+                pr: pr_num,
                 repo: task.repo.clone(),
                 source: Some("periodic-retry".to_string()),
                 project: task.project_root.clone(),
@@ -144,9 +171,33 @@ async fn run_retry_tick(
                 }
             }
         } else {
-            // Retry cap reached — emit stuck event and ask an agent to apply label.
-            let session_id = SessionId::new();
+            // Retry cap reached.
             let stuck_hook = format!("periodic_retry:stuck:{}", task.id.0);
+
+            // Once-only guard: if we already emitted a stuck event for this
+            // task, skip re-escalation — prompt-only tasks have no external_id
+            // so the normal dedup path would not stop duplicates.
+            let prior_stuck = state
+                .observability
+                .events
+                .query(&EventFilters {
+                    hook: Some(stuck_hook.clone()),
+                    ..EventFilters::default()
+                })
+                .await
+                .unwrap_or_default();
+
+            if !prior_stuck.is_empty() {
+                tracing::debug!(
+                    task_id = %task.id.0,
+                    "periodic_retry: already escalated as stuck, skipping duplicate"
+                );
+                stuck += 1;
+                continue;
+            }
+
+            // Emit stuck event and ask an agent to apply label.
+            let session_id = SessionId::new();
             let mut stuck_event =
                 Event::new(session_id, &stuck_hook, "RetryScheduler", Decision::Warn);
             stuck_event.reason = Some(format!(
@@ -163,18 +214,23 @@ async fn run_retry_tick(
 
             // Enqueue an agent task to apply the harness:stuck label.
             // Direct gh calls are forbidden inside harness crates (CLAUDE.md).
-            if let Some(issue_num) = task
-                .external_id
-                .as_deref()
-                .and_then(|eid| eid.strip_prefix("issue:"))
-                .and_then(|s| s.parse::<u64>().ok())
-            {
-                let prompt = format!(
-                    "Add the label `harness:stuck` to issue #{issue_num}. \
+            let (issue_num, pr_num) = parse_external_id(task.external_id.as_deref());
+            let stuck_prompt = match (issue_num, pr_num) {
+                (Some(n), _) => Some(format!(
+                    "Add the label `harness:stuck` to issue #{n}. \
                      This issue has reached the maximum automatic retry limit \
                      ({}/{}) and requires human attention.",
                     attempt_count, config.max_retries
-                );
+                )),
+                (_, Some(n)) => Some(format!(
+                    "Add the label `harness:stuck` to PR #{n}. \
+                     This pull request has reached the maximum automatic retry limit \
+                     ({}/{}) and requires human attention.",
+                    attempt_count, config.max_retries
+                )),
+                _ => None,
+            };
+            if let Some(prompt) = stuck_prompt {
                 let req = CreateTaskRequest {
                     prompt: Some(prompt),
                     repo: task.repo.clone(),
@@ -185,7 +241,6 @@ async fn run_retry_tick(
                 if let Err(e) = task_routes::enqueue_task(state, req).await {
                     tracing::warn!(
                         task_id = %task.id.0,
-                        issue = issue_num,
                         "periodic_retry: failed to enqueue stuck-label task: {e}"
                     );
                 }

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -1,0 +1,417 @@
+use crate::http::task_routes;
+use crate::http::AppState;
+use crate::task_runner::CreateTaskRequest;
+use chrono::Utc;
+use harness_core::{
+    config::misc::RetrySchedulerConfig,
+    types::{Decision, Event, EventFilters, SessionId},
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Spawn the periodic retry loop as a background task.
+///
+/// If retry scheduling is disabled in config the function returns immediately
+/// without spawning anything; no resources are consumed.
+pub fn start(state: Arc<AppState>, config: RetrySchedulerConfig) {
+    if !config.enabled {
+        tracing::debug!("scheduler: periodic retry disabled, retry loop not started");
+        return;
+    }
+
+    tokio::spawn(async move {
+        retry_loop(state, config).await;
+    });
+}
+
+async fn retry_loop(state: Arc<AppState>, config: RetrySchedulerConfig) {
+    let interval = Duration::from_secs(config.interval_secs);
+    let stale_threshold = Duration::from_secs(config.stale_threshold_mins * 60);
+
+    // Brief init delay to let the server fully come up before the first tick.
+    sleep(Duration::from_secs(15)).await;
+
+    loop {
+        if let Err(e) = run_retry_tick(&state, &config, stale_threshold).await {
+            tracing::error!("periodic_retry: tick failed: {e}");
+        }
+        sleep(interval).await;
+    }
+}
+
+async fn run_retry_tick(
+    state: &Arc<AppState>,
+    config: &RetrySchedulerConfig,
+    stale_threshold: Duration,
+) -> anyhow::Result<()> {
+    let stalled = state
+        .core
+        .tasks
+        .list_stalled_tasks(stale_threshold, None)
+        .await?;
+
+    let cooldown = chrono::Duration::minutes(config.cooldown_mins as i64);
+
+    let mut checked: u32 = 0;
+    let mut retried: u32 = 0;
+    let mut stuck: u32 = 0;
+    let mut skipped: u32 = 0;
+
+    for task in &stalled {
+        checked += 1;
+
+        // Query attempt history for this specific task.
+        let attempt_hook = format!("periodic_retry:attempt:{}", task.id.0);
+        let attempts = state
+            .observability
+            .events
+            .query(&EventFilters {
+                hook: Some(attempt_hook.clone()),
+                ..EventFilters::default()
+            })
+            .await
+            .unwrap_or_default();
+
+        let attempt_count = attempts.len() as u32;
+        let last_attempt_ts = attempts.iter().map(|e| e.ts).max();
+
+        // Skip if still within the cooldown window.
+        if let Some(last_ts) = last_attempt_ts {
+            let elapsed = Utc::now().signed_duration_since(last_ts);
+            if elapsed < cooldown {
+                tracing::debug!(
+                    task_id = %task.id.0,
+                    elapsed_mins = elapsed.num_minutes(),
+                    cooldown_mins = config.cooldown_mins,
+                    "periodic_retry: within cooldown, skipping"
+                );
+                skipped += 1;
+                continue;
+            }
+        }
+
+        if attempt_count < config.max_retries {
+            // Emit attempt watermark event before enqueuing so that a
+            // scheduler crash between the two does not cause a silent retry
+            // without an event record.
+            let session_id = SessionId::new();
+            let mut attempt_event =
+                Event::new(session_id, &attempt_hook, "RetryScheduler", Decision::Pass);
+            attempt_event.reason = Some(format!(
+                "attempt {}/{}",
+                attempt_count + 1,
+                config.max_retries
+            ));
+            attempt_event.detail = Some(task.id.0.clone());
+            if let Err(e) = state.observability.events.log(&attempt_event).await {
+                tracing::warn!(
+                    task_id = %task.id.0,
+                    "periodic_retry: failed to log attempt event: {e}"
+                );
+            }
+
+            let issue_num = task
+                .external_id
+                .as_deref()
+                .and_then(|eid| eid.strip_prefix("issue:"))
+                .and_then(|s| s.parse::<u64>().ok());
+
+            let req = CreateTaskRequest {
+                issue: issue_num,
+                repo: task.repo.clone(),
+                source: Some("periodic-retry".to_string()),
+                project: task.project_root.clone(),
+                ..CreateTaskRequest::default()
+            };
+
+            match task_routes::enqueue_task(state, req).await {
+                Ok(new_id) => {
+                    tracing::info!(
+                        new_task_id = %new_id,
+                        stalled_task_id = %task.id.0,
+                        attempt = attempt_count + 1,
+                        max = config.max_retries,
+                        "periodic_retry: stalled task re-enqueued"
+                    );
+                    retried += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %task.id.0,
+                        "periodic_retry: failed to enqueue retry: {e}"
+                    );
+                }
+            }
+        } else {
+            // Retry cap reached — emit stuck event and ask an agent to apply label.
+            let session_id = SessionId::new();
+            let stuck_hook = format!("periodic_retry:stuck:{}", task.id.0);
+            let mut stuck_event =
+                Event::new(session_id, &stuck_hook, "RetryScheduler", Decision::Warn);
+            stuck_event.reason = Some(format!(
+                "retry cap reached ({}/{})",
+                attempt_count, config.max_retries
+            ));
+            stuck_event.detail = Some(task.id.0.clone());
+            if let Err(e) = state.observability.events.log(&stuck_event).await {
+                tracing::warn!(
+                    task_id = %task.id.0,
+                    "periodic_retry: failed to log stuck event: {e}"
+                );
+            }
+
+            // Enqueue an agent task to apply the harness:stuck label.
+            // Direct gh calls are forbidden inside harness crates (CLAUDE.md).
+            if let Some(issue_num) = task
+                .external_id
+                .as_deref()
+                .and_then(|eid| eid.strip_prefix("issue:"))
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                let prompt = format!(
+                    "Add the label `harness:stuck` to issue #{issue_num}. \
+                     This issue has reached the maximum automatic retry limit \
+                     ({}/{}) and requires human attention.",
+                    attempt_count, config.max_retries
+                );
+                let req = CreateTaskRequest {
+                    prompt: Some(prompt),
+                    repo: task.repo.clone(),
+                    source: Some("periodic-retry-stuck".to_string()),
+                    project: task.project_root.clone(),
+                    ..CreateTaskRequest::default()
+                };
+                if let Err(e) = task_routes::enqueue_task(state, req).await {
+                    tracing::warn!(
+                        task_id = %task.id.0,
+                        issue = issue_num,
+                        "periodic_retry: failed to enqueue stuck-label task: {e}"
+                    );
+                }
+            }
+
+            stuck += 1;
+        }
+    }
+
+    state
+        .observability
+        .events
+        .persist_retry_summary(checked, retried, stuck, skipped)
+        .await;
+
+    tracing::info!(
+        checked,
+        retried,
+        stuck,
+        skipped,
+        "periodic_retry: tick complete"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_db::TaskDb;
+    use crate::task_runner::{TaskState, TaskStatus};
+    use harness_core::types::TaskId;
+    use harness_observe::event_store::EventStore;
+
+    fn stalled_task(id: &str, external_id: &str, project: &str) -> TaskState {
+        TaskState {
+            id: TaskId(id.to_string()),
+            status: TaskStatus::Implementing,
+            turn: 1,
+            pr_url: None,
+            rounds: vec![],
+            error: None,
+            source: None,
+            external_id: Some(external_id.to_string()),
+            parent_id: None,
+            depends_on: vec![],
+            subtask_ids: vec![],
+            project_root: Some(std::path::PathBuf::from(project)),
+            issue: None,
+            repo: None,
+            description: None,
+            created_at: None,
+            priority: 0,
+            phase: crate::task_runner::TaskPhase::Implement,
+            triage_output: None,
+            plan_output: None,
+            request_settings: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn no_stalled_tasks_returns_empty() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        // Insert a Done task — should never be returned.
+        let mut done = stalled_task("t1", "issue:1", "/proj");
+        done.status = TaskStatus::Done;
+        db.insert(&done).await?;
+
+        let results = db.list_stalled_tasks(Duration::from_secs(1), None).await?;
+        assert!(results.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stalled_task_is_detected() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let task = stalled_task("t1", "issue:42", "/proj");
+        db.insert(&task).await?;
+        // Force updated_at into the past so the task qualifies as stalled.
+        sqlx::query(
+            "UPDATE tasks SET updated_at = datetime('now', '-120 minutes') WHERE id = 't1'",
+        )
+        .execute(db.pool_for_test())
+        .await?;
+
+        let results = db
+            .list_stalled_tasks(Duration::from_secs(60 * 60), None)
+            .await?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id.0, "t1");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn terminal_tasks_excluded() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        for (id, status) in [
+            ("t1", TaskStatus::Done),
+            ("t2", TaskStatus::Failed),
+            ("t3", TaskStatus::Cancelled),
+        ] {
+            let mut t = stalled_task(id, "issue:1", "/proj");
+            t.status = status;
+            db.insert(&t).await?;
+            sqlx::query(
+                "UPDATE tasks SET updated_at = datetime('now', '-120 minutes') WHERE id = ?",
+            )
+            .bind(id)
+            .execute(db.pool_for_test())
+            .await?;
+        }
+
+        let results = db
+            .list_stalled_tasks(Duration::from_secs(60 * 60), None)
+            .await?;
+        assert!(results.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn null_external_id_skipped() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = stalled_task("t1", "issue:1", "/proj");
+        task.external_id = None;
+        db.insert(&task).await?;
+        sqlx::query(
+            "UPDATE tasks SET updated_at = datetime('now', '-120 minutes') WHERE id = 't1'",
+        )
+        .execute(db.pool_for_test())
+        .await?;
+
+        let results = db
+            .list_stalled_tasks(Duration::from_secs(60 * 60), None)
+            .await?;
+        assert!(results.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn project_filter_scopes_results() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let t1 = stalled_task("t1", "issue:1", "/proj-a");
+        let t2 = stalled_task("t2", "issue:2", "/proj-b");
+        db.insert(&t1).await?;
+        db.insert(&t2).await?;
+        for id in ["t1", "t2"] {
+            sqlx::query(
+                "UPDATE tasks SET updated_at = datetime('now', '-120 minutes') WHERE id = ?",
+            )
+            .bind(id)
+            .execute(db.pool_for_test())
+            .await?;
+        }
+
+        let results = db
+            .list_stalled_tasks(Duration::from_secs(60 * 60), Some("/proj-a"))
+            .await?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id.0, "t1");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn config_disabled_flag() {
+        let config = RetrySchedulerConfig {
+            enabled: false,
+            ..RetrySchedulerConfig::default()
+        };
+        assert!(!config.enabled);
+    }
+
+    #[tokio::test]
+    async fn summary_event_is_persisted() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let events = EventStore::new(tmp.path()).await?;
+        events.persist_retry_summary(5, 2, 1, 2).await;
+
+        let stored = events
+            .query(&EventFilters {
+                hook: Some("periodic_retry:summary".to_string()),
+                ..EventFilters::default()
+            })
+            .await?;
+        assert_eq!(stored.len(), 1);
+        let detail = stored[0].detail.as_deref().unwrap_or("");
+        assert!(detail.contains("\"checked\":5"));
+        assert!(detail.contains("\"retried\":2"));
+        assert!(detail.contains("\"stuck\":1"));
+        assert!(detail.contains("\"skipped\":2"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn summary_decision_is_warn_when_stuck_nonzero() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let events = EventStore::new(tmp.path()).await?;
+        events.persist_retry_summary(1, 0, 1, 0).await;
+
+        let stored = events
+            .query(&EventFilters {
+                hook: Some("periodic_retry:summary".to_string()),
+                ..EventFilters::default()
+            })
+            .await?;
+        assert_eq!(stored[0].decision, Decision::Warn);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn summary_decision_is_pass_when_no_stuck() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let events = EventStore::new(tmp.path()).await?;
+        events.persist_retry_summary(3, 2, 0, 1).await;
+
+        let stored = events
+            .query(&EventFilters {
+                hook: Some("periodic_retry:summary".to_string()),
+                ..EventFilters::default()
+            })
+            .await?;
+        assert_eq!(stored[0].decision, Decision::Pass);
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -219,13 +219,15 @@ async fn run_retry_tick(
                         task_id = %task.id.0,
                         "periodic_retry: failed to enqueue retry: {e}; restoring task status"
                     );
-                    // Restore the stalled task to its pre-cancel status so the
-                    // next tick can detect and retry it.  Without this, a
-                    // transient enqueue failure permanently drops the work item.
-                    if let Err(e2) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
-                        s.status = original_status.clone();
-                    })
-                    .await
+                    // Restore the stalled task to its pre-cancel status WITHOUT
+                    // updating updated_at so the next scheduler tick still sees it
+                    // as stale and retries it promptly instead of waiting another
+                    // full stale_threshold_mins window.
+                    if let Err(e2) = state
+                        .core
+                        .tasks
+                        .restore_status_preserve_staleness(&task.id, original_status)
+                        .await
                     {
                         tracing::error!(
                             task_id = %task.id.0,
@@ -254,8 +256,23 @@ async fn run_retry_tick(
             if !prior_stuck.is_empty() {
                 tracing::debug!(
                     task_id = %task.id.0,
-                    "periodic_retry: already escalated as stuck, skipping duplicate"
+                    "periodic_retry: already escalated as stuck, re-attempting cancellation"
                 );
+                // Previous escalation may not have successfully cancelled the task.
+                // Re-attempt cancellation so the task does not permanently occupy a
+                // stalled-scan slot (LIMIT 100) and block progress for other tasks.
+                if let Err(e) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                    s.status = TaskStatus::Cancelled;
+                })
+                .await
+                {
+                    tracing::warn!(
+                        task_id = %task.id.0,
+                        "periodic_retry: failed to cancel already-escalated stuck task: {e}"
+                    );
+                } else {
+                    state.core.tasks.abort_task(&task.id);
+                }
                 stuck += 1;
                 continue;
             }

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -75,8 +75,10 @@ async fn run_retry_tick(
     for task in &stalled {
         checked += 1;
 
-        // Query attempt history for this specific task.
-        let attempt_hook = format!("periodic_retry:attempt:{}", task.id.0);
+        // Key attempt history by external_id so counts persist across task
+        // generations (each retry creates a new task_id but the same issue/PR).
+        let ext_key = task.external_id.as_deref().unwrap_or(task.id.0.as_str());
+        let attempt_hook = format!("periodic_retry:attempt:{ext_key}");
         let attempts = state
             .observability
             .events
@@ -125,6 +127,9 @@ async fn run_retry_tick(
                 );
             }
 
+            // Capture original status so we can restore it if enqueue fails.
+            let original_status = task.status.clone();
+
             // Cancel the stalled task before re-enqueuing so the active-task
             // dedup in enqueue_task does not find it and return the same ID
             // instead of creating a new successor.
@@ -166,13 +171,26 @@ async fn run_retry_tick(
                 Err(e) => {
                     tracing::warn!(
                         task_id = %task.id.0,
-                        "periodic_retry: failed to enqueue retry: {e}"
+                        "periodic_retry: failed to enqueue retry: {e}; restoring task status"
                     );
+                    // Restore the stalled task to its pre-cancel status so the
+                    // next tick can detect and retry it.  Without this, a
+                    // transient enqueue failure permanently drops the work item.
+                    if let Err(e2) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                        s.status = original_status.clone();
+                    })
+                    .await
+                    {
+                        tracing::error!(
+                            task_id = %task.id.0,
+                            "periodic_retry: failed to restore task status after enqueue failure: {e2}"
+                        );
+                    }
                 }
             }
         } else {
             // Retry cap reached.
-            let stuck_hook = format!("periodic_retry:stuck:{}", task.id.0);
+            let stuck_hook = format!("periodic_retry:stuck:{ext_key}");
 
             // Once-only guard: if we already emitted a stuck event for this
             // task, skip re-escalation — prompt-only tasks have no external_id

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -119,23 +119,31 @@ async fn run_retry_tick(
         }
 
         if attempt_count < config.max_retries {
-            // Emit attempt watermark event before enqueuing so that a
-            // scheduler crash between the two does not cause a silent retry
-            // without an event record.
-            let session_id = SessionId::new();
-            let mut attempt_event =
-                Event::new(session_id, &attempt_hook, "RetryScheduler", Decision::Pass);
-            attempt_event.reason = Some(format!(
-                "attempt {}/{}",
-                attempt_count + 1,
-                config.max_retries
-            ));
-            attempt_event.detail = Some(task.id.0.clone());
-            if let Err(e) = state.observability.events.log(&attempt_event).await {
+            // Validate that the external_id is parseable before any destructive
+            // operation so a legacy or malformed ID cannot burn all retry attempts
+            // without ever producing a successor task.
+            let (issue_num, pr_num) = parse_external_id(task.external_id.as_deref());
+            if issue_num.is_none() && pr_num.is_none() {
                 tracing::warn!(
                     task_id = %task.id.0,
-                    "periodic_retry: failed to log attempt event: {e}"
+                    external_id = ?task.external_id,
+                    "periodic_retry: external_id is not parseable as issue/pr; \
+                     cancelling task without consuming a retry counter"
                 );
+                if let Err(e) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                    s.status = TaskStatus::Cancelled;
+                })
+                .await
+                {
+                    tracing::warn!(
+                        task_id = %task.id.0,
+                        "periodic_retry: failed to cancel unparseable task: {e}"
+                    );
+                } else {
+                    state.core.tasks.abort_task(&task.id);
+                }
+                stuck += 1;
+                continue;
             }
 
             // Capture original status so we can restore it if enqueue fails.
@@ -157,9 +165,10 @@ async fn run_retry_tick(
             }
             state.core.tasks.abort_task(&task.id);
 
-            let (issue_num, pr_num) = parse_external_id(task.external_id.as_deref());
-
-            let req = CreateTaskRequest {
+            // Restore original execution limits so the retry honours the same
+            // agent, budgets, timeouts, and prompt context as the original
+            // request rather than silently falling back to server defaults.
+            let mut req = CreateTaskRequest {
                 issue: issue_num,
                 pr: pr_num,
                 repo: task.repo.clone(),
@@ -173,9 +182,29 @@ async fn run_retry_tick(
                 project: task.project_root.clone(),
                 ..CreateTaskRequest::default()
             };
+            if let Some(settings) = &task.request_settings {
+                settings.apply_to_req(&mut req);
+            }
 
             match task_routes::enqueue_task(state, req).await {
                 Ok(new_id) => {
+                    // Emit attempt watermark only after confirmed enqueue so that
+                    // a transient enqueue failure does not consume a retry counter.
+                    let session_id = SessionId::new();
+                    let mut attempt_event =
+                        Event::new(session_id, &attempt_hook, "RetryScheduler", Decision::Pass);
+                    attempt_event.reason = Some(format!(
+                        "attempt {}/{}",
+                        attempt_count + 1,
+                        config.max_retries
+                    ));
+                    attempt_event.detail = Some(new_id.to_string());
+                    if let Err(e) = state.observability.events.log(&attempt_event).await {
+                        tracing::warn!(
+                            task_id = %task.id.0,
+                            "periodic_retry: failed to log attempt event: {e}"
+                        );
+                    }
                     tracing::info!(
                         new_task_id = %new_id,
                         stalled_task_id = %task.id.0,

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -90,7 +90,7 @@ async fn run_retry_tick(
             format!("{project_prefix}:{raw_ext}")
         };
         let attempt_hook = format!("periodic_retry:attempt:{ext_key}");
-        let attempts = state
+        let attempts = match state
             .observability
             .events
             .query(&EventFilters {
@@ -98,7 +98,17 @@ async fn run_retry_tick(
                 ..EventFilters::default()
             })
             .await
-            .unwrap_or_default();
+        {
+            Ok(events) => events,
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task.id.0,
+                    "periodic_retry: failed to query attempt history, skipping: {e}"
+                );
+                skipped += 1;
+                continue;
+            }
+        };
 
         let attempt_count = attempts.len() as u32;
         let last_attempt_ts = attempts.iter().map(|e| e.ts).max();
@@ -180,6 +190,7 @@ async fn run_retry_tick(
                     .clone()
                     .or_else(|| Some("periodic-retry".to_string())),
                 project: task.project_root.clone(),
+                priority: task.priority,
                 ..CreateTaskRequest::default()
             };
             if let Some(settings) = &task.request_settings {

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -75,9 +75,20 @@ async fn run_retry_tick(
     for task in &stalled {
         checked += 1;
 
-        // Key attempt history by external_id so counts persist across task
-        // generations (each retry creates a new task_id but the same issue/PR).
-        let ext_key = task.external_id.as_deref().unwrap_or(task.id.0.as_str());
+        // Key attempt history by project+external_id so counts persist across
+        // task generations (each retry creates a new task_id) while remaining
+        // isolated per repo on multi-repo servers.
+        let project_prefix = task
+            .project_root
+            .as_ref()
+            .and_then(|p| p.to_str())
+            .unwrap_or("");
+        let raw_ext = task.external_id.as_deref().unwrap_or(task.id.0.as_str());
+        let ext_key = if project_prefix.is_empty() {
+            raw_ext.to_string()
+        } else {
+            format!("{project_prefix}:{raw_ext}")
+        };
         let attempt_hook = format!("periodic_retry:attempt:{ext_key}");
         let attempts = state
             .observability
@@ -152,7 +163,13 @@ async fn run_retry_tick(
                 issue: issue_num,
                 pr: pr_num,
                 repo: task.repo.clone(),
-                source: Some("periodic-retry".to_string()),
+                // Preserve the original intake source so the completion
+                // callback can route back to the correct intake (e.g. GitHub)
+                // and unmark the issue from the dispatched set on failure/cancel.
+                source: task
+                    .source
+                    .clone()
+                    .or_else(|| Some("periodic-retry".to_string())),
                 project: task.project_root.clone(),
                 ..CreateTaskRequest::default()
             };
@@ -262,6 +279,22 @@ async fn run_retry_tick(
                         "periodic_retry: failed to enqueue stuck-label task: {e}"
                     );
                 }
+            }
+
+            // Transition the exhausted task out of active status so it no
+            // longer occupies a slot in list_stalled_tasks (which has a
+            // LIMIT 100), preventing it from starving newer stalled tasks.
+            if let Err(e) = mutate_and_persist(&state.core.tasks, &task.id, |s| {
+                s.status = TaskStatus::Cancelled;
+            })
+            .await
+            {
+                tracing::warn!(
+                    task_id = %task.id.0,
+                    "periodic_retry: failed to cancel stuck task: {e}"
+                );
+            } else {
+                state.core.tasks.abort_task(&task.id);
             }
 
             stuck += 1;

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -43,8 +43,10 @@ impl Scheduler {
         });
 
         let review_config = state.core.server.config.review.clone();
+        let retry_config = state.core.server.config.retry_scheduler.clone();
         crate::self_evolution::start(state.clone(), self.self_evolution_interval);
-        crate::periodic_reviewer::start(state, review_config);
+        crate::periodic_reviewer::start(state.clone(), review_config);
+        crate::periodic_retry::start(state, retry_config);
     }
 
     async fn run_health_tick(state: &AppState) -> anyhow::Result<()> {

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1001,6 +1001,50 @@ impl TaskDb {
         }
         Ok(pairs)
     }
+
+    /// Return tasks that are in an active status and have not been updated for
+    /// at least `stale_threshold`.
+    ///
+    /// Only tasks with a non-null `external_id` are returned (i.e. tasks linked
+    /// to a GitHub issue or PR).  Results are ordered by `updated_at ASC` so
+    /// the oldest stalls are retried first.  At most 100 rows are returned per
+    /// call to bound scheduler work per tick.
+    ///
+    /// `project` filters by project root path when provided.
+    pub async fn list_stalled_tasks(
+        &self,
+        stale_threshold: std::time::Duration,
+        project: Option<&str>,
+    ) -> anyhow::Result<Vec<TaskState>> {
+        let mins = stale_threshold.as_secs() / 60;
+        let modifier = format!("-{mins} minutes");
+        let sql = if project.is_some() {
+            format!(
+                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
+                 WHERE status IN ('implementing', 'agent_review', 'waiting', 'reviewing') \
+                 AND external_id IS NOT NULL \
+                 AND updated_at < datetime('now', ?) \
+                 AND project = ? \
+                 ORDER BY updated_at ASC \
+                 LIMIT 100"
+            )
+        } else {
+            format!(
+                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
+                 WHERE status IN ('implementing', 'agent_review', 'waiting', 'reviewing') \
+                 AND external_id IS NOT NULL \
+                 AND updated_at < datetime('now', ?) \
+                 ORDER BY updated_at ASC \
+                 LIMIT 100"
+            )
+        };
+        let mut q = sqlx::query_as::<_, TaskRow>(&sql).bind(&modifier);
+        if let Some(proj) = project {
+            q = q.bind(proj);
+        }
+        let rows = q.fetch_all(&self.pool).await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
 }
 
 #[derive(sqlx::FromRow)]
@@ -1181,6 +1225,14 @@ impl TaskSummaryRow {
             subtask_ids: Vec::new(),
             project: self.project,
         })
+    }
+}
+
+impl TaskDb {
+    /// Expose the raw pool for test-only SQL setup (e.g. back-dating `updated_at`).
+    #[cfg(test)]
+    pub(crate) fn pool_for_test(&self) -> &sqlx::sqlite::SqlitePool {
+        &self.pool
     }
 }
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -352,6 +352,20 @@ impl TaskDb {
         Ok(row)
     }
 
+    /// Update only the `status` column without touching `updated_at`.
+    ///
+    /// Used when rolling back a status change after a failed operation so that
+    /// stale-detection (`list_stalled_tasks`) continues to see the task as stale
+    /// on the next scheduler tick rather than deferring by a full threshold window.
+    pub(crate) async fn update_status_only(&self, id: &str, status: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE tasks SET status = ? WHERE id = ?")
+            .bind(status)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Back-fill `external_id` on a task that was created without one.
     ///
     /// The `AND external_id IS NULL` guard prevents overwriting a legitimately-set

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -879,6 +879,16 @@ impl TaskStore {
         }
     }
 
+    /// Return tasks that are in an active status and have not been updated for
+    /// at least `stale_threshold`.  Delegates to [`TaskDb::list_stalled_tasks`].
+    pub async fn list_stalled_tasks(
+        &self,
+        stale_threshold: std::time::Duration,
+        project: Option<&str>,
+    ) -> anyhow::Result<Vec<TaskState>> {
+        self.db.list_stalled_tasks(stale_threshold, project).await
+    }
+
     /// Return IDs of terminal tasks (Done, Failed, Cancelled) directly from the database.
     ///
     /// Used during startup for worktree cleanup. Only fetches task IDs to avoid

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1503,6 +1503,24 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Update status in cache and DB without resetting `updated_at`.
+    ///
+    /// Used to roll back a cancelled status after a failed retry enqueue so that
+    /// `list_stalled_tasks` still considers the task stale on the next tick instead
+    /// of deferring by a full `stale_threshold_mins` window.
+    pub(crate) async fn restore_status_preserve_staleness(
+        &self,
+        id: &TaskId,
+        status: TaskStatus,
+    ) -> anyhow::Result<()> {
+        if let Some(mut entry) = self.cache.get_mut(id) {
+            entry.value_mut().status = status.clone();
+        }
+        self.db
+            .update_status_only(id.0.as_str(), status.as_ref())
+            .await
+    }
+
     /// Validate recovered pending tasks by checking their GitHub PR state via `gh`.
     ///
     /// Spawned as a background task from `http.rs` after the completion callback is


### PR DESCRIPTION
## Summary

- Adds `RetrySchedulerConfig` (`enabled`, `interval_secs`, `stale_threshold_mins`, `cooldown_mins`, `max_retries`) to `HarnessConfig` under `[retry_scheduler]`; disabled by default — zero behaviour change for existing deployments
- New `TaskDb::list_stalled_tasks()` / `TaskStore::list_stalled_tasks()` query: selects active-status tasks with a non-null `external_id` that haven't been updated in over `stale_threshold_mins` minutes
- New `crates/harness-server/src/periodic_retry.rs`: background loop that detects stalled tasks, applies cooldown and retry-cap logic, re-enqueues via `task_routes::enqueue_task()`, and emits `periodic_retry:attempt:{id}` / `periodic_retry:stuck:{id}` / `periodic_retry:summary` events
- `EventStore::persist_retry_summary()` convenience method; `periodic_retry:*` hooks added to purge exclusion list alongside `periodic_review:*` so attempt history survives retention purges
- `Scheduler::start()` wires in `crate::periodic_retry::start()`

Closes #794. Depends on #791 for the `pr_state` guard (excluded from query until that column lands).

## Test plan

- [ ] 9 unit/integration tests in `periodic_retry.rs` — stall detection, terminal exclusion, null-external-id skip, project filter, summary event shape and decision, disabled-flag path
- [ ] All 1 400+ existing tests pass (`cargo test --workspace`)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied
- [ ] Pre-commit hook (fmt + clippy + test) passed

## Notes

- Direct `gh` / `git` calls inside harness crates are forbidden (CLAUDE.md); the stuck-label path enqueues an agent task with a prompt to apply the label instead
- No `Cargo.toml` version bump per project convention (version-bumps happen at release time only)

Signed-off-by: majiayu000 <1835304752@qq.com>