### PR TITLE
fix(db): enable sqlx TLS + after_connect search_path for Supabase pooler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3373,6 +3374,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -3383,6 +3385,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4519,6 +4522,24 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "sqlite", "postgres", "chrono", "uuid"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -17,13 +17,31 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
 }
 
 /// Create a Postgres connection pool where every connection has `search_path`
-/// set to `schema` via connection startup options. Used in test builds to give
-/// each test its own isolated schema namespace.
+/// set to `schema`. Used to give each store an isolated schema namespace.
+///
+/// Sets search_path via BOTH the connection `options` startup parameter AND an
+/// `after_connect` hook that runs `SET search_path TO <schema>` per connection.
+/// The after_connect hook is required for Supabase pgbouncer pooler, which
+/// silently strips the startup `options` parameter, causing all DDL to fall
+/// back to the default `public` schema and all stores to share a single
+/// `schema_migrations` table (migration-number collision bug).
 pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyhow::Result<PgPool> {
     let opts = PgConnectOptions::from_str(database_url)?.options([("search_path", schema)]);
+    let schema_for_hook = schema.to_string();
     let pool = PgPoolOptions::new()
         .max_connections(8)
         .acquire_timeout(std::time::Duration::from_secs(10))
+        .after_connect(move |conn, _meta| {
+            let schema = schema_for_hook.clone();
+            Box::pin(async move {
+                // Quoted identifier guards against injection from the schema name;
+                // schema here is constructed from a hash hex string so quoting is
+                // defensive in depth rather than strictly required.
+                let stmt = format!("SET search_path TO \"{}\"", schema);
+                sqlx::query(&stmt).execute(conn).await?;
+                Ok(())
+            })
+        })
         .connect_with(opts)
         .await?;
     Ok(pool)


### PR DESCRIPTION
Two blockers surfaced when pointing a fresh build at Supabase (a common deployment target) after PRs #829 and #831 completed the SQLite→Postgres migration:

## 1. `sqlx` was compiled without any TLS backend

```
Error: error occurred while attempting to establish a TLS connection:
TLS upgrade required by connect options but SQLx was built without TLS support enabled
```

Supabase — and essentially any managed Postgres — requires `sslmode=require`. The workspace `sqlx` dependency only had `runtime-tokio + sqlite + postgres + chrono + uuid` features; no TLS.

**Fix:** add `tls-rustls-ring-webpki` to the sqlx feature list in the workspace `Cargo.toml`. Pure-rust, no system openssl dependency, works on macOS/Linux/Docker images without extra setup.

## 2. Every store registered every migration as applied, leaving tables uncreated

On first connection to a fresh Supabase project, the `tasks`/`task_artifacts`/... tables were created correctly by `task_db`, but subsequent stores reported:

```
ERROR: relation "events" does not exist
ERROR: relation "threads" does not exist
ERROR: relation "scan_watermarks" does not exist
```

**Root cause:** `pg_open_pool_schematized` set `search_path` via the Postgres startup `options` parameter. Supabase's pgbouncer pooler — both Session mode (:5432) and Transaction mode (:6543) — silently strips that parameter. As a result:
- Each store's `PgMigrator` created its `schema_migrations` in `public`, not in the per-store hash-named schema
- Store #2's `PgMigrator::run()` saw versions `1..N` (belonging to store #1) already marked applied
- Store #2 skipped all its own DDL → its tables never materialised
- Store #2's runtime queries then hit the "relation does not exist" wall

Reproduced against a fresh free-tier Supabase project via Session pooler (:5432).

**Fix:** install an `after_connect` hook on the schematized pool that runs `SET search_path TO "<schema>"` on every acquired connection. This is authoritative regardless of whether an intermediate pooler honors startup options. The startup `options(...)` call is kept as defence-in-depth for direct connections and drivers that handle it natively.

The schema name is a hex-hash identifier constructed from the store's data-dir path, so SQL injection is not a concern; the quoted identifier is still used as belt-and-suspenders.

## Verification

- Fresh Supabase project, Session pooler URL
- `./target/release/harness serve` now reaches `"harness: ready"` in ~3 minutes (remote DB + many CREATE TABLEs)
- Each store's tables are created in its own `h<hash>` schema:
  ```
  h09a0d2e1be75dd4c: schema_migrations, tasks, task_artifacts, task_checkpoints, task_prompts
  ```
- `curl http://localhost:9800/health` returns `{"persistence": {"degraded_subsystems":[]}, "status": "ok", ...}`
- 74 events migrated from local `events.jsonl` successfully

## Related

- Builds on #829 (task_db migration) and #831 (7 remaining stores migration)
- Issue #832 (operator docs for the migration) — this PR unblocks the operator path; the README update is still pending there