### PR TITLE
chore(ops): simplify dev-db.sh with docker compose --wait

### DIFF
--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -7,11 +7,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Guard: --wait requires Compose v2 plugin (v2.1+); fail fast with a clear message.
+# Guard: --wait requires Compose v2.1+; fail fast with a clear message.
 if ! docker compose version &>/dev/null; then
   echo "ERROR: Docker Compose v2 plugin not found." >&2
-  echo "       Install via Docker Desktop or 'docker plugin install compose'." >&2
+  echo "       Install via Docker Desktop, the 'docker-compose-plugin' package" >&2
+  echo "       from your package manager, or the manual CLI plugin instructions at" >&2
+  echo "       https://docs.docker.com/compose/install/." >&2
   echo "       The legacy 'docker-compose' v1 command is not supported." >&2
+  exit 1
+fi
+
+# Guard: --wait was added in Compose v2.1; older v2 installs will fail at runtime.
+_dc_ver=$(docker compose version --short 2>/dev/null | sed 's/^v//')
+_dc_major=$(printf '%s' "$_dc_ver" | cut -d. -f1)
+_dc_minor=$(printf '%s' "$_dc_ver" | cut -d. -f2)
+if [ "${_dc_major:-0}" -lt 2 ] || { [ "${_dc_major:-0}" -eq 2 ] && [ "${_dc_minor:-0}" -lt 1 ]; }; then
+  echo "ERROR: Docker Compose v2.1+ required for --wait (found: v${_dc_ver})." >&2
+  echo "       Upgrade via Docker Desktop or your package manager." >&2
+  echo "       See https://docs.docker.com/compose/install/ for options." >&2
   exit 1
 fi
 

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# Guard: --wait requires Compose v2 plugin (v2.1+); fail fast with a clear message.
+if ! docker compose version &>/dev/null; then
+  echo "ERROR: Docker Compose v2 plugin not found." >&2
+  echo "       Install via Docker Desktop or 'docker plugin install compose'." >&2
+  echo "       The legacy 'docker-compose' v1 command is not supported." >&2
+  exit 1
+fi
+
 echo "Starting Postgres container and waiting until healthy..."
 docker compose -f "$REPO_ROOT/docker-compose.yml" up -d --wait postgres
 

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -7,19 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-echo "Starting Postgres container..."
-docker compose -f "$REPO_ROOT/docker-compose.yml" up -d postgres
-
-echo "Waiting for Postgres to be ready (max 30s)..."
-deadline=$(( $(date +%s) + 30 ))
-until docker compose -f "$REPO_ROOT/docker-compose.yml" exec -T postgres \
-    pg_isready -U harness -d harness -q 2>/dev/null; do
-  if [ "$(date +%s)" -ge "$deadline" ]; then
-    echo "ERROR: Postgres did not become ready within 30 seconds." >&2
-    exit 1
-  fi
-  sleep 1
-done
+echo "Starting Postgres container and waiting until healthy..."
+docker compose -f "$REPO_ROOT/docker-compose.yml" up -d --wait postgres
 
 echo ""
 echo "Postgres is ready. Set the following in your shell:"


### PR DESCRIPTION
## Summary

- Replace the manual `pg_isready` retry loop with `docker compose up -d --wait`
- The `--wait` flag blocks until all services with a healthcheck become healthy
- The postgres service in `docker-compose.yml` already has a healthcheck defined (pg_isready, 5s interval, 6 retries)

Closes #849

## Test plan

- [ ] Run `./scripts/dev-db.sh` — should start Postgres and block until healthy without a manual retry loop