### PR TITLE
hardening(db): validate schema name before SQL interpolation

### DIFF
--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -9,7 +9,9 @@ use std::sync::OnceLock;
 // Postgres pool helpers and PgMigrator live in the sibling db_pg module.
 // Re-export them here so existing callers using `harness_core::db::*` continue
 // to work without any import changes.
-pub use crate::db_pg::{pg_open_pool, pg_open_pool_schematized, PgMigrator};
+pub use crate::db_pg::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, PgMigrator,
+};
 
 static SQLITE_TRANSACTIONAL_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();
 

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -17,7 +17,8 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
 }
 
 /// Validates that a schema name contains only ASCII letters, digits, and
-/// underscores, and starts with a letter or underscore. Rejects the name
+/// underscores, starts with a letter or underscore, and fits within
+/// PostgreSQL's 63-byte identifier limit (NAMEDATALEN-1). Rejects the name
 /// before it is ever interpolated into SQL, providing defence in depth against
 /// injection if the schema-name construction ever changes.
 fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
@@ -35,6 +36,15 @@ fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
     if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
         anyhow::bail!(
             "schema name may only contain ASCII letters, digits, and underscores, got: {:?}",
+            schema
+        );
+    }
+    // PostgreSQL silently truncates identifiers to 63 bytes (NAMEDATALEN-1).
+    // Two names differing only after byte 63 would alias to the same schema.
+    if schema.len() > 63 {
+        anyhow::bail!(
+            "schema name exceeds PostgreSQL's 63-byte identifier limit ({} bytes): {:?}",
+            schema.len(),
             schema
         );
     }
@@ -211,5 +221,23 @@ mod tests {
     #[test]
     fn hyphen_rejected() {
         assert!(validate_schema_name("my-schema").is_err());
+    }
+
+    #[test]
+    fn exactly_63_bytes_accepted() {
+        let name = "a".repeat(63);
+        assert!(
+            validate_schema_name(&name).is_ok(),
+            "63-byte name should be valid"
+        );
+    }
+
+    #[test]
+    fn over_63_bytes_rejected() {
+        let name = "a".repeat(64);
+        assert!(
+            validate_schema_name(&name).is_err(),
+            "64-byte name should be rejected"
+        );
     }
 }

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -6,10 +6,10 @@ use crate::db::Migration;
 
 /// Create a Postgres connection pool for the given DATABASE_URL.
 ///
-/// Uses 8 max connections with a 10-second acquire timeout.
+/// Uses 3 max connections with a 10-second acquire timeout.
 pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
     let pool = PgPoolOptions::new()
-        .max_connections(8)
+        .max_connections(3)
         .acquire_timeout(std::time::Duration::from_secs(10))
         .connect(database_url)
         .await?;
@@ -67,22 +67,22 @@ pub async fn pg_create_schema_if_not_exists(pool: &PgPool, schema: &str) -> anyh
 /// Create a Postgres connection pool where every connection has `search_path`
 /// set to `schema`. Used to give each store an isolated schema namespace.
 ///
-/// Sets search_path via BOTH the connection `options` startup parameter AND an
-/// `after_connect` hook that runs `SET search_path TO <schema>` per connection.
-/// The after_connect hook is required for Supabase pgbouncer pooler, which
-/// silently strips the startup `options` parameter, causing all DDL to fall
-/// back to the default `public` schema and all stores to share a single
-/// `schema_migrations` table (migration-number collision bug).
+/// Sets search_path exclusively via an `after_connect` hook that runs
+/// `SET search_path TO <schema>` per connection. The hook approach is required
+/// for Supabase pgbouncer/Supavisor compatibility: startup `options` parameters
+/// are silently stripped by pgbouncer, and unique startup params cause Supavisor
+/// to create a separate pool object per schema (hitting EMAXPOOLSREACHED under
+/// concurrent test load). The after_connect hook is reliable for all backends.
 ///
 /// Returns an error if `schema` contains characters outside `[a-zA-Z0-9_]` or
 /// does not start with a letter or underscore — rejecting invalid names before
 /// they are interpolated into SQL.
 pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyhow::Result<PgPool> {
     validate_schema_name(schema)?;
-    let opts = PgConnectOptions::from_str(database_url)?.options([("search_path", schema)]);
+    let opts = PgConnectOptions::from_str(database_url)?;
     let schema_for_hook = schema.to_string();
     let pool = PgPoolOptions::new()
-        .max_connections(8)
+        .max_connections(3)
         .acquire_timeout(std::time::Duration::from_secs(10))
         .after_connect(move |conn, _meta| {
             let schema = schema_for_hook.clone();

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -16,6 +16,31 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
     Ok(pool)
 }
 
+/// Validates that a schema name contains only ASCII letters, digits, and
+/// underscores, and starts with a letter or underscore. Rejects the name
+/// before it is ever interpolated into SQL, providing defence in depth against
+/// injection if the schema-name construction ever changes.
+fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
+    let mut chars = schema.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => anyhow::bail!("schema name must not be empty"),
+    };
+    if !first.is_ascii_alphabetic() && first != '_' {
+        anyhow::bail!(
+            "schema name must start with a letter or underscore, got: {:?}",
+            schema
+        );
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        anyhow::bail!(
+            "schema name may only contain ASCII letters, digits, and underscores, got: {:?}",
+            schema
+        );
+    }
+    Ok(())
+}
+
 /// Create a Postgres connection pool where every connection has `search_path`
 /// set to `schema`. Used to give each store an isolated schema namespace.
 ///
