### PR TITLE
fix(learn): repair broken feedback loop across scheduler, grader, GC gates

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -204,6 +204,29 @@ pub struct GcConfig {
     /// Tools allowed during GC agent execution. Default: ["Read", "Grep", "Glob"].
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
+    /// Auto-adoption policy for drafts produced by `gc_agent.run`.
+    /// Default: `Off` — all drafts remain `Pending` and require explicit
+    /// `gc adopt` from the CLI or UI. See `AutoAdoptPolicy` for other modes.
+    #[serde(default)]
+    pub auto_adopt: AutoAdoptPolicy,
+    /// Target-path prefix (relative to project root) required for auto-adopt
+    /// to apply. Drafts whose artifacts target paths outside this prefix are
+    /// left `Pending` even when `auto_adopt` is enabled. Default: `.harness/generated/`.
+    #[serde(default = "default_auto_adopt_path_prefix")]
+    pub auto_adopt_path_prefix: String,
+}
+
+/// Controls whether drafts produced by a GC run are automatically moved to
+/// `Adopted` status (which writes their artifacts into the project tree).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AutoAdoptPolicy {
+    /// No auto-adoption. Drafts stay `Pending` until a human adopts them.
+    #[default]
+    Off,
+    /// Auto-adopt drafts whose signal remediation is `Rule`, provided all
+    /// artifact target paths fall under `auto_adopt_path_prefix`.
+    RulesOnly,
 }
 
 impl Default for GcConfig {
@@ -221,8 +244,14 @@ impl Default for GcConfig {
             auto_gc_cooldown_secs: default_auto_gc_cooldown_secs(),
             auto_pr: default_gc_auto_pr(),
             allowed_tools: None,
+            auto_adopt: AutoAdoptPolicy::default(),
+            auto_adopt_path_prefix: default_auto_adopt_path_prefix(),
         }
     }
