### PR TITLE
Route webhook tasks to per-repo project roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -88,10 +88,33 @@ fn configured_github_webhook_project_root(
         })
 }
 
+enum GitHubWebhookProjectRootError {
+    RepoNotConfigured(String),
+    RegistryLookup(String),
+}
+
+fn github_webhook_project_root_error_response(
+    error: GitHubWebhookProjectRootError,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match error {
+        // Treat unknown repositories as ignored so GitHub does not retry
+        // an event for a repo this harness instance is not configured to
+        // serve. Registry failures remain internal errors.
+        GitHubWebhookProjectRootError::RepoNotConfigured(reason) => (
+            StatusCode::OK,
+            Json(json!({ "status": "ignored", "reason": reason })),
+        ),
+        GitHubWebhookProjectRootError::RegistryLookup(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": error })),
+        ),
+    }
+}
+
 async fn resolve_github_webhook_project_root(
     state: &Arc<AppState>,
     repo: &str,
-) -> Result<PathBuf, String> {
+) -> Result<PathBuf, GitHubWebhookProjectRootError> {
     if let Some(project_root) = configured_github_webhook_project_root(
         state.core.server.config.intake.github.as_ref(),
         &state.core.project_root,
@@ -101,30 +124,34 @@ async fn resolve_github_webhook_project_root(
     }
 
     if let Some(registry) = state.core.project_registry.as_deref() {
-        if let Some(project) = registry
-            .get(repo)
-            .await
-            .map_err(|error| format!("project registry lookup failed: {error}"))?
-        {
+        if let Some(project) = registry.get(repo).await.map_err(|error| {
+            GitHubWebhookProjectRootError::RegistryLookup(format!(
+                "project registry lookup failed: {error}"
+            ))
+        })? {
             return Ok(project.root);
         }
-        if let Some(project) = registry
-            .get_by_name(repo)
-            .await
-            .map_err(|error| format!("project registry lookup failed: {error}"))?
-        {
+        if let Some(project) = registry.get_by_name(repo).await.map_err(|error| {
+            GitHubWebhookProjectRootError::RegistryLookup(format!(
+                "project registry lookup failed: {error}"
+            ))
+        })? {
             return Ok(project.root);
         }
     }
 
-    Err(format!(
+    Err(GitHubWebhookProjectRootError::RepoNotConfigured(format!(
         "webhook repository '{repo}' is not configured in intake.github and was not found in the project registry"
-    ))
+    )))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::configured_github_webhook_project_root;
+    use super::{
+        configured_github_webhook_project_root, github_webhook_project_root_error_response,
+        GitHubWebhookProjectRootError,
+    };
+    use axum::http::StatusCode;
     use harness_core::config::intake::{GitHubIntakeConfig, GitHubRepoConfig};
     use std::path::PathBuf;
 
@@ -190,6 +217,34 @@ mod tests {
             configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
 
         assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn unconfigured_github_repo_returns_ignored_response() {
+        let (status, body) = github_webhook_project_root_error_response(
+            GitHubWebhookProjectRootError::RepoNotConfigured(
+                "webhook repository 'org/repo-b' is not configured".to_string(),
+            ),
+        );
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.0["status"], "ignored");
+        assert!(body.0["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not configured"));
+    }
+
+    #[test]
+    fn registry_lookup_failures_return_internal_server_error() {
+        let (status, body) = github_webhook_project_root_error_response(
+            GitHubWebhookProjectRootError::RegistryLookup(
+                "project registry lookup failed: boom".to_string(),
+            ),
+        );
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.0["error"], "project registry lookup failed: boom");
     }
 }
 
@@ -278,7 +333,7 @@ pub(crate) async fn github_webhook(
         req.project = Some(match req.repo.as_deref() {
             Some(repo) => match resolve_github_webhook_project_root(&state, repo).await {
                 Ok(project_root) => project_root,
-                Err(error) => return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))),
+                Err(error) => return github_webhook_project_root_error_response(error),
             },
             None => state.core.project_root.clone(),
         });

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use harness_protocol::methods::RpcRequest;
 use serde_json::json;
