### PR TITLE
Surface active triage/plan load before implementing

### DIFF
--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -460,6 +460,8 @@ mod tests {
                 depends_on: Vec::new(),
                 subtask_ids: Vec::new(),
                 project: Some(project.clone()),
+                task_kind: crate::task_runner::TaskKind::default(),
+                workflow: None,
             }
             .view(Some("2026-04-22T00:00:00Z".to_string())),
             crate::task_runner::TaskSummary {
@@ -478,6 +480,8 @@ mod tests {
                 depends_on: Vec::new(),
                 subtask_ids: Vec::new(),
                 project: Some(project.clone()),
+                task_kind: crate::task_runner::TaskKind::default(),
+                workflow: None,
             }
             .view(Some("2026-04-22T00:01:00Z".to_string())),
             crate::task_runner::TaskSummary {
@@ -496,6 +500,8 @@ mod tests {
                 depends_on: Vec::new(),
                 subtask_ids: Vec::new(),
                 project: Some(project.clone()),
+                task_kind: crate::task_runner::TaskKind::default(),
+                workflow: None,
             }
             .view(Some("2026-04-22T00:02:00Z".to_string())),
             crate::task_runner::TaskSummary {
@@ -514,6 +520,8 @@ mod tests {
                 depends_on: Vec::new(),
                 subtask_ids: Vec::new(),
                 project: Some(project.clone()),
+                task_kind: crate::task_runner::TaskKind::default(),
+                workflow: None,
             }
             .view(Some("2026-04-22T00:03:00Z".to_string())),
         ];

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -3,6 +3,7 @@ use axum::{extract::State, http::StatusCode, Json};
 use harness_core::types::EventFilters;
 use harness_observe::{quality::QualityGrader, stats};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Rolling window for dashboard event queries. Keeps each `/api/dashboard` poll
@@ -14,6 +15,57 @@ const DASHBOARD_EVENT_WINDOW_DAYS: i64 = 30;
 /// so `uptime_secs` reflects true server uptime rather than time since first dashboard hit.
 pub(crate) static SERVER_START: std::sync::OnceLock<std::time::Instant> =
     std::sync::OnceLock::new();
+
+#[derive(Default, Clone)]
+struct ActivePhaseCounts {
+    triage: u64,
+    plan: u64,
+    implement: u64,
+    review: u64,
+}
+
+impl ActivePhaseCounts {
+    fn record(&mut self, phase: &crate::task_runner::TaskPhase) {
+        match phase {
+            crate::task_runner::TaskPhase::Triage => self.triage += 1,
+            crate::task_runner::TaskPhase::Plan => self.plan += 1,
+            crate::task_runner::TaskPhase::Implement => self.implement += 1,
+            crate::task_runner::TaskPhase::Review => self.review += 1,
+            crate::task_runner::TaskPhase::Terminal => {}
+        }
+    }
+
+    fn json(&self) -> Value {
+        json!({
+            "triage": self.triage,
+            "plan": self.plan,
+            "implement": self.implement,
+            "review": self.review,
+        })
+    }
+}
+
+fn collect_active_phase_counts(
+    task_views: &[crate::task_runner::TaskSummaryView],
+) -> (ActivePhaseCounts, HashMap<String, ActivePhaseCounts>) {
+    let mut global_active_phases = ActivePhaseCounts::default();
+    let mut project_active_phases: HashMap<String, ActivePhaseCounts> = HashMap::new();
+    for task in task_views {
+        if !task.agent_active {
+            continue;
+        }
+        if let Some(ref phase) = task.active_phase {
+            global_active_phases.record(phase);
+            if let Some(ref project) = task.task.project {
+                project_active_phases
+                    .entry(project.clone())
+                    .or_default()
+                    .record(phase);
+            }
+        }
+    }
+    (global_active_phases, project_active_phases)
+}
 
 /// GET /api/dashboard — JSON summary of all registered projects and global concurrency.
 ///
@@ -27,6 +79,17 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     let uptime_secs = start.elapsed().as_secs();
 
     let tq = &state.concurrency.task_queue;
+    let task_views = match state.core.tasks.list_all_summaries_with_terminal().await {
+        Ok(summaries) => summaries
+            .into_iter()
+            .map(|summary| state.core.tasks.decorate_summary(summary))
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            tracing::warn!("dashboard: failed to list task summaries: {e}");
+            Vec::new()
+        }
+    };
+    let (global_active_phases, project_active_phases) = collect_active_phase_counts(&task_views);
 
     // Global and per-project done/failed counts from in-memory cache in one pass,
     // avoiding both full TaskState cloning and double iteration.
@@ -162,6 +225,11 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                     "tasks": {
                         "running": qs.running,
                         "queued": qs.queued,
+                        "active_phases": project_active_phases
+                            .get(&key)
+                            .cloned()
+                            .unwrap_or_default()
+                            .json(),
                         "done": done,
                         "failed": failed,
                     },
@@ -211,6 +279,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         "global": {
             "running": tq.running_count(),
             "queued": tq.queued_count(),
+            "active_phases": global_active_phases.json(),
             "max_concurrent": tq.global_limit(),
             "uptime_secs": uptime_secs,
             "done": global_done,
@@ -232,6 +301,7 @@ mod tests {
     use axum::{body::to_bytes, routing::get, Router};
     use harness_agents::registry::AgentRegistry;
     use harness_core::config::HarnessConfig;
+    use harness_core::types::TaskId as CoreTaskId;
     use std::sync::Arc;
 
     async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
@@ -368,5 +438,95 @@ mod tests {
             "idle host must have 0.0 assignment_pressure"
         );
         Ok(())
+    }
+
+    #[test]
+    fn collect_active_phase_counts_includes_pending_triage_and_plan() {
+        let project = "/tmp/demo".to_string();
+        let views = vec![
+            crate::task_runner::TaskSummary {
+                id: CoreTaskId("triage".to_string()),
+                status: crate::task_runner::TaskStatus::Pending,
+                turn: 0,
+                pr_url: None,
+                error: None,
+                source: None,
+                parent_id: None,
+                external_id: None,
+                repo: None,
+                description: None,
+                created_at: None,
+                phase: crate::task_runner::TaskPhase::Triage,
+                depends_on: Vec::new(),
+                subtask_ids: Vec::new(),
+                project: Some(project.clone()),
+            }
+            .view(Some("2026-04-22T00:00:00Z".to_string())),
+            crate::task_runner::TaskSummary {
+                id: CoreTaskId("plan".to_string()),
+                status: crate::task_runner::TaskStatus::Pending,
+                turn: 0,
+                pr_url: None,
+                error: None,
+                source: None,
+                parent_id: None,
+                external_id: None,
+                repo: None,
+                description: None,
+                created_at: None,
+                phase: crate::task_runner::TaskPhase::Plan,
+                depends_on: Vec::new(),
+                subtask_ids: Vec::new(),
+                project: Some(project.clone()),
+            }
+            .view(Some("2026-04-22T00:01:00Z".to_string())),
+            crate::task_runner::TaskSummary {
+                id: CoreTaskId("implement".to_string()),
+                status: crate::task_runner::TaskStatus::Implementing,
+                turn: 1,
+                pr_url: None,
+                error: None,
+                source: None,
+                parent_id: None,
+                external_id: None,
+                repo: None,
+                description: None,
+                created_at: None,
+                phase: crate::task_runner::TaskPhase::Implement,
+                depends_on: Vec::new(),
+                subtask_ids: Vec::new(),
+                project: Some(project.clone()),
+            }
+            .view(Some("2026-04-22T00:02:00Z".to_string())),
+            crate::task_runner::TaskSummary {
+                id: CoreTaskId("idle".to_string()),
+                status: crate::task_runner::TaskStatus::Pending,
+                turn: 0,
+                pr_url: None,
+                error: None,
+                source: None,
+                parent_id: None,
+                external_id: None,
+                repo: None,
+                description: None,
+                created_at: None,
+                phase: crate::task_runner::TaskPhase::Implement,
+                depends_on: Vec::new(),
+                subtask_ids: Vec::new(),
+                project: Some(project.clone()),
+            }
+            .view(Some("2026-04-22T00:03:00Z".to_string())),
+        ];
+
+        let (global, by_project) = collect_active_phase_counts(&views);
+        assert_eq!(global.triage, 1);
+        assert_eq!(global.plan, 1);
+        assert_eq!(global.implement, 1);
+        assert_eq!(global.review, 0);
+
+        let project_counts = by_project.get(&project).expect("project counts present");
+        assert_eq!(project_counts.triage, 1);
+        assert_eq!(project_counts.plan, 1);
+        assert_eq!(project_counts.implement, 1);
     }
 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -510,7 +510,11 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                     };
                 }
             }
