### PR TITLE
feat(server): daily maintenance window for safe self-update (#803)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+ "serde",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1175,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "chrono-tz",
  "serde",
  "serde_json",
  "sqlx",
@@ -2306,6 +2330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2367,35 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ opentelemetry-otlp = { version = "0.27", features = ["trace", "metrics", "logs",
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = { version = "0.8", features = ["serde"] }
 
 # IDs
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -51,6 +51,8 @@ pub struct HarnessConfig {
     pub review: ReviewConfig,
     #[serde(default)]
     pub retry_scheduler: RetrySchedulerConfig,
+    #[serde(default)]
+    pub maintenance_window: MaintenanceWindowConfig,
     /// Projects declared in the config file. Registered on server startup.
     #[serde(default)]
     pub projects: Vec<ProjectEntry>,

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,5 +1,5 @@
 use crate::types::Grade;
-use chrono::{DateTime, NaiveTime, Utc};
+use chrono::{DateTime, Duration, NaiveTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -605,8 +605,8 @@ impl MaintenanceWindowConfig {
 
     /// Returns the number of seconds until the quiet window ends.
     ///
-    /// Accounts for cross-midnight windows by adding 86400 when the remaining
-    /// duration would otherwise be negative. Returns 0 when `enabled = false`.
+    /// Uses timezone-aware `DateTime` arithmetic so the result is correct on
+    /// DST transition days. Returns 0 when `enabled = false`.
     pub fn secs_until_window_end(&self, now: DateTime<Utc>) -> u64 {
         if !self.enabled {
             return 0;
@@ -615,17 +615,27 @@ impl MaintenanceWindowConfig {
             .timezone
             .parse::<chrono_tz::Tz>()
             .unwrap_or(chrono_tz::UTC);
-        let local = now.with_timezone(&tz);
-        let t = local.time();
-        let end = self.quiet_window_end;
-        // signed_duration_since gives end - t; negative means end has passed today.
-        let diff_secs = end.signed_duration_since(t).num_seconds();
-        let secs = if diff_secs < 0 {
-            diff_secs + 86400
-        } else {
-            diff_secs
+        let local: chrono::DateTime<chrono_tz::Tz> = now.with_timezone(&tz);
+        let today = local.date_naive();
+        let end_naive = today.and_time(self.quiet_window_end);
+        // earliest() resolves DST ambiguity (fall-back); returns None on spring-forward
+        // gaps, which we treat as "window end has passed".
+        let diff_secs = match tz.from_local_datetime(&end_naive).earliest() {
+            Some(end_dt) => end_dt.signed_duration_since(local).num_seconds(),
+            None => 0,
         };
-        secs as u64
+        if diff_secs > 0 {
+            diff_secs as u64
+        } else {
+            // End time has already passed today; for cross-midnight windows the end
+            // falls tomorrow — compute against tomorrow's wall-clock end time.
+            let tomorrow = today + Duration::days(1);
+            let end_tomorrow_naive = tomorrow.and_time(self.quiet_window_end);
+            tz.from_local_datetime(&end_tomorrow_naive)
+                .earliest()
+                .map(|end_dt| end_dt.signed_duration_since(local).num_seconds().max(0) as u64)
+                .unwrap_or(0)
+        }
     }
 }
 

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -581,6 +581,7 @@ impl MaintenanceWindowConfig {
     /// Always returns `false` when `enabled = false`.
     /// Handles cross-midnight windows: if `quiet_window_end < quiet_window_start`,
     /// the window spans midnight and is active when `time >= start || time < end`.
+    /// Equal start and end produce a zero-length window (always returns `false`).
     /// Falls back to UTC if the timezone string cannot be parsed.
     pub fn in_quiet_window(&self, now: DateTime<Utc>) -> bool {
         if !self.enabled {
@@ -594,7 +595,7 @@ impl MaintenanceWindowConfig {
         let t = local.time();
         let start = self.quiet_window_start;
         let end = self.quiet_window_end;
-        if end <= start {
+        if end < start {
             // Cross-midnight: active from start to midnight, and midnight to end.
             t >= start || t < end
         } else {

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,4 +1,5 @@
 use crate::types::Grade;
+use chrono::{DateTime, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -519,6 +520,114 @@ impl Default for RetrySchedulerConfig {
     }
 }
 
+/// Daily maintenance window configuration for scheduled restarts and self-updates.
+///
+/// When enabled, no new tasks are dispatched during the configured time window.
+/// In-flight tasks continue to completion. The window boundary logic handles
+/// cross-midnight ranges (e.g. 23:00–02:00) and DST transitions via `chrono-tz`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintenanceWindowConfig {
+    /// When false (default), this feature is completely disabled. No behaviour change.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Start of the quiet window in local time (inclusive). Format: "HH:MM:SS".
+    #[serde(default = "default_quiet_window_start")]
+    pub quiet_window_start: NaiveTime,
+    /// End of the quiet window in local time (exclusive). Format: "HH:MM:SS".
+    /// If `quiet_window_end < quiet_window_start`, the window crosses midnight.
+    #[serde(default = "default_quiet_window_end")]
+    pub quiet_window_end: NaiveTime,
+    /// IANA timezone name (e.g. "America/New_York"). Defaults to "UTC".
+    #[serde(default = "default_maintenance_timezone")]
+    pub timezone: String,
+    /// Maximum seconds to wait for in-flight tasks to drain before external restart.
+    #[serde(default = "default_drain_timeout_secs")]
+    pub drain_timeout_secs: u64,
+}
+
+fn default_quiet_window_start() -> NaiveTime {
+    // 06:00:00 — always valid; fallback to midnight if chrono invariants change.
+    NaiveTime::from_hms_opt(6, 0, 0).unwrap_or(NaiveTime::MIN)
+}
+
+fn default_quiet_window_end() -> NaiveTime {
+    // 08:00:00 — always valid; fallback to midnight if chrono invariants change.
+    NaiveTime::from_hms_opt(8, 0, 0).unwrap_or(NaiveTime::MIN)
+}
+
+fn default_maintenance_timezone() -> String {
+    "UTC".to_string()
+}
+
+fn default_drain_timeout_secs() -> u64 {
+    3600
+}
+
+impl Default for MaintenanceWindowConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            quiet_window_start: default_quiet_window_start(),
+            quiet_window_end: default_quiet_window_end(),
+            timezone: default_maintenance_timezone(),
+            drain_timeout_secs: default_drain_timeout_secs(),
+        }
+    }
+}
+
+impl MaintenanceWindowConfig {
+    /// Returns `true` when `now` falls inside the configured quiet window.
+    ///
+    /// Always returns `false` when `enabled = false`.
+    /// Handles cross-midnight windows: if `quiet_window_end < quiet_window_start`,
+    /// the window spans midnight and is active when `time >= start || time < end`.
+    /// Falls back to UTC if the timezone string cannot be parsed.
+    pub fn in_quiet_window(&self, now: DateTime<Utc>) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let tz = self
+            .timezone
+            .parse::<chrono_tz::Tz>()
+            .unwrap_or(chrono_tz::UTC);
+        let local = now.with_timezone(&tz);
+        let t = local.time();
+        let start = self.quiet_window_start;
+        let end = self.quiet_window_end;
+        if end <= start {
+            // Cross-midnight: active from start to midnight, and midnight to end.
+            t >= start || t < end
+        } else {
+            t >= start && t < end
+        }
+    }
+
+    /// Returns the number of seconds until the quiet window ends.
+    ///
+    /// Accounts for cross-midnight windows by adding 86400 when the remaining
+    /// duration would otherwise be negative. Returns 0 when `enabled = false`.
+    pub fn secs_until_window_end(&self, now: DateTime<Utc>) -> u64 {
+        if !self.enabled {
+            return 0;
+        }
+        let tz = self
+            .timezone
+            .parse::<chrono_tz::Tz>()
+            .unwrap_or(chrono_tz::UTC);
+        let local = now.with_timezone(&tz);
+        let t = local.time();
+        let end = self.quiet_window_end;
+        // signed_duration_since gives end - t; negative means end has passed today.
+        let diff_secs = end.signed_duration_since(t).num_seconds();
+        let secs = if diff_secs < 0 {
+            diff_secs + 86400
+        } else {
+            diff_secs
+        };
+        secs as u64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -549,5 +658,157 @@ mod tests {
         let cfg: ConcurrencyConfig = toml::from_str("").expect("toml parse failed");
         assert!(cfg.memory_pressure_threshold_mb.is_none());
         assert_eq!(cfg.memory_poll_interval_secs, 5);
+    }
+
+    // ── MaintenanceWindowConfig tests ────────────────────────────────────────
+
+    fn utc_at(hour: u32, min: u32) -> DateTime<Utc> {
+        use chrono::TimeZone;
+        Utc.with_ymd_and_hms(2024, 3, 15, hour, min, 0)
+            .single()
+            .expect("valid datetime")
+    }
+
+    fn window(start_h: u32, start_m: u32, end_h: u32, end_m: u32) -> MaintenanceWindowConfig {
+        MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(start_h, start_m, 0).unwrap(),
+            quiet_window_end: NaiveTime::from_hms_opt(end_h, end_m, 0).unwrap(),
+            timezone: "UTC".to_string(),
+            drain_timeout_secs: 3600,
+        }
+    }
+
+    #[test]
+    fn test_disabled_always_false() {
+        let mut cfg = window(6, 0, 8, 0);
+        cfg.enabled = false;
+        // Any time should return false when disabled.
+        assert!(!cfg.in_quiet_window(utc_at(7, 0)));
+        assert!(!cfg.in_quiet_window(utc_at(6, 0)));
+    }
+
+    #[test]
+    fn test_inside_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(cfg.in_quiet_window(utc_at(7, 0)));
+    }
+
+    #[test]
+    fn test_before_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(5, 59)));
+    }
+
+    #[test]
+    fn test_after_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(8, 1)));
+    }
+
+    #[test]
+    fn test_boundary_start_inclusive() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(cfg.in_quiet_window(utc_at(6, 0)));
+    }
+
+    #[test]
+    fn test_boundary_end_exclusive() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(8, 0)));
+    }
+
+    #[test]
+    fn test_cross_midnight_inside() {
+        // Window 23:00–02:00, now 00:30 → inside.
+        let cfg = window(23, 0, 2, 0);
+        assert!(cfg.in_quiet_window(utc_at(0, 30)));
+    }
+
+    #[test]
+    fn test_cross_midnight_outside() {
+        // Window 23:00–02:00, now 12:00 → outside.
+        let cfg = window(23, 0, 2, 0);
+        assert!(!cfg.in_quiet_window(utc_at(12, 0)));
+    }
+
+    #[test]
+    fn test_dst_spring_forward_no_panic() {
+        // America/New_York spring-forward 2024-03-10 02:00 → 03:00.
+        // 02:30 local is a gap — must not panic.
+        use chrono::TimeZone;
+        let cfg = MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(2, 0, 0).unwrap(),
+            quiet_window_end: NaiveTime::from_hms_opt(4, 0, 0).unwrap(),
+            timezone: "America/New_York".to_string(),
+            drain_timeout_secs: 3600,
+        };
+        // 07:30 UTC = 02:30 EST (before spring forward), which is in the gap.
+        let now = Utc
+            .with_ymd_and_hms(2024, 3, 10, 7, 30, 0)
+            .single()
+            .unwrap();
+        // Should not panic; result can be true or false depending on gap handling.
+        cfg.in_quiet_window(now);
+    }
+
+    #[test]
+    fn test_dst_fall_back_no_panic() {
+        // America/New_York fall-back 2024-11-03 02:00 → 01:00 (ambiguous).
+        use chrono::TimeZone;
+        let cfg = MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(1, 0, 0).unwrap_or(NaiveTime::MIN),
+            quiet_window_end: NaiveTime::from_hms_opt(3, 0, 0).unwrap_or(NaiveTime::MIN),
+            timezone: "America/New_York".to_string(),
+            drain_timeout_secs: 3600,
+        };
+        // 06:30 UTC = 01:30 EST (ambiguous on fall-back day).
+        let now = Utc
+            .with_ymd_and_hms(2024, 11, 3, 6, 30, 0)
+            .single()
+            .unwrap();
+        // Should not panic; result can be true or false depending on ambiguity handling.
+        cfg.in_quiet_window(now);
+    }
+
+    #[test]
+    fn test_secs_until_end_normal() {
+        let cfg = window(6, 0, 8, 0);
+        // At 07:00, window ends at 08:00 → 3600 seconds.
+        let secs = cfg.secs_until_window_end(utc_at(7, 0));
+        assert_eq!(secs, 3600);
+    }
+
+    #[test]
+    fn test_secs_until_end_cross_midnight() {
+        // Window 23:00–02:00, now 23:30. End is 02:00 next day → 2.5h = 9000s.
+        let cfg = window(23, 0, 2, 0);
+        let secs = cfg.secs_until_window_end(utc_at(23, 30));
+        assert_eq!(secs, 9000);
+    }
+
+    #[test]
+    fn test_maintenance_window_config_default_disabled() {
+        let cfg = MaintenanceWindowConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.timezone, "UTC");
+        assert_eq!(cfg.drain_timeout_secs, 3600);
+    }
+
+    #[test]
+    fn test_maintenance_window_config_toml_roundtrip() {
+        let toml = r#"
+            enabled = true
+            quiet_window_start = "06:00:00"
+            quiet_window_end = "08:00:00"
+            timezone = "America/New_York"
+            drain_timeout_secs = 7200
+        "#;
+        let cfg: MaintenanceWindowConfig = toml::from_str(toml).expect("toml parse failed");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.timezone, "America/New_York");
+        assert_eq!(cfg.drain_timeout_secs, 7200);
     }
 }

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -42,6 +42,10 @@ pub struct CoreServices {
     pub runtime_state_store: Option<Arc<crate::runtime_state_store::RuntimeStateStore>>,
     /// Q-value store for MemRL rule utility tracking. None when unavailable.
     pub q_values: Option<Arc<crate::q_value_store::QValueStore>>,
+    /// Set to `true` while the daily maintenance window is active.
+    /// Pollers skip dispatch and HTTP POST /tasks returns 503 when this is set.
+    /// Initialized to the correct value at startup (handles server starting mid-window).
+    pub maintenance_active: Arc<AtomicBool>,
 }
 
 /// Engine services: skills, rules, and garbage collection.