+use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
@@ -67,6 +68,128 @@ pub(crate) async fn handle_rpc(
     match router::handle_request(&state, req).await {
         Some(resp) => (StatusCode::OK, Json(resp)).into_response(),
         None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+fn configured_github_webhook_project_root(
+    github: Option<&harness_core::config::intake::GitHubIntakeConfig>,
+    default_root: &StdPath,
+    repo: &str,
+) -> Option<PathBuf> {
+    github?
+        .effective_repos()
+        .into_iter()
+        .find(|repo_cfg| repo_cfg.repo == repo)
+        .map(|repo_cfg| {
+            repo_cfg
+                .project_root
+                .map(PathBuf::from)
+                .unwrap_or_else(|| default_root.to_path_buf())
+        })
+}
+
+async fn resolve_github_webhook_project_root(
+    state: &Arc<AppState>,
+    repo: &str,
+) -> Result<PathBuf, String> {
+    if let Some(project_root) = configured_github_webhook_project_root(
+        state.core.server.config.intake.github.as_ref(),
+        &state.core.project_root,
+        repo,
+    ) {
+        return Ok(project_root);
+    }
+
+    if let Some(registry) = state.core.project_registry.as_deref() {
+        if let Some(project) = registry
+            .get(repo)
+            .await
+            .map_err(|error| format!("project registry lookup failed: {error}"))?
+        {
+            return Ok(project.root);
+        }
+        if let Some(project) = registry
+            .get_by_name(repo)
+            .await
+            .map_err(|error| format!("project registry lookup failed: {error}"))?
+        {
+            return Ok(project.root);
+        }
+    }
+
+    Err(format!(
+        "webhook repository '{repo}' is not configured in intake.github and was not found in the project registry"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::configured_github_webhook_project_root;
+    use harness_core::config::intake::{GitHubIntakeConfig, GitHubRepoConfig};
+    use std::path::PathBuf;
+
+    #[test]
+    fn multi_repo_github_webhook_uses_repo_specific_project_root_override() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![
+                GitHubRepoConfig {
+                    repo: "org/repo-a".to_string(),
+                    label: "harness".to_string(),
+                    project_root: None,
+                },
+                GitHubRepoConfig {
+                    repo: "org/repo-b".to_string(),
+                    label: "harness".to_string(),
+                    project_root: Some("/srv/repo-b".to_string()),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
+
+        assert_eq!(resolved, Some(PathBuf::from("/srv/repo-b")));
+    }
+
+    #[test]
+    fn configured_github_repo_without_override_falls_back_to_default_project_root() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![GitHubRepoConfig {
+                repo: "org/repo-a".to_string(),
+                label: "harness".to_string(),
+                project_root: None,
+            }],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-a");
+
+        assert_eq!(resolved, Some(default_root));
+    }
+
+    #[test]
+    fn unconfigured_github_repo_has_no_configured_project_root() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![GitHubRepoConfig {
+                repo: "org/repo-a".to_string(),
+                label: "harness".to_string(),
+                project_root: None,
+            }],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
+
+        assert_eq!(resolved, None);
     }
 }
 
@@ -152,7 +275,13 @@ pub(crate) async fn github_webhook(
     };
 
     if req.project.is_none() {
-        req.project = Some(state.core.project_root.clone());
+        req.project = Some(match req.repo.as_deref() {
+            Some(repo) => match resolve_github_webhook_project_root(&state, repo).await {
+                Ok(project_root) => project_root,
+                Err(error) => return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))),
+            },
+            None => state.core.project_root.clone(),
+        });
     }
 
     match task_routes::enqueue_task(&state, req).await {

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -221,7 +221,28 @@ async fn make_test_state_with_agent(
 ) -> anyhow::Result<(Arc<AppState>, Arc<CapturingAgent>)> {
     let mut config = harness_core::config::HarnessConfig::default();
     config.server.github_webhook_secret = webhook_secret.map(ToString::to_string);
+    build_test_state_with_agent(dir, config).await
+}
 
+async fn make_test_state_with_agent_and_repo(
+    dir: &std::path::Path,
+    webhook_secret: Option<&str>,
+    repo: &str,
+) -> anyhow::Result<(Arc<AppState>, Arc<CapturingAgent>)> {
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.github_webhook_secret = webhook_secret.map(ToString::to_string);
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repo: repo.to_string(),
+        ..Default::default()
+    });
+    build_test_state_with_agent(dir, config).await
+}
+
+async fn build_test_state_with_agent(
+    dir: &std::path::Path,
+    config: harness_core::config::HarnessConfig,
+) -> anyhow::Result<(Arc<AppState>, Arc<CapturingAgent>)> {
     let capturing = CapturingAgent::new();
     let mut registry = harness_agents::registry::AgentRegistry::new("test");
     registry.register("test", capturing.clone());
@@ -470,7 +491,8 @@ async fn token_usage_route_is_registered() -> anyhow::Result<()> {
 async fn webhook_issue_mention_creates_issue_task() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let secret = "secret";
-    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let (state, _agent) =
+        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "majiayu000/harness").await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -504,7 +526,8 @@ async fn webhook_issue_mention_creates_issue_task() -> anyhow::Result<()> {
 async fn webhook_review_on_pr_creates_pr_review_task() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let secret = "secret";
-    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let (state, _agent) =
+        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "majiayu000/harness").await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -538,7 +561,8 @@ async fn webhook_review_on_pr_creates_pr_review_task() -> anyhow::Result<()> {
 async fn webhook_fix_ci_on_pr_creates_fix_ci_task() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let secret = "secret";
-    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let (state, _agent) =
+        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "majiayu000/harness").await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -1183,7 +1207,8 @@ async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Resu
     let dir = tempfile::tempdir()?;
     init_fake_git_repo(dir.path())?;
     let secret = "secret";
-    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let (state, _agent) =
+        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "org/repo").await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -1219,7 +1244,8 @@ async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Resu
 async fn webhook_pull_request_review_changes_requested_creates_task() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let secret = "secret";