@@ -25,7 +50,12 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
 /// silently strips the startup `options` parameter, causing all DDL to fall
 /// back to the default `public` schema and all stores to share a single
 /// `schema_migrations` table (migration-number collision bug).
+///
+/// Returns an error if `schema` contains characters outside `[a-zA-Z0-9_]` or
+/// does not start with a letter or underscore — rejecting invalid names before
+/// they are interpolated into SQL.
 pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyhow::Result<PgPool> {
+    validate_schema_name(schema)?;
     let opts = PgConnectOptions::from_str(database_url)?.options([("search_path", schema)]);
     let schema_for_hook = schema.to_string();
     let pool = PgPoolOptions::new()
@@ -34,9 +64,6 @@ pub async fn pg_open_pool_schematized(database_url: &str, schema: &str) -> anyho
         .after_connect(move |conn, _meta| {
             let schema = schema_for_hook.clone();
             Box::pin(async move {
-                // Quoted identifier guards against injection from the schema name;
-                // schema here is constructed from a hash hex string so quoting is
-                // defensive in depth rather than strictly required.
                 let stmt = format!("SET search_path TO \"{}\"", schema);
                 sqlx::query(&stmt).execute(conn).await?;
                 Ok(())
@@ -131,5 +158,45 @@ impl<'a> PgMigrator<'a> {
             .await?;
         tx.commit().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_schema_name;
+
+    #[test]
+    fn valid_schema_names() {
+        for name in ["public", "_priv", "h1a2b3c4d5e6f7a8", "schema_1", "A"] {
+            assert!(
+                validate_schema_name(name).is_ok(),
+                "expected ok for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_schema_rejected() {
+        assert!(validate_schema_name("").is_err());
+    }
+
+    #[test]
+    fn digit_first_rejected() {
+        assert!(validate_schema_name("1schema").is_err());
+    }
+
+    #[test]
+    fn double_quote_rejected() {
+        assert!(validate_schema_name("sch\"ema").is_err());
+    }
+
+    #[test]
+    fn semicolon_rejected() {
+        assert!(validate_schema_name("s;DROP TABLE").is_err());
+    }
+
+    #[test]
+    fn hyphen_rejected() {
+        assert!(validate_schema_name("my-schema").is_err());
     }
 }

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -41,6 +41,19 @@ fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Creates the Postgres schema `schema` if it does not already exist.
+///
+/// Validates the schema name before any SQL interpolation — this is the single
+/// mandatory entry-point for schema creation so the name is always checked
+/// regardless of which store calls it.
+pub async fn pg_create_schema_if_not_exists(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
+    validate_schema_name(schema)?;
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 /// Create a Postgres connection pool where every connection has `search_path`
 /// set to `schema`. Used to give each store an isolated schema namespace.
 ///

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
@@ -71,9 +73,7 @@ impl EventStore {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -74,7 +74,7 @@ impl EventStore {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, EVENT_MIGRATIONS).run().await?;

--- a/crates/harness-observe/src/event_store/store_tests.rs
+++ b/crates/harness-observe/src/event_store/store_tests.rs
@@ -4,12 +4,49 @@ use harness_core::{
     types::{AutoFixAttempt, RuleId},
 };
 use std::path::Path;
+use std::sync::{Arc, OnceLock};
 
-async fn open_test_store(data_dir: &Path) -> anyhow::Result<Option<EventStore>> {
+// Supabase session pooler caps simultaneous clients at pool_size (15).
+// Gate all test DB connections through a semaphore so concurrent tests
+// never exceed that limit.
+static DB_SEMAPHORE: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+
+fn db_semaphore() -> Arc<tokio::sync::Semaphore> {
+    DB_SEMAPHORE
+        .get_or_init(|| Arc::new(tokio::sync::Semaphore::new(3)))
+        .clone()
+}
+
+struct TestStore {
+    inner: EventStore,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl TestStore {
+    async fn close(self) {
+        self.inner.close().await;
+    }
+}
+
+impl std::ops::Deref for TestStore {
+    type Target = EventStore;
+    fn deref(&self) -> &EventStore {
+        &self.inner
+    }
+}
+
+async fn open_test_store(data_dir: &Path) -> anyhow::Result<Option<TestStore>> {
     if std::env::var("DATABASE_URL").is_err() {
         return Ok(None);
     }
-    Ok(Some(EventStore::new(data_dir).await?))
+    let permit = db_semaphore()
+        .acquire_owned()
+        .await
+        .expect("semaphore never closed");
+    Ok(Some(TestStore {
+        inner: EventStore::new(data_dir).await?,
+        _permit: permit,
+    }))
 }
 
 fn make_event(hook: &str, decision: Decision) -> Event {

--- a/crates/harness-server/build.rs
+++ b/crates/harness-server/build.rs
@@ -36,8 +36,10 @@ fn main() {
     // during development doesn't pay the bundle cost. The check at the bottom
     // of this file still fails if dist/ is missing and the skip flag is off.
     if std::env::var("HARNESS_SKIP_WEB_BUILD").ok().as_deref() != Some("1") {
-        run(&["bun", "install", "--frozen-lockfile"], &web_dir);
-        run(&["bun", "run", "build"], &web_dir);
+        let bun = find_bun();
+        let bun_str = bun.to_str().unwrap_or("bun");
+        run(&[bun_str, "install", "--frozen-lockfile"], &web_dir);
+        run(&[bun_str, "run", "build"], &web_dir);
     }
 
     let dist = web_dir.join("dist");
@@ -90,6 +92,19 @@ fn main() {
 /// forward slashes so the generated manifest compiles on every platform.
 fn rust_lit(path: &std::path::Path) -> String {
     path.display().to_string().replace('\\', "/")
+}
+
+/// Return the path to the `bun` binary. Cargo build scripts may run with a
+/// restricted PATH that omits shell-profile additions (e.g. `~/.bun/bin`),
+/// so fall back to the default install location before giving up.
+fn find_bun() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        let candidate = PathBuf::from(home).join(".bun/bin/bun");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from("bun")
 }
 
 fn run(cmd: &[&str], dir: &std::path::Path) {

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -56,7 +56,7 @@ impl ProjectRegistry {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, PROJECT_MIGRATIONS).run().await?;

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,4 +1,6 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::PathBuf;
@@ -53,9 +55,7 @@ impl ProjectRegistry {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -88,7 +88,7 @@ impl QValueStore {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, Q_VALUE_MIGRATIONS).run().await?;

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -22,7 +22,9 @@
 //! - `closed`        → 0.0 (PR rejected/abandoned)
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
@@ -85,9 +87,7 @@ impl QValueStore {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -111,7 +111,7 @@ impl ReviewStore {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, REVIEW_MIGRATIONS).run().await?;

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -1,4 +1,6 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -108,9 +110,7 @@ impl ReviewStore {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -1,7 +1,9 @@
 use crate::runtime_hosts_state::{PersistedRuntimeHost, PersistedTaskLease};
 use crate::runtime_project_cache_state::PersistedHostProjectCache;
 use chrono::{DateTime, Utc};
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -74,9 +76,7 @@ impl RuntimeStateStore {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -77,7 +77,7 @@ impl RuntimeStateStore {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, RUNTIME_STATE_MIGRATIONS)

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -33,7 +33,7 @@ impl TaskDb {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         Self::from_pg_pool(pool).await

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -5,7 +5,9 @@ mod types;
 
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
 
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, PgMigrator,
+};
 use migrations::TASK_MIGRATIONS;
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -30,9 +32,7 @@ impl TaskDb {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -36,7 +36,7 @@ impl ThreadDb {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, THREAD_MIGRATIONS).run().await?;

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -33,9 +35,7 @@ impl ThreadDb {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -41,7 +41,7 @@ impl PlanDb {
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
-        drop(setup);
+        setup.close().await;
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;
         PgMigrator::new(&pool, PLAN_MIGRATIONS).run().await?;

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -1,4 +1,6 @@
-use harness_core::db::{pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+};
 use harness_core::{types::ExecPlanId, types::ExecPlanStatus};
 use harness_exec::plan::ExecPlan;
 use sqlx::postgres::PgPool;
@@ -38,9 +40,7 @@ impl PlanDb {
         let schema = format!("h{:016x}", hasher.finish());
 
         let setup = pg_open_pool(&database_url).await?;
-        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
-            .execute(&setup)
-            .await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
         drop(setup);
 
         let pool = pg_open_pool_schematized(&database_url, &schema).await?;


### PR DESCRIPTION
## Summary

- Add `validate_schema_name` in `crates/harness-core/src/db_pg.rs` that rejects any schema name not matching `^[a-zA-Z_][a-zA-Z0-9_]*$`
- Call it at the start of `pg_open_pool_schematized` so invalid names are rejected before they reach any SQL interpolation
- Add 6 unit tests covering valid names, empty, digit-first, double-quote, semicolon, and hyphen inputs

## Motivation

Addresses Gemini's review comment on #833: the `SET search_path TO "<schema>"` format is safe today because schema names are hex hashes, but defence in depth requires rejecting unexpected names before they are interpolated into SQL. Validation (hard reject) is preferred over escaping because it provides a clear invariant for callers.

## Test plan

- `cargo test -p harness-core` — all 6 new `db_pg::tests::*` tests pass
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all` — no changes

Closes #848