### PR TITLE
fix(review_loop): quota-heuristic graduation when Gemini quota exhausted

### DIFF
--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -21,9 +21,10 @@ pub use issue::{
     wrap_external_data,
 };
 pub use parsing::{
-    extract_pr_number, extract_review_issues, is_lgtm, is_waiting, parse_complexity,
-    parse_created_issue_number, parse_github_pr_url, parse_issue_count, parse_plan_issue,
-    parse_pr_url, parse_triage, repo_slug_from_pr_url, TriageComplexity, TriageDecision,
+    extract_pr_number, extract_review_issues, is_lgtm, is_quota_exhausted, is_waiting,
+    parse_complexity, parse_created_issue_number, parse_github_pr_url, parse_issue_count,
+    parse_plan_issue, parse_pr_url, parse_triage, repo_slug_from_pr_url, TriageComplexity,
+    TriageDecision,
 };
 pub use pr::{check_existing_pr, continue_existing_pr, rebase_conflicting_pr};
 pub use review::{

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -166,6 +166,27 @@ pub fn is_waiting(output: &str) -> bool {
     last_non_empty_line(output) == Some("WAITING")
 }
 
+/// Check if reviewer output indicates quota exhaustion (e.g., Gemini 24h rate limit).
+///
+/// Requires ≥ 2 co-occurring quota-signal terms, or a single high-specificity phrase,
+/// to prevent false positives from reviews that incidentally mention "quota" in code.
+pub fn is_quota_exhausted(output: &str) -> bool {
+    let lower = output.to_lowercase();
+    // High-specificity phrase: shortcut without requiring two co-occurring indicators.
+    if lower.contains("start processing again") {
+        return true;
+    }
+    let indicators = [
+        "quota",
+        "rate limit",
+        "24 hour",
+        "processing again",
+        "will be processed",
+        "not available",
+    ];
+    indicators.iter().filter(|&&s| lower.contains(s)).count() >= 2
+}
+
 /// Extract `ISSUES=N` from agent output (any line). Returns `None` if absent.
 pub fn parse_issue_count(output: &str) -> Option<u32> {
     for line in output.lines().rev() {
@@ -282,6 +303,40 @@ mod tests {
         assert!(is_waiting("WAITING\n"));
         assert!(!is_waiting("LGTM"));
         assert!(!is_waiting("FIXED"));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_gemini_exact_phrase() {
+        // Gemini's actual quota-warning phrasing triggers the high-specificity shortcut.
+        assert!(is_quota_exhausted(
+            "I will start processing again in 24 hours once the quota resets."
+        ));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_two_co_occurring_indicators() {
+        assert!(is_quota_exhausted(
+            "rate limit exceeded, quota exhausted for today"
+        ));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_false_for_lgtm() {
+        assert!(!is_quota_exhausted("LGTM"));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_false_for_normal_review() {
+        let review = "\
+The implementation looks clean. I noticed a potential edge case in the error \
+handler: when the input is empty the function returns Ok(()) without logging, \
+which could mask silent failures.\nISSUES=1\nFIXED";
+        assert!(!is_quota_exhausted(review));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_false_for_empty_string() {
+        assert!(!is_quota_exhausted(""));
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -82,6 +82,9 @@ pub(crate) async fn run_review_loop(
     // Tracks the most recent non-waiting review output for Jaccard loop detection.
     let mut prev_review_output: Option<String> = None;
 
+    const QUOTA_EXHAUSTED_THRESHOLD: u32 = 3;
+    let mut quota_exhausted_rounds: u32 = 0;
+
     // Review loop.
     // Use an explicit counter so WAITING responses don't consume a round — `continue`
     // inside a `for` loop would silently advance the iterator even without a real review.
@@ -206,11 +209,12 @@ pub(crate) async fn run_review_loop(
 
         let raw_lgtm = prompts::is_lgtm(&output);
         let waiting = prompts::is_waiting(&output);
+        let quota_exhausted = !raw_lgtm && !waiting && prompts::is_quota_exhausted(&output);
         // If post-execute validation failed this round, block LGTM acceptance even
         // if the reviewer approved — the local validator caught an issue that must be
         // fixed before the PR can be marked done.
         let lgtm = raw_lgtm && pending_test_failure.is_none();
-        let fixed = !lgtm && !waiting;
+        let fixed = !lgtm && !waiting && !quota_exhausted;
 
         // Parse issue count before the Jaccard check so loop detection can distinguish
         // genuine forward progress (decreasing issue count) from true stuck loops.
@@ -220,7 +224,8 @@ pub(crate) async fn run_review_loop(
         // too similar indicate the reviewer is stuck repeating itself without making progress.
         // Skip when the raw output is an approval: repeated LGTM is legitimate convergence
         // (e.g., reviewer approves again after a test-gate previously blocked acceptance).
-        if !waiting && !raw_lgtm {
+        // Quota-exhausted rounds are also skipped — they contain no real review content.
+        if !waiting && !raw_lgtm && !quota_exhausted {
             if let Some(ref prev) = prev_review_output {
                 let score = jaccard_word_similarity(prev, &output);
                 if score >= jaccard_threshold {
@@ -254,7 +259,7 @@ pub(crate) async fn run_review_loop(
             prev_review_output = None;
         }
 
-        if !waiting {
+        if !waiting && !quota_exhausted {
             issue_counts.push(current_issues);
         }
 
@@ -298,6 +303,84 @@ pub(crate) async fn run_review_loop(
                 sleep(Duration::from_secs(wait_secs)).await;
                 continue;
             }
+        }
+
+        // Quota-exhausted: reviewer posted a quota warning instead of a real review.
+        // Don't consume a round — sleep and retry. After K consecutive quota rounds,
+        // run the test gate as a heuristic graduation check.
+        if quota_exhausted {
+            quota_exhausted_rounds += 1;
+            tracing::info!(
+                round,
+                quota_exhausted_rounds,
+                "PR #{pr_num} reviewer quota exhausted; not consuming a review round"
+            );
+            mutate_and_persist(store, task_id, |s| {
+                s.rounds.push(RoundResult {
+                    turn: round,
+                    action: "review".into(),
+                    result: "quota_exhausted".into(),
+                    detail: None,
+                    first_token_latency_ms: None,
+                });
+            })
+            .await?;
+
+            if quota_exhausted_rounds >= QUOTA_EXHAUSTED_THRESHOLD && !lgtm_test_gate_rejected {
+                tracing::info!(
+                    task_id = %task_id,
+                    quota_exhausted_rounds,
+                    "quota-heuristic graduation: running test gate after {} quota-exhausted rounds",
+                    quota_exhausted_rounds
+                );
+                match super::run_test_gate(
+                    project,
+                    &project_config.validation.pre_push,
+                    project_config.validation.test_gate_timeout_secs,
+                    cargo_env,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!(
+                            task_id = %task_id,
+                            quota_exhausted_rounds,
+                            "quota-heuristic graduation: tests passed — marking done"
+                        );
+                        mutate_and_persist(store, task_id, |s| {
+                            s.status = TaskStatus::Done;
+                            s.turn = round.saturating_add(1);
+                            s.error = Some(format!(
+                                "LGTM via quota-heuristic: external reviewer quota exhausted after {} rounds, tests passed",
+                                quota_exhausted_rounds
+                            ));
+                        })
+                        .await?;
+                        return Ok(());
+                    }
+                    Err(_test_output) => {
+                        tracing::warn!(
+                            task_id = %task_id,
+                            quota_exhausted_rounds,
+                            "quota-heuristic graduation: tests failed — marking failed"
+                        );
+                        mutate_and_persist(store, task_id, |s| {
+                            s.status = TaskStatus::Failed;
+                            s.turn = round.saturating_add(1);
+                            s.error = Some(format!(
+                                "Quota-heuristic: tests failed after {} quota-exhausted rounds",
+                                quota_exhausted_rounds
+                            ));
+                        })
+                        .await?;
+                        return Ok(());
+                    }
+                }
+            }
+
+            update_status(store, task_id, TaskStatus::Waiting, waiting_count).await?;
+            sleep(Duration::from_secs(wait_secs)).await;
+            continue; // Don't increment round — quota rounds are free
         }
 
         let result_label = if lgtm { "lgtm" } else { "fixed" };
@@ -395,6 +478,9 @@ pub(crate) async fn run_review_loop(
         // Also treat a test gate rejection as a "fixed" round — the agent needs
         // to push a fix and get a fresh review before LGTM can be accepted.
         prev_fixed = fixed || pending_test_failure.is_some();
+        if fixed {
+            quota_exhausted_rounds = 0;
+        }
         tracing::info!("PR #{pr_num} fixed at round {round}; waiting for bot re-review");
         if round < max_rounds {
             waiting_count += 1;


### PR DESCRIPTION
## Summary

- Adds `prompts::is_quota_exhausted(output: &str) -> bool` to detect Gemini 24h quota-warning messages (requires ≥2 co-occurring quota indicators or the high-specificity phrase `"start processing again"` to avoid false positives)
- Re-exports `is_quota_exhausted` alongside `is_lgtm`/`is_waiting` from `prompts/mod.rs`
- In `review_loop.rs`: tracks `quota_exhausted_rounds` counter; quota rounds do not consume a review-round slot, do not feed Jaccard loop detection, and do not push to `issue_counts`; after `QUOTA_EXHAUSTED_THRESHOLD = 3` consecutive quota-exhausted rounds, runs the test gate — pass → `TaskStatus::Done` with a `lgtm_source=heuristic` warning, fail → `TaskStatus::Failed`; a genuine reviewer response resets the counter

## Test plan

- [ ] `is_quota_exhausted` unit tests (5): Gemini exact phrase, two co-occurring indicators, false for LGTM, false for normal review, false for empty string
- [ ] All existing tests pass (`cargo test --workspace`)
- [ ] Clippy and fmt clean (`RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`)
- [ ] Existing LGTM path unchanged (regression: normal LGTM on round 2 still produces `TaskStatus::Done` via normal path)
- [ ] Existing max-rounds cap still fires when reviewer finds genuine issues

Closes #828