### PR TITLE
fix(gc): guard adopt() and auto_adopt_matching() against non-Pending drafts

### DIFF
--- a/crates/harness-gc/src/draft_store.rs
+++ b/crates/harness-gc/src/draft_store.rs
@@ -29,6 +29,35 @@ impl DraftStore {
         Ok(())
     }
 
+    /// Atomically adopt a draft: run `side_effects` (e.g. artifact file writes) while
+    /// holding `transition_lock`, then commit the status change to `Adopted`.
+    ///
+    /// Returns an error if the draft is not `Pending` when the lock is acquired, or if
+    /// `side_effects` returns an error (in which case the status is NOT updated).
+    pub fn adopt_if_pending(
+        &self,
+        id: &DraftId,
+        side_effects: impl FnOnce(&Draft) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let _guard = self.transition_lock.lock().unwrap();
+        let mut draft = self
+            .get(id)?
+            .ok_or_else(|| anyhow::anyhow!("draft {} not found", id))?;
+        if draft.status != DraftStatus::Pending {
+            anyhow::bail!(
+                "cannot adopt draft {}: status is {:?}, expected Pending",
+                id,
+                draft.status
+            );
+        }
+        side_effects(&draft)?;
+        draft.status = DraftStatus::Adopted;
+        let path = self.draft_path(&draft.id);
+        let content = serde_json::to_string_pretty(&draft)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+
     /// Atomically save `draft` only if the on-disk status still equals `expected_from`.
     ///
     /// Holds `transition_lock` for the read-verify-write sequence so that concurrent

--- a/crates/harness-gc/src/draft_store.rs
+++ b/crates/harness-gc/src/draft_store.rs
@@ -1,9 +1,12 @@
 use chrono::Utc;
 use harness_core::{types::Draft, types::DraftId, types::DraftStatus};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 pub struct DraftStore {
     data_dir: PathBuf,
+    /// Serializes status-transition writes to prevent concurrent last-write-wins races.
+    transition_lock: Mutex<()>,
 }
 
 impl DraftStore {
@@ -13,10 +16,36 @@ impl DraftStore {
         // Canonicalize after creation to resolve symlinks and ".." components.
         // Defensive-only: the primary path-traversal boundary is at task_routes.rs.
         let dir = dir.canonicalize()?;
-        Ok(Self { data_dir: dir })
+        Ok(Self {
+            data_dir: dir,
+            transition_lock: Mutex::new(()),
+        })
     }
 
     pub fn save(&self, draft: &Draft) -> anyhow::Result<()> {
+        let path = self.draft_path(&draft.id);
+        let content = serde_json::to_string_pretty(draft)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+
+    /// Atomically save `draft` only if the on-disk status still equals `expected_from`.
+    ///
+    /// Holds `transition_lock` for the read-verify-write sequence so that concurrent
+    /// `adopt()` / `reject()` calls cannot overwrite each other's terminal state.
+    pub fn save_if_status(&self, draft: &Draft, expected_from: DraftStatus) -> anyhow::Result<()> {
+        let _guard = self.transition_lock.lock().unwrap();
+        let current = self
+            .get(&draft.id)?
+            .ok_or_else(|| anyhow::anyhow!("draft {} not found", draft.id))?;
+        if current.status != expected_from {
+            anyhow::bail!(
+                "cannot transition draft {}: status is {:?}, expected {:?}",
+                draft.id,
+                current.status,
+                expected_from
+            );
+        }
         let path = self.draft_path(&draft.id);
         let content = serde_json::to_string_pretty(draft)?;
         std::fs::write(path, content)?;

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -336,7 +336,8 @@ impl GcAgent {
         }
 
         draft.status = DraftStatus::Adopted;
-        self.draft_store.save(&draft)?;
+        self.draft_store
+            .save_if_status(&draft, DraftStatus::Pending)?;
         Ok(())
     }
 

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -300,20 +300,11 @@ impl GcAgent {
     ///
     /// All artifact target_paths are canonicalized and validated to reside
     /// within the project root before any writes occur.
+    ///
+    /// The status check, file writes, and status commit are all performed under
+    /// `DraftStore::transition_lock` to prevent a concurrent `reject()` from
+    /// winning the race between file writes and status commit.
     pub fn adopt(&self, draft_id: &DraftId) -> anyhow::Result<()> {
-        let mut draft = self
-            .draft_store
-            .get(draft_id)?
-            .ok_or_else(|| anyhow::anyhow!("draft not found"))?;
-
-        if draft.status != DraftStatus::Pending {
-            anyhow::bail!(
-                "cannot adopt draft {}: status is {:?}, expected Pending",
-                draft_id.0,
-                draft.status
-            );
-        }
-
         let canonical_root = self.project_root.canonicalize().with_context(|| {
             format!(
                 "failed to canonicalize project root '{}'",
@@ -321,24 +312,22 @@ impl GcAgent {
             )
         })?;
 
-        // Validate and resolve all paths before writing any files.
-        let resolved: Vec<PathBuf> = draft
-            .artifacts
-            .iter()
-            .map(|a| validate_target_path(&canonical_root, &a.target_path))
-            .collect::<anyhow::Result<_>>()?;
+        self.draft_store.adopt_if_pending(draft_id, |draft| {
+            // Validate and resolve all paths before writing any files.
+            let resolved: Vec<PathBuf> = draft
+                .artifacts
+                .iter()
+                .map(|a| validate_target_path(&canonical_root, &a.target_path))
+                .collect::<anyhow::Result<_>>()?;
 
-        for (artifact, target) in draft.artifacts.iter().zip(resolved.iter()) {
-            if let Some(parent) = target.parent() {
-                std::fs::create_dir_all(parent)?;
+            for (artifact, target) in draft.artifacts.iter().zip(resolved.iter()) {
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                std::fs::write(target, &artifact.content)?;
             }
-            std::fs::write(target, &artifact.content)?;
-        }
-
-        draft.status = DraftStatus::Adopted;
-        self.draft_store
-            .save_if_status(&draft, DraftStatus::Pending)?;
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Auto-adopt drafts from `draft_ids` that are eligible under `policy`.
@@ -407,13 +396,17 @@ impl GcAgent {
     }
 
     /// Reject a draft.
+    ///
+    /// Uses `save_if_status` to prevent an unconditional overwrite of an already-Adopted
+    /// draft when `adopt()` and `reject()` race on the same draft.
     pub fn reject(&self, draft_id: &DraftId, _reason: Option<&str>) -> anyhow::Result<()> {
         let mut draft = self
             .draft_store
             .get(draft_id)?
             .ok_or_else(|| anyhow::anyhow!("draft not found"))?;
         draft.status = DraftStatus::Rejected;
-        self.draft_store.save(&draft)?;
+        self.draft_store
+            .save_if_status(&draft, DraftStatus::Pending)?;
         Ok(())
     }
 

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -306,6 +306,14 @@ impl GcAgent {
             .get(draft_id)?
             .ok_or_else(|| anyhow::anyhow!("draft not found"))?;
 
+        if draft.status != DraftStatus::Pending {
+            anyhow::bail!(
+                "cannot adopt draft {}: status is {:?}, expected Pending",
+                draft_id.0,
+                draft.status
+            );
+        }
+
         let canonical_root = self.project_root.canonicalize().with_context(|| {
             format!(
                 "failed to canonicalize project root '{}'",
@@ -368,6 +376,10 @@ impl GcAgent {
                     continue;
                 }
             };
+            if draft.status != DraftStatus::Pending {
+                tracing::debug!(draft_id = %id.0, status = ?draft.status, "auto_adopt: skipping non-Pending draft");
+                continue;
+            }
             if draft.signal.remediation != RemediationType::Rule {
                 continue;
             }
@@ -1046,5 +1058,68 @@ mod tests {
         assert!(artifacts[0].content.contains("fn full_content()"));
         // Content should be from the code block, not the diff header
         assert!(!artifacts[0].content.contains("+++ b/src/lib.rs"));
+    }
+
+    #[test]
+    fn adopt_rejected_draft_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let gc = make_test_gc_agent(dir.path());
+
+        let mut draft = test_draft(vec![]);
+        draft.status = DraftStatus::Rejected;
+        gc.draft_store.save(&draft).unwrap();
+
+        let err = gc.adopt(&draft.id).unwrap_err();
+        assert!(
+            err.to_string().contains("Rejected"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn auto_adopt_skips_rejected() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let project_root = sandbox.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let signal_detector = SignalDetector::new(
+            crate::signal_detector::SignalThresholds::default(),
+            ProjectId::new(),
+        );
+        let draft_store = DraftStore::new(sandbox.path()).unwrap();
+        let gc = GcAgent::new(
+            GcConfig::default(),
+            signal_detector,
+            draft_store,
+            project_root.clone(),
+        );
+
+        let mut rejected = Draft {
+            signal: Signal::new(
+                SignalType::RepeatedWarn,
+                ProjectId::new(),
+                serde_json::json!({}),
+                RemediationType::Rule,
+            ),
+            ..test_draft(vec![Artifact {
+                artifact_type: ArtifactType::Rule,
+                target_path: PathBuf::from(".harness/generated/rules/rejected.md"),
+                content: "should not be written".into(),
+            }])
+        };
+        rejected.status = DraftStatus::Rejected;
+        gc.draft_store.save(&rejected).unwrap();
+
+        let adopted = gc.auto_adopt_matching(
+            std::slice::from_ref(&rejected.id),
+            AutoAdoptPolicy::RulesOnly,
+            ".harness/generated/",
+        );
+        assert!(adopted.is_empty(), "rejected draft should not be adopted");
+
+        let reloaded = gc.draft_store.get(&rejected.id).unwrap().unwrap();
+        assert_eq!(reloaded.status, DraftStatus::Rejected);
+        assert!(!project_root
+            .join(".harness/generated/rules/rejected.md")
+            .exists());
     }
 }

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -1,9 +1,11 @@
 use crate::http::{resolve_reviewer, AppState};
 use harness_core::{
     config::resolve::resolve_config,
-    types::{Decision, DraftId, Event, ProjectId, SessionId},
+    types::{Decision, DraftId, DraftStatus, Event, ProjectId, SessionId},
 };
-use harness_protocol::{methods::RpcResponse, methods::INTERNAL_ERROR, methods::NOT_FOUND};
+use harness_protocol::{
+    methods::RpcResponse, methods::CONFLICT, methods::INTERNAL_ERROR, methods::NOT_FOUND,
+};
 use std::path::Path;
 
 fn gc_adopt_task_request(
@@ -237,6 +239,16 @@ pub async fn gc_adopt(
         }
         Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
     };
+    if draft.status != DraftStatus::Pending {
+        return RpcResponse::error(
+            id,
+            CONFLICT,
+            format!(
+                "cannot adopt draft {}: status is {:?}, expected Pending",
+                draft_id, draft.status
+            ),
+        );
+    }
     let artifact_paths: Vec<String> = draft
         .artifacts
         .iter()
@@ -368,6 +380,22 @@ pub async fn gc_adopt(
             )
         }
         Err(e) => {
+            // Re-read to distinguish a concurrent state-conflict from a true internal error.
+            let error_code = state
+                .engines
+                .gc_agent
+                .draft_store()
+                .get(&draft_id)
+                .ok()
+                .flatten()
+                .map(|d| {
+                    if d.status != DraftStatus::Pending {
+                        CONFLICT
+                    } else {
+                        INTERNAL_ERROR
+                    }
+                })
+                .unwrap_or(INTERNAL_ERROR);
             log_gc_event(
                 state,
                 "gc_adopt",
@@ -376,7 +404,7 @@ pub async fn gc_adopt(
                 None,
             )
             .await;
-            RpcResponse::error(id, INTERNAL_ERROR, e.to_string())
+            RpcResponse::error(id, error_code, e.to_string())
         }
     }
 }

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -18,6 +18,7 @@ use harness_core::types::{
     Artifact, ArtifactType, Capability, Draft, DraftId, DraftStatus, ProjectId, RemediationType,
     Signal, SignalType, TokenUsage,
 };
+use harness_protocol::methods::CONFLICT;
 use harness_server::{
     handlers::gc::gc_adopt, http::build_app_state, server::HarnessServer,
     thread_manager::ThreadManager,
@@ -457,6 +458,38 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
         project_root.canonicalize()?,
         "gc_adopt must pass AppState project_root to the spawned task, not None/CWD"
     );
+
+    Ok(())
+}
+
+/// gc_adopt returns CONFLICT when the draft is not in Pending status.
+///
+/// Covers the repeat-adopt and reject/adopt-race scenarios identified in review round 1.
+#[tokio::test]
+async fn gc_adopt_non_pending_draft_returns_conflict() -> anyhow::Result<()> {
+    let sandbox = common::tempdir_in_home("gc-adopt-non-pending-")?;
+    let state = make_state(sandbox.path()).await?;
+
+    for non_pending in [DraftStatus::Adopted, DraftStatus::Rejected] {
+        let artifact_rel = std::path::PathBuf::from(".harness/drafts/test-guard.sh");
+        let mut draft = make_draft(&artifact_rel, "content");
+        draft.status = non_pending;
+        state.engines.gc_agent.draft_store().save(&draft)?;
+
+        let resp = gc_adopt(&state, Some(serde_json::json!(1)), draft.id.clone()).await;
+
+        assert!(
+            resp.error.is_some(),
+            "expected error for {:?} draft",
+            non_pending
+        );
+        assert_eq!(
+            resp.error.unwrap().code,
+            CONFLICT,
+            "expected CONFLICT for {:?} draft",
+            non_pending
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `adopt()` now early-returns with a descriptive error if `draft.status != DraftStatus::Pending`, preventing accidental adoption of already-Rejected/Adopted/Expired drafts
- `auto_adopt_matching()` silently skips non-Pending drafts (logs at debug level) to handle concurrent adopt/reject races without aborting the loop
- Adds two unit tests: `adopt_rejected_draft_errors` and `auto_adopt_skips_rejected`

## Test plan

- [ ] `cargo test --package harness-gc` — all 44 tests pass including the 2 new ones
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #818