### PR TITLE
Respect server.database_url over DATABASE_URL fallback

### DIFF
--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -81,6 +81,7 @@ impl ServerConfig {
     /// - `HARNESS_HTTP_ADDR`       — `http_addr` (parsed as `SocketAddr`)
     /// - `HARNESS_DATA_DIR`        — `data_dir`
     /// - `HARNESS_PROJECT_ROOT`    — `project_root`
+    /// - `HARNESS_DATABASE_URL`    — `database_url`
     /// - `HARNESS_API_TOKEN`       — `api_token`
     /// - `GITHUB_TOKEN`            — `github_token`
     /// - `GITHUB_WEBHOOK_SECRET`   — `github_webhook_secret`
@@ -93,6 +94,11 @@ impl ServerConfig {
         if let Ok(v) = std::env::var("HARNESS_PROJECT_ROOT") {
             if !v.is_empty() {
                 self.project_root = std::path::PathBuf::from(v);
+            }
+        }
+        if let Ok(v) = std::env::var("HARNESS_DATABASE_URL") {
+            if !v.is_empty() {
+                self.database_url = Some(v);
             }
         }
         if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
@@ -304,6 +310,39 @@ mod tests {
     }
 
     #[test]
+    fn env_override_database_url() {
+        temp_env::with_vars(
+            [(
+                "HARNESS_DATABASE_URL",
+                Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+            )],
+            || {
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(
+                    cfg.database_url,
+                    Some("postgres://env-user:env-pass@env-host:5432/envdb".to_string())
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn env_override_empty_database_url_does_not_override_toml_url() {
+        temp_env::with_vars([("HARNESS_DATABASE_URL", Some(""))], || {
+            let mut cfg = ServerConfig {
+                database_url: Some("postgres://cfg-user:cfg-pass@cfg-host:5432/cfgdb".to_string()),
+                ..ServerConfig::default()
+            };
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(
+                cfg.database_url,
+                Some("postgres://cfg-user:cfg-pass@cfg-host:5432/cfgdb".to_string())
+            );
+        });
+    }
+
+    #[test]
     fn env_override_api_token() {
         temp_env::with_vars([("HARNESS_API_TOKEN", Some("tok-test"))], || {
             let mut cfg = ServerConfig::default();
@@ -383,6 +422,7 @@ mod tests {
                 ("HARNESS_HTTP_ADDR", None::<&str>),
                 ("HARNESS_DATA_DIR", None::<&str>),
                 ("HARNESS_PROJECT_ROOT", None::<&str>),
+                ("HARNESS_DATABASE_URL", None::<&str>),
                 ("HARNESS_API_TOKEN", None::<&str>),
                 ("GITHUB_TOKEN", None::<&str>),
             ],
@@ -395,6 +435,7 @@ mod tests {
                 cfg.apply_env_overrides().unwrap();
                 assert_eq!(cfg.http_addr, http_addr_before);
                 assert_eq!(cfg.data_dir, data_dir_before);
+                assert_eq!(cfg.database_url, None);
                 assert_eq!(cfg.api_token, None);
                 assert_eq!(cfg.github_token, None);
             },

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -12,6 +12,12 @@ pub struct ServerConfig {
     pub data_dir: PathBuf,
     #[serde(default = "default_project_root")]
     pub project_root: PathBuf,
+    /// Postgres connection string for all persistent server stores.
+    ///
+    /// When set, this wins over the legacy `DATABASE_URL` environment variable
+    /// fallback used by lower-level store initializers.
+    #[serde(default)]
+    pub database_url: Option<String>,
     #[serde(default)]
     pub github_webhook_secret: Option<String>,
     #[serde(default = "default_notification_broadcast_capacity")]
@@ -135,6 +141,7 @@ impl fmt::Debug for ServerConfig {
             http_addr,
             data_dir,
             project_root,
+            database_url,
             github_webhook_secret,
             notification_broadcast_capacity,
             notification_lag_log_every,
@@ -153,6 +160,7 @@ impl fmt::Debug for ServerConfig {
             .field("http_addr", http_addr)
             .field("data_dir", data_dir)
             .field("project_root", project_root)
+            .field("database_url", &database_url.as_ref().map(|_| "[REDACTED]"))
             .field(
                 "github_webhook_secret",
                 &github_webhook_secret.as_ref().map(|_| "[REDACTED]"),
@@ -185,6 +193,7 @@ impl Default for ServerConfig {
             http_addr: SocketAddr::from(([127, 0, 0, 1], 9800)),
             data_dir: dirs_data_dir().join("harness"),
             project_root: default_project_root(),
+            database_url: None,
             github_webhook_secret: None,
             notification_broadcast_capacity: default_notification_broadcast_capacity(),
             notification_lag_log_every: default_notification_lag_log_every(),

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -10,7 +10,8 @@ use std::sync::OnceLock;
 // Re-export them here so existing callers using `harness_core::db::*` continue
 // to work without any import changes.
 pub use crate::db_pg::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    PgMigrator,
 };
 
 static SQLITE_TRANSACTIONAL_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -4,6 +4,29 @@ use std::str::FromStr as _;
 
 use crate::db::Migration;
 
+/// Resolve the effective Postgres connection string.
+///
+/// Precedence:
+/// 1. Explicit configured URL (for example `server.database_url` from TOML)
+/// 2. Legacy `DATABASE_URL` environment variable fallback
+pub fn resolve_database_url(configured_database_url: Option<&str>) -> anyhow::Result<String> {
+    if let Some(url) = configured_database_url
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    {
+        return Ok(url.to_string());
+    }
+    if let Ok(url) = std::env::var("DATABASE_URL") {
+        let url = url.trim();
+        if !url.is_empty() {
+            return Ok(url.to_string());
+        }
+    }
+    anyhow::bail!(
+        "database URL is not configured; set server.database_url in TOML or DATABASE_URL in the environment"
+    )
+}
+
 /// Create a Postgres connection pool for the given DATABASE_URL.
 ///
 /// Uses 3 max connections with a 10-second acquire timeout.
@@ -186,7 +209,7 @@ impl<'a> PgMigrator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_schema_name;
+    use super::{resolve_database_url, validate_schema_name};
 
     #[test]
     fn valid_schema_names() {
@@ -239,5 +262,47 @@ mod tests {
             validate_schema_name(&name).is_err(),
             "64-byte name should be rejected"
         );
+    }
+
+    #[test]
+    fn configured_database_url_wins_over_environment() {
+        temp_env::with_vars(
+            [(
+                "DATABASE_URL",
+                Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+            )],
+            || {
+                let resolved =
+                    resolve_database_url(Some("postgres://cfg-user:cfg-pass@cfg-host:5432/cfgdb"))
+                        .expect("configured database URL should resolve");
+                assert_eq!(resolved, "postgres://cfg-user:cfg-pass@cfg-host:5432/cfgdb");
+            },
+        );
+    }
+
+    #[test]
+    fn environment_database_url_used_as_fallback() {
+        temp_env::with_vars(
+            [(
+                "DATABASE_URL",
+                Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+            )],
+            || {
+                let resolved =
+                    resolve_database_url(None).expect("environment database URL should resolve");
+                assert_eq!(resolved, "postgres://env-user:env-pass@env-host:5432/envdb");
+            },
+        );
+    }
+
+    #[test]
+    fn missing_database_url_returns_error() {
+        temp_env::with_vars([("DATABASE_URL", None::<&str>)], || {
+            let err = resolve_database_url(None).expect_err("missing database URL should fail");
+            assert!(
+                err.to_string().contains("server.database_url"),
+                "error should mention server.database_url, got: {err}"
+            );
+        });
     }
 }

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -25,9 +25,14 @@ pub(crate) async fn build_registry(
     project_root: &Path,
     tasks: &Arc<crate::task_runner::TaskStore>,
 ) -> anyhow::Result<RegistryBundle> {
+    let configured_database_url = server.config.server.database_url.as_deref();
     // ── Thread DB ─────────────────────────────────────────────────────────────
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
-    let thread_db = crate::thread_db::ThreadDb::open(&thread_db_path).await?;
+    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
+        &thread_db_path,
+        configured_database_url,
+    )
+    .await?;
 
     // Load persisted threads into the in-memory ThreadManager cache.
     for thread in thread_db.list().await? {
@@ -69,8 +74,9 @@ pub(crate) async fn build_registry(
     }
 
     // ── Project registry ──────────────────────────────────────────────────────
-    let project_registry = crate::project_registry::ProjectRegistry::open(
+    let project_registry = crate::project_registry::ProjectRegistry::open_with_database_url(
         &harness_core::config::dirs::default_db_path(data_dir, "projects"),
+        configured_database_url,
     )
     .await?;
 
@@ -178,7 +184,12 @@ pub(crate) async fn build_registry(
     let runtime_state_store = {
         let runtime_state_db_path =
             harness_core::config::dirs::default_db_path(data_dir, "runtime_state");
-        match crate::runtime_state_store::RuntimeStateStore::open(&runtime_state_db_path).await {
+        match crate::runtime_state_store::RuntimeStateStore::open_with_database_url(
+            &runtime_state_db_path,
+            configured_database_url,
+        )
+        .await
+        {
             Ok(store) => Some(Arc::new(store)),
             Err(e) => {
                 tracing::warn!(

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -43,9 +43,10 @@ pub(crate) async fn build_registry(
     }
 
     // ── Plan DB + cache ───────────────────────────────────────────────────────
-    let plan_db = crate::plan_db::PlanDb::open(&harness_core::config::dirs::default_db_path(
-        data_dir, "plans",
-    ))
+    let plan_db = crate::plan_db::PlanDb::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(data_dir, "plans"),
+        configured_database_url,
+    )
     .await?;
 
     let plans_md_dir = data_dir.join("plans");

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -15,7 +15,15 @@ pub(crate) struct StorageBundle {
 ///
 /// On Unix this function refuses to proceed if `data_dir` is a symbolic link
 /// to prevent symlink-hijacking attacks on the persistent data directory.
+#[cfg(test)]
 pub(crate) async fn build_storage(data_dir: &Path) -> anyhow::Result<StorageBundle> {
+    build_storage_with_database_url(data_dir, None).await
+}
+
+pub(crate) async fn build_storage_with_database_url(
+    data_dir: &Path,
+    configured_database_url: Option<&str>,
+) -> anyhow::Result<StorageBundle> {
     std::fs::create_dir_all(data_dir)?;
 
     #[cfg(unix)]
@@ -38,20 +46,22 @@ pub(crate) async fn build_storage(data_dir: &Path) -> anyhow::Result<StorageBund
 
     let db_path = harness_core::config::dirs::default_db_path(data_dir, "tasks");
     tracing::debug!("task db: {}", db_path.display());
-    let tasks = TaskStore::open(&db_path).await?;
+    let tasks = TaskStore::open_with_database_url(&db_path, configured_database_url).await?;
 
     let q_values_db_path = harness_core::config::dirs::default_db_path(data_dir, "q_values");
     tracing::debug!("q_value db: {}", q_values_db_path.display());
-    let q_values = match QValueStore::open(&q_values_db_path).await {
-        Ok(store) => Some(Arc::new(store)),
-        Err(e) => {
-            tracing::warn!(
-                path = %q_values_db_path.display(),
-                "q_value store init failed, rule utility tracking will be disabled: {e}"
-            );
-            None
-        }
-    };
+    let q_values =
+        match QValueStore::open_with_database_url(&q_values_db_path, configured_database_url).await
+        {
+            Ok(store) => Some(Arc::new(store)),
+            Err(e) => {
+                tracing::warn!(
+                    path = %q_values_db_path.display(),
+                    "q_value store init failed, rule utility tracking will be disabled: {e}"
+                );
+                None
+            }
+        };
 
     Ok(StorageBundle { tasks, q_values })
 }

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -81,7 +81,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     }
 
     // Phase 1: storage — dir validation (symlink check, chmod), task DB, q_value DB.
-    let storage = builders::storage::build_storage(&dir).await?;
+    let storage = builders::storage::build_storage_with_database_url(
+        &dir,
+        server.config.server.database_url.as_deref(),
+    )
+    .await?;
 
     // Phase 2: engines — rule engine, event store (+purge task), GC agent, skill store.
     // Depends on: storage (none directly, but must precede registry which uses storage.tasks).
@@ -141,7 +145,12 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
 
     let review_store = {
         let review_db_path = harness_core::config::dirs::default_db_path(&dir, "reviews");
-        match crate::review_store::ReviewStore::open(&review_db_path).await {
+        match crate::review_store::ReviewStore::open_with_database_url(
+            &review_db_path,
+            server.config.server.database_url.as_deref(),
+        )
+        .await
+        {
             Ok(store) => Some(Arc::new(store)),
             Err(e) => {
                 tracing::warn!("review store init failed, reviews will not be persisted: {e}");

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,5 +1,6 @@
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
@@ -47,8 +48,14 @@ pub struct ProjectRegistry {
 
 impl ProjectRegistry {
     pub async fn open(path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &std::path::Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -23,7 +23,8 @@
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -79,8 +80,14 @@ pub struct QValueStore {
 impl QValueStore {
     /// Open (or create) the Q-value store at `path`, running any pending migrations.
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -1,5 +1,6 @@
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
@@ -102,8 +103,14 @@ pub struct ReviewStore {
 impl ReviewStore {
     /// Open (or create) the review store, running any pending migrations.
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -2,7 +2,8 @@ use crate::runtime_hosts_state::{PersistedRuntimeHost, PersistedTaskLease};
 use crate::runtime_project_cache_state::PersistedHostProjectCache;
 use chrono::{DateTime, Utc};
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
@@ -68,8 +69,14 @@ impl LoadSnapshotOutcome {
 
 impl RuntimeStateStore {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -6,7 +6,8 @@ mod types;
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
 
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    PgMigrator,
 };
 use migrations::TASK_MIGRATIONS;
 use sqlx::postgres::PgPool;
@@ -24,8 +25,14 @@ impl TaskDb {
     /// fully isolated. The schema is created if it does not exist and migrations
     /// are applied before any queries run.
     pub async fn open(db_path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(db_path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        db_path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = db_path
             .to_str()

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -32,7 +32,14 @@ pub struct TaskStore {
 
 impl TaskStore {
     pub async fn open(db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
-        let db = TaskDb::open(db_path).await?;
+        Self::open_with_database_url(db_path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        db_path: &std::path::Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let db = TaskDb::open_with_database_url(db_path, configured_database_url).await?;
 
         // 1. Event replay: runs BEFORE recover_in_progress so event-sourced
         //    data (pr_url, terminal status) wins over checkpoint data.

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
 use sqlx::postgres::PgPool;
@@ -27,8 +28,14 @@ pub struct ThreadDb {
 
 impl ThreadDb {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -1,5 +1,6 @@
 use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, Migration, PgMigrator,
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
 };
 use harness_core::{types::ExecPlanId, types::ExecPlanStatus};
 use harness_exec::plan::ExecPlan;
@@ -42,8 +43,14 @@ pub struct PlanDb {
 
 impl PlanDb {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let database_url = std::env::var("DATABASE_URL")
-            .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable is not set"))?;
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
         use sha2::{Digest, Sha256};
         let path_utf8 = path
             .to_str()


### PR DESCRIPTION
## What

Adds a first-class `server.database_url` config field, centralizes Postgres URL resolution, and threads the configured value through startup builders and PG-backed stores so explicit server config wins over the legacy `DATABASE_URL` fallback.

## Why

`harness serve --config config/default.toml` could still connect task/thread/runtime stores to a remote database whenever the launch shell exported `DATABASE_URL`, because those stores were bypassing server config and reading the environment directly. This change removes that split-brain startup behavior and makes DB selection consistent with operator expectations.

## Test Plan

- [x] Tests pass
- [ ] Tested manually