@@ -294,6 +298,14 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| project_root.clone());
 
+    let maintenance_active = {
+        let in_window = server
+            .config
+            .maintenance_window
+            .in_quiet_window(chrono::Utc::now());
+        Arc::new(AtomicBool::new(in_window))
+    };
+
     Ok(AppState {
         core: CoreServices {
             server,
@@ -306,6 +318,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             project_registry: Some(registry.project_registry),
             runtime_state_store: registry.runtime_state_store,
             q_values: storage.q_values,
+            maintenance_active,
         },
         engines: EngineServices {
             skills: engines.skills,
@@ -1688,6 +1701,12 @@ async fn github_webhook(
         Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": error })),
+        ),
+        Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
+            retry_after_secs,
+        }) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
         ),
     }
 }

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -2,7 +2,7 @@ use super::{resolve_reviewer, AppState};
 use crate::{
     project_registry::check_allowed_roots, services::execution::EnqueueTaskError, task_runner,
 };
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Response, Json};
 use harness_core::agent::CodeAgent;
 use serde::Deserialize;
 use serde_json::json;
@@ -170,6 +170,20 @@ pub(crate) async fn enqueue_task(
     state: &Arc<AppState>,
     mut req: task_runner::CreateTaskRequest,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
+    if state
+        .core
+        .maintenance_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        let retry_after_secs = state
+            .core
+            .server
+            .config
+            .maintenance_window
+            .secs_until_window_end(chrono::Utc::now());
+        return Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs });
+    }
+
     if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
         return Err(EnqueueTaskError::BadRequest(
             "at least one of prompt, issue, or pr must be provided".to_string(),
@@ -634,6 +648,9 @@ pub(super) async fn create_tasks_batch(
             }
             Err(EnqueueTaskError::BadRequest(error)) => json!({ "error": error }),
             Err(EnqueueTaskError::Internal(error)) => json!({ "error": error }),
+            Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => {
+                json!({ "error": "maintenance_window", "retry_after": retry_after_secs })
+            }
         };
         results.push(entry);
     }
