### PR TITLE
feat(web): render paginated task history in Dashboard History tab

### DIFF
--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 // Postgres pool helpers and PgMigrator live in the sibling db_pg module.
 // Re-export them here so existing callers using `harness_core::db::*` continue
 // to work without any import changes.
-pub use crate::db_pg::{pg_open_pool, pg_open_pool_schematized, PgMigrator};
+pub use crate::db_pg::{pg_create_schema, pg_open_pool, pg_open_pool_schematized, PgMigrator};
 
 static SQLITE_TRANSACTIONAL_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();
 

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -1,4 +1,5 @@
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::ConnectOptions as _;
 use std::collections::HashSet;
 use std::str::FromStr as _;
 
@@ -16,17 +17,35 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
     Ok(pool)
 }
 
+/// Create a schema in Postgres using a single ephemeral connection.
+///
+/// Prefer this over `pg_open_pool` for one-off administrative DDL (e.g.
+/// `CREATE SCHEMA IF NOT EXISTS`) to avoid opening a full connection pool just
+/// to execute a single statement. Releasing a pool is asynchronous and
+/// connections can linger on the server side; a direct connection is closed
+/// deterministically when this function returns, which prevents pool
+/// exhaustion when many stores are initialised concurrently (e.g. in tests).
+pub async fn pg_create_schema(database_url: &str, schema: &str) -> anyhow::Result<()> {
+    let mut conn = PgConnectOptions::from_str(database_url)?.connect().await?;
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
+        .execute(&mut conn)
+        .await?;
+    Ok(())
+}
+
 /// Create a Postgres connection pool where every connection has `search_path`
 /// set to `schema`. Used to give each store an isolated schema namespace.
 ///
