### PR TITLE
feat(web): rewire /worktrees page with dedicated GET /api/worktrees endpoint

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod runtime_project_cache;
 pub mod skills;
 pub mod thread;
 pub mod token_usage;
+pub mod worktrees;
 
 #[cfg(test)]
 mod runtime_project_cache_api_tests;

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -516,6 +516,7 @@ mod tests {
                 crate::workspace::ActiveWorkspace {
                     workspace_path: dir.path().join(format!("ws/fake-{i}")),
                     source_repo: dir.path().to_path_buf(),
+                    created_at: std::time::SystemTime::now(),
                 },
             );
         }

--- a/crates/harness-server/src/handlers/worktrees.rs
+++ b/crates/harness-server/src/handlers/worktrees.rs
@@ -1,0 +1,134 @@
+use crate::http::AppState;
+use crate::task_runner::{TaskPhase, TaskState};
+use axum::{extract::State, http::StatusCode, Json};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::Serialize;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Serialize)]
+pub struct WorktreeRecord {
+    task_id: String,
+    branch: String,
+    workspace_path: String,
+    path_short: String,
+    source_repo: String,
+    repo: String,
+    status: String,
+    phase: String,
+    description: String,
+    turn: u32,
+    max_turns: Option<u32>,
+    created_at: String,
+    duration_secs: u64,
+    pr_url: Option<String>,
+    project: String,
+}
+
+pub async fn worktrees(
+    State(state): State<Arc<AppState>>,
+) -> (StatusCode, Json<Vec<WorktreeRecord>>) {
+    let Some(workspace_mgr) = state.concurrency.workspace_mgr.as_ref() else {
+        return (StatusCode::OK, Json(Vec::new()));
+    };
+
+    let mut records = Vec::new();
+    for entry in workspace_mgr.entries() {
+        let Some(task) = state
+            .core
+            .tasks
+            .get_with_db_fallback(&entry.task_id)
+            .await
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+
+        if task.status.is_terminal() {
+            continue;
+        }
+
+        let max_turns = task
+            .request_settings
+            .as_ref()
+            .and_then(|settings| settings.max_turns)
+            .or(state.core.server.config.concurrency.max_turns);
+
+        records.push(WorktreeRecord {
+            task_id: entry.task_id.0.clone(),
+            branch: entry.branch,
+            workspace_path: entry.workspace_path.display().to_string(),
+            path_short: shorten_path(&entry.workspace_path),
+            source_repo: entry.source_repo.display().to_string(),
+            repo: task
+                .repo
+                .clone()
+                .unwrap_or_else(|| repo_fallback(&entry.source_repo)),
+            status: task.status.as_ref().to_string(),
+            phase: phase_name(&task.phase).to_string(),
+            description: task
+                .description
+                .clone()
+                .unwrap_or_else(|| "No description".to_string()),
+            turn: task.turn,
+            max_turns,
+            created_at: format_system_time(entry.created_at),
+            duration_secs: duration_secs(entry.created_at),
+            pr_url: task.pr_url.clone(),
+            project: project_name(&task, &entry.source_repo),
+        });
+    }
+
+    (StatusCode::OK, Json(records))
+}
+
+fn shorten_path(path: &Path) -> String {
+    let parts: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    if parts.len() >= 2 {
+        format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1])
+    } else {
+        path.display().to_string()
+    }
+}
+
+fn repo_fallback(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn project_name(task: &TaskState, source_repo: &Path) -> String {
+    task.project_root
+        .as_deref()
+        .and_then(|path| path.file_name())
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| repo_fallback(source_repo))
+}
+
+fn phase_name(phase: &TaskPhase) -> &'static str {
+    match phase {
+        TaskPhase::Triage => "triage",
+        TaskPhase::Plan => "plan",
+        TaskPhase::Implement => "implement",
+        TaskPhase::Review => "review",
+        TaskPhase::Terminal => "terminal",
+    }
+}
+
+fn format_system_time(time: SystemTime) -> String {
+    DateTime::<Utc>::from(time).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn duration_secs(created_at: SystemTime) -> u64 {
+    SystemTime::now()
+        .duration_since(created_at)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -115,6 +115,7 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
             | "/favicon.ico"
             | "/auth/reset-password"
             | "/"
+            | "/dashboard"
             | "/overview"
             | "/worktrees"
             | "/ws"
@@ -124,7 +125,7 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
 /// Bearer token authentication middleware.
 ///
 /// Exempts `/health`, `/webhook`, `/webhook/feishu`, `/signals`, `/favicon.ico`,
-/// `/auth/reset-password`, `/` (dashboard HTML), `/overview` (system overview
+/// `/auth/reset-password`, `/` and `/dashboard` (dashboard HTML), `/overview` (system overview
 /// HTML), `/assets/*` (hashed React bundle assets), and `/ws` (WebSocket
 /// upgrade).
 /// The dashboard HTML no longer embeds the token, so it is safe to serve without

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -16,6 +16,7 @@ use super::{
 pub(super) fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(crate::dashboard::index))
+        .route("/dashboard", get(crate::dashboard::index))
         .route("/overview", get(crate::overview::index))
         .route("/worktrees", get(crate::dashboard::index))
         .route(
@@ -51,6 +52,7 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             "/api/operator-snapshot",
             get(crate::handlers::operator_snapshot::operator_snapshot),
         )
+        .route("/api/worktrees", get(crate::handlers::worktrees::worktrees))
         .route("/api/intake", get(intake_status))
         .route(
             "/api/workflows/issues/by-issue",

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -3,6 +3,7 @@ use dashmap::DashMap;
 use harness_core::config::misc::WorkspaceConfig;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 use tokio::time::{timeout, Duration};
 
 /// Git hook invocations inherit repository-local environment variables such as
@@ -39,6 +40,16 @@ fn git_command() -> tokio::process::Command {
 pub(crate) struct ActiveWorkspace {
     pub(crate) workspace_path: PathBuf,
     pub(crate) source_repo: PathBuf,
+    pub(crate) created_at: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceEntry {
+    pub task_id: TaskId,
+    pub workspace_path: PathBuf,
+    pub source_repo: PathBuf,
+    pub branch: String,
+    pub created_at: SystemTime,
 }
 
 pub struct WorkspaceManager {
@@ -90,6 +101,7 @@ impl WorkspaceManager {
                     vac.insert(ActiveWorkspace {
                         workspace_path: workspace_path.clone(),
                         source_repo: source_repo.to_path_buf(),
+                        created_at: SystemTime::now(),
                     });
                 }
             }
@@ -254,6 +266,23 @@ impl WorkspaceManager {
     /// Number of worktrees currently checked out and not yet reaped.
     pub fn live_count(&self) -> u64 {
         self.active.len() as u64
+    }
+
+    /// Snapshot active worktrees in a stable order for API/UI consumers.
+    pub fn entries(&self) -> Vec<WorkspaceEntry> {
+        let mut entries: Vec<WorkspaceEntry> = self
+            .active
+            .iter()
+            .map(|entry| WorkspaceEntry {
+                task_id: entry.key().clone(),
+                workspace_path: entry.workspace_path.clone(),
+                source_repo: entry.source_repo.clone(),
+                branch: format!("harness/{}", entry.key().0),
+                created_at: entry.created_at,
+            })
+            .collect();
+        entries.sort_by(|a, b| a.task_id.0.cmp(&b.task_id.0));
+        entries
     }
 
     /// Remove workspaces for all given terminal task IDs. Errors are logged, not returned.
@@ -789,5 +818,78 @@ mod tests {
                 "workspace for {id:?} should have been cleaned up"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn entries_return_single_workspace_metadata() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let task_id = harness_core::types::TaskId("entries-task-001".to_string());
+
+        let ws_path = mgr
+            .create_workspace(&task_id, source.path(), "origin", &branch)
+            .await
+            .expect("create");
+
+        let entries = mgr.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].task_id, task_id);
+        assert_eq!(entries[0].workspace_path, ws_path);
+        assert_eq!(entries[0].source_repo, source.path());
+        assert_eq!(entries[0].branch, "harness/entries-task-001");
+        assert!(entries[0].created_at <= SystemTime::now());
+    }
+
+    #[tokio::test]
+    async fn entries_preserve_parallel_and_sequential_workspace_ids() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+
+        let seq_task = harness_core::types::TaskId("parent-task-seq".to_string());
+        let parallel_task = harness_core::types::TaskId("parent-task-p2".to_string());
+
+        mgr.create_workspace(&seq_task, source.path(), "origin", &branch)
+            .await
+            .expect("create seq");
+        mgr.create_workspace(&parallel_task, source.path(), "origin", &branch)
+            .await
+            .expect("create parallel");
+
+        let entries = mgr.entries();
+        let seq_entry = entries
+            .iter()
+            .find(|entry| entry.task_id == seq_task)
+            .expect("seq entry");
+        assert_eq!(seq_entry.branch, "harness/parent-task-seq");
+        assert!(
+            seq_entry.workspace_path.ends_with("parent-task-seq"),
+            "seq workspace should preserve suffix"
+        );
+
+        let parallel_entry = entries
+            .iter()
+            .find(|entry| entry.task_id == parallel_task)
+            .expect("parallel entry");
+        assert_eq!(parallel_entry.branch, "harness/parent-task-p2");
+        assert!(
+            parallel_entry.workspace_path.ends_with("parent-task-p2"),
+            "parallel workspace should preserve suffix"
+        );
     }
 }

--- a/crates/harness-server/tests/worktrees_api.rs
+++ b/crates/harness-server/tests/worktrees_api.rs
@@ -1,0 +1,229 @@
+use axum::{
+    body::{to_bytes, Body},
+    http::Request,
+    routing::get,
+    Router,
+};
+use harness_agents::registry::AgentRegistry;
+use harness_core::config::HarnessConfig;
+use harness_server::{
+    handlers::worktrees::worktrees,
+    http::build_app_state,
+    server::HarnessServer,
+    task_db::TaskDb,
+    task_runner::{PersistedRequestSettings, TaskPhase, TaskState, TaskStatus},
+    thread_manager::ThreadManager,
+};
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use tower::util::ServiceExt;
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(["-C", &repo.to_string_lossy()])
+        .args(args)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn init_git_repo(repo: &Path) {
+    run_git(repo, &["init", "-b", "main"]);
+    run_git(repo, &["config", "user.email", "test@example.com"]);
+    run_git(repo, &["config", "user.name", "Harness Test"]);
+    std::fs::write(repo.join("README.md"), "hello\n").expect("write seed file");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-m", "init"]);
+}
+
+fn task_with_settings(
+    id: &str,
+    status: TaskStatus,
+    turn: u32,
+    phase: TaskPhase,
+    project_root: &Path,
+    max_turns: Option<u32>,
+) -> TaskState {
+    TaskState {
+        id: harness_core::types::TaskId(id.to_string()),
+        status,
+        turn,
+        pr_url: Some("https://github.com/majiayu000/harness/pull/999".to_string()),
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("882".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(project_root.to_path_buf()),
+        issue: None,
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some(format!("issue #{id}")),
+        created_at: Some("2026-04-22T11:00:00Z".to_string()),
+        priority: 0,
+        phase,
+        triage_output: None,
+        plan_output: None,
+        request_settings: max_turns.map(|value| PersistedRequestSettings {
+            max_turns: Some(value),
+            ..Default::default()
+        }),
+    }
+}
+
+#[tokio::test]
+async fn get_worktrees_returns_live_workspace_records() -> anyhow::Result<()> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping worktrees_api: DATABASE_URL is unset");
+        return Ok(());
+    };
+    let Ok(pool) = harness_core::db::pg_open_pool(&database_url).await else {
+        eprintln!("skipping worktrees_api: DATABASE_URL is not reachable");
+        return Ok(());
+    };
+    pool.close().await;
+
+    let dir = tempfile::tempdir()?;
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&repo_root)?;
+    init_git_repo(&repo_root);
+
+    let mut config = HarnessConfig::default();
+    config.server.data_dir = dir.path().join("data");
+    config.server.project_root = repo_root.clone();
+    config.workspace.root = dir.path().join("worktrees");
+    config.concurrency.max_turns = Some(21);
+    config.server.database_url = Some(database_url);
+    std::fs::create_dir_all(&config.server.data_dir)?;
+
+    let db_path = harness_core::config::dirs::default_db_path(&config.server.data_dir, "tasks");
+    let db = match TaskDb::open(&db_path).await {
+        Ok(db) => db,
+        Err(error) => {
+            eprintln!("skipping worktrees_api: failed to open task db: {error}");
+            return Ok(());
+        }
+    };
+    db.insert(&task_with_settings(
+        "active-override",
+        TaskStatus::Implementing,
+        3,
+        TaskPhase::Implement,
+        &repo_root,
+        Some(7),
+    ))
+    .await?;
+    db.insert(&task_with_settings(
+        "active-fallback",
+        TaskStatus::Reviewing,
+        5,
+        TaskPhase::Review,
+        &repo_root,
+        None,
+    ))
+    .await?;
+    drop(db);
+
+    let server = Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let state = match build_app_state(server).await {
+        Ok(state) => Arc::new(state),
+        Err(error) => {
+            eprintln!("skipping worktrees_api: failed to build app state: {error}");
+            return Ok(());
+        }
+    };
+    let workspace_mgr = state
+        .concurrency
+        .workspace_mgr
+        .as_ref()
+        .expect("workspace manager enabled")
+        .clone();
+
+    workspace_mgr
+        .create_workspace(
+            &harness_core::types::TaskId("active-override".to_string()),
+            &repo_root,
+            "origin",
+            "main",
+        )
+        .await?;
+    workspace_mgr
+        .create_workspace(
+            &harness_core::types::TaskId("active-fallback".to_string()),
+            &repo_root,
+            "origin",
+            "main",
+        )
+        .await?;
+
+    let app = Router::new()
+        .route("/api/worktrees", get(worktrees))
+        .with_state(state.clone());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/worktrees")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await?;
+
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let body: Value = serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await?)?;
+    let rows = body.as_array().expect("array response");
+    assert_eq!(rows.len(), 2);
+
+    let override_row = rows
+        .iter()
+        .find(|row| row["task_id"] == "active-override")
+        .expect("override row");
+    assert_eq!(override_row["branch"], "harness/active-override");
+    assert_eq!(override_row["path_short"], "worktrees/active-override");
+    assert_eq!(override_row["source_repo"], repo_root.display().to_string());
+    assert_eq!(override_row["repo"], "majiayu000/harness");
+    assert_eq!(override_row["status"], "implementing");
+    assert_eq!(override_row["phase"], "implement");
+    assert_eq!(override_row["turn"], 3);
+    assert_eq!(override_row["max_turns"], 7);
+    assert_eq!(
+        override_row["project"],
+        repo_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("repo dir name")
+    );
+    assert_eq!(
+        override_row["pr_url"],
+        "https://github.com/majiayu000/harness/pull/999"
+    );
+    assert!(override_row["created_at"]
+        .as_str()
+        .expect("created_at string")
+        .ends_with('Z'));
+    assert!(
+        override_row["duration_secs"]
+            .as_u64()
+            .expect("duration secs")
+            <= 60,
+        "newly-created workspace should have a short lifetime in test"
+    );
+
+    let fallback_row = rows
+        .iter()
+        .find(|row| row["task_id"] == "active-fallback")
+        .expect("fallback row");
+    assert_eq!(fallback_row["status"], "reviewing");
+    assert_eq!(fallback_row["phase"], "review");
+    assert_eq!(fallback_row["max_turns"], 21);
+
+    state.observability.events.shutdown().await;
+    Ok(())
+}

