### PR TITLE
fix(gc): replace auto_pr bool with exhaustive AutoAdoptPolicy enum (U-23)

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -176,6 +176,22 @@ impl Default for ValidationConfig {
     }
 }
 
+/// Controls whether and how `gc adopt` automatically dispatches an agent task after writing
+/// draft artifacts to disk.
+///
+/// Use an exhaustive `match` on this enum at every call site so that adding a new variant
+/// causes a compile error instead of a silent no-op.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutoAdoptPolicy {
+    /// Do not automatically dispatch any agent task after adopting a draft.
+    Off,
+    /// Dispatch an agent task to create a branch, commit the fix, push, and open a PR.
+    /// This is the default.
+    #[default]
+    RulesOnly,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GcConfig {
     pub max_drafts_per_run: usize,
@@ -197,10 +213,10 @@ pub struct GcConfig {
     /// Minimum seconds between auto-triggered GC runs (cooldown). Default: 300.
     #[serde(default = "default_auto_gc_cooldown_secs")]
     pub auto_gc_cooldown_secs: u64,
-    /// When true, `gc adopt` automatically creates a branch, commits the fix, pushes,
-    /// and opens a PR via the agent prompt flow. Default: true.
-    #[serde(default = "default_gc_auto_pr")]
-    pub auto_pr: bool,
+    /// Controls whether and how `gc adopt` automatically dispatches an agent task.
+    /// Default: `rules_only` (dispatch a task to create a branch, commit, push, and open a PR).
+    #[serde(default)]
+    pub auto_adopt_policy: AutoAdoptPolicy,
     /// Tools allowed during GC agent execution. Default: ["Read", "Grep", "Glob"].
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
@@ -219,7 +235,7 @@ impl Default for GcConfig {
             signal_thresholds: SignalThresholdsConfig::default(),
             auto_gc_grades: default_auto_gc_grades(),
             auto_gc_cooldown_secs: default_auto_gc_cooldown_secs(),
-            auto_pr: default_gc_auto_pr(),
+            auto_adopt_policy: AutoAdoptPolicy::default(),
             allowed_tools: None,
         }
     }
@@ -247,10 +263,6 @@ fn default_auto_gc_grades() -> Vec<Grade> {
 
 fn default_auto_gc_cooldown_secs() -> u64 {
     300
-}
-
-fn default_gc_auto_pr() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -192,7 +192,67 @@ pub enum AutoAdoptPolicy {
     RulesOnly,
 }
 
+/// Intermediate deserialization target for [`GcConfig`].
+///
+/// Handles backward compatibility for the legacy `auto_pr: bool` field that was
+/// superseded by `auto_adopt_policy: AutoAdoptPolicy`.  When `auto_pr = false`
+/// is present and `auto_adopt_policy` is absent, the effective policy becomes
+/// `Off`, preserving the operator's intent instead of silently defaulting to
+/// `RulesOnly`.
+#[derive(Deserialize)]
+struct GcConfigRaw {
+    pub max_drafts_per_run: usize,
+    pub budget_per_signal_usd: f64,
+    pub total_budget_usd: f64,
+    #[serde(default = "default_gc_adopt_wait_secs")]
+    pub adopt_wait_secs: u64,
+    #[serde(default = "default_gc_adopt_max_rounds")]
+    pub adopt_max_rounds: u32,
+    #[serde(default = "default_gc_adopt_turn_timeout_secs")]
+    pub adopt_turn_timeout_secs: u64,
+    #[serde(default = "default_gc_draft_ttl_hours")]
+    pub draft_ttl_hours: u64,
+    pub signal_thresholds: SignalThresholdsConfig,
+    #[serde(default = "default_auto_gc_grades")]
+    pub auto_gc_grades: Vec<Grade>,
+    #[serde(default = "default_auto_gc_cooldown_secs")]
+    pub auto_gc_cooldown_secs: u64,
+    /// New field — takes precedence over `auto_pr` when present.
+    #[serde(default)]
+    pub auto_adopt_policy: Option<AutoAdoptPolicy>,
+    /// Legacy field — superseded by `auto_adopt_policy`.
+    /// `false` maps to `Off`; `true` (or absent) maps to `RulesOnly`.
+    #[serde(default)]
+    pub auto_pr: Option<bool>,
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+impl From<GcConfigRaw> for GcConfig {
+    fn from(raw: GcConfigRaw) -> Self {
+        let auto_adopt_policy = raw.auto_adopt_policy.unwrap_or_else(|| match raw.auto_pr {
+            Some(false) => AutoAdoptPolicy::Off,
+            _ => AutoAdoptPolicy::default(),
+        });
+        Self {
+            max_drafts_per_run: raw.max_drafts_per_run,
+            budget_per_signal_usd: raw.budget_per_signal_usd,
+            total_budget_usd: raw.total_budget_usd,
+            adopt_wait_secs: raw.adopt_wait_secs,
+            adopt_max_rounds: raw.adopt_max_rounds,
+            adopt_turn_timeout_secs: raw.adopt_turn_timeout_secs,
+            draft_ttl_hours: raw.draft_ttl_hours,
+            signal_thresholds: raw.signal_thresholds,
+            auto_gc_grades: raw.auto_gc_grades,
+            auto_gc_cooldown_secs: raw.auto_gc_cooldown_secs,
+            auto_adopt_policy,
+            allowed_tools: raw.allowed_tools,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "GcConfigRaw")]
 pub struct GcConfig {
     pub max_drafts_per_run: usize,
     pub budget_per_signal_usd: f64,

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -1,6 +1,6 @@
 use crate::http::{resolve_reviewer, AppState};
 use harness_core::{
-    config::resolve::resolve_config,
+    config::{misc::AutoAdoptPolicy, resolve::resolve_config},
     types::{Decision, DraftId, Event, ProjectId, SessionId},
 };
 use harness_protocol::{methods::RpcResponse, methods::INTERNAL_ERROR, methods::NOT_FOUND};
@@ -242,14 +242,18 @@ pub async fn gc_adopt(
         .iter()
         .map(|a| a.target_path.display().to_string())
         .collect();
-    let needs_task_dispatch = !artifact_paths.is_empty() && state.core.server.config.gc.auto_pr;
+    let needs_task_dispatch = !artifact_paths.is_empty()
+        && match state.core.server.config.gc.auto_adopt_policy {
+            AutoAdoptPolicy::Off => false,
+            AutoAdoptPolicy::RulesOnly => true,
+        };
 
     let task_dispatch_plan = if needs_task_dispatch {
         let Some(agent) = state.core.server.agent_registry.default_agent() else {
             return RpcResponse::error(
                 id,
                 INTERNAL_ERROR,
-                "gc_adopt auto_pr requires a registered default agent",
+                "gc_adopt requires a registered default agent",
             );
         };
         let path_refs: Vec<&str> = artifact_paths.iter().map(String::as_str).collect();

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -240,11 +240,10 @@ async fn gc_adopt_response_includes_task_id() -> anyhow::Result<()> {
     assert_eq!(
         err.code,
         harness_protocol::methods::INTERNAL_ERROR,
-        "gc_adopt should fail fast when auto_pr is enabled but no default agent exists"
+        "gc_adopt should fail fast when auto_adopt_policy is RulesOnly but no default agent exists"
     );
     assert!(
-        err.message
-            .contains("auto_pr requires a registered default agent"),
+        err.message.contains("requires a registered default agent"),
         "unexpected error message: {}",
         err.message
     );

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use harness_agents::registry::AgentRegistry;
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
-use harness_core::config::HarnessConfig;
+use harness_core::config::{misc::AutoAdoptPolicy, HarnessConfig};
 use harness_core::error::HarnessError;
 use harness_core::types::{
     Artifact, ArtifactType, Capability, Draft, DraftId, DraftStatus, ProjectId, RemediationType,
@@ -89,7 +89,11 @@ async fn make_state_with_auto_pr(
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
     config.agents.default_agent = "mock-pr".to_string();
-    config.gc.auto_pr = auto_pr;
+    config.gc.auto_adopt_policy = if auto_pr {
+        AutoAdoptPolicy::RulesOnly
+    } else {
+        AutoAdoptPolicy::Off
+    };
 
     let mut registry = AgentRegistry::new("mock-pr");
     registry.register("mock-pr", Arc::new(MockPrAgent));
@@ -108,7 +112,7 @@ async fn make_state_without_default_agent(
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
     config.agents.default_agent = "missing".to_string();
-    config.gc.auto_pr = true;
+    config.gc.auto_adopt_policy = AutoAdoptPolicy::RulesOnly;
 
     let registry = AgentRegistry::new("missing");
     let server = Arc::new(HarnessServer::new(config, ThreadManager::new(), registry));
@@ -390,7 +394,7 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root.clone();
     config.agents.default_agent = "capturing".to_string();
-    config.gc.auto_pr = true;
+    config.gc.auto_adopt_policy = AutoAdoptPolicy::RulesOnly;
     // Point workspace root at a path under the blocker file so create_dir_all fails.
     config.workspace.root = ws_blocker.join("workspaces");
 


### PR DESCRIPTION
## Summary
- Introduce `AutoAdoptPolicy { Off, RulesOnly }` enum in `harness-core::config::misc`, replacing the bare `auto_pr: bool` field in `GcConfig`
- Replace the boolean check in `handlers/gc.rs` with an exhaustive `match` so any future variant causes a compile error instead of a silent no-op (U-23)
- Update test helpers and assertions to use the new enum

## Test plan
- [ ] `cargo fmt --all` — clean
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] `cargo test --workspace` — all pass