### PR TITLE
fix(health): surface degraded persistence state in /health endpoint

### DIFF
--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -15,6 +15,10 @@ pub(crate) struct ServicesBundle {
     pub execution_svc: Arc<dyn crate::services::execution::ExecutionService>,
     pub runtime_hosts: Arc<crate::runtime_hosts::RuntimeHostManager>,
     pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
+    /// True when the runtime state snapshot load was attempted but failed
+    /// (schema mismatch, I/O error, or unexpected outcome). The store itself
+    /// may still be usable for future writes; only the recovery was incomplete.
+    pub snapshot_load_failed: bool,
 }
 
 /// Initialize interceptors, service impls, runtime host/project-cache managers,
@@ -77,6 +81,7 @@ pub(crate) async fn build_services(
         Arc::new(crate::runtime_project_cache::RuntimeProjectCacheManager::new());
 
     // Restore persisted runtime state snapshot when available.
+    let mut snapshot_load_failed = false;
     if let Some(store) = registry.runtime_state_store.as_ref() {
         match store.try_load_snapshot().await {
             Ok((Some(snapshot), crate::runtime_state_store::LoadSnapshotOutcome::Loaded)) => {
@@ -102,18 +107,22 @@ pub(crate) async fn build_services(
                     expected_schema_version = expected,
                     "runtime state snapshot skipped on startup due to schema mismatch"
                 );
+                snapshot_load_failed = true;
             }
             Ok((None, crate::runtime_state_store::LoadSnapshotOutcome::Loaded)) => {
                 tracing::warn!("runtime state snapshot load returned loaded outcome without data");
+                snapshot_load_failed = true;
             }
             Ok((Some(_), outcome)) => {
                 tracing::warn!(
                     ?outcome,
                     "runtime state snapshot load returned unexpected outcome"
                 );
+                snapshot_load_failed = true;
             }
             Err(e) => {
                 tracing::warn!("failed to load runtime state snapshot on startup: {e}");
+                snapshot_load_failed = true;
             }
         }
     }
@@ -138,6 +147,7 @@ pub(crate) async fn build_services(
         execution_svc,
         runtime_hosts,
         runtime_project_cache,
+        snapshot_load_failed,
     })
 }
 

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -139,6 +139,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         Arc::new(AtomicBool::new(in_window))
     };
 