-    let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
+    let (state, _agent) =
+        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "org/repo").await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -230,6 +230,11 @@ async fn make_test_state_with_agent(
     Ok((state, capturing))
 }
 
+fn init_fake_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(root.join(".git"))?;
+    Ok(())
+}
+
 fn task_app(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health_check))
@@ -1176,6 +1181,7 @@ async fn feishu_webhook_rejects_invalid_token() -> anyhow::Result<()> {
 #[tokio::test]
 async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
+    init_fake_git_repo(dir.path())?;
     let secret = "secret";
     let (state, _agent) = make_test_state_with_agent(dir.path(), Some(secret)).await?;
     let before_count = state.core.tasks.count();
@@ -1186,7 +1192,8 @@ async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Resu
         "issue": {
             "number": 77,
             "body": "@harness please implement this feature"
-        }
+        },
+        "repository": { "full_name": "org/repo" }
     });
     let payload_body = payload.to_string();
     let signature = webhook_signature(secret, payload_body.as_bytes());

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -30,16 +30,24 @@ fn default_active() -> bool {
     true
 }
 
-static PROJECT_MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    description: "create projects table",
-    sql: "CREATE TABLE IF NOT EXISTS projects (
-        id         TEXT PRIMARY KEY,
-        data       TEXT NOT NULL,
-        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-    )",
-}];
+static PROJECT_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create projects table",
+        sql: "CREATE TABLE IF NOT EXISTS projects (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "index project name lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_projects_name_created_at
+              ON projects ((data::jsonb ->> 'name'), created_at DESC)",
+    },
+];
 
 /// Registry of projects backed by Postgres. Survives server restarts.
 pub struct ProjectRegistry {

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -128,10 +128,20 @@ impl ProjectRegistry {
 
     /// Find a project by its configured `name` field. Returns the first match.
     pub async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Project>> {
-        let projects = self.list().await?;
-        Ok(projects
-            .into_iter()
-            .find(|p| p.name.as_deref() == Some(name)))
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data
+             FROM projects
+             WHERE data::jsonb ->> 'name' = $1
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            Some((data,)) => Ok(Some(serde_json::from_str(&data)?)),
+            None => Ok(None),
+        }
     }
 }
 

--- a/crates/harness-server/src/webhook.rs
+++ b/crates/harness-server/src/webhook.rs
@@ -40,6 +40,7 @@ struct GitHubIssueCommentEvent {
 struct GitHubIssuesEvent {
     action: String,
     issue: GitHubIssueRef,
+    repository: GitHubRepositoryRef,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,15 +67,17 @@ struct GitHubPullRequestReviewEvent {
     repository: GitHubRepositoryRef,
 }
 
-fn issue_task_request(issue_number: u64) -> CreateTaskRequest {
+fn issue_task_request(issue_number: u64, repo: &str) -> CreateTaskRequest {
     let mut req = CreateTaskRequest::default();
     req.issue = Some(issue_number);
+    req.repo = Some(repo.to_string());
     req
 }
 
-fn review_task_request(pr_number: u64) -> CreateTaskRequest {
+fn review_task_request(pr_number: u64, repo: &str) -> CreateTaskRequest {
     let mut req = CreateTaskRequest::default();
     req.pr = Some(pr_number);
+    req.repo = Some(repo.to_string());
     req
 }
 
@@ -88,6 +91,7 @@ fn pr_rework_task_request(event: &GitHubPullRequestReviewEvent) -> CreateTaskReq
         event.review.html_url.as_deref(),
         event.pull_request.html_url.as_deref(),
     ));
+    req.repo = Some(event.repository.full_name.clone());
     req
 }
 
@@ -98,6 +102,7 @@ fn pr_approved_task_request(event: &GitHubPullRequestReviewEvent) -> CreateTaskR
         event.pull_request.number,
         event.review.html_url.as_deref(),
     ));
+    req.repo = Some(event.repository.full_name.clone());
     req
 }
 