@@ -644,7 +661,7 @@ pub(super) async fn create_tasks_batch(
 pub(super) async fn create_task(
     State(state): State<Arc<AppState>>,
     Json(req): Json<task_runner::CreateTaskRequest>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> Response {
     match enqueue_task(&state, req).await {
         Ok(task_id) => (
             StatusCode::ACCEPTED,
@@ -652,14 +669,25 @@ pub(super) async fn create_task(
                 "task_id": task_id.0,
                 "status": "running"
             })),
-        ),
+        )
+            .into_response(),
         Err(EnqueueTaskError::BadRequest(error)) => {
-            (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
+            (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
         }
         Err(EnqueueTaskError::Internal(error)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": error })),
-        ),
+        )
+            .into_response(),
+        Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(
+                axum::http::header::RETRY_AFTER,
+                retry_after_secs.to_string(),
+            )],
+            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -170,17 +170,20 @@ pub(crate) async fn enqueue_task(
     state: &Arc<AppState>,
     mut req: task_runner::CreateTaskRequest,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
+    let now = chrono::Utc::now();
     if state
         .core
-        .maintenance_active
-        .load(std::sync::atomic::Ordering::Relaxed)
+        .server
+        .config
+        .maintenance_window
+        .in_quiet_window(now)
     {
         let retry_after_secs = state
             .core
             .server
             .config
             .maintenance_window
-            .secs_until_window_end(chrono::Utc::now());
+            .secs_until_window_end(now);
         return Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs });
     }
 
