### PR TITLE
perf(learn): per-agent scan watermark in QualityTrigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "annotate-snippets"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +446,33 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -570,6 +609,61 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1115,6 +1209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "harness-agents"
 version = "0.6.33"
 dependencies = [
@@ -1225,6 +1330,7 @@ version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "harness-core",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2177,6 +2283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2580,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2761,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2864,6 +3024,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3693,6 +3862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,6 +4546,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/harness-observe/Cargo.toml
+++ b/crates/harness-observe/Cargo.toml
@@ -20,3 +20,8 @@ opentelemetry-otlp = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+criterion = "0.5"
+
+[[bench]]
+name = "event_store_bench"
+harness = false

--- a/crates/harness-observe/benches/event_store_bench.rs
+++ b/crates/harness-observe/benches/event_store_bench.rs
@@ -1,0 +1,65 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use harness_core::types::{Decision, Event, EventFilters, SessionId};
+use harness_observe::event_store::EventStore;
+
+const EVENT_COUNT: usize = 10_000;
+// Watermark placed at the 9900th event, leaving ~100 events in the incremental window.
+const WATERMARK_INDEX: usize = 9_900;
+
+fn bench_event_scan(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    let store = rt.block_on(async {
+        let store = EventStore::new(dir.path()).await.unwrap();
+
+        // Seed events with monotonically increasing timestamps (oldest first).
+        for i in 0..EVENT_COUNT {
+            let mut event = Event::new(SessionId::new(), "pre_tool_use", "Edit", Decision::Pass);
+            event.ts = chrono::Utc::now() - chrono::Duration::seconds((EVENT_COUNT - i) as i64);
+
+            if i + 1 == WATERMARK_INDEX {
+                store
+                    .set_scan_watermark("bench_project", "gc", event.ts)
+                    .await
+                    .unwrap();
+            }
+            store.log(&event).await.unwrap();
+        }
+        store
+    });
+
+    let mut group = c.benchmark_group("event_scan");
+
+    group.bench_function("full_scan_10k", |b| {
+        b.iter(|| rt.block_on(store.query(&EventFilters::default())).unwrap());
+    });
+
+    group.bench_function("watermarked_scan_100", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let ts = store
+                    .get_scan_watermark("bench_project", "gc")
+                    .await
+                    .unwrap();
+                store
+                    .query(&EventFilters {
+                        since: ts,
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap()
+            })
+        });
+    });
+
+    group.finish();
+    // Keep `dir` alive until after the benchmark group completes.
+    drop(dir);
+}
+
+criterion_group!(benches, bench_event_scan);
+criterion_main!(benches);

--- a/crates/harness-observe/src/event_store.rs
+++ b/crates/harness-observe/src/event_store.rs
@@ -35,6 +35,16 @@ static EVENT_MIGRATIONS: &[Migration] = &[
         description: "add content column to events table",
         sql: "ALTER TABLE events ADD COLUMN content TEXT",
     },
+    Migration {
+        version: 3,
+        description: "create scan_watermarks table",
+        sql: "CREATE TABLE IF NOT EXISTS scan_watermarks (
+            project      TEXT NOT NULL,
+            agent_id     TEXT NOT NULL,
+            last_scan_ts TEXT NOT NULL,
+            PRIMARY KEY (project, agent_id)
+        )",
+    },
 ];
 
 /// Event store backed by SQLite (same database as other harness stores).
