### PR TITLE
feat(server): system overview page at /overview with live aggregated API

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod gc;
 pub mod health;
 pub mod learn;
 pub mod observe;
+pub mod overview;
 pub mod preflight;
 pub mod projects;
 pub mod rules;

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -11,7 +11,7 @@ use crate::http::AppState;
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Duration, Timelike, Utc};
 use harness_core::types::{Decision, Event, EventFilters};
-use harness_observe::{quality::QualityGrader, stats};
+use harness_observe::quality::QualityGrader;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,7 +30,14 @@ const FEED_LIMIT: usize = 40;
 /// GET /api/overview — JSON payload driving the system overview page.
 pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Value>) {
     let now = Utc::now();
-    let since_dt = now - Duration::hours(OVERVIEW_WINDOW_HOURS);
+    // Snap the query window to the start of the oldest bucket on the hour
+    // axis so that SQL rows and JS buckets agree. Without this, tasks
+    // completed in the partial "now - 24h .. oldest-bucket-start" slice are
+    // counted in the global `merged_24h` KPI but dropped when their
+    // `strftime('%H:00:00Z')` hour key falls outside the axis, which makes
+    // per-project sums understate the KPI for every request that is not
+    // exactly on the hour.
+    let since_dt = window_start(now);
     let since = since_dt.to_rfc3339();
 
     // ---- global task queue counts (reuse existing services) ----
@@ -238,21 +245,30 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     (StatusCode::OK, Json(body))
 }
 
+/// Start of the oldest bucket on the hour axis. Shared by the SQL `since`
+/// filter and [`build_hour_axis`] so the two views align.
+fn window_start(now: DateTime<Utc>) -> DateTime<Utc> {
+    hour_top(now) - Duration::hours((THROUGHPUT_BUCKETS as i64) - 1)
+}
+
+/// Top of the current hour (i.e. `HH:00:00Z`). Falls back to `now` on the
+/// near-impossible DST-style failure of `with_minute(0)`.
+fn hour_top(now: DateTime<Utc>) -> DateTime<Utc> {
+    now.with_minute(0)
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or(now)
+}
+
 /// Build an ISO-8601 hour axis covering the last [`THROUGHPUT_BUCKETS`] hours
 /// ending at `now`, oldest first. Each element matches the format produced by
 /// `TaskDb::done_per_project_hour_since` so the two can be joined by string
 /// equality.
 fn build_hour_axis(now: DateTime<Utc>) -> Vec<String> {
-    let Some(hour_top) = now
-        .with_minute(0)
-        .and_then(|t| t.with_second(0))
-        .and_then(|t| t.with_nanosecond(0))
-    else {
-        return Vec::new();
-    };
+    let top = hour_top(now);
     let mut out = Vec::with_capacity(THROUGHPUT_BUCKETS);
     for i in (0..THROUGHPUT_BUCKETS).rev() {
-        let ts = hour_top - Duration::hours(i as i64);
+        let ts = top - Duration::hours(i as i64);
         out.push(ts.format("%Y-%m-%dT%H:00:00Z").to_string());
     }
     out
@@ -283,16 +299,23 @@ fn compute_grade(events: &[Event]) -> (Option<f64>, Option<Value>) {
 
 /// Percentage of `rule_check` events in the window that blocked. Returns `0.0`
 /// when no rule_check events fired.
+///
+/// The denominator is every rule_check (Pass/Warn/Block), NOT just blocks —
+/// `harness_observe::stats::linter_feedback_count` already filters to blocks,
+/// so using it as the total would collapse the metric to 0% / 100%.
 fn compute_rule_fail_rate_pct(events: &[Event]) -> f64 {
-    let total = stats::linter_feedback_count(events) as f64;
-    if total == 0.0 {
+    let (total, failed) =
+        events
+            .iter()
+            .filter(|e| e.hook == "rule_check")
+            .fold((0u64, 0u64), |(t, f), e| {
+                let blocked = u64::from(matches!(e.decision, Decision::Block));
+                (t + 1, f + blocked)
+            });
+    if total == 0 {
         return 0.0;
     }
-    let failed = events
-        .iter()
-        .filter(|e| e.hook == "rule_check" && matches!(e.decision, Decision::Block))
-        .count() as f64;
-    (failed / total) * 100.0
+    (failed as f64 / total as f64) * 100.0
 }
 
 /// Build the cross-project live activity feed from the latest events.

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -38,7 +38,6 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     // per-project sums understate the KPI for every request that is not
     // exactly on the hour.
     let since_dt = window_start(now);
-    let since = since_dt.to_rfc3339();
 
     // ---- global task queue counts (reuse existing services) ----
     let tq = &state.concurrency.task_queue;
@@ -50,11 +49,11 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     let global_done = dashboard_counts.global_done;
     let global_failed = dashboard_counts.global_failed;
 
-    let merged_24h = state.task_svc.count_done_since(&since).await;
+    let merged_24h = state.task_svc.count_done_since(since_dt).await;
 
     // Per-project hourly done counts — drives both the fleet throughput chart
     // and each project's 24h trend sparkline.
-    let hour_rows = state.task_svc.done_per_project_hour_since(&since).await;
+    let hour_rows = state.task_svc.done_per_project_hour_since(since_dt).await;
     let hours = build_hour_axis(now);
     let hour_index: HashMap<String, usize> = hours
         .iter()
@@ -110,16 +109,26 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
         }));
     }
 
