### PR TITLE
chore(gitignore): ignore SDK build artifacts and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ docs/artifacts/
 .worktrees/
 web/node_modules/
 web/dist/
+
+# SDK build artifacts (TypeScript bindings)
+sdk/typescript/node_modules/
+sdk/typescript/dist/
+
+# macOS finder metadata
+.DS_Store


### PR DESCRIPTION
A fresh checkout + \`bun install\` under \`sdk/typescript/\` surfaces three kinds of untracked noise in \`git status\` that should never be committed:

- \`sdk/typescript/node_modules/\` — bun/npm install output
- \`sdk/typescript/dist/\` — TypeScript compiler output
- \`.DS_Store\` — macOS Finder metadata that quietly lands anywhere a dev opens a folder in Finder (global rule rather than per-directory)

The \`.gitignore\` already handles \`web/node_modules/\` + \`web/dist/\`; this just extends the same pattern to the newer \`sdk/typescript\` tree.

\`sdk/typescript/bun.lock\` is intentionally left trackable — lockfiles belong in version control.