@@ -572,6 +582,50 @@ impl EventStore {
         if let Err(e) = self.log(&event).await {
             tracing::warn!("periodic_retry: failed to log summary event: {e}");
         }
+    }
+
+    /// Return the last-scan watermark for a `(project, agent_id)` pair, or `None`
+    /// if no watermark has been recorded yet.
+    pub async fn get_scan_watermark(
+        &self,
+        project: &str,
+        agent_id: &str,
+    ) -> anyhow::Result<Option<DateTime<Utc>>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT last_scan_ts FROM scan_watermarks WHERE project = ? AND agent_id = ?",
+        )
+        .bind(project)
+        .bind(agent_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            None => Ok(None),
+            Some((ts_str,)) => {
+                let ts = chrono::DateTime::parse_from_rfc3339(&ts_str)
+                    .map_err(|e| anyhow::anyhow!("invalid watermark ts '{ts_str}': {e}"))?
+                    .with_timezone(&chrono::Utc);
+                Ok(Some(ts))
+            }
+        }
+    }
+
+    /// Persist (or replace) the last-scan watermark for a `(project, agent_id)` pair.
+    pub async fn set_scan_watermark(
+        &self,
+        project: &str,
+        agent_id: &str,
+        ts: DateTime<Utc>,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO scan_watermarks (project, agent_id, last_scan_ts)
+             VALUES (?, ?, ?)",
+        )
+        .bind(project)
+        .bind(agent_id)
+        .bind(ts.to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     pub async fn query_recent(&self, duration: std::time::Duration) -> anyhow::Result<Vec<Event>> {
@@ -1209,6 +1263,62 @@ mod tests {
         let results = store.query(&EventFilters::default()).await?;
         assert_eq!(results.len(), 1, "only the newest watermark should remain");
         assert_eq!(results[0].id, wm_new.id);
+        store.close().await;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn watermark_returns_none_before_first_set() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = EventStore::new(dir.path()).await?;
+        let result = store.get_scan_watermark("proj", "gc").await?;
+        assert!(result.is_none());
+        store.close().await;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_then_get_watermark_roundtrip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = EventStore::new(dir.path()).await?;
+        let ts = chrono::Utc::now();
+        store.set_scan_watermark("proj", "gc", ts).await?;
+        let retrieved = store
+            .get_scan_watermark("proj", "gc")
+            .await?
+            .expect("watermark must exist after set");
+        assert_eq!(retrieved.timestamp(), ts.timestamp());
+        store.close().await;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn watermarks_are_per_project_and_agent() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = EventStore::new(dir.path()).await?;
+        let ts = chrono::Utc::now();
+        store.set_scan_watermark("proj1", "gc", ts).await?;
+        let r1 = store.get_scan_watermark("proj1", "other").await?;
+        assert!(r1.is_none(), "different agent_id must not share watermark");
+        let r2 = store.get_scan_watermark("proj2", "gc").await?;
+        assert!(r2.is_none(), "different project must not share watermark");
+        store.close().await;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_watermark_overwrites_previous() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = EventStore::new(dir.path()).await?;
+        let ts1 = chrono::Utc::now() - chrono::Duration::hours(1);
+        let ts2 = chrono::Utc::now();
+        store.set_scan_watermark("proj", "gc", ts1).await?;
+        store.set_scan_watermark("proj", "gc", ts2).await?;
+        let retrieved = store
+            .get_scan_watermark("proj", "gc")
+            .await?
+            .expect("watermark must exist");
+        assert_eq!(retrieved.timestamp(), ts2.timestamp());
         store.close().await;
         Ok(())
     }

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -109,6 +109,38 @@ pub(crate) async fn build_engines(
         });
     }
 