-    // Tasks with no registered project still contribute to the global
-    // throughput; surface them as an "unassigned" series so the KPI stays
-    // consistent with `merged_24h`.
-    if let Some(unassigned) = per_project_buckets.remove("") {
-        if unassigned.iter().any(|&v| v > 0) {
-            throughput_series.push(json!({
-                "project": "unassigned",
-                "values": unassigned,
-            }));
+    // Any buckets left over after draining the registry belong to tasks
+    // whose project is no longer registered (or was never registered).
+    // Emit them as fallback series so the stacked-area sum still matches
+    // the global `merged_24h` KPI — otherwise deleting a project while it
+    // had recent done tasks would silently desync the chart from the KPI.
+    let mut leftover: Vec<(String, Vec<u64>)> = per_project_buckets.drain().collect();
+    leftover.sort_by(|a, b| a.0.cmp(&b.0));
+    for (key, values) in leftover {
+        if !values.iter().any(|&v| v > 0) {
+            continue;
         }
+        let label = if key.is_empty() {
+            "unassigned".to_string()
+        } else {
+            format!("unregistered · {key}")
+        };
+        throughput_series.push(json!({
+            "project": label,
+            "values": values,
+        }));
     }
 
     // ---- runtime fleet ----
@@ -198,7 +207,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     let body = json!({
         "window": {
             "hours": OVERVIEW_WINDOW_HOURS,
-            "since": since,
+            "since": since_dt.to_rfc3339(),
             "now": now.to_rfc3339(),
         },
         "kpi": {

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -298,7 +298,7 @@ fn compute_rule_fail_rate_pct(events: &[Event]) -> f64 {
 /// Build the cross-project live activity feed from the latest events.
 fn build_feed(events: &[Event], now: DateTime<Utc>) -> Vec<Value> {
     let mut sorted: Vec<&Event> = events.iter().collect();
-    sorted.sort_by(|a, b| b.ts.cmp(&a.ts));
+    sorted.sort_by_key(|e| std::cmp::Reverse(e.ts));
     sorted
         .into_iter()
         .take(FEED_LIMIT)

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -1,0 +1,454 @@
+//! GET /api/overview — system-level aggregated view across all projects.
+//!
+//! Feeds the `/overview` HTML page (served from `crate::overview::index`).
+//! Aggregates data from existing services rather than introducing new
+//! tracking: task counts come from `TaskService`, runtime fleet state from
+//! `RuntimeHostManager`, quality grade and rule-fail rate from the event
+//! store. Metrics that harness does not yet track (per-agent tokens, runtime
+//! CPU/RAM) are returned as `null` so the UI degrades gracefully.
+
+use crate::http::AppState;
+use axum::{extract::State, http::StatusCode, Json};
+use chrono::{DateTime, Duration, Timelike, Utc};
+use harness_core::types::{Decision, Event, EventFilters};
+use harness_observe::{quality::QualityGrader, stats};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Rolling window for the overview page. Matches the `24h` segment pill in
+/// the design; other windows are a client-side concern.
+const OVERVIEW_WINDOW_HOURS: i64 = 24;
+
+/// Number of hourly buckets for the throughput chart and per-project trend.
+const THROUGHPUT_BUCKETS: usize = 24;
+
+/// Number of feed items returned. The design's mock feed shows ~14 rows with
+/// scroll; capping at 40 keeps the payload bounded without starving the UI.
+const FEED_LIMIT: usize = 40;
+
+/// GET /api/overview — JSON payload driving the system overview page.
+pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Value>) {
+    let now = Utc::now();
+    let since_dt = now - Duration::hours(OVERVIEW_WINDOW_HOURS);
+    let since = since_dt.to_rfc3339();
+
+    // ---- global task queue counts (reuse existing services) ----
+    let tq = &state.concurrency.task_queue;
+    let running = tq.running_count();
+    let queued = tq.queued_count();
+    let max_concurrent = tq.global_limit();
+
+    let dashboard_counts = state.task_svc.count_for_dashboard().await;
+    let global_done = dashboard_counts.global_done;
+    let global_failed = dashboard_counts.global_failed;
+
+    let merged_24h = state.task_svc.count_done_since(&since).await;
+
+    // Per-project hourly done counts — drives both the fleet throughput chart
+    // and each project's 24h trend sparkline.
+    let hour_rows = state.task_svc.done_per_project_hour_since(&since).await;
+    let hours = build_hour_axis(now);
+    let hour_index: HashMap<String, usize> = hours
+        .iter()
+        .enumerate()
+        .map(|(i, h)| (h.clone(), i))
+        .collect();
+    let mut per_project_buckets: HashMap<String, Vec<u64>> = HashMap::new();
+    for (project_key, hour, count) in hour_rows {
+        if let Some(&idx) = hour_index.get(&hour) {
+            let entry = per_project_buckets
+                .entry(project_key)
+                .or_insert_with(|| vec![0; THROUGHPUT_BUCKETS]);
+            entry[idx] = entry[idx].saturating_add(count);
+        }
+    }
+
+    // ---- projects table ----
+    let project_pr_urls = state.task_svc.latest_done_pr_urls_all_projects().await;
+    let project_list = state.project_svc.list().await.unwrap_or_else(|e| {
+        tracing::warn!("overview: failed to list projects: {e}");
+        Vec::new()
+    });
+    let mut projects_json: Vec<Value> = Vec::with_capacity(project_list.len());
+    let mut throughput_series: Vec<Value> = Vec::with_capacity(project_list.len());
+    for p in &project_list {
+        let key = p.root.to_string_lossy().into_owned();
+        let qs = tq.project_stats(&key);
+        let counts = dashboard_counts.by_project.get(&key);
+        let done = counts.map_or(0, |c| c.done);
+        let failed = counts.map_or(0, |c| c.failed);
+        let buckets = per_project_buckets
+            .remove(&key)
+            .unwrap_or_else(|| vec![0; THROUGHPUT_BUCKETS]);
+        let merged_window: u64 = buckets.iter().sum();
+        projects_json.push(json!({
+            "id": p.id,
+            "root": p.root,
+            "running": qs.running,
+            "queued": qs.queued,
+            "done": done,
+            "failed": failed,
+            "merged_24h": merged_window,
+            "trend": buckets,
+            "avg_score": Value::Null,
+            "worktrees": Value::Null,
+            "tokens_24h": Value::Null,
+            "agents": Vec::<String>::new(),
+            "latest_pr": project_pr_urls.get(&key),
+        }));
+        throughput_series.push(json!({
+            "project": p.id,
+            "values": buckets,
+        }));
+    }
+
+    // Tasks with no registered project still contribute to the global
+    // throughput; surface them as an "unassigned" series so the KPI stays
+    // consistent with `merged_24h`.
+    if let Some(unassigned) = per_project_buckets.remove("") {
+        if unassigned.iter().any(|&v| v > 0) {
+            throughput_series.push(json!({
+                "project": "unassigned",
+                "values": unassigned,
+            }));
+        }
+    }
+
+    // ---- runtime fleet ----
+    let runtime_hosts = state.runtime_hosts.list_hosts();
+    let mut runtimes_json: Vec<Value> = Vec::with_capacity(runtime_hosts.len());
+    let mut worktrees_used: u64 = 0;
+    for host in &runtime_hosts {
+        let active_leases = state.runtime_hosts.active_lease_count(&host.id) as u64;
+        worktrees_used = worktrees_used.saturating_add(active_leases);
+        let watched_projects = state
+            .runtime_project_cache
+            .get_host_cache(&host.id)
+            .map(|snapshot| snapshot.project_count)
+            .unwrap_or(0);
+        runtimes_json.push(json!({
+            "id": host.id,
+            "display_name": host.display_name,
+            "capabilities": host.capabilities,
+            "online": host.online,
+            "last_heartbeat_at": host.last_heartbeat_at,
+            "active_leases": active_leases,
+            "watched_projects": watched_projects,
+            "cpu_pct": Value::Null,
+            "ram_pct": Value::Null,
+            "tokens_24h": Value::Null,
+        }));
+    }
+
+    // ---- event-derived metrics (grade, rule fail rate, feed, alerts) ----
+    let events = match state
+        .observability
+        .events
+        .query(&EventFilters {
+            since: Some(since_dt),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("overview: failed to query events: {e}");
+            Vec::new()
+        }
+    };
+
+    let (avg_review_score, grade_letter) = compute_grade(&events);
+    let rule_fail_rate_pct = compute_rule_fail_rate_pct(&events);
+
+    let feed = build_feed(&events, now);
+    let alerts = build_alerts(&events, &runtime_hosts);
+
+    // Cluster heatmap: per-project 24-bucket intensity (normalised to the
+    // project's peak hour). Runtime-dimension is collapsed because task rows
+    // don't carry host attribution yet.
+    let heatmap_rows: Vec<Value> = projects_json
+        .iter()
+        .filter_map(|p| {
+            let label = p["id"].as_str()?;
+            let trend = p["trend"].as_array()?;
+            let values: Vec<u64> = trend.iter().filter_map(|v| v.as_u64()).collect();
+            let peak = values.iter().copied().max().unwrap_or(0);
+            let intensity: Vec<f64> = if peak == 0 {
+                values.iter().map(|_| 0.0).collect()
+            } else {
+                values.iter().map(|v| *v as f64 / peak as f64).collect()
+            };
+            Some(json!({ "label": label, "intensity": intensity }))
+        })
+        .collect();
+
+    let uptime_secs = crate::handlers::dashboard::SERVER_START
+        .get()
+        .map(|s| s.elapsed().as_secs())
+        .unwrap_or(0);
+
+    let body = json!({
+        "window": {
+            "hours": OVERVIEW_WINDOW_HOURS,
+            "since": since,
+            "now": now.to_rfc3339(),
+        },
+        "kpi": {
+            "active_tasks": (running as u64) + (queued as u64),
+            "merged_24h": merged_24h,
+            "avg_review_score": avg_review_score,
+            "grade": grade_letter,
+            "rule_fail_rate_pct": rule_fail_rate_pct,
+            "tokens_24h": Value::Null,
+            "worktrees": {
+                "used": worktrees_used,
+                "total": max_concurrent,
+            },
+        },
+        "distribution": {
+            "queued": queued,
+            "running": running,
+            "review": 0,
+            "merged": global_done,
+            "failed": global_failed,
+        },
+        "throughput": {
+            "hours": hours,
+            "series": throughput_series,
+        },
+        "projects": projects_json,
+        "runtimes": runtimes_json,
+        "heatmap": {
+            "bucket_minutes": 60,
+            "rows": heatmap_rows,
+        },
+        "feed": feed,
+        "alerts": alerts,
+        "global": {
+            "uptime_secs": uptime_secs,
+            "running": running,
+            "queued": queued,
+            "done": global_done,
+            "failed": global_failed,
+            "max_concurrent": max_concurrent,
+        },
+    });
+
+    (StatusCode::OK, Json(body))
+}
+
+/// Build an ISO-8601 hour axis covering the last [`THROUGHPUT_BUCKETS`] hours
+/// ending at `now`, oldest first. Each element matches the format produced by
+/// `TaskDb::done_per_project_hour_since` so the two can be joined by string
+/// equality.
+fn build_hour_axis(now: DateTime<Utc>) -> Vec<String> {
+    let Some(hour_top) = now
+        .with_minute(0)
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(THROUGHPUT_BUCKETS);
+    for i in (0..THROUGHPUT_BUCKETS).rev() {
+        let ts = hour_top - Duration::hours(i as i64);
+        out.push(ts.format("%Y-%m-%dT%H:00:00Z").to_string());
+    }
+    out
+}
+
+/// Compute (numeric_score, letter_grade) from the event window. Returns
+/// `(None, None)` when no `rule_scan` session anchors the window — a quiet
+/// instance should show "unknown", not a fake A.
+fn compute_grade(events: &[Event]) -> (Option<f64>, Option<Value>) {
+    if events.iter().all(|e| e.hook != "rule_scan") {
+        return (None, None);
+    }
+    let violation_count = events
+        .iter()
+        .rev()
+        .find(|e| e.hook == "rule_scan")
+        .map(|scan| {
+            events
+                .iter()
+                .filter(|e| e.hook == "rule_check" && e.session_id == scan.session_id)
+                .count()
+        })
+        .unwrap_or(0);
+    let report = QualityGrader::grade(events, violation_count);
+    let letter = serde_json::to_value(report.grade).ok();
+    (Some(report.score), letter)
+}
+
+/// Percentage of `rule_check` events in the window that blocked. Returns `0.0`
+/// when no rule_check events fired.
+fn compute_rule_fail_rate_pct(events: &[Event]) -> f64 {
+    let total = stats::linter_feedback_count(events) as f64;
+    if total == 0.0 {
+        return 0.0;
+    }
+    let failed = events
+        .iter()
+        .filter(|e| e.hook == "rule_check" && matches!(e.decision, Decision::Block))
+        .count() as f64;
+    (failed / total) * 100.0
+}
+
+/// Build the cross-project live activity feed from the latest events.
+fn build_feed(events: &[Event], now: DateTime<Utc>) -> Vec<Value> {
+    let mut sorted: Vec<&Event> = events.iter().collect();
+    sorted.sort_by(|a, b| b.ts.cmp(&a.ts));
+    sorted
+        .into_iter()
+        .take(FEED_LIMIT)
+        .map(|e| {
+            let level = match e.decision {
+                Decision::Block | Decision::Escalate => "err",
+                Decision::Warn => "warn",
+                Decision::Pass | Decision::Complete => "ok",
+                Decision::Gate => "",
+            };
+            let body = e
+                .reason
+                .clone()
+                .or_else(|| e.detail.clone())
+                .unwrap_or_default();
+            json!({
+                "ts": e.ts.to_rfc3339(),
+                "ago": relative_ago(now, e.ts),
+                "kind": e.hook,
+                "tool": e.tool,
+                "body": body,
+                "level": level,
+                "project": "",
+            })
+        })
+        .collect()
+}
+
+/// Derive open-alert rows from the event window and current runtime state.
+fn build_alerts(events: &[Event], hosts: &[crate::runtime_hosts::RuntimeHostInfo]) -> Vec<Value> {
+    let mut out = Vec::new();
+
+    let offline: Vec<&crate::runtime_hosts::RuntimeHostInfo> =
+        hosts.iter().filter(|h| !h.online).collect();
+    if !offline.is_empty() {
+        let names: Vec<&str> = offline.iter().map(|h| h.display_name.as_str()).collect();
+        out.push(json!({
+            "level": "warn",
+            "msg": format!("{} runtime(s) offline", offline.len()),
+            "sub": names.join(" · "),
+            "ts": Value::Null,
+        }));
+    }
+
+    let recent_blocks = events
+        .iter()
+        .filter(|e| e.hook == "rule_check" && matches!(e.decision, Decision::Block))
+        .count();
+    if recent_blocks > 0 {
+        out.push(json!({
+            "level": "err",
+            "msg": format!("{} rule violation(s) in last {}h", recent_blocks, OVERVIEW_WINDOW_HOURS),
+            "sub": "see observability page",
+            "ts": Value::Null,
+        }));
+    }
+
+    out
+}
+
+/// Human-readable delta such as `14s`, `3m`, `2h`, `1d` — matches the feed
+/// column spacing in the design.
+fn relative_ago(now: DateTime<Utc>, then: DateTime<Utc>) -> String {
+    let secs = (now - then).num_seconds().max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3_600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h", secs / 3_600)
+    } else {
+        format!("{}d", secs / 86_400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers;
+    use axum::{body::to_bytes, routing::get, Router};
+
+    #[test]
+    fn hour_axis_has_expected_length_and_order() {
+        let now = Utc::now();
+        let axis = build_hour_axis(now);
+        assert_eq!(axis.len(), THROUGHPUT_BUCKETS);
+        // Oldest first, strictly increasing.
+        for pair in axis.windows(2) {
+            assert!(pair[0] < pair[1]);
+        }
+    }
+
+    #[test]
+    fn relative_ago_formats_each_bucket() {
+        let now = Utc::now();
+        assert!(relative_ago(now, now).ends_with('s'));
+        assert!(relative_ago(now, now - Duration::minutes(5)).ends_with('m'));
+        assert!(relative_ago(now, now - Duration::hours(3)).ends_with('h'));
+        assert!(relative_ago(now, now - Duration::days(2)).ends_with('d'));
+    }
+
+    #[test]
+    fn rule_fail_rate_zero_when_no_events() {
+        assert_eq!(compute_rule_fail_rate_pct(&[]), 0.0);
+    }
+
+    #[tokio::test]
+    async fn overview_returns_expected_shape() -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-overview-")?;
+        let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+
+        let app = Router::new()
+            .route("/api/overview", get(overview))
+            .with_state(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/api/overview")
+            .body(axum::body::Body::empty())?;
+
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        for key in [
+            "window",
+            "kpi",
+            "distribution",
+            "throughput",
+            "projects",
+            "runtimes",
+            "heatmap",
+            "feed",
+            "alerts",
+            "global",
+        ] {
+            assert!(body.get(key).is_some(), "missing top-level key: {key}");
+        }
+        assert!(body["kpi"]["active_tasks"].is_number());
+        assert!(body["kpi"]["merged_24h"].is_number());
+        assert!(body["kpi"]["worktrees"]["used"].is_number());
+        assert!(body["kpi"]["worktrees"]["total"].is_number());
+        assert!(body["throughput"]["hours"].is_array());
+        assert_eq!(
+            body["throughput"]["hours"].as_array().unwrap().len(),
+            THROUGHPUT_BUCKETS
+        );
+
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/http.rs
+++ b/crates/harness-server/src/http.rs
@@ -1427,6 +1427,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
 
     let app = Router::new()
         .route("/", get(crate::dashboard::index))
+        .route("/overview", get(crate::overview::index))
         .route("/favicon.ico", get(crate::dashboard::favicon))
         .route("/health", get(health_check))
         .route("/rpc", post(handle_rpc))
@@ -1450,6 +1451,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         )
         .route("/projects/queue-stats", get(project_queue_stats))
         .route("/api/dashboard", get(crate::handlers::dashboard::dashboard))
+        .route("/api/overview", get(crate::handlers::overview::overview))
         .route("/api/intake", get(intake_status))
         .route(
             "/api/runtime-hosts",

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -31,7 +31,8 @@ pub(crate) fn resolve_api_token(
 /// Bearer token authentication middleware.
 ///
 /// Exempts `/health`, `/webhook`, `/webhook/feishu`, `/signals`, `/favicon.ico`,
-/// `/auth/reset-password`, `/` (dashboard HTML), and `/ws` (WebSocket upgrade).
+/// `/auth/reset-password`, `/` (dashboard HTML), `/overview` (system overview
+/// HTML), and `/ws` (WebSocket upgrade).
 /// The dashboard HTML no longer embeds the token, so it is safe to serve without
 /// auth. `/ws` is exempt from *this middleware* because the WebSocket upgrade
 /// cannot carry a body and must be handled before axum reads headers twice;
@@ -61,6 +62,7 @@ pub(crate) async fn api_auth_middleware(
             | "/favicon.ico"
             | "/auth/reset-password"
             | "/"
+            | "/overview"
             | "/ws"
     ) {
         return next.run(req).await;

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -24,6 +24,7 @@ pub mod http;
 pub mod intake;
 pub mod memory_monitor;
 pub mod notify;
+pub mod overview;
 pub mod parallel_dispatch;
 pub mod periodic_reviewer;
 pub use harness_workflow::plan_db;

--- a/crates/harness-server/src/overview.rs
+++ b/crates/harness-server/src/overview.rs
@@ -1,0 +1,13 @@
+//! GET /overview — system-level overview HTML page.
+//!
+//! Mirrors the inline-CSS/JS pattern used by [`crate::dashboard`]. The static
+//! asset in `static/overview.html` is a self-contained prototype produced by
+//! Claude Design; it fetches live data from `/api/overview` on load and
+//! re-renders every [`OVERVIEW_REFRESH_MS`] ms.
+use axum::response::{Html, IntoResponse};
+
+const PAGE: &str = include_str!("../static/overview.html");
+
+pub async fn index() -> impl IntoResponse {
+    Html(PAGE)
+}

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -38,6 +38,16 @@ pub trait TaskService: Send + Sync {
     /// Most recent completed-task PR URL keyed by canonical project root string,
     /// for all projects. Used by the dashboard to show per-project latest PR.
     async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String>;
+
+    /// Count tasks that reached `done` with `updated_at >= since`.
+    /// `since` is an ISO-8601 UTC timestamp. Used by the system overview to
+    /// display "merged in last 24h".
+    async fn count_done_since(&self, since: &str) -> u64;
+
+    /// Per-(project, hour) done counts since `since`. Returns rows of
+    /// `(project_key, hour_iso, count)`. Rows with no project carry an empty
+    /// project key. Used to build the fleet-throughput chart.
+    async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)>;
 }
 
 /// Production implementation backed by [`TaskStore`].
@@ -89,6 +99,14 @@ impl TaskService for DefaultTaskService {
 
     async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String> {
         self.store.latest_done_pr_urls_all_projects().await
+    }
+
+    async fn count_done_since(&self, since: &str) -> u64 {
+        self.store.count_done_since(since).await
+    }
+
+    async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)> {
+        self.store.done_per_project_hour_since(since).await
     }
 }
 

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -39,15 +39,17 @@ pub trait TaskService: Send + Sync {
     /// for all projects. Used by the dashboard to show per-project latest PR.
     async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String>;
 
-    /// Count tasks that reached `done` with `updated_at >= since`.
-    /// `since` is an ISO-8601 UTC timestamp. Used by the system overview to
-    /// display "merged in last 24h".
-    async fn count_done_since(&self, since: &str) -> u64;
+    /// Count tasks that reached `done` with `updated_at >= since`. Used by
+    /// the system overview to display "merged in last 24h".
+    async fn count_done_since(&self, since: chrono::DateTime<chrono::Utc>) -> u64;
 
     /// Per-(project, hour) done counts since `since`. Returns rows of
     /// `(project_key, hour_iso, count)`. Rows with no project carry an empty
     /// project key. Used to build the fleet-throughput chart.
-    async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)>;
+    async fn done_per_project_hour_since(
+        &self,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<(String, String, u64)>;
 }
 
 /// Production implementation backed by [`TaskStore`].
@@ -101,11 +103,14 @@ impl TaskService for DefaultTaskService {
         self.store.latest_done_pr_urls_all_projects().await
     }
 
-    async fn count_done_since(&self, since: &str) -> u64 {
+    async fn count_done_since(&self, since: chrono::DateTime<chrono::Utc>) -> u64 {
         self.store.count_done_since(since).await
     }
 
-    async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)> {
+    async fn done_per_project_hour_since(
+        &self,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<(String, String, u64)> {
         self.store.done_per_project_hour_since(since).await
     }
 }

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -871,6 +871,48 @@ impl TaskDb {
         Ok((global.0 as u64, global.1 as u64, by_project))
     }
 
+    /// Count tasks that reached `done` status with `updated_at >= since`.
+    ///
+    /// `since` must be an ISO-8601 UTC timestamp (e.g. `2026-04-17T23:00:00Z`).
+    /// Uses the `idx_tasks_status_updated` index. Used by the system overview
+    /// endpoint to compute "merged in last 24h" without loading full task rows.
+    pub async fn count_done_since(&self, since: &str) -> anyhow::Result<u64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'done' AND updated_at >= ?")
+                .bind(since)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0 as u64)
+    }
+
+    /// Per-(project, hour-bucket) count of tasks that reached `done` after `since`.
+    ///
+    /// Returns rows of `(project_key, hour_iso, count)` where `hour_iso` is the
+    /// `updated_at` timestamp truncated to the hour in UTC (format
+    /// `YYYY-MM-DDTHH:00:00Z`). Rows with `project IS NULL` are reported with
+    /// an empty project key. Used to build the fleet-throughput stacked-area
+    /// chart (per project, per hour over the window).
+    pub async fn done_per_project_hour_since(
+        &self,
+        since: &str,
+    ) -> anyhow::Result<Vec<(String, String, u64)>> {
+        let rows: Vec<(Option<String>, String, i64)> = sqlx::query_as(
+            "SELECT project, \
+                    strftime('%Y-%m-%dT%H:00:00Z', updated_at) AS hour, \
+                    COUNT(*) \
+             FROM tasks \
+             WHERE status = 'done' AND updated_at >= ? \
+             GROUP BY project, hour",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(p, h, c)| (p.unwrap_or_default(), h, c as u64))
+            .collect())
+    }
+
     /// Return all tasks whose `parent_id` matches the given parent task ID.
     pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
         let sql = format!(

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -873,15 +873,25 @@ impl TaskDb {
 
     /// Count tasks that reached `done` status with `updated_at >= since`.
     ///
-    /// `since` must be an ISO-8601 UTC timestamp (e.g. `2026-04-17T23:00:00Z`).
-    /// Uses the `idx_tasks_status_updated` index. Used by the system overview
-    /// endpoint to compute "merged in last 24h" without loading full task rows.
+    /// `since` may be any datetime string SQLite's `datetime()` understands
+    /// (RFC3339 with `T`/offset is fine — it is normalised before comparison).
+    /// Both sides of the predicate are wrapped in `datetime(...)` because
+    /// `tasks.updated_at` is written via `datetime('now')`, which produces the
+    /// `YYYY-MM-DD HH:MM:SS` form; comparing that TEXT to an RFC3339 string
+    /// lexicographically would silently drop same-day rows (space `0x20` sorts
+    /// before `T` `0x54`). Uses the `idx_tasks_status_updated` index — the
+    /// index lookup is still viable because `datetime(updated_at)` is a
+    /// monotonic transform, so SQLite will range-scan on the index and filter.
+    /// Used by the system overview endpoint to compute "merged in last 24h"
+    /// without loading full task rows.
     pub async fn count_done_since(&self, since: &str) -> anyhow::Result<u64> {
-        let row: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'done' AND updated_at >= ?")
-                .bind(since)
-                .fetch_one(&self.pool)
-                .await?;
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM tasks \
+             WHERE status = 'done' AND datetime(updated_at) >= datetime(?)",
+        )
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await?;
         Ok(row.0 as u64)
     }
 
@@ -891,7 +901,8 @@ impl TaskDb {
     /// `updated_at` timestamp truncated to the hour in UTC (format
     /// `YYYY-MM-DDTHH:00:00Z`). Rows with `project IS NULL` are reported with
     /// an empty project key. Used to build the fleet-throughput stacked-area
-    /// chart (per project, per hour over the window).
+    /// chart (per project, per hour over the window). Uses `datetime(...)` on
+    /// both sides for the same reason [`Self::count_done_since`] does.
     pub async fn done_per_project_hour_since(
         &self,
         since: &str,
@@ -901,7 +912,7 @@ impl TaskDb {
                     strftime('%Y-%m-%dT%H:00:00Z', updated_at) AS hour, \
                     COUNT(*) \
              FROM tasks \
-             WHERE status = 'done' AND updated_at >= ? \
+             WHERE status = 'done' AND datetime(updated_at) >= datetime(?) \
              GROUP BY project, hour",
         )
         .bind(since)
@@ -1771,6 +1782,34 @@ mod tests {
         assert_eq!(global_done, 1);
         assert_eq!(global_failed, 1);
         assert_eq!(by_project, vec![(root.to_string(), 1, 1)]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn count_done_since_counts_same_day_rows() -> anyhow::Result<()> {
+        // Regression for PR #816: tasks.updated_at is stored via
+        // datetime('now') in `YYYY-MM-DD HH:MM:SS` form, so raw TEXT
+        // comparison against an RFC3339 `since` (with `T` separator)
+        // would silently drop all same-day rows because space `0x20`
+        // sorts before `T` `0x54`. datetime(updated_at) >= datetime(?)
+        // must normalise both sides.
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+
+        db.insert(&make_task("fresh", TaskStatus::Done)).await?;
+
+        // RFC3339 string representing an hour ago.
+        let since = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        assert_eq!(db.count_done_since(&since).await?, 1);
+
+        let rows = db.done_per_project_hour_since(&since).await?;
+        let total: u64 = rows.iter().map(|(_, _, c)| *c).sum();
+        assert_eq!(total, 1);
+
+        // A future `since` still returns zero — sanity check that the
+        // predicate is not inverted.
+        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        assert_eq!(db.count_done_since(&future).await?, 0);
         Ok(())
     }
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1,5 +1,6 @@
 use crate::http::parse_pr_num_from_url;
 use crate::task_runner::{TaskState, TaskStatus};
+use chrono::{DateTime, Utc};
 use harness_core::db::{open_pool, Migration, Migrator};
 use harness_core::error::TaskDbDecodeError;
 use serde::{Deserialize, Serialize};
@@ -9,6 +10,15 @@ use std::path::{Path, PathBuf};
 
 /// Maximum artifact content size in bytes before truncation.
 const ARTIFACT_MAX_BYTES: usize = 65_536;
+
+/// Format a `DateTime<Utc>` exactly the way SQLite's `datetime('now')` writes
+/// `tasks.updated_at` (`YYYY-MM-DD HH:MM:SS`, space separator, no offset),
+/// so raw `updated_at >= ?` comparisons stay monotonic and the planner can
+/// still use the `idx_tasks_status_updated` / `idx_tasks_project_status_updated`
+/// range indexes.
+fn sqlite_datetime(ts: DateTime<Utc>) -> String {
+    ts.format("%Y-%m-%d %H:%M:%S").to_string()
+}
 
 /// Column list for `query_as::<_, TaskRow>` — single source of truth.
 ///
@@ -873,25 +883,21 @@ impl TaskDb {
 
     /// Count tasks that reached `done` status with `updated_at >= since`.
     ///
-    /// `since` may be any datetime string SQLite's `datetime()` understands
-    /// (RFC3339 with `T`/offset is fine — it is normalised before comparison).
-    /// Both sides of the predicate are wrapped in `datetime(...)` because
-    /// `tasks.updated_at` is written via `datetime('now')`, which produces the
-    /// `YYYY-MM-DD HH:MM:SS` form; comparing that TEXT to an RFC3339 string
-    /// lexicographically would silently drop same-day rows (space `0x20` sorts
-    /// before `T` `0x54`). Uses the `idx_tasks_status_updated` index — the
-    /// index lookup is still viable because `datetime(updated_at)` is a
-    /// monotonic transform, so SQLite will range-scan on the index and filter.
+    /// `since` is formatted to the exact storage form (`YYYY-MM-DD HH:MM:SS`
+    /// UTC, matching what `datetime('now')` writes) so the raw TEXT comparison
+    /// is monotonic and the planner can range-scan on the
+    /// `idx_tasks_status_updated` index. Wrapping `updated_at` in `datetime()`
+    /// would defeat that index and force a full scan of `status='done'` rows,
+    /// which is painful when the overview page polls every 5 seconds.
     /// Used by the system overview endpoint to compute "merged in last 24h"
     /// without loading full task rows.
-    pub async fn count_done_since(&self, since: &str) -> anyhow::Result<u64> {
-        let row: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM tasks \
-             WHERE status = 'done' AND datetime(updated_at) >= datetime(?)",
-        )
-        .bind(since)
-        .fetch_one(&self.pool)
-        .await?;
+    pub async fn count_done_since(&self, since: DateTime<Utc>) -> anyhow::Result<u64> {
+        let since_str = sqlite_datetime(since);
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'done' AND updated_at >= ?")
+                .bind(&since_str)
+                .fetch_one(&self.pool)
+                .await?;
         Ok(row.0 as u64)
     }
 
@@ -901,21 +907,23 @@ impl TaskDb {
     /// `updated_at` timestamp truncated to the hour in UTC (format
     /// `YYYY-MM-DDTHH:00:00Z`). Rows with `project IS NULL` are reported with
     /// an empty project key. Used to build the fleet-throughput stacked-area
-    /// chart (per project, per hour over the window). Uses `datetime(...)` on
-    /// both sides for the same reason [`Self::count_done_since`] does.
+    /// chart (per project, per hour over the window). Formats `since` like
+    /// [`Self::count_done_since`] so the `idx_tasks_project_status_updated`
+    /// index range scan stays viable.
     pub async fn done_per_project_hour_since(
         &self,
-        since: &str,
+        since: DateTime<Utc>,
     ) -> anyhow::Result<Vec<(String, String, u64)>> {
+        let since_str = sqlite_datetime(since);
         let rows: Vec<(Option<String>, String, i64)> = sqlx::query_as(
             "SELECT project, \
                     strftime('%Y-%m-%dT%H:00:00Z', updated_at) AS hour, \
                     COUNT(*) \
              FROM tasks \
-             WHERE status = 'done' AND datetime(updated_at) >= datetime(?) \
+             WHERE status = 'done' AND updated_at >= ? \
              GROUP BY project, hour",
         )
-        .bind(since)
+        .bind(&since_str)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
@@ -1788,28 +1796,28 @@ mod tests {
     #[tokio::test]
     async fn count_done_since_counts_same_day_rows() -> anyhow::Result<()> {
         // Regression for PR #816: tasks.updated_at is stored via
-        // datetime('now') in `YYYY-MM-DD HH:MM:SS` form, so raw TEXT
-        // comparison against an RFC3339 `since` (with `T` separator)
-        // would silently drop all same-day rows because space `0x20`
-        // sorts before `T` `0x54`. datetime(updated_at) >= datetime(?)
-        // must normalise both sides.
+        // datetime('now') in `YYYY-MM-DD HH:MM:SS` form. Comparing an
+        // RFC3339 `since` (with `T` separator) as raw TEXT would silently
+        // drop all same-day rows because space `0x20` sorts before
+        // `T` `0x54`. sqlite_datetime() now formats `since` in the stored
+        // form so `updated_at >= ?` is monotonic and the index range scan
+        // stays intact.
         let tmp = tempfile::tempdir()?;
         let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
 
         db.insert(&make_task("fresh", TaskStatus::Done)).await?;
 
-        // RFC3339 string representing an hour ago.
-        let since = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
-        assert_eq!(db.count_done_since(&since).await?, 1);
+        let since = chrono::Utc::now() - chrono::Duration::hours(1);
+        assert_eq!(db.count_done_since(since).await?, 1);
 
-        let rows = db.done_per_project_hour_since(&since).await?;
+        let rows = db.done_per_project_hour_since(since).await?;
         let total: u64 = rows.iter().map(|(_, _, c)| *c).sum();
         assert_eq!(total, 1);
 
         // A future `since` still returns zero — sanity check that the
         // predicate is not inverted.
-        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
-        assert_eq!(db.count_done_since(&future).await?, 0);
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+        assert_eq!(db.count_done_since(future).await?, 0);
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1139,6 +1139,33 @@ impl TaskStore {
         }
     }
 
+    /// Count tasks that completed (`done`) with `updated_at >= since`.
+    ///
+    /// Forwards to [`TaskDb::count_done_since`]; used by the system overview
+    /// to compute merged-in-last-24h without materialising full task rows.
+    pub async fn count_done_since(&self, since: &str) -> u64 {
+        match self.db.count_done_since(since).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("count_done_since: SQL aggregation failed: {e}");
+                0
+            }
+        }
+    }
+
+    /// Per-(project, hour) done counts since `since`. Forwards to
+    /// [`TaskDb::done_per_project_hour_since`] and returns an empty vec on
+    /// error so callers can degrade gracefully.
+    pub async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)> {
+        match self.db.done_per_project_hour_since(since).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::warn!("done_per_project_hour_since: SQL aggregation failed: {e}");
+                Vec::new()
+            }
+        }
+    }
+
     /// Collect lightweight inputs for LLM metrics computation.
     ///
     /// Both **turn counts** and **first-token latencies** are collected in two

--- a/crates/harness-server/src/task_runner.rs
+++ b/crates/harness-server/src/task_runner.rs
@@ -1143,7 +1143,7 @@ impl TaskStore {
     ///
     /// Forwards to [`TaskDb::count_done_since`]; used by the system overview
     /// to compute merged-in-last-24h without materialising full task rows.
-    pub async fn count_done_since(&self, since: &str) -> u64 {
+    pub async fn count_done_since(&self, since: chrono::DateTime<chrono::Utc>) -> u64 {
         match self.db.count_done_since(since).await {
             Ok(v) => v,
             Err(e) => {
@@ -1156,7 +1156,10 @@ impl TaskStore {
     /// Per-(project, hour) done counts since `since`. Forwards to
     /// [`TaskDb::done_per_project_hour_since`] and returns an empty vec on
     /// error so callers can degrade gracefully.
-    pub async fn done_per_project_hour_since(&self, since: &str) -> Vec<(String, String, u64)> {
+    pub async fn done_per_project_hour_since(
+        &self,
+        since: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<(String, String, u64)> {
         match self.db.done_per_project_hour_since(since).await {
             Ok(rows) => rows,
             Err(e) => {

--- a/crates/harness-server/static/overview.html
+++ b/crates/harness-server/static/overview.html
@@ -654,11 +654,58 @@ function basename(path){
   return parts.length ? parts[parts.length-1] : String(path);
 }
 
+/* ---------- auth ----------
+   /overview is an exempt public HTML page, but /api/overview sits behind
+   `api_auth_middleware`. Mirror the dashboard's sessionStorage-based token
+   flow (see crates/harness-server/static/dashboard.js) so a bearer token
+   saved from the dashboard carries over here and a 401 prompts for one. */
+function authHeaders(){
+  const tok = sessionStorage.getItem('harness_token');
+  return tok ? { 'Authorization': 'Bearer ' + tok } : {};
+}
+function promptToken(onSaved){
+  if (document.getElementById('token-overlay')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'token-overlay';
+  overlay.style.cssText =
+    'position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;' +
+    'align-items:center;justify-content:center;z-index:9999';
+  overlay.innerHTML =
+    '<div style="background:var(--bg-1);padding:1.5rem;border:1px solid var(--line-2);min-width:320px;font-family:var(--sans)">' +
+    '<p style="margin:0 0 1rem;font-weight:600;color:var(--ink)">Enter API token</p>' +
+    '<input id="token-input" type="password" placeholder="Bearer token" ' +
+    'style="width:100%;padding:.5rem;border:1px solid var(--line-2);' +
+    'background:var(--bg);color:var(--ink);box-sizing:border-box;font-family:var(--mono)" />' +
+    '<div style="margin-top:1rem;display:flex;gap:.5rem;justify-content:flex-end">' +
+    '<button id="token-save" style="padding:.4rem .9rem;' +
+    'background:var(--rust);color:#fff;border:0;cursor:pointer;font-family:var(--mono)">Save</button>' +
+    '</div></div>';
+  document.body.appendChild(overlay);
+  const input = document.getElementById('token-input');
+  const save = () => {
+    const val = input.value.trim();
+    if (!val) return;
+    sessionStorage.setItem('harness_token', val);
+    overlay.remove();
+    if (onSaved) onSaved();
+  };
+  document.getElementById('token-save').addEventListener('click', save);
+  input.addEventListener('keydown', e => { if (e.key === 'Enter') save(); });
+  input.focus();
+}
+
 /* ---------- top-level fetch loop ---------- */
 let lastPayload = null;
 async function fetchOverview(){
   try {
-    const resp = await fetch('/api/overview', { headers: { accept: 'application/json' } });
+    const resp = await fetch('/api/overview', {
+      headers: { accept: 'application/json', ...authHeaders() },
+    });
+    if (resp.status === 401) {
+      setStatus(false);
+      promptToken(fetchOverview);
+      return;
+    }
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const payload = await resp.json();
     lastPayload = payload;

--- a/crates/harness-server/static/overview.html
+++ b/crates/harness-server/static/overview.html
@@ -1,0 +1,1046 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>harness — system overview</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#0e0c09;--bg-1:#16130e;--bg-2:#1c1812;--bg-3:#221c15;
+  --line:#2a241c;--line-2:#3a3226;--line-3:#4a4030;
+  --ink:#f1ebe0;--ink-2:#c8bfae;--ink-3:#8a8070;--ink-4:#5a5346;
+  --rust:#e26a2c;--rust-deep:#b14a15;--rust-soft:#ffa36a;
+  --moss:#8da35a;--sand:#d8c39a;--plum:#b07ab0;--sky:#6fa5c9;
+  --danger:#d65a4a;--warn:#cf9b3a;--ok:#7aae52;
+  --mono:'JetBrains Mono',ui-monospace,Menlo,monospace;
+  --sans:'Inter',ui-sans-serif,system-ui,sans-serif;
+  --serif:'Instrument Serif',Georgia,serif;
+}
+html[data-palette="ember"]{--bg:#0e0c09;--bg-1:#16130e;--bg-2:#1c1812;--bg-3:#221c15;--line:#2a241c;--line-2:#3a3226;--line-3:#4a4030;--ink:#f1ebe0;--ink-2:#c8bfae;--ink-3:#8a8070;--ink-4:#5a5346;--rust:#e26a2c;--rust-deep:#b14a15}
+html[data-palette="forge"]{--bg:#0a0c10;--bg-1:#11141a;--bg-2:#171b23;--bg-3:#1f242e;--line:#222833;--line-2:#323a49;--line-3:#42495a;--ink:#e6ebf4;--ink-2:#b4bcca;--ink-3:#7a8394;--ink-4:#4c5465;--rust:#f5a524;--rust-deep:#b97406}
+html[data-palette="ink"]{--bg:#06070a;--bg-1:#0c0e13;--bg-2:#12151c;--bg-3:#181c26;--line:#1c2029;--line-2:#2b3140;--line-3:#3a4255;--ink:#eef2f8;--ink-2:#b8bec9;--ink-3:#737a88;--ink-4:#474c58;--rust:#53d4ff;--rust-deep:#1e8ab3}
+html[data-palette="bloom"]{--bg:#0c0a12;--bg-1:#13101c;--bg-2:#1a1625;--bg-3:#231d2f;--line:#261f33;--line-2:#382e4a;--line-3:#4c3f63;--ink:#f3edfb;--ink-2:#c7bde0;--ink-3:#8b82a6;--ink-4:#554f6b;--rust:#ff5fae;--rust-deep:#bc2d7d}
+html[data-palette="terminal"]{--bg:#060a06;--bg-1:#0a110a;--bg-2:#0f180f;--bg-3:#152115;--line:#1b2a1b;--line-2:#2a3f2a;--line-3:#3a563a;--ink:#c7f4bf;--ink-2:#8fd383;--ink-3:#5a9553;--ink-4:#386234;--rust:#7aff7a;--rust-deep:#339a33}
+html[data-palette="mint"]{--bg:#f4efe6;--bg-1:#ebe4d6;--bg-2:#e0d7c3;--bg-3:#d4c9af;--line:#c8bea8;--line-2:#a89d85;--line-3:#8a7f68;--ink:#1e1b16;--ink-2:#3d3930;--ink-3:#6b6554;--ink-4:#938c78;--rust:#1f7a54;--rust-deep:#0f5a3c}
+html[data-palette="linen"]{--bg:#fbf7ee;--bg-1:#f3ecdc;--bg-2:#eadfc5;--bg-3:#ddd0b0;--line:#d6c9a8;--line-2:#b6a581;--line-3:#8f7f5e;--ink:#141820;--ink-2:#353c4a;--ink-3:#6a7180;--ink-4:#a09a88;--rust:#2747cf;--rust-deep:#15307f}
+html[data-palette="porcelain"]{--bg:#f6f5f2;--bg-1:#ecebe6;--bg-2:#dfded6;--bg-3:#d0cec3;--line:#cbc9bf;--line-2:#a6a498;--line-3:#808074;--ink:#1a1a1a;--ink-2:#3d3d3d;--ink-3:#6f6f6d;--ink-4:#9a988f;--rust:#d84a2f;--rust-deep:#9a2e18}
+html[data-palette="pixel"]{--bg:#14161f;--bg-1:#1c1f2c;--bg-2:#252938;--bg-3:#2f3448;--line:#2f3448;--line-2:#434966;--line-3:#565d80;--ink:#e8ecf4;--ink-2:#b0b8cc;--ink-3:#7a8299;--ink-4:#4f566d;--rust:#f4b860;--rust-deep:#c68a3a}
+html[data-palette="multica"]{--bg:#0a0b14;--bg-1:#111324;--bg-2:#181b33;--bg-3:#1f2340;--line:#242945;--line-2:#373d63;--line-3:#4a5180;--ink:#f2f1fb;--ink-2:#c7c4e0;--ink-3:#8a88ad;--ink-4:#55557a;--rust:#ff7a59;--rust-deep:#d14a2a}
+html[data-palette="multica"] body{background:radial-gradient(1000px 600px at 90% -10%,rgba(167,139,250,.14),transparent 55%),radial-gradient(800px 500px at -10% 30%,rgba(111,224,199,.08),transparent 55%),var(--bg);background-attachment:fixed}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+a{color:inherit;text-decoration:none}
+::selection{background:var(--rust);color:#fff}
+button{font:inherit;color:inherit;background:none;border:0;cursor:pointer;padding:0}
+.mono{font-family:var(--mono)}
+
+/* ========== app shell — matches dashboard.html ========== */
+.app{display:grid;grid-template-columns:240px 1fr;height:100vh;overflow:hidden}
+.sidebar{border-right:1px solid var(--line);background:var(--bg-1);display:flex;flex-direction:column;min-height:0}
+.sb-head{padding:16px 18px;display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--line)}
+.sb-head .glyph{width:22px;height:22px;color:var(--rust)}
+.sb-head .glyph svg{width:22px;height:22px}
+.sb-head .name{font-family:var(--mono);font-size:13px;font-weight:600;letter-spacing:.02em}
+.sb-head .env{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--ink-3);padding:2px 7px;border:1px solid var(--line-2);border-radius:2px}
+
+.sb-context{padding:12px 14px;border-bottom:1px solid var(--line);display:flex;gap:10px;align-items:center;cursor:pointer}
+.sb-context:hover{background:var(--bg-2)}
+.sb-context .globe{width:28px;height:28px;background:var(--bg-3);border:1px solid var(--line-2);display:grid;place-items:center;color:var(--rust)}
+.sb-context .info{flex:1;min-width:0}
+.sb-context .pn{font-size:13px;font-weight:500;color:var(--ink)}
+.sb-context .pm{font-family:var(--mono);font-size:11px;color:var(--ink-3)}
+.sb-context .chev{color:var(--ink-3)}
+
+.sb-nav{padding:10px 8px;flex:1;overflow:auto}
+.sb-sec{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-4);padding:14px 10px 6px}
+.sb-item{display:flex;align-items:center;gap:10px;padding:7px 10px;border-radius:4px;color:var(--ink-2);font-size:13px;cursor:pointer;position:relative}
+.sb-item:hover{background:var(--bg-2);color:var(--ink)}
+.sb-item.active{background:var(--bg-2);color:var(--ink)}
+.sb-item.active::before{content:"";position:absolute;left:-8px;top:8px;bottom:8px;width:2px;background:var(--rust)}
+.sb-item svg{width:15px;height:15px;color:var(--ink-3);flex:none}
+.sb-item.active svg{color:var(--rust)}
+.sb-item .count{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--ink-3);padding:1px 6px;border:1px solid var(--line-2);border-radius:10px;min-width:22px;text-align:center}
+.sb-item.active .count{color:var(--rust);border-color:var(--rust)}
+.sb-item .trend{margin-left:auto;color:var(--ok);font-family:var(--mono);font-size:10.5px}
+
+.sb-foot{padding:12px 14px;border-top:1px solid var(--line);display:flex;gap:10px;align-items:center}
+.sb-foot .u{width:26px;height:26px;border-radius:50%;background:linear-gradient(135deg,var(--rust),var(--rust-deep));display:grid;place-items:center;color:#fff;font-family:var(--mono);font-size:11px;font-weight:600}
+.sb-foot .info{flex:1;min-width:0}
+.sb-foot .un{font-size:12.5px;color:var(--ink)}
+.sb-foot .ue{font-family:var(--mono);font-size:10.5px;color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.back-link{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);display:inline-flex;gap:6px;align-items:center}
+.back-link:hover{color:var(--rust)}
+
+/* main pane */
+.main{display:flex;flex-direction:column;min-height:0;min-width:0}
+.topbar{height:48px;border-bottom:1px solid var(--line);background:var(--bg);display:flex;align-items:center;padding:0 18px;gap:12px;flex:none}
+.breadcrumb{font-family:var(--mono);font-size:12px;color:var(--ink-3);display:flex;align-items:center;gap:8px}
+.breadcrumb .sep{color:var(--ink-4)}
+.breadcrumb b{color:var(--ink);font-weight:500}
+.topbar .spacer{flex:1}
+.search{position:relative;width:320px}
+.search input{width:100%;height:30px;background:var(--bg-1);border:1px solid var(--line-2);padding:0 10px 0 32px;color:var(--ink);font-family:var(--mono);font-size:12px;border-radius:3px;outline:none}
+.search input::placeholder{color:var(--ink-3)}
+.search input:focus{border-color:var(--rust)}
+.search svg{position:absolute;left:10px;top:7px;width:14px;height:14px;color:var(--ink-3)}
+.search .kbd{position:absolute;right:8px;top:6px;font-family:var(--mono);font-size:10.5px;padding:2px 6px;border:1px solid var(--line-2);color:var(--ink-3);border-radius:3px}
+
+.btn{display:inline-flex;align-items:center;gap:6px;height:30px;padding:0 12px;border-radius:3px;font-family:var(--mono);font-size:12px;cursor:pointer;border:1px solid transparent;transition:filter .12s, transform .08s}
+.btn:hover{filter:brightness(1.08)}
+.btn:active{transform:translateY(1px)}
+.btn-primary{background:var(--rust);color:#fff}
+.btn-ghost{border-color:var(--line-2);color:var(--ink-2);background:transparent}
+.btn-ghost:hover{border-color:var(--line-3);color:var(--ink)}
+.btn svg{width:13px;height:13px}
+
+.content{flex:1;overflow:auto;min-height:0}
+
+/* view header — matches dashboard */
+.vhead{padding:18px 24px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:16px;background:var(--bg)}
+.vhead h1{margin:0;font-size:20px;font-weight:500;letter-spacing:-.01em}
+.vhead h1 em{font-family:var(--serif);font-style:italic;color:var(--rust);font-weight:400}
+.vhead .sub{font-family:var(--mono);font-size:12px;color:var(--ink-3);margin-left:4px}
+.vhead .right{margin-left:auto;display:flex;gap:8px;align-items:center}
+.vhead .status{display:inline-flex;align-items:center;gap:7px;padding:4px 10px;border:1px solid color-mix(in oklab,var(--ok) 40%,var(--line-2));color:var(--ok);border-radius:3px;font-family:var(--mono);font-size:11px}
+.vhead .status i{width:7px;height:7px;border-radius:50%;background:var(--ok);box-shadow:0 0 0 3px color-mix(in oklab,var(--ok) 25%,transparent);animation:pulse 1.8s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.45}}
+.seg{display:inline-flex;border:1px solid var(--line-2);border-radius:3px;overflow:hidden}
+.seg button{padding:5px 10px;font-family:var(--mono);font-size:11.5px;color:var(--ink-3);border-right:1px solid var(--line-2);background:var(--bg-1)}
+.seg button:last-child{border-right:0}
+.seg button.on{color:var(--ink);background:var(--bg-2)}
+
+.filters{padding:10px 24px;border-bottom:1px solid var(--line);display:flex;gap:8px;align-items:center;flex-wrap:wrap;background:var(--bg)}
+.filter{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border:1px solid var(--line-2);border-radius:3px;font-family:var(--mono);font-size:11.5px;color:var(--ink-2);cursor:pointer;background:var(--bg-1)}
+.filter:hover{border-color:var(--line-3)}
+.filter.active{border-color:var(--rust);color:var(--rust);background:color-mix(in oklab,var(--rust) 10%,var(--bg-1))}
+.filter .lbl{color:var(--ink-3)}
+.filter .v{color:var(--ink)}
+.filter.active .v{color:var(--rust)}
+.filter svg{width:12px;height:12px}
+.filters .sp{flex:1}
+
+/* ========= KPI band ========= */
+.kpi-band{display:grid;grid-template-columns:repeat(6,1fr);border-bottom:1px solid var(--line)}
+.kpi-band > div{padding:16px 20px;border-right:1px solid var(--line);position:relative}
+.kpi-band > div:last-child{border-right:0}
+.kpi-band .l{font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3)}
+.kpi-band .v{font-family:var(--mono);font-size:24px;color:var(--ink);margin-top:6px;letter-spacing:-.01em;line-height:1}
+.kpi-band .v small{color:var(--ink-3);font-size:13px;margin-left:3px;font-weight:normal}
+.kpi-band .delta{font-family:var(--mono);font-size:11px;margin-top:6px;display:inline-flex;align-items:center;gap:4px}
+.kpi-band .delta.up{color:var(--ok)}
+.kpi-band .delta.down{color:var(--danger)}
+.kpi-band .delta.flat{color:var(--ink-3)}
+.kpi-band .sp{position:absolute;right:16px;top:16px;display:flex;gap:2px;height:22px;align-items:flex-end}
+.kpi-band .sp i{width:3px;background:color-mix(in oklab,var(--rust) 55%,transparent)}
+
+/* ========= grid row ========= */
+.grid2{display:grid;grid-template-columns:1.6fr 1fr}
+.grid2 > .panel{border-right:1px solid var(--line)}
+.grid2 > .panel:last-child{border-right:0}
+
+.panel{border-bottom:1px solid var(--line)}
+.panel-h{padding:10px 18px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:10px;background:var(--bg);position:sticky;top:0;z-index:1}
+.panel-h h3{margin:0;font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);font-weight:500}
+.panel-h .sub{font-family:var(--mono);font-size:11px;color:var(--ink-4);margin-left:2px}
+.panel-h .r{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--ink-3);display:flex;align-items:center;gap:10px}
+.panel-h .r a{color:var(--ink-3)}
+.panel-h .r a:hover{color:var(--rust)}
+
+/* throughput svg area */
+.throughput{padding:16px 20px;height:240px;position:relative}
+.throughput svg{width:100%;height:100%;overflow:visible}
+.legend{display:flex;gap:14px;padding:0 20px 14px;font-family:var(--mono);font-size:11px;color:var(--ink-3)}
+.legend span{display:inline-flex;align-items:center;gap:6px;cursor:pointer}
+.legend i{width:10px;height:10px;border-radius:2px;display:inline-block}
+.legend span.off i{opacity:.3}
+.legend span.off{color:var(--ink-4)}
+
+/* projects table — looks like dashboard list */
+.prj-table{width:100%;border-collapse:collapse;font-size:13px}
+.prj-table th{font-family:var(--mono);font-size:10.5px;color:var(--ink-3);text-transform:uppercase;letter-spacing:.08em;font-weight:500;text-align:left;padding:10px 16px;border-bottom:1px solid var(--line);background:var(--bg);position:sticky;top:41px;z-index:0}
+.prj-table td{padding:12px 16px;border-bottom:1px solid var(--line);vertical-align:middle}
+.prj-table tr{cursor:pointer;transition:background .1s}
+.prj-table tr:hover td{background:var(--bg-1)}
+.prj-table tr:hover .go{opacity:1;color:var(--rust)}
+.prj-table .pn{display:flex;align-items:center;gap:10px}
+.prj-table .pn .av{width:28px;height:28px;background:var(--bg-3);border:1px solid var(--line-2);display:grid;place-items:center;font-family:var(--mono);font-weight:600;color:var(--rust);font-size:11px;flex:none}
+.prj-table .pn .path{font-family:var(--mono);font-size:11px;color:var(--ink-3)}
+.prj-table .pn b{font-weight:500;color:var(--ink)}
+.prj-table .mini-bar{width:120px;height:6px;background:var(--bg-2);border:1px solid var(--line);position:relative;overflow:hidden}
+.prj-table .mini-bar i{position:absolute;top:0;bottom:0;display:block}
+.prj-table .mini-bar i.running{background:var(--rust);left:0}
+.prj-table .mini-bar i.review{background:var(--warn)}
+.prj-table .mini-bar i.queued{background:var(--ink-4)}
+.prj-table .mono-cell{font-family:var(--mono);font-size:12px;color:var(--ink-2)}
+.prj-table .score{font-family:var(--mono);font-size:12.5px;padding:2px 7px;border:1px solid var(--line-2);border-radius:3px;color:var(--ink)}
+.prj-table .score.high{color:var(--ok);border-color:color-mix(in oklab,var(--ok) 40%,var(--line-2))}
+.prj-table .score.mid{color:var(--warn);border-color:color-mix(in oklab,var(--warn) 40%,var(--line-2))}
+.prj-table .trend{width:58px;height:20px;display:inline-block;vertical-align:-4px}
+.prj-table .go{color:var(--ink-3);opacity:0;transition:opacity .1s;font-family:var(--mono)}
+.prj-table .pipe-meta{color:var(--ink-3);margin-top:4px;font-size:11px;font-family:var(--mono)}
+
+/* cluster heatmap */
+.cluster{padding:16px 20px}
+.cluster-row{margin-bottom:12px}
+.cluster-row:last-child{margin-bottom:0}
+.cluster-row .h{display:flex;justify-content:space-between;align-items:flex-end;font-family:var(--mono);font-size:11px;color:var(--ink-3);margin-bottom:4px}
+.cluster-row .h .n{color:var(--ink-2)}
+.cluster-row .h .m{color:var(--ink-4)}
+.cluster-row .grid{display:grid;grid-template-columns:repeat(48,1fr);gap:2px}
+.cluster-row .grid i{aspect-ratio:1;background:var(--bg-2);border:1px solid var(--line)}
+
+/* agent token usage */
+.agent-usage{padding:16px 20px}
+.agent-row{display:grid;grid-template-columns:130px 1fr 100px;gap:14px;align-items:center;padding:8px 0;border-bottom:1px dashed var(--line);font-family:var(--mono);font-size:12px}
+.agent-row:last-child{border-bottom:0}
+.agent-row .nm{display:flex;align-items:center;gap:8px;color:var(--ink)}
+.agent-row .nm .av{width:16px;height:16px;border-radius:3px;display:inline-block;flex:none}
+.agent-row .bar-wrap{height:6px;background:var(--bg-2);border:1px solid var(--line);position:relative;overflow:hidden}
+.agent-row .bar-wrap i{position:absolute;top:0;bottom:0;left:0}
+.agent-row .val{text-align:right;color:var(--ink)}
+.agent-row .val small{color:var(--ink-3)}
+
+/* distribution */
+.dist{padding:16px 20px}
+.dist .row-bar{display:flex;height:22px;overflow:hidden;border:1px solid var(--line)}
+.dist .row-bar i{display:block}
+.dist .stats{display:grid;grid-template-columns:repeat(5,1fr);gap:8px;margin-top:12px;font-family:var(--mono);font-size:11px}
+.dist .stats div{display:flex;flex-direction:column}
+.dist .stats .k{color:var(--ink-3);display:flex;align-items:center;gap:5px;text-transform:uppercase;letter-spacing:.05em;font-size:10px}
+.dist .stats .k i{width:8px;height:8px;display:inline-block}
+.dist .stats .v{color:var(--ink);font-size:16px;margin-top:4px}
+
+/* runtime cards — same as dashboard */
+.rt-wrap{padding:14px 20px;display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:12px}
+.rtc{border:1px solid var(--line);background:var(--bg-1);padding:14px;cursor:pointer;transition:border-color .12s}
+.rtc:hover{border-color:var(--line-3)}
+.rtc-h{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.rtc-h .i{width:28px;height:28px;display:grid;place-items:center;border:1px solid var(--line-2);color:var(--rust);flex:none}
+.rtc-h .n{font-size:13.5px;font-weight:500}
+.rtc-h .m{font-family:var(--mono);font-size:11px;color:var(--ink-3)}
+.rtc-h .state{margin-left:auto;display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11px;padding:3px 8px;border:1px solid var(--line-2);border-radius:3px}
+.rtc-h .state i{width:7px;height:7px;border-radius:50%}
+.rtc-h .state.on{color:var(--ok);border-color:color-mix(in oklab,var(--ok) 40%,var(--line-2))}
+.rtc-h .state.on i{background:var(--ok);box-shadow:0 0 0 3px color-mix(in oklab,var(--ok) 25%,transparent)}
+.rtc-h .state.off{color:var(--ink-4)}
+.rtc-h .state.off i{background:var(--ink-4)}
+.rtc .rows{font-family:var(--mono);font-size:11px;color:var(--ink-3);display:grid;grid-template-columns:1fr 1fr;gap:4px 12px}
+.rtc .rows div{display:flex;justify-content:space-between}
+.rtc .rows b{color:var(--ink-2);font-weight:500}
+.rtc .bar{height:4px;background:var(--bg-2);border:1px solid var(--line);overflow:hidden;grid-column:1/-1;margin:2px 0}
+.rtc .bar i{display:block;height:100%;background:linear-gradient(90deg,var(--rust),var(--rust-deep))}
+.rtc .agents{display:flex;gap:4px;flex-wrap:wrap;margin-top:10px}
+.rtc .agents .ag{font-family:var(--mono);font-size:10px;padding:1px 6px;border:1px solid var(--line-2);border-radius:3px;color:var(--ink-3)}
+
+/* feed */
+.feed{padding:6px 18px 12px;max-height:460px;overflow:auto}
+.feed .item{display:grid;grid-template-columns:70px 1fr auto;gap:12px;padding:10px 0;border-bottom:1px solid var(--line);align-items:flex-start;font-family:var(--mono);font-size:11.5px;color:var(--ink-2)}
+.feed .item:last-child{border-bottom:0}
+.feed .ts{color:var(--ink-4)}
+.feed .body{line-height:1.55}
+.feed .ev{color:var(--rust);margin-right:6px}
+.feed .ev.ok{color:var(--ok)}
+.feed .ev.warn{color:var(--warn)}
+.feed .ev.err{color:var(--danger)}
+.feed .proj{font-family:var(--mono);font-size:10px;color:var(--ink-3);padding:1px 6px;border:1px solid var(--line-2);border-radius:2px}
+
+/* alerts */
+.alerts{padding:6px 18px 12px}
+.alerts .al{padding:10px 0;border-bottom:1px solid var(--line);display:grid;grid-template-columns:24px 1fr auto;gap:12px;font-family:var(--mono);font-size:11.5px}
+.alerts .al:last-child{border-bottom:0}
+.alerts .al .ic{width:22px;height:22px;border:1px solid var(--line-2);display:grid;place-items:center;flex:none}
+.alerts .al .ic.warn{color:var(--warn);border-color:color-mix(in oklab,var(--warn) 40%,var(--line-2))}
+.alerts .al .ic.err{color:var(--danger);border-color:color-mix(in oklab,var(--danger) 40%,var(--line-2))}
+.alerts .al .ic.ok{color:var(--ok);border-color:color-mix(in oklab,var(--ok) 40%,var(--line-2))}
+.alerts .al .txt{color:var(--ink);line-height:1.45}
+.alerts .al .txt .sub{color:var(--ink-3);font-size:10.5px;margin-top:2px}
+.alerts .al .ts{color:var(--ink-4);font-size:10.5px;align-self:center}
+
+/* FAB + palette popover */
+#tw-fab{position:fixed;right:20px;bottom:20px;z-index:90;display:inline-flex;align-items:center;gap:8px;padding:9px 13px;border:1px solid var(--line-2);background:var(--bg-1);color:var(--ink-2);font-family:var(--mono);font-size:11.5px;cursor:pointer;border-radius:3px;box-shadow:0 6px 24px rgba(0,0,0,.35)}
+#tw-fab:hover{color:var(--rust);border-color:var(--rust)}
+#tw-fab svg{width:13px;height:13px}
+#tweaks{position:fixed;right:20px;bottom:66px;z-index:95;width:300px;background:var(--bg-1);border:1px solid var(--line-2);display:none;font-family:var(--sans);box-shadow:0 24px 60px rgba(0,0,0,.55)}
+#tweaks.open{display:block}
+#tweaks .tw-head{display:flex;justify-content:space-between;align-items:center;padding:12px 14px;border-bottom:1px solid var(--line);font-family:var(--mono);font-size:11px;color:var(--ink-3);letter-spacing:.12em;text-transform:uppercase}
+#tweaks .tw-body{padding:8px;display:flex;flex-direction:column;gap:3px;max-height:60vh;overflow:auto}
+.tw-opt{display:flex;align-items:center;gap:12px;padding:7px 10px;background:transparent;border:1px solid transparent;cursor:pointer;text-align:left;color:var(--ink-2)}
+.tw-opt:hover{background:var(--bg-2);border-color:var(--line)}
+.tw-opt.active{border-color:var(--rust);background:var(--bg-2)}
+.tw-sw{display:flex;gap:2px;flex:none}
+.tw-sw i{width:13px;height:24px;display:block}
+.tw-n{font-family:var(--mono);font-size:12px;color:var(--ink);font-weight:500}
+.tw-s{font-family:var(--mono);font-size:10.5px;color:var(--ink-3);margin-top:2px}
+
+::-webkit-scrollbar{width:10px;height:10px}
+::-webkit-scrollbar-thumb{background:var(--line-2);border-radius:4px}
+::-webkit-scrollbar-thumb:hover{background:var(--line-3)}
+::-webkit-scrollbar-track{background:transparent}
+
+@media (max-width:1200px){
+  .kpi-band{grid-template-columns:repeat(3,1fr)}
+  .kpi-band > div:nth-child(-n+3){border-bottom:1px solid var(--line)}
+  .grid2{grid-template-columns:1fr}
+  .grid2 > .panel{border-right:0;border-bottom:1px solid var(--line)}
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- ============ SIDEBAR ============ -->
+  <aside class="sidebar">
+    <div class="sb-head">
+      <span class="glyph">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+          <path d="M4 4 L12 8 L20 4 L20 20 L12 16 L4 20 Z" fill="color-mix(in oklab, currentColor 18%, transparent)"/>
+          <path d="M12 8 L12 16"/>
+        </svg>
+      </span>
+      <span class="name">harness</span>
+      <span class="env">local</span>
+    </div>
+
+    <div class="sb-context" title="switch scope">
+      <div class="globe">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a13 13 0 010 18M12 3a13 13 0 000 18"/></svg>
+      </div>
+      <div class="info">
+        <div class="pn">all projects</div>
+        <div class="pm">system · 4 projects</div>
+      </div>
+      <svg class="chev" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M7 10l5 5 5-5"/></svg>
+    </div>
+
+    <nav class="sb-nav">
+      <div class="sb-sec">System</div>
+      <div class="sb-item active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></svg>
+        Overview
+        <span class="trend">▲ 12</span>
+      </div>
+      <div class="sb-item" onclick="location.href='/#projects'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 7l9-4 9 4v10l-9 4-9-4z"/><path d="M12 11v10M3 7l9 4 9-4"/></svg>
+        Projects
+        <span class="count">4</span>
+      </div>
+      <div class="sb-item" onclick="location.href='/#runtimes'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="1"/><path d="M7 10h3M7 14h3M14 10h3"/></svg>
+        Runtimes
+        <span class="count">4</span>
+      </div>
+      <div class="sb-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 12h4l3-8 4 16 3-8h4"/></svg>
+        Observability
+      </div>
+
+      <div class="sb-sec">Fleet</div>
+      <div class="sb-item" onclick="location.href='/'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="4" width="7" height="16"/><rect x="14" y="4" width="7" height="11"/></svg>
+        All tasks
+        <span class="count">47</span>
+      </div>
+      <div class="sb-item" onclick="location.href='/#worktrees'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="18" cy="18" r="2"/><path d="M6 8v8a2 2 0 002 2h8M18 8v6"/></svg>
+        Worktrees
+        <span class="count">12</span>
+      </div>
+
+      <div class="sb-sec">Policy</div>
+      <div class="sb-item" onclick="location.href='/#rules'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="4" y="4" width="16" height="16" rx="1"/><path d="M8 12l3 3 5-6"/></svg>
+        Rules
+        <span class="count">34</span>
+      </div>
+      <div class="sb-item" onclick="location.href='/#skills'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 2l3 5 5 1-4 4 1 6-5-3-5 3 1-6-4-4 5-1z"/></svg>
+        Skills
+        <span class="count">128</span>
+      </div>
+
+      <div class="sb-sec">Reference</div>
+      <div class="sb-item" onclick="location.href='harness.html'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 5h16v14H4z"/><path d="M8 9h8M8 13h8M8 17h5"/></svg>
+        Docs
+      </div>
+    </nav>
+
+    <div class="sb-foot">
+      <div class="u">MJ</div>
+      <div class="info">
+        <div class="un">majiayu</div>
+        <div class="ue">mj@harness.local</div>
+      </div>
+      <a class="back-link" href="harness.html" title="landing page">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M15 18l-6-6 6-6"/></svg>
+      </a>
+    </div>
+  </aside>
+
+  <!-- ============ MAIN ============ -->
+  <main class="main">
+    <div class="topbar">
+      <div class="breadcrumb">
+        <span>system</span><span class="sep">/</span><b>overview</b>
+      </div>
+      <div class="spacer"></div>
+      <div class="search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="11" cy="11" r="7"/><path d="M16 16l5 5"/></svg>
+        <input placeholder="Search projects, runtimes, tasks…"/>
+        <span class="kbd">⌘K</span>
+      </div>
+      <button class="btn btn-ghost" onclick="location.href='/'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        open project
+      </button>
+    </div>
+
+    <div class="content">
+      <div class="vhead">
+        <h1>System <em>overview</em></h1>
+        <span class="sub" id="vhead-sub">loading…</span>
+        <div class="right">
+          <div class="seg">
+            <button>1h</button>
+            <button class="on">24h</button>
+            <button>7d</button>
+            <button>30d</button>
+          </div>
+          <div class="status"><i></i>all systems nominal</div>
+        </div>
+      </div>
+
+      <div class="filters">
+        <button class="filter active"><span class="lbl">Project</span><span class="v">all</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M7 10l5 5 5-5"/></svg></button>
+        <button class="filter"><span class="lbl">Agent</span><span class="v">Claude · Codex · Gemini</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M7 10l5 5 5-5"/></svg></button>
+        <button class="filter"><span class="lbl">Runtime</span><span class="v">all</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M7 10l5 5 5-5"/></svg></button>
+        <button class="filter"><span class="lbl">Status</span><span class="v">any</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M7 10l5 5 5-5"/></svg></button>
+        <span class="sp"></span>
+        <button class="filter"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 20v-8M5 12l7-7 7 7"/></svg> export JSON</button>
+      </div>
+
+      <!-- KPI BAND -->
+      <div class="kpi-band">
+        <div>
+          <div class="l">Active tasks</div>
+          <div class="v">47</div>
+          <div class="delta up">▲ 12 vs 24h</div>
+          <div class="sp" id="sp1"></div>
+        </div>
+        <div>
+          <div class="l">Merged · 24h</div>
+          <div class="v">218</div>
+          <div class="delta up">▲ 18%</div>
+          <div class="sp" id="sp2"></div>
+        </div>
+        <div>
+          <div class="l">Avg review score</div>
+          <div class="v">91<small>/100</small></div>
+          <div class="delta flat">— 0.4</div>
+          <div class="sp" id="sp3"></div>
+        </div>
+        <div>
+          <div class="l">Rule fail rate</div>
+          <div class="v">2.1<small>%</small></div>
+          <div class="delta down">▼ 0.8pp</div>
+          <div class="sp" id="sp4"></div>
+        </div>
+        <div>
+          <div class="l">Tokens · 24h</div>
+          <div class="v">84.2<small>M</small></div>
+          <div class="delta up">▲ 6%</div>
+          <div class="sp" id="sp5"></div>
+        </div>
+        <div>
+          <div class="l">Worktrees</div>
+          <div class="v">12<small>/32</small></div>
+          <div class="delta flat">38% util</div>
+          <div class="sp" id="sp6"></div>
+        </div>
+      </div>
+
+      <!-- ROW 1: throughput + distribution / agents -->
+      <div class="grid2">
+        <div class="panel">
+          <div class="panel-h">
+            <h3>Fleet throughput</h3>
+            <span class="sub">tasks completed per hour · stacked by project</span>
+            <div class="r"><a>open metrics →</a></div>
+          </div>
+          <div class="throughput" id="through"></div>
+          <div class="legend" id="legend"></div>
+        </div>
+        <div class="panel">
+          <div class="panel-h">
+            <h3>Task distribution</h3>
+            <span class="sub">47 active · all projects</span>
+          </div>
+          <div class="dist">
+            <div class="row-bar">
+              <i style="background:var(--ink-4);width:32%" title="queued"></i>
+              <i style="background:var(--rust);width:26%" title="running"></i>
+              <i style="background:var(--warn);width:15%" title="review"></i>
+              <i style="background:var(--ok);width:22%" title="merged"></i>
+              <i style="background:var(--danger);width:5%" title="failed"></i>
+            </div>
+            <div class="stats">
+              <div><span class="k"><i style="background:var(--ink-4)"></i>queued</span><span class="v">15</span></div>
+              <div><span class="k"><i style="background:var(--rust)"></i>running</span><span class="v">12</span></div>
+              <div><span class="k"><i style="background:var(--warn)"></i>review</span><span class="v">7</span></div>
+              <div><span class="k"><i style="background:var(--ok)"></i>merged</span><span class="v">10</span></div>
+              <div><span class="k"><i style="background:var(--danger)"></i>failed</span><span class="v">3</span></div>
+            </div>
+          </div>
+
+          <div class="panel-h" style="border-top:1px solid var(--line)">
+            <h3>Agent token usage</h3>
+            <span class="sub">last 24h</span>
+          </div>
+          <div class="agent-usage">
+            <div class="agent-row">
+              <div class="nm"><span class="av" style="background:#d97757"></span>Claude S4.5</div>
+              <div class="bar-wrap"><i style="background:#d97757;width:62%"></i></div>
+              <div class="val">38.2M <small>tok</small></div>
+            </div>
+            <div class="agent-row">
+              <div class="nm"><span class="av" style="background:#10a37f"></span>Codex</div>
+              <div class="bar-wrap"><i style="background:#10a37f;width:48%"></i></div>
+              <div class="val">24.8M <small>tok</small></div>
+            </div>
+            <div class="agent-row">
+              <div class="nm"><span class="av" style="background:#4285f4"></span>Gemini CLI</div>
+              <div class="bar-wrap"><i style="background:#4285f4;width:22%"></i></div>
+              <div class="val">14.1M <small>tok</small></div>
+            </div>
+            <div class="agent-row">
+              <div class="nm"><span class="av" style="background:#a78bfa"></span>OpenClaw</div>
+              <div class="bar-wrap"><i style="background:#a78bfa;width:12%"></i></div>
+              <div class="val">7.1M <small>tok</small></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- PROJECTS TABLE -->
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Projects</h3>
+          <span class="sub">click a row to enter the project dashboard</span>
+          <div class="r">
+            <span>sort: activity ▾</span>
+            <a onclick="location.href='/#projects'">manage →</a>
+          </div>
+        </div>
+        <table class="prj-table" id="prj-table"></table>
+      </div>
+
+      <!-- RUNTIMES -->
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Fleet runtimes</h3>
+          <span class="sub">connected machines &amp; cloud endpoints</span>
+          <div class="r"><a onclick="location.href='/#runtimes'">manage →</a></div>
+        </div>
+        <div class="rt-wrap" id="rt-wrap"></div>
+      </div>
+
+      <!-- ROW 3: cluster + feed + alerts -->
+      <div class="grid2">
+        <div class="panel">
+          <div class="panel-h">
+            <h3>Cluster activity</h3>
+            <span class="sub">30-min buckets · last 24h · per runtime</span>
+            <div class="r">
+              <span style="color:var(--ink-4)">low</span>
+              <span style="display:flex;gap:2px">
+                <i style="width:10px;height:10px;background:var(--bg-2);border:1px solid var(--line)"></i>
+                <i style="width:10px;height:10px;background:color-mix(in oklab,var(--rust) 30%,var(--bg-2));border:1px solid var(--line-2)"></i>
+                <i style="width:10px;height:10px;background:color-mix(in oklab,var(--rust) 60%,var(--bg-2));border:1px solid var(--line-2)"></i>
+                <i style="width:10px;height:10px;background:var(--rust);border:1px solid var(--rust)"></i>
+              </span>
+              <span style="color:var(--ink-4)">high</span>
+            </div>
+          </div>
+          <div class="cluster" id="cluster"></div>
+        </div>
+        <div class="panel">
+          <div class="panel-h">
+            <h3>Live activity</h3>
+            <span class="sub">cross-project stream</span>
+            <div class="r"><a>pause</a></div>
+          </div>
+          <div class="feed" id="feed"></div>
+          <div class="panel-h" style="border-top:1px solid var(--line)">
+            <h3>System alerts</h3>
+            <span class="sub">3 open</span>
+          </div>
+          <div class="alerts" id="alerts"></div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<!-- ============ palette FAB ============ -->
+<button id="tw-fab" title="palette">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 000 18M3 12h18"/></svg>
+  palette
+</button>
+<div id="tweaks">
+  <div class="tw-head"><span>Palette</span><button onclick="document.getElementById('tweaks').classList.remove('open')" style="color:var(--ink-3);font-size:18px">×</button></div>
+  <div class="tw-body" id="tw-body"></div>
+</div>
+
+<script>
+/* ============================================================
+   /overview — live system dashboard
+   - polls /api/overview every REFRESH_MS
+   - palette choice persists to localStorage (shared with /)
+   - sections that depend on unavailable metrics (per-agent tokens,
+     runtime cpu/ram) hide themselves when values are null
+   ============================================================ */
+const REFRESH_MS = 5000;
+
+/* ---------- palette switcher (unchanged from design) ---------- */
+const PALETTES = [
+  { id:'ember',     name:'Ember',     sub:'warm · rust · original', swatch:['#0e0c09','#1c1812','#e26a2c','#f1ebe0'] },
+  { id:'forge',     name:'Forge',     sub:'steel · amber',          swatch:['#0a0c10','#1f242e','#f5a524','#e6ebf4'] },
+  { id:'ink',       name:'Ink',       sub:'deep · cyan',            swatch:['#06070a','#181c26','#53d4ff','#eef2f8'] },
+  { id:'bloom',     name:'Bloom',     sub:'violet · magenta',       swatch:['#0c0a12','#231d2f','#ff5fae','#f3edfb'] },
+  { id:'terminal',  name:'Terminal',  sub:'classic green phosphor', swatch:['#060a06','#152115','#7aff7a','#c7f4bf'] },
+  { id:'mint',      name:'Mint',      sub:'light · paper',          swatch:['#f4efe6','#d4c9af','#1f7a54','#1e1b16'] },
+  { id:'linen',     name:'Linen',     sub:'warm paper · indigo',    swatch:['#fbf7ee','#ddd0b0','#2747cf','#141820'] },
+  { id:'porcelain', name:'Porcelain', sub:'neutral · crimson',      swatch:['#f6f5f2','#d0cec3','#d84a2f','#1a1a1a'] },
+  { id:'pixel',     name:'Pixel',     sub:'muted · 8-bit amber',    swatch:['#14161f','#2f3448','#f4b860','#e8ecf4'] },
+  { id:'multica',   name:'Multica',   sub:'cosmic · aurora',        swatch:['#0a0b14','#1f2340','#ff7a59','#f2f1fb'] },
+];
+function renderPalette(){
+  const cur = document.documentElement.getAttribute('data-palette') || 'ember';
+  document.getElementById('tw-body').innerHTML = PALETTES.map(p => `
+    <button class="tw-opt ${p.id===cur?'active':''}" data-pal="${p.id}">
+      <span class="tw-sw">${p.swatch.map(c => `<i style="background:${c}"></i>`).join('')}</span>
+      <div><div class="tw-n">${p.name}</div><div class="tw-s">${p.sub}</div></div>
+    </button>`).join('');
+  document.querySelectorAll('#tw-body .tw-opt').forEach(b => b.addEventListener('click', () => {
+    document.documentElement.setAttribute('data-palette', b.dataset.pal);
+    localStorage.setItem('harness.palette', b.dataset.pal);
+    renderPalette();
+    if (lastPayload) renderAll(lastPayload);
+  }));
+}
+document.documentElement.setAttribute(
+  'data-palette',
+  localStorage.getItem('harness.palette') || 'ember'
+);
+document.getElementById('tw-fab').addEventListener('click', () => {
+  document.getElementById('tweaks').classList.toggle('open');
+});
+renderPalette();
+
+/* ---------- helpers ---------- */
+const $ = (sel, root=document) => root.querySelector(sel);
+const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+function fmtInt(n){ return Number.isFinite(n) ? n.toLocaleString() : '—'; }
+function fmtScore(n){ return Number.isFinite(n) ? n.toFixed(0) : '—'; }
+function fmtPct(n){ return Number.isFinite(n) ? n.toFixed(1) : '—'; }
+function escHtml(s){ return String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+function basename(path){
+  if (!path) return '';
+  const parts = String(path).split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length-1] : String(path);
+}
+
+/* ---------- top-level fetch loop ---------- */
+let lastPayload = null;
+async function fetchOverview(){
+  try {
+    const resp = await fetch('/api/overview', { headers: { accept: 'application/json' } });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const payload = await resp.json();
+    lastPayload = payload;
+    renderAll(payload);
+    setStatus(true);
+  } catch (e) {
+    console.warn('overview fetch failed:', e);
+    setStatus(false);
+  }
+}
+function setStatus(ok){
+  const s = $('.vhead .status');
+  if (!s) return;
+  s.textContent = '';
+  const dot = document.createElement('i'); s.appendChild(dot);
+  s.appendChild(document.createTextNode(ok ? 'all systems nominal' : 'connection lost'));
+  s.style.color = ok ? '' : 'var(--danger)';
+  s.style.borderColor = ok ? '' : 'color-mix(in oklab,var(--danger) 40%,var(--line-2))';
+}
+
+function renderAll(p){
+  renderHeader(p);
+  renderKpiBand(p);
+  renderThroughput(p);
+  renderDistribution(p);
+  renderAgentUsage(p);
+  renderProjects(p);
+  renderRuntimes(p);
+  renderHeatmap(p);
+  renderFeed(p);
+  renderAlerts(p);
+}
+
+/* ---------- header ---------- */
+function renderHeader(p){
+  const sub = $('#vhead-sub');
+  if (sub) {
+    const nprojects = (p.projects || []).length;
+    const nruntimes = (p.runtimes || []).length;
+    sub.textContent = `${nprojects} project${nprojects===1?'':'s'} · ${nruntimes} runtime${nruntimes===1?'':'s'}`;
+  }
+  // Sidebar context subtitle.
+  const ctx = $('.sb-context .pm');
+  if (ctx) ctx.textContent = `system · ${(p.projects||[]).length} projects`;
+  // Sidebar counts for Projects / Runtimes / All tasks / Worktrees.
+  const activeTasks = p.kpi?.active_tasks ?? 0;
+  const worktreesUsed = p.kpi?.worktrees?.used ?? 0;
+  setSidebarCount('Projects', (p.projects || []).length);
+  setSidebarCount('Runtimes', (p.runtimes || []).length);
+  setSidebarCount('All tasks', activeTasks);
+  setSidebarCount('Worktrees', worktreesUsed);
+}
+function setSidebarCount(label, value){
+  for (const item of $$('.sb-item')) {
+    if (item.textContent.trim().startsWith(label)) {
+      const c = item.querySelector('.count');
+      if (c) c.textContent = fmtInt(value);
+      return;
+    }
+  }
+}
+
+/* ---------- KPI band ---------- */
+function renderKpiBand(p){
+  const kpi = p.kpi || {};
+  const cells = $$('.kpi-band > div');
+  const setCell = (idx, value, delta) => {
+    const cell = cells[idx]; if (!cell) return;
+    const v = cell.querySelector('.v');
+    const d = cell.querySelector('.delta');
+    if (v) v.innerHTML = value;
+    if (d) { d.textContent = delta; d.className = 'delta flat'; }
+  };
+  setCell(0, fmtInt(kpi.active_tasks ?? 0), `window ${p.window?.hours ?? 24}h`);
+  setCell(1, fmtInt(kpi.merged_24h ?? 0), 'in window');
+  const score = kpi.avg_review_score;
+  setCell(2,
+    Number.isFinite(score) ? `${fmtScore(score)}<small>/100</small>` : '—',
+    kpi.grade ? `grade ${kpi.grade}` : 'no scans'
+  );
+  setCell(3, `${fmtPct(kpi.rule_fail_rate_pct ?? 0)}<small>%</small>`, 'rule_check');
+  setCell(4, kpi.tokens_24h != null ? `${fmtInt(kpi.tokens_24h)}` : '—', 'per-agent n/a');
+  const wt = kpi.worktrees || {};
+  const used = wt.used ?? 0, total = wt.total ?? 0;
+  const util = total ? Math.round((used/total)*100) : 0;
+  setCell(5, `${fmtInt(used)}<small>/${fmtInt(total)}</small>`, `${util}% util`);
+
+  // Sparklines — use per-project merged trend as global-activity proxy.
+  const globalBuckets = buildGlobalBuckets(p);
+  drawSparkline('sp1', globalBuckets);
+  drawSparkline('sp2', globalBuckets);
+  drawSparkline('sp3', []);        // no score trend; leave flat
+  drawSparkline('sp4', []);        // no rule-rate trend; leave flat
+  drawSparkline('sp5', []);
+  drawSparkline('sp6', globalBuckets);
+}
+function buildGlobalBuckets(p){
+  const series = p.throughput?.series || [];
+  const N = (p.throughput?.hours || []).length;
+  if (!series.length || !N) return [];
+  const out = new Array(N).fill(0);
+  for (const s of series) {
+    (s.values || []).forEach((v,i) => { if (i < N) out[i] += v; });
+  }
+  return out;
+}
+function drawSparkline(id, values){
+  const el = document.getElementById(id); if (!el) return;
+  if (!values.length) {
+    el.innerHTML = '<i style="height:4px;opacity:.5"></i>'.repeat(24);
+    return;
+  }
+  const max = Math.max(...values, 1);
+  el.innerHTML = values.map(v =>
+    `<i style="height:${Math.max(2, Math.round((v/max)*19))}px"></i>`
+  ).join('');
+}
+
+/* ---------- throughput stacked area ---------- */
+const SERIES_COLORS = ['var(--rust)','var(--moss)','var(--sky)','var(--plum)','var(--sand)','var(--rust-soft)'];
+function renderThroughput(p){
+  const series = (p.throughput?.series || []).map((s, i) => ({
+    name: s.project,
+    values: s.values || [],
+    color: SERIES_COLORS[i % SERIES_COLORS.length],
+  }));
+  renderLegend(series);
+  drawThroughput(series);
+}
+function renderLegend(series){
+  const el = document.getElementById('legend'); if (!el) return;
+  el.innerHTML = series.map((s,i) =>
+    `<span data-s="${i}"><i style="background:${s.color}"></i>${escHtml(s.name)}</span>`
+  ).join('');
+  $$('#legend span').forEach(s => s.addEventListener('click', () => {
+    s.classList.toggle('off');
+    if (lastPayload) drawThroughput(getActiveSeries());
+  }));
+}
+function getActiveSeries(){
+  const series = (lastPayload.throughput?.series || []).map((s, i) => ({
+    name: s.project,
+    values: s.values || [],
+    color: SERIES_COLORS[i % SERIES_COLORS.length],
+    off: $(`#legend span[data-s="${i}"]`)?.classList.contains('off'),
+  }));
+  return series;
+}
+function drawThroughput(series){
+  const el = document.getElementById('through'); if (!el) return;
+  const active = series.filter(s => !s.off);
+  const N = active[0]?.values.length || 0;
+  if (!N) { el.innerHTML = '<div style="color:var(--ink-4);font-family:var(--mono);font-size:11px;padding:12px">no data in window</div>'; return; }
+  const W = el.clientWidth || 900, H = 200;
+  const stacked = new Array(N).fill(0);
+  const layers = active.map(s => s.values.map((v,i) => {
+    const bottom = stacked[i]; stacked[i] += v; return { bottom, top: stacked[i] };
+  }));
+  const maxY = Math.max(...stacked, 1) * 1.15;
+  const x = i => (i/Math.max(1,N-1))*W;
+  const y = v => H - (v/maxY)*H;
+  let svg = `<svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">`;
+  for (let i=0;i<=4;i++) svg += `<line x1="0" x2="${W}" y1="${(i/4)*H}" y2="${(i/4)*H}" stroke="rgba(128,128,128,.08)"/>`;
+  layers.forEach((layer, si) => {
+    let path = `M ${x(0)} ${y(layer[0].bottom)} `;
+    for (let i=0;i<N;i++) path += `L ${x(i)} ${y(layer[i].top)} `;
+    for (let i=N-1;i>=0;i--) path += `L ${x(i)} ${y(layer[i].bottom)} `;
+    path += 'Z';
+    svg += `<path d="${path}" fill="${active[si].color}" fill-opacity="0.85" stroke="${active[si].color}" stroke-width="0.8"/>`;
+  });
+  svg += '</svg>';
+  el.innerHTML = svg;
+}
+addEventListener('resize', () => { if (lastPayload) drawThroughput(getActiveSeries()); });
+
+/* ---------- distribution ---------- */
+function renderDistribution(p){
+  const d = p.distribution || {};
+  const order = ['queued','running','review','merged','failed'];
+  const total = order.reduce((a,k) => a + (d[k] ?? 0), 0) || 1;
+  const bars = $$('.dist .row-bar i');
+  const stats = $$('.dist .stats .v');
+  order.forEach((k, i) => {
+    const v = d[k] ?? 0;
+    if (bars[i]) bars[i].style.width = `${(v/total)*100}%`;
+    if (stats[i]) stats[i].textContent = fmtInt(v);
+  });
+  const sub = $('.panel:nth-of-type(1) ~ .panel .panel-h:first-of-type .sub, .grid2 .panel:nth-child(2) .panel-h .sub');
+  if (sub) sub.textContent = `${fmtInt(total)} tasks · all projects`;
+}
+
+/* ---------- agent usage ---------- */
+function renderAgentUsage(p){
+  // Backend does not yet track per-agent tokens; hide the panel entirely
+  // when no data is supplied rather than show misleading mock bars.
+  const wrap = $('.agent-usage'); if (!wrap) return;
+  const tokens = p.kpi?.tokens_24h;
+  if (tokens == null) {
+    wrap.innerHTML = '<div style="padding:10px 0;color:var(--ink-4);font-family:var(--mono);font-size:11px">per-agent token tracking not yet wired — see harness-observe roadmap</div>';
+  }
+}
+
+/* ---------- projects table ---------- */
+const SCORE_CLASS = score => (score == null || !Number.isFinite(score)) ? '' : score >= 85 ? 'high' : score >= 70 ? 'mid' : '';
+function trendSvg(arr){
+  if (!arr || !arr.length) return '<span style="color:var(--ink-4);font-family:var(--mono);font-size:11px">—</span>';
+  const w=58, h=20;
+  const mx = Math.max(...arr), mn = Math.min(...arr);
+  const denom = (mx - mn) || 1;
+  const pts = arr.map((v,i)=>`${(i/Math.max(1,arr.length-1))*w},${h-((v-mn)/denom)*(h-2)-1}`).join(' ');
+  return `<svg class="trend" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline fill="none" stroke="currentColor" stroke-width="1.3" points="${pts}"/></svg>`;
+}
+function renderProjects(p){
+  const projects = p.projects || [];
+  const table = $('#prj-table'); if (!table) return;
+  if (!projects.length) {
+    table.innerHTML = '<tbody><tr><td style="padding:20px;color:var(--ink-4);font-family:var(--mono);font-size:11px">no projects registered yet — register one via POST /projects</td></tr></tbody>';
+    return;
+  }
+  table.innerHTML = `
+    <thead><tr>
+      <th>Project</th><th>Pipeline</th><th>Merged 24h</th><th>Avg score</th><th>Trend</th><th>Worktrees</th><th>Tokens 24h</th><th>Agents</th><th></th>
+    </tr></thead>
+    <tbody>${projects.map(proj => {
+      const running = proj.running ?? 0;
+      const review  = proj.review  ?? 0;
+      const queued  = proj.queued  ?? 0;
+      const total = running + review + queued;
+      const rw = total ? (running/total)*100 : 0;
+      const rv = total ? (review /total)*100 : 0;
+      const rq = total ? (queued /total)*100 : 0;
+      const av = (proj.id || '?').slice(0,1).toUpperCase();
+      const scoreClass = SCORE_CLASS(proj.avg_score);
+      const scoreText = Number.isFinite(proj.avg_score) ? fmtScore(proj.avg_score) : '—';
+      const wt = proj.worktrees != null ? escHtml(proj.worktrees) : '—';
+      const toks = proj.tokens_24h != null ? escHtml(proj.tokens_24h) : '—';
+      const agents = (proj.agents && proj.agents.length) ? proj.agents.join(' · ') : '—';
+      const pathDisplay = proj.root || '';
+      return `<tr onclick="location.href='/?project=${encodeURIComponent(proj.id || '')}'">
+        <td><div class="pn"><div class="av">${escHtml(av)}</div><div><div><b>${escHtml(proj.id || basename(pathDisplay))}</b></div><div class="path">${escHtml(pathDisplay)}</div></div></div></td>
+        <td>
+          <div class="mini-bar">
+            <i class="running" style="width:${rw}%"></i>
+            <i class="review"  style="left:${rw}%;width:${rv}%"></i>
+            <i class="queued"  style="left:${rw+rv}%;width:${rq}%"></i>
+          </div>
+          <div class="pipe-meta">${running} running · ${review} review · ${queued} queued</div>
+        </td>
+        <td class="mono-cell">${fmtInt(proj.merged_24h ?? 0)}</td>
+        <td><span class="score ${scoreClass}">${scoreText}</span></td>
+        <td style="color:var(--rust)">${trendSvg(proj.trend)}</td>
+        <td class="mono-cell">${wt}</td>
+        <td class="mono-cell">${toks}</td>
+        <td class="mono-cell" style="color:var(--ink-3)">${escHtml(agents)}</td>
+        <td><span class="go">→</span></td>
+      </tr>`;
+    }).join('')}</tbody>`;
+}
+
+/* ---------- runtimes ---------- */
+const RT_ICONS = {
+  mac:   '<rect x="3" y="5" width="18" height="12" rx="1"/><path d="M2 20h20"/>',
+  linux: '<rect x="4" y="3" width="16" height="8" rx="1"/><rect x="4" y="13" width="16" height="8" rx="1"/>',
+  cloud: '<path d="M7 18a5 5 0 110-10 6 6 0 0111 3.5A4 4 0 0117 18z"/>',
+  server:'<rect x="3" y="5" width="18" height="14" rx="1"/><path d="M7 10h3M7 14h3M14 10h3"/>',
+};
+function classifyRuntime(rt){
+  const name = (rt.display_name || rt.id || '').toLowerCase();
+  if (name.includes('mac') || name.includes('book')) return 'mac';
+  if (name.includes('linux') || name.includes('ubuntu') || name.includes('debian')) return 'linux';
+  if (name.includes('api') || name.includes('cloud') || name.includes('openai') || name.includes('anthropic')) return 'cloud';
+  return 'server';
+}
+function renderRuntimes(p){
+  const wrap = $('#rt-wrap'); if (!wrap) return;
+  const runtimes = p.runtimes || [];
+  if (!runtimes.length) {
+    wrap.innerHTML = '<div style="color:var(--ink-4);font-family:var(--mono);font-size:11px;padding:12px">no runtime hosts connected</div>';
+    return;
+  }
+  wrap.innerHTML = runtimes.map(rt => {
+    const kind = classifyRuntime(rt);
+    const online = !!rt.online;
+    const capabilities = rt.capabilities || [];
+    const cpu = rt.cpu_pct, ram = rt.ram_pct;
+    const hasPerf = Number.isFinite(cpu) && Number.isFinite(ram);
+    return `
+    <div class="rtc" onclick="location.href='/#runtimes'">
+      <div class="rtc-h">
+        <div class="i"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6">${RT_ICONS[kind]}</svg></div>
+        <div><div class="n">${escHtml(rt.display_name || rt.id)}</div><div class="m">${escHtml(rt.id)}</div></div>
+        <div class="state ${online?'on':'off'}"><i></i>${online?'online':'offline'}</div>
+      </div>
+      <div class="rows">
+        <div><span>active leases</span><b>${fmtInt(rt.active_leases ?? 0)}</b></div>
+        <div><span>watched</span><b>${fmtInt(rt.watched_projects ?? 0)}</b></div>
+        ${hasPerf ? `
+          <div><span>cpu</span><b>${cpu}%</b></div>
+          <div><span>ram</span><b>${ram}%</b></div>
+          <div class="bar"><i style="width:${cpu}%"></i></div>
+        ` : `
+          <div><span>capabilities</span><b>${capabilities.length}</b></div>
+          <div><span>kind</span><b>${kind}</b></div>
+        `}
+      </div>
+      <div class="agents">${capabilities.map(a => `<span class="ag">${escHtml(a)}</span>`).join('') || '<span class="ag" style="color:var(--ink-4)">no caps declared</span>'}</div>
+    </div>`;
+  }).join('');
+}
+
+/* ---------- cluster heatmap ---------- */
+function renderHeatmap(p){
+  const el = $('#cluster'); if (!el) return;
+  const rows = p.heatmap?.rows || [];
+  if (!rows.length) {
+    el.innerHTML = '<div style="color:var(--ink-4);font-family:var(--mono);font-size:11px">no project activity in window</div>';
+    return;
+  }
+  el.innerHTML = rows.map(r => {
+    const cells = (r.intensity || []).map(v => {
+      const clamped = Math.max(0, Math.min(1, v));
+      const a = clamped < 0.05 ? 0 : clamped < 0.35 ? 30 : clamped < 0.70 ? 60 : 100;
+      const bg = a===0 ? 'var(--bg-2)' : `color-mix(in oklab,var(--rust) ${a}%,var(--bg-2))`;
+      const br = a===0 ? 'var(--line)' : 'var(--line-2)';
+      return `<i style="background:${bg};border-color:${br}"></i>`;
+    }).join('');
+    const active = (r.intensity || []).filter(v => v > 0.05).length;
+    return `<div class="cluster-row">
+      <div class="h"><span class="n">${escHtml(r.label)}</span><span class="m">${active} active bucket${active===1?'':'s'}</span></div>
+      <div class="grid">${cells}</div>
+    </div>`;
+  }).join('');
+}
+
+/* ---------- feed ---------- */
+function renderFeed(p){
+  const el = $('#feed'); if (!el) return;
+  const feed = p.feed || [];
+  if (!feed.length) {
+    el.innerHTML = '<div style="color:var(--ink-4);font-family:var(--mono);font-size:11px;padding:12px 0">no events in window</div>';
+    return;
+  }
+  el.innerHTML = feed.map(f => `
+    <div class="item">
+      <span class="ts">${escHtml(f.ago || '')} ago</span>
+      <div class="body"><span class="ev ${escHtml(f.level || '')}">${escHtml(f.kind || '')}</span>${escHtml(f.body || f.tool || '')}</div>
+      <span class="proj">${escHtml(f.project || 'system')}</span>
+    </div>`).join('');
+}
+
+/* ---------- alerts ---------- */
+const ALERT_ICONS = {
+  warn:'<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 3l10 18H2z"/><path d="M12 10v5M12 18v.5"/></svg>',
+  err: '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><path d="M8 8l8 8M16 8l-8 8"/></svg>',
+  ok:  '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 12l5 5L20 7"/></svg>',
+};
+function renderAlerts(p){
+  const el = $('#alerts'); if (!el) return;
+  const alerts = p.alerts || [];
+  // Update the "N open" subtitle.
+  const heads = $$('.alerts').map(a => a.previousElementSibling).filter(Boolean);
+  for (const h of heads) {
+    const sub = h.querySelector?.('.sub');
+    if (sub && sub.textContent.match(/open/)) sub.textContent = `${alerts.length} open`;
+  }
+  if (!alerts.length) {
+    el.innerHTML = '<div style="color:var(--ink-4);font-family:var(--mono);font-size:11px;padding:10px 0">no open alerts</div>';
+    return;
+  }
+  el.innerHTML = alerts.map(a => {
+    const lvl = a.level || 'warn';
+    return `<div class="al">
+      <div class="ic ${escHtml(lvl)}">${ALERT_ICONS[lvl] || ALERT_ICONS.warn}</div>
+      <div class="txt">${escHtml(a.msg || '')}<div class="sub">${escHtml(a.sub || '')}</div></div>
+      <span class="ts">${escHtml(a.ts || '')}</span>
+    </div>`;
+  }).join('');
+}
+
+/* ---------- boot ---------- */
+fetchOverview();
+setInterval(fetchOverview, REFRESH_MS);
+</script>
+</body>
+</html>

--- a/crates/harness-server/static/overview.html
+++ b/crates/harness-server/static/overview.html
@@ -528,7 +528,7 @@ button{font:inherit;color:inherit;background:none;border:0;cursor:pointer;paddin
       <div class="panel">
         <div class="panel-h">
           <h3>Projects</h3>
-          <span class="sub">click a row to enter the project dashboard</span>
+          <span class="sub">click a row to open the dashboard — per-project scope is tracked as a follow-up</span>
           <div class="r">
             <span>sort: activity ▾</span>
             <a onclick="location.href='/#projects'">manage →</a>
@@ -944,7 +944,10 @@ function renderProjects(p){
       const toks = proj.tokens_24h != null ? escHtml(proj.tokens_24h) : '—';
       const agents = (proj.agents && proj.agents.length) ? proj.agents.join(' · ') : '—';
       const pathDisplay = proj.root || '';
-      return `<tr onclick="location.href='/?project=${encodeURIComponent(proj.id || '')}'">
+      // The dashboard does not yet parse `?project=` / scope its view to
+      // a project, so passing the id in the URL would be a false promise.
+      // Plain navigation until the dashboard grows project scoping.
+      return `<tr onclick="location.href='/'">
         <td><div class="pn"><div class="av">${escHtml(av)}</div><div><div><b>${escHtml(proj.id || basename(pathDisplay))}</b></div><div class="path">${escHtml(pathDisplay)}</div></div></div></td>
         <td>
           <div class="mini-bar">


### PR DESCRIPTION
## Summary

- Adds a new system-level overview page at `GET /overview` (before any single project is selected), backed by `GET /api/overview` that aggregates live data across all projects, runtimes, and the event store.
- Ports the Claude Design export into the server: inline CSS/JS prototype is embedded via `include_str!`, the mocked JS data is swapped for a 5-second fetch loop that drives KPIs, stacked-area fleet throughput, project table, runtime cards, cluster heatmap, live activity feed, and heuristic alerts.
- Metrics that the project doesn't yet track (per-agent tokens, runtime CPU / RAM) return `null` and the UI falls back to a muted "not wired" note instead of fabricating numbers.

## Changes

- `task_db.rs` / `task_runner.rs` / `services/task.rs` — new `count_done_since` and `done_per_project_hour_since` queries (reuse existing `idx_tasks_status_updated` and `idx_tasks_project_status_updated` indexes).
- `handlers/overview.rs` — new `GET /api/overview` handler, reuses `TaskService`, `RuntimeHostManager`, `RuntimeProjectCache`, and the quality grader / event store.
- `overview.rs` + `static/overview.html` — page handler + design file with live fetch; auth middleware exempts `/overview` for the same reason `/` is exempt (no embedded token, public endpoint only).
- `http.rs` — routes `/overview` and `/api/overview`.

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p harness-server --lib` (776/776 passed)
- [x] New handler covered by 4 tests, including end-to-end JSON shape assertion
- [ ] Manual: start server, open `http://localhost:9800/overview`, verify KPI band / projects table / runtimes / feed render and refresh every 5 s
- [ ] Manual: confirm palette FAB persists choice across reload and shares `harness.palette` key with `/`

## Design

Ported from the Claude Design handoff bundle (`xw4fxxcTtCUBzKbpJkQueA`, `overview.html`). The chat transcript established a "system overview before picking a project" scope; this PR builds the live version. Nav links inside the page point to `/` (dashboard) so `system → project` flow works.