+    // NOTE: add a matching entry here whenever a new optional store is added.
+    let mut degraded_subsystems: Vec<&'static str> = Vec::new();
+    if storage.q_values.is_none() {
+        degraded_subsystems.push("q_value_store");
+    }
+    if registry.runtime_state_store.is_none() {
+        degraded_subsystems.push("runtime_state_store");
+    }
+    if registry.workspace_mgr.is_none() {
+        degraded_subsystems.push("workspace_manager");
+    }
+
     Ok(AppState {
         core: CoreServices {
             server,
@@ -195,6 +207,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             ws_shutdown_tx: broadcast::channel(1).0,
         },
         interceptors: services.interceptors,
+        degraded_subsystems,
         intake: IntakeServices {
             feishu_intake: intake.feishu_intake,
             github_pollers: intake.github_pollers.into_iter().map(|(_, p)| p).collect(),

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -139,6 +139,17 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         Arc::new(AtomicBool::new(in_window))
     };
 
+    let review_store = {
+        let review_db_path = harness_core::config::dirs::default_db_path(&dir, "reviews");
+        match crate::review_store::ReviewStore::open(&review_db_path).await {
+            Ok(store) => Some(Arc::new(store)),
+            Err(e) => {
+                tracing::warn!("review store init failed, reviews will not be persisted: {e}");
+                None
+            }
+        }
+    };
+
     // NOTE: add a matching entry here whenever a new optional store is added.
     let mut degraded_subsystems: Vec<&'static str> = Vec::new();
     if storage.q_values.is_none() {
@@ -149,6 +160,9 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     }
     if registry.workspace_mgr.is_none() {
         degraded_subsystems.push("workspace_manager");
+    }
+    if review_store.is_none() {
+        degraded_subsystems.push("review_store");
     }
 
     Ok(AppState {
@@ -176,18 +190,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             password_reset_rate_limiter: Arc::new(rate_limit::PasswordResetRateLimiter::new(
                 password_reset_rate_limit,
             )),
-            review_store: {
-                let review_db_path = harness_core::config::dirs::default_db_path(&dir, "reviews");
-                match crate::review_store::ReviewStore::open(&review_db_path).await {
-                    Ok(store) => Some(Arc::new(store)),
-                    Err(e) => {
-                        tracing::warn!(
-                            "review store init failed, reviews will not be persisted: {e}"
-                        );
-                        None
-                    }
-                }
-            },
+            review_store,
         },
         concurrency: ConcurrencyServices {
             task_queue: intake.task_queue,

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -155,7 +155,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     if storage.q_values.is_none() {
         degraded_subsystems.push("q_value_store");
     }
-    if registry.runtime_state_store.is_none() {
+    if registry.runtime_state_store.is_none() || services.snapshot_load_failed {
         degraded_subsystems.push("runtime_state_store");
     }
     if registry.workspace_mgr.is_none() {

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -225,7 +225,21 @@ async fn shutdown_signal() {
 
 pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let count = state.core.tasks.count();
-    Json(json!({"status": "ok", "tasks": count}))
+    let dirty = state.is_runtime_state_dirty();
+    let degraded = &state.degraded_subsystems;
+    let status = if degraded.is_empty() && !dirty {
+        "ok"
+    } else {
+        "degraded"
+    };
+    Json(json!({
+        "status": status,
+        "tasks": count,
+        "persistence": {
+            "degraded_subsystems": degraded,
+            "runtime_state_dirty": dirty,
+        }
+    }))
 }
 
 /// GET /projects/queue-stats — per-project queue stats alongside the global queue summary.

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -101,6 +101,9 @@ pub struct AppState {
     pub notifications: NotificationServices,
     pub intake: IntakeServices,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    /// Subsystem names that degraded to `None` at startup (optional stores only).
+    /// Set once during `build_app_state`; read-only thereafter.
+    pub degraded_subsystems: Vec<&'static str>,
 
     // ── Service layer ────────────────────────────────────────────────────────
     // Trait-based abstractions for independent testability. Each service owns

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -168,6 +168,7 @@ async fn make_test_state_with(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake,
             github_pollers: vec![],
@@ -342,33 +343,98 @@ fn webhook_signature(secret: &str, payload: &[u8]) -> String {
     format!("sha256={digest_hex}")
 }
 
+#[derive(serde::Deserialize, Debug)]
+struct HealthResponse {
+    status: String,
+    tasks: u64,
+    persistence: PersistenceBlock,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct PersistenceBlock {
+    degraded_subsystems: Vec<String>,
+    runtime_state_dirty: bool,
+}
+
+async fn call_health(state: Arc<AppState>) -> anyhow::Result<HealthResponse> {
+    use http_body_util::BodyExt;
+    let app = Router::new()
+        .route("/health", get(health_check))
+        .with_state(state);
+    let response = app
+        .oneshot(Request::builder().uri("/health").body(Body::empty())?)
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await?.to_bytes();
+    Ok(serde_json::from_slice(&body)?)
+}
+
 #[tokio::test]
 async fn health_endpoint_returns_ok_and_task_count() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
-
-    let app = Router::new()
-        .route("/health", get(health_check))
-        .with_state(state);
-
-    let response = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty())?)
-        .await?;
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    #[derive(serde::Deserialize, Debug)]
-    struct HealthResponse {
-        status: String,
-        tasks: u64,
-    }
-
-    use http_body_util::BodyExt;
-    let body = response.into_body().collect().await?.to_bytes();
-    let health: HealthResponse = serde_json::from_slice(&body)?;
-
+    let health = call_health(state).await?;
     assert_eq!(health.status, "ok");
     assert_eq!(health.tasks, 0);
+    assert!(health.persistence.degraded_subsystems.is_empty());
+    assert!(!health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_when_subsystem_missing() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    Arc::get_mut(&mut state).unwrap().degraded_subsystems = vec!["q_value_store"];
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert_eq!(health.persistence.degraded_subsystems, ["q_value_store"]);
+    assert!(!health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
+    use std::sync::atomic::Ordering;
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    state.runtime_state_dirty.store(true, Ordering::Release);
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert!(health.persistence.degraded_subsystems.is_empty());
+    assert!(health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_multiple_subsystems() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    Arc::get_mut(&mut state).unwrap().degraded_subsystems =
+        vec!["q_value_store", "runtime_state_store"];
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert_eq!(
+        health.persistence.degraded_subsystems,
+        ["q_value_store", "runtime_state_store"]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_both_conditions() -> anyhow::Result<()> {
+    use std::sync::atomic::Ordering;
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    Arc::get_mut(&mut state).unwrap().degraded_subsystems = vec!["workspace_manager"];
+    state.runtime_state_dirty.store(true, Ordering::Release);
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert_eq!(
+        health.persistence.degraded_subsystems,
+        ["workspace_manager"]
+    );
+    assert!(health.persistence.runtime_state_dirty);
     Ok(())
 }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -113,6 +113,7 @@ async fn make_test_state_with_config_and_registry(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
@@ -1434,6 +1435,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -229,6 +229,7 @@ mod tests {
                 ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
             },
             interceptors: vec![],
+            degraded_subsystems: vec![],
             intake: crate::http::IntakeServices {
                 feishu_intake: None,
                 github_pollers: vec![],

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -191,6 +191,7 @@ async fn make_state_inner(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -369,6 +369,7 @@ mod tests {
                 ws_shutdown_tx,
             },
             interceptors: vec![],
+            degraded_subsystems: vec![],
             intake: crate::http::IntakeServices {
                 feishu_intake: None,
                 github_pollers: vec![],


### PR DESCRIPTION
## Summary

- Add `degraded_subsystems: Vec<&'static str>` to `AppState`, populated at startup when optional stores (`q_value_store`, `runtime_state_store`, `workspace_manager`) fail to initialize
- Extend `/health` to return `"degraded"` status and a `persistence` block with subsystem names and `runtime_state_dirty` flag; HTTP status stays 200
- Add 5 new tests covering: all-ok, single subsystem missing, dirty flag only, multiple subsystems, and both conditions combined

## Response shape change

```json
{
  "status": "ok|degraded",
  "tasks": 0,
  "persistence": {
    "degraded_subsystems": [],
    "runtime_state_dirty": false
  }
}
```

Monitoring that hardcodes `"ok"` will now alert on degradation — this is the intended behavior.

## Test plan
- [x] `cargo test --package harness-server -- health` — 5 tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] Pre-commit hook (fmt + clippy + test) — passed

Closes #695