### PR TITLE
fix(db): PgMigrator SQL splitter + JSONB columns + optimistic locking enforcement

### DIFF
--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -47,6 +47,167 @@ pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyho
     Ok(pool)
 }
 
+/// Split a SQL string into individual statements, correctly handling:
+/// - Single-quoted string literals (including escaped `''`)
+/// - Double-quoted identifiers (including escaped `""`)
+/// - Line comments (`--`)
+/// - Block comments (`/* */`)
+/// - Dollar-quoted strings (`$$...$$` or `$tag$...$tag$`)
+fn pg_split_statements(sql: &str) -> Vec<String> {
+    let mut statements: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut chars = sql.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            // Line comment: -- ... \n
+            '-' if chars.peek() == Some(&'-') => {
+                current.push(ch);
+                if let Some(c) = chars.next() {
+                    current.push(c);
+                }
+                for c in chars.by_ref() {
+                    current.push(c);
+                    if c == '\n' {
+                        break;
+                    }
+                }
+            }
+            // Block comment: /* ... */
+            '/' if chars.peek() == Some(&'*') => {
+                current.push(ch);
+                if let Some(c) = chars.next() {
+                    current.push(c);
+                }
+                loop {
+                    match chars.next() {
+                        None => break,
+                        Some(c) => {
+                            current.push(c);
+                            if c == '*' && chars.peek() == Some(&'/') {
+                                if let Some(c) = chars.next() {
+                                    current.push(c);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            // Single-quoted string: '...' with '' escape
+            '\'' => {
+                current.push(ch);
+                loop {
+                    match chars.next() {
+                        None => break,
+                        Some(c) => {
+                            current.push(c);
+                            if c == '\'' {
+                                if chars.peek() == Some(&'\'') {
+                                    if let Some(q) = chars.next() {
+                                        current.push(q);
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // Double-quoted identifier: "..." with "" escape
+            '"' => {
+                current.push(ch);
+                loop {
+                    match chars.next() {
+                        None => break,
+                        Some(c) => {
+                            current.push(c);
+                            if c == '"' {
+                                if chars.peek() == Some(&'"') {
+                                    if let Some(q) = chars.next() {
+                                        current.push(q);
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // Dollar-quoted string: $tag$...$tag$ (tag may be empty: $$...$$)
+            '$' => {
+                let mut tag = String::from('$');
+                let mut is_dollar_quote = false;
+                let mut speculative: Vec<char> = Vec::new();
+                loop {
+                    match chars.peek().copied() {
+                        Some(c) if c.is_ascii_alphanumeric() || c == '_' => {
+                            let Some(c) = chars.next() else {
+                                break;
+                            };
+                            speculative.push(c);
+                            tag.push(c);
+                        }
+                        Some('$') => {
+                            if chars.next().is_none() {
+                                break;
+                            }
+                            tag.push('$');
+                            is_dollar_quote = true;
+                            break;
+                        }
+                        _ => break,
+                    }
+                }
+                if is_dollar_quote {
+                    current.push_str(&tag);
+                    let mut body = String::new();
+                    loop {
+                        match chars.next() {
+                            None => {
+                                current.push_str(&body);
+                                break;
+                            }
+                            Some(c) => {
+                                body.push(c);
+                                if body.ends_with(&tag) {
+                                    current.push_str(&body);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    current.push('$');
+                    for c in speculative {
+                        current.push(c);
+                    }
+                }
+            }
+            // Statement separator
+            ';' => {
+                let stmt = current.trim().to_string();
+                if !stmt.is_empty() {
+                    statements.push(stmt);
+                }
+                current.clear();
+            }
+            c => {
+                current.push(c);
+            }
+        }
+    }
+
+    let trailing = current.trim().to_string();
+    if !trailing.is_empty() {
+        statements.push(trailing);
+    }
+
+    statements
+}
+
 fn pg_duplicate_column_error(statement: &str, error: &sqlx::Error) -> bool {
     if !statement.to_ascii_uppercase().contains("ADD COLUMN") {
         return false;
@@ -106,13 +267,9 @@ impl<'a> PgMigrator<'a> {
 
     async fn apply(&self, migration: &Migration) -> anyhow::Result<()> {
         let mut tx = self.pool.begin().await?;
-        for raw in migration.sql.split(';') {
-            let stmt = raw.trim();
-            if stmt.is_empty() {
-                continue;
-            }
-            if let Err(e) = sqlx::query(stmt).execute(&mut *tx).await {
-                if pg_duplicate_column_error(stmt, &e) {
+        for stmt in pg_split_statements(migration.sql) {
+            if let Err(e) = sqlx::query(&stmt).execute(&mut *tx).await {
+                if pg_duplicate_column_error(&stmt, &e) {
                     continue;
                 }
                 return Err(anyhow::anyhow!(
@@ -131,5 +288,56 @@ impl<'a> PgMigrator<'a> {
             .await?;
         tx.commit().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pg_split_statements;
+
+    #[test]
+    fn single_statement_no_semicolon() {
+        let stmts = pg_split_statements("SELECT 1");
+        assert_eq!(stmts, vec!["SELECT 1"]);
+    }
+
+    #[test]
+    fn two_statements_separated_by_semicolon() {
+        let stmts = pg_split_statements("SELECT 1; SELECT 2");
+        assert_eq!(stmts, vec!["SELECT 1", "SELECT 2"]);
+    }
+
+    #[test]
+    fn semicolon_inside_string_literal_not_split() {
+        let stmts = pg_split_statements("SELECT ';' AS x");
+        assert_eq!(stmts, vec!["SELECT \';\' AS x"]);
+    }
+
+    #[test]
+    fn semicolon_in_line_comment_not_split() {
+        let stmts = pg_split_statements("SELECT 1 -- comment;\n, 2");
+        assert_eq!(stmts, vec!["SELECT 1 -- comment;\n, 2"]);
+    }
+
+    #[test]
+    fn semicolon_in_block_comment_not_split() {
+        let stmts = pg_split_statements("SELECT /* block; comment */ 1");
+        assert_eq!(stmts, vec!["SELECT /* block; comment */ 1"]);
+    }
+
+    #[test]
+    fn dollar_quoted_block_not_split() {
+        let sql = "DO $$ BEGIN PERFORM 1; END $$";
+        let stmts = pg_split_statements(sql);
+        assert_eq!(stmts, vec!["DO $$ BEGIN PERFORM 1; END $$"]);
+    }
+
+    #[test]
+    fn v17_migration_produces_exactly_two_statements() {
+        let sql = "CREATE TABLE IF NOT EXISTS task_prompts (\n            id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,\n            task_id    TEXT NOT NULL,\n            UNIQUE(task_id)\n        ); CREATE INDEX IF NOT EXISTS idx_task_prompts_task_id\n           ON task_prompts(task_id)";
+        let stmts = pg_split_statements(sql);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].starts_with("CREATE TABLE"));
+        assert!(stmts[1].starts_with("CREATE INDEX"));
     }
 }

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -92,6 +92,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -182,6 +183,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -205,6 +207,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     let task_b_id = task_b.id.clone();
 
@@ -279,6 +282,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -344,6 +348,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1560,6 +1560,7 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -1627,6 +1628,7 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        version: 0,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -406,6 +406,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
+            version: 0,
         }
     }
 

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -160,6 +160,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            version: 0,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -201,6 +202,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            version: 0,
         };
         store.insert(&parent_state).await;
 
@@ -226,6 +228,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            version: 0,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -13,6 +13,7 @@ use harness_core::db::Migration;
 /// v14 – add description column for task observability after restart.
 /// v15 – add (status, updated_at DESC) index for project-agnostic terminal queries.
 /// v18 – add version column for optimistic locking.
+/// v19 – convert JSON columns from TEXT to JSONB for native validation and operators.
 pub(super) static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -132,5 +133,10 @@ pub(super) static TASK_MIGRATIONS: &[Migration] = &[
         version: 18,
         description: "add version column for optimistic locking",
         sql: "ALTER TABLE tasks ADD COLUMN version INTEGER NOT NULL DEFAULT 0",
+    },
+    Migration {
+        version: 19,
+        description: "convert JSON columns from TEXT to JSONB",
+        sql: "ALTER TABLE tasks ALTER COLUMN rounds TYPE JSONB USING rounds::jsonb;               ALTER TABLE tasks ALTER COLUMN depends_on TYPE JSONB USING depends_on::jsonb;               ALTER TABLE tasks ALTER COLUMN phase TYPE JSONB USING phase::jsonb;               ALTER TABLE tasks ALTER COLUMN request_settings TYPE JSONB USING request_settings::jsonb",
     },
 ];

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -139,9 +139,13 @@ impl TaskDb {
         &self,
     ) -> anyhow::Result<Vec<(TaskState, TaskCheckpoint)>> {
         let rows = sqlx::query_as::<_, PendingCheckpointRow>(
-            "SELECT t.id, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
-                    t.external_id, t.parent_id, t.created_at, t.repo, t.depends_on, \
-                    t.project, t.priority, t.phase, t.description, t.request_settings, \
+            "SELECT t.id, t.status, t.turn, t.pr_url, \
+                    t.rounds::text AS rounds, t.error, t.source, \
+                    t.external_id, t.parent_id, t.created_at, t.repo, \
+                    t.depends_on::text AS depends_on, \
+                    t.project, t.priority, \
+                    t.phase::text AS phase, t.description, \
+                    t.request_settings::text AS request_settings, t.version, \
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
                     c.last_phase, \
                     TO_CHAR(c.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS ck_updated_at \
@@ -175,6 +179,7 @@ impl TaskDb {
                 phase: row.phase,
                 description: row.description,
                 request_settings: row.request_settings,
+                version: row.version,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -221,7 +221,8 @@ impl TaskDb {
     pub async fn list_summaries(&self) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
         let rows = sqlx::query_as::<_, TaskSummaryRow>(
             "SELECT id, status, turn, pr_url, error, source, external_id, parent_id, \
-             created_at, repo, depends_on, project, phase, description \
+             created_at, repo, depends_on::text AS depends_on, project, \
+             phase::text AS phase, description \
              FROM tasks ORDER BY created_at DESC",
         )
         .fetch_all(&self.pool)

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -64,12 +64,12 @@ impl TaskDb {
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
-        sqlx::query(
+        let result = sqlx::query(
             "UPDATE tasks SET status = $1, turn = $2, pr_url = $3, rounds = $4, error = $5, \
                     source = $6, external_id = $7, repo = $8, depends_on = $9, project = $10, \
                     priority = $11, phase = $12, description = $13, request_settings = $14, \
                     updated_at = CURRENT_TIMESTAMP, version = version + 1 \
-             WHERE id = $15",
+             WHERE id = $15 AND version = $16",
         )
         .bind(status)
         .bind(state.turn as i64)
@@ -91,8 +91,15 @@ impl TaskDb {
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
         .bind(&state.id.0)
+        .bind(state.version)
         .execute(&self.pool)
         .await?;
+        if result.rows_affected() == 0 {
+            return Err(anyhow::anyhow!(
+                "concurrent update conflict on task {}",
+                state.id.0
+            ));
+        }
         Ok(())
     }
 

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -77,7 +77,7 @@ pub(super) struct RecoveryRow {
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-pub(super) const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, repo, depends_on, project, priority, phase, description, request_settings";
+pub(super) const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url,     rounds::text AS rounds, error, source, external_id, parent_id, created_at, repo,     depends_on::text AS depends_on, project, priority,     phase::text AS phase, description,     request_settings::text AS request_settings, version";
 
 #[derive(sqlx::FromRow)]
 pub(super) struct TaskRow {
@@ -98,6 +98,7 @@ pub(super) struct TaskRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
+    pub(super) version: i32,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -124,6 +125,7 @@ pub(super) struct PendingCheckpointRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
+    pub(super) version: i32,
     // Checkpoint columns (aliased)
     pub(super) triage_output: Option<String>,
     pub(super) plan_output: Option<String>,
@@ -171,6 +173,7 @@ impl TaskRow {
             phase,
             description,
             request_settings,
+            version,
         } = self;
 
         let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
@@ -220,6 +223,7 @@ impl TaskRow {
             plan_output: None,
             repo,
             request_settings: decoded_request_settings,
+            version,
         })
     }
 }

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -75,6 +75,9 @@ pub struct TaskState {
     /// requested rather than silently falling back to server defaults.
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
+    /// Optimistic locking counter. Loaded from DB on every get(); checked on update().
+    #[serde(default)]
+    pub version: i32,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -139,6 +142,7 @@ impl TaskState {
             plan_output: None,
             repo: None,
             request_settings: None,
+            version: 0,
         }
     }
 

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -792,6 +792,9 @@ impl TaskStore {
         let snapshot = self.cache.get(id).map(|state| state.value().clone());
         if let Some(state) = snapshot {
             self.db.update(&state).await?;
+            if let Some(mut entry) = self.cache.get_mut(id) {
+                entry.version += 1;
+            }
 
             // Persist a checkpoint to the DB so that recover_in_progress() can
             // restore the task if the server is killed mid-flight. Only written
@@ -1357,6 +1360,62 @@ mod tests {
         let key = root.to_string_lossy().into_owned();
         assert_eq!(counts.by_project[&key].done, 1);
         assert_eq!(counts.by_project[&key].failed, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn persist_advances_cached_version_after_successful_update() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let id = harness_core::types::TaskId("version-sync".to_string());
+
+        store.insert(&TaskState::new(id.clone())).await;
+
+        mutate_and_persist(&store, &id, |state| {
+            state.turn = 1;
+        })
+        .await?;
+        assert_eq!(
+            store.get(&id).as_ref().map(|state| state.version),
+            Some(1),
+            "cache must track the version increment after the first successful persist"
+        );
+
+        mutate_and_persist(&store, &id, |state| {
+            state.turn = 2;
+        })
+        .await?;
+        assert_eq!(
+            store.get(&id).as_ref().map(|state| state.version),
+            Some(2),
+            "sequential persists should continue from the updated cache version"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_all_summaries_handles_jsonb_backed_fields() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let id = harness_core::types::TaskId("summary-jsonb".to_string());
+        let dep = harness_core::types::TaskId("dep-1".to_string());
+
+        let mut task = TaskState::new(id.clone());
+        task.depends_on = vec![dep.clone()];
+        task.description = Some("summary row".to_string());
+        store.insert(&task).await;
+
+        let summary = store
+            .list_all_summaries_with_terminal()
+            .await?
+            .into_iter()
+            .find(|summary| summary.id == id)
+            .expect("inserted task should appear in summaries");
+
+        assert_eq!(summary.depends_on, vec![dep]);
+        assert_eq!(summary.phase, crate::task_runner::TaskPhase::default());
+        assert_eq!(summary.description.as_deref(), Some("summary row"));
         Ok(())
     }
 

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -33,6 +33,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         plan_output: None,
         repo: None,
         request_settings: None,
+        version: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

- **SQL splitting correctness**: Replace naive `split(';')` in `PgMigrator::apply()` with a proper SQL-aware splitter (`pg_split_statements`) that handles semicolons inside single-quoted strings, double-quoted identifiers, line comments (`--`), block comments (`/* */`), and dollar-quoted PL/pgSQL blocks (`$$...$$`, `$tag$...$tag$`)
- **JSONB column types**: Add migration v19 to convert the `rounds`, `depends_on`, `phase`, and `request_settings` TEXT columns to JSONB; update all SELECT queries to use `col::text AS col` casts so sqlx can decode them as `String`, and update INSERT/UPDATE to bind the raw JSON string (PostgreSQL auto-parses it into JSONB)
- **Optimistic locking enforcement**: Add `version` field to `TaskState` and `TaskRow`; extend the UPDATE query with `AND version = $N` + `version = version + 1`; check `rows_affected() == 0` and return a conflict error — previously the `version` column was incremented but never checked, making the locking a no-op

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean (no warnings)
- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes
- [x] `cargo test -p harness-core` — 317 tests pass (includes 7 new `pg_split_statements` unit tests)
- [x] `cargo test -p harness-agents` — 89 tests pass
- [x] Unit tests for `pg_split_statements`: single statement, two statements, semicolon-in-string, semicolon-in-line-comment, semicolon-in-block-comment, dollar-quoted block, v17 migration shape

Closes #845