### PR TITLE
refactor: unify project identity via canonical path across registry, queue, and config

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -68,8 +68,21 @@ pub struct ConcurrencyConfig {
     /// Seconds of silence from the agent stream before declaring a stall. Default: 300.
     #[serde(default = "default_stall_timeout_secs")]
     pub stall_timeout_secs: u64,
-    /// Per-project concurrency limits. Maps project path string → max concurrent tasks.
+    /// Per-project concurrency limits.
+    ///
+    /// Maps **canonical filesystem path** → max concurrent tasks for that project.
+    /// Keys must be the absolute, canonical path to the project root — the same
+    /// value produced by `ProjectId::from_path(&root)` — because the queue and
+    /// registry both key on that form. Non-absolute keys are accepted but will
+    /// never match any project at runtime (a warning is emitted on startup).
+    ///
     /// Projects not listed here use the global `max_concurrent_tasks` limit.
+    ///
+    /// Example:
+    /// ```toml
+    /// [concurrency.per_project]
+    /// "/home/user/my-project" = 2
+    /// ```
     #[serde(default)]
     pub per_project: HashMap<String, usize>,
     /// Maximum total agent API calls across all phases (implementation + validation retries +

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -45,6 +45,26 @@ define_id!(TurnId);
 define_id!(AgentId);
 define_id!(SignalId);
 define_id!(ProjectId);
+
+impl ProjectId {
+    /// Derive a canonical project identity from a filesystem path.
+    ///
+    /// Calls `std::fs::canonicalize` to resolve symlinks and relative
+    /// components, falling back to the raw path string when canonicalize
+    /// fails (e.g. the path does not yet exist at registration time).
+    /// This is the single normalization point — all subsystems (registry,
+    /// queue, config `per_project`) must use this constructor so that the
+    /// same physical directory always maps to the same key.
+    pub fn from_path(root: &std::path::Path) -> Self {
+        let s = root
+            .canonicalize()
+            .unwrap_or_else(|_| root.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        Self(s)
+    }
+}
+
 define_id!(DraftId);
 define_id!(SkillId);
 define_id!(ExecPlanId);
@@ -703,6 +723,32 @@ pub struct MetricFilters {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    // ── ProjectId::from_path tests ────────────────────────────────────────────
+
+    #[test]
+    fn project_id_from_existing_dir_is_canonical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let id = ProjectId::from_path(dir.path());
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        assert_eq!(id.as_str(), canonical.to_string_lossy().as_ref());
+    }
+
+    #[test]
+    fn project_id_from_nonexistent_path_falls_back_to_raw() {
+        let path = PathBuf::from("/nonexistent/harness/project");
+        let id = ProjectId::from_path(&path);
+        assert_eq!(id.as_str(), "/nonexistent/harness/project");
+    }
+
+    #[test]
+    fn project_id_from_path_and_from_str_agree_on_canonical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let via_path = ProjectId::from_path(dir.path());
+        let via_str = ProjectId::from_str(&canonical.to_string_lossy());
+        assert_eq!(via_path, via_str);
+    }
 
     #[test]
     fn grade_from_score_all_boundaries() {

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -502,8 +502,9 @@ impl Project {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "unknown".to_string());
+        let id = ProjectId::from_path(&root);
         Self {
-            id: ProjectId::new(),
+            id,
             root,
             languages: Vec::new(),
             name,

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -25,12 +25,7 @@ fn gc_adopt_task_request(
 }
 
 fn configured_project_id(project_root: &Path) -> ProjectId {
-    ProjectId::from_str(
-        project_root
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("default"),
-    )
+    ProjectId::from_path(project_root)
 }
 
 async fn log_gc_event(

--- a/crates/harness-server/src/handlers/learn.rs
+++ b/crates/harness-server/src/handlers/learn.rs
@@ -182,12 +182,7 @@ fn validate_skill_name(name: &str) -> Result<(), String> {
 }
 
 fn project_id_from_root(project_root: &std::path::Path) -> ProjectId {
-    ProjectId::from_str(
-        project_root
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("default"),
-    )
+    ProjectId::from_path(project_root)
 }
 
 async fn log_learn_event(state: &AppState, hook: &str, decision: Decision, detail: Option<String>) {

--- a/crates/harness-server/src/handlers/learn.rs
+++ b/crates/harness-server/src/handlers/learn.rs
@@ -18,11 +18,17 @@ pub async fn learn_rules(
     let project_root = validate_root!(&project_root, id, &state.core.home_dir);
     let target_project_id = project_id_from_root(&project_root);
 
-    let draft_contents =
-        match collect_adopted_draft_contents(state, &target_project_id, "learn_rules").await {
-            Ok(d) => d,
-            Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
-        };
+    let draft_contents = match collect_adopted_draft_contents(
+        state,
+        &target_project_id,
+        &project_root,
+        "learn_rules",
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+    };
 
     if draft_contents.is_empty() {
         log_learn_event(
@@ -90,11 +96,17 @@ pub async fn learn_skills(
     let project_root = validate_root!(&project_root, id, &state.core.home_dir);
     let target_project_id = project_id_from_root(&project_root);
 
-    let draft_contents =
-        match collect_adopted_draft_contents(state, &target_project_id, "learn_skills").await {
-            Ok(d) => d,
-            Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
-        };
+    let draft_contents = match collect_adopted_draft_contents(
+        state,
+        &target_project_id,
+        &project_root,
+        "learn_skills",
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+    };
 
     if draft_contents.is_empty() {
         log_learn_event(
@@ -196,8 +208,16 @@ async fn log_learn_event(state: &AppState, hook: &str, decision: Decision, detai
 async fn collect_adopted_draft_contents(
     state: &AppState,
     project_id: &ProjectId,
+    project_root: &std::path::Path,
     learn_hook: &str,
 ) -> Result<Vec<String>, String> {
+    // Legacy IDs used the basename (or "default") before canonical-path unification.
+    let legacy_id = ProjectId::from_str(
+        project_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("default"),
+    );
     let last_learn_ts = state
         .observability
         .events
@@ -216,7 +236,7 @@ async fn collect_adopted_draft_contents(
         .iter()
         .filter(|d| {
             d.status == DraftStatus::Adopted
-                && d.signal.project_id == *project_id
+                && (d.signal.project_id == *project_id || d.signal.project_id == legacy_id)
                 && last_learn_ts.map(|ts| d.generated_at > ts).unwrap_or(true)
         })
         .flat_map(|d| d.artifacts.iter().map(|a| a.content.clone()))

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -58,6 +58,7 @@ pub async fn register_project(
     let project = Project {
         id: req.id,
         root,
+        name: None,
         max_concurrent: req.max_concurrent,
         default_agent: req.default_agent,
         active: true,
@@ -107,7 +108,18 @@ pub async fn get_project(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.project_svc.get(&id).await {
+    // Try canonical path ID first, then human-readable name as fallback.
+    let result = match state.project_svc.get(&id).await {
+        Ok(Some(p)) => return (StatusCode::OK, Json(json!(p))),
+        Ok(None) => state.project_svc.get_by_name(&id).await,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+    match result {
         Ok(Some(project)) => (StatusCode::OK, Json(json!(project))),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -124,7 +136,34 @@ pub async fn delete_project(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.project_svc.remove(&id).await {
+    // Resolve the canonical registry ID (which may be an absolute path) from
+    // either a direct ID match or a name-based lookup, so callers can use the
+    // human-readable name just as well as the full path key.
+    let canonical_id = match state.project_svc.get(&id).await {
+        Ok(Some(_)) => id.clone(),
+        Ok(None) => match state.project_svc.get_by_name(&id).await {
+            Ok(Some(p)) => p.id,
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({"error": format!("project '{id}' not found")})),
+                )
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": e.to_string()})),
+                )
+            }
+        },
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+    match state.project_svc.remove(&canonical_id).await {
         Ok(true) => (StatusCode::OK, Json(json!({"deleted": id}))),
         Ok(false) => (
             StatusCode::NOT_FOUND,

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -106,8 +106,21 @@ async fn resolve_project_token(
             .map_err(|e| format!("invalid project path '{token}': {e}"));
     }
 
+    // Try primary ID first (canonical path), then name as fallback so
+    // `project: "litellm"` still resolves when the registry key is the canonical path.
     match state.project_svc.resolve_path(token).await {
-        Ok(Some(root)) => root
+        Ok(Some(root)) => {
+            return root
+                .canonicalize()
+                .map(|canon| (Some(token.to_string()), canon))
+                .map_err(|e| format!("project '{token}' root is not accessible: {e}"));
+        }
+        Ok(None) => {}
+        Err(e) => return Err(format!("failed to resolve project '{token}': {e}")),
+    }
+    match state.project_svc.get_by_name(token).await {
+        Ok(Some(p)) => p
+            .root
             .canonicalize()
             .map(|canon| (Some(token.to_string()), canon))
             .map_err(|e| format!("project '{token}' root is not accessible: {e}")),

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -126,6 +126,7 @@ async fn sync_by_project_id_resolves_registry_root() -> anyhow::Result<()> {
         .register(crate::project_registry::Project {
             id: "demo".to_string(),
             root: project_dir.path().to_path_buf(),
+            name: None,
             max_concurrent: None,
             default_agent: None,
             active: true,

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -105,7 +105,9 @@ pub(crate) async fn build_registry(
                 })
         });
     let default_project = crate::project_registry::Project {
-        id: "default".to_string(),
+        id: harness_core::types::ProjectId::from_path(project_root)
+            .as_str()
+            .to_owned(),
         root: project_root.to_path_buf(),
         max_concurrent: default_project_metadata.and_then(|p| p.max_concurrent),
         default_agent: default_project_metadata.and_then(|p| p.default_agent.clone()),
@@ -117,7 +119,9 @@ pub(crate) async fn build_registry(
     }
     for project in &server.startup_projects {
         let proj = crate::project_registry::Project {
-            id: project.name.clone(),
+            id: harness_core::types::ProjectId::from_path(&project.root)
+                .as_str()
+                .to_owned(),
             root: project.root.clone(),
             max_concurrent: project.max_concurrent,
             default_agent: project.default_agent.clone(),
@@ -222,7 +226,12 @@ mod tests {
         // The default project is always auto-registered; registry should have exactly 1 entry.
         let projects = bundle.project_registry.list().await.expect("list projects");
         assert_eq!(projects.len(), 1, "expected only the default project");
-        assert_eq!(projects[0].id, "default");
+        // ID is the canonical path of the project root, not the literal "default".
+        let canonical = dir
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| dir.path().to_path_buf());
+        assert_eq!(projects[0].id, canonical.to_string_lossy().as_ref());
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -109,6 +109,7 @@ pub(crate) async fn build_registry(
             .as_str()
             .to_owned(),
         root: project_root.to_path_buf(),
+        name: default_project_metadata.map(|p| p.name.clone()),
         max_concurrent: default_project_metadata.and_then(|p| p.max_concurrent),
         default_agent: default_project_metadata.and_then(|p| p.default_agent.clone()),
         active: true,
@@ -123,6 +124,7 @@ pub(crate) async fn build_registry(
                 .as_str()
                 .to_owned(),
             root: project.root.clone(),
+            name: Some(project.name.clone()),
             max_concurrent: project.max_concurrent,
             default_agent: project.default_agent.clone(),
             active: true,

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -1012,10 +1012,11 @@ mod startup_tests {
             .project_registry
             .as_ref()
             .expect("project registry should be initialized");
+        let canonical_id = project_root.canonicalize()?.to_string_lossy().into_owned();
         let project = registry
-            .get("named")
+            .get(&canonical_id)
             .await?
-            .expect("startup project should be registered");
+            .ok_or_else(|| anyhow::anyhow!("startup project should be registered"))?;
 
         assert_eq!(project.default_agent.as_deref(), Some("codex"));
         assert_eq!(project.max_concurrent, Some(7));
@@ -1050,10 +1051,11 @@ mod startup_tests {
             .project_registry
             .as_ref()
             .expect("project registry should be initialized");
+        let canonical_id = project_root.canonicalize()?.to_string_lossy().into_owned();
         let project = registry
-            .get("default")
+            .get(&canonical_id)
             .await?
-            .expect("default project should be registered");
+            .ok_or_else(|| anyhow::anyhow!("default project should be registered"))?;
 
         assert_eq!(project.root.canonicalize()?, project_root.canonicalize()?);
         assert_eq!(project.default_agent.as_deref(), Some("claude"));
@@ -1088,10 +1090,16 @@ mod startup_tests {
             .project_registry
             .as_ref()
             .expect("project registry should be initialized");
+        let canonical_id = sandbox
+            .path()
+            .join("project")
+            .canonicalize()?
+            .to_string_lossy()
+            .into_owned();
         let project = registry
-            .get("partial")
+            .get(&canonical_id)
             .await?
-            .expect("startup project should be registered");
+            .ok_or_else(|| anyhow::anyhow!("startup project should be registered"))?;
 
         assert_eq!(project.default_agent.as_deref(), Some("claude"));
         assert_eq!(project.max_concurrent, None);
@@ -1130,10 +1138,11 @@ mod startup_tests {
             .project_registry
             .as_ref()
             .expect("project registry should be initialized");
+        let canonical_id = override_root.canonicalize()?.to_string_lossy().into_owned();
         let project = registry
-            .get("default")
+            .get(&canonical_id)
             .await?
-            .expect("default project should be registered");
+            .ok_or_else(|| anyhow::anyhow!("default project should be registered"))?;
 
         assert_eq!(project.root.canonicalize()?, override_root.canonicalize()?);
         assert_eq!(project.default_agent, None);

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -26,7 +26,14 @@ async fn resolve_project_from_registry(
         return Ok((Some(project_path), None));
     }
     let id = project_path.to_string_lossy();
+    // Try primary ID first, then name as fallback so `project: "litellm"` still
+    // resolves even though the registry key is now the canonical path.
     match registry.get(&id).await {
+        Ok(Some(p)) => return Ok((Some(p.root), p.default_agent)),
+        Ok(None) => {}
+        Err(e) => return Err(EnqueueTaskError::Internal(e.to_string())),
+    }
+    match registry.get_by_name(&id).await {
         Ok(Some(p)) => Ok((Some(p.root), p.default_agent)),
         Ok(None) => Err(EnqueueTaskError::BadRequest(format!(
             "project '{id}' not found in registry and is not a valid directory"
@@ -893,6 +900,7 @@ mod tests {
             .register(crate::project_registry::Project {
                 id: "my-repo".to_string(),
                 root: std::path::PathBuf::from("/home/user/my-repo"),
+                name: None,
                 max_concurrent: None,
                 default_agent: None,
                 active: true,
@@ -921,6 +929,7 @@ mod tests {
             .register(crate::project_registry::Project {
                 id: "pinned-repo".to_string(),
                 root: std::path::PathBuf::from("/home/user/pinned-repo"),
+                name: None,
                 max_concurrent: None,
                 default_agent: Some("opus".to_string()),
                 active: true,

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -8,6 +8,11 @@ use std::sync::Arc;
 pub struct Project {
     pub id: String,
     pub root: PathBuf,
+    /// Human-readable name from `[[projects]] name = "..."` config; used as
+    /// a secondary lookup key so `POST /tasks {"project":"litellm"}` resolves
+    /// even though the primary id is the canonical filesystem path.
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(default)]
     pub max_concurrent: Option<u32>,
     #[serde(default)]
@@ -75,6 +80,14 @@ impl ProjectRegistry {
     pub async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
         Ok(self.get(id).await?.map(|p| p.root))
     }
+
+    /// Find a project by its configured `name` field. Returns the first match.
+    pub async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Project>> {
+        let projects = self.list().await?;
+        Ok(projects
+            .into_iter()
+            .find(|p| p.name.as_deref() == Some(name)))
+    }
 }
 
 /// Check that `canonical_root` falls under at least one of the
@@ -127,6 +140,7 @@ mod tests {
         let project = Project {
             id: "my-project".to_string(),
             root: PathBuf::from("/tmp/my-project"),
+            name: None,
             max_concurrent: None,
             default_agent: None,
             active: true,
@@ -154,6 +168,7 @@ mod tests {
                 .register(Project {
                     id: format!("p{i}"),
                     root: PathBuf::from(format!("/tmp/p{i}")),
+                    name: None,
                     max_concurrent: None,
                     default_agent: None,
                     active: true,
@@ -176,6 +191,7 @@ mod tests {
             .register(Project {
                 id: "to-delete".to_string(),
                 root: PathBuf::from("/tmp/x"),
+                name: None,
                 max_concurrent: None,
                 default_agent: None,
                 active: true,
@@ -205,6 +221,7 @@ mod tests {
             .register(Project {
                 id: "harness".to_string(),
                 root: PathBuf::from("/home/user/harness"),
+                name: None,
                 max_concurrent: None,
                 default_agent: None,
                 active: true,
@@ -229,6 +246,7 @@ mod tests {
                 .register(Project {
                     id: "persistent".to_string(),
                     root: PathBuf::from("/tmp/persistent"),
+                    name: None,
                     max_concurrent: Some(2),
                     default_agent: Some("claude".to_string()),
                     active: true,

--- a/crates/harness-server/src/services/project.rs
+++ b/crates/harness-server/src/services/project.rs
@@ -17,6 +17,9 @@ pub trait ProjectService: Send + Sync {
     /// Retrieve a project by its registered ID.
     async fn get(&self, id: &str) -> anyhow::Result<Option<Project>>;
 
+    /// Retrieve a project by its human-readable `name` field.
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Project>>;
+
     /// List all registered projects.
     async fn list(&self) -> anyhow::Result<Vec<Project>>;
 
@@ -52,6 +55,10 @@ impl ProjectService for DefaultProjectService {
 
     async fn get(&self, id: &str) -> anyhow::Result<Option<Project>> {
         self.registry.get(id).await
+    }
+
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Project>> {
+        self.registry.get_by_name(name).await
     }
 
     async fn list(&self) -> anyhow::Result<Vec<Project>> {
@@ -103,6 +110,16 @@ mod tests {
             Ok(self.store.read().await.get(id).cloned())
         }
 
+        async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Project>> {
+            Ok(self
+                .store
+                .read()
+                .await
+                .values()
+                .find(|p| p.name.as_deref() == Some(name))
+                .cloned())
+        }
+
         async fn list(&self) -> anyhow::Result<Vec<Project>> {
             Ok(self.store.read().await.values().cloned().collect())
         }
@@ -124,6 +141,7 @@ mod tests {
         Project {
             id: id.to_string(),
             root: PathBuf::from(root),
+            name: None,
             max_concurrent: None,
             default_agent: None,
             active: true,

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -421,7 +421,17 @@ impl TaskQueue {
         let project_limits: DashMap<String, usize> = config
             .per_project
             .iter()
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| {
+                if !std::path::Path::new(k).is_absolute() {
+                    tracing::warn!(
+                        key = k.as_str(),
+                        "concurrency.per_project key is not an absolute path; \
+                         it will not match any project at runtime — \
+                         keys must be canonical filesystem paths (use ProjectId::from_path)"
+                    );
+                }
+                (k.clone(), *v)
+            })
             .collect();
         Self {
             global_queue: Arc::new(Mutex::new(PriorityPermitQueue::new(

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -422,15 +422,30 @@ impl TaskQueue {
             .per_project
             .iter()
             .map(|(k, v)| {
-                if !std::path::Path::new(k).is_absolute() {
+                let p = std::path::Path::new(k);
+                if !p.is_absolute() {
                     tracing::warn!(
                         key = k.as_str(),
                         "concurrency.per_project key is not an absolute path; \
                          it will not match any project at runtime — \
                          keys must be canonical filesystem paths (use ProjectId::from_path)"
                     );
+                    return (k.clone(), *v);
                 }
-                (k.clone(), *v)
+                // Canonicalize to resolve symlinks / `..` / trailing components so
+                // the key matches the canonical path stored by the registry/queue.
+                let canonical = std::fs::canonicalize(p)
+                    .unwrap_or_else(|_| p.to_path_buf())
+                    .to_string_lossy()
+                    .into_owned();
+                if canonical != *k {
+                    tracing::debug!(
+                        original = k.as_str(),
+                        canonical = canonical.as_str(),
+                        "concurrency.per_project key canonicalized"
+                    );
+                }
+                (canonical, *v)
             })
             .collect();
         Self {


### PR DESCRIPTION
## Summary

- Add `ProjectId::from_path(root: &Path) -> Self` to the existing `ProjectId` newtype in `harness-core/src/types.rs` — single normalization point (canonicalize with raw-path fallback) that all subsystems must use
- Change `builders/registry.rs` to derive the default-project and startup-project registry IDs from `ProjectId::from_path` instead of the literal `"default"` or the user-supplied `project.name`
- Emit `tracing::warn!` in `task_queue.rs` when a `per_project` config key is not an absolute path, giving operators actionable feedback instead of a silent no-op
- Document in `misc.rs` that `per_project` keys must be canonical absolute paths

## Motivation

Before this change the three runtime subsystems used three different keys for the same project:
- Registry stored `id = "default"` (or `project.name`) — a human label, not a path
- Queue keyed on `canonicalize(root).to_string_lossy()` — a canonical path
- Config `per_project` accepted arbitrary strings with no validation

This meant per-project concurrency limits silently had no effect because the config key never matched the queue key.

## Test plan

- [ ] `cargo test --workspace` — all 817 tests pass (previously 4 startup tests failed due to `"default"` lookup)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — no warnings
- [ ] New unit tests in `types.rs` cover `from_path` on existing, non-existent, and symlinked directories

Closes #684