### PR TITLE
fix(review): defer startup periodic review until next interval

### DIFF
--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -60,7 +60,10 @@ impl GitHubIssuesPoller {
         };
         let dm = DashMap::new();
         for (k, v) in map {
-            dm.insert(k, harness_core::types::TaskId(v));
+            dm.insert(
+                normalize_issue_external_id(&k),
+                harness_core::types::TaskId(v),
+            );
         }
         dm
     }
@@ -89,6 +92,19 @@ impl GitHubIssuesPoller {
             Err(e) => tracing::warn!("failed to serialize dispatched state: {e}"),
         }
     }
+}
+
+fn normalize_issue_external_id(external_id: &str) -> String {
+    let trimmed = external_id.trim();
+    trimmed
+        .strip_prefix("issue:")
+        .filter(|id| !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()))
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+fn dispatched_contains_issue(dispatched: &DashMap<String, TaskId>, issue_id: &str) -> bool {
+    dispatched.contains_key(issue_id) || dispatched.contains_key(&format!("issue:{issue_id}"))
 }
 
 /// Raw GitHub issue fields returned by `gh issue list --json`.
@@ -129,7 +145,10 @@ fn parse_gh_output(
         issues.iter().map(|i| i.number.to_string()).collect();
     let new_issues = issues
         .into_iter()
-        .filter(|issue| !dispatched.contains_key(&issue.number.to_string()))
+        .filter(|issue| {
+            let issue_id = issue.number.to_string();
+            !dispatched_contains_issue(dispatched, &issue_id)
+        })
         .map(|issue| IncomingIssue {
             source: "github".to_string(),
             external_id: issue.number.to_string(),
@@ -196,7 +215,11 @@ impl IntakeSource for GitHubIssuesPoller {
             .dispatched
             .iter()
             .map(|e| e.key().clone())
-            .filter(|id| !parsed.open_issue_ids.contains(id))
+            .filter(|id| {
+                !parsed
+                    .open_issue_ids
+                    .contains(&normalize_issue_external_id(id))
+            })
             .collect();
         if !stale.is_empty() {
             for id in &stale {
@@ -214,13 +237,14 @@ impl IntakeSource for GitHubIssuesPoller {
 
     async fn mark_dispatched(&self, external_id: &str, task_id: &TaskId) -> anyhow::Result<()> {
         self.dispatched
-            .insert(external_id.to_string(), task_id.clone());
+            .insert(normalize_issue_external_id(external_id), task_id.clone());
         self.persist_dispatched();
         Ok(())
     }
 
     async fn unmark_dispatched(&self, external_id: &str) {
-        self.dispatched.remove(external_id);
+        self.dispatched
+            .remove(&normalize_issue_external_id(external_id));
         self.persist_dispatched();
     }
 
@@ -241,7 +265,8 @@ impl IntakeSource for GitHubIssuesPoller {
         // retry them later if they remain open. Done tasks and permanent failures stay
         // dispatched to avoid re-processing.
         if (result.status.is_failure() || result.status.is_cancelled()) && !needs_manual {
-            self.dispatched.remove(external_id);
+            self.dispatched
+                .remove(&normalize_issue_external_id(external_id));
             self.persist_dispatched();
         }
         Ok(())
@@ -315,6 +340,25 @@ mod tests {
         assert_eq!(parsed.new_issues.len(), 1);
         assert_eq!(parsed.new_issues[0].external_id, "3");
         assert_eq!(parsed.open_issue_ids.len(), 3);
+    }
+
+    #[test]
+    fn parse_gh_output_filters_canonical_dispatched_issue_keys() {
+        let json = br#"[
+            {"number": 1, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
+            {"number": 2, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null},
+            {"number": 3, "title": "C", "body": null, "url": "u3", "labels": [], "createdAt": null}
+        ]"#;
+
+        let dispatched = make_dispatched(&["1"]);
+        dispatched.insert(
+            "issue:2".to_string(),
+            harness_core::types::TaskId("task-2".to_string()),
+        );
+        let parsed = parse_gh_output(json, "owner/repo", &dispatched, None).unwrap();
+
+        assert_eq!(parsed.new_issues.len(), 1);
+        assert_eq!(parsed.new_issues[0].external_id, "3");
     }
 
     #[test]
@@ -452,6 +496,34 @@ mod tests {
         assert!(
             !poller.dispatched.contains_key(external_id),
             "issue must be removed from dispatched after transient failure so poller can retry"
+        );
+    }
+
+    #[test]
+    fn on_task_complete_transient_failure_removes_canonical_external_id_from_dispatched() {
+        let repo_cfg = harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: None,
+        };
+        let poller = GitHubIssuesPoller::new(&repo_cfg, None);
+        poller.dispatched.insert(
+            "88".to_string(),
+            harness_core::types::TaskId("task-88".to_string()),
+        );
+
+        let result = TaskCompletionResult {
+            status: TaskStatus::Failed,
+            pr_url: None,
+            error: Some("triage phase agent error".to_string()),
+            summary: "transient failure".to_string(),
+        };
+
+        futures::executor::block_on(poller.on_task_complete("issue:88", &result)).unwrap();
+
+        assert!(
+            !poller.dispatched.contains_key("88"),
+            "canonical external_id should remove the raw GitHub issue key"
         );
     }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -110,6 +110,32 @@ fn startup_project_delay(
     }
 }
 
+struct StartupDelayOutcome {
+    delay: Duration,
+    last_review_ts: Option<DateTime<Utc>>,
+    overdue: bool,
+    elapsed: Option<chrono::Duration>,
+}
+
+fn startup_delay_outcome(
+    run_on_startup: bool,
+    interval: Duration,
+    last_review_ts: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> StartupDelayOutcome {
+    let interval_chrono =
+        chrono::Duration::from_std(interval).unwrap_or_else(|_| chrono::Duration::hours(24));
+    let elapsed = last_review_ts.map(|ts| now.signed_duration_since(ts));
+    let overdue = elapsed.is_some_and(|elapsed| elapsed >= interval_chrono);
+    let delay = startup_project_delay(run_on_startup, interval, last_review_ts, now);
+    StartupDelayOutcome {
+        delay,
+        last_review_ts,
+        overdue,
+        elapsed,
+    }
+}
+
 async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     let interval = config.effective_interval();
 
@@ -132,32 +158,33 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // On startup, compute the per-project remaining time and the global minimum.
     // Only projects whose individual delay falls within the minimum sleep window
     // are run on the first tick; others wait for the regular interval loop.
-    let interval_chrono =
-        chrono::Duration::from_std(interval).unwrap_or_else(|_| chrono::Duration::hours(24));
-    let startup_now = Utc::now();
+    let default_startup_delay = if config.run_on_startup {
+        Duration::ZERO
+    } else {
+        interval
+    };
     let mut min_delay = interval;
     let mut project_delays: Vec<Duration> = Vec::with_capacity(projects.len());
     for project in &projects {
         let hook_key = project_hook_key(&project.name, &project.root);
         let last_review_ts = last_review_timestamp(&state, &hook_key).await;
-        let delay =
-            startup_project_delay(config.run_on_startup, interval, last_review_ts, startup_now);
-        match last_review_ts {
+        let outcome =
+            startup_delay_outcome(config.run_on_startup, interval, last_review_ts, Utc::now());
+        match outcome.last_review_ts {
             Some(last_ts) => {
-                let elapsed = startup_now.signed_duration_since(last_ts);
-                if elapsed >= interval_chrono {
+                if outcome.overdue {
                     if config.run_on_startup {
                         tracing::info!(
                             project = %project.name,
                             last_review = %last_ts,
-                            elapsed_hours = elapsed.num_hours(),
+                            elapsed_hours = outcome.elapsed.map(|e| e.num_hours()).unwrap_or_default(),
                             "scheduler: periodic review overdue, triggering now"
                         );
                     } else {
                         tracing::info!(
                             project = %project.name,
                             last_review = %last_ts,
-                            next_in_secs = delay.as_secs(),
+                            next_in_secs = outcome.delay.as_secs(),
                             "scheduler: startup review suppressed for overdue project; deferring until next interval"
                         );
                     }
@@ -165,7 +192,7 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
                     tracing::info!(
                         project = %project.name,
                         last_review = %last_ts,
-                        next_in_secs = delay.as_secs(),
+                        next_in_secs = outcome.delay.as_secs(),
                         "scheduler: periodic review not yet due, sleeping"
                     );
                 }
@@ -179,15 +206,15 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
                 } else {
                     tracing::info!(
                         project = %project.name,
-                        next_in_secs = delay.as_secs(),
+                        next_in_secs = outcome.delay.as_secs(),
                         "scheduler: startup review suppressed for first run; deferring until next interval"
                     );
                 }
             }
         }
-        project_delays.push(delay);
-        if delay < min_delay {
-            min_delay = delay;
+        project_delays.push(outcome.delay);
+        if outcome.delay < min_delay {
+            min_delay = outcome.delay;
         }
     }
 
@@ -224,11 +251,6 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // Projects whose remaining time exceeds min_delay are deferred to the regular
     // interval loop, avoiding unnecessary task/quota spikes on restart.
     for project in &projects {
-        let default_startup_delay = if config.run_on_startup {
-            Duration::ZERO
-        } else {
-            interval
-        };
         let project_delay = *startup_delay_by_name
             .get(&project.name)
             .unwrap_or(&default_startup_delay);

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -79,6 +79,37 @@ pub fn start(state: Arc<AppState>, config: ReviewConfig) {
     });
 }
 
+fn startup_project_delay(
+    run_on_startup: bool,
+    interval: Duration,
+    last_review_ts: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Duration {
+    let interval_chrono =
+        chrono::Duration::from_std(interval).unwrap_or_else(|_| chrono::Duration::hours(24));
+    match last_review_ts {
+        Some(last_ts) => {
+            let elapsed = now.signed_duration_since(last_ts);
+            if elapsed >= interval_chrono {
+                if run_on_startup {
+                    Duration::ZERO
+                } else {
+                    interval
+                }
+            } else {
+                (interval_chrono - elapsed).to_std().unwrap_or(interval)
+            }
+        }
+        None => {
+            if run_on_startup {
+                Duration::ZERO
+            } else {
+                interval
+            }
+        }
+    }
+}
+
 async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     let interval = config.effective_interval();
 
@@ -103,40 +134,57 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // are run on the first tick; others wait for the regular interval loop.
     let interval_chrono =
         chrono::Duration::from_std(interval).unwrap_or_else(|_| chrono::Duration::hours(24));
+    let startup_now = Utc::now();
     let mut min_delay = interval;
     let mut project_delays: Vec<Duration> = Vec::with_capacity(projects.len());
     for project in &projects {
         let hook_key = project_hook_key(&project.name, &project.root);
-        let delay = match last_review_timestamp(&state, &hook_key).await {
+        let last_review_ts = last_review_timestamp(&state, &hook_key).await;
+        let delay =
+            startup_project_delay(config.run_on_startup, interval, last_review_ts, startup_now);
+        match last_review_ts {
             Some(last_ts) => {
-                let elapsed = Utc::now().signed_duration_since(last_ts);
+                let elapsed = startup_now.signed_duration_since(last_ts);
                 if elapsed >= interval_chrono {
-                    tracing::info!(
-                        project = %project.name,
-                        last_review = %last_ts,
-                        elapsed_hours = elapsed.num_hours(),
-                        "scheduler: periodic review overdue, triggering now"
-                    );
-                    Duration::from_secs(0)
+                    if config.run_on_startup {
+                        tracing::info!(
+                            project = %project.name,
+                            last_review = %last_ts,
+                            elapsed_hours = elapsed.num_hours(),
+                            "scheduler: periodic review overdue, triggering now"
+                        );
+                    } else {
+                        tracing::info!(
+                            project = %project.name,
+                            last_review = %last_ts,
+                            next_in_secs = delay.as_secs(),
+                            "scheduler: startup review suppressed for overdue project; deferring until next interval"
+                        );
+                    }
                 } else {
-                    let remaining = (interval_chrono - elapsed).to_std().unwrap_or(interval);
                     tracing::info!(
                         project = %project.name,
                         last_review = %last_ts,
-                        next_in_secs = remaining.as_secs(),
+                        next_in_secs = delay.as_secs(),
                         "scheduler: periodic review not yet due, sleeping"
                     );
-                    remaining
                 }
             }
             None => {
-                tracing::info!(
-                    project = %project.name,
-                    "scheduler: no prior periodic review found, triggering now"
-                );
-                Duration::from_secs(0)
+                if config.run_on_startup {
+                    tracing::info!(
+                        project = %project.name,
+                        "scheduler: no prior periodic review found, triggering now"
+                    );
+                } else {
+                    tracing::info!(
+                        project = %project.name,
+                        next_in_secs = delay.as_secs(),
+                        "scheduler: startup review suppressed for first run; deferring until next interval"
+                    );
+                }
             }
-        };
+        }
         project_delays.push(delay);
         if delay < min_delay {
             min_delay = delay;
@@ -150,7 +198,8 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // Re-collect after the startup sleep to pick up projects registered via
     // `POST /projects` during the sleep window (5 s init + min_delay).
     // Build a delay-by-name lookup first so newly registered projects (absent
-    // from the original snapshot) default to delay=0 and run on the first tick.
+    // from the original snapshot) inherit the startup policy: immediate when
+    // run_on_startup is enabled, otherwise deferred until the next interval.
     let startup_delay_by_name: HashMap<String, Duration> = projects
         .iter()
         .zip(project_delays.iter())
@@ -175,9 +224,14 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // Projects whose remaining time exceeds min_delay are deferred to the regular
     // interval loop, avoiding unnecessary task/quota spikes on restart.
     for project in &projects {
+        let default_startup_delay = if config.run_on_startup {
+            Duration::ZERO
+        } else {
+            interval
+        };
         let project_delay = *startup_delay_by_name
             .get(&project.name)
-            .unwrap_or(&Duration::ZERO);
+            .unwrap_or(&default_startup_delay);
         if project_delay > min_delay {
             tracing::debug!(
                 project = %project.name,
@@ -1615,6 +1669,60 @@ mod tests {
             ..ReviewConfig::default()
         };
         assert_eq!(config.effective_interval(), Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn startup_project_delay_runs_immediately_when_enabled_and_no_watermark() {
+        let now = Utc::now();
+        let interval = Duration::from_secs(3600);
+        assert_eq!(
+            startup_project_delay(true, interval, None, now),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn startup_project_delay_runs_immediately_when_enabled_and_overdue() {
+        let now = Utc::now();
+        let interval = Duration::from_secs(3600);
+        let last_review = now - chrono::Duration::hours(2);
+        assert_eq!(
+            startup_project_delay(true, interval, Some(last_review), now),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn startup_project_delay_waits_full_interval_when_disabled_and_no_watermark() {
+        let now = Utc::now();
+        let interval = Duration::from_secs(3600);
+        assert_eq!(startup_project_delay(false, interval, None, now), interval);
+    }
+
+    #[test]
+    fn startup_project_delay_waits_full_interval_when_disabled_and_overdue() {
+        let now = Utc::now();
+        let interval = Duration::from_secs(3600);
+        let last_review = now - chrono::Duration::hours(2);
+        assert_eq!(
+            startup_project_delay(false, interval, Some(last_review), now),
+            interval
+        );
+    }
+
+    #[test]
+    fn startup_project_delay_preserves_remaining_time_when_not_yet_due() {
+        let now = Utc::now();
+        let interval = Duration::from_secs(3600);
+        let last_review = now - chrono::Duration::minutes(15);
+        assert_eq!(
+            startup_project_delay(false, interval, Some(last_review), now),
+            Duration::from_secs(2700)
+        );
+        assert_eq!(
+            startup_project_delay(true, interval, Some(last_review), now),
+            Duration::from_secs(2700)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- defer startup periodic review by one full interval when `review.run_on_startup = false` and a project has no watermark or an overdue watermark
- preserve existing startup behavior when `review.run_on_startup = true`
- add focused tests for startup delay semantics

## Test plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo test startup_project_delay
- [ ] cargo test (blocked by unrelated `harness-observe` pool timeout failures tracked in #893)

## Issues
- Fixes #894
- Related: #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)