@@ -110,6 +115,7 @@ fn fix_ci_task_request(payload: &GitHubIssueCommentEvent) -> CreateTaskRequest {
         payload.comment.html_url.as_deref(),
         payload.issue.html_url.as_deref(),
     ));
+    req.repo = Some(payload.repository.full_name.clone());
     req
 }
 
@@ -137,7 +143,10 @@ pub(crate) fn parse_github_webhook_task_request(
             }
             match parse_harness_mention_command(parsed.issue.body.as_deref().unwrap_or("")) {
                 Some(HarnessMentionCommand::Mention) => Ok((
-                    Some(issue_task_request(parsed.issue.number)),
+                    Some(issue_task_request(
+                        parsed.issue.number,
+                        &parsed.repository.full_name,
+                    )),
                     "issue mention".to_string(),
                 )),
                 Some(HarnessMentionCommand::Review) => {
@@ -164,7 +173,10 @@ pub(crate) fn parse_github_webhook_task_request(
             if parsed.issue.pull_request.is_some() {
                 return match command {
                     HarnessMentionCommand::Mention | HarnessMentionCommand::Review => Ok((
-                        Some(review_task_request(parsed.issue.number)),
+                        Some(review_task_request(
+                            parsed.issue.number,
+                            &parsed.repository.full_name,
+                        )),
                         "pr review command".to_string(),
                     )),
                     HarnessMentionCommand::FixCi => Ok((
@@ -176,7 +188,10 @@ pub(crate) fn parse_github_webhook_task_request(
 
             match command {
                 HarnessMentionCommand::Mention => Ok((
-                    Some(issue_task_request(parsed.issue.number)),
+                    Some(issue_task_request(
+                        parsed.issue.number,
+                        &parsed.repository.full_name,
+                    )),
                     "issue mention command".to_string(),
                 )),
                 HarnessMentionCommand::Review => {
@@ -370,7 +385,8 @@ mod tests {
             "issue": {
                 "number": 77,
                 "body": "@harness please implement this feature"
-            }
+            },
+            "repository": { "full_name": "org/repo" }
         });
 
         let (request, reason) =
@@ -380,6 +396,7 @@ mod tests {
         assert_eq!(request.issue, Some(77));
         assert_eq!(request.pr, None);
         assert_eq!(request.prompt, None);
+        assert_eq!(request.repo.as_deref(), Some("org/repo"));
     }
 
     #[test]
@@ -389,7 +406,8 @@ mod tests {
             "issue": {
                 "number": 88,
                 "body": "This is still broken, @harness fix it"
-            }
+            },
+            "repository": { "full_name": "org/repo" }
         });
 
         let (request, reason) =
@@ -397,6 +415,7 @@ mod tests {
         let request = request.expect("request should exist");
         assert_eq!(reason, "issue mention");
         assert_eq!(request.issue, Some(88));
+        assert_eq!(request.repo.as_deref(), Some("org/repo"));
     }
 
     #[test]
@@ -406,7 +425,8 @@ mod tests {
             "issue": {
                 "number": 99,
                 "body": "This issue has no harness mention"
-            }
+            },
+            "repository": { "full_name": "org/repo" }
         });
 
         let (request, reason) =
@@ -419,7 +439,8 @@ mod tests {
     fn parse_issues_opened_with_no_body_is_ignored() {
         let payload = serde_json::json!({
             "action": "opened",
-            "issue": { "number": 100 }
+            "issue": { "number": 100 },
+            "repository": { "full_name": "org/repo" }
         });
 
         let (request, reason) =
@@ -435,7 +456,8 @@ mod tests {
             "issue": {
                 "number": 106,
                 "body": "@harness please handle this issue"
-            }
+            },
+            "repository": { "full_name": "org/repo" }
         });
 
         let (request, reason) =
@@ -512,7 +534,8 @@ mod tests {
                 "number": 5,
                 "body": "@harness handle",
                 "pull_request": { "url": "https://api.github.com/repos/org/repo/pulls/5" }
-            }
+            },
+            "repository": { "full_name": "org/repo" }
         });
         let (request, reason) =
             parse_github_webhook_task_request("issues", payload.to_string().as_bytes()).unwrap();


### PR DESCRIPTION
## Summary
- preserve GitHub webhook repository identity on issue, PR review, and fix-ci task requests
- resolve webhook task project roots through `intake.github` repo mappings or the project registry instead of defaulting to the server root
- add regression coverage for repo propagation and multi-repo project-root resolution

## Testing
- `cargo fmt --all`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harness-server parse_issues_opened_with_harness_mention_creates_issue_task`
- `cargo test -p harness-server misc_routes::tests`
- `CARGO_TARGET_DIR=/tmp/harness-validate-ad20 cargo test --workspace` *(fails in unrelated `harness_observe::event_store` tests outside the touched webhook files)*