### PR TITLE
fix(worktree): prevent cross-task worktree pollution (#799)

### DIFF
--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -49,6 +49,12 @@ pub(crate) fn parse_implementation_outcome(output: &str) -> ImplementationOutcom
     }
 }
 
+/// Returns true if the agent output contains the sentinel string that indicates
+/// the agent is operating inside a stale worktree owned by another harness session.
+pub(crate) fn contains_worktree_collision_sentinel(output: &str) -> bool {
+    output.contains("managed by another harness session")
+}
+
 pub(crate) fn prepend_constitution(prompt: String, enabled: bool) -> String {
     const CONSTITUTION: &str = include_str!("../../../../config/constitution.md");
     if enabled {
@@ -498,6 +504,45 @@ pub(crate) async fn run_implement_phase(
             tracing::warn!(stderr = %stderr, "agent stderr during implementation");
         }
 
+        // Fast-fail: if the agent observed a stale worktree managed by another harness
+        // session, abort immediately. This prevents the task from pushing commits to the
+        // wrong PR (issue #799).
+        if contains_worktree_collision_sentinel(&output) {
+            tracing::error!(
+                task_id = %task_id,
+                "WorktreeCollision: agent observed stale worktree; aborting task"
+            );
+            mutate_and_persist(store, task_id, |s| {
+                s.status = TaskStatus::Failed;
+                s.turn = 1;
+                s.error = Some(
+                    "WorktreeCollision: agent observed worktree managed by another harness session"
+                        .into(),
+                );
+                s.rounds.push(RoundResult {
+                    turn: 1,
+                    action: "implement".into(),
+                    result: "worktree_collision".into(),
+                    detail: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.clone())
+                    },
+                    first_token_latency_ms: impl_first_token_ms,
+                });
+            })
+            .await?;
+            tracing::info!(
+                task_id = %task_id,
+                status = "failed",
+                turns = 1,
+                pr_url = tracing::field::Empty,
+                total_elapsed_secs = task_start.elapsed().as_secs(),
+                "task_completed"
+            );
+            return Ok(ImplementOutcome::Done);
+        }
+
         // Review-only tasks produce a report, not a PR.
         // Persist the output and return immediately — no PR parsing or review loop.
         let is_review_task = store.get(task_id).is_some_and(|s| {
@@ -740,6 +785,25 @@ mod tests {
                 pr_num: Some(42),
                 created_issue_num: None,
             }
+        );
+    }
+
+    #[test]
+    fn worktree_collision_sentinel_detected() {
+        let collision_output =
+            "Pushed. Now clean up the worktree (it's managed by another harness session so I'll skip removing it):\nPR_URL=https://github.com/owner/repo/pull/796";
+        assert!(
+            contains_worktree_collision_sentinel(collision_output),
+            "sentinel should be detected in collision output"
+        );
+    }
+
+    #[test]
+    fn worktree_collision_sentinel_absent_in_normal_output() {
+        let normal_output = "Done.\nPR_URL=https://github.com/owner/repo/pull/42";
+        assert!(
+            !contains_worktree_collision_sentinel(normal_output),
+            "sentinel should not be detected in normal output"
         );
     }
 

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -508,6 +508,12 @@ pub(crate) async fn run_implement_phase(
         // session, abort immediately. This prevents the task from pushing commits to the
         // wrong PR (issue #799).
         if contains_worktree_collision_sentinel(&output) {
+            // If the agent already pushed to a PR before we detected the collision,
+            // capture the URL so there is a tracked handle for cleanup.
+            let collision_pr_url = match parse_implementation_outcome(&output) {
+                ImplementationOutcome::ParsedPr { pr_url, .. } => pr_url,
+                _ => None,
+            };
             tracing::error!(
                 task_id = %task_id,
                 "WorktreeCollision: agent observed stale worktree; aborting task"
@@ -515,6 +521,7 @@ pub(crate) async fn run_implement_phase(
             mutate_and_persist(store, task_id, |s| {
                 s.status = TaskStatus::Failed;
                 s.turn = 1;
+                s.pr_url = collision_pr_url.clone();
                 s.error = Some(
                     "WorktreeCollision: agent observed worktree managed by another harness session"
                         .into(),
@@ -536,7 +543,7 @@ pub(crate) async fn run_implement_phase(
                 task_id = %task_id,
                 status = "failed",
                 turns = 1,
-                pr_url = tracing::field::Empty,
+                pr_url = ?collision_pr_url,
                 total_elapsed_secs = task_start.elapsed().as_secs(),
                 "task_completed"
             );

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -2096,9 +2096,12 @@ where
             }
         };
 
-        // Cleanup workspace when task ends (Done or Failed) if auto_cleanup is set.
+        // Cleanup workspace when task ends.
+        // On failure: always remove to prevent stale worktrees from polluting subsequent
+        // tasks (the root cause of cross-task PR pollution, issue #799).
+        // On success: respect auto_cleanup so users can inspect the worktree post-run.
         if let Some(wmgr) = workspace_mgr {
-            if wmgr.config.auto_cleanup {
+            if task_result.is_err() || wmgr.config.auto_cleanup {
                 if let Err(e) = wmgr.remove_workspace(&id).await {
                     tracing::warn!("workspace cleanup failed for {id:?}: {e}");
                 }

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -42,7 +42,7 @@ pub enum TaskPhase {
     Terminal,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
     Pending,
@@ -2101,7 +2101,13 @@ where
         // tasks (the root cause of cross-task PR pollution, issue #799).
         // On success: respect auto_cleanup so users can inspect the worktree post-run.
         if let Some(wmgr) = workspace_mgr {
-            if task_result.is_err() || wmgr.config.auto_cleanup {
+            // Also force cleanup when the task ended with Failed status even though the
+            // executor returned Ok(()) — the worktree-collision path sets TaskStatus::Failed
+            // then returns Ok(ImplementOutcome::Done) so task_result.is_err() is false.
+            let task_is_failed = store
+                .get(&id)
+                .is_some_and(|s| s.status == TaskStatus::Failed);
+            if task_result.is_err() || task_is_failed || wmgr.config.auto_cleanup {
                 if let Err(e) = wmgr.remove_workspace(&id).await {
                     tracing::warn!("workspace cleanup failed for {id:?}: {e}");
                 }

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -96,10 +96,20 @@ impl WorkspaceManager {
         }
 
         // Stale-state guard: if the workspace directory already exists on disk but was
-        // not tracked as active (Occupied path above), a previous failed task left it
-        // behind without cleanup. Reject immediately so this task cannot silently inherit
-        // a stale branch or push commits to the wrong PR.
+        // not tracked as active (Occupied path above), check whether it is this task's
+        // own worktree left behind by a server crash (recovery path) or a truly foreign
+        // worktree (collision path).
         if workspace_path.exists() {
+            let expected_branch = format!("harness/{}", task_id.0);
+            if is_worktree_on_branch(&workspace_path, &expected_branch).await {
+                // Recovery: same task's worktree survived a crash — re-register and reuse.
+                tracing::info!(
+                    task_id = %task_id.0,
+                    path = ?workspace_path,
+                    "workspace recovery: re-using existing worktree from previous run"
+                );
+                return Ok(workspace_path);
+            }
             self.active.remove(task_id);
             anyhow::bail!(
                 "WorktreeCollision: workspace path {:?} already exists on disk for task {}; \
@@ -346,6 +356,26 @@ fn sanitize_task_id(id: &str) -> String {
             }
         })
         .collect()
+}
+
+/// Returns true when the git worktree at `path` is currently on `branch`.
+/// Used to distinguish crash-recovery (same task's worktree) from a true collision.
+async fn is_worktree_on_branch(path: &Path, branch: &str) -> bool {
+    git_command()
+        .args([
+            "-C",
+            &path.to_string_lossy(),
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        ])
+        .output()
+        .await
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|b| b.trim() == branch)
+        .unwrap_or(false)
 }
 
 async fn run_hook(script: &str, cwd: &Path) -> anyhow::Result<()> {

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -95,6 +95,20 @@ impl WorkspaceManager {
             }
         }
 
+        // Stale-state guard: if the workspace directory already exists on disk but was
+        // not tracked as active (Occupied path above), a previous failed task left it
+        // behind without cleanup. Reject immediately so this task cannot silently inherit
+        // a stale branch or push commits to the wrong PR.
+        if workspace_path.exists() {
+            self.active.remove(task_id);
+            anyhow::bail!(
+                "WorktreeCollision: workspace path {:?} already exists on disk for task {}; \
+                 a previous run did not clean up — remove the directory to retry",
+                workspace_path,
+                task_id.0
+            );
+        }
+
         // Fetch latest base_branch from remote so the worktree starts from upstream HEAD.
         let fetch_output = git_command()
             .args([
@@ -673,6 +687,40 @@ mod tests {
         );
         // Should not be tracked in active map.
         assert!(mgr.get_workspace(&task_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn create_workspace_rejects_stale_directory() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let task_id = harness_core::types::TaskId("stale-task-check-001".to_string());
+
+        // Pre-create the directory to simulate a stale worktree from a previous failed run.
+        let stale_path = workspaces.path().join("stale-task-check-001");
+        std::fs::create_dir_all(&stale_path).expect("create stale dir");
+
+        let result = mgr
+            .create_workspace(&task_id, source.path(), "origin", &branch)
+            .await;
+        assert!(result.is_err(), "should fail when stale directory exists");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("WorktreeCollision"),
+            "error should mention WorktreeCollision, got: {err_msg}"
+        );
+        // Task must not be left in the active map after a collision error.
+        assert!(
+            mgr.get_workspace(&task_id).is_none(),
+            "task should not be in active map after collision"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Root cause**: failed tasks left stale worktrees on disk; a subsequent task for the same project could silently inherit one, pushing commits to the wrong PR.
- Three-layer defence, each independent:
  1. `workspace.rs` — stale-state guard before `git worktree add`: reject with `WorktreeCollision` if the workspace directory already exists on disk from a previous run.
  2. `task_runner.rs` — always remove the worktree when a task transitions to `Failed`, regardless of the `auto_cleanup` flag. `auto_cleanup` now governs success-path cleanup only.
  3. `implement_pipeline.rs` — scan agent output for the `"managed by another harness session"` sentinel; if detected, immediately fail the task with a `WorktreeCollision` error instead of letting the agent push stale commits.

## Test plan

- [ ] `workspace::tests::create_workspace_rejects_stale_directory` — pre-seeds a stale directory, asserts `WorktreeCollision` error and no active-map entry.
- [ ] `implement_pipeline::tests::worktree_collision_sentinel_detected` — asserts sentinel string is detected.
- [ ] `implement_pipeline::tests::worktree_collision_sentinel_absent_in_normal_output` — asserts no false positive on normal output.
- [ ] Full workspace test suite (`cargo test --workspace`): 0 failures.

Closes #799