-            Json(summaries).into_response()
+            let views: Vec<_> = summaries
+                .into_iter()
+                .map(|summary| state.core.tasks.decorate_summary(summary))
+                .collect();
+            Json(views).into_response()
         }
         Err(e) => {
             tracing::error!("list_tasks: database error: {e}");
@@ -533,7 +537,7 @@ pub(crate) async fn get_task(
         .get_with_db_fallback(&harness_core::types::TaskId(id))
         .await
     {
-        Ok(Some(task)) => Json(task).into_response(),
+        Ok(Some(task)) => Json(state.core.tasks.decorate_task(task)).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -25,11 +25,7 @@ pub(crate) async fn run_plan_for_prompt(
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     let prompt_text = req.prompt.as_deref().unwrap_or_default();
     tracing::info!(task_id = %task_id, "pipeline: starting plan phase for prompt-only task");
-
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Plan;
-    })
-    .await?;
+    store.transition_phase(task_id, TaskPhase::Plan).await?;
 
     let plan_prompt = prompts::plan_for_prompt_task(prompt_text);
 
@@ -56,9 +52,11 @@ pub(crate) async fn run_plan_for_prompt(
     let plan_text = plan_resp.output.clone();
     mutate_and_persist(store, task_id, |state| {
         state.plan_output = Some(plan_text.clone());
-        state.phase = TaskPhase::Implement;
     })
     .await?;
+    store
+        .transition_phase(task_id, TaskPhase::Implement)
+        .await?;
     // NOTE: intentionally no write_checkpoint() here.  Prompt-only tasks cannot
     // be recovered after a crash (http.rs startup recovery hard-fails them because
     // the original prompt is not persisted — by design, to avoid writing
@@ -87,10 +85,7 @@ pub(crate) async fn run_triage_plan_pipeline(
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     // --- Phase 1: Triage ---
     tracing::info!(task_id = %task_id, issue, "pipeline: starting triage phase");
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Triage;
-    })
-    .await?;
+    store.transition_phase(task_id, TaskPhase::Triage).await?;
 
     let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
     let triage_req = AgentRequest {
@@ -132,10 +127,10 @@ pub(crate) async fn run_triage_plan_pipeline(
         prompts::TriageDecision::Skip => {
             mutate_and_persist(store, task_id, |state| {
                 state.status = crate::task_runner::TaskStatus::Done;
-                state.phase = TaskPhase::Terminal;
                 state.error = Some("Triage: skipped — not worth implementing".to_string());
             })
             .await?;
+            store.transition_phase(task_id, TaskPhase::Terminal).await?;
             anyhow::bail!("triage decided to skip issue #{issue}");
         }
         prompts::TriageDecision::NeedsClarification => {
@@ -154,10 +149,7 @@ pub(crate) async fn run_triage_plan_pipeline(
 
     // --- Phase 2: Plan ---
     tracing::info!(task_id = %task_id, issue, "pipeline: starting plan phase");
-    mutate_and_persist(store, task_id, |state| {
-        state.phase = TaskPhase::Plan;
-    })
-    .await?;
+    store.transition_phase(task_id, TaskPhase::Plan).await?;
 
     let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
     let plan_req = AgentRequest {
@@ -179,9 +171,11 @@ pub(crate) async fn run_triage_plan_pipeline(
     let plan_text = plan_resp.output.clone();
     mutate_and_persist(store, task_id, |state| {
         state.plan_output = Some(plan_text.clone());
-        state.phase = TaskPhase::Implement;
     })
     .await?;
+    store
+        .transition_phase(task_id, TaskPhase::Implement)
+        .await?;
     if let Err(e) = store
         .write_checkpoint(task_id, None, Some(&plan_text), None, "plan_done")
         .await

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -23,7 +23,10 @@ pub use spawn::{
     check_awaiting_deps, effective_turn_timeout, prompt_requires_plan, register_pending_task,
     resolve_canonical_project, spawn_preregistered_task, spawn_task, spawn_task_awaiting_deps,
 };
-pub use state::{active_agent_phase, task_agent_active, RecentFailureTask, RoundResult, TaskState, TaskSummary, TaskSummaryView, TaskView};
+pub use state::{
+    active_agent_phase, task_agent_active, RecentFailureTask, RoundResult, TaskState, TaskSummary,
+    TaskSummaryView, TaskView,
+};
 pub use store::{mutate_and_persist, update_status, TaskStore};
 pub use types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -23,7 +23,7 @@ pub use spawn::{
     check_awaiting_deps, effective_turn_timeout, prompt_requires_plan, register_pending_task,
     resolve_canonical_project, spawn_preregistered_task, spawn_task, spawn_task_awaiting_deps,
 };
-pub use state::{RecentFailureTask, RoundResult, TaskState, TaskSummary};
+pub use state::{active_agent_phase, task_agent_active, RecentFailureTask, RoundResult, TaskState, TaskSummary, TaskSummaryView, TaskView};
 pub use store::{mutate_and_persist, update_status, TaskStore};
 pub use types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -600,12 +600,12 @@ where
         if req.issue.is_none() && req.pr.is_none() && !task_kind.is_non_decomposable_prompt() {
             if let Some(ref prompt) = req.prompt {
                 if prompt_requires_plan(prompt) {
-                    mutate_and_persist(&store, &id, |s| {
-                        if s.phase == TaskPhase::Implement {
-                            s.phase = TaskPhase::Plan;
-                        }
-                    })
-                    .await?;
+                    if store
+                        .get(&id)
+                        .is_some_and(|s| s.phase == TaskPhase::Implement)
+                    {
+                        store.transition_phase(&id, TaskPhase::Plan).await?;
+                    }
                     tracing::info!(
                         task_id = %id.0,
                         "planning gate: complex prompt — forcing Plan phase before Implement"

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -140,6 +140,28 @@ pub struct RecentFailureTask {
     pub failed_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskView {
+    #[serde(flatten)]
+    pub task: TaskState,
+    pub agent_active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_phase: Option<TaskPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase_started_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskSummaryView {
+    #[serde(flatten)]
+    pub task: TaskSummary,
+    pub agent_active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_phase: Option<TaskPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase_started_at: Option<String>,
+}
+
 impl TaskState {
     pub(crate) fn new(id: TaskId) -> Self {
         Self {
@@ -193,5 +215,76 @@ impl TaskState {
                 .map(|p| p.to_string_lossy().into_owned()),
             workflow: None,
         }
+    }
+}
+
+pub fn active_agent_phase(status: &TaskStatus, phase: &TaskPhase) -> Option<TaskPhase> {
+    match status {
+        TaskStatus::Pending => match phase {
+            TaskPhase::Triage | TaskPhase::Plan => Some(phase.clone()),
+            _ => None,
+        },
+        TaskStatus::Implementing => Some(TaskPhase::Implement),
+        TaskStatus::AgentReview | TaskStatus::Reviewing => Some(TaskPhase::Review),
+        _ => None,
+    }
+}
+
+pub fn task_agent_active(status: &TaskStatus, phase: &TaskPhase) -> bool {
+    active_agent_phase(status, phase).is_some()
+}
+
+impl TaskState {
+    pub fn view(self, phase_started_at: Option<String>) -> TaskView {
+        let agent_active = task_agent_active(&self.status, &self.phase);
+        let active_phase = active_agent_phase(&self.status, &self.phase);
+        TaskView {
+            task: self,
+            agent_active,
+            active_phase,
+            phase_started_at,
+        }
+    }
+}
+
+impl TaskSummary {
+    pub fn view(self, phase_started_at: Option<String>) -> TaskSummaryView {
+        let agent_active = task_agent_active(&self.status, &self.phase);
+        let active_phase = active_agent_phase(&self.status, &self.phase);
+        TaskSummaryView {
+            task: self,
+            agent_active,
+            active_phase,
+            phase_started_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::types::TaskId as CoreTaskId;
+
+    #[test]
+    fn pending_triage_is_reported_as_active_agent_work() {
+        let mut task = TaskState::new(CoreTaskId("t-triage".to_string()));
+        task.phase = TaskPhase::Triage;
+
+        let view = task.view(Some("2026-04-22T00:00:00Z".to_string()));
+        assert!(view.agent_active);
+        assert_eq!(view.active_phase, Some(TaskPhase::Triage));
+        assert_eq!(
+            view.phase_started_at.as_deref(),
+            Some("2026-04-22T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn pending_implement_is_reported_as_idle() {
+        let task = TaskState::new(CoreTaskId("t-pending".to_string()));
+
+        let view = task.view(Some("2026-04-22T00:00:00Z".to_string()));
+        assert!(!view.agent_active);
+        assert_eq!(view.active_phase, None);
     }
 }

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
 
 use super::metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
-use super::state::{TaskState, TaskSummary};
-use super::types::{TaskId, TaskStatus};
+use super::state::{TaskState, TaskSummary, TaskSummaryView, TaskView};
+use super::types::{TaskId, TaskPhase, TaskStatus};
 use super::CompletionCallback;
 
 /// Broadcast channel capacity for per-task stream events.
@@ -34,6 +34,7 @@ struct RecoveredPrStatusUpdate {
 
 pub struct TaskStore {
     pub(crate) cache: DashMap<TaskId, TaskState>,
+    phase_started_at: DashMap<TaskId, String>,
     pub(super) db: TaskDb,
     persist_locks: DashMap<TaskId, Arc<Mutex<()>>>,
     /// Per-task broadcast channels for real-time stream forwarding to SSE clients.
@@ -100,6 +101,7 @@ impl TaskStore {
         };
 
         let cache = DashMap::new();
+        let phase_started_at = DashMap::new();
         let persist_locks = DashMap::new();
         // Only load active (non-terminal) tasks into the in-memory cache to prevent
         // unbounded memory growth from historical completed tasks.
@@ -117,10 +119,16 @@ impl TaskStore {
         ];
         for task in db.list_by_status(active_statuses).await? {
             persist_locks.insert(task.id.clone(), Arc::new(Mutex::new(())));
+            let phase_ts = task
+                .created_at
+                .clone()
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+            phase_started_at.insert(task.id.clone(), phase_ts);
             cache.insert(task.id.clone(), task);
         }
         let store = Arc::new(Self {
             cache,
+            phase_started_at,
             db,
             persist_locks,
             stream_txs: DashMap::new(),
@@ -133,6 +141,39 @@ impl TaskStore {
 
     pub fn get(&self, id: &TaskId) -> Option<TaskState> {
         self.cache.get(id).map(|r| r.value().clone())
+    }
+
+    pub fn phase_started_at(&self, id: &TaskId) -> Option<String> {
+        self.phase_started_at.get(id).map(|ts| ts.value().clone())
+    }
+
+    pub fn decorate_summary(&self, summary: TaskSummary) -> TaskSummaryView {
+        let phase_started_at = self
+            .phase_started_at(&summary.id)
+            .or_else(|| summary.created_at.clone());
+        summary.view(phase_started_at)
+    }
+
+    pub fn decorate_task(&self, task: TaskState) -> TaskView {
+        let phase_started_at = self
+            .phase_started_at(&task.id)
+            .or_else(|| task.created_at.clone());
+        task.view(phase_started_at)
+    }
+
+    pub async fn transition_phase(&self, id: &TaskId, phase: TaskPhase) -> anyhow::Result<()> {
+        let mut changed = false;
+        if let Some(mut entry) = self.cache.get_mut(id) {
+            if entry.phase != phase {
+                entry.phase = phase;
+                changed = true;
+            }
+        }
+        if changed {
+            self.phase_started_at
+                .insert(id.clone(), chrono::Utc::now().to_rfc3339());
+        }
+        self.persist(id).await
     }
 
     /// Look up a task by ID, checking the in-memory cache first.
@@ -809,6 +850,13 @@ impl TaskStore {
         self.persist_locks
             .entry(state.id.clone())
             .or_insert_with(|| Arc::new(Mutex::new(())));
+        self.phase_started_at.insert(
+            state.id.clone(),
+            state
+                .created_at
+                .clone()
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
+        );
         self.cache.insert(state.id.clone(), state.clone());
         if let Err(e) = self.db.insert(state).await {
             tracing::error!("task_db insert failed: {e}");
@@ -1116,11 +1164,25 @@ pub async fn update_status(
     turn: u32,
 ) -> anyhow::Result<()> {
     let status_str = status.as_ref().to_string();
+    let mapped_phase = match status {
+        TaskStatus::Implementing => Some(TaskPhase::Implement),
+        TaskStatus::AgentReview | TaskStatus::Reviewing => Some(TaskPhase::Review),
+        TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => Some(TaskPhase::Terminal),
+        _ => None,
+    };
     mutate_and_persist(store, task_id, |s| {
         s.status = status;
         s.turn = turn;
+        if let Some(ref phase) = mapped_phase {
+            s.phase = phase.clone();
+        }
     })
     .await?;
+    if mapped_phase.is_some() {
+        store
+            .phase_started_at
+            .insert(task_id.clone(), chrono::Utc::now().to_rfc3339());
+    }
     store.log_event(crate::event_replay::TaskEvent::StatusChanged {
         task_id: task_id.0.clone(),
         ts: crate::event_replay::now_ts(),

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -15,12 +15,20 @@ import { useTasks, useDashboard } from "@/lib/queries";
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
 const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
 
-function makeTask(id: string, project: string | null, status = "running", task_kind = "issue"): Task {
+function makeTask(
+  id: string,
+  project: string | null,
+  status = "running",
+  overrides: Partial<Task> = {},
+): Task {
   return {
     id,
-    task_kind,
+    task_kind: "issue",
     status,
     turn: 1,
+    agent_active: status === "running" || status === "implementing",
+    active_phase: status === "running" || status === "implementing" ? "implement" : null,
+    phase_started_at: null,
     pr_url: null,
     error: null,
     source: null,
@@ -34,6 +42,7 @@ function makeTask(id: string, project: string | null, status = "running", task_k
     subtask_ids: [],
     project,
     workflow: null,
+    ...overrides,
   };
 }
 
@@ -87,7 +96,7 @@ describe("<Active>", () => {
     wrap(<Active projectFilter="nonexistent" />);
     expect(screen.queryByText("t1")).not.toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
-    const dashes = screen.getAllByText("—");
+    const dashes = screen.getAllByText("\u2014");
     expect(dashes.length).toBeGreaterThan(0);
   });
 
@@ -111,21 +120,24 @@ describe("<Active>", () => {
     expect(columnCount("Pending")).toBe("0");
   });
 
-  it("groups planner and review lifecycle statuses outside implementing", () => {
+  it("surfaces pending triage and plan work before implementing", () => {
     mockUseTasks.mockReturnValue({
       data: [
-        makeTask("planner-task", "harness", "planner_waiting", "planner"),
-        makeTask("review-task", "harness", "review_generating", "review"),
-        makeTask("impl-task", "harness", "implementing", "issue"),
+        makeTask("pending-idle", "harness", "pending", { agent_active: false, active_phase: null }),
+        makeTask("triage-live", "harness", "pending", { agent_active: true, active_phase: "triage" }),
+        makeTask("plan-live", "harness", "pending", { agent_active: true, active_phase: "plan" }),
       ],
       isLoading: false,
       isError: false,
     });
-    wrap(<Active />);
-    expect(screen.getByText("Planning")).toBeInTheDocument();
-    expect(screen.getByText("Review")).toBeInTheDocument();
-    expect(screen.getByText("planner-task")).toBeInTheDocument();
-    expect(screen.getByText("review-task")).toBeInTheDocument();
-    expect(screen.getByText("impl-task")).toBeInTheDocument();
+    wrap(<Active projectFilter="harness" />);
+
+    const triageColumn = screen.getByText("Triage").parentElement?.parentElement;
+    const planColumn = screen.getByText("Plan").parentElement?.parentElement;
+    const pendingColumn = screen.getByText("Pending").parentElement?.parentElement;
+
+    expect(within(triageColumn!).getByText("triage-live")).toBeInTheDocument();
+    expect(within(planColumn!).getByText("plan-live")).toBeInTheDocument();
+    expect(within(pendingColumn!).getByText("pending-idle")).toBeInTheDocument();
   });
 });

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,11 +1,10 @@
 import { useTasks, useDashboard } from "@/lib/queries";
-import type { Task, WorkflowSummary } from "@/types";
+import type { Task } from "@/types";
 
 interface Column {
   key: string;
   label: string;
-  workflowStates: string[];
-  fallbackTaskStatuses: string[];
+  matches: (task: Task) => boolean;
 }
 
 /**
@@ -18,59 +17,67 @@ const COLUMNS: Column[] = [
   {
     key: "pending",
     label: "Pending",
-    workflowStates: ["discovered", "scheduled"],
-    fallbackTaskStatuses: ["pending", "queued", "awaiting_deps"],
+    matches: (task) => ["pending", "queued"].includes(task.status) && !task.agent_active,
+  },
+  {
+    key: "triage",
+    label: "Triage",
+    matches: (task) => task.agent_active && task.active_phase === "triage",
+  },
+  {
+    key: "plan",
+    label: "Plan",
+    matches: (task) => task.agent_active && task.active_phase === "plan",
   },
   {
     key: "implementing",
     label: "Implementing",
-    workflowStates: ["implementing"],
-    fallbackTaskStatuses: ["implementing", "running", "triage", "plan"],
-  },
-  {
-    key: "planning",
-    label: "Planning",
-    workflowStates: [],
-    fallbackTaskStatuses: ["planner_generating", "planner_waiting"],
+    matches: (task) =>
+      task.status === "implementing" || (task.agent_active && task.active_phase === "implement"),
   },
   {
     key: "review",
     label: "Review",
-    workflowStates: [],
-    fallbackTaskStatuses: ["review_generating", "review_waiting"],
+    matches: (task) =>
+      ["agent_review", "reviewing_agent", "reviewing"].includes(task.status) ||
+      (task.agent_active && task.active_phase === "review"),
   },
   {
     key: "feedback",
     label: "Feedback",
-    workflowStates: ["pr_open", "awaiting_feedback", "addressing_feedback"],
-    fallbackTaskStatuses: ["agent_review", "reviewing_agent", "waiting", "reviewing"],
+    matches: (task) =>
+      ["pr_open", "awaiting_feedback", "addressing_feedback"].includes(
+        task.workflow?.state ?? "",
+      ) || ["agent_review", "reviewing"].includes(task.status),
   },
   {
     key: "ready",
     label: "Ready",
-    workflowStates: ["ready_to_merge"],
-    fallbackTaskStatuses: [],
+    matches: (task) => task.workflow?.state === "ready_to_merge",
   },
   {
     key: "blocked",
     label: "Blocked",
-    workflowStates: ["blocked", "degraded", "paused"],
-    fallbackTaskStatuses: [],
+    matches: (task) =>
+      ["blocked", "degraded", "paused"].includes(task.workflow?.state ?? ""),
   },
+  { key: "waiting", label: "Waiting", matches: (task) => task.status === "waiting" },
 ];
 
 const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
 
-function columnOf(taskStatus: string, workflowState?: string | null): string {
-  if (workflowState) {
-    for (const c of COLUMNS) {
-      if (c.workflowStates.includes(workflowState)) return c.key;
-    }
-  }
+function taskColumn(task: Task): string {
   for (const c of COLUMNS) {
-    if (c.fallbackTaskStatuses.includes(taskStatus)) return c.key;
+    if (c.matches(task)) return c.key;
   }
   return "other";
+}
+
+function formatPhaseTime(ts: string | null): string | null {
+  if (!ts) return null;
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function workflowLabel(state: string): string {
@@ -118,8 +125,11 @@ function workflowLabel(state: string): string {
   }
 }
 
-function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary | null }) {
+function TaskCard({ task }: { task: Task }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
+  const phaseLabel = task.active_phase ?? task.phase;
+  const phaseTime = formatPhaseTime(task.phase_started_at);
+  const workflow = task.workflow ?? null;
   return (
     <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
@@ -138,6 +148,12 @@ function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary |
               force-execute
             </span>
           ) : null}
+        </div>
+      )}
+      {(phaseLabel || phaseTime) && (
+        <div className="mt-1 font-mono text-[10px] text-ink-3 uppercase tracking-[0.08em]">
+          {phaseLabel ?? "phase"}
+          {phaseTime ? ` · ${phaseTime}` : ""}
         </div>
       )}
       <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
@@ -186,8 +202,7 @@ export function Active({ projectFilter }: Props) {
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];
   for (const t of active) {
-    const workflow = t.workflow ?? null;
-    const col = columnOf(t.status, workflow?.state ?? null);
+    const col = taskColumn(t);
     if (col === "other") other.push(t);
     else grouped[col].push(t);
   }
@@ -213,7 +228,7 @@ export function Active({ projectFilter }: Props) {
                 </div>
               )}
               {rows.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+                <TaskCard key={t.id} task={t} />
               ))}
             </div>
           </div>
@@ -227,7 +242,7 @@ export function Active({ projectFilter }: Props) {
           </div>
             <div className="p-2 flex-1 overflow-auto">
               {other.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+                <TaskCard key={t.id} task={t} />
               ))}
             </div>
           </div>

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { useDashboard } from "@/lib/queries";
+import { useDashboard, useTasks } from "@/lib/queries";
+import type { Task } from "@/types";
 
 interface Props {
   projectFilter?: string | null;
@@ -7,6 +8,7 @@ interface Props {
 
 export function History({ projectFilter }: Props) {
   const { data } = useDashboard();
+  const { data: tasks } = useTasks();
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
   const scopedProject = projectFilter ? (data?.projects.find((p) => p.id === projectFilter) ?? null) : null;
@@ -16,6 +18,29 @@ export function History({ projectFilter }: Props) {
   const totalFailed = projectFilter
     ? (scopedProject?.tasks.failed ?? 0)
     : (data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0);
+  const normalizedQuery = query.trim().toLowerCase();
+  const rows = (tasks ?? [])
+    .filter((task) => !projectFilter || task.project === scopedProject?.root || task.project === projectFilter)
+    .filter((task) => filter === "all" || task.status === filter)
+    .filter((task) => {
+      if (!normalizedQuery) return true;
+      return [
+        task.id,
+        task.description,
+        task.repo,
+        task.status,
+        task.phase,
+        task.active_phase,
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedQuery));
+    })
+    .sort((a, b) => {
+      const aTs = Date.parse(a.phase_started_at ?? a.created_at ?? "") || 0;
+      const bTs = Date.parse(b.phase_started_at ?? b.created_at ?? "") || 0;
+      return bTs - aTs;
+    })
+    .slice(0, 50);
 
   return (
     <div>
@@ -38,10 +63,51 @@ export function History({ projectFilter }: Props) {
       </div>
       <div className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">
         done {totalDone} · failed {totalFailed} · filter {filter} · query {query || "(none)"}
-        <div className="mt-3 text-ink-4 text-[11px]">
-          Task list endpoint is /tasks; cursor-based pagination TBD in a separate PR.
+      </div>
+      <div className="mt-4 border border-line bg-bg-1">
+        {rows.length === 0 ? (
+          <div className="p-4 font-mono text-[12px] text-ink-4">No matching tasks</div>
+        ) : (
+          rows.map((task) => <HistoryRow key={task.id} task={task} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return "—";
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function HistoryRow({ task }: { task: Task }) {
+  const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
+  const phaseLabel = task.active_phase ?? task.phase ?? "unknown";
+  const phaseTs = task.phase_started_at ?? task.created_at;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,2.2fr)_110px_120px_150px] gap-3 px-4 py-3 border-b border-line last:border-b-0">
+      <div className="min-w-0">
+        <div className="text-[12.5px] text-ink truncate" title={title}>
+          {title}
+        </div>
+        <div className="mt-1 font-mono text-[10px] text-ink-4">
+          {task.repo ?? task.id}
         </div>
       </div>
+      <div className="font-mono text-[11px] text-ink-3 uppercase">{task.status}</div>
+      <div className="font-mono text-[11px] text-ink-3 uppercase">
+        {phaseLabel}
+        {task.agent_active ? " active" : ""}
+      </div>
+      <div className="font-mono text-[11px] text-ink-4">{formatTimestamp(phaseTs)}</div>
     </div>
   );
 }

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -1,6 +1,14 @@
+export interface DashboardActivePhases {
+  triage: number;
+  plan: number;
+  implement: number;
+  review: number;
+}
+
 export interface DashboardProjectTasks {
   running: number;
   queued: number;
+  active_phases: DashboardActivePhases;
   done: number;
   failed: number;
 }
@@ -34,6 +42,7 @@ export interface DashboardLlmMetrics {
 export interface DashboardGlobal {
   running: number;
   queued: number;
+  active_phases: DashboardActivePhases;
   max_concurrent: number;
   uptime_secs: number;
   done: number;

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -7,6 +7,9 @@ export interface Task {
   task_kind: string;
   status: string;
   turn: number;
+  agent_active: boolean;
+  active_phase: string | null;
+  phase_started_at: string | null;
   pr_url: string | null;
   error: string | null;
   source: string | null;


### PR DESCRIPTION
## Summary
- make task API responses expose explicit live agent activity via agent_active, active_phase, and phase_started_at
- count active work by phase in /api/dashboard so triage and plan load is visible before implementing
- split dashboard task views to show Triage and Plan lanes and surface phase timestamps in Active/History

## Testing
- cargo fmt --all
- cargo check --workspace --all-targets
- RUSTFLAGS='-Dwarnings' cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p harness-server pending_triage_is_reported_as_active_agent_work -- --nocapture --test-threads=1
- cargo test -p harness-server collect_active_phase_counts_includes_pending_triage_and_plan -- --nocapture --test-threads=1
- cd web && bun run typecheck
- cd web && bun run test -- src/routes/dashboard/Active.test.tsx

## Validation note
- cargo test --workspace currently fails in this multi-agent environment because the shared DATABASE_URL-backed Postgres session pool hits EMAXCONNSESSION max-client limits during harness_observe event-store tests

Closes #883