+}
+
+fn default_auto_adopt_path_prefix() -> String {
+    ".harness/generated/".to_string()
 }
 
 fn default_gc_adopt_wait_secs() -> u64 {
@@ -242,7 +271,11 @@ fn default_gc_draft_ttl_hours() -> u64 {
 }
 
 fn default_auto_gc_grades() -> Vec<Grade> {
-    vec![Grade::D]
+    // Any grade below A triggers GC. Previously this was `[Grade::D]` alone,
+    // which meant an otherwise-uncalibrated grader that rarely (or never)
+    // emitted D silently disabled the entire GC feedback loop. Widening the
+    // trigger set to B/C/D ensures any degradation produces a draft.
+    vec![Grade::B, Grade::C, Grade::D]
 }
 
 fn default_auto_gc_cooldown_secs() -> u64 {

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -5,7 +5,10 @@ use crate::signal_detector::SignalDetector;
 use anyhow::Context;
 use chrono::Utc;
 use harness_core::agent::{AgentRequest, CodeAgent};
-use harness_core::config::{agents::CapabilityProfile, misc::GcConfig};
+use harness_core::config::{
+    agents::CapabilityProfile,
+    misc::{AutoAdoptPolicy, GcConfig},
+};
 use harness_core::types::{
     Artifact, ArtifactType, Draft, DraftId, DraftStatus, ExternalSignal, Project, RemediationType,
     Signal, SignalType,
@@ -20,6 +23,10 @@ const DEFAULT_GC_TOOLS: &[&str] = &["Read", "Grep", "Glob"];
 pub struct GcReport {
     pub signals: Vec<Signal>,
     pub drafts_generated: usize,
+    /// IDs of drafts created during this run. Used by auto-adoption paths that
+    /// need to identify freshly-created drafts without re-querying the store.
+    #[serde(default)]
+    pub draft_ids: Vec<DraftId>,
     pub errors: Vec<String>,
 }
 
@@ -172,6 +179,7 @@ impl GcAgent {
 
         // 3. Generate fix drafts (up to max_drafts_per_run).
         let mut drafts_generated = 0;
+        let mut draft_ids: Vec<DraftId> = Vec::new();
         let mut errors = Vec::new();
         let allowed_tools: Vec<String> = self
             .config
@@ -218,6 +226,7 @@ impl GcAgent {
                         errors.push(format!("failed to save draft: {e}"));
                     } else {
                         drafts_generated += 1;
+                        draft_ids.push(draft.id.clone());
                     }
                 }
                 Err(e) => {
@@ -232,6 +241,7 @@ impl GcAgent {
         let report = GcReport {
             signals,
             drafts_generated,
+            draft_ids,
             errors,
         };
 
@@ -284,6 +294,64 @@ impl GcAgent {
         draft.status = DraftStatus::Adopted;
         self.draft_store.save(&draft)?;
         Ok(())
+    }
+
+    /// Auto-adopt drafts from `draft_ids` that are eligible under `policy`.
+    ///
+    /// For `AutoAdoptPolicy::RulesOnly`, a draft is eligible when:
+    ///   1. its signal remediation is `RemediationType::Rule`, AND
+    ///   2. every artifact `target_path` (after lexical normalization) is a
+    ///      relative path whose first component(s) match `path_prefix`.
+    ///
+    /// Returns the list of draft IDs that were successfully adopted. Failures
+    /// to adopt individual drafts are logged and do not abort the loop.
+    ///
+    /// This method is a no-op when `policy` is `Off` or `draft_ids` is empty.
+    pub fn auto_adopt_matching(
+        &self,
+        draft_ids: &[DraftId],
+        policy: AutoAdoptPolicy,
+        path_prefix: &str,
+    ) -> Vec<DraftId> {
+        if matches!(policy, AutoAdoptPolicy::Off) || draft_ids.is_empty() {
+            return Vec::new();
+        }
+        let mut adopted = Vec::new();
+        for id in draft_ids {
+            let draft = match self.draft_store.get(id) {
+                Ok(Some(d)) => d,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::warn!(draft_id = %id.0, error = %e, "auto_adopt: failed to load draft");
+                    continue;
+                }
+            };
+            if !matches!(policy, AutoAdoptPolicy::RulesOnly) {
+                continue;
+            }
+            if draft.signal.remediation != RemediationType::Rule {
+                continue;
+            }
+            if draft.artifacts.is_empty() {
+                continue;
+            }
+            let all_under_prefix = draft
+                .artifacts
+                .iter()
+                .all(|a| artifact_path_under_prefix(&a.target_path, path_prefix));
+            if !all_under_prefix {
+                continue;
+            }
+            match self.adopt(id) {
+                Ok(()) => adopted.push(id.clone()),
+                Err(e) => tracing::warn!(
+                    draft_id = %id.0,
+                    error = %e,
+                    "auto_adopt: adopt failed"
+                ),
+            }
+        }
+        adopted
     }
 
     /// Reject a draft.
@@ -365,6 +433,29 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     out
+}
+
+/// Returns true when `target_path` is a relative path that, after lexical
+/// normalization, lies under `path_prefix`. Used by auto-adoption to limit
+/// writes to a configured sandbox directory (e.g. `.harness/generated/`).
+///
+/// Absolute paths and paths that escape the prefix (`..`) return false.
+fn artifact_path_under_prefix(target_path: &Path, path_prefix: &str) -> bool {
+    if target_path.is_absolute() {
+        return false;
+    }
+    let normalized = normalize_path(target_path);
+    // Reject paths that still contain ParentDir segments after normalization
+    // (e.g. `..` at the front, which normalize_path leaves intact when the
+    // output is empty).
+    if normalized
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return false;
+    }
+    let prefix_normalized = normalize_path(Path::new(path_prefix));
+    normalized.starts_with(&prefix_normalized)
 }
 
 /// Walk up from `path` to find the nearest existing ancestor, canonicalize it,
@@ -602,6 +693,128 @@ mod tests {
             generated_at: Utc::now(),
             agent_model: "test".into(),
         }
+    }
+
+    #[test]
+    fn artifact_path_under_prefix_accepts_paths_inside_prefix() {
+        assert!(artifact_path_under_prefix(
+            Path::new(".harness/generated/rules/new.md"),
+            ".harness/generated/"
+        ));
+        assert!(artifact_path_under_prefix(
+            Path::new(".harness/generated/rules/./new.md"),
+            ".harness/generated/"
+        ));
+    }
+
+    #[test]
+    fn artifact_path_under_prefix_rejects_paths_outside_prefix() {
+        assert!(!artifact_path_under_prefix(
+            Path::new("src/main.rs"),
+            ".harness/generated/"
+        ));
+        assert!(!artifact_path_under_prefix(
+            Path::new("/etc/passwd"),
+            ".harness/generated/"
+        ));
+        assert!(!artifact_path_under_prefix(
+            Path::new(".harness/generated/../../etc/passwd"),
+            ".harness/generated/"
+        ));
+    }
+
+    #[test]
+    fn auto_adopt_matching_off_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let gc = make_test_gc_agent(dir.path());
+        let draft = test_draft(vec![]);
+        gc.draft_store.save(&draft).unwrap();
+        let adopted = gc.auto_adopt_matching(
+            std::slice::from_ref(&draft.id),
+            AutoAdoptPolicy::Off,
+            ".harness/generated/",
+        );
+        assert!(adopted.is_empty());
+    }
+
+    #[test]
+    fn auto_adopt_matching_rules_only_adopts_rule_drafts_under_prefix() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let signal_detector = SignalDetector::new(
+            crate::signal_detector::SignalThresholds::default(),
+            ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(sandbox.path()).unwrap();
+        let gc = GcAgent::new(
+            GcConfig::default(),
+            signal_detector,
+            draft_store,
+            project_root.clone(),
+        );
+
+        // Eligible: Rule remediation + artifact under prefix.
+        let eligible = Draft {
+            signal: Signal::new(
+                SignalType::RepeatedWarn,
+                ProjectId::new(),
+                serde_json::json!({}),
+                RemediationType::Rule,
+            ),
+            ..test_draft(vec![Artifact {
+                artifact_type: ArtifactType::Rule,
+                target_path: PathBuf::from(".harness/generated/rules/new.md"),
+                content: "rule".into(),
+            }])
+        };
+        gc.draft_store.save(&eligible).unwrap();
+
+        // Ineligible — remediation is Guard.
+        let guard_draft = test_draft(vec![Artifact {
+            artifact_type: ArtifactType::Guard,
+            target_path: PathBuf::from(".harness/generated/guards/g.sh"),
+            content: "guard".into(),
+        }]);
+        gc.draft_store.save(&guard_draft).unwrap();
+
+        // Ineligible — artifact outside prefix.
+        let outside = Draft {
+            signal: Signal::new(
+                SignalType::RepeatedWarn,
+                ProjectId::new(),
+                serde_json::json!({}),
+                RemediationType::Rule,
+            ),
+            ..test_draft(vec![Artifact {
+                artifact_type: ArtifactType::Rule,
+                target_path: PathBuf::from("src/main.rs"),
+                content: "rule".into(),
+            }])
+        };
+        gc.draft_store.save(&outside).unwrap();
+
+        let adopted = gc.auto_adopt_matching(
+            &[
+                eligible.id.clone(),
+                guard_draft.id.clone(),
+                outside.id.clone(),
+            ],
+            AutoAdoptPolicy::RulesOnly,
+            ".harness/generated/",
+        );
+        assert_eq!(adopted, vec![eligible.id.clone()]);
+
+        let reloaded = gc.draft_store.get(&eligible.id).unwrap().unwrap();
+        assert_eq!(reloaded.status, DraftStatus::Adopted);
+        let written =
+            std::fs::read_to_string(project_root.join(".harness/generated/rules/new.md")).unwrap();
+        assert_eq!(written, "rule");
+
+        let guard_reloaded = gc.draft_store.get(&guard_draft.id).unwrap().unwrap();
+        assert_eq!(guard_reloaded.status, DraftStatus::Pending);
+        let outside_reloaded = gc.draft_store.get(&outside.id).unwrap().unwrap();
+        assert_eq!(outside_reloaded.status, DraftStatus::Pending);
     }
 
     #[test]

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -140,6 +140,8 @@ pub(crate) async fn build_intake(
             gc_cfg.auto_gc_grades.clone(),
             gc_cfg.auto_gc_cooldown_secs,
             challenger,
+            gc_cfg.auto_adopt,
+            gc_cfg.auto_adopt_path_prefix.clone(),
         ))
     };
 

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -1,5 +1,7 @@
 use crate::handlers::cross_review::run_cross_review;