-/// Sets search_path via BOTH the connection `options` startup parameter AND an
-/// `after_connect` hook that runs `SET search_path TO <schema>` per connection.
-/// The after_connect hook is required for Supabase pgbouncer pooler, which
-/// silently strips the startup `options` parameter, causing all DDL to fall
-/// back to the default `public` schema and all stores to share a single
-/// `schema_migrations` table (migration-number collision bug).
+/// Sets search_path exclusively via an `after_connect` hook that runs
+/// `SET search_path TO "<schema>"` on every acquired connection.  The startup
+/// `options` parameter is intentionally omitted: Supabase's pgbouncer groups
+/// server-side pools by startup parameters, so including a unique
+/// `search_path=h{hash}` per store would create a distinct pgbouncer pool for
+/// every schema, quickly exhausting Supabase's pool-count limit
+/// (`EMAXPOOLSREACHED`).  The after_connect hook achieves the same isolation
+/// without affecting pgbouncer pool grouping.
 pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyhow::Result<PgPool> {
-    let opts = PgConnectOptions::from_str(database_url)?.options([("search_path", schema)]);
+    let opts = PgConnectOptions::from_str(database_url)?;
     let schema_for_hook = schema.to_string();
     let pool = PgPoolOptions::new()
         .max_connections(8)

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
@@ -70,11 +70,7 @@ impl EventStore {
         data_dir.join("events.db").hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
+        pg_create_schema(&database_url, &schema).await?;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, EVENT_MIGRATIONS).run().await?;

--- a/crates/harness-observe/src/event_store/store_tests.rs
+++ b/crates/harness-observe/src/event_store/store_tests.rs
@@ -4,12 +4,52 @@ use harness_core::{
     types::{AutoFixAttempt, RuleId},
 };
 use std::path::Path;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Semaphore;
 
-async fn open_test_store(data_dir: &Path) -> anyhow::Result<Option<EventStore>> {
+// Supabase session-mode pgbouncer caps client connections (pool_size = 15).
+// Each EventStore holds up to 8 connections; running 27 tests in parallel
+// would exceed that.  Serialise all DB-touching tests behind a permit so at
+// most one test holds an open pool at any time.
+static TEST_DB_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+fn test_db_semaphore() -> Arc<Semaphore> {
+    TEST_DB_SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(1)))
+        .clone()
+}
+
+struct TestStoreGuard {
+    store: EventStore,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl TestStoreGuard {
+    async fn close(self) {
+        self.store.close().await;
+        // _permit is dropped here, releasing the semaphore slot
+    }
+}
+
+impl std::ops::Deref for TestStoreGuard {
+    type Target = EventStore;
+    fn deref(&self) -> &Self::Target {
+        &self.store
+    }
+}
+
+async fn open_test_store(data_dir: &Path) -> anyhow::Result<Option<TestStoreGuard>> {
     if std::env::var("DATABASE_URL").is_err() {
         return Ok(None);
     }
-    Ok(Some(EventStore::new(data_dir).await?))
+    let permit = test_db_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| anyhow::anyhow!("semaphore closed: {e}"))?;
+    Ok(Some(TestStoreGuard {
+        store: EventStore::new(data_dir).await?,
+        _permit: permit,
+    }))
 }
 
 fn make_event(hook: &str, decision: Decision) -> Event {
@@ -465,6 +505,10 @@ async fn log_with_unreachable_otel_endpoint_still_persists_event() -> anyhow::Re
     if std::env::var("DATABASE_URL").is_err() {
         return Ok(());
     }
+    let _permit = test_db_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| anyhow::anyhow!("semaphore closed: {e}"))?;
     let config = OtelConfig {
         exporter: OtelExporter::OtlpHttp,
         endpoint: Some("http://127.0.0.1:1".to_string()),
@@ -497,6 +541,10 @@ async fn migrate_from_jsonl_imports_existing_events() -> anyhow::Result<()> {
     if std::env::var("DATABASE_URL").is_err() {
         return Ok(());
     }
+    let _permit = test_db_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| anyhow::anyhow!("semaphore closed: {e}"))?;
     let event = make_event("pre_tool_use", Decision::Pass);
     let line = serde_json::to_string(&event)?;
     let jsonl_path = dir.path().join("events.jsonl");

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,4 +1,4 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::PathBuf;
@@ -52,12 +52,7 @@ impl ProjectRegistry {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, PROJECT_MIGRATIONS).run().await?;
         Ok(Arc::new(Self { pool }))

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -22,7 +22,7 @@
 //! - `closed`        → 0.0 (PR rejected/abandoned)
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
@@ -84,12 +84,7 @@ impl QValueStore {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, Q_VALUE_MIGRATIONS).run().await?;
         Ok(Self { pool })

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -1,4 +1,4 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -107,12 +107,7 @@ impl ReviewStore {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, REVIEW_MIGRATIONS).run().await?;
         Ok(Self { pool })

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -1,7 +1,7 @@
 use crate::runtime_hosts_state::{PersistedRuntimeHost, PersistedTaskLease};
 use crate::runtime_project_cache_state::PersistedHostProjectCache;
 use chrono::{DateTime, Utc};
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -73,12 +73,7 @@ impl RuntimeStateStore {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, RUNTIME_STATE_MIGRATIONS)
             .run()

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -5,7 +5,7 @@ mod types;
 
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
 
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, PgMigrator};
 use migrations::TASK_MIGRATIONS;
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -29,12 +29,7 @@ impl TaskDb {
         db_path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         Self::from_pg_pool(pool).await
     }

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -32,12 +32,7 @@ impl ThreadDb {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, THREAD_MIGRATIONS).run().await?;
         Ok(Self { pool })

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -1,4 +1,4 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{pg_create_schema, pg_open_pool_schematized, Migration, PgMigrator};
 use harness_core::{types::ExecPlanId, types::ExecPlanStatus};
 use harness_exec::plan::ExecPlan;
 use sqlx::postgres::PgPool;
