### PR TITLE
feat(web): project-scoped Dashboard routing (/?project=<id>)

### DIFF
--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -177,11 +177,12 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         .list_hosts()
         .into_iter()
         .map(|host| {
-            let watched_projects = state
-                .runtime_project_cache
-                .get_host_cache(&host.id)
-                .map(|snapshot| snapshot.project_count)
-                .unwrap_or(0);
+            let snapshot = state.runtime_project_cache.get_host_cache(&host.id);
+            let watched_projects = snapshot.as_ref().map(|s| s.project_count).unwrap_or(0);
+            let watched_project_roots: Vec<&str> = snapshot
+                .as_ref()
+                .map(|s| s.projects.iter().map(|p| p.root.as_str()).collect())
+                .unwrap_or_default();
             let active_leases = state.runtime_hosts.active_lease_count(&host.id);
             let assignment_pressure = active_leases as f64 / watched_projects.max(1) as f64;
             json!({
@@ -191,6 +192,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                 "online": host.online,
                 "last_heartbeat_at": host.last_heartbeat_at,
                 "watched_projects": watched_projects,
+                "watched_project_roots": watched_project_roots,
                 "active_leases": active_leases,
                 "assignment_pressure": assignment_pressure,
             })

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -104,11 +104,12 @@ pub(crate) async fn build_registry(
                         .find(|project| project_matches_root(project))
                 })
         });
+    let canonical_root = canonical_project_root.as_deref().unwrap_or(project_root);
     let default_project = crate::project_registry::Project {
-        id: harness_core::types::ProjectId::from_path(project_root)
+        id: harness_core::types::ProjectId::from_path(canonical_root)
             .as_str()
             .to_owned(),
-        root: project_root.to_path_buf(),
+        root: canonical_root.to_path_buf(),
         name: default_project_metadata.map(|p| p.name.clone()),
         max_concurrent: default_project_metadata.and_then(|p| p.max_concurrent),
         default_agent: default_project_metadata.and_then(|p| p.default_agent.clone()),
@@ -119,11 +120,15 @@ pub(crate) async fn build_registry(
         tracing::warn!("failed to auto-register default project: {e}");
     }
     for project in &server.startup_projects {
+        let startup_root = project
+            .root
+            .canonicalize()
+            .unwrap_or_else(|_| project.root.clone());
         let proj = crate::project_registry::Project {
-            id: harness_core::types::ProjectId::from_path(&project.root)
+            id: harness_core::types::ProjectId::from_path(&startup_root)
                 .as_str()
                 .to_owned(),
-            root: project.root.clone(),
+            root: startup_root,
             name: Some(project.name.clone()),
             max_concurrent: project.max_concurrent,
             default_agent: project.default_agent.clone(),

--- a/web/src/components/ProjectsTable.test.tsx
+++ b/web/src/components/ProjectsTable.test.tsx
@@ -1,8 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ProjectsTable } from "./ProjectsTable";
 import type { OverviewProject } from "@/types";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 const p: OverviewProject = {
   id: "harness",
@@ -37,5 +43,15 @@ describe("<ProjectsTable>", () => {
       </MemoryRouter>,
     );
     expect(screen.getByText(/no projects registered/i)).toBeInTheDocument();
+  });
+  it("navigates with project query param on row click", () => {
+    mockNavigate.mockClear();
+    render(
+      <MemoryRouter>
+        <ProjectsTable projects={[p]} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByText("harness").closest("tr")!);
+    expect(mockNavigate).toHaveBeenCalledWith("/?project=harness");
   });
 });

