### PR TITLE
fix(web): hash-scroll sidebar nav + real kanban cards

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 import { Dashboard } from "./routes/Dashboard";
 import { Overview } from "./routes/Overview";
 import { PaletteProvider } from "./lib/palette";
@@ -16,10 +17,33 @@ const queryClient = new QueryClient({
   },
 });
 
+/**
+ * Scroll to a fragment target when the URL hash changes. React Router v6
+ * updates the URL for hash links but does NOT scroll — so sidebar items
+ * like /overview#projects would otherwise update the bar with no visible
+ * effect. Runs after the route commits so the panel being targeted has
+ * already mounted.
+ */
+function ScrollToHash() {
+  const { hash, pathname } = useLocation();
+  useEffect(() => {
+    if (!hash) return;
+    const id = hash.slice(1);
+    // Defer to after paint so newly-mounted panels exist in the DOM.
+    const t = setTimeout(() => {
+      const el = document.getElementById(id);
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+    return () => clearTimeout(t);
+  }, [hash, pathname]);
+  return null;
+}
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <PaletteProvider>
+        <ScrollToHash />
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/overview" element={<Overview />} />

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "./api";
-import type { DashboardPayload, OverviewPayload } from "@/types";
+import type { DashboardPayload, OverviewPayload, Task } from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -13,5 +13,12 @@ export function useOverview() {
   return useQuery<OverviewPayload, Error>({
     queryKey: ["overview"],
     queryFn: ({ signal }) => apiJson<OverviewPayload>("/api/overview", { signal }),
+  });
+}
+
+export function useTasks() {
+  return useQuery<Task[], Error>({
+    queryKey: ["tasks"],
+    queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
   });
 }

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -134,7 +134,7 @@ export function Overview() {
             </div>
           </Panel>
 
-          <div className="grid grid-cols-[1.6fr_1fr]">
+          <div id="observability" className="grid grid-cols-[1.6fr_1fr] scroll-mt-12">
             <Panel title="Cluster activity" sub="hourly buckets" className="border-r border-line">
               <div className="p-5">
                 {(data?.heatmap.rows ?? []).map((r) => (

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,37 +1,114 @@
-import { useDashboard } from "@/lib/queries";
+import { useTasks } from "@/lib/queries";
+import type { Task } from "@/types";
 
-const COLUMNS: Array<{ key: string; label: string }> = [
-  { key: "pending", label: "Pending" },
-  { key: "implementing", label: "Implementing" },
-  { key: "agent_review", label: "Agent Review" },
-  { key: "waiting", label: "Waiting" },
-  { key: "reviewing", label: "Reviewing" },
+interface Column {
+  key: string;
+  label: string;
+  /** Status strings from `GET /tasks` that belong in this column. */
+  statuses: string[];
+}
+
+/**
+ * Columns used by the dashboard kanban. Keep in sync with harness-core's
+ * `TaskStatus` enum — any status not listed here is collected under the
+ * catch-all "Other" column so operators always see every task.
+ */
+const COLUMNS: Column[] = [
+  { key: "pending", label: "Pending", statuses: ["pending", "queued"] },
+  { key: "implementing", label: "Implementing", statuses: ["implementing", "running", "triage", "plan"] },
+  { key: "agent_review", label: "Agent Review", statuses: ["agent_review", "reviewing_agent"] },
+  { key: "waiting", label: "Waiting", statuses: ["waiting"] },
+  { key: "reviewing", label: "Reviewing", statuses: ["reviewing"] },
 ];
 
+const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
+
+function columnOf(status: string): string {
+  for (const c of COLUMNS) {
+    if (c.statuses.includes(status)) return c.key;
+  }
+  return "other";
+}
+
+function TaskCard({ task }: { task: Task }) {
+  const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
+  return (
+    <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
+      <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
+        {title}
+      </div>
+      <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
+        <span className="truncate">{task.repo ?? "—"}</span>
+        {task.turn > 0 && <span>turn {task.turn}</span>}
+      </div>
+      {task.pr_url && (
+        <a
+          href={task.pr_url}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="mt-1 block font-mono text-[10px] text-rust hover:underline truncate"
+        >
+          {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
+        </a>
+      )}
+    </div>
+  );
+}
+
 export function Active() {
-  const { data } = useDashboard();
-  const projects = data?.projects ?? [];
-  const byStatus: Record<string, number> = {
-    pending: projects.reduce((a, p) => a + p.tasks.queued, 0),
-    implementing: projects.reduce((a, p) => a + p.tasks.running, 0),
-    agent_review: 0,
-    waiting: 0,
-    reviewing: 0,
-  };
+  const { data, isLoading, isError } = useTasks();
+
+  const active = (data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
+  const grouped: Record<string, Task[]> = {};
+  for (const c of COLUMNS) grouped[c.key] = [];
+  const other: Task[] = [];
+  for (const t of active) {
+    const col = columnOf(t.status);
+    if (col === "other") other.push(t);
+    else grouped[col].push(t);
+  }
+  const showOther = other.length > 0;
 
   return (
-    <div className="grid gap-3" style={{ gridTemplateColumns: `repeat(${COLUMNS.length}, 1fr)` }}>
-      {COLUMNS.map((col) => (
-        <div key={col.key} className="border border-line bg-bg-1 min-h-[200px]">
-          <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between">
-            <span>{col.label}</span>
-            <span className="text-ink-2">{byStatus[col.key] ?? 0}</span>
+    <div
+      className="grid gap-3"
+      style={{ gridTemplateColumns: `repeat(${COLUMNS.length + (showOther ? 1 : 0)}, 1fr)` }}
+    >
+      {COLUMNS.map((col) => {
+        const rows = grouped[col.key];
+        return (
+          <div key={col.key} className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+            <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
+              <span>{col.label}</span>
+              <span className="text-ink-2">{rows.length}</span>
+            </div>
+            <div className="p-2 flex-1 overflow-auto">
+              {rows.length === 0 && (
+                <div className="text-ink-4 font-mono text-[11px] p-1">
+                  {isLoading ? "loading…" : isError ? "error" : "—"}
+                </div>
+              )}
+              {rows.map((t) => (
+                <TaskCard key={t.id} task={t} />
+              ))}
+            </div>
           </div>
-          <div className="p-2 text-ink-4 font-mono text-[11px]">
-            live task cards land here — harness-server doesn't yet emit per-task status broken down by kanban column
+        );
+      })}
+      {showOther && (
+        <div className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+          <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
+            <span>Other</span>
+            <span className="text-ink-2">{other.length}</span>
+          </div>
+          <div className="p-2 flex-1 overflow-auto">
+            {other.map((t) => (
+              <TaskCard key={t.id} task={t} />
+            ))}
           </div>
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./dashboard";
 export * from "./overview";
+export * from "./task";

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -1,0 +1,20 @@
+/**
+ * Shape of a single row returned by `GET /tasks`. Kept minimal — only the
+ * fields the dashboard kanban actually renders. Extend as consumers grow.
+ */
+export interface Task {
+  id: string;
+  status: string;
+  turn: number;
+  pr_url: string | null;
+  error: string | null;
+  source: string | null;
+  parent_id: string | null;
+  repo: string | null;
+  description: string | null;
+  created_at: string | null;
+  phase: string | null;
+  depends_on: string[];
+  subtask_ids: string[];
+  project: string | null;
+}


### PR DESCRIPTION
## Summary

Two post-#827 UX fixes for the React SPA:

- **Sidebar navigation** — items under Projects/Runtimes/Observability/All tasks/Worktrees had hrefs like `/overview#projects` but React Router v6 doesn't scroll to hash targets by default. Clicks produced no visible effect. Added a small `<ScrollToHash/>` mounted in App that calls `scrollIntoView` when `location.hash` changes, plus `id="observability"` on the bottom Cluster+Live-activity grid with `scroll-mt-12` offset for the sticky TopBar.
- **Dashboard kanban** — Active tab previously showed the same placeholder string in every column (`harness-server doesn't yet emit per-task status broken down by kanban column`). `GET /tasks` already returns full per-task rows; the plan deferral was over-conservative. New `useTasks()` hook + `Task` type + rewritten Active that buckets tasks into the five canonical columns by status, with a catch-all "Other" column so no task is ever hidden.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` 44/44 passing (no test changes; rendering logic is covered by integration-with-backend path)
- [x] `bun run build` produces fresh hashed bundle
- [ ] Manual: start server, click each sidebar item on /overview — page scrolls to matching section; on / verify Active tab populates real cards grouped per column