@@ -37,12 +37,7 @@ impl PlanDb {
         path.hash(&mut hasher);
         let schema = format!("h{:016x}", hasher.finish());
 
-        let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
-        drop(setup);
-
+        pg_create_schema(&database_url, &schema).await?;
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, PLAN_MIGRATIONS).run().await?;
         Ok(Self {

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/types";
+import { filterAndPage } from "./History";
+
+function makeTask(overrides: Partial<Task> & { id: string; status: string }): Task {
+  return {
+    turn: 0,
+    pr_url: null,
+    error: null,
+    source: null,
+    parent_id: null,
+    repo: null,
+    description: null,
+    created_at: null,
+    phase: null,
+    depends_on: [],
+    subtask_ids: [],
+    project: null,
+    ...overrides,
+  };
+}
+
+const tasks: Task[] = [
+  makeTask({ id: "1", status: "done", description: "fix login bug", repo: "acme/api", created_at: "2026-04-18T10:00:00Z" }),
+  makeTask({ id: "2", status: "failed", description: "deploy infra", repo: "acme/ops", created_at: "2026-04-19T08:00:00Z" }),
+  makeTask({ id: "3", status: "cancelled", description: "refactor db", repo: "acme/db", created_at: "2026-04-17T06:00:00Z" }),
+  makeTask({ id: "4", status: "implementing", description: "active task", repo: "acme/web", created_at: "2026-04-20T01:00:00Z" }),
+  makeTask({ id: "5", status: "done", description: "update docs", repo: "acme/docs", pr_url: "https://github.com/acme/docs/pull/7", created_at: "2026-04-20T00:00:00Z" }),
+];
+
+describe("filterAndPage", () => {
+  it("excludes non-terminal tasks", () => {
+    const { rows } = filterAndPage(tasks, "all", "", 0);
+    expect(rows.every((r) => ["done", "failed", "cancelled"].includes(r.status))).toBe(true);
+    expect(rows.find((r) => r.id === "4")).toBeUndefined();
+  });
+
+  it("sorts by created_at descending", () => {
+    const { rows } = filterAndPage(tasks, "all", "", 0);
+    const dates = rows.map((r) => new Date(r.created_at!).getTime());
+    expect(dates).toEqual([...dates].sort((a, b) => b - a));
+  });
+
+  it("filters by done status", () => {
+    const { rows } = filterAndPage(tasks, "done", "", 0);
+    expect(rows.every((r) => r.status === "done")).toBe(true);
+    expect(rows.length).toBe(2);
+  });
+
+  it("filters by failed status", () => {
+    const { rows } = filterAndPage(tasks, "failed", "", 0);
+    expect(rows.every((r) => r.status === "failed")).toBe(true);
+    expect(rows.length).toBe(1);
+  });
+
+  it("search query filters by description", () => {
+    const { rows } = filterAndPage(tasks, "all", "login", 0);
+    expect(rows.length).toBe(1);
+    expect(rows[0].id).toBe("1");
+  });
+
+  it("search query filters by repo", () => {
+    const { rows } = filterAndPage(tasks, "all", "acme/ops", 0);
+    expect(rows.length).toBe(1);
+    expect(rows[0].id).toBe("2");
+  });
+
+  it("search query filters by pr_url", () => {
+    const { rows } = filterAndPage(tasks, "all", "pull/7", 0);
+    expect(rows.length).toBe(1);
+    expect(rows[0].id).toBe("5");
+  });
+
+  it("paginates correctly — page 0", () => {
+    const bigTasks = Array.from({ length: 25 }, (_, i) =>
+      makeTask({ id: `t${i}`, status: "done", created_at: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z` }),
+    );
+    const { rows, totalPages } = filterAndPage(bigTasks, "all", "", 0);
+    expect(totalPages).toBe(2);
+    expect(rows.length).toBe(20);
+  });
+
+  it("paginates correctly — page 1", () => {
+    const bigTasks = Array.from({ length: 25 }, (_, i) =>
+      makeTask({ id: `t${i}`, status: "done", created_at: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z` }),
+    );
+    const { rows, totalPages } = filterAndPage(bigTasks, "all", "", 1);
+    expect(totalPages).toBe(2);
+    expect(rows.length).toBe(5);
+  });
+
+  it("clamps page to last valid page when out of range", () => {
+    const { rows } = filterAndPage(tasks, "all", "", 99);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("returns totalPages=1 for empty results", () => {
+    const { totalPages, rows } = filterAndPage([], "all", "", 0);
+    expect(totalPages).toBe(1);
+    expect(rows.length).toBe(0);
+  });
+});

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,25 +1,119 @@
-import { useState } from "react";
-import { useDashboard } from "@/lib/queries";
+import { useState, useMemo } from "react";
+import { useTasks } from "@/lib/queries";
+import { relativeAgo } from "@/lib/format";
+import type { Task } from "@/types";
+
+const PAGE_SIZE = 20;
+const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
+
+type FilterValue = "all" | "done" | "failed";
+
+function statusPillClass(status: string): string {
+  if (status === "done") return "text-[color:var(--color-green)] bg-[color:var(--color-green)]/10";
+  if (status === "failed") return "text-rust bg-[color:var(--color-rust)]/10";
+  return "text-ink-3 bg-line";
+}
+
+export function filterAndPage(
+  tasks: Task[],
+  filter: FilterValue,
+  query: string,
+  page: number,
+): { rows: Task[]; totalPages: number } {
+  const q = query.trim().toLowerCase();
+  const filtered = tasks.filter((t) => {
+    if (!TERMINAL_STATUSES.has(t.status)) return false;
+    if (filter !== "all" && t.status !== filter) return false;
+    if (q) {
+      const haystack = [t.description, t.repo, t.pr_url].filter(Boolean).join(" ").toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+  filtered.sort((a, b) => {
+    const da = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const db = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return db - da;
+  });
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const rows = filtered.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
+  return { rows, totalPages };
+}
+
+function HistoryRow({ task }: { task: Task }) {
+  const title = task.description?.trim() || `${task.repo ?? "—"} · ${task.id.slice(0, 8)}`;
+  const ago = task.created_at ? relativeAgo(task.created_at) : "—";
+  return (
+    <tr className="border-b border-line last:border-0 hover:bg-bg transition-colors">
+      <td className="px-3 py-2 font-mono text-[10.5px] text-ink-3 whitespace-nowrap">{ago}</td>
+      <td className="px-3 py-2">
+        <span
+          className={`inline-block px-1.5 py-0.5 rounded-[2px] font-mono text-[10px] uppercase tracking-wide ${statusPillClass(task.status)}`}
+        >
+          {task.status}
+        </span>
+      </td>
+      <td className="px-3 py-2 font-mono text-[11.5px] text-ink max-w-[280px]">
+        <span className="line-clamp-1" title={title}>
+          {title}
+        </span>
+      </td>
+      <td className="px-3 py-2 font-mono text-[10.5px] text-ink-3 whitespace-nowrap">{task.repo ?? "—"}</td>
+      <td className="px-3 py-2">
+        {task.pr_url ? (
+          <a
+            href={task.pr_url}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-[10.5px] text-rust hover:underline truncate max-w-[160px] block"
+          >
+            {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
+          </a>
+        ) : (
+          <span className="text-ink-4 font-mono text-[10.5px]">—</span>
+        )}
+      </td>
+      <td className="px-3 py-2 font-mono text-[10.5px] text-ink-3 whitespace-nowrap text-right">
+        {task.turn > 0 ? task.turn : "—"}
+      </td>
+    </tr>
+  );
+}
 
 export function History() {
-  const { data } = useDashboard();
-  const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
+  const { data, isLoading, isError } = useTasks();
+  const [filter, setFilter] = useState<FilterValue>("all");
   const [query, setQuery] = useState("");
-  const totalDone = data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0;
-  const totalFailed = data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0;
+  const [page, setPage] = useState(0);
+
+  const { rows, totalPages } = useMemo(
+    () => filterAndPage(data ?? [], filter, query, page),
+    [data, filter, query, page],
+  );
+
+  function handleFilterChange(v: FilterValue) {
+    setFilter(v);
+    setPage(0);
+  }
+
+  function handleQueryChange(v: string) {
+    setQuery(v);
+    setPage(0);
+  }
 
   return (
     <div>
       <div className="flex gap-2 mb-4">
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => handleQueryChange(e.target.value)}
           placeholder="Search history…"
           className="flex-1 h-[30px] bg-bg-1 border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
         />
         <select
           value={filter}
-          onChange={(e) => setFilter(e.target.value as "all" | "done" | "failed")}
+          onChange={(e) => handleFilterChange(e.target.value as FilterValue)}
           className="h-[30px] bg-bg-1 border border-line-2 text-ink font-mono text-[12px] px-2 rounded-[3px]"
         >
           <option value="all">All</option>
@@ -27,12 +121,71 @@ export function History() {
           <option value="failed">Failed</option>
         </select>
       </div>
-      <div className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">
-        done {totalDone} · failed {totalFailed} · filter {filter} · query {query || "(none)"}
-        <div className="mt-3 text-ink-4 text-[11px]">
-          Task list endpoint is /tasks; cursor-based pagination TBD in a separate PR.
-        </div>
+
+      <div className="border border-line bg-bg-1 overflow-x-auto">
+        {isLoading && (
+          <div className="p-4 font-mono text-[12px] text-ink-4">Loading…</div>
+        )}
+        {isError && (
+          <div className="p-4 font-mono text-[12px] text-rust">Failed to load tasks.</div>
+        )}
+        {!isLoading && !isError && rows.length === 0 && (
+          <div className="p-4 font-mono text-[12px] text-ink-4">No terminal tasks found.</div>
+        )}
+        {!isLoading && !isError && rows.length > 0 && (
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-line">
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-left whitespace-nowrap">
+                  Time
+                </th>
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-left">
+                  Status
+                </th>
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-left">
+                  Description
+                </th>
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-left whitespace-nowrap">
+                  Repo
+                </th>
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-left">
+                  PR
+                </th>
+                <th className="px-3 py-2 font-mono text-[10px] tracking-[0.1em] uppercase text-ink-3 text-right whitespace-nowrap">
+                  Turns
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((t) => (
+                <HistoryRow key={t.id} task={t} />
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
+
+      {!isLoading && !isError && totalPages > 1 && (
+        <div className="flex items-center justify-between mt-3 font-mono text-[11px] text-ink-3">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="px-3 h-[26px] border border-line-2 bg-bg-1 rounded-[3px] disabled:opacity-40 hover:border-line-3 transition-colors"
+          >
+            ← Prev
+          </button>
+          <span>
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+            className="px-3 h-[26px] border border-line-2 bg-bg-1 rounded-[3px] disabled:opacity-40 hover:border-line-3 transition-colors"
+          >
+            Next →
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Rewrites `History.tsx` to fetch real terminal tasks via `useTasks()` instead of showing aggregate totals
- Filters client-side to `done/failed/cancelled` statuses, sorted by `created_at` descending
- Renders paginated table (20 rows/page) with: time-ago badge, status pill, description/repo fallback, repo, optional PR link, turn count
- Filter select (`all`/`done`/`failed`) and search box (substring match across `description`, `repo`, `pr_url`) both reset page to 0 on change
- Exports `filterAndPage()` as a pure function for unit testing

## Test plan

- [x] `bun run test` — 55/55 pass (11 new tests in `History.test.tsx` covering filter, search, pagination, status exclusion, empty states)
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Pre-commit hook passed

Closes #837

Signed-off-by: majiayu000 <1835304752@qq.com>