+    // ── GC watermark migration ────────────────────────────────────────────────
+    // On first boot after upgrading from file-checkpoint to KV-watermark, seed
+    // the KV watermark from gc-checkpoint.json so the first incremental scan
+    // doesn't regress to a full O(total-events) scan.
+    let project_key = project_root.to_string_lossy().into_owned();
+    match events.get_scan_watermark(&project_key, "gc").await {
+        Ok(None) => {
+            // No KV watermark yet — try the legacy file checkpoint.
+            let checkpoint_path = harness_gc::checkpoint::default_checkpoint_path(project_root);
+            if let Some(cp) = harness_gc::checkpoint::GcCheckpoint::load(&checkpoint_path) {
+                match events
+                    .set_scan_watermark(&project_key, "gc", cp.last_scan_at)
+                    .await
+                {
+                    Ok(()) => {
+                        tracing::info!(
+                            ts = %cp.last_scan_at,
+                            "gc: migrated legacy checkpoint to KV watermark"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("gc: failed to seed KV watermark from checkpoint: {e}");
+                    }
+                }
+            }
+        }
+        Ok(Some(_)) => {} // already seeded — nothing to do
+        Err(e) => {
+            tracing::warn!("gc: failed to read KV watermark during migration check: {e}");
+        }
+    }
+
     // ── GC agent ─────────────────────────────────────────────────────────────
     let signal_detector = harness_gc::signal_detector::SignalDetector::new(
         server.config.gc.signal_thresholds.clone().into(),

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -120,15 +120,16 @@ pub(crate) async fn build_engines(
         ),
     );
     let draft_store = harness_gc::draft_store::DraftStore::new(data_dir)?;
-    let gc_agent = Arc::new(
-        harness_gc::gc_agent::GcAgent::new(
-            server.config.gc.clone(),
-            signal_detector,
-            draft_store,
-            project_root.to_path_buf(),
-        )
-        .with_checkpoint(data_dir.join("gc-checkpoint.json")),
-    );
+    // No file checkpoint: QualityTrigger owns the scan watermark via the KV
+    // store (get_scan_watermark / set_scan_watermark).  A second file-based
+    // cursor in GcAgent would create two independent cursors that can diverge
+    // and silently drop events.
+    let gc_agent = Arc::new(harness_gc::gc_agent::GcAgent::new(
+        server.config.gc.clone(),
+        signal_detector,
+        draft_store,
+        project_root.to_path_buf(),
+    ));
 
     // ── Skill store ───────────────────────────────────────────────────────────
     let mut skill_store = harness_skills::store::SkillStore::new()

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -286,12 +286,12 @@ impl QualityTrigger {
             tracing::warn!("quality_trigger: no agent registered, skipping auto-GC");
             return;
         };
-        // Query events since the GC checkpoint so the DB restriction is applied at
-        // query time rather than loading the entire event history into memory.
-        // Falls back to a full scan when no checkpoint exists (first run).
-        // gc_agent.run() applies filter_events_since() again internally, which is a
-        // no-op on the already-restricted slice — this is intentional.
-        let gc_since = self.gc_agent.checkpoint_since();
+        let project_key = self.project_root.to_string_lossy().into_owned();
+        let gc_since = self
+            .events
+            .get_scan_watermark(&project_key, "gc")
+            .await
+            .unwrap_or(None);
         let all_events = match self
             .events
             .query(&EventFilters {
@@ -315,6 +315,13 @@ impl QualityTrigger {
         .await
         {
             Ok(Ok(report)) => {
+                if let Err(e) = self
+                    .events
+                    .set_scan_watermark(&project_key, "gc", Utc::now())
+                    .await
+                {
+                    tracing::warn!("quality_trigger: failed to update scan watermark: {e}");
+                }
                 if !matches!(self.auto_adopt, AutoAdoptPolicy::Off) && !report.draft_ids.is_empty()
                 {
                     let adopted = self.gc_agent.auto_adopt_matching(

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -292,6 +292,10 @@ impl QualityTrigger {
             .get_scan_watermark(&project_key, "gc")
             .await
             .unwrap_or(None);
+        // Capture the scan boundary before querying so that events written
+        // while gc_agent.run() executes are included in the NEXT run, not
+        // silently skipped (same pattern as periodic_reviewer).
+        let scan_ts = Utc::now();
         let all_events = match self
             .events
             .query(&EventFilters {
@@ -317,7 +321,7 @@ impl QualityTrigger {
             Ok(Ok(report)) => {
                 if let Err(e) = self
                     .events
-                    .set_scan_watermark(&project_key, "gc", Utc::now())
+                    .set_scan_watermark(&project_key, "gc", scan_ts)
                     .await
                 {
                     tracing::warn!("quality_trigger: failed to update scan watermark: {e}");

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -319,12 +319,23 @@ impl QualityTrigger {
         .await
         {
             Ok(Ok(report)) => {
-                if let Err(e) = self
-                    .events
-                    .set_scan_watermark(&project_key, "gc", scan_ts)
-                    .await
-                {
-                    tracing::warn!("quality_trigger: failed to update scan watermark: {e}");
+                // Only advance the watermark when the run completed without
+                // errors.  Partial failures (e.g. a transient agent error or a
+                // draft-store write) are recorded in report.errors; keeping the
+                // watermark behind lets the next scan retry those events.
+                if report.errors.is_empty() {
+                    if let Err(e) = self
+                        .events
+                        .set_scan_watermark(&project_key, "gc", scan_ts)
+                        .await
+                    {
+                        tracing::warn!("quality_trigger: failed to update scan watermark: {e}");
+                    }
+                } else {
+                    tracing::warn!(
+                        error_count = report.errors.len(),
+                        "quality_trigger: gc run had errors; watermark not advanced for retry"
+                    );
                 }
                 if !matches!(self.auto_adopt, AutoAdoptPolicy::Off) && !report.draft_ids.is_empty()
                 {


### PR DESCRIPTION
## Summary

- Adds `scan_watermarks` SQLite table to `EventStore` (migration v3) with `get_scan_watermark` / `set_scan_watermark` keyed by `(project, agent_id)`
- `QualityTrigger` now reads the KV watermark before querying events for `gc_agent.run`, reducing the event slice from O(total events) to O(events since last scan)
- Watermark is written after every successful `gc_agent.run` (`Ok(Ok(_))` branch only — not on error or timeout)
- Adds 4 unit tests: none-before-set, roundtrip, per-project/agent isolation, overwrite semantics
- Adds `criterion` benchmark (`benches/event_store_bench.rs`) comparing full-scan vs watermarked-scan on a 10k-event synthetic log

## Test plan

- [ ] `cargo test --package harness-observe` — 4 new watermark tests pass
- [ ] `cargo test --workspace` — all tests pass (confirmed locally)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean (confirmed locally)
- [ ] `cargo bench --package harness-observe -- event_scan` — runs before/after comparison

Closes #819