--- a/crates/harness-server/tests/worktrees_api.rs
+++ b/crates/harness-server/tests/worktrees_api.rs
@@ -189,7 +189,8 @@ async fn get_worktrees_returns_live_workspace_records() -> anyhow::Result<()> {
     assert_eq!(override_row["path_short"], "worktrees/active-override");
     assert_eq!(override_row["source_repo"], repo_root.display().to_string());
     assert_eq!(override_row["repo"], "majiayu000/harness");
-    assert_eq!(override_row["status"], "implementing");
+    // Startup recovery resumes in-flight tasks as pending while preserving phase/checkpoints.
+    assert_eq!(override_row["status"], "pending");
     assert_eq!(override_row["phase"], "implement");
     assert_eq!(override_row["turn"], 3);
     assert_eq!(override_row["max_turns"], 7);
@@ -220,7 +221,7 @@ async fn get_worktrees_returns_live_workspace_records() -> anyhow::Result<()> {
         .iter()
         .find(|row| row["task_id"] == "active-fallback")
         .expect("fallback row");
-    assert_eq!(fallback_row["status"], "reviewing");
+    assert_eq!(fallback_row["status"], "pending");
     assert_eq!(fallback_row["phase"], "review");
     assert_eq!(fallback_row["max_turns"], 21);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,6 +47,7 @@ export function App() {
         <ScrollToHash />
         <Routes>
           <Route path="/" element={<Dashboard />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/overview" element={<Overview />} />
           <Route path="/worktrees" element={<Worktrees />} />
         </Routes>

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fmtInt, fmtScore, fmtPct, relativeAgo } from "./format";
+import { fmtInt, fmtScore, fmtPct, formatDurationShort, relativeAgo } from "./format";
 
 describe("fmtInt", () => {
   it("formats integers with thousands separators", () => {
@@ -30,6 +30,19 @@ describe("fmtPct", () => {
   });
   it("em-dashes missing", () => {
     expect(fmtPct(null)).toBe("—");
+  });
+});
+
+describe("formatDurationShort", () => {
+  it("formats seconds, minutes, hours, and days", () => {
+    expect(formatDurationShort(45)).toBe("45s");
+    expect(formatDurationShort(120)).toBe("2m");
+    expect(formatDurationShort(10_800)).toBe("3h");
+    expect(formatDurationShort(172_800)).toBe("2d");
+  });
+
+  it("returns em-dash for missing values", () => {
+    expect(formatDurationShort(null)).toBe("—");
   });
 });
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -19,6 +19,14 @@ export function fmtPct(n: number | null | undefined): string {
   return n.toFixed(1);
 }
 
+export function formatDurationShort(seconds: number | null | undefined): string {
+  if (!isFiniteNumber(seconds)) return EM_DASH;
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
 export function relativeAgo(then: Date | string, now: Date = new Date()): string {
   const thenDate = typeof then === "string" ? new Date(then) : then;
   const seconds = Math.max(0, Math.floor((now.getTime() - thenDate.getTime()) / 1000));

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -14,16 +14,10 @@ function makeWrapper() {
   return Wrapper;
 }
 
-type TaskStub = { id: string; status: string; turn?: number; project?: null };
-
-function mockFetch(tasks: TaskStub[]) {
-  const overview = { projects: [], runtimes: [], kpi: { active_tasks: 0 } };
-  global.fetch = vi.fn().mockImplementation((url: string) => {
-    const body = url.includes("/api/overview")
-      ? JSON.stringify(overview)
-      : JSON.stringify(tasks);
-    return Promise.resolve(new Response(body, { status: 200 }));
-  }) as unknown as typeof fetch;
+function mockFetch(body: unknown) {
+  global.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), { status: 200 }),
+  ) as unknown as typeof fetch;
 }
 
 const originalFetch = global.fetch;
@@ -33,44 +27,39 @@ afterEach(() => {
   sessionStorage.clear();
 });
 
-// ── useWorktrees: active-status filtering ─────────────────────────────────────
-
-describe("useWorktrees – active-status filtering", () => {
-  it("includes all non-terminal statuses as active worktrees", async () => {
+describe("useWorktrees", () => {
+  it("fetches the dedicated /api/worktrees payload", async () => {
     mockFetch([
-      { id: "1", status: "implementing", turn: 1, project: null },
-      { id: "2", status: "pending", turn: 0, project: null },
-      { id: "3", status: "agent_review", turn: 3, project: null },
-      { id: "4", status: "waiting", turn: 2, project: null },
-      { id: "5", status: "reviewing", turn: 4, project: null },
-      { id: "6", status: "awaiting_deps", turn: 0, project: null },
+      {
+        task_id: "task-1",
+        branch: "harness/task-1",
+        workspace_path: "/tmp/worktrees/task-1",
+        path_short: "worktrees/task-1",
+        source_repo: "/tmp/repo",
+        repo: "majiayu000/harness",
+        status: "implementing",
+        phase: "implement",
+        description: "issue #882",
+        turn: 2,
+        max_turns: 8,
+        created_at: "2026-04-22T11:00:00Z",
+        duration_secs: 120,
+        pr_url: null,
+        project: "harness",
+      },
     ]);
+
     const { result } = renderHook(() => useWorktrees(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.cards).toHaveLength(6);
-  });
 
-  it("excludes terminal statuses: done, failed, cancelled", async () => {
-    mockFetch([
-      { id: "1", status: "done", turn: 5, project: null },
-      { id: "2", status: "failed", turn: 2, project: null },
-      { id: "3", status: "cancelled", turn: 1, project: null },
-      { id: "4", status: "implementing", turn: 3, project: null },
-    ]);
-    const { result } = renderHook(() => useWorktrees(), { wrapper: makeWrapper() });
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.cards).toHaveLength(1);
-    expect(result.current.cards[0].taskId).toBe("4");
-  });
-
-  it("returns empty array when all tasks are terminal", async () => {
-    mockFetch([
-      { id: "a", status: "done", turn: 1, project: null },
-      { id: "b", status: "failed", turn: 0, project: null },
-    ]);
-    const { result } = renderHook(() => useWorktrees(), { wrapper: makeWrapper() });
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.cards).toHaveLength(0);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/worktrees",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].task_id).toBe("task-1");
   });
 });
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "./api";
-import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task } from "@/types";
+import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task, Worktree } from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -31,56 +31,11 @@ export function useTasks() {
   });
 }
 
-export interface WorktreeCard {
-  taskId: string;
-  pathShort: string;
-  branch: string;
-  status: string;
-  turn: number;
-  maxTurns: number | null;
-  cpuPct: number | null;
-  ramPct: number | null;
-  diskBytes: number | null;
-}
-
-export function useWorktrees(): { cards: WorktreeCard[]; isLoading: boolean; error: Error | null } {
-  const tasks = useTasks();
-  const overview = useOverview();
-
-  const isLoading = tasks.isLoading || overview.isLoading;
-  const error = tasks.error ?? overview.error ?? null;
-
-  const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
-  const runningTasks = (tasks.data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
-
-  const cards: WorktreeCard[] = runningTasks.map((task) => {
-    const project = (overview.data?.projects ?? []).find(
-      (p) => p.id === task.project || p.root === task.project,
-    );
-
-    let pathShort = "—";
-    if (project?.root) {
-      const parts = project.root.replace(/\\/g, "/").split("/").filter(Boolean);
-      pathShort = parts.slice(-2).join("/") || project.root;
-    }
-
-    const agentId = project?.agents?.[0];
-    const runtime = agentId
-      ? (overview.data?.runtimes ?? []).find((r) => r.id === agentId)
-      : undefined;
-
-    return {
-      taskId: task.id,
-      pathShort,
-      branch: "—",
-      status: task.status,
-      turn: task.turn,
-      maxTurns: null,
-      cpuPct: runtime?.cpu_pct ?? null,
-      ramPct: runtime?.ram_pct ?? null,
-      diskBytes: null,
-    };
+export function useWorktrees() {
+  return useQuery<Worktree[], Error>({
+    queryKey: ["worktrees"],
+    queryFn: ({ signal }) => apiJson<Worktree[]>("/api/worktrees", { signal }),
+    refetchInterval: 5000,
+    refetchIntervalInBackground: true,
   });
-
-  return { cards, isLoading, error };
 }

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
@@ -12,11 +12,26 @@ import { useDashboard } from "@/lib/queries";
 
 type Tab = "board" | "history" | "channels" | "submit";
 
+function resolveTab(value: string | null): Tab {
+  switch (value) {
+    case "history":
+    case "channels":
+    case "submit":
+      return value;
+    default:
+      return "board";
+  }
+}
+
 export function Dashboard() {
-  const [tab, setTab] = useState<Tab>("board");
-  const { isError } = useDashboard();
   const [searchParams] = useSearchParams();
+  const [tab, setTab] = useState<Tab>(() => resolveTab(searchParams.get("tab")));
+  const { isError } = useDashboard();
   const projectFilter = searchParams.get("project");
+
+  useEffect(() => {
+    setTab(resolveTab(searchParams.get("tab")));
+  }, [searchParams]);
 
   const sections: SidebarSection[] = [
     {

--- a/web/src/routes/Worktrees.test.tsx
+++ b/web/src/routes/Worktrees.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PaletteProvider } from "@/lib/palette";
+import { Worktrees } from "./Worktrees";
+
+vi.mock("@/lib/queries", () => ({
+  useOverview: vi.fn(),
+  useWorktrees: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+import { useOverview, useWorktrees } from "@/lib/queries";
+
+const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
+const mockUseWorktrees = useWorktrees as ReturnType<typeof vi.fn>;
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <PaletteProvider>
+        <MemoryRouter>
+          <Worktrees />
+        </MemoryRouter>
+      </PaletteProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockUseOverview.mockReturnValue({
+    data: {
+      projects: [],
+      runtimes: [],
+      kpi: { active_tasks: 0 },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<Worktrees>", () => {
+  it("sorts failed worktrees ahead of reviewing and implementing", () => {
+    mockUseWorktrees.mockReturnValue({
+      data: [
+        {
+          task_id: "impl-2",
+          branch: "harness/impl-2",
+          workspace_path: "/tmp/worktrees/impl-2",
+          path_short: "worktrees/impl-2",
+          source_repo: "/tmp/repo",
+          repo: "majiayu000/harness",
+          status: "implementing",
+          phase: "implement",
+          description: "Implement feature",
+          turn: 2,
+          max_turns: 8,
+          created_at: "2026-04-22T11:00:00Z",
+          duration_secs: 120,
+          pr_url: null,
+          project: "harness",
+        },
+        {
+          task_id: "fail-1",
+          branch: "harness/fail-1",
+          workspace_path: "/tmp/worktrees/fail-1",
+          path_short: "worktrees/fail-1",
+          source_repo: "/tmp/repo",
+          repo: "majiayu000/harness",
+          status: "failed",
+          phase: "review",
+          description: "Broken review run",
+          turn: 5,
+          max_turns: 8,
+          created_at: "2026-04-22T11:00:00Z",
+          duration_secs: 120,
+          pr_url: null,
+          project: "harness",
+        },
+        {
+          task_id: "review-3",
+          branch: "harness/review-3",
+          workspace_path: "/tmp/worktrees/review-3",
+          path_short: "worktrees/review-3",
+          source_repo: "/tmp/repo",
+          repo: "majiayu000/harness",
+          status: "reviewing",
+          phase: "review",
+          description: "Review in progress",
+          turn: 4,
+          max_turns: 8,
+          created_at: "2026-04-22T11:00:00Z",
+          duration_secs: 120,
+          pr_url: null,
+          project: "harness",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = renderPage();
+    const cards = Array.from(container.querySelectorAll("article")).map((node) => node.textContent ?? "");
+    expect(cards[0]).toContain("Broken review run");
+    expect(cards[1]).toContain("Review in progress");
+    expect(cards[2]).toContain("Implement feature");
+  });
+
+  it("shows a submit CTA when there are no active worktrees", () => {
+    mockUseWorktrees.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    expect(screen.getByText("No active worktrees")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open submit tab" })).toHaveAttribute(
+      "href",
+      "/dashboard?tab=submit",
+    );
+  });
+});

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -3,36 +3,63 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
 import { PaletteFab } from "@/components/PaletteFab";
-import { useWorktrees, useOverview } from "@/lib/queries";
+import { useOverview, useWorktrees } from "@/lib/queries";
 import { apiFetch, TOKEN_KEY } from "@/lib/api";
-import type { WorktreeCard } from "@/lib/queries";
+import { formatDurationShort } from "@/lib/format";
+import type { Worktree } from "@/types";
 
-function fmtPct(v: number | null): string {
-  return v != null ? `${v.toFixed(1)}%` : "—";
+function titleCase(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
-function fmtBytes(v: number | null): string {
-  return v != null ? `${(v / 1_073_741_824).toFixed(1)} GB` : "—";
+function statusOrder(status: string): number {
+  switch (status) {
+    case "failed":
+      return 0;
+    case "agent_review":
+    case "reviewing":
+      return 1;
+    case "implementing":
+      return 2;
+    case "pending":
+    case "awaiting_deps":
+    case "waiting":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function sortWorktrees(worktrees: Worktree[]): Worktree[] {
+  return [...worktrees].sort((a, b) => {
+    const byStatus = statusOrder(a.status) - statusOrder(b.status);
+    if (byStatus !== 0) return byStatus;
+    return a.task_id.localeCompare(b.task_id);
+  });
 }
 
 function statusColor(status: string): string {
   switch (status) {
+    case "failed":
+      return "text-danger border-danger/40 bg-danger/5";
     case "implementing":
     case "planner_generating":
-      return "text-ok border-ok/40";
+      return "text-ok border-ok/40 bg-ok/5";
     case "review_generating":
-      return "text-rust border-rust/40";
+    case "agent_review":
+    case "reviewing":
+      return "text-rust border-rust/40 bg-rust/5";
     case "review_waiting":
     case "planner_waiting":
     case "pending":
     case "awaiting_deps":
     case "waiting":
-      return "text-sand border-sand/40";
-    case "agent_review":
-    case "reviewing":
-      return "text-rust border-rust/40";
+      return "text-sand border-sand/40 bg-sand/10";
     default:
-      return "text-ink-3 border-line-2";
+      return "text-ink-3 border-line-2 bg-bg-2";
   }
 }
 
@@ -44,96 +71,116 @@ function openStream(taskId: string): void {
 }
 
 interface CardProps {
-  card: WorktreeCard;
+  worktree: Worktree;
   onCancel: (taskId: string) => void;
   cancelling: boolean;
 }
 
-function WorktreeCardItem({ card, onCancel, cancelling }: CardProps) {
-  const pct = card.maxTurns != null ? Math.round((card.turn / card.maxTurns) * 100) : null;
+function WorktreeCardItem({ worktree, onCancel, cancelling }: CardProps) {
+  const pct = worktree.max_turns != null && worktree.max_turns > 0
+    ? Math.min(100, Math.round((worktree.turn / worktree.max_turns) * 100))
+    : null;
+  const leftBorder = worktree.status === "failed" ? "border-l-2 border-l-danger" : "border-l-2 border-l-transparent";
 
   return (
-    <div className="border border-line rounded-[4px] bg-bg-1 flex flex-col gap-0 overflow-hidden">
-      <div className="px-4 py-3 flex items-center gap-2 border-b border-line">
-        <span className="font-mono text-[13px] text-ink font-medium truncate" title={card.pathShort}>
-          {card.pathShort}
-        </span>
-        <span className="font-mono text-[10.5px] px-1.5 py-[1px] border border-line-2 text-ink-3 rounded-[3px] flex-none">
-          {card.taskId.slice(0, 8)}
-        </span>
-        <span className="font-mono text-[10.5px] px-1.5 py-[1px] border border-line-2 text-ink-3 rounded-[3px] flex-none">
-          {card.branch}
-        </span>
-        <span
-          className={`ml-auto font-mono text-[10.5px] px-1.5 py-[1px] border rounded-[10px] ${statusColor(card.status)}`}
-        >
-          {card.status}
-        </span>
+    <article className={`border border-line rounded-[4px] bg-bg-1 overflow-hidden ${leftBorder}`}>
+      <div className="px-4 py-3 border-b border-line space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10.5px] px-1.5 py-[1px] border border-line-2 text-ink-3 rounded-[3px]">
+            {worktree.repo}
+          </span>
+          <span
+            className={`font-mono text-[10.5px] px-1.5 py-[1px] border rounded-[10px] ${statusColor(worktree.status)}`}
+          >
+            {titleCase(worktree.status)}
+          </span>
+          <span className="ml-auto font-mono text-[10.5px] text-ink-4 uppercase tracking-[0.1em]">
+            {titleCase(worktree.phase)}
+          </span>
+        </div>
+        <div>
+          <div className="text-[15px] leading-6 text-ink font-medium truncate">{worktree.description}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-ink-3">
+            <span>{worktree.task_id}</span>
+            <span>{worktree.branch}</span>
+            <span title={worktree.workspace_path}>{worktree.path_short}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 py-3 border-b border-line grid grid-cols-3 gap-3">
+        <div>
+          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">Project</div>
+          <div className="font-mono text-[12px] text-ink">{worktree.project}</div>
+        </div>
+        <div>
+          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">Age</div>
+          <div className="font-mono text-[12px] text-ink">{formatDurationShort(worktree.duration_secs)}</div>
+        </div>
+        <div>
+          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">Source</div>
+          <div className="font-mono text-[12px] text-ink truncate" title={worktree.source_repo}>
+            {worktree.source_repo}
+          </div>
+        </div>
       </div>
 
       {pct != null && (
-        <div className="px-4 py-2 border-b border-line">
+        <div className="px-4 py-3 border-b border-line">
           <div className="flex items-center gap-2 mb-1">
             <span className="font-mono text-[10.5px] text-ink-3">
-              turn {card.turn}/{card.maxTurns}
+              turn {worktree.turn}/{worktree.max_turns}
             </span>
             <span className="ml-auto font-mono text-[10.5px] text-ink-3">{pct}%</span>
           </div>
           <div className="h-[3px] bg-bg-2 rounded-full overflow-hidden">
-            <div
-              className="h-full bg-rust rounded-full"
-              style={{ width: `${pct}%` }}
-            />
+            <div className="h-full bg-rust rounded-full" style={{ width: `${pct}%` }} />
           </div>
         </div>
       )}
 
-      <div className="px-4 py-2 grid grid-cols-3 border-b border-line">
-        <div>
-          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">CPU</div>
-          <div className="font-mono text-[12px] text-ink">{fmtPct(card.cpuPct)}</div>
-        </div>
-        <div>
-          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">RAM</div>
-          <div className="font-mono text-[12px] text-ink">{fmtPct(card.ramPct)}</div>
-        </div>
-        <div>
-          <div className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.1em]">Disk</div>
-          <div className="font-mono text-[12px] text-ink">{fmtBytes(card.diskBytes)}</div>
-        </div>
-      </div>
-
       <div className="px-4 py-2.5 flex items-center gap-2">
         <button
           type="button"
-          onClick={() => openStream(card.taskId)}
+          onClick={() => openStream(worktree.task_id)}
           className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-2 rounded-[3px] hover:bg-bg-2 hover:text-ink"
         >
           Logs
         </button>
-        <button
-          type="button"
-          disabled
-          title="Coming soon"
-          className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-4 rounded-[3px] cursor-not-allowed"
-        >
-          Shell
-        </button>
+        {worktree.pr_url ? (
+          <a
+            href={worktree.pr_url}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-2 rounded-[3px] hover:bg-bg-2 hover:text-ink"
+          >
+            PR
+          </a>
+        ) : (
+          <button
+            type="button"
+            disabled
+            title="PR not created yet"
+            className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-4 rounded-[3px] cursor-not-allowed"
+          >
+            PR
+          </button>
+        )}
         <button
           type="button"
           disabled={cancelling}
-          onClick={() => onCancel(card.taskId)}
+          onClick={() => onCancel(worktree.task_id)}
           className="ml-auto font-mono text-[11.5px] px-3 py-1 border border-danger/40 text-danger rounded-[3px] hover:bg-danger/5 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {cancelling ? "Cancelling…" : "Cancel"}
         </button>
       </div>
-    </div>
+    </article>
   );
 }
 
 export function Worktrees() {
-  const { cards, isLoading, error } = useWorktrees();
+  const { data: worktrees = [], isLoading, error } = useWorktrees();
   const { data: overview } = useOverview();
   const queryClient = useQueryClient();
 
@@ -145,7 +192,10 @@ export function Worktrees() {
     setCancelling((prev) => new Set(prev).add(taskId));
     try {
       await apiFetch(`/tasks/${taskId}/cancel`, { method: "POST" });
-      await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["worktrees"] }),
+        queryClient.invalidateQueries({ queryKey: ["tasks"] }),
+      ]);
     } catch (err) {
       setCancelError(err instanceof Error ? err.message : "Cancel failed");
     } finally {
@@ -156,6 +206,8 @@ export function Worktrees() {
       });
     }
   };
+
+  const sortedWorktrees = sortWorktrees(worktrees);
 
   const sections: SidebarSection[] = [
     {
@@ -171,7 +223,7 @@ export function Worktrees() {
       label: "Fleet",
       items: [
         { id: "tasks", label: "All tasks", href: "/overview#projects", count: overview?.kpi.active_tasks },
-        { id: "worktrees", label: "Worktrees", href: "/worktrees", active: true, count: cards.length },
+        { id: "worktrees", label: "Worktrees", href: "/worktrees", active: true, count: sortedWorktrees.length },
       ],
     },
     {
@@ -194,7 +246,7 @@ export function Worktrees() {
               Fleet <em className="font-serif italic text-rust font-normal">worktrees</em>
             </h1>
             <span className="font-mono text-[12px] text-ink-3 ml-1">
-              {isLoading ? "loading…" : `${cards.length} active`}
+              {isLoading ? "loading…" : `${sortedWorktrees.length} active`}
             </span>
           </div>
 
@@ -209,18 +261,27 @@ export function Worktrees() {
                 {cancelError}
               </div>
             )}
-            {!isLoading && !error && cards.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-24 text-ink-3">
-                <span className="font-mono text-[13px]">No active worktrees</span>
+            {!isLoading && !error && sortedWorktrees.length === 0 ? (
+              <div className="border border-dashed border-line-2 rounded-[4px] bg-bg-1 px-6 py-16 text-center">
+                <div className="font-mono text-[13px] text-ink-3">No active worktrees</div>
+                <p className="mt-2 mb-5 text-sm text-ink-3">
+                  Submit a task to create a dedicated workspace and track it here.
+                </p>
+                <a
+                  href="/dashboard?tab=submit"
+                  className="inline-flex items-center justify-center font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-2 rounded-[3px] hover:bg-bg-2 hover:text-ink"
+                >
+                  Open submit tab
+                </a>
               </div>
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
-                {cards.map((card) => (
+                {sortedWorktrees.map((worktree) => (
                   <WorktreeCardItem
-                    key={card.taskId}
-                    card={card}
+                    key={worktree.task_id}
+                    worktree={worktree}
                     onCancel={handleCancel}
-                    cancelling={cancelling.has(card.taskId)}
+                    cancelling={cancelling.has(worktree.task_id)}
                   />
                 ))}
               </div>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./dashboard";
 export * from "./operator_snapshot";
 export * from "./overview";
 export * from "./task";
+export * from "./worktree";

--- a/web/src/types/worktree.ts
+++ b/web/src/types/worktree.ts
@@ -1,0 +1,17 @@
+export interface Worktree {
+  task_id: string;
+  branch: string;
+  workspace_path: string;
+  path_short: string;
+  source_repo: string;
+  repo: string;
+  status: string;
+  phase: string;
+  description: string;
+  turn: number;
+  max_turns: number | null;
+  created_at: string;
+  duration_secs: number;
+  pr_url: string | null;
+  project: string;
+}


### PR DESCRIPTION
## Summary
- add a dedicated `GET /api/worktrees` handler backed by live `WorkspaceManager` entries and task state
- rewire the React `/worktrees` route to consume that endpoint directly, including real branch/path/duration/max-turn data and an empty-state CTA to `/dashboard?tab=submit`
- add backend and frontend coverage for the new contract

## Validation
- `cargo fmt --all`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test -- ./src/lib/queries.test.ts ./src/lib/format.test.ts ./src/routes/Worktrees.test.tsx`
- `cargo test -p harness-server entries_ --lib`
- `cargo test -p harness-server --test worktrees_api get_worktrees_returns_live_workspace_records -- --nocapture`

## Notes
- `cargo test --workspace` is not green in this shell because the environment's Postgres configuration is not usable for the repo's database-backed test set; issue-specific tests above pass.

Closes #882