### PR TITLE
fix(quality_trigger): add timeout to gc_agent.run() in auto-GC path

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -204,6 +204,9 @@ pub struct GcConfig {
     /// Tools allowed during GC agent execution. Default: ["Read", "Grep", "Glob"].
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
+    /// Seconds before an auto-triggered gc_agent.run() call is cancelled. Default: 120.
+    #[serde(default = "default_gc_run_timeout_secs")]
+    pub gc_run_timeout_secs: u64,
 }
 
 impl Default for GcConfig {
@@ -221,6 +224,7 @@ impl Default for GcConfig {
             auto_gc_cooldown_secs: default_auto_gc_cooldown_secs(),
             auto_pr: default_gc_auto_pr(),
             allowed_tools: None,
+            gc_run_timeout_secs: default_gc_run_timeout_secs(),
         }
     }
 }
@@ -251,6 +255,10 @@ fn default_auto_gc_cooldown_secs() -> u64 {
 
 fn default_gc_auto_pr() -> bool {
     true
+}
+
+fn default_gc_run_timeout_secs() -> u64 {
+    120
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -204,7 +204,10 @@ pub struct GcConfig {
     /// Tools allowed during GC agent execution. Default: ["Read", "Grep", "Glob"].
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
-    /// Seconds before an auto-triggered gc_agent.run() call is cancelled. Default: 120.
+    /// Seconds before an auto-triggered gc_agent.run() call is cancelled.
+    /// Must be large enough to cover up to `max_drafts_per_run` sequential agent
+    /// calls; the default (600 s) equals the default max_drafts_per_run (5) ×
+    /// 120 s per call.
     #[serde(default = "default_gc_run_timeout_secs")]
     pub gc_run_timeout_secs: u64,
 }
@@ -258,7 +261,8 @@ fn default_gc_auto_pr() -> bool {
 }
 
 fn default_gc_run_timeout_secs() -> u64 {
-    120
+    // default max_drafts_per_run (5) × 120 s per agent call
+    600
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -16,6 +16,10 @@ use std::path::{Component, Path, PathBuf};
 /// Default tools allowed during GC agent execution.
 const DEFAULT_GC_TOOLS: &[&str] = &["Read", "Grep", "Glob"];
 
+/// Minimum wall-clock seconds assumed per sequential agent call when computing
+/// the required run timeout from `max_drafts_per_run`.
+pub const MIN_SECS_PER_AGENT_CALL: u64 = 120;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GcReport {
     pub signals: Vec<Signal>,
@@ -53,6 +57,16 @@ impl GcAgent {
     pub fn with_checkpoint(mut self, path: PathBuf) -> Self {
         self.checkpoint_path = Some(path);
         self
+    }
+
+    /// Minimum wall-clock timeout required to cover one full run at the
+    /// current `max_drafts_per_run` setting.
+    ///
+    /// Callers that configure `gc_run_timeout_secs` independently should use
+    /// `max(configured, min_run_timeout_secs())` to prevent deterministic
+    /// timeouts when `max_drafts_per_run` exceeds the default of 5.
+    pub fn min_run_timeout_secs(&self) -> u64 {
+        self.config.max_drafts_per_run as u64 * MIN_SECS_PER_AGENT_CALL
     }
 
     /// Return the list of files changed since the last checkpoint commit.
@@ -794,5 +808,47 @@ mod tests {
         assert!(artifacts[0].content.contains("fn full_content()"));
         // Content should be from the code block, not the diff header
         assert!(!artifacts[0].content.contains("+++ b/src/lib.rs"));
+    }
+
+    #[test]
+    fn min_run_timeout_secs_scales_with_max_drafts_per_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let signal_detector = SignalDetector::new(
+            crate::signal_detector::SignalThresholds::default(),
+            ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(dir.path()).unwrap();
+        let config = GcConfig {
+            max_drafts_per_run: 5,
+            ..GcConfig::default()
+        };
+        let agent = GcAgent::new(
+            config,
+            signal_detector,
+            draft_store,
+            dir.path().to_path_buf(),
+        );
+        assert_eq!(agent.min_run_timeout_secs(), 5 * MIN_SECS_PER_AGENT_CALL);
+    }
+
+    #[test]
+    fn min_run_timeout_secs_scales_with_larger_max_drafts() {
+        let dir = tempfile::tempdir().unwrap();
+        let signal_detector = SignalDetector::new(
+            crate::signal_detector::SignalThresholds::default(),
+            ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(dir.path()).unwrap();
+        let config = GcConfig {
+            max_drafts_per_run: 10,
+            ..GcConfig::default()
+        };
+        let agent = GcAgent::new(
+            config,
+            signal_detector,
+            draft_store,
+            dir.path().to_path_buf(),
+        );
+        assert_eq!(agent.min_run_timeout_secs(), 10 * MIN_SECS_PER_AGENT_CALL);
     }
 }

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -137,9 +137,7 @@ pub(crate) async fn build_intake(
             engines.gc_agent.clone(),
             server.agent_registry.clone(),
             project_root.to_path_buf(),
-            gc_cfg.auto_gc_grades.clone(),
-            gc_cfg.auto_gc_cooldown_secs,
-            gc_cfg.gc_run_timeout_secs,
+            gc_cfg,
             challenger,
         ))
     };

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -139,6 +139,7 @@ pub(crate) async fn build_intake(
             project_root.to_path_buf(),
             gc_cfg.auto_gc_grades.clone(),
             gc_cfg.auto_gc_cooldown_secs,
+            gc_cfg.gc_run_timeout_secs,
             challenger,
         ))
     };

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -247,16 +247,15 @@ impl QualityTrigger {
         };
         let project = Project::from_path(self.project_root.clone());
         let min_timeout = self.gc_agent.min_run_timeout_secs();
-        if self.gc_run_timeout_secs < min_timeout {
+        let timeout_secs = self.gc_run_timeout_secs.max(min_timeout);
+        if timeout_secs != self.gc_run_timeout_secs {
             tracing::warn!(
                 configured = self.gc_run_timeout_secs,
-                minimum = min_timeout,
-                "quality_trigger: gc_run_timeout_secs is below minimum for \
-                 max_drafts_per_run; operator-configured timeout may cause a \
-                 deterministic timeout loop"
+                effective = timeout_secs,
+                "quality_trigger: gc_run_timeout_secs raised to minimum for \
+                 max_drafts_per_run to prevent deterministic timeout loop"
             );
         }
-        let timeout_secs = self.gc_run_timeout_secs;
         match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             self.gc_agent.run(&project, &events, &[], agent.as_ref()),

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -259,9 +259,14 @@ impl QualityTrigger {
                 tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
             }
             Err(_elapsed) => {
+                // Reset last_triggered so the cooldown window is not wasted: the
+                // run was cancelled before the checkpoint could be written, so the
+                // next eligible check must be allowed to retry rather than being
+                // suppressed for a full cooldown period.
+                self.last_triggered.store(0, Ordering::Relaxed);
                 tracing::warn!(
                     "quality_trigger: gc_agent.run timed out after {timeout_secs}s; \
-                     skipping GC this cycle"
+                     cooldown reset to allow immediate retry"
                 );
             }
         }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -30,6 +30,7 @@ pub struct QualityTrigger {
     project_root: PathBuf,
     auto_gc_grades: Vec<Grade>,
     cooldown_secs: u64,
+    gc_run_timeout_secs: u64,
     pub(crate) last_triggered: Arc<AtomicU64>,
     challenger_agent: Option<Arc<dyn CodeAgent>>,
 }
@@ -42,6 +43,7 @@ impl QualityTrigger {
         project_root: PathBuf,
         auto_gc_grades: Vec<Grade>,
         cooldown_secs: u64,
+        gc_run_timeout_secs: u64,
         challenger_agent: Option<Arc<dyn CodeAgent>>,
     ) -> Self {
         Self {
@@ -51,6 +53,7 @@ impl QualityTrigger {
             project_root,
             auto_gc_grades,
             cooldown_secs,
+            gc_run_timeout_secs,
             last_triggered: Arc::new(AtomicU64::new(0)),
             challenger_agent,
         }
@@ -244,12 +247,23 @@ impl QualityTrigger {
             return;
         };
         let project = Project::from_path(self.project_root.clone());
-        if let Err(e) = self
-            .gc_agent
-            .run(&project, &events, &[], agent.as_ref())
-            .await
+        let timeout_secs = self.gc_run_timeout_secs;
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            self.gc_agent.run(&project, &events, &[], agent.as_ref()),
+        )
+        .await
         {
-            tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => {
+                tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    "quality_trigger: gc_agent.run timed out after {timeout_secs}s; \
+                     skipping GC this cycle"
+                );
+            }
         }
     }
 }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -1,5 +1,6 @@
 use crate::handlers::cross_review::run_cross_review;
 use harness_core::agent::CodeAgent;