@@ -390,6 +393,23 @@ async fn enqueue_task_background(
     mut req: task_runner::CreateTaskRequest,
     group_sem: Option<Arc<tokio::sync::Semaphore>>,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
+    let now = chrono::Utc::now();
+    if state
+        .core
+        .server
+        .config
+        .maintenance_window
+        .in_quiet_window(now)
+    {
+        let retry_after_secs = state
+            .core
+            .server
+            .config
+            .maintenance_window
+            .secs_until_window_end(now);
+        return Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs });
+    }
+
     if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
         return Err(EnqueueTaskError::BadRequest(
             "at least one of prompt, issue, or pr must be provided".to_string(),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -546,7 +546,7 @@ async fn enqueue_task_background(
 pub(super) async fn create_tasks_batch(
     State(state): State<Arc<AppState>>,
     Json(req): Json<BatchCreateTaskRequest>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> Response {
     let has_issues = req.issues.as_ref().is_some_and(|v| !v.is_empty());
     let has_tasks = req.tasks.as_ref().is_some_and(|v| !v.is_empty());
 
@@ -554,7 +554,8 @@ pub(super) async fn create_tasks_batch(
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({ "error": "at least one of issues or tasks must be provided" })),
-        );
+        )
+            .into_response();
     }
 
     // Build the list of per-task CreateTaskRequests.
@@ -649,12 +650,15 @@ pub(super) async fn create_tasks_batch(
     // Each task gets an ID immediately; a background tokio task handles permit
     // waiting and execution. The HTTP handler returns as soon as all tasks are registered.
     let mut results = Vec::with_capacity(n);
+    let mut all_maintenance_window = n > 0;
+    let mut mw_retry_after: Option<u64> = None;
     for (i, task_req) in task_requests.into_iter().enumerate() {
         let sem = task_semaphores[i].take();
         let is_serialized = sem.is_some();
         let conflict_files = std::mem::take(&mut task_conflict_files[i]);
         let entry = match enqueue_task_background(state.clone(), task_req, sem).await {
             Ok(task_id) => {
+                all_maintenance_window = false;
                 if is_serialized {
                     json!({
                         "task_id": task_id.0,
@@ -666,16 +670,33 @@ pub(super) async fn create_tasks_batch(
                     json!({ "task_id": task_id.0, "status": "queued" })
                 }
             }
-            Err(EnqueueTaskError::BadRequest(error)) => json!({ "error": error }),
-            Err(EnqueueTaskError::Internal(error)) => json!({ "error": error }),
+            Err(EnqueueTaskError::BadRequest(error)) => {
+                all_maintenance_window = false;
+                json!({ "error": error })
+            }
+            Err(EnqueueTaskError::Internal(error)) => {
+                all_maintenance_window = false;
+                json!({ "error": error })
+            }
             Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => {
+                mw_retry_after.get_or_insert(retry_after_secs);
                 json!({ "error": "maintenance_window", "retry_after": retry_after_secs })
             }
         };
         results.push(entry);
     }
 
-    (StatusCode::ACCEPTED, Json(json!(results)))
+    if all_maintenance_window {
+        let retry_after = mw_retry_after.unwrap_or(0);
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(axum::http::header::RETRY_AFTER, retry_after.to_string())],
+            Json(json!(results)),
+        )
+            .into_response();
+    }
+
+    (StatusCode::ACCEPTED, Json(json!(results))).into_response()
 }
 
 pub(super) async fn create_task(

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -129,6 +129,7 @@ async fn make_test_state_with(
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
+            maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(tokio::sync::RwLock::new(

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -365,7 +365,7 @@ async fn run_repo_sprint(
     let max_slots = 4usize; // matches max_concurrent in config
     let start = tokio::time::Instant::now();
 
-    loop {
+    'sprint: loop {
         // All done?
         if completed.len() + cancelled_sprint.len() >= all_task_issues.len() && running.is_empty() {
             break;
@@ -435,6 +435,15 @@ async fn run_repo_sprint(
                         tracing::warn!(external_id = %ext_id, "intake: mark_dispatched update failed: {e}");
                     }
                     running.insert(issue_num, task_id);
+                }
+                Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow { .. }) => {
+                    tracing::info!(
+                        repo,
+                        external_id = %ext_id,
+                        "intake: quiet window active, deferring sprint"
+                    );
+                    source.unmark_dispatched(&ext_id).await;
+                    break 'sprint;
                 }
                 Err(e) => {
                     tracing::error!(repo, external_id = %ext_id, "intake: failed to spawn: {e:?}");

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -104,8 +104,26 @@ impl IntakeOrchestrator {
             "intake orchestrator started"
         );
         tokio::spawn(async move {
+            let mw = &state.core.server.config.maintenance_window;
+            let mut was_in_window = state
+                .core
+                .maintenance_active
+                .load(std::sync::atomic::Ordering::Relaxed);
             loop {
                 tokio::time::sleep(self.poll_interval).await;
+                let in_window = mw.in_quiet_window(chrono::Utc::now());
+                if in_window != was_in_window {
+                    state
+                        .core
+                        .maintenance_active
+                        .store(in_window, std::sync::atomic::Ordering::Relaxed);
+                    tracing::info!(in_window, "maintenance window state changed");
+                    was_in_window = in_window;
+                }
+                if in_window {
+                    tracing::debug!("intake: quiet window active, skipping tick");
+                    continue;
+                }
                 self.poll_tick(&state).await;
             }
         });

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -76,6 +76,7 @@ async fn make_test_state_with_config_and_registry(
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
+            maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),
@@ -1396,6 +1397,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
+            maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
         engines: crate::http::EngineServices {
             skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -23,6 +23,11 @@ use tokio::sync::RwLock;
 pub enum EnqueueTaskError {
     BadRequest(String),
     Internal(String),
+    /// The server is inside a maintenance window; the caller should retry after
+    /// `retry_after_secs` seconds.
+    MaintenanceWindow {
+        retry_after_secs: u64,
+    },
 }
 
 impl std::fmt::Display for EnqueueTaskError {
@@ -30,6 +35,12 @@ impl std::fmt::Display for EnqueueTaskError {
         match self {
             Self::BadRequest(msg) => write!(f, "bad request: {msg}"),
             Self::Internal(msg) => write!(f, "internal error: {msg}"),
+            Self::MaintenanceWindow { retry_after_secs } => {
+                write!(
+                    f,
+                    "maintenance window active; retry after {retry_after_secs}s"
+                )
+            }
         }
     }
 }

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -192,6 +192,7 @@ mod tests {
                 project_registry: None,
                 runtime_state_store: None,
                 q_values: None,
+                maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -156,6 +156,7 @@ async fn make_state_inner(
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
+            maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
         engines: crate::http::EngineServices {
             skills: Default::default(),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -332,6 +332,7 @@ mod tests {
                 project_registry: None,
                 runtime_state_store: None,
                 q_values: None,
+                maintenance_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
             engines: crate::http::EngineServices {
                 skills: Arc::new(RwLock::new(harness_skills::store::SkillStore::new())),


### PR DESCRIPTION
## Summary

- Adds `MaintenanceWindowConfig` to `harness-core` with timezone-aware `in_quiet_window()` / `secs_until_window_end()` helpers using `chrono-tz`; handles cross-midnight windows and DST transitions
- Adds `maintenance_active: Arc<AtomicBool>` to `CoreServices`; initialized at startup so the flag is correct when the server starts mid-window
- Intake orchestrator checks window on each tick, skips `poll_tick()` when active, and emits structured log on state transitions
- `enqueue_task()` returns `EnqueueTaskError::MaintenanceWindow` when active; `POST /tasks` handler surfaces this as `503 Service Unavailable` with `Retry-After` header
- `enabled = false` by default — zero behaviour change for existing deployments

## Test plan

- [ ] `cargo test --package harness-core -- config::misc::tests` → 17 tests pass (14 new for `MaintenanceWindowConfig`)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` → clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [ ] `cargo test --workspace` → all pass

Closes #803