### PR TITLE
perf(event_store): skip JSONL replay when events table is already populated

### DIFF
--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -199,8 +199,30 @@ impl EventStore {
     }
 
     /// Import events from an existing `events.jsonl` file (backward compat).
+    ///
+    /// Fast-paths out when the `events` table already contains rows: on each
+    /// startup we previously re-read the full JSONL and fired one `INSERT
+    /// ... ON CONFLICT DO NOTHING` per line. Against a remote Postgres (e.g.
+    /// Supabase session pooler, ~1s RTT per statement) this added ~N seconds
+    /// to every server boot for N lines in the file, even though every row
+    /// was already in the DB. Checking the table once is a single query.
     async fn migrate_from_jsonl(&self) {
         use std::io::BufRead as _;
+
+        // Fast-path: if any events are already in the DB, assume a prior
+        // successful migration and skip the per-line replay entirely.
+        match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events")
+            .fetch_one(&self.pool)
+            .await
+        {
+            Ok(n) if n > 0 => return,
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "event store: could not check existing event count, will still attempt JSONL migration: {e}"
+                );
+            }
+        }
 
         let path = self.data_dir.join("events.jsonl");
         let file = match std::fs::File::open(&path) {


### PR DESCRIPTION
## Problem

Every `harness serve` startup spends ~1 second per line in `events.jsonl` even when all rows are already in the database.

`EventStore::new` calls `migrate_from_jsonl` which reads the full JSONL file and fires one `INSERT ... ON CONFLICT (id) DO NOTHING` per line. Against a remote Postgres (e.g. Supabase Session pooler, ~1s per-statement RTT), this single phase dominates startup time: the JSONL file only grows, so every subsequent boot replays all prior events.

Observed today against the newly-provisioned Supabase project: 74 events in the JSONL → ~75-second "migrating events" section of every startup, even though all 74 rows were already in the DB from the previous boot (confirmed via `SELECT COUNT(*) FROM events` after startup). Total server startup pushed past 3 minutes.

The fundamental cost is not the data, it's the round-trip-per-statement pattern against a remote DB.

## Fix

Short-circuit `migrate_from_jsonl` by running a single `SELECT COUNT(*) FROM events` first. If the table is non-empty, return immediately without touching the JSONL.

- **Steady state (DB populated)**: ~75-second phase → ~1 second (one COUNT query)
- **First boot (empty DB)**: code path unchanged — full JSONL import still runs
- **Transient error on the probe query**: fall through to the existing per-line import so a genuine empty DB + probe hiccup still recovers

## Verification

- `cargo check -p harness-observe` clean
- `cargo test` pre-commit hook passed (54 tests)
- Re-running `./target/release/harness serve --config config/default.toml` after this fix should log the existing `"ready"` line within a minute rather than >3 minutes against Supabase

## Future work (not in scope)

Combining this with the shared-pool refactor (#753) should bring startup against remote DBs well under a minute. Batching the actual first-time import into multi-row INSERTs would further help first-boot time when a very large JSONL backup is present, but is a separate change.