### PR TITLE
fix(server): include local WorkspaceManager in overview worktree KPI

### DIFF
--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -134,7 +134,15 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     // ---- runtime fleet ----
     let runtime_hosts = state.runtime_hosts.list_hosts();
     let mut runtimes_json: Vec<Value> = Vec::with_capacity(runtime_hosts.len());
-    let mut worktrees_used: u64 = 0;
+    // Local single-host worktrees managed by WorkspaceManager, plus any leases
+    // held by remote runtime hosts. Without the workspace_mgr term, single-host
+    // deployments (no registered runtimes) always report 0.
+    let local_worktrees = state
+        .concurrency
+        .workspace_mgr
+        .as_ref()
+        .map_or(0, |m| m.live_count());
+    let mut worktrees_used: u64 = local_worktrees;
     for host in &runtime_hosts {
         let active_leases = state.runtime_hosts.active_lease_count(&host.id) as u64;
         worktrees_used = worktrees_used.saturating_add(active_leases);
@@ -479,6 +487,52 @@ mod tests {
         assert_eq!(
             body["throughput"]["hours"].as_array().unwrap().len(),
             THROUGHPUT_BUCKETS
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn worktrees_used_includes_local_workspace_manager() -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-overview-wt-")?;
+        let mut state = test_helpers::make_test_state(dir.path()).await?;
+
+        // Seed the workspace manager with 3 live entries (no real git ops needed).
+        let ws_config = harness_core::config::misc::WorkspaceConfig {
+            root: dir.path().join("ws"),
+            ..Default::default()
+        };
+        let mgr = Arc::new(crate::workspace::WorkspaceManager::new(ws_config)?);
+        for i in 0..3u64 {
+            mgr.active.insert(
+                harness_core::types::TaskId(format!("fake-{i}")),
+                crate::workspace::ActiveWorkspace {
+                    workspace_path: dir.path().join(format!("ws/fake-{i}")),
+                    source_repo: dir.path().to_path_buf(),
+                },
+            );
+        }
+        state.concurrency.workspace_mgr = Some(mgr);
+
+        let app = Router::new()
+            .route("/api/overview", get(overview))
+            .with_state(Arc::new(state));
+
+        let req = axum::http::Request::builder()
+            .uri("/api/overview")
+            .body(axum::body::Body::empty())?;
+
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        assert_eq!(
+            body["kpi"]["worktrees"]["used"].as_u64(),
+            Some(3),
+            "kpi.worktrees.used should count local workspace manager entries"
         );
 
         Ok(())

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -36,14 +36,14 @@ fn git_command() -> tokio::process::Command {
     cmd
 }
 
-struct ActiveWorkspace {
-    workspace_path: PathBuf,
-    source_repo: PathBuf,
+pub(crate) struct ActiveWorkspace {
+    pub(crate) workspace_path: PathBuf,
+    pub(crate) source_repo: PathBuf,
 }
 
 pub struct WorkspaceManager {
     pub(crate) config: WorkspaceConfig,
-    active: DashMap<TaskId, ActiveWorkspace>,
+    pub(crate) active: DashMap<TaskId, ActiveWorkspace>,
 }
 
 impl WorkspaceManager {
@@ -249,6 +249,11 @@ impl WorkspaceManager {
     /// Return the workspace path for the given task if it is active.
     pub fn get_workspace(&self, task_id: &TaskId) -> Option<PathBuf> {
         self.active.get(task_id).map(|e| e.workspace_path.clone())
+    }
+
+    /// Number of worktrees currently checked out and not yet reaped.
+    pub fn live_count(&self) -> u64 {
+        self.active.len() as u64
     }
 
     /// Remove workspaces for all given terminal task IDs. Errors are logged, not returned.


### PR DESCRIPTION
## Summary

- `/api/overview` was summing only remote runtime-host leases for `kpi.worktrees.used`, so single-host deployments (no registered runtimes) always reported 0 active worktrees
- Added `WorkspaceManager::live_count()` returning the number of worktrees in the active `DashMap`
- `worktrees_used` in the overview handler is now seeded with `local_worktrees` before accumulating remote leases — multi-host behaviour is preserved (no regression)
- Exposed `ActiveWorkspace` and `WorkspaceManager::active` as `pub(crate)` to enable the new test to seed fake entries without real git operations
- Added `worktrees_used_includes_local_workspace_manager` integration test asserting `kpi.worktrees.used == 3` when the workspace manager holds 3 live entries

Closes #864

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test --package harness-server --lib -- handlers::overview --test-threads=1` — 5/5 pass (including new test)