### PR TITLE
docs(ops): add Postgres dev setup docs and docker-compose (#832)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy this file to .env and fill in the values.
+# .env is in .gitignore — never commit real credentials.
+
+# Required: Postgres connection string.
+# Use the docker-compose dev DB (see docker-compose.yml / scripts/dev-db.sh),
+# or point at any Postgres 14+ instance.
+DATABASE_URL=postgres://harness:harness@localhost:5432/harness
+
+# Required for GitHub integration (webhooks, auto-review, issue/PR tasks).
+# Generate at https://github.com/settings/tokens with repo + read:org scope.
+GITHUB_TOKEN=ghp_your_token_here
+
+# Required when receiving GitHub webhooks (harness serve --transport http).
+# Set the same secret in your GitHub repo → Settings → Webhooks.
+GITHUB_WEBHOOK_SECRET=your_webhook_secret_here
+
+# Optional: override the default Anthropic API base URL.
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+# Optional: Anthropic API key (only needed for the anthropic_api agent adapter).
+# ANTHROPIC_API_KEY=sk-ant-your_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 config/*.toml
+.env
 exec-plan-*.md
 .harness/*
 !.harness/guards

--- a/README.md
+++ b/README.md
@@ -97,6 +97,46 @@ The facade groups the stable parts of `harness-core`, `harness-protocol`,
 `harness-sandbox`, and `harness-exec` under one crate without forcing callers to
 track internal crate layout changes.
 
+### Database Setup
+
+Harness requires Postgres 14+ (SQLite was removed in v0.x). Set `DATABASE_URL`
+before starting the server — migrations run automatically on first connect.
+
+**Option A — Docker Compose (recommended for local dev):**
+
+```bash
+# Start Postgres container (idempotent — safe to re-run)
+bash scripts/dev-db.sh
+
+# Then export the printed connection string:
+export DATABASE_URL=postgres://harness:harness@localhost:5432/harness
+```
+
+**Option B — docker compose directly:**
+
+```bash
+docker compose up -d postgres
+export DATABASE_URL=postgres://harness:harness@localhost:5432/harness
+```
+
+**Option C — existing Postgres instance:**
+
+```bash
+export DATABASE_URL=postgres://user:password@host:5432/dbname
+```
+
+Copy `.env.example` to `.env` for a reference of all required env vars.
+`.env` is git-ignored; never commit real credentials.
+
+**Running tests against a real database:**
+
+```bash
+DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
+```
+
+Integration tests that require a database (e.g. `runtime_state_store`,
+`thread_db`, `q_value_store`) skip automatically when `DATABASE_URL` is unset.
+
 ### Run
 
 **HTTP server:**

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -1,5 +1,20 @@
 # Harness example configuration — copy to config/default.toml and edit as needed.
 # Start the server with: harness serve --config config/default.toml
+#
+# REQUIRED ENVIRONMENT VARIABLES (set in shell before starting the server):
+#
+#   DATABASE_URL=postgres://harness:harness@localhost:5432/harness
+#       Postgres 14+ connection string. TOML cannot read env vars — this MUST
+#       be exported in your shell (or a .env loader). See .env.example and
+#       scripts/dev-db.sh for a one-command local dev setup.
+#
+#   GITHUB_TOKEN=ghp_...
+#       Personal access token with repo + read:org scope. Required for
+#       GitHub integration (webhooks, auto-review, issue/PR tasks).
+#
+#   GITHUB_WEBHOOK_SECRET=...
+#       HMAC secret matching the value set in GitHub repo → Settings → Webhooks.
+#       Required only when receiving inbound webhook events.
 
 [server]
 transport = "http"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: harness
+      POSTGRES_USER: harness
+      POSTGRES_PASSWORD: harness
+    ports:
+      - "5432:5432"
+    volumes:
+      - harness_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U harness -d harness"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+
+volumes:
+  harness_pg_data:

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Start the local dev Postgres container and print the DATABASE_URL.
+# Requires Docker with Compose v2 plugin (docker compose, not docker-compose v1).
+# Safe to run multiple times — docker compose up -d is idempotent.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Starting Postgres container..."
+docker compose -f "$REPO_ROOT/docker-compose.yml" up -d postgres
+
+echo "Waiting for Postgres to be ready (max 30s)..."
+deadline=$(( $(date +%s) + 30 ))
+until docker compose -f "$REPO_ROOT/docker-compose.yml" exec -T postgres \
+    pg_isready -U harness -d harness -q 2>/dev/null; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "ERROR: Postgres did not become ready within 30 seconds." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo ""
+echo "Postgres is ready. Set the following in your shell:"
+echo ""
+echo "  export DATABASE_URL=postgres://harness:harness@localhost:5432/harness"
+echo ""
+echo "Migrations run automatically when the server starts — no manual step needed."


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` with `postgres:16` service and named volume for one-command local dev database
- Add `scripts/dev-db.sh` — idempotent helper that starts the container, waits for readiness, and prints the `DATABASE_URL`
- Add `.env.example` documenting all required env vars (`DATABASE_URL`, `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`)
- Update `README.md` with a "Database Setup" section (quickstart A/B/C, test command, migration note)
- Update `config/default.toml.example` with a comment block listing required env vars and explaining TOML ≠ env vars
- Add `.env` to `.gitignore` so real credentials are never committed

Closes #832

## Test plan

- [x] `docker compose config` — YAML parses without errors
- [x] `shellcheck scripts/dev-db.sh` — no warnings
- [x] `cargo fmt --all -- --check` — passes
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` — passes
- [x] Pre-commit hook passes (DB-dependent crates excluded when `DATABASE_URL` not set per hook design)
- [ ] Manual smoke: `bash scripts/dev-db.sh` → export DATABASE_URL → `./target/release/harness serve` starts without error