### PR TITLE
fix(intake): recover when sprint planner emits dependency outside sprint plan

### DIFF
--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -389,6 +389,47 @@ fn parse_issue_external_id(external_id: &str) -> Option<u64> {
         .ok()
 }
 
+fn latest_timestamp_at_least(candidate: Option<&str>, existing: Option<&str>) -> bool {
+    match (candidate, existing) {
+        (Some(candidate), Some(existing)) => candidate >= existing,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => true,
+    }
+}
+
+fn latest_unblocking_issue_numbers(
+    external_statuses: std::collections::HashMap<
+        String,
+        (Option<String>, crate::task_runner::TaskStatus),
+    >,
+) -> std::collections::HashSet<u64> {
+    let mut latest_by_issue: std::collections::HashMap<
+        u64,
+        (Option<String>, crate::task_runner::TaskStatus),
+    > = std::collections::HashMap::new();
+
+    for (external_id, (created_at, status)) in external_statuses {
+        let Some(issue) = parse_issue_external_id(&external_id) else {
+            continue;
+        };
+        let should_replace = latest_by_issue
+            .get(&issue)
+            .map(|(existing_created_at, _)| {
+                latest_timestamp_at_least(created_at.as_deref(), existing_created_at.as_deref())
+            })
+            .unwrap_or(true);
+        if should_replace {
+            latest_by_issue.insert(issue, (created_at, status));
+        }
+    }
+
+    latest_by_issue
+        .into_iter()
+        .filter_map(|(issue, (_, status))| status_unblocks_dependents(&status).then_some(issue))
+        .collect()
+}
+
 async fn completed_issue_numbers_for_project(
     tasks: &crate::task_runner::TaskStore,
     project_id: &str,
@@ -398,11 +439,7 @@ async fn completed_issue_numbers_for_project(
         .list_latest_external_statuses_by_project_and_repo(project_id, repo)
         .await
     {
-        Ok(external_statuses) => external_statuses
-            .into_iter()
-            .filter(|(_, status)| status_unblocks_dependents(status))
-            .filter_map(|(external_id, _)| parse_issue_external_id(&external_id))
-            .collect(),
+        Ok(external_statuses) => latest_unblocking_issue_numbers(external_statuses),
         Err(e) => {
             tracing::warn!(
                 project = project_id,
@@ -1403,6 +1440,29 @@ mod tests {
 
         assert_eq!(completed, make_issues(&[41, 42]));
         Ok(())
+    }
+
+    #[test]
+    fn latest_unblocking_issue_numbers_prefers_latest_issue_id_format() {
+        let completed = latest_unblocking_issue_numbers(std::collections::HashMap::from([
+            (
+                "42".to_string(),
+                (Some("2026-04-22T09:00:00Z".to_string()), TaskStatus::Done),
+            ),
+            (
+                "issue:42".to_string(),
+                (
+                    Some("2026-04-22T09:05:00Z".to_string()),
+                    TaskStatus::Implementing,
+                ),
+            ),
+            (
+                "issue:43".to_string(),
+                (Some("2026-04-22T09:10:00Z".to_string()), TaskStatus::Done),
+            ),
+        ]));
+
+        assert_eq!(completed, make_issues(&[43]));
     }
 
     #[test]

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -389,24 +389,25 @@ fn parse_issue_external_id(external_id: &str) -> Option<u64> {
         .ok()
 }
 
-const DEPENDENCY_UNBLOCKING_TASK_STATUSES: &[&str] = &["done", "failed"];
-
 async fn completed_issue_numbers_for_project(
     tasks: &crate::task_runner::TaskStore,
     project_id: &str,
+    repo: Option<&str>,
 ) -> std::collections::HashSet<u64> {
     match tasks
-        .list_external_ids_by_project_and_statuses(project_id, DEPENDENCY_UNBLOCKING_TASK_STATUSES)
+        .list_latest_external_statuses_by_project_and_repo(project_id, repo)
         .await
     {
-        Ok(external_ids) => external_ids
+        Ok(external_statuses) => external_statuses
             .into_iter()
-            .filter_map(|external_id| parse_issue_external_id(&external_id))
+            .filter(|(_, status)| status_unblocks_dependents(status))
+            .filter_map(|(external_id, _)| parse_issue_external_id(&external_id))
             .collect(),
         Err(e) => {
             tracing::warn!(
                 project = project_id,
-                "intake: failed to inspect terminal tasks during sprint normalization: {e}"
+                repo,
+                "intake: failed to inspect latest task statuses during sprint normalization: {e}"
             );
             std::collections::HashSet::new()
         }
@@ -592,7 +593,8 @@ async fn run_repo_sprint(
     };
 
     let completed_issues =
-        completed_issue_numbers_for_project(state.core.tasks.as_ref(), &project_id).await;
+        completed_issue_numbers_for_project(state.core.tasks.as_ref(), &project_id, Some(repo))
+            .await;
     let planner_skip_set: std::collections::HashSet<u64> =
         plan.skip.iter().map(|skip| skip.issue).collect();
     let normalized =
@@ -1316,34 +1318,88 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_issue_numbers_for_project_includes_failed_tasks() -> anyhow::Result<()> {
+    async fn completed_issue_numbers_for_project_uses_repo_and_latest_status() -> anyhow::Result<()>
+    {
         let dir = tempfile::tempdir()?;
         let store = crate::task_runner::TaskStore::open(&dir.path().join("tasks.db")).await?;
         let project_root = std::path::PathBuf::from("/projects/alpha");
         let other_project_root = std::path::PathBuf::from("/projects/beta");
+        let repo = "owner/current";
 
-        for (id, issue, status, root) in [
-            ("done", 41_u64, TaskStatus::Done, &project_root),
-            ("failed", 42_u64, TaskStatus::Failed, &project_root),
-            ("cancelled", 43_u64, TaskStatus::Cancelled, &project_root),
+        for (id, issue, status, root, task_repo, created_at) in [
+            (
+                "done",
+                41_u64,
+                TaskStatus::Done,
+                &project_root,
+                repo,
+                Some("2026-04-22T09:00:00Z"),
+            ),
+            (
+                "failed",
+                42_u64,
+                TaskStatus::Failed,
+                &project_root,
+                repo,
+                Some("2026-04-22T09:05:00Z"),
+            ),
+            (
+                "cancelled",
+                43_u64,
+                TaskStatus::Cancelled,
+                &project_root,
+                repo,
+                Some("2026-04-22T09:10:00Z"),
+            ),
             (
                 "other-project",
                 44_u64,
                 TaskStatus::Done,
                 &other_project_root,
+                repo,
+                Some("2026-04-22T09:15:00Z"),
+            ),
+            (
+                "other-repo",
+                45_u64,
+                TaskStatus::Done,
+                &project_root,
+                "owner/other",
+                Some("2026-04-22T09:20:00Z"),
+            ),
+            (
+                "done-old-attempt",
+                46_u64,
+                TaskStatus::Done,
+                &project_root,
+                repo,
+                Some("2026-04-22T09:25:00Z"),
+            ),
+            (
+                "retry-latest",
+                46_u64,
+                TaskStatus::Implementing,
+                &project_root,
+                repo,
+                Some("2026-04-22T09:30:00Z"),
             ),
         ] {
             let mut task =
                 crate::task_runner::TaskState::new(harness_core::types::TaskId(id.to_string()));
             task.status = status;
             task.project_root = Some(root.clone());
+            task.repo = Some(task_repo.to_string());
             task.external_id = Some(format!("issue:{issue}"));
+            task.created_at = created_at.map(str::to_string);
             store.insert(&task).await;
         }
 
-        let completed =
-            completed_issue_numbers_for_project(store.as_ref(), &project_root.to_string_lossy())
-                .await;
+        let completed = completed_issue_numbers_for_project(
+            store.as_ref(),
+            &project_root.to_string_lossy(),
+            Some(repo),
+        )
+        .await;
 
         assert_eq!(completed, make_issues(&[41, 42]));
         Ok(())

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -389,26 +389,19 @@ fn parse_issue_external_id(external_id: &str) -> Option<u64> {
         .ok()
 }
 
+const DEPENDENCY_UNBLOCKING_TASK_STATUSES: &[&str] = &["done", "failed"];
+
 async fn completed_issue_numbers_for_project(
     tasks: &crate::task_runner::TaskStore,
     project_id: &str,
 ) -> std::collections::HashSet<u64> {
-    match tasks.list_all_with_terminal().await {
-        Ok(all_tasks) => all_tasks
+    match tasks
+        .list_external_ids_by_project_and_statuses(project_id, DEPENDENCY_UNBLOCKING_TASK_STATUSES)
+        .await
+    {
+        Ok(external_ids) => external_ids
             .into_iter()
-            .filter(|task| {
-                matches!(task.status, TaskStatus::Done)
-                    && task
-                        .project_root
-                        .as_ref()
-                        .map(|path| path.to_string_lossy() == project_id)
-                        .unwrap_or(false)
-            })
-            .filter_map(|task| {
-                task.external_id
-                    .as_deref()
-                    .and_then(parse_issue_external_id)
-            })
+            .filter_map(|external_id| parse_issue_external_id(&external_id))
             .collect(),
         Err(e) => {
             tracing::warn!(
@@ -1320,6 +1313,40 @@ mod tests {
     fn done_and_failed_tasks_still_count_as_completed_dependencies() {
         assert!(status_unblocks_dependents(&TaskStatus::Done));
         assert!(status_unblocks_dependents(&TaskStatus::Failed));
+    }
+
+    #[tokio::test]
+    async fn completed_issue_numbers_for_project_includes_failed_tasks() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = crate::task_runner::TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = std::path::PathBuf::from("/projects/alpha");
+        let other_project_root = std::path::PathBuf::from("/projects/beta");
+
+        for (id, issue, status, root) in [
+            ("done", 41_u64, TaskStatus::Done, &project_root),
+            ("failed", 42_u64, TaskStatus::Failed, &project_root),
+            ("cancelled", 43_u64, TaskStatus::Cancelled, &project_root),
+            (
+                "other-project",
+                44_u64,
+                TaskStatus::Done,
+                &other_project_root,
+            ),
+        ] {
+            let mut task =
+                crate::task_runner::TaskState::new(harness_core::types::TaskId(id.to_string()));
+            task.status = status;
+            task.project_root = Some(root.clone());
+            task.external_id = Some(format!("issue:{issue}"));
+            store.insert(&task).await;
+        }
+
+        let completed =
+            completed_issue_numbers_for_project(store.as_ref(), &project_root.to_string_lossy())
+                .await;
+
+        assert_eq!(completed, make_issues(&[41, 42]));
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -291,6 +291,135 @@ fn validate_dag(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedTaskSkip {
+    issue: u64,
+    upstream: u64,
+    reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SprintPlanNormalization {
+    tasks: Vec<harness_core::prompts::SprintTask>,
+    dropped_completed_edges: Vec<(u64, u64)>,
+    skipped_tasks: Vec<NormalizedTaskSkip>,
+}
+
+fn normalize_sprint_tasks(
+    tasks: Vec<harness_core::prompts::SprintTask>,
+    planner_skips: &std::collections::HashSet<u64>,
+    completed_issues: &std::collections::HashSet<u64>,
+) -> SprintPlanNormalization {
+    let mut tasks = tasks;
+    let mut removed_tasks: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut dropped_completed_edges = Vec::new();
+    let mut skipped_tasks = Vec::new();
+
+    loop {
+        let current_issues: std::collections::HashSet<u64> =
+            tasks.iter().map(|t| t.issue).collect();
+        let mut changed = false;
+        let mut next_tasks = Vec::with_capacity(tasks.len());
+
+        for mut task in tasks {
+            let mut filtered_deps = Vec::with_capacity(task.depends_on.len());
+            let mut skip_detail: Option<NormalizedTaskSkip> = None;
+
+            for dep in task.depends_on {
+                if planner_skips.contains(&dep) {
+                    continue;
+                }
+                if removed_tasks.contains(&dep) {
+                    skip_detail = Some(NormalizedTaskSkip {
+                        issue: task.issue,
+                        upstream: dep,
+                        reason: format!(
+                            "upstream issue {dep} was removed from this sprint during intake normalization"
+                        ),
+                    });
+                    break;
+                }
+                if current_issues.contains(&dep) {
+                    filtered_deps.push(dep);
+                    continue;
+                }
+                if completed_issues.contains(&dep) {
+                    dropped_completed_edges.push((task.issue, dep));
+                    changed = true;
+                    continue;
+                }
+                skip_detail = Some(NormalizedTaskSkip {
+                    issue: task.issue,
+                    upstream: dep,
+                    reason: format!(
+                        "upstream issue {dep} is outside the sprint plan and not completed"
+                    ),
+                });
+                break;
+            }
+
+            if let Some(skip) = skip_detail {
+                removed_tasks.insert(task.issue);
+                skipped_tasks.push(skip);
+                changed = true;
+                continue;
+            }
+
+            task.depends_on = filtered_deps;
+            next_tasks.push(task);
+        }
+
+        if !changed {
+            return SprintPlanNormalization {
+                tasks: next_tasks,
+                dropped_completed_edges,
+                skipped_tasks,
+            };
+        }
+
+        tasks = next_tasks;
+    }
+}
+
+fn parse_issue_external_id(external_id: &str) -> Option<u64> {
+    external_id
+        .strip_prefix("issue:")
+        .unwrap_or(external_id)
+        .parse()
+        .ok()
+}
+
+async fn completed_issue_numbers_for_project(
+    tasks: &crate::task_runner::TaskStore,
+    project_id: &str,
+) -> std::collections::HashSet<u64> {
+    match tasks.list_all_with_terminal().await {
+        Ok(all_tasks) => all_tasks
+            .into_iter()
+            .filter(|task| {
+                matches!(task.status, TaskStatus::Done)
+                    && task
+                        .project_root
+                        .as_ref()
+                        .map(|path| path.to_string_lossy() == project_id)
+                        .unwrap_or(false)
+            })
+            .filter_map(|task| {
+                task.external_id
+                    .as_deref()
+                    .and_then(parse_issue_external_id)
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!(
+                project = project_id,
+                "intake: failed to inspect terminal tasks during sprint normalization: {e}"
+            );
+            std::collections::HashSet::new()
+        }
+    }
+}
+
 fn ready_issues(
     all_task_issues: &std::collections::HashSet<u64>,
     completed: &std::collections::HashSet<u64>,
@@ -426,7 +555,7 @@ async fn run_repo_sprint(
         return;
     };
 
-    let Some(plan) = harness_core::prompts::parse_sprint_plan(&planner_output) else {
+    let Some(mut plan) = harness_core::prompts::parse_sprint_plan(&planner_output) else {
         if let Some(workflows) = state.core.project_workflow_store.as_ref() {
             if let Err(e) = workflows
                 .record_degraded(&project_id, Some(repo), "failed to parse sprint plan")
@@ -456,7 +585,47 @@ async fn run_repo_sprint(
             .map(|(src, issue)| (issue.external_id.clone(), (src, issue)))
             .collect();
 
-    // 2. Mark skipped.
+    let project_id = match crate::task_runner::resolve_canonical_project(Some(project_root.clone()))
+        .await
+    {
+        Ok(path) => path.to_string_lossy().into_owned(),
+        Err(e) => {
+            tracing::warn!(
+                repo,
+                "intake: failed to canonicalize project root for slot limit lookup, using raw path: {e}"
+            );
+            project_root.to_string_lossy().into_owned()
+        }
+    };
+
+    let completed_issues =
+        completed_issue_numbers_for_project(state.core.tasks.as_ref(), &project_id).await;
+    let planner_skip_set: std::collections::HashSet<u64> =
+        plan.skip.iter().map(|skip| skip.issue).collect();
+    let normalized =
+        normalize_sprint_tasks(plan.tasks.clone(), &planner_skip_set, &completed_issues);
+    for (issue, upstream) in &normalized.dropped_completed_edges {
+        tracing::info!(
+            repo,
+            issue = *issue,
+            upstream = *upstream,
+            normalization = "drop_completed_upstream_edge",
+            "intake: repaired sprint dependency outside plan"
+        );
+    }
+    for skip in &normalized.skipped_tasks {
+        tracing::warn!(
+            repo,
+            issue = skip.issue,
+            upstream = skip.upstream,
+            normalization = "skip_task_missing_upstream",
+            reason = %skip.reason,
+            "intake: skipped task during sprint normalization"
+        );
+    }
+    plan.tasks = normalized.tasks;
+
+    // 2. Mark planner-directed skips.
     for skip in &plan.skip {
         let ext_id = skip.issue.to_string();
         if let Some((source, _)) = issue_map.get(&ext_id) {
@@ -477,29 +646,17 @@ async fn run_repo_sprint(
     let all_task_issues: std::collections::HashSet<u64> =
         plan.tasks.iter().map(|t| t.issue).collect();
 
-    // Build the dep map, filtering out any dep IDs that belong to skipped issues
-    // so they are not flagged as missing upstreams.
-    let skip_set: std::collections::HashSet<u64> = plan.skip.iter().map(|s| s.issue).collect();
     let deps: std::collections::HashMap<u64, Vec<u64>> = plan
         .tasks
         .iter()
-        .map(|t| {
-            let filtered: Vec<u64> = t
-                .depends_on
-                .iter()
-                .copied()
-                .filter(|dep| !skip_set.contains(dep))
-                .collect();
-            (t.issue, filtered)
-        })
+        .map(|t| (t.issue, t.depends_on.clone()))
         .collect();
 
-    // Validate DAG before starting execution.
+    // Validate DAG after normalization.
     if let Err(e) = validate_dag(&all_task_issues, &deps) {
-        tracing::error!(repo, error = %e, "intake: invalid sprint DAG — aborting");
+        tracing::error!(repo, error = %e, "intake: invalid sprint DAG after normalization — aborting");
         return;
     }
-
     let start = tokio::time::Instant::now();
     let mut transient_retry_count = 0u32;
     let mut project_workflow_monitoring_started = false;
@@ -1046,6 +1203,83 @@ mod tests {
         // Simulates the caller filtering out dep 10 (a skipped issue) before calling validate_dag.
         let deps = make_deps(&[(1, &[]), (2, &[])]);
         assert!(validate_dag(&issues, &deps).is_ok());
+    }
+
+    fn make_tasks(pairs: &[(u64, &[u64])]) -> Vec<harness_core::prompts::SprintTask> {
+        pairs
+            .iter()
+            .map(|&(issue, deps)| harness_core::prompts::SprintTask {
+                issue,
+                depends_on: deps.to_vec(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn normalize_sprint_tasks_drops_completed_missing_upstream() {
+        let normalized = normalize_sprint_tasks(
+            make_tasks(&[(1, &[]), (2, &[99])]),
+            &std::collections::HashSet::new(),
+            &make_issues(&[99]),
+        );
+
+        assert!(normalized.skipped_tasks.is_empty());
+        assert_eq!(normalized.dropped_completed_edges, vec![(2, 99)]);
+        assert_eq!(normalized.tasks, make_tasks(&[(1, &[]), (2, &[])]));
+    }
+
+    #[test]
+    fn normalize_sprint_tasks_skips_unresolved_missing_upstream() {
+        let normalized = normalize_sprint_tasks(
+            make_tasks(&[(1, &[]), (2, &[99])]),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        );
+
+        assert!(normalized.dropped_completed_edges.is_empty());
+        assert_eq!(normalized.tasks, make_tasks(&[(1, &[])]));
+        assert_eq!(
+            normalized.skipped_tasks,
+            vec![NormalizedTaskSkip {
+                issue: 2,
+                upstream: 99,
+                reason: "upstream issue 99 is outside the sprint plan and not completed"
+                    .to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn normalize_sprint_tasks_handles_mixed_valid_and_invalid_edges() {
+        let normalized = normalize_sprint_tasks(
+            make_tasks(&[(1, &[]), (2, &[1]), (3, &[7]), (4, &[99]), (5, &[4])]),
+            &std::collections::HashSet::new(),
+            &make_issues(&[7]),
+        );
+
+        assert_eq!(normalized.dropped_completed_edges, vec![(3, 7)]);
+        assert_eq!(
+            normalized.tasks,
+            make_tasks(&[(1, &[]), (2, &[1]), (3, &[])])
+        );
+        assert_eq!(
+            normalized.skipped_tasks,
+            vec![
+                NormalizedTaskSkip {
+                    issue: 4,
+                    upstream: 99,
+                    reason: "upstream issue 99 is outside the sprint plan and not completed"
+                        .to_string(),
+                },
+                NormalizedTaskSkip {
+                    issue: 5,
+                    upstream: 4,
+                    reason:
+                        "upstream issue 4 was removed from this sprint during intake normalization"
+                            .to_string(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -3,7 +3,9 @@ use crate::task_runner::{TaskState, TaskStatus};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
-use super::types::{RecentFailureRow, RecoveryRow, TaskRow, TaskSummaryRow, TASK_ROW_COLUMNS};
+use super::types::{
+    ExternalStatusRow, RecentFailureRow, RecoveryRow, TaskRow, TaskSummaryRow, TASK_ROW_COLUMNS,
+};
 use super::{RecoveryResult, TaskDb};
 
 impl TaskDb {
@@ -132,26 +134,43 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
-    /// Return `(task_id, external_id)` pairs for tasks in `project` whose `status`
-    /// column matches any value in `statuses`.
-    pub async fn list_external_ids_by_project_and_statuses(
+    /// Return the latest `(external_id, status, created_at)` row for each issue task
+    /// in a single project/repo namespace.
+    pub async fn list_latest_external_statuses_by_project_and_repo(
         &self,
         project: &str,
-        statuses: &[&str],
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        if statuses.is_empty() {
-            return Ok(Vec::new());
-        }
-        let placeholders = Self::numbered_placeholders(2, statuses.len());
-        let sql = format!(
-            "SELECT id, external_id FROM tasks \
-             WHERE project = $1 AND external_id IS NOT NULL AND status IN ({placeholders})"
-        );
-        let mut q = sqlx::query_as::<_, (String, String)>(&sql).bind(project);
-        for status in statuses {
-            q = q.bind(*status);
-        }
-        q.fetch_all(&self.pool).await.map_err(Into::into)
+        repo: Option<&str>,
+    ) -> anyhow::Result<Vec<(String, String, Option<String>)>> {
+        let base_sql = "SELECT external_id, status, created_at FROM (\
+                 SELECT external_id, status, created_at, \
+                        ROW_NUMBER() OVER (PARTITION BY external_id ORDER BY created_at DESC, id DESC) AS rn \
+                 FROM tasks \
+                 WHERE project = $1 AND external_id IS NOT NULL";
+        let rows: Vec<ExternalStatusRow> = if let Some(repo) = repo {
+            let sql = format!("{base_sql} AND repo = $2) latest WHERE rn = 1");
+            sqlx::query_as::<_, ExternalStatusRow>(&sql)
+                .bind(project)
+                .bind(repo)
+                .fetch_all(&self.pool)
+                .await?
+        } else {
+            let sql = format!("{base_sql} AND repo IS NULL) latest WHERE rn = 1");
+            sqlx::query_as::<_, ExternalStatusRow>(&sql)
+                .bind(project)
+                .fetch_all(&self.pool)
+                .await?
+        };
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.external_id,
+                    row.status,
+                    row.created_at.map(|dt| dt.to_rfc3339()),
+                )
+            })
+            .collect())
     }
 
     /// Find an active (non-terminal) task for the same project + external_id.

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -132,6 +132,28 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Return `(task_id, external_id)` pairs for tasks in `project` whose `status`
+    /// column matches any value in `statuses`.
+    pub async fn list_external_ids_by_project_and_statuses(
+        &self,
+        project: &str,
+        statuses: &[&str],
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        if statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = Self::numbered_placeholders(2, statuses.len());
+        let sql = format!(
+            "SELECT id, external_id FROM tasks \
+             WHERE project = $1 AND external_id IS NOT NULL AND status IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, String)>(&sql).bind(project);
+        for status in statuses {
+            q = q.bind(*status);
+        }
+        q.fetch_all(&self.pool).await.map_err(Into::into)
+    }
+
     /// Find an active (non-terminal) task for the same project + external_id.
     pub async fn find_active_duplicate(
         &self,

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -163,6 +163,13 @@ pub(super) struct RecentFailureRow {
     pub(super) updated_at: Option<DateTime<Utc>>,
 }
 
+#[derive(sqlx::FromRow)]
+pub(super) struct ExternalStatusRow {
+    pub(super) external_id: String,
+    pub(super) status: String,
+    pub(super) created_at: Option<DateTime<Utc>>,
+}
+
 impl TaskRow {
     pub(super) fn try_into_task_state(self) -> anyhow::Result<TaskState> {
         let Self {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -350,6 +350,46 @@ impl TaskStore {
         Ok(by_id)
     }
 
+    /// Return external IDs for tasks in `project_id` whose status matches `statuses`.
+    ///
+    /// Queries the database with project/status filters applied so callers do not
+    /// need to deserialize every historical task row just to inspect a narrow slice.
+    /// Matching cache entries override DB rows for the same task ID.
+    pub async fn list_external_ids_by_project_and_statuses(
+        &self,
+        project_id: &str,
+        statuses: &[&str],
+    ) -> anyhow::Result<Vec<String>> {
+        let mut by_id: HashMap<TaskId, String> = self
+            .db
+            .list_external_ids_by_project_and_statuses(project_id, statuses)
+            .await?
+            .into_iter()
+            .map(|(id, external_id)| (harness_core::types::TaskId(id), external_id))
+            .collect();
+        if statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let status_set: std::collections::HashSet<&str> = statuses.iter().copied().collect();
+        for entry in self.cache.iter() {
+            let task = entry.value();
+            let same_project = task
+                .project_root
+                .as_ref()
+                .map(|path| path.to_string_lossy() == project_id)
+                .unwrap_or(false);
+            if !same_project || !status_set.contains(task.status.as_ref()) {
+                continue;
+            }
+            if let Some(external_id) = task.external_id.clone() {
+                by_id.insert(entry.key().clone(), external_id);
+            }
+        }
+
+        Ok(by_id.into_values().collect())
+    }
+
     /// Run `f` only if the task still exists and is live-`pending`.
     ///
     /// Holding the mutable cache guard across `f` prevents a concurrent status

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -359,7 +359,7 @@ impl TaskStore {
         &self,
         project_id: &str,
         repo: Option<&str>,
-    ) -> anyhow::Result<HashMap<String, TaskStatus>> {
+    ) -> anyhow::Result<HashMap<String, (Option<String>, TaskStatus)>> {
         let mut by_external_id: HashMap<String, (Option<String>, TaskStatus)> = self
             .db
             .list_latest_external_statuses_by_project_and_repo(project_id, repo)
@@ -404,10 +404,7 @@ impl TaskStore {
             }
         }
 
-        Ok(by_external_id
-            .into_iter()
-            .map(|(external_id, (_, status))| (external_id, status))
-            .collect())
+        Ok(by_external_id)
     }
 
     /// Run `f` only if the task still exists and is live-`pending`.

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -350,28 +350,28 @@ impl TaskStore {
         Ok(by_id)
     }
 
-    /// Return external IDs for tasks in `project_id` whose status matches `statuses`.
+    /// Return the latest status for each `external_id` in a single project/repo namespace.
     ///
-    /// Queries the database with project/status filters applied so callers do not
-    /// need to deserialize every historical task row just to inspect a narrow slice.
-    /// Matching cache entries override DB rows for the same task ID.
-    pub async fn list_external_ids_by_project_and_statuses(
+    /// The database query collapses historical attempts down to the newest row per
+    /// issue. In-memory cache entries then override the DB result when the server
+    /// is holding a newer status transition that has not been re-read from storage.
+    pub async fn list_latest_external_statuses_by_project_and_repo(
         &self,
         project_id: &str,
-        statuses: &[&str],
-    ) -> anyhow::Result<Vec<String>> {
-        let mut by_id: HashMap<TaskId, String> = self
+        repo: Option<&str>,
+    ) -> anyhow::Result<HashMap<String, TaskStatus>> {
+        let mut by_external_id: HashMap<String, (Option<String>, TaskStatus)> = self
             .db
-            .list_external_ids_by_project_and_statuses(project_id, statuses)
+            .list_latest_external_statuses_by_project_and_repo(project_id, repo)
             .await?
             .into_iter()
-            .map(|(id, external_id)| (harness_core::types::TaskId(id), external_id))
+            .filter_map(|(external_id, status, created_at)| {
+                status
+                    .parse::<TaskStatus>()
+                    .ok()
+                    .map(|parsed| (external_id, (created_at, parsed)))
+            })
             .collect();
-        if statuses.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let status_set: std::collections::HashSet<&str> = statuses.iter().copied().collect();
         for entry in self.cache.iter() {
             let task = entry.value();
             let same_project = task
@@ -379,15 +379,35 @@ impl TaskStore {
                 .as_ref()
                 .map(|path| path.to_string_lossy() == project_id)
                 .unwrap_or(false);
-            if !same_project || !status_set.contains(task.status.as_ref()) {
+            let same_repo = match (repo, task.repo.as_deref()) {
+                (Some(expected), Some(actual)) => expected == actual,
+                (None, None) => true,
+                _ => false,
+            };
+            if !same_project || !same_repo {
                 continue;
             }
-            if let Some(external_id) = task.external_id.clone() {
-                by_id.insert(entry.key().clone(), external_id);
+            let Some(external_id) = task.external_id.clone() else {
+                continue;
+            };
+            let should_replace = by_external_id
+                .get(&external_id)
+                .map(|(existing_created_at, _)| {
+                    latest_timestamp_at_least(
+                        task.created_at.as_deref(),
+                        existing_created_at.as_deref(),
+                    )
+                })
+                .unwrap_or(true);
+            if should_replace {
+                by_external_id.insert(external_id, (task.created_at.clone(), task.status.clone()));
             }
         }
 
-        Ok(by_id.into_values().collect())
+        Ok(by_external_id
+            .into_iter()
+            .map(|(external_id, (_, status))| (external_id, status))
+            .collect())
     }
 
     /// Run `f` only if the task still exists and is live-`pending`.
@@ -1119,6 +1139,15 @@ pub async fn mutate_and_persist(
         f(entry.value_mut());
     }
     store.persist(id).await
+}
+
+fn latest_timestamp_at_least(candidate: Option<&str>, existing: Option<&str>) -> bool {
+    match (candidate, existing) {
+        (Some(candidate), Some(existing)) => candidate >= existing,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => true,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- normalize sprint-plan dependencies before DAG validation so intake no longer aborts the full repo sprint on one out-of-plan edge
- drop missing edges when the upstream issue is already done in the task store, and skip only the affected task when the upstream is still unresolved
- add intake unit coverage for completed upstream, unresolved upstream, and mixed valid/invalid dependency graphs

Closes #884

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test -p harness-server normalize_sprint_tasks_
- cargo test --workspace *(blocked by unrelated harness_observe event_store tests failing with Postgres session exhaustion / pool timeout: EMAXCONNSESSION)*