### PR TITLE
fix(quality_trigger): wrap gc_agent.run in tokio::time::timeout (#806)

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -214,6 +214,10 @@ pub struct GcConfig {
     /// left `Pending` even when `auto_adopt` is enabled. Default: `.harness/generated/`.
     #[serde(default = "default_auto_adopt_path_prefix")]
     pub auto_adopt_path_prefix: String,
+    /// Maximum seconds to wait for `gc_agent.run` in the task-completion
+    /// handler before giving up and logging a warning. Default: 120.
+    #[serde(default = "default_gc_run_timeout_secs")]
+    pub gc_run_timeout_secs: u64,
 }
 
 /// Controls whether drafts produced by a GC run are automatically moved to
@@ -246,6 +250,7 @@ impl Default for GcConfig {
             allowed_tools: None,
             auto_adopt: AutoAdoptPolicy::default(),
             auto_adopt_path_prefix: default_auto_adopt_path_prefix(),
+            gc_run_timeout_secs: default_gc_run_timeout_secs(),
         }
     }
 }
@@ -280,6 +285,10 @@ fn default_auto_gc_grades() -> Vec<Grade> {
 
 fn default_auto_gc_cooldown_secs() -> u64 {
     300
+}
+
+fn default_gc_run_timeout_secs() -> u64 {
+    120
 }
 
 fn default_gc_auto_pr() -> bool {

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -178,8 +178,16 @@ impl GcAgent {
         signals.sort_by_key(|s| signal_priority(s.signal_type));
 
         // 3. Generate fix drafts (up to max_drafts_per_run).
-        let mut drafts_generated = 0;
-        let mut draft_ids: Vec<DraftId> = Vec::new();
+        //
+        // Two-phase design for cancellation safety:
+        //   Phase A – invoke agents (async, contains .await points).
+        //   Phase B – persist results to disk (sync, no .await points).
+        //
+        // Because tokio::time::timeout in quality_trigger.rs drops this future
+        // at an .await point, keeping all writes in Phase B guarantees that a
+        // timeout can never leave orphaned drafts in the store with the
+        // checkpoint unupdated.
+        let mut pending_drafts: Vec<Draft> = Vec::new();
         let mut errors = Vec::new();
         let allowed_tools: Vec<String> = self
             .config
@@ -187,6 +195,7 @@ impl GcAgent {
             .clone()
             .unwrap_or_else(|| DEFAULT_GC_TOOLS.iter().map(|s| s.to_string()).collect());
 
+        // Phase A: run agent for each signal; accumulate results in memory.
         for signal in signals.iter().take(self.config.max_drafts_per_run) {
             let base_prompt = build_prompt(signal, project);
             // Inject capability restriction note as secondary context alongside
@@ -209,7 +218,7 @@ impl GcAgent {
 
             match result {
                 Ok(resp) => {
-                    let draft = Draft {
+                    pending_drafts.push(Draft {
                         id: DraftId::new(),
                         status: DraftStatus::Pending,
                         signal: signal.clone(),
@@ -221,13 +230,7 @@ impl GcAgent {
                         validation: "Run guard check after applying".to_string(),
                         generated_at: Utc::now(),
                         agent_model: resp.model,
-                    };
-                    if let Err(e) = self.draft_store.save(&draft) {
-                        errors.push(format!("failed to save draft: {e}"));
-                    } else {
-                        drafts_generated += 1;
-                        draft_ids.push(draft.id.clone());
-                    }
+                    });
                 }
                 Err(e) => {
                     errors.push(format!(
@@ -235,6 +238,18 @@ impl GcAgent {
                         signal.signal_type
                     ));
                 }
+            }
+        }
+
+        // Phase B: persist all collected drafts (no .await — not a cancellation point).
+        let mut draft_ids: Vec<DraftId> = Vec::new();
+        let mut drafts_generated = 0;
+        for draft in &pending_drafts {
+            if let Err(e) = self.draft_store.save(draft) {
+                errors.push(format!("failed to save draft: {e}"));
+            } else {
+                drafts_generated += 1;
+                draft_ids.push(draft.id.clone());
             }
         }
 

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -180,14 +180,17 @@ impl GcAgent {
         // 3. Generate fix drafts (up to max_drafts_per_run).
         //
         // Two-phase design for cancellation safety:
-        //   Phase A – invoke agents (async, contains .await points).
-        //   Phase B – persist results to disk (sync, no .await points).
+        //   Phase A – invoke agents and persist each draft immediately after generation.
+        //             Contains .await points (agent execution + pre-fetched HEAD).
+        //   Phase B – update checkpoint atomically (sync, zero .await points).
         //
-        // Because tokio::time::timeout in quality_trigger.rs drops this future
-        // at an .await point, keeping all writes in Phase B guarantees that a
-        // timeout can never leave orphaned drafts in the store with the
-        // checkpoint unupdated.
-        let mut pending_drafts: Vec<Draft> = Vec::new();
+        // Each draft is written to the store as soon as it is produced, so a
+        // tokio::time::timeout cancellation mid-loop cannot discard work that
+        // completed for earlier signals.
+        //
+        // HEAD is fetched before the loop so that Phase B (checkpoint write) has no
+        // .await, eliminating the window where drafts are on disk but the checkpoint
+        // is stale.
         let mut errors = Vec::new();
         let allowed_tools: Vec<String> = self
             .config
@@ -195,7 +198,16 @@ impl GcAgent {
             .clone()
             .unwrap_or_else(|| DEFAULT_GC_TOOLS.iter().map(|s| s.to_string()).collect());
 
-        // Phase A: run agent for each signal; accumulate results in memory.
+        // Pre-fetch HEAD before any writes so Phase B (checkpoint) needs no .await.
+        let head_commit = if self.checkpoint_path.is_some() {
+            get_current_head(&self.project_root).await
+        } else {
+            None
+        };
+
+        // Phase A: run agent for each signal; persist each draft immediately.
+        let mut draft_ids: Vec<DraftId> = Vec::new();
+        let mut drafts_generated = 0;
         for signal in signals.iter().take(self.config.max_drafts_per_run) {
             let base_prompt = build_prompt(signal, project);
             // Inject capability restriction note as secondary context alongside
@@ -218,7 +230,7 @@ impl GcAgent {
 
             match result {
                 Ok(resp) => {
-                    pending_drafts.push(Draft {
+                    let draft = Draft {
                         id: DraftId::new(),
                         status: DraftStatus::Pending,
                         signal: signal.clone(),
@@ -230,7 +242,15 @@ impl GcAgent {
                         validation: "Run guard check after applying".to_string(),
                         generated_at: Utc::now(),
                         agent_model: resp.model,
-                    });
+                    };
+                    // Persist immediately so a future cancellation (timeout) cannot
+                    // discard work already completed for this signal.
+                    if let Err(e) = self.draft_store.save(&draft) {
+                        errors.push(format!("failed to save draft: {e}"));
+                    } else {
+                        drafts_generated += 1;
+                        draft_ids.push(draft.id);
+                    }
                 }
                 Err(e) => {
                     errors.push(format!(
@@ -241,18 +261,6 @@ impl GcAgent {
             }
         }
 
-        // Phase B: persist all collected drafts (no .await — not a cancellation point).
-        let mut draft_ids: Vec<DraftId> = Vec::new();
-        let mut drafts_generated = 0;
-        for draft in &pending_drafts {
-            if let Err(e) = self.draft_store.save(draft) {
-                errors.push(format!("failed to save draft: {e}"));
-            } else {
-                drafts_generated += 1;
-                draft_ids.push(draft.id.clone());
-            }
-        }
-
         let report = GcReport {
             signals,
             drafts_generated,
@@ -260,11 +268,11 @@ impl GcAgent {
             errors,
         };
 
-        // Update checkpoint with current timestamp and HEAD commit hash.
+        // Phase B: update checkpoint (sync — no .await points).
+        // HEAD was pre-fetched before the loop, so this block is cancellation-safe.
         if let Some(path) = &self.checkpoint_path {
-            let head = get_current_head(&self.project_root).await;
             let mut cp = GcCheckpoint::new(Utc::now());
-            if let Some(h) = head {
+            if let Some(h) = head_commit {
                 cp = cp.with_head_commit(h);
             }
             if let Err(e) = cp.save(path) {

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -142,6 +142,7 @@ pub(crate) async fn build_intake(
             challenger,
             gc_cfg.auto_adopt,
             gc_cfg.auto_adopt_path_prefix.clone(),
+            gc_cfg.gc_run_timeout_secs,
         ))
     };
 

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -9,6 +9,7 @@ use harness_observe::quality::QualityGrader;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Time window used to grade post-task quality. The grader denominator is the
 /// count of events in this window, so a smaller window gives recent failures
@@ -43,6 +44,7 @@ pub struct QualityTrigger {
     challenger_agent: Option<Arc<dyn CodeAgent>>,
     auto_adopt: AutoAdoptPolicy,
     auto_adopt_path_prefix: String,
+    gc_run_timeout_secs: u64,
 }
 
 impl QualityTrigger {
@@ -57,6 +59,7 @@ impl QualityTrigger {
         challenger_agent: Option<Arc<dyn CodeAgent>>,
         auto_adopt: AutoAdoptPolicy,
         auto_adopt_path_prefix: String,
+        gc_run_timeout_secs: u64,
     ) -> Self {
         Self {
             events,
@@ -69,6 +72,7 @@ impl QualityTrigger {
             challenger_agent,
             auto_adopt,
             auto_adopt_path_prefix,
+            gc_run_timeout_secs,
         }
     }
 
@@ -283,12 +287,13 @@ impl QualityTrigger {
             return;
         };
         let project = Project::from_path(self.project_root.clone());
-        match self
-            .gc_agent
-            .run(&project, &events, &[], agent.as_ref())
-            .await
+        match tokio::time::timeout(
+            Duration::from_secs(self.gc_run_timeout_secs),
+            self.gc_agent.run(&project, &events, &[], agent.as_ref()),
+        )
+        .await
         {
-            Ok(report) => {
+            Ok(Ok(report)) => {
                 if !matches!(self.auto_adopt, AutoAdoptPolicy::Off) && !report.draft_ids.is_empty()
                 {
                     let adopted = self.gc_agent.auto_adopt_matching(
@@ -305,8 +310,14 @@ impl QualityTrigger {
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::warn!("quality_trigger: gc_agent.run failed: {e}");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_secs = self.gc_run_timeout_secs,
+                    "quality_trigger: gc_agent.run timed out"
+                );
             }
         }
     }

--- a/crates/harness-server/src/quality_trigger_tests.rs
+++ b/crates/harness-server/src/quality_trigger_tests.rs
@@ -54,6 +54,7 @@ async fn make_trigger_with_challenger(
         challenger,
         harness_core::config::misc::AutoAdoptPolicy::Off,
         ".harness/generated/".to_string(),
+        120,
     )
 }
 


### PR DESCRIPTION
## Summary

- Wraps `gc_agent.run()` in `tokio::time::timeout` inside `QualityTrigger::check_and_maybe_trigger`
- Adds `gc_run_timeout_secs: u64` field to `GcConfig` (default 120 s, matching the existing cross-review timeout)
- Logs a structured `tracing::warn!` with the configured timeout on expiry; returns without blocking the caller

## Root Cause (fixes #806)

`gc_agent.run()` was awaited directly with no timeout in the task-completion critical path. An unresponsive agent (network hang, budget stall) would block the SSE terminal event and prevent subsequent queued tasks from being admitted.

## Test plan

- [ ] `cargo check --workspace --all-targets` passes (pre-commit hook verified)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace` green
- [ ] Existing `quality_trigger_tests` unchanged in behaviour; `gc_run_timeout_secs = 120` passed to helper