### PR TITLE
fix(server): return 501 for unimplemented password reset endpoint

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -511,65 +511,13 @@ pub(crate) async fn ingest_signal(
     )
 }
 
-#[derive(serde::Deserialize)]
-pub(crate) struct PasswordResetRequest {
-    pub(crate) email: String,
-}
-
 /// POST /auth/reset-password — initiate a password reset.
 ///
-/// Rate-limited per email address to prevent enumeration and brute-force.
-/// Always returns a generic success response regardless of whether the email
-/// exists, to avoid leaking account information.
-pub(crate) async fn password_reset(
-    State(state): State<Arc<AppState>>,
-    Json(req): Json<PasswordResetRequest>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    let email = req.email.trim().to_lowercase();
-    if email.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "email is required"})),
-        );
-    }
-
-    let limit = state
-        .core
-        .server
-        .config
-        .server
-        .password_reset_rate_limit_per_hour;
-
-    if !state
-        .observability
-        .password_reset_rate_limiter
-        .check_and_increment(&email)
-    {
-        return (
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(json!({
-                "error": format!(
-                    "rate limit exceeded: max {} password reset requests per hour",
-                    limit
-                )
-            })),
-        );
-    }
-
-    tracing::info!(
-        email_hash = %format!("{:x}", {
-            use std::hash::{Hash, Hasher};
-            let mut h = std::collections::hash_map::DefaultHasher::new();
-            email.hash(&mut h);
-            h.finish()
-        }),
-        "password reset requested"
-    );
-
+/// Not yet implemented: email delivery has not been wired up.
+/// Returns 501 until SMTP integration is complete.
+pub(crate) async fn password_reset() -> (StatusCode, Json<serde_json::Value>) {
     (
-        StatusCode::OK,
-        Json(
-            json!({"status": "ok", "message": "If that email is registered, a reset link has been sent."}),
-        ),
+        StatusCode::NOT_IMPLEMENTED,
+        Json(json!({"error": "password reset is not yet available"})),
     )
 }


### PR DESCRIPTION
## Summary

- `POST /auth/reset-password` previously responded `200 OK` with the message _"If that email is registered, a reset link has been sent."_ despite containing zero email-sending logic
- Replace the misleading handler with `501 Not Implemented` and an honest error message
- Remove the now-unused `PasswordResetRequest` struct and dead rate-limiter call

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (pre-existing DB pool failures in `harness-observe` are unrelated)
- [ ] Manual: `curl -X POST /auth/reset-password` returns `501` with `{"error":"password reset is not yet available"}`

Signed-off-by: majiayu000 <1835304752@qq.com>