### PR TITLE
test(task_runner): add coverage for rate-limit circuit-breaker (#717)

### DIFF
--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -3388,7 +3388,7 @@ mod tests {
         store.wait_for_rate_limit().await;
         // After the limit expires, a subsequent call must return immediately.
         tokio::time::timeout(
-            std::time::Duration::from_millis(10),
+            std::time::Duration::from_millis(100),
             store.wait_for_rate_limit(),
         )
         .await

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -3361,6 +3361,41 @@ mod tests {
         Ok(())
     }
 
+    // --- rate-limit circuit-breaker tests ---
+
+    #[tokio::test]
+    async fn wait_for_rate_limit_no_op_when_none() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            store.wait_for_rate_limit(),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("wait_for_rate_limit must return immediately when no limit is active")
+        })?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rate_limit_cleared_after_deadline() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        store
+            .set_rate_limit(std::time::Duration::from_millis(50))
+            .await;
+        store.wait_for_rate_limit().await;
+        // After the limit expires, a subsequent call must return immediately.
+        tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            store.wait_for_rate_limit(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("rate limit must be cleared after its deadline passes"))?;
+        Ok(())
+    }
+
     // --- dependency scheduling tests ---
 
     fn tid(s: &str) -> harness_core::types::TaskId {


### PR DESCRIPTION
## Summary

Issue #717 identified `is_rate_limited()` as a dead public function orphaned from `set_rate_limit()` and `wait_for_rate_limit()`. The dead function was removed in PR #780; this PR adds the missing test coverage for the two live functions.

- `wait_for_rate_limit_no_op_when_none`: verifies no-limit path returns immediately (timeout guard)
- `rate_limit_cleared_after_deadline`: sets a 50ms limit, calls `wait_for_rate_limit`, then verifies the state is cleared so a subsequent call returns immediately

## Test plan

- [ ] `cargo test --package harness-server -- wait_for_rate_limit_no_op rate_limit_cleared_after_deadline` — both pass
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #717