### PR TITLE
feat(ui): persist and surface agent prompts per turn (#792)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "harness-workflow",
  "hmac",
  "http-body-util",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -580,13 +580,15 @@ pub enum ExecutionPhase {
     Rebase,
     /// Simple review pass that does not require deep reasoning (uses lightweight model).
     SimpleReview,
+    /// Initial triage/assessment pass before planning (uses high-reasoning model).
+    Triage,
 }
 
 impl ExecutionPhase {
     /// Returns the Claude Code CLI `--effort` level for this phase.
     pub fn effort_level(self) -> &'static str {
         match self {
-            ExecutionPhase::Planning => "max",
+            ExecutionPhase::Planning | ExecutionPhase::Triage => "max",
             ExecutionPhase::Execution => "high",
             ExecutionPhase::Validation => "max",
             ExecutionPhase::Rebase => "low",
@@ -659,7 +661,7 @@ impl ReasoningBudget {
     /// Returns the model identifier for the given execution phase.
     pub fn model_for_phase(&self, phase: ExecutionPhase) -> &str {
         let tier = match phase {
-            ExecutionPhase::Planning => self.planning_tier,
+            ExecutionPhase::Planning | ExecutionPhase::Triage => self.planning_tier,
             ExecutionPhase::Execution => self.execution_tier,
             ExecutionPhase::Validation => self.validation_tier,
             ExecutionPhase::Rebase | ExecutionPhase::SimpleReview => BudgetTier::Medium,

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -35,6 +35,7 @@ subtle = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 sysinfo = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1771,6 +1771,24 @@ async fn get_task_artifacts(
 /// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
 async fn get_task_prompts(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
     let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("get_task_prompts: database error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+        Ok(Some(_)) => {}
+    }
     match state.core.tasks.get_prompts(&task_id).await {
         Ok(prompts) => Json(prompts).into_response(),
         Err(e) => {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1771,24 +1771,6 @@ async fn get_task_artifacts(
 /// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
 async fn get_task_prompts(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
     let task_id = harness_core::types::TaskId(id);
-    match state.core.tasks.get_with_db_fallback(&task_id).await {
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            tracing::error!("get_task_prompts: database error: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response();
-        }
-        Ok(Some(_)) => {}
-    }
     match state.core.tasks.get_prompts(&task_id).await {
         Ok(prompts) => Json(prompts).into_response(),
         Err(e) => {

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1438,6 +1438,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         .route("/tasks/{id}", get(get_task))
         .route("/tasks/{id}/cancel", post(task_routes::cancel_task))
         .route("/tasks/{id}/artifacts", get(get_task_artifacts))
+        .route("/tasks/{id}/prompts", get(get_task_prompts))
         .route("/tasks/{id}/stream", get(stream_task_sse))
         .route(
             "/projects",
@@ -1758,6 +1759,40 @@ async fn get_task_artifacts(
         Ok(artifacts) => Json(artifacts).into_response(),
         Err(e) => {
             tracing::error!("get_task_artifacts: list artifacts error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
+async fn get_task_prompts(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("get_task_prompts: database error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+        Ok(Some(_)) => {}
+    }
+    match state.core.tasks.get_prompts(&task_id).await {
+        Ok(prompts) => Json(prompts).into_response(),
+        Err(e) => {
+            tracing::error!("get_task_prompts: query error: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "internal server error"})),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -33,6 +33,7 @@ pub mod post_validator;
 pub mod project_registry;
 pub mod q_value_store;
 pub mod quality_trigger;
+pub mod redact;
 pub mod review_store;
 pub mod router;
 pub mod rule_enforcer;

--- a/crates/harness-server/src/redact.rs
+++ b/crates/harness-server/src/redact.rs
@@ -1,0 +1,101 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+static SECRET_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+
+fn secret_patterns() -> &'static Vec<Regex> {
+    SECRET_PATTERNS.get_or_init(|| {
+        let raw = [
+            r"ghp_[A-Za-z0-9]{36,}",
+            r"ghs_[A-Za-z0-9]{36,}",
+            r"[0-9a-f]{40}",
+            r"Bearer\s+\S+",
+            r"sk-[A-Za-z0-9]{32,}",
+        ];
+        raw.iter().filter_map(|p| Regex::new(p).ok()).collect()
+    })
+}
+
+/// Redact secret values from a prompt string before persistence.
+///
+/// Pass 1: env var values ≥ 8 chars, sorted longest-first to avoid partial matches.
+/// Pass 2: regex patterns for common token formats.
+pub fn redact_secrets(prompt: &str, env_vars: &HashMap<String, String>) -> String {
+    let mut sorted_vars: Vec<(&str, &str)> = env_vars
+        .iter()
+        .filter(|(_, v)| v.len() >= 8)
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    sorted_vars.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+    let mut result = prompt.to_string();
+    for (key, value) in &sorted_vars {
+        result = result.replace(value, &format!("[REDACTED:{key}]"));
+    }
+
+    for re in secret_patterns() {
+        result = re.replace_all(&result, "[REDACTED]").into_owned();
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn known_env_var_is_replaced() {
+        let vars = env(&[("GITHUB_TOKEN", "supersecrettoken123")]);
+        let result = redact_secrets("token: supersecrettoken123 end", &vars);
+        assert_eq!(result, "token: [REDACTED:GITHUB_TOKEN] end");
+    }
+
+    #[test]
+    fn unknown_secret_passes_through() {
+        let result = redact_secrets("hello world", &env(&[]));
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn multiple_values_replaced_longest_first() {
+        let vars = env(&[("SHORT", "abcdefgh"), ("LONG", "abcdefghijklmnop")]);
+        let prompt = "abcdefghijklmnop and abcdefgh";
+        let result = redact_secrets(prompt, &vars);
+        assert!(result.contains("[REDACTED:LONG]"));
+        assert!(result.contains("[REDACTED:SHORT]"));
+        assert!(!result.contains("abcdefghijklmnop"));
+        assert!(!result.contains("abcdefgh"));
+    }
+
+    #[test]
+    fn regex_catches_ghp_token() {
+        let result = redact_secrets(
+            "token=ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA end",
+            &env(&[]),
+        );
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("ghp_"));
+    }
+
+    #[test]
+    fn empty_prompt_returns_empty() {
+        let result = redact_secrets("", &env(&[("KEY", "somesecret")]));
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn short_value_not_redacted() {
+        let vars = env(&[("FLAG", "true")]);
+        let result = redact_secrets("flag is true", &vars);
+        assert_eq!(result, "flag is true");
+    }
+}

--- a/crates/harness-server/src/redact.rs
+++ b/crates/harness-server/src/redact.rs
@@ -7,11 +7,23 @@ static SECRET_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
 fn secret_patterns() -> &'static Vec<Regex> {
     SECRET_PATTERNS.get_or_init(|| {
         let raw = [
+            // GitHub tokens: classic PAT, server-to-server, fine-grained PAT, OAuth, user-to-server, refresh
             r"ghp_[A-Za-z0-9]{36,}",
             r"ghs_[A-Za-z0-9]{36,}",
+            r"github_pat_[A-Za-z0-9_]{36,}",
+            r"ghu_[A-Za-z0-9]{36,}",
+            r"gho_[A-Za-z0-9]{36,}",
+            r"ghr_[A-Za-z0-9]{36,}",
+            // 40-char hex — SHA1-length tokens (catches legacy API tokens that look like git hashes)
             r"[0-9a-f]{40}",
+            // Authorization header bearer values
             r"Bearer\s+\S+",
-            r"sk-[A-Za-z0-9]{32,}",
+            // OpenAI / Anthropic style keys: sk-xxx, sk-proj-xxx, sk-ant-xxx, sk-svcacct-xxx, etc.
+            r"sk-[A-Za-z0-9_\-]{20,}",
+            // JWTs: three base64url segments joined by dots
+            r"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+",
+            // PEM private keys: SSH, TLS, PKCS#8 (dotall — key body spans multiple lines)
+            r"(?s)-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----",
         ];
         raw.iter().filter_map(|p| Regex::new(p).ok()).collect()
     })
@@ -97,5 +109,52 @@ mod tests {
         let vars = env(&[("FLAG", "true")]);
         let result = redact_secrets("flag is true", &vars);
         assert_eq!(result, "flag is true");
+    }
+
+    #[test]
+    fn fine_grained_github_pat_is_redacted() {
+        let result = redact_secrets(
+            "token=github_pat_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA end",
+            &env(&[]),
+        );
+        assert!(result.contains("[REDACTED]"), "got: {result}");
+        assert!(!result.contains("github_pat_"));
+    }
+
+    #[test]
+    fn ghu_token_is_redacted() {
+        let result = redact_secrets(
+            "oauth=ghu_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA end",
+            &env(&[]),
+        );
+        assert!(result.contains("[REDACTED]"), "got: {result}");
+        assert!(!result.contains("ghu_"));
+    }
+
+    #[test]
+    fn openai_project_key_is_redacted() {
+        let result = redact_secrets(
+            "key=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 end",
+            &env(&[]),
+        );
+        assert!(result.contains("[REDACTED]"), "got: {result}");
+        assert!(!result.contains("sk-proj-"));
+    }
+
+    #[test]
+    fn jwt_is_redacted() {
+        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        let result = redact_secrets(&format!("auth: {jwt}"), &env(&[]));
+        assert!(result.contains("[REDACTED]"), "got: {result}");
+        assert!(!result.contains("eyJ"));
+    }
+
+    #[test]
+    fn pem_private_key_is_redacted() {
+        let key =
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----";
+        let result = redact_secrets(&format!("key: {key} end"), &env(&[]));
+        assert!(result.contains("[REDACTED]"), "got: {result}");
+        assert!(!result.contains("PRIVATE KEY"));
     }
 }

--- a/crates/harness-server/src/redact.rs
+++ b/crates/harness-server/src/redact.rs
@@ -14,8 +14,8 @@ fn secret_patterns() -> &'static Vec<Regex> {
             r"ghu_[A-Za-z0-9]{36,}",
             r"gho_[A-Za-z0-9]{36,}",
             r"ghr_[A-Za-z0-9]{36,}",
-            // Authorization header bearer values
-            r"Bearer\s+\S+",
+            // Authorization header bearer values (case-insensitive per RFC 7235)
+            r"(?i)Bearer\s+\S+",
             // OpenAI / Anthropic style keys: sk-xxx, sk-proj-xxx, sk-ant-xxx, sk-svcacct-xxx, etc.
             r"sk-[A-Za-z0-9_\-]{20,}",
             // JWTs: three base64url segments joined by dots

--- a/crates/harness-server/src/redact.rs
+++ b/crates/harness-server/src/redact.rs
@@ -39,7 +39,7 @@ pub fn redact_secrets(prompt: &str, env_vars: &HashMap<String, String>) -> Strin
         .filter(|(_, v)| v.len() >= 8)
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    sorted_vars.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    sorted_vars.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     let mut result = prompt.to_string();
     for (key, value) in &sorted_vars {

--- a/crates/harness-server/src/redact.rs
+++ b/crates/harness-server/src/redact.rs
@@ -14,8 +14,6 @@ fn secret_patterns() -> &'static Vec<Regex> {
             r"ghu_[A-Za-z0-9]{36,}",
             r"gho_[A-Za-z0-9]{36,}",
             r"ghr_[A-Za-z0-9]{36,}",
-            // 40-char hex — SHA1-length tokens (catches legacy API tokens that look like git hashes)
-            r"[0-9a-f]{40}",
             // Authorization header bearer values
             r"Bearer\s+\S+",
             // OpenAI / Anthropic style keys: sk-xxx, sk-proj-xxx, sk-ant-xxx, sk-svcacct-xxx, etc.

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -20,6 +20,9 @@ fn sqlite_datetime(ts: DateTime<Utc>) -> String {
     ts.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
+/// Maximum prompt content size in bytes before truncation (2 MB).
+const PROMPT_MAX_BYTES: usize = 2 * 1024 * 1024;
+
 /// Column list for `query_as::<_, TaskRow>` — single source of truth.
 ///
 /// Every SELECT that maps to `TaskRow` MUST use this constant.
@@ -141,6 +144,20 @@ static TASK_MIGRATIONS: &[Migration] = &[
         description: "add request_settings column for execution limit recovery",
         sql: "ALTER TABLE tasks ADD COLUMN request_settings TEXT",
     },
+    Migration {
+        version: 17,
+        description: "create task_prompts table for per-turn prompt persistence",
+        sql: "CREATE TABLE IF NOT EXISTS task_prompts (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id    TEXT NOT NULL,
+            turn       INTEGER NOT NULL,
+            phase      TEXT NOT NULL,
+            prompt     TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(task_id, turn, phase)
+        ); CREATE INDEX IF NOT EXISTS idx_task_prompts_task_id
+           ON task_prompts(task_id, turn)",
+    },
 ];
 
 /// A single persisted artifact captured from agent output during task execution.
@@ -150,6 +167,16 @@ pub struct TaskArtifact {
     pub turn: i64,
     pub artifact_type: String,
     pub content: String,
+    pub created_at: String,
+}
+
+/// A single persisted agent prompt captured per turn for UI observability.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TaskPrompt {
+    pub task_id: String,
+    pub turn: i64,
+    pub phase: String,
+    pub prompt: String,
     pub created_at: String,
 }
 
@@ -1002,6 +1029,49 @@ impl TaskDb {
         let rows = sqlx::query_as::<_, TaskArtifact>(
             "SELECT task_id, turn, artifact_type, content, created_at
              FROM task_artifacts WHERE task_id = ? ORDER BY id ASC",
+        )
+        .bind(task_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Persist a redacted agent prompt for a task turn, overwriting any previous
+    /// entry for the same (task_id, turn, phase) triplet.
+    pub async fn save_task_prompt(
+        &self,
+        task_id: &str,
+        turn: u32,
+        phase: &str,
+        prompt: &str,
+    ) -> anyhow::Result<()> {
+        let stored = if prompt.len() > PROMPT_MAX_BYTES {
+            let mut boundary = PROMPT_MAX_BYTES;
+            while boundary > 0 && !prompt.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            format!("{}\n[TRUNCATED]", &prompt[..boundary])
+        } else {
+            prompt.to_string()
+        };
+        sqlx::query(
+            "INSERT OR REPLACE INTO task_prompts (task_id, turn, phase, prompt)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(task_id)
+        .bind(turn as i64)
+        .bind(phase)
+        .bind(&stored)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return all prompts for a task ordered by turn ascending.
+    pub async fn get_task_prompts(&self, task_id: &str) -> anyhow::Result<Vec<TaskPrompt>> {
+        let rows = sqlx::query_as::<_, TaskPrompt>(
+            "SELECT task_id, turn, phase, prompt, created_at
+             FROM task_prompts WHERE task_id = ? ORDER BY turn ASC",
         )
         .bind(task_id)
         .fetch_all(&self.pool)

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1071,7 +1071,7 @@ impl TaskDb {
     pub async fn get_task_prompts(&self, task_id: &str) -> anyhow::Result<Vec<TaskPrompt>> {
         let rows = sqlx::query_as::<_, TaskPrompt>(
             "SELECT task_id, turn, phase, prompt, created_at
-             FROM task_prompts WHERE task_id = ? ORDER BY turn ASC",
+             FROM task_prompts WHERE task_id = ? ORDER BY turn ASC, id ASC",
         )
         .bind(task_id)
         .fetch_all(&self.pool)

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -555,16 +555,24 @@ pub(crate) async fn run_agent_streaming(
     let turn_start = Instant::now();
 
     // Persist redacted prompt before req is consumed by execute_stream.
+    // Skip prompt-only tasks: their prompts may contain user-supplied credentials
+    // and must not be written at rest (per the privacy contract in task_runner.rs).
+    let is_prompt_only = store
+        .get(task_id)
+        .map(|s| s.description.as_deref() == Some("prompt task"))
+        .unwrap_or(false);
     let phase_str = req
         .execution_phase
         .map(|p| format!("{p:?}").to_lowercase())
         .unwrap_or_else(|| "unknown".into());
-    let redacted_prompt = crate::redact::redact_secrets(&req.prompt, &req.env_vars);
-    if let Err(e) = store
-        .save_prompt(task_id, turn, &phase_str, &redacted_prompt)
-        .await
-    {
-        tracing::warn!(task_id = %task_id, turn, "failed to persist prompt: {e}");
+    if !is_prompt_only {
+        let redacted_prompt = crate::redact::redact_secrets(&req.prompt, &req.env_vars);
+        if let Err(e) = store
+            .save_prompt(task_id, turn, &phase_str, &redacted_prompt)
+            .await
+        {
+            tracing::warn!(task_id = %task_id, turn, "failed to persist prompt: {e}");
+        }
     }
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamItem>(128);

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -553,6 +553,20 @@ pub(crate) async fn run_agent_streaming(
     turn: u32,
 ) -> harness_core::error::Result<(AgentResponse, Option<u64>)> {
     let turn_start = Instant::now();
+
+    // Persist redacted prompt before req is consumed by execute_stream.
+    let phase_str = req
+        .execution_phase
+        .map(|p| format!("{p:?}").to_lowercase())
+        .unwrap_or_else(|| "unknown".into());
+    let redacted_prompt = crate::redact::redact_secrets(&req.prompt, &req.env_vars);
+    if let Err(e) = store
+        .save_prompt(task_id, turn, &phase_str, &redacted_prompt)
+        .await
+    {
+        tracing::warn!(task_id = %task_id, turn, "failed to persist prompt: {e}");
+    }
+
     let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamItem>(128);
     let mut exec = std::pin::pin!(agent.execute_stream(req, tx));
     let mut exec_result: Option<harness_core::error::Result<()>> = None;

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -40,6 +40,16 @@ pub(crate) async fn run_plan_for_prompt(
     };
 
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
+
+    // Persist redacted prompt before plan_req is consumed by agent.execute().
+    let redacted_plan_prompt = crate::redact::redact_secrets(&plan_req.prompt, &plan_req.env_vars);
+    if let Err(e) = store
+        .save_prompt(task_id, 0, "planning", &redacted_plan_prompt)
+        .await
+    {
+        tracing::warn!(task_id = %task_id, "failed to persist plan prompt: {e}");
+    }
+
     // Use agent.execute() directly — NOT run_agent_streaming — to avoid the
     // state side-effects that run_agent_streaming performs: PR_URL extraction,
     // turn counter mutations, and status updates.  Those side-effects would

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -41,15 +41,6 @@ pub(crate) async fn run_plan_for_prompt(
 
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
 
-    // Persist redacted prompt before plan_req is consumed by agent.execute().
-    let redacted_plan_prompt = crate::redact::redact_secrets(&plan_req.prompt, &plan_req.env_vars);
-    if let Err(e) = store
-        .save_prompt(task_id, 0, "planning", &redacted_plan_prompt)
-        .await
-    {
-        tracing::warn!(task_id = %task_id, "failed to persist plan prompt: {e}");
-    }
-
     // Use agent.execute() directly — NOT run_agent_streaming — to avoid the
     // state side-effects that run_agent_streaming performs: PR_URL extraction,
     // turn counter mutations, and status updates.  Those side-effects would
@@ -104,7 +95,7 @@ pub(crate) async fn run_triage_plan_pipeline(
         prompt: triage_prompt,
         project_root: project.to_path_buf(),
         env_vars: cargo_env.clone(),
-        execution_phase: Some(ExecutionPhase::Planning),
+        execution_phase: Some(ExecutionPhase::Triage),
         ..Default::default()
     };
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1420,6 +1420,27 @@ impl TaskStore {
         self.db.list_artifacts(&task_id.0).await
     }
 
+    /// Persist a redacted agent prompt for a task turn (fire-and-forget wrapper).
+    pub(crate) async fn save_prompt(
+        &self,
+        task_id: &TaskId,
+        turn: u32,
+        phase: &str,
+        prompt: &str,
+    ) -> anyhow::Result<()> {
+        self.db
+            .save_task_prompt(&task_id.0, turn, phase, prompt)
+            .await
+    }
+
+    /// Return all persisted prompts for a task ordered by turn.
+    pub async fn get_prompts(
+        &self,
+        task_id: &TaskId,
+    ) -> anyhow::Result<Vec<crate::task_db::TaskPrompt>> {
+        self.db.get_task_prompts(&task_id.0).await
+    }
+
     /// Append a [`TaskEvent`] to the event log. No-op when the log is not open.
     pub(crate) fn log_event(&self, event: crate::event_replay::TaskEvent) {
         if let Some(ref log) = self.event_log {

--- a/crates/harness-server/static/dashboard.css
+++ b/crates/harness-server/static/dashboard.css
@@ -865,3 +865,24 @@ body {
   .filter-select { width: 100%; }
   .detail-sheet { width: 100vw; }
 }
+
+/* Prompts panel */
+.prompt-item { border: 1px solid #e0e0e8; border-radius: .4rem; margin-top: .6rem; overflow: hidden; }
+.prompt-header { display: flex; align-items: center; justify-content: space-between;
+  padding: .45rem .7rem; background: #f0f0f8; cursor: default; }
+.prompt-meta { font-size: .8rem; color: #555; }
+.prompt-actions { display: flex; gap: .35rem; align-items: center; }
+.prompt-actions button { font-size: .75rem; padding: .2rem .5rem; border-radius: .25rem;
+  border: 1px solid #bbb; background: #fff; cursor: pointer; }
+.prompt-actions button:hover { background: #e8e8f0; }
+.prompt-body { padding: .5rem .7rem; }
+.prompt-collapsed { display: none; }
+.prompt-pre { max-height: 14rem; overflow-y: auto; white-space: pre-wrap; word-break: break-word;
+  font-size: .78rem; margin: 0; }
+.prompt-expand-btn { margin-top: .3rem; font-size: .75rem; padding: .2rem .5rem;
+  border-radius: .25rem; border: 1px solid #bbb; background: #fff; cursor: pointer; }
+.prompt-diff-panel { padding: .5rem .7rem; background: #fafafa; border-top: 1px solid #e0e0e8; }
+.prompt-diff-body { font-family: monospace; font-size: .75rem; line-height: 1.4; }
+.diff-added { background: #e6ffe6; color: #1a6e1a; padding: 0 .2rem; }
+.diff-removed { background: #ffe6e6; color: #8b1a1a; padding: 0 .2rem; }
+.prompts-empty { font-size: .85rem; color: #888; margin: .4rem 0; }

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -18,6 +18,7 @@ let currentTasks = [];
 let historyPage = 0;
 let historyQuery = "";
 let historyFilter = "all";
+let _activeDetailTaskId = null;
 
 function $(sel) { return document.querySelector(sel); }
 
@@ -441,7 +442,9 @@ function showDetail(task) {
 
   document.getElementById("detail-body").innerHTML = body;
 
-  // Async: fetch and render the prompts panel after initial HTML is set.
+  // Track which task is active so the async fetch can bail if the user
+  // switches to a different task before the response arrives.
+  _activeDetailTaskId = task.id;
   fetchAndRenderPrompts(task.id);
 
   const cancelBtn = document.querySelector(".cancel-btn[data-task-id]");
@@ -499,6 +502,9 @@ async function fetchAndRenderPrompts(taskId) {
     if (!resp || !resp.ok) return;
     prompts = await resp.json();
   } catch { return; }
+
+  // Guard: user may have opened a different task while this fetch was in flight.
+  if (_activeDetailTaskId !== taskId) return;
 
   if (!Array.isArray(prompts) || prompts.length === 0) {
     const el = document.createElement("div");

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -476,18 +476,36 @@ function showDetail(task) {
 function lineDiff(a, b) {
   const aLines = a.split("\n");
   const bLines = b.split("\n");
-  const aSet = new Set(aLines);
-  const bSet = new Set(bLines);
-  let html = "";
-  for (const line of aLines) {
-    if (!bSet.has(line)) {
-      html += `<div class="diff-removed">- ${escapeHtml(line)}</div>`;
+  const MAX = 500;
+  if (aLines.length > MAX || bLines.length > MAX) {
+    return "<em>Prompts too large for line diff</em>";
+  }
+  const m = aLines.length, n = bLines.length;
+  const dp = Array.from({length: m + 1}, () => new Uint16Array(n + 1));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = aLines[i - 1] === bLines[j - 1]
+        ? dp[i - 1][j - 1] + 1
+        : Math.max(dp[i - 1][j], dp[i][j - 1]);
     }
   }
-  for (const line of bLines) {
-    if (!aSet.has(line)) {
-      html += `<div class="diff-added">+ ${escapeHtml(line)}</div>`;
+  const ops = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && aLines[i - 1] === bLines[j - 1]) {
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({type: "add", line: bLines[--j]});
+    } else {
+      ops.push({type: "rem", line: aLines[--i]});
     }
+  }
+  let html = "";
+  for (let k = ops.length - 1; k >= 0; k--) {
+    const op = ops[k];
+    html += op.type === "add"
+      ? `<div class="diff-added">+ ${escapeHtml(op.line)}</div>`
+      : `<div class="diff-removed">- ${escapeHtml(op.line)}</div>`;
   }
   return html || "<em>No line-level differences</em>";
 }
@@ -543,7 +561,7 @@ async function fetchAndRenderPrompts(taskId) {
     const preview = p.prompt.length > 2048 ? p.prompt.slice(0, 2048) + "\u2026" : p.prompt;
     panel.innerHTML = `<pre class="detail-pre prompt-pre">${escapeHtml(preview)}</pre>` +
       (p.prompt.length > 2048
-        ? `<button class="prompt-expand-btn" data-full="${encodeURIComponent(p.prompt)}" data-panel="${panelId}">Show full prompt</button>`
+        ? `<button class="prompt-expand-btn" data-idx="${idx}" data-panel="${panelId}">Show full prompt</button>`
         : "");
 
     const diffPanel = document.createElement("div");
@@ -581,7 +599,8 @@ async function fetchAndRenderPrompts(taskId) {
   // Wire expand buttons
   section.querySelectorAll(".prompt-expand-btn").forEach(btn => {
     btn.addEventListener("click", () => {
-      const full = decodeURIComponent(btn.dataset.full);
+      const idx = parseInt(btn.dataset.idx, 10);
+      const full = prompts[idx].prompt;
       const panel = document.getElementById(btn.dataset.panel);
       if (panel) panel.querySelector("pre").textContent = full;
       btn.remove();

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -441,6 +441,9 @@ function showDetail(task) {
 
   document.getElementById("detail-body").innerHTML = body;
 
+  // Async: fetch and render the prompts panel after initial HTML is set.
+  fetchAndRenderPrompts(task.id);
+
   const cancelBtn = document.querySelector(".cancel-btn[data-task-id]");
   if (cancelBtn) {
     cancelBtn.addEventListener("click", async () => {
@@ -463,6 +466,137 @@ function showDetail(task) {
 
   panel.classList.add("detail-panel-open");
   document.body.style.overflow = "hidden";
+}
+
+// --- Prompts panel ---
+
+function lineDiff(a, b) {
+  const aLines = a.split("\n");
+  const bLines = b.split("\n");
+  const aSet = new Set(aLines);
+  const bSet = new Set(bLines);
+  let html = "";
+  for (const line of aLines) {
+    if (!bSet.has(line)) {
+      html += `<div class="diff-removed">- ${escapeHtml(line)}</div>`;
+    }
+  }
+  for (const line of bLines) {
+    if (!aSet.has(line)) {
+      html += `<div class="diff-added">+ ${escapeHtml(line)}</div>`;
+    }
+  }
+  return html || "<em>No line-level differences</em>";
+}
+
+async function fetchAndRenderPrompts(taskId) {
+  const body = document.getElementById("detail-body");
+  if (!body) return;
+
+  let prompts;
+  try {
+    const resp = await apiFetch(`/tasks/${encodeURIComponent(taskId)}/prompts`, { headers: authHeaders() });
+    if (!resp || !resp.ok) return;
+    prompts = await resp.json();
+  } catch { return; }
+
+  if (!Array.isArray(prompts) || prompts.length === 0) {
+    const el = document.createElement("div");
+    el.className = "detail-section";
+    el.innerHTML = `<div class="detail-section-title">Agent Prompts</div><p class="prompts-empty">No prompts yet.</p>`;
+    body.appendChild(el);
+    return;
+  }
+
+  const section = document.createElement("div");
+  section.className = "detail-section";
+  section.innerHTML = `<div class="detail-section-title">Agent Prompts (${prompts.length} turn${prompts.length > 1 ? "s" : ""})</div>`;
+
+  prompts.forEach((p, idx) => {
+    const panelId = `prompt-body-${idx}`;
+    const diffId = `prompt-diff-${idx}`;
+    const hasPrev = idx > 0;
+
+    const item = document.createElement("div");
+    item.className = "prompt-item";
+
+    const header = document.createElement("div");
+    header.className = "prompt-header";
+    header.innerHTML =
+      `<span class="prompt-meta">Turn ${p.turn} &mdash; <em>${escapeHtml(p.phase)}</em></span>` +
+      `<span class="prompt-actions">` +
+      (hasPrev ? `<button class="prompt-diff-btn" data-diff="${diffId}" data-prev="${idx - 1}" data-cur="${idx}">Diff</button> ` : "") +
+      `<button class="prompt-copy-btn" data-idx="${idx}">Copy</button>` +
+      `<button class="prompt-toggle-btn" data-panel="${panelId}">\u25bc</button>` +
+      `</span>`;
+
+    const panel = document.createElement("div");
+    panel.id = panelId;
+    panel.className = "prompt-body prompt-collapsed";
+
+    const preview = p.prompt.length > 2048 ? p.prompt.slice(0, 2048) + "\u2026" : p.prompt;
+    panel.innerHTML = `<pre class="detail-pre prompt-pre">${escapeHtml(preview)}</pre>` +
+      (p.prompt.length > 2048
+        ? `<button class="prompt-expand-btn" data-full="${encodeURIComponent(p.prompt)}" data-panel="${panelId}">Show full prompt</button>`
+        : "");
+
+    const diffPanel = document.createElement("div");
+    diffPanel.id = diffId;
+    diffPanel.className = "prompt-diff-panel prompt-collapsed";
+
+    item.appendChild(header);
+    item.appendChild(panel);
+    item.appendChild(diffPanel);
+    section.appendChild(item);
+  });
+
+  body.appendChild(section);
+
+  // Wire toggle buttons
+  section.querySelectorAll(".prompt-toggle-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const panel = document.getElementById(btn.dataset.panel);
+      if (!panel) return;
+      const collapsed = panel.classList.toggle("prompt-collapsed");
+      btn.textContent = collapsed ? "\u25bc" : "\u25b2";
+    });
+  });
+
+  // Wire copy buttons
+  section.querySelectorAll(".prompt-copy-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const idx = parseInt(btn.dataset.idx, 10);
+      navigator.clipboard.writeText(prompts[idx].prompt).catch(() => {});
+      btn.textContent = "Copied!";
+      setTimeout(() => { btn.textContent = "Copy"; }, 1500);
+    });
+  });
+
+  // Wire expand buttons
+  section.querySelectorAll(".prompt-expand-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const full = decodeURIComponent(btn.dataset.full);
+      const panel = document.getElementById(btn.dataset.panel);
+      if (panel) panel.querySelector("pre").textContent = full;
+      btn.remove();
+    });
+  });
+
+  // Wire diff buttons
+  section.querySelectorAll(".prompt-diff-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const diffPanel = document.getElementById(btn.dataset.diff);
+      if (!diffPanel) return;
+      const collapsed = diffPanel.classList.toggle("prompt-collapsed");
+      if (!collapsed && !diffPanel.dataset.rendered) {
+        const prevIdx = parseInt(btn.dataset.prev, 10);
+        const curIdx = parseInt(btn.dataset.cur, 10);
+        diffPanel.innerHTML = `<div class="prompt-diff-body">${lineDiff(prompts[prevIdx].prompt, prompts[curIdx].prompt)}</div>`;
+        diffPanel.dataset.rendered = "1";
+      }
+      btn.textContent = collapsed ? "Diff" : "Hide Diff";
+    });
+  });
 }
 
 function closeDetail() {

--- a/crates/harness-server/static/dashboard.js
+++ b/crates/harness-server/static/dashboard.js
@@ -19,6 +19,7 @@ let historyPage = 0;
 let historyQuery = "";
 let historyFilter = "all";
 let _activeDetailTaskId = null;
+let _detailGeneration = 0;
 
 function $(sel) { return document.querySelector(sel); }
 
@@ -443,9 +444,12 @@ function showDetail(task) {
   document.getElementById("detail-body").innerHTML = body;
 
   // Track which task is active so the async fetch can bail if the user
-  // switches to a different task before the response arrives.
+  // switches to a different task before the response arrives. The generation
+  // counter additionally prevents duplicate panels when showDetail is called
+  // multiple times for the same task while a fetch is still in flight.
   _activeDetailTaskId = task.id;
-  fetchAndRenderPrompts(task.id);
+  const generation = ++_detailGeneration;
+  fetchAndRenderPrompts(task.id, generation);
 
   const cancelBtn = document.querySelector(".cancel-btn[data-task-id]");
   if (cancelBtn) {
@@ -510,7 +514,7 @@ function lineDiff(a, b) {
   return html || "<em>No line-level differences</em>";
 }
 
-async function fetchAndRenderPrompts(taskId) {
+async function fetchAndRenderPrompts(taskId, generation) {
   const body = document.getElementById("detail-body");
   if (!body) return;
 
@@ -521,8 +525,8 @@ async function fetchAndRenderPrompts(taskId) {
     prompts = await resp.json();
   } catch { return; }
 
-  // Guard: user may have opened a different task while this fetch was in flight.
-  if (_activeDetailTaskId !== taskId) return;
+  // Guard: bail if the user switched tasks or re-opened the same task (new generation).
+  if (_activeDetailTaskId !== taskId || _detailGeneration !== generation) return;
 
   if (!Array.isArray(prompts) || prompts.length === 0) {
     const el = document.createElement("div");


### PR DESCRIPTION
## Summary

- **DB**: v17 migration adds `task_prompts(id, task_id, turn, phase, prompt, created_at)` with a `UNIQUE(task_id, turn, phase)` constraint for upsert-on-retry semantics; capped at 2 MB with `[TRUNCATED]` marker.
- **Redaction** (`redact.rs`): two-pass — env-var values ≥ 8 chars (sorted longest-first) then regex patterns (`ghp_*`, `ghs_*`, 40-hex, `Bearer …`, `sk-*`).
- **Capture points**: `run_agent_streaming()` in `helpers.rs` captures `req.prompt` + `req.env_vars` before `execute_stream` consumes the request; `run_plan_for_prompt()` in `triage_pipeline.rs` captures the non-streaming planning path.
- **API**: `GET /tasks/{id}/prompts` returns `Vec<TaskPrompt>` ordered by turn ascending; 404 when task not found.
- **UI**: task detail panel fetches prompts asynchronously and renders each turn collapsed by default, with a copy-to-clipboard button, expand toggle, and a line-level diff between consecutive turns.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — all tests pass (0 failures)
- [ ] Open a task in the dashboard after a turn completes → Prompts panel appears with the expanded prompt text
- [ ] Copy button copies full prompt to clipboard
- [ ] Expand toggle shows/hides prompt body; arrow rotates
- [ ] Diff button between turn N and N+1 highlights added/removed lines
- [ ] `GITHUB_TOKEN` and `ANTHROPIC_API_KEY` values do not appear in persisted prompt

Closes #792