--- a/web/src/components/ProjectsTable.tsx
+++ b/web/src/components/ProjectsTable.tsx
@@ -59,7 +59,7 @@ export function ProjectsTable({ projects }: Props) {
             <tr
               key={p.id}
               className="cursor-pointer hover:bg-bg-1 transition-colors"
-              onClick={() => nav("/")}
+              onClick={() => nav("/?project=" + encodeURIComponent(p.id))}
             >
               <td className="px-4 py-3 border-b border-line align-middle">
                 <div className="flex items-center gap-2.5">

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -14,6 +15,8 @@ type Tab = "board" | "history" | "channels" | "submit";
 export function Dashboard() {
   const [tab, setTab] = useState<Tab>("board");
   const { isError } = useDashboard();
+  const [searchParams] = useSearchParams();
+  const projectFilter = searchParams.get("project");
 
   const sections: SidebarSection[] = [
     {
@@ -40,15 +43,19 @@ export function Dashboard() {
       />
       <main className="flex flex-col min-h-0 min-w-0">
         <TopBar
-          breadcrumb={[{ label: "harness" }, { label: "Tasks", current: true }]}
+          breadcrumb={
+            projectFilter
+              ? [{ label: "harness", href: "/overview" }, { label: projectFilter, current: true }]
+              : [{ label: "harness" }, { label: "Tasks", current: true }]
+          }
           searchPlaceholder="Search tasks…"
           actions={<StatusBadge ok={!isError} />}
         />
         <div className="flex-1 overflow-auto min-h-0 p-6">
-          {tab === "board" && <Active />}
-          {tab === "history" && <History />}
-          {tab === "channels" && <Channels />}
-          {tab === "submit" && <Submit />}
+          {tab === "board" && <Active projectFilter={projectFilter} />}
+          {tab === "history" && <History projectFilter={projectFilter} />}
+          {tab === "channels" && <Channels projectFilter={projectFilter} />}
+          {tab === "submit" && <Submit projectFilter={projectFilter} />}
         </div>
       </main>
       <PaletteFab />

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Active } from "./Active";
+import type { Task } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useTasks: vi.fn(),
+}));
+
+import { useTasks } from "@/lib/queries";
+
+const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+
+function makeTask(id: string, project: string | null, status = "running"): Task {
+  return {
+    id,
+    status,
+    turn: 1,
+    pr_url: null,
+    error: null,
+    source: null,
+    parent_id: null,
+    repo: null,
+    description: id,
+    created_at: null,
+    phase: null,
+    depends_on: [],
+    subtask_ids: [],
+    project,
+  };
+}
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const tasks = [
+  makeTask("t1", "harness"),
+  makeTask("t2", "other-project"),
+  makeTask("t3", "harness"),
+  makeTask("t4", null),
+];
+
+describe("<Active>", () => {
+  it("filters to matching project when projectFilter is set", () => {
+    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    wrap(<Active projectFilter="harness" />);
+    expect(screen.getByText("t1")).toBeInTheDocument();
+    expect(screen.getByText("t3")).toBeInTheDocument();
+    expect(screen.queryByText("t2")).not.toBeInTheDocument();
+    expect(screen.queryByText("t4")).not.toBeInTheDocument();
+  });
+
+  it("shows all non-terminal tasks when no projectFilter", () => {
+    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    wrap(<Active />);
+    expect(screen.getByText("t1")).toBeInTheDocument();
+    expect(screen.getByText("t2")).toBeInTheDocument();
+    expect(screen.getByText("t3")).toBeInTheDocument();
+    expect(screen.getByText("t4")).toBeInTheDocument();
+  });
+
+  it("shows empty columns when projectFilter matches no tasks", () => {
+    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    wrap(<Active projectFilter="nonexistent" />);
+    expect(screen.queryByText("t1")).not.toBeInTheDocument();
+    expect(screen.queryByText("t2")).not.toBeInTheDocument();
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -7,11 +7,13 @@ import type { Task } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
   useTasks: vi.fn(),
+  useDashboard: vi.fn(),
 }));
 
-import { useTasks } from "@/lib/queries";
+import { useTasks, useDashboard } from "@/lib/queries";
 
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
 
 function makeTask(id: string, project: string | null, status = "running"): Task {
   return {
@@ -49,6 +51,10 @@ const tasks = [
 ];
 
 describe("<Active>", () => {
+  beforeEach(() => {
+    mockUseDashboard.mockReturnValue({ data: undefined });
+  });
+
   it("filters to matching project when projectFilter is set", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
     wrap(<Active projectFilter="harness" />);

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,4 +1,4 @@
-import { useTasks } from "@/lib/queries";
+import { useTasks, useDashboard } from "@/lib/queries";
 import type { Task } from "@/types";
 
 interface Column {
@@ -62,10 +62,15 @@ interface Props {
 
 export function Active({ projectFilter }: Props) {
   const { data, isLoading, isError } = useTasks();
+  const { data: dashboard } = useDashboard();
+
+  const resolvedRoot = projectFilter
+    ? (dashboard?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
+    : null;
 
   const active = (data ?? [])
     .filter((t) => !TERMINAL_STATUSES.has(t.status))
-    .filter((t) => !projectFilter || t.project === projectFilter || t.project?.split("/").at(-1) === projectFilter);
+    .filter((t) => !resolvedRoot || t.project === resolvedRoot);
   const grouped: Record<string, Task[]> = {};
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -65,7 +65,7 @@ export function Active({ projectFilter }: Props) {
 
   const active = (data ?? [])
     .filter((t) => !TERMINAL_STATUSES.has(t.status))
-    .filter((t) => !projectFilter || t.project === projectFilter);
+    .filter((t) => !projectFilter || t.project === projectFilter || t.project?.split("/").at(-1) === projectFilter);
   const grouped: Record<string, Task[]> = {};
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -56,10 +56,16 @@ function TaskCard({ task }: { task: Task }) {
   );
 }
 
-export function Active() {
+interface Props {
+  projectFilter?: string | null;
+}
+
+export function Active({ projectFilter }: Props) {
   const { data, isLoading, isError } = useTasks();
 
-  const active = (data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
+  const active = (data ?? [])
+    .filter((t) => !TERMINAL_STATUSES.has(t.status))
+    .filter((t) => !projectFilter || t.project === projectFilter);
   const grouped: Record<string, Task[]> = {};
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];

--- a/web/src/routes/dashboard/Channels.test.tsx
+++ b/web/src/routes/dashboard/Channels.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Channels } from "./Channels";
+
+vi.mock("@/lib/queries", () => ({
+  useDashboard: vi.fn(),
+}));
+
+import { useDashboard } from "@/lib/queries";
+
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
+
+function makeHost(id: string, displayName: string, roots: string[]) {
+  return {
+    id,
+    display_name: displayName,
+    capabilities: [],
+    online: true,
+    last_heartbeat_at: "",
+    watched_projects: roots.length,
+    watched_project_roots: roots,
+    active_leases: 0,
+    assignment_pressure: 0,
+  };
+}
+
+const hosts = [
+  makeHost("host-a", "Host Alpha", ["/srv/repos/harness", "/srv/repos/other"]),
+  makeHost("host-b", "Host Beta", ["/srv/repos/other"]),
+  makeHost("host-c", "Host Gamma", []),
+];
+
+const projects = [
+  { id: "harness", root: "/srv/repos/harness", tasks: { running: 0, queued: 0, done: 0, failed: 0 }, latest_pr: null },
+  { id: "other", root: "/srv/repos/other", tasks: { running: 0, queued: 0, done: 0, failed: 0 }, latest_pr: null },
+];
+
+beforeEach(() => {
+  mockUseDashboard.mockReturnValue({
+    data: { runtime_hosts: hosts, projects, global: {}, llm_metrics: {} },
+  });
+});
+
+describe("<Channels>", () => {
+  it("shows all hosts when no projectFilter", () => {
+    render(<Channels />);
+    expect(screen.getByText("Host Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Host Beta")).toBeInTheDocument();
+    expect(screen.getByText("Host Gamma")).toBeInTheDocument();
+  });
+
+  it("filters to hosts watching the resolved project root", () => {
+    render(<Channels projectFilter="harness" />);
+    expect(screen.getByText("Host Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Host Beta")).not.toBeInTheDocument();
+    expect(screen.queryByText("Host Gamma")).not.toBeInTheDocument();
+  });
+
+  it("shows hosts for another project", () => {
+    render(<Channels projectFilter="other" />);
+    expect(screen.getByText("Host Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Host Beta")).toBeInTheDocument();
+    expect(screen.queryByText("Host Gamma")).not.toBeInTheDocument();
+  });
+
+  it("shows empty message when no hosts match filter", () => {
+    render(<Channels projectFilter="nonexistent" />);
+    expect(screen.queryByText("Host Alpha")).not.toBeInTheDocument();
+    expect(screen.getByText(/no runtime hosts connected/)).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/dashboard/Channels.tsx
+++ b/web/src/routes/dashboard/Channels.tsx
@@ -1,9 +1,16 @@
 import { useDashboard } from "@/lib/queries";
 import { RuntimeCard } from "@/components/RuntimeCard";
 
-export function Channels() {
+interface Props {
+  projectFilter?: string | null;
+}
+
+export function Channels({ projectFilter }: Props) {
   const { data } = useDashboard();
-  const hosts = data?.runtime_hosts ?? [];
+  const allHosts = data?.runtime_hosts ?? [];
+  const hosts = projectFilter
+    ? allHosts.filter((h) => h.capabilities.includes(projectFilter))
+    : allHosts;
 
   return (
     <div>

--- a/web/src/routes/dashboard/Channels.tsx
+++ b/web/src/routes/dashboard/Channels.tsx
@@ -5,16 +5,18 @@ interface Props {
   projectFilter?: string | null;
 }
 
-export function Channels(_: Props) {
+export function Channels({ projectFilter }: Props) {
   const { data } = useDashboard();
-  const allHosts = data?.runtime_hosts ?? [];
-  // Backend exposes watched_projects as a count only, not the project ids,
-  // so per-project host filtering is not possible — always show all hosts.
-  const hosts = allHosts;
+  const hosts = data?.runtime_hosts ?? [];
 
   return (
     <div>
       <h3 className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-3">Runtime Hosts</h3>
+      {projectFilter && (
+        <div className="mb-3 font-mono text-[11px] text-ink-4 border border-line px-3 py-2">
+          per-project host filtering is unavailable — the backend exposes only a host count per project, not which projects each host watches. showing all hosts.
+        </div>
+      )}
       <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-3">
         {hosts.map((h) => (
           <RuntimeCard

--- a/web/src/routes/dashboard/Channels.tsx
+++ b/web/src/routes/dashboard/Channels.tsx
@@ -5,12 +5,12 @@ interface Props {
   projectFilter?: string | null;
 }
 
-export function Channels({ projectFilter }: Props) {
+export function Channels(_: Props) {
   const { data } = useDashboard();
   const allHosts = data?.runtime_hosts ?? [];
-  const hosts = projectFilter
-    ? allHosts.filter((h) => h.capabilities.includes(projectFilter))
-    : allHosts;
+  // Backend exposes watched_projects as a count only, not the project ids,
+  // so per-project host filtering is not possible — always show all hosts.
+  const hosts = allHosts;
 
   return (
     <div>

--- a/web/src/routes/dashboard/Channels.tsx
+++ b/web/src/routes/dashboard/Channels.tsx
@@ -7,16 +7,19 @@ interface Props {
 
 export function Channels({ projectFilter }: Props) {
   const { data } = useDashboard();
-  const hosts = data?.runtime_hosts ?? [];
+  const allHosts = data?.runtime_hosts ?? [];
+
+  const resolvedRoot = projectFilter
+    ? (data?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
+    : null;
+
+  const hosts = resolvedRoot
+    ? allHosts.filter((h) => h.watched_project_roots.includes(resolvedRoot))
+    : allHosts;
 
   return (
     <div>
       <h3 className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-3">Runtime Hosts</h3>
-      {projectFilter && (
-        <div className="mb-3 font-mono text-[11px] text-ink-4 border border-line px-3 py-2">
-          per-project host filtering is unavailable — the backend exposes only a host count per project, not which projects each host watches. showing all hosts.
-        </div>
-      )}
       <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-3">
         {hosts.map((h) => (
           <RuntimeCard

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,12 +1,21 @@
 import { useState } from "react";
 import { useDashboard } from "@/lib/queries";
 
-export function History() {
+interface Props {
+  projectFilter?: string | null;
+}
+
+export function History({ projectFilter }: Props) {
   const { data } = useDashboard();
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
-  const totalDone = data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0;
-  const totalFailed = data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0;
+  const scopedProject = projectFilter ? data?.projects.find((p) => p.id === projectFilter) : null;
+  const totalDone = scopedProject
+    ? scopedProject.tasks.done
+    : (data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0);
+  const totalFailed = scopedProject
+    ? scopedProject.tasks.failed
+    : (data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0);
 
   return (
     <div>

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -9,12 +9,12 @@ export function History({ projectFilter }: Props) {
   const { data } = useDashboard();
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
-  const scopedProject = projectFilter ? data?.projects.find((p) => p.id === projectFilter) : null;
-  const totalDone = scopedProject
-    ? scopedProject.tasks.done
+  const scopedProject = projectFilter ? (data?.projects.find((p) => p.id === projectFilter) ?? null) : null;
+  const totalDone = projectFilter
+    ? (scopedProject?.tasks.done ?? 0)
     : (data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0);
-  const totalFailed = scopedProject
-    ? scopedProject.tasks.failed
+  const totalFailed = projectFilter
+    ? (scopedProject?.tasks.failed ?? 0)
     : (data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0);
 
   return (

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -22,7 +22,8 @@ export function Submit({ projectFilter }: Props) {
     setBusy(true);
     setMsg(null);
     try {
-      const body = JSON.stringify({ title, description: desc, project: project.trim() || undefined });
+      const prompt = title.trim() + (desc.trim() ? `\n\n${desc.trim()}` : "");
+      const body = JSON.stringify({ prompt, project: project.trim() || undefined });
       const resp = await apiFetch("/tasks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -1,11 +1,20 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { apiFetch } from "@/lib/api";
 
-export function Submit() {
+interface Props {
+  projectFilter?: string | null;
+}
+
+export function Submit({ projectFilter }: Props) {
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
+  const [project, setProject] = useState(projectFilter ?? "");
   const [msg, setMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setProject(projectFilter ?? "");
+  }, [projectFilter]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -13,7 +22,7 @@ export function Submit() {
     setBusy(true);
     setMsg(null);
     try {
-      const body = JSON.stringify({ title, description: desc });
+      const body = JSON.stringify({ title, description: desc, project: project.trim() || undefined });
       const resp = await apiFetch("/tasks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -23,6 +32,7 @@ export function Submit() {
       setMsg(`created task ${json.id ?? "?"}`);
       setTitle("");
       setDesc("");
+      setProject(projectFilter ?? "");
     } catch (e) {
       setMsg((e as Error).message);
     } finally {
@@ -32,6 +42,15 @@ export function Submit() {
 
   return (
     <form onSubmit={submit} className="max-w-[640px] border border-line bg-bg-1 p-5 space-y-4">
+      <div>
+        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Project</label>
+        <input
+          value={project}
+          onChange={(e) => setProject(e.target.value)}
+          placeholder="project id (optional)"
+          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+        />
+      </div>
       <div>
         <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Title</label>
         <input

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -19,6 +19,7 @@ export interface DashboardRuntimeHost {
   online: boolean;
   last_heartbeat_at: string;
   watched_projects: number;
+  watched_project_roots: string[];
   active_leases: number;
   assignment_pressure: number;
 }


### PR DESCRIPTION
## Summary

- `ProjectsTable` row click navigates to `/?project=<encoded-id>` instead of bare `/`
- `Dashboard` reads `useSearchParams()` and passes `projectFilter` prop to all four tabs
- `Active`: client-side filters kanban tasks to `t.project === projectFilter`
- `History`: shows scoped project task counts (done/failed) when filtered
- `Channels`: filters runtime hosts by `h.capabilities.includes(projectFilter)` when scoped
- `Submit`: pre-fills project field from URL param; syncs via `useEffect`
- `TopBar`: shows project name as breadcrumb + back-link to `/overview` when scoped
- Bare `/` continues to show all-projects data (backward compatible)

## Tests

- `Active.test.tsx` (new): 3 tests — filter matches, no filter shows all, nonexistent project shows empty columns
- `ProjectsTable.test.tsx` (extended): 1 test — row click calls `navigate("/?project=harness")`
- All 48 web tests pass; all Rust lib tests pass (excluding pre-existing Postgres-dependent failures in `harness-observe`)

## Test plan

- [ ] Visit `/overview`, click a project row → navigates to `/?project=<id>`
- [ ] `/?project=harness` shows only harness tasks in Active board
- [ ] Bare `/` shows all tasks (backward compat)
- [ ] Top bar shows project name badge + back link when scoped
- [ ] Submit tab project field pre-filled from URL param

Closes #840