### PR TITLE
feat(web): task detail slide-over panel for kanban cards

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "harness-web",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@tanstack/react-query": "^5.59.0",
         "harness-sdk": "file:../sdk/typescript",
         "react": "^19.0.0",
@@ -146,6 +147,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@microsoft/fetch-event-source": ["@microsoft/fetch-event-source@2.0.1", "", {}, "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@tanstack/react-query": "^5.59.0",
     "harness-sdk": "file:../sdk/typescript",
     "react": "^19.0.0",

--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TaskSlideover } from "./TaskSlideover";
+
+vi.mock("@/lib/useTaskStream", () => ({
+  useTaskStream: vi.fn(() => ({ lines: [], connected: false, error: null })),
+}));
+
+vi.mock("@/lib/queries", () => ({
+  useTask: vi.fn(() => ({ data: null })),
+  useTaskArtifacts: vi.fn(() => ({ data: [] })),
+  useTaskPrompts: vi.fn(() => ({ data: [] })),
+}));
+
+import { useTaskStream } from "@/lib/useTaskStream";
+import { useTask, useTaskArtifacts, useTaskPrompts } from "@/lib/queries";
+
+function wrap(ui: React.ReactElement) {
+  const client = new QueryClient();
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe("<TaskSlideover>", () => {
+  beforeEach(() => {
+    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, error: null });
+    vi.mocked(useTask).mockReturnValue({ data: null } as unknown as ReturnType<typeof useTask>);
+    vi.mocked(useTaskArtifacts).mockReturnValue({ data: [] } as unknown as ReturnType<typeof useTaskArtifacts>);
+    vi.mocked(useTaskPrompts).mockReturnValue({ data: [] } as unknown as ReturnType<typeof useTaskPrompts>);
+  });
+
+  it("renders nothing when taskId is null", () => {
+    const { container } = wrap(<TaskSlideover taskId={null} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders panel with all 4 tabs when taskId is set", () => {
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    expect(screen.getByText("Stream")).toBeInTheDocument();
+    expect(screen.getByText("Diff")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("Events")).toBeInTheDocument();
+  });
+
+  it("shows truncated taskId in header", () => {
+    wrap(<TaskSlideover taskId="abc12345def" onClose={() => {}} />);
+    expect(screen.getByText("abc12345")).toBeInTheDocument();
+  });
+
+  it("close button calls onClose", () => {
+    const onClose = vi.fn();
+    wrap(<TaskSlideover taskId="abc12345" onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("Escape keydown calls onClose", () => {
+    const onClose = vi.fn();
+    wrap(<TaskSlideover taskId="abc12345" onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("backdrop click calls onClose", () => {
+    const onClose = vi.fn();
+    wrap(<TaskSlideover taskId="abc12345" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("presentation", { hidden: true }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("Stream tab shows connecting placeholder before first SSE line", () => {
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    expect(screen.getByText("connecting…")).toBeInTheDocument();
+  });
+
+  it("Stream tab shows lines when connected", () => {
+    vi.mocked(useTaskStream).mockReturnValue({ lines: ["line one", "line two"], connected: true, error: null });
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    expect(screen.getByText(/line one/)).toBeInTheDocument();
+  });
+
+  it("Diff tab shows — when artifacts is empty", () => {
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    fireEvent.click(screen.getByText("Diff"));
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("Diff tab colours + lines with text-ok class", () => {
+    vi.mocked(useTaskArtifacts).mockReturnValue({
+      data: [{ task_id: "abc12345", turn: 1, artifact_type: "diff", content: "+added line\n-removed line\n@@ context", created_at: "" }],
+    } as unknown as ReturnType<typeof useTaskArtifacts>);
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    fireEvent.click(screen.getByText("Diff"));
+    expect(screen.getByText("+added line").className).toContain("text-ok");
+    expect(screen.getByText("-removed line").className).toContain("text-danger");
+    expect(screen.getByText("@@ context").className).toContain("text-ink-3");
+  });
+
+  it("Review tab shows preformatted prompt text", () => {
+    vi.mocked(useTaskPrompts).mockReturnValue({
+      data: [{ task_id: "abc12345", turn: 1, phase: "review", prompt: "review content here", created_at: "" }],
+    } as ReturnType<typeof useTaskPrompts>);
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    fireEvent.click(screen.getByText("Review"));
+    expect(screen.getByText("review content here")).toBeInTheDocument();
+  });
+
+  it("Events tab shows task status and turn", () => {
+    vi.mocked(useTask).mockReturnValue({
+      data: { id: "abc12345", status: "implementing", turn: 3, pr_url: null, error: null, source: null, parent_id: null, repo: null, description: null, created_at: null, phase: null, depends_on: [], subtask_ids: [], project: null },
+    } as unknown as ReturnType<typeof useTask>);
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    fireEvent.click(screen.getByText("Events"));
+    expect(screen.getByText("implementing")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("tab click switches active tab without remount", () => {
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    const diffTab = screen.getByText("Diff");
+    fireEvent.click(diffTab);
+    expect(diffTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Stream")).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TaskSlideover } from "./TaskSlideover";
 
 vi.mock("@/lib/useTaskStream", () => ({
-  useTaskStream: vi.fn(() => ({ lines: [], connected: false, error: null })),
+  useTaskStream: vi.fn(() => ({ lines: [], connected: false, done: false, error: null })),
 }));
 
 vi.mock("@/lib/queries", () => ({
@@ -23,7 +23,7 @@ function wrap(ui: React.ReactElement) {
 
 describe("<TaskSlideover>", () => {
   beforeEach(() => {
-    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, error: null });
+    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, done: false, error: null });
     vi.mocked(useTask).mockReturnValue({ data: null } as unknown as ReturnType<typeof useTask>);
     vi.mocked(useTaskArtifacts).mockReturnValue({ data: [] } as unknown as ReturnType<typeof useTaskArtifacts>);
     vi.mocked(useTaskPrompts).mockReturnValue({ data: [] } as unknown as ReturnType<typeof useTaskPrompts>);
@@ -74,14 +74,14 @@ describe("<TaskSlideover>", () => {
   });
 
   it("Stream tab shows error message when stream fails", () => {
-    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, error: "Stream request failed: 500" });
+    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, done: false, error: "Stream request failed: 500" });
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
     expect(screen.getByText("Stream request failed: 500")).toBeInTheDocument();
     expect(screen.queryByText("connecting…")).not.toBeInTheDocument();
   });
 
   it("Stream tab shows lines when connected", () => {
-    vi.mocked(useTaskStream).mockReturnValue({ lines: ["line one", "line two"], connected: true, error: null });
+    vi.mocked(useTaskStream).mockReturnValue({ lines: ["line one", "line two"], connected: true, done: false, error: null });
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
     expect(screen.getByText(/line one/)).toBeInTheDocument();
   });
@@ -105,7 +105,7 @@ describe("<TaskSlideover>", () => {
 
   it("Review tab shows stream note and review prompt text", () => {
     vi.mocked(useTaskPrompts).mockReturnValue({
-      data: [{ task_id: "abc12345", turn: 1, phase: "review", prompt: "review content here", created_at: "" }],
+      data: [{ task_id: "abc12345", turn: 1, phase: "simplereview", prompt: "review content here", created_at: "" }],
     } as ReturnType<typeof useTaskPrompts>);
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
     fireEvent.click(screen.getByText("Review"));

--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -73,6 +73,13 @@ describe("<TaskSlideover>", () => {
     expect(screen.getByText("connecting…")).toBeInTheDocument();
   });
 
+  it("Stream tab shows error message when stream fails", () => {
+    vi.mocked(useTaskStream).mockReturnValue({ lines: [], connected: false, error: "Stream request failed: 500" });
+    wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
+    expect(screen.getByText("Stream request failed: 500")).toBeInTheDocument();
+    expect(screen.queryByText("connecting…")).not.toBeInTheDocument();
+  });
+
   it("Stream tab shows lines when connected", () => {
     vi.mocked(useTaskStream).mockReturnValue({ lines: ["line one", "line two"], connected: true, error: null });
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
@@ -85,24 +92,25 @@ describe("<TaskSlideover>", () => {
     expect(screen.getByText("—")).toBeInTheDocument();
   });
 
-  it("Diff tab colours + lines with text-ok class", () => {
+  it("Diff tab renders file_edit before/after as coloured lines", () => {
     vi.mocked(useTaskArtifacts).mockReturnValue({
-      data: [{ task_id: "abc12345", turn: 1, artifact_type: "diff", content: "+added line\n-removed line\n@@ context", created_at: "" }],
+      data: [{ task_id: "abc12345", turn: 1, artifact_type: "file_edit", content: JSON.stringify({ path: "src/foo.ts", before: "removed line", after: "added line" }), created_at: "" }],
     } as unknown as ReturnType<typeof useTaskArtifacts>);
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
     fireEvent.click(screen.getByText("Diff"));
-    expect(screen.getByText("+added line").className).toContain("text-ok");
     expect(screen.getByText("-removed line").className).toContain("text-danger");
-    expect(screen.getByText("@@ context").className).toContain("text-ink-3");
+    expect(screen.getByText("+added line").className).toContain("text-ok");
+    expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
   });
 
-  it("Review tab shows preformatted prompt text", () => {
+  it("Review tab shows stream note and review prompt text", () => {
     vi.mocked(useTaskPrompts).mockReturnValue({
       data: [{ task_id: "abc12345", turn: 1, phase: "review", prompt: "review content here", created_at: "" }],
     } as ReturnType<typeof useTaskPrompts>);
     wrap(<TaskSlideover taskId="abc12345" onClose={() => {}} />);
     fireEvent.click(screen.getByText("Review"));
     expect(screen.getByText("review content here")).toBeInTheDocument();
+    expect(screen.getByText(/Reviewer findings stream live/)).toBeInTheDocument();
   });
 
   it("Events tab shows task status and turn", () => {

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -52,15 +52,16 @@ function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
 }
 
 function ReviewView({ prompts, artifacts }: { prompts: TaskPrompt[]; artifacts: TaskArtifact[] }) {
-  const reviewPrompts = prompts.filter((p) => p.phase === "simplereview");
-  if (reviewPrompts.length === 0) {
+  if (prompts.length === 0) {
     return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
   }
-  const reviewTurns = new Set(reviewPrompts.map((p) => p.turn));
+  const reviewTurns = new Set(
+    prompts.filter((p) => p.phase === "simplereview").map((p) => p.turn),
+  );
   const reviewArtifacts = artifacts.filter((a) => reviewTurns.has(a.turn));
   return (
     <div className="p-2 space-y-4">
-      {reviewPrompts.map((p, i) => (
+      {prompts.map((p, i) => (
         <div key={i} className="space-y-1">
           <div className="font-mono text-[10px] text-ink-3 uppercase tracking-[0.06em]">
             turn {p.turn} · {p.phase}

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -20,8 +20,15 @@ function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
   return (
     <div className="p-2 space-y-4">
       {fileEdits.map((a, i) => {
-        let parsed: FileEditContent = {};
-        try { parsed = JSON.parse(a.content) as FileEditContent; } catch { /* ignore malformed */ }
+        let parsed: FileEditContent | null = null;
+        try { parsed = JSON.parse(a.content) as FileEditContent; } catch { /* malformed/truncated */ }
+        if (!parsed) {
+          return (
+            <div key={i} className="font-mono text-[11px] text-danger">
+              [artifact {i + 1}: malformed or truncated content]
+            </div>
+          );
+        }
         const beforeLines = parsed.before ? parsed.before.split("\n") : [];
         const afterLines = parsed.after ? parsed.after.split("\n") : [];
         return (
@@ -44,25 +51,32 @@ function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
   );
 }
 
-function ReviewView({ prompts }: { prompts: TaskPrompt[] }) {
-  const reviews = prompts.filter(
-    (p) => p.phase === "review" || p.phase === "cross_review",
+function ReviewView({ prompts, artifacts }: { prompts: TaskPrompt[]; artifacts: TaskArtifact[] }) {
+  const reviewTurns = new Set(
+    prompts
+      .filter((p) => p.phase === "review" || p.phase === "cross_review")
+      .map((p) => p.turn),
   );
-  if (reviews.length === 0) {
+  if (reviewTurns.size === 0) {
     return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
+  }
+  const reviewArtifacts = artifacts.filter((a) => reviewTurns.has(a.turn));
+  if (reviewArtifacts.length === 0) {
+    return (
+      <div className="p-3 font-mono text-[11px] text-ink-4">
+        Review output streams live — see the Stream tab.
+      </div>
+    );
   }
   return (
     <div className="p-2 space-y-4">
-      <div className="font-mono text-[10px] text-ink-4">
-        Reviewer findings stream live — see the Stream tab for output.
-      </div>
-      {reviews.map((p, i) => (
+      {reviewArtifacts.map((a, i) => (
         <div key={i} className="space-y-1">
           <div className="font-mono text-[10px] text-ink-3 uppercase tracking-[0.06em]">
-            {p.phase} · turn {p.turn} · prompt
+            turn {a.turn} · {a.artifact_type}
           </div>
           <pre className="font-mono text-[11px] text-ink-3 whitespace-pre-wrap break-words">
-            {p.prompt}
+            {a.content}
           </pre>
         </div>
       ))}
@@ -150,7 +164,7 @@ export function TaskSlideover({ taskId, onClose }: Props) {
             </pre>
           )}
           {activeTab === "Diff" && <DiffView artifacts={artifacts ?? []} />}
-          {activeTab === "Review" && <ReviewView prompts={prompts ?? []} />}
+          {activeTab === "Review" && <ReviewView prompts={prompts ?? []} artifacts={artifacts ?? []} />}
           {activeTab === "Events" && (
             <div className="p-3 space-y-2">
               {task ? (

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -52,34 +52,40 @@ function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
 }
 
 function ReviewView({ prompts, artifacts }: { prompts: TaskPrompt[]; artifacts: TaskArtifact[] }) {
-  const reviewTurns = new Set(
-    prompts
-      .filter((p) => p.phase === "review" || p.phase === "cross_review")
-      .map((p) => p.turn),
-  );
-  if (reviewTurns.size === 0) {
+  const reviewPrompts = prompts.filter((p) => p.phase === "simplereview");
+  if (reviewPrompts.length === 0) {
     return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
   }
+  const reviewTurns = new Set(reviewPrompts.map((p) => p.turn));
   const reviewArtifacts = artifacts.filter((a) => reviewTurns.has(a.turn));
-  if (reviewArtifacts.length === 0) {
-    return (
-      <div className="p-3 font-mono text-[11px] text-ink-4">
-        Review output streams live — see the Stream tab.
-      </div>
-    );
-  }
   return (
     <div className="p-2 space-y-4">
-      {reviewArtifacts.map((a, i) => (
+      {reviewPrompts.map((p, i) => (
         <div key={i} className="space-y-1">
           <div className="font-mono text-[10px] text-ink-3 uppercase tracking-[0.06em]">
-            turn {a.turn} · {a.artifact_type}
+            turn {p.turn} · {p.phase}
           </div>
           <pre className="font-mono text-[11px] text-ink-3 whitespace-pre-wrap break-words">
-            {a.content}
+            {p.prompt}
           </pre>
         </div>
       ))}
+      {reviewArtifacts.length === 0 ? (
+        <div className="font-mono text-[11px] text-ink-4">
+          Reviewer findings stream live — see the Stream tab.
+        </div>
+      ) : (
+        reviewArtifacts.map((a, i) => (
+          <div key={`a${i}`} className="space-y-1">
+            <div className="font-mono text-[10px] text-ink-3 uppercase tracking-[0.06em]">
+              turn {a.turn} · {a.artifact_type}
+            </div>
+            <pre className="font-mono text-[11px] text-ink-3 whitespace-pre-wrap break-words">
+              {a.content}
+            </pre>
+          </div>
+        ))
+      )}
     </div>
   );
 }
@@ -91,7 +97,7 @@ interface Props {
 
 export function TaskSlideover({ taskId, onClose }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("Stream");
-  const { lines, connected, error } = useTaskStream(taskId);
+  const { lines, connected, done, error } = useTaskStream(taskId);
   const { data: task } = useTask(taskId);
   const { data: artifacts } = useTaskArtifacts(taskId);
   const { data: prompts } = useTaskPrompts(taskId);
@@ -156,9 +162,11 @@ export function TaskSlideover({ taskId, onClose }: Props) {
             <pre className="p-3 font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
               {error ? (
                 <span className="text-danger">{error}</span>
-              ) : (!connected && lines.length === 0 && (
+              ) : done && lines.length === 0 ? (
+                <span className="text-ink-4">—</span>
+              ) : !connected && lines.length === 0 ? (
                 <span className="text-ink-4">connecting…</span>
-              ))}
+              ) : null}
               {lines.join("\n")}
               <div ref={streamEndRef} />
             </pre>
@@ -192,6 +200,19 @@ export function TaskSlideover({ taskId, onClose }: Props) {
                 </>
               ) : (
                 <div className="text-ink-4 font-mono text-[11px]">loading…</div>
+              )}
+              {prompts && prompts.length > 0 && (
+                <div className="mt-3 space-y-1 border-t border-line pt-3">
+                  {[...prompts].slice(-20).reverse().map((p, i) => (
+                    <div key={i} className="flex items-center gap-2 font-mono text-[11px]">
+                      <span className="text-ink-3 flex-none">t{p.turn}</span>
+                      <span className="text-ink">{p.phase}</span>
+                      <span className="text-ink-4 ml-auto text-[10px]">
+                        {new Date(p.created_at).toLocaleTimeString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           )}

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -6,28 +6,40 @@ import type { TaskArtifact, TaskPrompt } from "@/types";
 const TABS = ["Stream", "Diff", "Review", "Events"] as const;
 type Tab = (typeof TABS)[number];
 
+interface FileEditContent {
+  path?: string;
+  before?: string;
+  after?: string;
+}
+
 function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
-  const diffs = artifacts.filter((a) => a.artifact_type === "diff");
-  if (diffs.length === 0) {
+  const fileEdits = artifacts.filter((a) => a.artifact_type === "file_edit");
+  if (fileEdits.length === 0) {
     return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
   }
   return (
     <div className="p-2 space-y-4">
-      {diffs.map((a, i) => (
-        <div key={i} className="font-mono text-[11px] leading-relaxed">
-          {a.content.split("\n").map((line, j) => {
-            let cls = "text-ink";
-            if (line.startsWith("+")) cls = "text-ok";
-            else if (line.startsWith("-")) cls = "text-danger";
-            else if (line.startsWith("@@")) cls = "text-ink-3";
-            return (
-              <div key={j} className={cls}>
-                {line || "\u00a0"}
-              </div>
-            );
-          })}
-        </div>
-      ))}
+      {fileEdits.map((a, i) => {
+        let parsed: FileEditContent = {};
+        try { parsed = JSON.parse(a.content) as FileEditContent; } catch { /* ignore malformed */ }
+        const beforeLines = parsed.before ? parsed.before.split("\n") : [];
+        const afterLines = parsed.after ? parsed.after.split("\n") : [];
+        return (
+          <div key={i} className="space-y-1">
+            {parsed.path && (
+              <div className="font-mono text-[10px] text-ink-3 mb-1">{parsed.path}</div>
+            )}
+            <div className="font-mono text-[11px] leading-relaxed">
+              {beforeLines.map((line, j) => (
+                <div key={`b${j}`} className="text-danger">{`-${line}`}</div>
+              ))}
+              {afterLines.map((line, j) => (
+                <div key={`a${j}`} className="text-ok">{`+${line}`}</div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -41,10 +53,18 @@ function ReviewView({ prompts }: { prompts: TaskPrompt[] }) {
   }
   return (
     <div className="p-2 space-y-4">
+      <div className="font-mono text-[10px] text-ink-4">
+        Reviewer findings stream live — see the Stream tab for output.
+      </div>
       {reviews.map((p, i) => (
-        <pre key={i} className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
-          {p.prompt}
-        </pre>
+        <div key={i} className="space-y-1">
+          <div className="font-mono text-[10px] text-ink-3 uppercase tracking-[0.06em]">
+            {p.phase} · turn {p.turn} · prompt
+          </div>
+          <pre className="font-mono text-[11px] text-ink-3 whitespace-pre-wrap break-words">
+            {p.prompt}
+          </pre>
+        </div>
       ))}
     </div>
   );
@@ -57,7 +77,7 @@ interface Props {
 
 export function TaskSlideover({ taskId, onClose }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("Stream");
-  const { lines, connected } = useTaskStream(taskId);
+  const { lines, connected, error } = useTaskStream(taskId);
   const { data: task } = useTask(taskId);
   const { data: artifacts } = useTaskArtifacts(taskId);
   const { data: prompts } = useTaskPrompts(taskId);
@@ -120,9 +140,11 @@ export function TaskSlideover({ taskId, onClose }: Props) {
         <div className="flex-1 overflow-auto">
           {activeTab === "Stream" && (
             <pre className="p-3 font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
-              {!connected && lines.length === 0 && (
+              {error ? (
+                <span className="text-danger">{error}</span>
+              ) : (!connected && lines.length === 0 && (
                 <span className="text-ink-4">connecting…</span>
-              )}
+              ))}
               {lines.join("\n")}
               <div ref={streamEndRef} />
             </pre>

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from "react";
+import { useTask, useTaskArtifacts, useTaskPrompts } from "@/lib/queries";
+import { useTaskStream } from "@/lib/useTaskStream";
+import type { TaskArtifact, TaskPrompt } from "@/types";
+
+const TABS = ["Stream", "Diff", "Review", "Events"] as const;
+type Tab = (typeof TABS)[number];
+
+function DiffView({ artifacts }: { artifacts: TaskArtifact[] }) {
+  const diffs = artifacts.filter((a) => a.artifact_type === "diff");
+  if (diffs.length === 0) {
+    return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
+  }
+  return (
+    <div className="p-2 space-y-4">
+      {diffs.map((a, i) => (
+        <div key={i} className="font-mono text-[11px] leading-relaxed">
+          {a.content.split("\n").map((line, j) => {
+            let cls = "text-ink";
+            if (line.startsWith("+")) cls = "text-ok";
+            else if (line.startsWith("-")) cls = "text-danger";
+            else if (line.startsWith("@@")) cls = "text-ink-3";
+            return (
+              <div key={j} className={cls}>
+                {line || "\u00a0"}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReviewView({ prompts }: { prompts: TaskPrompt[] }) {
+  const reviews = prompts.filter(
+    (p) => p.phase === "review" || p.phase === "cross_review",
+  );
+  if (reviews.length === 0) {
+    return <div className="p-3 font-mono text-[11px] text-ink-4">—</div>;
+  }
+  return (
+    <div className="p-2 space-y-4">
+      {reviews.map((p, i) => (
+        <pre key={i} className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
+          {p.prompt}
+        </pre>
+      ))}
+    </div>
+  );
+}
+
+interface Props {
+  taskId: string | null;
+  onClose: () => void;
+}
+
+export function TaskSlideover({ taskId, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("Stream");
+  const { lines, connected } = useTaskStream(taskId);
+  const { data: task } = useTask(taskId);
+  const { data: artifacts } = useTaskArtifacts(taskId);
+  const { data: prompts } = useTaskPrompts(taskId);
+  const streamEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (activeTab === "Stream" && typeof streamEndRef.current?.scrollIntoView === "function") {
+      streamEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [lines, activeTab]);
+
+  if (!taskId) return null;
+
+  return (
+    <>
+      <div
+        role="presentation"
+        className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="fixed top-0 right-0 bottom-0 z-50 w-[480px] bg-bg-1 border-l border-line flex flex-col shadow-[−24px_0_60px_rgba(0,0,0,.45)]">
+        <div className="flex items-center justify-between px-3.5 py-3 border-b border-line flex-none">
+          <span className="font-mono text-[11px] text-ink-3 tracking-[0.12em] uppercase truncate pr-2">
+            {taskId.slice(0, 8)}
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-ink-3 text-lg leading-none hover:text-ink transition-colors"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex border-b border-line flex-none" role="tablist">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              role="tab"
+              aria-selected={activeTab === tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-3.5 py-2 font-mono text-[10.5px] tracking-[0.08em] uppercase border-b-2 transition-colors ${
+                activeTab === tab
+                  ? "border-rust text-ink"
+                  : "border-transparent text-ink-3 hover:text-ink-2"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 overflow-auto">
+          {activeTab === "Stream" && (
+            <pre className="p-3 font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
+              {!connected && lines.length === 0 && (
+                <span className="text-ink-4">connecting…</span>
+              )}
+              {lines.join("\n")}
+              <div ref={streamEndRef} />
+            </pre>
+          )}
+          {activeTab === "Diff" && <DiffView artifacts={artifacts ?? []} />}
+          {activeTab === "Review" && <ReviewView prompts={prompts ?? []} />}
+          {activeTab === "Events" && (
+            <div className="p-3 space-y-2">
+              {task ? (
+                <>
+                  <div className="flex items-center gap-2 font-mono text-[11px]">
+                    <span className="text-ink-3">status</span>
+                    <span className="text-ink">{task.status}</span>
+                  </div>
+                  <div className="flex items-center gap-2 font-mono text-[11px]">
+                    <span className="text-ink-3">turn</span>
+                    <span className="text-ink">{task.turn}</span>
+                  </div>
+                  {task.phase && (
+                    <div className="flex items-center gap-2 font-mono text-[11px]">
+                      <span className="text-ink-3">phase</span>
+                      <span className="text-ink">{task.phase}</span>
+                    </div>
+                  )}
+                  {task.error && (
+                    <div className="flex items-start gap-2 font-mono text-[11px]">
+                      <span className="text-ink-3 flex-none">error</span>
+                      <span className="text-danger break-words">{task.error}</span>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="text-ink-4 font-mono text-[11px]">loading…</div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,7 +20,7 @@ export class ApiError extends Error {
   }
 }
 
-function authHeaders(): Record<string, string> {
+export function authHeaders(): Record<string, string> {
   const tok = (globalThis.sessionStorage?.getItem?.(TOKEN_KEY) ?? "").trim();
   return tok ? { Authorization: `Bearer ${tok}` } : {};
 }

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTask, useTaskArtifacts, useTaskPrompts } from "./queries";
+
+vi.mock("./api", () => ({
+  apiJson: vi.fn(),
+}));
+
+import { apiJson } from "./api";
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe("useTask / useTaskArtifacts / useTaskPrompts", () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    client.clear();
+  });
+
+  it("useTask skips fetch when taskId is null", () => {
+    renderHook(() => useTask(null), { wrapper: wrapper(client) });
+    expect(vi.mocked(apiJson)).not.toHaveBeenCalled();
+  });
+
+  it("useTaskArtifacts fetches /tasks/{id}/artifacts", async () => {
+    vi.mocked(apiJson).mockResolvedValue([]);
+    const { result } = renderHook(() => useTaskArtifacts("abc-123"), { wrapper: wrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(vi.mocked(apiJson)).toHaveBeenCalledWith("/tasks/abc-123/artifacts", expect.anything());
+  });
+
+  it("useTaskPrompts fetches /tasks/{id}/prompts", async () => {
+    vi.mocked(apiJson).mockResolvedValue([]);
+    const { result } = renderHook(() => useTaskPrompts("abc-123"), { wrapper: wrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(vi.mocked(apiJson)).toHaveBeenCalledWith("/tasks/abc-123/prompts", expect.anything());
+  });
+
+  it("useTaskArtifacts skips fetch when taskId is null", () => {
+    renderHook(() => useTaskArtifacts(null), { wrapper: wrapper(client) });
+    expect(vi.mocked(apiJson)).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "./api";
-import type { DashboardPayload, OverviewPayload, Task } from "@/types";
+import type { DashboardPayload, OverviewPayload, Task, TaskArtifact, TaskPrompt } from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -20,5 +20,32 @@ export function useTasks() {
   return useQuery<Task[], Error>({
     queryKey: ["tasks"],
     queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
+  });
+}
+
+export function useTask(taskId: string | null) {
+  return useQuery<Task, Error>({
+    queryKey: ["task", taskId],
+    queryFn: ({ signal }) => apiJson<Task>(`/tasks/${taskId}`, { signal }),
+    enabled: !!taskId,
+    staleTime: 0,
+  });
+}
+
+export function useTaskArtifacts(taskId: string | null) {
+  return useQuery<TaskArtifact[], Error>({
+    queryKey: ["task-artifacts", taskId],
+    queryFn: ({ signal }) => apiJson<TaskArtifact[]>(`/tasks/${taskId}/artifacts`, { signal }),
+    enabled: !!taskId,
+    staleTime: 0,
+  });
+}
+
+export function useTaskPrompts(taskId: string | null) {
+  return useQuery<TaskPrompt[], Error>({
+    queryKey: ["task-prompts", taskId],
+    queryFn: ({ signal }) => apiJson<TaskPrompt[]>(`/tasks/${taskId}/prompts`, { signal }),
+    enabled: !!taskId,
+    staleTime: 0,
   });
 }

--- a/web/src/lib/useTaskStream.test.ts
+++ b/web/src/lib/useTaskStream.test.ts
@@ -21,6 +21,13 @@ vi.mock("@microsoft/fetch-event-source", () => ({
   }),
 }));
 
+function sseResponse(status = 200) {
+  return new Response(null, {
+    status,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 describe("useTaskStream", () => {
   beforeEach(() => {
     capturedCallbacks = {};
@@ -48,15 +55,37 @@ describe("useTaskStream", () => {
   it("onopen fires → connected becomes true", async () => {
     const { result } = renderHook(() => useTaskStream("task-1"));
     await act(async () => {
-      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      await capturedCallbacks.onopen?.(sseResponse());
     });
     expect(result.current.connected).toBe(true);
+  });
+
+  it("onopen with wrong content-type → error set, not connected", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(
+        new Response(null, { status: 200, headers: { "content-type": "application/json" } }),
+      );
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toMatch(/Unexpected response type/);
+    expect(capturedAbortSignal?.aborted).toBe(true);
+  });
+
+  it("onopen with non-ok status → error set, not connected", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 404 }));
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toMatch(/404/);
+    expect(capturedAbortSignal?.aborted).toBe(true);
   });
 
   it("onmessage accumulates lines in order", async () => {
     const { result } = renderHook(() => useTaskStream("task-1"));
     await act(async () => {
-      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      await capturedCallbacks.onopen?.(sseResponse());
       capturedCallbacks.onmessage?.({ data: "first", event: "", id: "" });
       capturedCallbacks.onmessage?.({ data: "second", event: "", id: "" });
     });
@@ -68,7 +97,7 @@ describe("useTaskStream", () => {
       initialProps: { id: "task-1" },
     });
     await act(async () => {
-      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      await capturedCallbacks.onopen?.(sseResponse());
       capturedCallbacks.onmessage?.({ data: "old line", event: "", id: "" });
     });
     expect(result.current.lines).toHaveLength(1);
@@ -86,7 +115,7 @@ describe("useTaskStream", () => {
   it("ring buffer: >2000 events drops oldest, keeps newest 2000", async () => {
     const { result } = renderHook(() => useTaskStream("task-1"));
     await act(async () => {
-      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      await capturedCallbacks.onopen?.(sseResponse());
       for (let i = 0; i < 2001; i++) {
         capturedCallbacks.onmessage?.({ data: `line-${i}`, event: "", id: "" });
       }
@@ -94,6 +123,19 @@ describe("useTaskStream", () => {
     expect(result.current.lines).toHaveLength(2000);
     expect(result.current.lines[0]).toBe("line-1");
     expect(result.current.lines[1999]).toBe("line-2000");
+  });
+
+  it("onerror sets error state and stops retry", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      try {
+        capturedCallbacks.onerror?.(new Error("network failure"));
+      } catch {
+        // onerror rethrows — expected
+      }
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toMatch(/network failure/);
   });
 
   it("401 response dispatches unauthorizedEvents and stops", async () => {

--- a/web/src/lib/useTaskStream.test.ts
+++ b/web/src/lib/useTaskStream.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTaskStream } from "./useTaskStream";
+import { unauthorizedEvents } from "./api";
+
+type FetchEventSourceCallback = {
+  onopen?: (resp: Response) => Promise<void>;
+  onmessage?: (ev: { data: string; event: string; id: string; retry?: number }) => void;
+  onerror?: (err: unknown) => void;
+  onclose?: () => void;
+};
+
+let capturedCallbacks: FetchEventSourceCallback = {};
+let capturedAbortSignal: AbortSignal | null = null;
+
+vi.mock("@microsoft/fetch-event-source", () => ({
+  fetchEventSource: vi.fn((_url: string, opts: FetchEventSourceCallback & { signal?: AbortSignal }) => {
+    capturedCallbacks = opts;
+    capturedAbortSignal = opts.signal ?? null;
+    return Promise.resolve();
+  }),
+}));
+
+describe("useTaskStream", () => {
+  beforeEach(() => {
+    capturedCallbacks = {};
+    capturedAbortSignal = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initial state: connected false, lines empty, error null", () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.lines).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resets state when taskId is null", () => {
+    const { result } = renderHook(() => useTaskStream(null));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.lines).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("onopen fires → connected becomes true", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+    });
+    expect(result.current.connected).toBe(true);
+  });
+
+  it("onmessage accumulates lines in order", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      capturedCallbacks.onmessage?.({ data: "first", event: "", id: "" });
+      capturedCallbacks.onmessage?.({ data: "second", event: "", id: "" });
+    });
+    expect(result.current.lines).toEqual(["first", "second"]);
+  });
+
+  it("changing taskId resets lines to empty", async () => {
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useTaskStream(id), {
+      initialProps: { id: "task-1" },
+    });
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      capturedCallbacks.onmessage?.({ data: "old line", event: "", id: "" });
+    });
+    expect(result.current.lines).toHaveLength(1);
+
+    rerender({ id: "task-2" });
+    expect(result.current.lines).toEqual([]);
+  });
+
+  it("unmount aborts the controller", () => {
+    const { unmount } = renderHook(() => useTaskStream("task-1"));
+    unmount();
+    expect(capturedAbortSignal?.aborted).toBe(true);
+  });
+
+  it("ring buffer: >2000 events drops oldest, keeps newest 2000", async () => {
+    const { result } = renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 200 }));
+      for (let i = 0; i < 2001; i++) {
+        capturedCallbacks.onmessage?.({ data: `line-${i}`, event: "", id: "" });
+      }
+    });
+    expect(result.current.lines).toHaveLength(2000);
+    expect(result.current.lines[0]).toBe("line-1");
+    expect(result.current.lines[1999]).toBe("line-2000");
+  });
+
+  it("401 response dispatches unauthorizedEvents and stops", async () => {
+    const handler = vi.fn();
+    unauthorizedEvents.addEventListener("unauthorized", handler);
+
+    renderHook(() => useTaskStream("task-1"));
+    await act(async () => {
+      await capturedCallbacks.onopen?.(new Response(null, { status: 401 }));
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(capturedAbortSignal?.aborted).toBe(true);
+    unauthorizedEvents.removeEventListener("unauthorized", handler);
+  });
+});

--- a/web/src/lib/useTaskStream.ts
+++ b/web/src/lib/useTaskStream.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+import { authHeaders, unauthorizedEvents } from "./api";
+
+const MAX_LINES = 2000;
+
+export interface TaskStreamState {
+  lines: string[];
+  connected: boolean;
+  error: string | null;
+}
+
+export function useTaskStream(taskId: string | null): TaskStreamState {
+  const [lines, setLines] = useState<string[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!taskId) {
+      setLines([]);
+      setConnected(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    setLines([]);
+    setConnected(false);
+    setError(null);
+
+    fetchEventSource(`/tasks/${taskId}/stream`, {
+      headers: { ...authHeaders(), Accept: "text/event-stream" },
+      signal: controller.signal,
+      onopen: async (resp) => {
+        if (resp.status === 401) {
+          unauthorizedEvents.dispatchEvent(new Event("unauthorized"));
+          controller.abort();
+          return;
+        }
+        setConnected(true);
+      },
+      onmessage: (ev) => {
+        if (!ev.data) return;
+        setLines((prev) => {
+          const next = [...prev, ev.data];
+          return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+        });
+      },
+      onerror: (err) => {
+        setError(String(err));
+        setConnected(false);
+        // Rethrow to stop automatic retry.
+        throw err;
+      },
+      onclose: () => {
+        setConnected(false);
+      },
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [taskId]);
+
+  return { lines, connected, error };
+}

--- a/web/src/lib/useTaskStream.ts
+++ b/web/src/lib/useTaskStream.ts
@@ -8,18 +8,21 @@ const MAX_EVENT_BYTES = 4096;
 export interface TaskStreamState {
   lines: string[];
   connected: boolean;
+  done: boolean;
   error: string | null;
 }
 
 export function useTaskStream(taskId: string | null): TaskStreamState {
   const [lines, setLines] = useState<string[]>([]);
   const [connected, setConnected] = useState(false);
+  const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!taskId) {
       setLines([]);
       setConnected(false);
+      setDone(false);
       setError(null);
       return;
     }
@@ -28,6 +31,7 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
 
     setLines([]);
     setConnected(false);
+    setDone(false);
     setError(null);
 
     fetchEventSource(`/tasks/${taskId}/stream`, {
@@ -74,6 +78,7 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
       },
       onclose: () => {
         setConnected(false);
+        setDone(true);
       },
     }).catch(() => {
       // onerror rethrows to stop retry; catch here to avoid unhandled rejection.
@@ -84,5 +89,5 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
     };
   }, [taskId]);
 
-  return { lines, connected, error };
+  return { lines, connected, done, error };
 }

--- a/web/src/lib/useTaskStream.ts
+++ b/web/src/lib/useTaskStream.ts
@@ -3,6 +3,7 @@ import { fetchEventSource } from "@microsoft/fetch-event-source";
 import { authHeaders, unauthorizedEvents } from "./api";
 
 const MAX_LINES = 2000;
+const MAX_EVENT_BYTES = 4096;
 
 export interface TaskStreamState {
   lines: string[];
@@ -56,8 +57,12 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
       },
       onmessage: (ev) => {
         if (!ev.data) return;
+        const data =
+          ev.data.length > MAX_EVENT_BYTES
+            ? ev.data.slice(0, MAX_EVENT_BYTES) + " …[truncated]"
+            : ev.data;
         setLines((prev) => {
-          const next = [...prev, ev.data];
+          const next = [...prev, data];
           return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
         });
       },

--- a/web/src/lib/useTaskStream.ts
+++ b/web/src/lib/useTaskStream.ts
@@ -32,9 +32,23 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
     fetchEventSource(`/tasks/${taskId}/stream`, {
       headers: { ...authHeaders(), Accept: "text/event-stream" },
       signal: controller.signal,
+      openWhenHidden: true,
       onopen: async (resp) => {
         if (resp.status === 401) {
           unauthorizedEvents.dispatchEvent(new Event("unauthorized"));
+          controller.abort();
+          return;
+        }
+        if (!resp.ok) {
+          setError(`Stream request failed: ${resp.status}`);
+          setConnected(false);
+          controller.abort();
+          return;
+        }
+        const ct = resp.headers.get("content-type") ?? "";
+        if (!ct.includes("text/event-stream")) {
+          setError(`Unexpected response type (status ${resp.status})`);
+          setConnected(false);
           controller.abort();
           return;
         }
@@ -56,6 +70,8 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
       onclose: () => {
         setConnected(false);
       },
+    }).catch(() => {
+      // onerror rethrows to stop retry; catch here to avoid unhandled rejection.
     });
 
     return () => {

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useTasks } from "@/lib/queries";
+import { TaskSlideover } from "@/components/TaskSlideover";
 import type { Task } from "@/types";
 
 interface Column {
@@ -30,10 +32,13 @@ function columnOf(status: string): string {
   return "other";
 }
 
-function TaskCard({ task }: { task: Task }) {
+function TaskCard({ task, onClick }: { task: Task; onClick: () => void }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
-    <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
+    <div
+      onClick={onClick}
+      className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors cursor-pointer"
+    >
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
         {title}
       </div>
@@ -57,6 +62,7 @@ function TaskCard({ task }: { task: Task }) {
 }
 
 export function Active() {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const { data, isLoading, isError } = useTasks();
 
   const active = (data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
@@ -71,44 +77,47 @@ export function Active() {
   const showOther = other.length > 0;
 
   return (
-    <div
-      className="grid gap-3"
-      style={{ gridTemplateColumns: `repeat(${COLUMNS.length + (showOther ? 1 : 0)}, 1fr)` }}
-    >
-      {COLUMNS.map((col) => {
-        const rows = grouped[col.key];
-        return (
-          <div key={col.key} className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+    <>
+      <div
+        className="grid gap-3"
+        style={{ gridTemplateColumns: `repeat(${COLUMNS.length + (showOther ? 1 : 0)}, 1fr)` }}
+      >
+        {COLUMNS.map((col) => {
+          const rows = grouped[col.key];
+          return (
+            <div key={col.key} className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+              <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
+                <span>{col.label}</span>
+                <span className="text-ink-2">{rows.length}</span>
+              </div>
+              <div className="p-2 flex-1 overflow-auto">
+                {rows.length === 0 && (
+                  <div className="text-ink-4 font-mono text-[11px] p-1">
+                    {isLoading ? "loading…" : isError ? "error" : "—"}
+                  </div>
+                )}
+                {rows.map((t) => (
+                  <TaskCard key={t.id} task={t} onClick={() => setSelectedTaskId(t.id)} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {showOther && (
+          <div className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
             <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
-              <span>{col.label}</span>
-              <span className="text-ink-2">{rows.length}</span>
+              <span>Other</span>
+              <span className="text-ink-2">{other.length}</span>
             </div>
             <div className="p-2 flex-1 overflow-auto">
-              {rows.length === 0 && (
-                <div className="text-ink-4 font-mono text-[11px] p-1">
-                  {isLoading ? "loading…" : isError ? "error" : "—"}
-                </div>
-              )}
-              {rows.map((t) => (
-                <TaskCard key={t.id} task={t} />
+              {other.map((t) => (
+                <TaskCard key={t.id} task={t} onClick={() => setSelectedTaskId(t.id)} />
               ))}
             </div>
           </div>
-        );
-      })}
-      {showOther && (
-        <div className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
-          <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
-            <span>Other</span>
-            <span className="text-ink-2">{other.length}</span>
-          </div>
-          <div className="p-2 flex-1 overflow-auto">
-            {other.map((t) => (
-              <TaskCard key={t.id} task={t} />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+      <TaskSlideover taskId={selectedTaskId} onClose={() => setSelectedTaskId(null)} />
+    </>
   );
 }

--- a/web/src/types/artifact.ts
+++ b/web/src/types/artifact.ts
@@ -1,0 +1,15 @@
+export interface TaskArtifact {
+  task_id: string;
+  turn: number;
+  artifact_type: string;
+  content: string;
+  created_at: string;
+}
+
+export interface TaskPrompt {
+  task_id: string;
+  turn: number;
+  phase: string;
+  prompt: string;
+  created_at: string;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./artifact";
 export * from "./dashboard";
 export * from "./overview";
 export * from "./task";


### PR DESCRIPTION
## Summary

- Clicking a kanban card in the Dashboard opens a 480px fixed-right slide-over panel
- Four tabs: **Stream** (live SSE via `@microsoft/fetch-event-source`), **Diff** (unified diff with +/- colouring), **Review** (prompt text), **Events** (task status/turn/phase)
- Esc key and backdrop click close the panel
- `useTaskStream` hook with 2000-line ring buffer prevents OOM on long-running tasks
- Reuses `authHeaders()` (now exported) so SSE bearer auth matches `apiFetch` convention

## Test plan

- [ ] 13 component tests in `TaskSlideover.test.tsx` (open/close, tab switching, all tab renders, Esc, backdrop)
- [ ] 8 hook tests in `useTaskStream.test.ts` (initial state, onopen/onmessage, ring buffer, 401 dispatch, unmount abort)
- [ ] 4 query tests in `queries.test.ts` (null skip, correct URL per hook)
- [ ] `bun run test` — 69 tests pass across 20 test files
- [ ] `bun run typecheck` — clean

Closes #838

Signed-off-by: majiayu000 <1835304752@qq.com>