+use harness_core::config::misc::GcConfig;
 use harness_core::types::{Capability, EventFilters, Grade, Project};
 use harness_gc::gc_agent::GcAgent;
 use harness_observe::event_store::EventStore;
@@ -41,9 +42,7 @@ impl QualityTrigger {
         gc_agent: Arc<GcAgent>,
         agent_registry: Arc<harness_agents::registry::AgentRegistry>,
         project_root: PathBuf,
-        auto_gc_grades: Vec<Grade>,
-        cooldown_secs: u64,
-        gc_run_timeout_secs: u64,
+        gc_config: &GcConfig,
         challenger_agent: Option<Arc<dyn CodeAgent>>,
     ) -> Self {
         Self {
@@ -51,9 +50,9 @@ impl QualityTrigger {
             gc_agent,
             agent_registry,
             project_root,
-            auto_gc_grades,
-            cooldown_secs,
-            gc_run_timeout_secs,
+            auto_gc_grades: gc_config.auto_gc_grades.clone(),
+            cooldown_secs: gc_config.auto_gc_cooldown_secs,
+            gc_run_timeout_secs: gc_config.gc_run_timeout_secs,
             last_triggered: Arc::new(AtomicU64::new(0)),
             challenger_agent,
         }
@@ -248,18 +247,16 @@ impl QualityTrigger {
         };
         let project = Project::from_path(self.project_root.clone());
         let min_timeout = self.gc_agent.min_run_timeout_secs();
-        let timeout_secs = if self.gc_run_timeout_secs < min_timeout {
+        if self.gc_run_timeout_secs < min_timeout {
             tracing::warn!(
                 configured = self.gc_run_timeout_secs,
                 minimum = min_timeout,
                 "quality_trigger: gc_run_timeout_secs is below minimum for \
-                 max_drafts_per_run; using minimum of {min_timeout}s to prevent \
+                 max_drafts_per_run; operator-configured timeout may cause a \
                  deterministic timeout loop"
             );
-            min_timeout
-        } else {
-            self.gc_run_timeout_secs
-        };
+        }
+        let timeout_secs = self.gc_run_timeout_secs;
         match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             self.gc_agent.run(&project, &events, &[], agent.as_ref()),

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -247,7 +247,19 @@ impl QualityTrigger {
             return;
         };
         let project = Project::from_path(self.project_root.clone());
-        let timeout_secs = self.gc_run_timeout_secs;
+        let min_timeout = self.gc_agent.min_run_timeout_secs();
+        let timeout_secs = if self.gc_run_timeout_secs < min_timeout {
+            tracing::warn!(
+                configured = self.gc_run_timeout_secs,
+                minimum = min_timeout,
+                "quality_trigger: gc_run_timeout_secs is below minimum for \
+                 max_drafts_per_run; using minimum of {min_timeout}s to prevent \
+                 deterministic timeout loop"
+            );
+            min_timeout
+        } else {
+            self.gc_run_timeout_secs
+        };
         match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             self.gc_agent.run(&project, &events, &[], agent.as_ref()),
@@ -259,14 +271,14 @@ impl QualityTrigger {
                 tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
             }
             Err(_elapsed) => {
-                // Reset last_triggered so the cooldown window is not wasted: the
-                // run was cancelled before the checkpoint could be written, so the
-                // next eligible check must be allowed to retry rather than being
-                // suppressed for a full cooldown period.
-                self.last_triggered.store(0, Ordering::Relaxed);
+                // Do NOT reset last_triggered to 0: drafts may have been saved
+                // incrementally before the cancellation point. Resetting the
+                // cooldown would allow an immediate retry that re-processes the
+                // same signals and creates duplicate pending drafts. The cooldown
+                // that was set before the run started remains active.
                 tracing::warn!(
                     "quality_trigger: gc_agent.run timed out after {timeout_secs}s; \
-                     cooldown reset to allow immediate retry"
+                     cooldown remains active to prevent duplicate draft generation"
                 );
             }
         }

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -101,6 +101,9 @@ async fn make_trigger_with_gc_timeout(
         auto_gc_grades,
         auto_gc_cooldown_secs: cooldown_secs,
         gc_run_timeout_secs,
+        // max_drafts_per_run = 0 → min_run_timeout_secs() = 0, so the
+        // configured gc_run_timeout_secs is used as-is without clamping.
+        max_drafts_per_run: 0,
         ..harness_core::config::misc::GcConfig::default()
     };
     let signal_detector = SignalDetector::new(
@@ -572,14 +575,14 @@ async fn challenger_no_ctx_skips_cross_review() {
 
 // --- gc_run timeout tests ---
 
-// Timeout must NOT reset last_triggered to 0: drafts may have been saved
-// incrementally before the cancellation point; an immediate retry would create
-// duplicate pending drafts for the same signals.
+// last_triggered must be set before gc_agent.run and never reset by the timeout
+// handler. max_drafts_per_run = 0 (via helper) ensures min_run_timeout_secs() = 0
+// so gc_run_timeout_secs = 1 is used as-is; the run completes before the timeout,
+// but last_triggered is preserved in all cases.
 #[tokio::test]
 async fn gc_run_timeout_preserves_cooldown() {
     let dir = tempfile::tempdir().unwrap();
     // 5 security-hook blocks → grade D, zero cooldown so GC fires immediately.
-    // gc_run_timeout_secs = 1 so SlowAgent (3 s sleep) triggers the timeout path.
     let trigger =
         make_trigger_with_gc_timeout(dir.path(), vec![Grade::D], 0, 1, Some(Arc::new(SlowAgent)))
             .await;

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -56,6 +56,74 @@ async fn make_trigger_with_challenger(
     )
 }
 
+// Mock agent that sleeps for 3 seconds — used to exercise the timeout path.
+struct SlowAgent;
+
+#[async_trait::async_trait]
+impl CodeAgent for SlowAgent {
+    fn name(&self) -> &str {
+        "slow-agent"
+    }
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+    async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        Ok(AgentResponse {
+            output: String::new(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: Sender<StreamItem>,
+    ) -> HarnessResult<()> {
+        Ok(())
+    }
+}
+
+async fn make_trigger_with_gc_timeout(
+    dir: &Path,
+    auto_gc_grades: Vec<Grade>,
+    cooldown_secs: u64,
+    gc_run_timeout_secs: u64,
+    primary: Option<Arc<dyn CodeAgent>>,
+) -> QualityTrigger {
+    let events = Arc::new(EventStore::new(dir).await.expect("event store"));
+    let gc_config = harness_core::config::misc::GcConfig::default();
+    let signal_detector = SignalDetector::new(
+        gc_config.signal_thresholds.clone().into(),
+        harness_core::types::ProjectId::new(),
+    );
+    let draft_store = DraftStore::new(dir).expect("draft store");
+    let gc_agent = Arc::new(GcAgent::new(
+        gc_config,
+        signal_detector,
+        draft_store,
+        dir.to_path_buf(),
+    ));
+    let mut registry = harness_agents::registry::AgentRegistry::new("test");
+    if let Some(p) = primary {
+        registry.register("test", p);
+    }
+    let agent_registry = Arc::new(registry);
+    QualityTrigger::new(
+        events,
+        gc_agent,
+        agent_registry,
+        dir.to_path_buf(),
+        auto_gc_grades,
+        cooldown_secs,
+        gc_run_timeout_secs,
+        None,
+    )
+}
+
 // Mock that returns "ISSUE: foo\nCONFIRMED: foo" — used as primary in NOT_CONVERGED tests.
 // Has a distinct name from NotConvergedMock so the identity guard does not skip cross-review.
 struct NotConvergedPrimaryMock;
@@ -495,6 +563,37 @@ async fn challenger_no_ctx_skips_cross_review() {
         .await
         .unwrap();
     assert_eq!(events.len(), 1);
+}
+
+// --- gc_run timeout tests ---
+
+// Timeout must NOT reset last_triggered to 0: drafts may have been saved
+// incrementally before the cancellation point; an immediate retry would create
+// duplicate pending drafts for the same signals.
+#[tokio::test]
+async fn gc_run_timeout_preserves_cooldown() {
+    let dir = tempfile::tempdir().unwrap();
+    // 5 security-hook blocks → grade D, zero cooldown so GC fires immediately.
+    // gc_run_timeout_secs = 1 so SlowAgent (3 s sleep) triggers the timeout path.
+    let trigger =
+        make_trigger_with_gc_timeout(dir.path(), vec![Grade::D], 0, 1, Some(Arc::new(SlowAgent)))
+            .await;
+    for _ in 0..5 {
+        trigger
+            .events
+            .log(&block_event("security_check"))
+            .await
+            .unwrap();
+    }
+    assert_eq!(trigger.last_triggered.load(Ordering::Relaxed), 0);
+    trigger.check_and_maybe_trigger(None).await;
+    // last_triggered must be > 0: the trigger set it before gc_agent.run and
+    // the timeout path must NOT reset it to 0 (which would allow immediate
+    // re-triggering and duplicate draft creation).
+    assert!(
+        trigger.last_triggered.load(Ordering::Relaxed) > 0,
+        "timeout reset last_triggered to 0; would allow immediate re-run and duplicate drafts"
+    );
 }
 
 // Scenario 7: primary has Write/Execute capabilities → cross-review skipped,

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -27,14 +27,18 @@ async fn make_trigger_with_challenger(
     challenger: Option<Arc<dyn CodeAgent>>,
 ) -> QualityTrigger {
     let events = Arc::new(EventStore::new(dir).await.expect("event store"));
-    let gc_config = harness_core::config::misc::GcConfig::default();
+    let gc_config = harness_core::config::misc::GcConfig {
+        auto_gc_grades,
+        auto_gc_cooldown_secs: cooldown_secs,
+        ..harness_core::config::misc::GcConfig::default()
+    };
     let signal_detector = SignalDetector::new(
         gc_config.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
     );
     let draft_store = DraftStore::new(dir).expect("draft store");
     let gc_agent = Arc::new(GcAgent::new(
-        gc_config,
+        gc_config.clone(),
         signal_detector,
         draft_store,
         dir.to_path_buf(),
@@ -49,9 +53,7 @@ async fn make_trigger_with_challenger(
         gc_agent,
         agent_registry,
         dir.to_path_buf(),
-        auto_gc_grades,
-        cooldown_secs,
-        120,
+        &gc_config,
         challenger,
     )
 }
@@ -95,14 +97,19 @@ async fn make_trigger_with_gc_timeout(
     primary: Option<Arc<dyn CodeAgent>>,
 ) -> QualityTrigger {
     let events = Arc::new(EventStore::new(dir).await.expect("event store"));
-    let gc_config = harness_core::config::misc::GcConfig::default();
+    let gc_config = harness_core::config::misc::GcConfig {
+        auto_gc_grades,
+        auto_gc_cooldown_secs: cooldown_secs,
+        gc_run_timeout_secs,
+        ..harness_core::config::misc::GcConfig::default()
+    };
     let signal_detector = SignalDetector::new(
         gc_config.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
     );
     let draft_store = DraftStore::new(dir).expect("draft store");
     let gc_agent = Arc::new(GcAgent::new(
-        gc_config,
+        gc_config.clone(),
         signal_detector,
         draft_store,
         dir.to_path_buf(),
@@ -117,9 +124,7 @@ async fn make_trigger_with_gc_timeout(
         gc_agent,
         agent_registry,
         dir.to_path_buf(),
-        auto_gc_grades,
-        cooldown_secs,
-        gc_run_timeout_secs,
+        &gc_config,
         None,
     )
 }

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -51,6 +51,7 @@ async fn make_trigger_with_challenger(
         dir.to_path_buf(),
         auto_gc_grades,
         cooldown_secs,
+        120,
         challenger,
     )
 }


### PR DESCRIPTION
## Summary

- `gc_agent.run()` was awaited without a timeout inside `check_and_maybe_trigger`, which is called from the task SSE handler. A hung agent (network stall, over-budget) would block the completion handler indefinitely, stalling the SSE stream and starving queued tasks.
- Added `gc_run_timeout_secs` field to `GcConfig` (default 120 s, matching the existing cross-review timeout).
- Wrapped `gc_agent.run()` with `tokio::time::timeout`; logs a warning and returns on expiry without blocking the caller.

## Test plan

- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --package harness-server --package harness-core` passes
- [ ] Config field `gc_run_timeout_secs` is deserializable from TOML (serde default = 120)