+use chrono::{Duration as ChronoDuration, Utc};
 use harness_core::agent::CodeAgent;
+use harness_core::config::misc::AutoAdoptPolicy;
 use harness_core::types::{Capability, EventFilters, Grade, Project};
 use harness_gc::gc_agent::GcAgent;
 use harness_observe::event_store::EventStore;
@@ -7,6 +9,13 @@ use harness_observe::quality::QualityGrader;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+/// Time window used to grade post-task quality. The grader denominator is the
+/// count of events in this window, so a smaller window gives recent failures
+/// proportionally more weight. Grading against the lifetime event log (the
+/// previous behavior) drowned out single-task failures in thousands of older
+/// pass events and pinned every task at Grade::A regardless of outcome.
+const QUALITY_WINDOW_HOURS: i64 = 1;
 
 pub(crate) fn unix_now() -> u64 {
     std::time::SystemTime::now()
@@ -32,9 +41,12 @@ pub struct QualityTrigger {
     cooldown_secs: u64,
     pub(crate) last_triggered: Arc<AtomicU64>,
     challenger_agent: Option<Arc<dyn CodeAgent>>,
+    auto_adopt: AutoAdoptPolicy,
+    auto_adopt_path_prefix: String,
 }
 
 impl QualityTrigger {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         events: Arc<EventStore>,
         gc_agent: Arc<GcAgent>,
@@ -43,6 +55,8 @@ impl QualityTrigger {
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
         challenger_agent: Option<Arc<dyn CodeAgent>>,
+        auto_adopt: AutoAdoptPolicy,
+        auto_adopt_path_prefix: String,
     ) -> Self {
         Self {
             events,
@@ -53,6 +67,8 @@ impl QualityTrigger {
             cooldown_secs,
             last_triggered: Arc::new(AtomicU64::new(0)),
             challenger_agent,
+            auto_adopt,
+            auto_adopt_path_prefix,
         }
     }
 
@@ -80,7 +96,15 @@ impl QualityTrigger {
     /// Grade recent events, run optional cross-review, log the result, and
     /// auto-trigger GC if warranted.
     pub async fn check_and_maybe_trigger(&self, task_ctx: Option<&TaskReviewContext>) {
-        let events = match self.events.query(&EventFilters::default()).await {
+        // Grade only events from the recent window so that a single task's
+        // failures affect the grade rather than being averaged over lifetime
+        // history. See `QUALITY_WINDOW_HOURS` docstring.
+        let since = Utc::now() - ChronoDuration::hours(QUALITY_WINDOW_HOURS);
+        let filters = EventFilters {
+            since: Some(since),
+            ..EventFilters::default()
+        };
+        let events = match self.events.query(&filters).await {
             Ok(e) => e,
             Err(e) => {
                 tracing::warn!("quality_trigger: failed to query events: {e}");
@@ -88,7 +112,22 @@ impl QualityTrigger {
             }
         };
 
-        let mut report = QualityGrader::grade(&events, 0);
+        // Pull the most recent rule_scan violation count from the same window
+        // so the grader's coverage dimension reflects reality. Previously this
+        // was hard-coded to 0, which locked coverage at 100%.
+        let violation_count = events
+            .iter()
+            .filter(|e| e.hook == "rule_scan")
+            .filter_map(|e| {
+                e.reason
+                    .as_deref()
+                    .and_then(|r| r.strip_prefix("violations="))
+                    .and_then(|s| s.parse::<usize>().ok())
+            })
+            .next_back()
+            .unwrap_or(0);
+
+        let mut report = QualityGrader::grade(&events, violation_count);
 
         // Cross-review gate: skip if no challenger, no task context, or grade=A.
         if let (Some(challenger), Some(ctx)) = (&self.challenger_agent, task_ctx) {
@@ -244,12 +283,31 @@ impl QualityTrigger {
             return;
         };
         let project = Project::from_path(self.project_root.clone());
-        if let Err(e) = self
+        match self
             .gc_agent
             .run(&project, &events, &[], agent.as_ref())
             .await
         {
-            tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+            Ok(report) => {
+                if !matches!(self.auto_adopt, AutoAdoptPolicy::Off) && !report.draft_ids.is_empty()
+                {
+                    let adopted = self.gc_agent.auto_adopt_matching(
+                        &report.draft_ids,
+                        self.auto_adopt,
+                        &self.auto_adopt_path_prefix,
+                    );
+                    if !adopted.is_empty() {
+                        tracing::info!(
+                            adopted_count = adopted.len(),
+                            path_prefix = %self.auto_adopt_path_prefix,
+                            "quality_trigger: auto-adopted GC drafts"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+            }
         }
     }
 }

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -52,6 +52,8 @@ async fn make_trigger_with_challenger(
         auto_gc_grades,
         cooldown_secs,
         challenger,
+        harness_core::config::misc::AutoAdoptPolicy::Off,
+        ".harness/generated/".to_string(),
     )
 }
 

--- a/crates/harness-server/src/self_evolution.rs
+++ b/crates/harness-server/src/self_evolution.rs
@@ -20,13 +20,22 @@ pub(crate) struct SelfEvolutionReport {
 ///
 /// Each tick invokes the existing `learn_rules` + `learn_skills` pipeline and
 /// logs an aggregate `self_evolution_tick` event for observability.
+///
+/// The first tick runs immediately after startup (after a brief delay to let
+/// the rest of the server finish wiring up). Subsequent ticks wait `interval`
+/// between runs. This ensures the learning loop is observable on every restart
+/// instead of requiring the server to stay up for a full `interval` (24h by
+/// default) before producing any output.
 pub fn start(state: Arc<AppState>, interval: Duration) {
     tokio::spawn(async move {
+        // Small warm-up delay so AppState finishes initialization (event store
+        // migrations, skill discovery) before the first tick queries them.
+        sleep(Duration::from_secs(30)).await;
         loop {
-            sleep(interval).await;
             if let Err(err) = run_tick(&state).await {
                 tracing::error!("scheduler: periodic self-evolution tick failed: {err}");
             }
+            sleep(interval).await;
         }
     });
 }


### PR DESCRIPTION
## Summary

The self-evolution learn loop had been silently broken at four layers, which is why harness degraded over recent weeks despite hundreds of `task_failure` events being logged. Events.db analysis showed:

- Last `self_evolution_tick` fired on 2026-04-07 — **11 days ago**, once
- 812 consecutive `quality_grade` events all at Grade::A (97–99 score)
- Only 5 drafts ever produced, all static since March 18

This PR closes all four gates.

## Changes

**Gate 1 — Scheduler warmup** (`self_evolution.rs`)
`start()` slept the full `interval` (24h default) before the first `run_tick`. Now: 30s warm-up, then tick at loop top so the first learn cycle is observable on startup.

**Gate 2 — auto_gc_grades too narrow** (`config/misc.rs`)
Default was `[Grade::D]`; grader rarely emits D so GC almost never triggered. Widened to `[B, C, D]`.

**Gate 3 — Quality grading window** (`quality_trigger.rs`)
Previously graded against the lifetime event log with `violation_count=0` hard-coded, pinning every task at A. Now grades against the last hour and derives violation count from the most recent `rule_scan` event in that window.

**Gate 4 — Manual-only draft adoption** (`gc_agent.rs`, `quality_trigger.rs`, `intake.rs`, `config/misc.rs`)
Drafts stayed `Pending` until human `gc adopt`, so the learn loop never saw them. New `AutoAdoptPolicy::{Off, RulesOnly}` in `GcConfig` (default `Off`). `RulesOnly` auto-adopts drafts where:
- `signal.remediation == Rule`, AND
- every artifact `target_path` is under `auto_adopt_path_prefix` (default `.harness/generated/`)

`GcReport.draft_ids` is new; `QualityTrigger` forwards it to `GcAgent::auto_adopt_matching` after each run.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets`
- [x] `cargo test -p harness-gc` (42 pass, 3 new: `artifact_path_under_prefix_*`, `auto_adopt_matching_*`)
- [x] `cargo test -p harness-server` (733 pass, including unchanged `run_tick_logs_summary_event_when_no_adopted_drafts`)
- [x] Pre-commit hook (fmt + clippy + test) green
- [ ] Post-merge: rebuild + restart server from standalone terminal; verify `self_evolution_tick` fires within 30s of startup
- [ ] Post-merge: verify `quality_grade` events produce non-A grades after a failing task