### PR TITLE
feat(prompts): validate PR body via scripts/pr_body_check.sh before publish (Symphony-style)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,19 @@
-## What
+## Summary
 
-Brief description of changes.
+<!-- Bullet list of what changed and why. Each bullet ≤ 120 chars. -->
 
-## Why
+-
 
-Why is this change needed?
+## Test plan
 
-## Test Plan
+<!-- List the checks you ran. -->
 
-- [ ] Tests pass
-- [ ] Tested manually
+- [ ] `cargo check --workspace --all-targets`
+- [ ] `cargo test --workspace` (or the focused package test for this change)
+- [ ] Manual verification if UI/runtime behaviour changed
+
+<!--
+  When this PR closes a GitHub issue, end the body with a line like
+  `Closes #<issue>` (or `Fixes #<issue>` / `Resolves #<issue>`).
+  scripts/pr_body_check.sh --file <this-file> --issue <N> validates it.
+-->

--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -118,8 +118,15 @@ pub fn implement_from_issue(
              3. Implement the change with the minimum necessary modifications\n\
              4. Run `cargo check` and `cargo test` — fix any failures before proceeding\n\
              5. Create a feature branch, commit with a descriptive message, push\n\
-             6. Create a PR with `gh pr create`. Include \"Closes #{issue}\" in the PR body \
-so that GitHub and harness can identify this PR as closing the issue."
+             6. Draft the PR body in `/tmp/pr_body.md`. Follow \
+`.github/pull_request_template.md` (Summary + Test plan sections) and end \
+with a line reading exactly `Closes #{issue}` so GitHub auto-closes the issue \
+on merge.\n\
+             7. Validate the body before publishing: \
+`scripts/pr_body_check.sh --file /tmp/pr_body.md --issue {issue}` — this \
+must exit 0. Fix the body and re-run until it passes.\n\
+             8. Publish with `gh pr create --body-file /tmp/pr_body.md` (do NOT \
+use `--body`; the validator only guards the file-backed path)."
         ),
         context: git_line,
         dynamic_payload: "On the last line of your output, print PR_URL=<full PR URL>".to_string(),

--- a/scripts/pr_body_check.sh
+++ b/scripts/pr_body_check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Validate a PR body file before `gh pr create --body-file <file>`.
+#
+# Inspired by Symphony's `mix pr_body.check`: the agent writes the body to a
+# file, this script lints it, and only on exit 0 does the agent proceed to
+# invoke `gh pr create`. Keeps the LLM in charge of the prose while making
+# structural requirements (like issue linkage) machine-verifiable.
+#
+# Usage:
+#   scripts/pr_body_check.sh --file /tmp/pr_body.md [--issue <N>]
+#
+# Checks:
+#   1. File exists and is non-empty.
+#   2. Body has a `## Summary` section with at least one line of content.
+#   3. Body has a `## Test` section (matches "Test plan", "Testing", etc.).
+#   4. If --issue N is provided, body contains `Closes #N` or `Fixes #N` or
+#      `Resolves #N` on its own line so GitHub auto-closes on merge.
+#
+# Exits non-zero with a clear, actionable message on any failure.
+
+set -euo pipefail
+
+FILE=""
+ISSUE=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --file <path> [--issue <N>]
+
+Required:
+  --file <path>      PR body markdown file to validate
+
+Optional:
+  --issue <N>        GitHub issue number this PR closes; when set, the body
+                     must contain Closes #N / Fixes #N / Resolves #N on its
+                     own line so GitHub auto-closes the issue on merge.
+
+Exit codes:
+  0  — body is valid
+  1  — file missing or empty
+  2  — required section missing
+  3  — issue linkage missing or mismatched
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file) FILE="${2:-}"; shift 2 ;;
+    --issue) ISSUE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+if [ -z "$FILE" ]; then
+  echo "ERROR: --file is required" >&2
+  usage >&2
+  exit 64
+fi
+
+if [ ! -s "$FILE" ]; then
+  echo "ERROR: body file '$FILE' is missing or empty" >&2
+  exit 1
+fi
+
+body=$(cat "$FILE")
+
+# Check 2: Summary section
+if ! grep -qE '^##[[:space:]]+Summary\b' <<<"$body"; then
+  echo "ERROR: PR body is missing a '## Summary' section." >&2
+  echo "       Add one with a short bullet list describing what changed and why." >&2
+  exit 2
+fi
+
+# Check 3: Test section (accept several spellings)
+if ! grep -qiE '^##[[:space:]]+(Test(ing|[[:space:]]+plan)?)\b' <<<"$body"; then
+  echo "ERROR: PR body is missing a '## Test plan' / '## Testing' / '## Test' section." >&2
+  echo "       List the checks you ran (cargo check, cargo test, manual steps, etc.)." >&2
+  exit 2
+fi
+
+# Check 4: Issue linkage when --issue is passed
+if [ -n "$ISSUE" ]; then
+  # Match `Closes #123`, `Fixes: #123`, `Resolves #123`, etc., on its own line.
+  # The keyword and issue number must both appear; extra trailing whitespace ok.
+  pattern="^[[:space:]]*(Closes|Fixes|Resolves)[:[:space:]]+#${ISSUE}[[:space:]]*$"
+  if ! grep -qiE "$pattern" <<<"$body"; then
+    echo "ERROR: PR body must contain a GitHub closing keyword for issue #${ISSUE}." >&2
+    echo "       Add a line on its own that reads exactly:" >&2
+    echo "           Closes #${ISSUE}" >&2
+    echo "       GitHub uses this to auto-close the issue when the PR merges." >&2
+    exit 3
+  fi
+fi
+
+echo "PR body validation passed: file=${FILE} issue=${ISSUE:-<none>}"


### PR DESCRIPTION
## Summary

- Add `scripts/pr_body_check.sh` — bash validator that exits non-zero when the body lacks `## Summary` / `## Test plan` sections or, when `--issue N` is passed, a matching `Closes #N` / `Fixes #N` / `Resolves #N` linkage
- Rewrite `.github/pull_request_template.md` so section headings match what the validator checks, and point the template comment at the script
- Update `issue_prompt` in `crates/harness-core/src/prompts/issue.rs` so the agent drafts the body to `/tmp/pr_body.md`, runs the validator, and only on exit 0 publishes via `gh pr create --body-file`

Follows Symphony's pattern: external deterministic check replaces prompt-only guidance. Agent keeps prose freedom; structural requirements (issue linkage, required sections) become machine-verified.

## Test plan

- [x] `bash scripts/pr_body_check.sh --file /tmp/empty.md` — exit 1 (file missing)
- [x] `bash scripts/pr_body_check.sh --file /tmp/ok.md --issue 42` with body missing Closes → exit 3
- [x] Same body with `Closes #42` line → exit 0
- [x] `cargo check -p harness-core` passes
- [x] pre-commit hook (fmt + clippy + test) passes

Closes #850
