### PR TITLE
Make issue workflows the orchestration authority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ web/dist/
 # SDK build artifacts (TypeScript bindings)
 sdk/typescript/node_modules/
 sdk/typescript/dist/
+sdk/typescript/bun.lock
 
 # macOS finder metadata
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "chrono-tz",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sqlx",
  "temp-env",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -302,7 +302,16 @@ curl -X POST http://127.0.0.1:9800/tasks \
   -d '{
     "project": "/path/to/project",
     "issue": 42,
-    "description": "fix: handle edge case in parser"
+    "prompt": "fix: handle edge case in parser"
+  }'
+
+# Submit an issue task but bypass triage/plan and go straight to implementation
+curl -X POST http://127.0.0.1:9800/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project": "/path/to/project",
+    "issue": 42,
+    "skip_triage": true
   }'
 
 # Submit a task by PR number (for review/fix)

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,26 @@
+---
+issue_workflow:
+  force_execute_label: force-execute
+  auto_replan_on_plan_issue: true
+pr_feedback:
+  enabled: true
+  sweep_interval_secs: 60
+---
+
+# Harness Workflow
+
+This file defines high-level workflow policy for Harness.
+
+Current externally configurable rules:
+
+- `issue_workflow.force_execute_label`
+  - GitHub issue label that forces execution even when the agent raises a plan concern.
+
+- `issue_workflow.auto_replan_on_plan_issue`
+  - Whether `PLAN_ISSUE` should trigger an automatic replan by default.
+
+- `pr_feedback.sweep_interval_secs`
+  - Background interval for sweeping issue workflows with attached PRs and enqueuing `pr:N` review/fix tasks.
+
+- `pr_feedback.enabled`
+  - Enables or disables automatic background PR feedback sweeping.

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -60,8 +60,9 @@ const AGENT_INTERNAL_PREFIXES: &[&str] = &[
 /// These contain source code keywords but are not real errors.
 fn looks_like_code_content(line: &str) -> bool {
     let trimmed = line.trim_start();
+    let had_indent = trimmed.len() != line.len();
     // Lines starting with a digit followed by whitespace are numbered source lines.
-    trimmed
+    if trimmed
         .as_bytes()
         .first()
         .is_some_and(|b| b.is_ascii_digit())
@@ -73,10 +74,113 @@ fn looks_like_code_content(line: &str) -> bool {
                     .get(pos)
                     .is_some_and(|b| b.is_ascii_whitespace())
             })
+    {
+        return true;
+    }
+
+    // Diff hunks and inline patch content frequently contain words like
+    // "warn"/"error" but should stay debug-only.
+    if trimmed.starts_with('+')
+        || trimmed.starts_with('-')
+        || trimmed.starts_with("@@")
+        || trimmed.starts_with("diff --git")
+    {
+        return true;
+    }
+
+    if had_indent {
+        const INDENTED_CODE_PREFIXES: &[&str] = &[
+            "\"",
+            "//",
+            "/*",
+            "#[",
+            "tracing::",
+            "sqlx::",
+            "tokio::",
+            "let ",
+            "fn ",
+            "pub ",
+            "impl ",
+            "struct ",
+            "enum ",
+            "match ",
+            "if ",
+            "for ",
+            "while ",
+            "loop",
+            "return ",
+            "Err(",
+            "Ok(",
+            "Some(",
+            "None",
+            ".",
+        ];
+        if INDENTED_CODE_PREFIXES
+            .iter()
+            .any(|prefix| trimmed.starts_with(prefix))
+        {
+            return true;
+        }
+        if trimmed.ends_with('{')
+            || trimmed.ends_with('}')
+            || trimmed.ends_with(',')
+            || trimmed.ends_with(");")
+            || trimmed.ends_with(")]")
+            || trimmed.ends_with("=>")
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn looks_like_git_commit_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some((hash, rest)) = trimmed.split_once(' ') else {
+        return false;
+    };
+    (7..=40).contains(&hash.len())
+        && hash.chars().all(|c| c.is_ascii_hexdigit())
+        && !rest.is_empty()
+}
+
+fn looks_like_search_result(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some((path, rest)) = trimmed.split_once(':') else {
+        return false;
+    };
+    let Some((line_no, _tail)) = rest.split_once(':') else {
+        return false;
+    };
+    !path.is_empty()
+        && !line_no.is_empty()
+        && line_no.chars().all(|c| c.is_ascii_digit())
+        && (path.starts_with("./")
+            || path.starts_with('/')
+            || path.contains('/')
+            || path.ends_with(".rs")
+            || path.ends_with(".md")
+            || path.ends_with(".toml"))
+}
+
+fn looks_like_markdown_prompt_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('#')
+        || trimmed.starts_with("- ")
+        || trimmed.starts_with("* ")
+        || trimmed.starts_with("> ")
+        || trimmed.starts_with("Pass: ")
+        || trimmed.starts_with("Warn: ")
+        || trimmed.starts_with("Block: ")
 }
 
 fn is_agent_internal(line: &str) -> bool {
-    if looks_like_code_content(line) {
+    if looks_like_code_content(line)
+        || looks_like_git_commit_line(line)
+        || looks_like_search_result(line)
+        || looks_like_markdown_prompt_line(line)
+    {
         return true;
     }
     let lower = line.to_lowercase();
@@ -484,5 +588,67 @@ mod tests {
         let long_line = "x".repeat(2000);
         // Should not panic
         log_captured_stderr(&long_line, "agent");
+    }
+
+    #[test]
+    fn looks_like_code_content_matches_indented_rust_fragments() {
+        assert!(looks_like_code_content(
+            "                        tracing::warn!("
+        ));
+        assert!(looks_like_code_content(
+            "                                error = %e,"
+        ));
+        assert!(looks_like_code_content(
+            "                                \"scheduler: failed to load registry project config, skipping\""
+        ));
+    }
+
+    #[test]
+    fn looks_like_code_content_matches_patch_lines() {
+        assert!(looks_like_code_content(
+            "+        // Incomplete %XX should be left as-is, not panic"
+        ));
+        assert!(looks_like_code_content(
+            "+                Err(e) => tracing::warn!("
+        ));
+    }
+
+    #[test]
+    fn looks_like_code_content_does_not_hide_real_warning_lines() {
+        assert!(!looks_like_code_content("warning: unused import"));
+        assert!(!looks_like_code_content(
+            "agent execution failed: codex exited with status 1"
+        ));
+    }
+
+    #[test]
+    fn looks_like_git_commit_line_matches_history_output() {
+        assert!(looks_like_git_commit_line(
+            "7f84b9a fix(lifecycle): add Item::Error for agent-not-found and stall paths"
+        ));
+        assert!(looks_like_git_commit_line(
+            "fb15c77 Merge pull request #352 from majiayu000/feat/issue-88-warn-missing-preflight-skill"
+        ));
+    }
+
+    #[test]
+    fn looks_like_search_result_matches_path_line_output() {
+        assert!(looks_like_search_result(
+            "./rules/go/quality.md:20:Return errors instead. `panic` only in `main()` for truly unrecoverable states."
+        ));
+        assert!(looks_like_search_result(
+            "./crates/harness-server/src/http/background.rs:382:                            format!(\"startup recovery: failed to acquire concurrency permit: {e}\");"
+        ));
+    }
+
+    #[test]
+    fn looks_like_markdown_prompt_line_matches_headings_and_bullets() {
+        assert!(looks_like_markdown_prompt_line("## Warnings"));
+        assert!(looks_like_markdown_prompt_line(
+            "- <action to resolve block/warn>"
+        ));
+        assert!(looks_like_markdown_prompt_line(
+            "Pass: <N> | Warn: <N> | Block: <N>"
+        ));
     }
 }

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -154,6 +154,7 @@ fn looks_like_search_result(line: &str) -> bool {
         return false;
     };
     !path.is_empty()
+        && !path.contains(char::is_whitespace)
         && !line_no.is_empty()
         && line_no.chars().all(|c| c.is_ascii_digit())
         && (path.starts_with("./")
@@ -638,6 +639,9 @@ mod tests {
         ));
         assert!(looks_like_search_result(
             "./crates/harness-server/src/http/background.rs:382:                            format!(\"startup recovery: failed to acquire concurrency permit: {e}\");"
+        ));
+        assert!(!looks_like_search_result(
+            "thread 'main' panicked at src/main.rs:10:5:"
         ));
     }
 

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core domain model, configuration, prompts, and agent traits for H
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 toml = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -5,6 +5,7 @@ pub mod misc;
 pub mod project;
 pub mod resolve;
 pub mod server;
+pub mod workflow;
 
 use self::agents::*;
 use self::intake::*;

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueWorkflowPolicy {
+    #[serde(default = "default_force_execute_label")]
+    pub force_execute_label: String,
+    #[serde(default = "default_true")]
+    pub auto_replan_on_plan_issue: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrFeedbackPolicy {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_feedback_sweep_interval_secs")]
+    pub sweep_interval_secs: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowConfig {
+    #[serde(default)]
+    pub issue_workflow: IssueWorkflowPolicy,
+    #[serde(default)]
+    pub pr_feedback: PrFeedbackPolicy,
+}
+
+impl Default for IssueWorkflowPolicy {
+    fn default() -> Self {
+        Self {
+            force_execute_label: default_force_execute_label(),
+            auto_replan_on_plan_issue: default_true(),
+        }
+    }
+}
+
+impl Default for PrFeedbackPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: default_true(),
+            sweep_interval_secs: default_feedback_sweep_interval_secs(),
+        }
+    }
+}
+
+fn default_force_execute_label() -> String {
+    "force-execute".to_string()
+}
+
+fn default_feedback_sweep_interval_secs() -> u64 {
+    60
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Load workflow policy from `{project_root}/WORKFLOW.md`.
+///
+/// Only the YAML front matter is parsed. Missing files or missing front matter
+/// fall back to defaults.
+pub fn load_workflow_config(project_root: &Path) -> anyhow::Result<WorkflowConfig> {
+    let path = project_root.join("WORKFLOW.md");
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(WorkflowConfig::default()),
+        Err(e) => return Err(e.into()),
+    };
+
+    let Some(front_matter) = extract_front_matter(&contents) else {
+        return Ok(WorkflowConfig::default());
+    };
+    if front_matter.trim().is_empty() {
+        return Ok(WorkflowConfig::default());
+    }
+
+    serde_yaml::from_str(front_matter).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to parse workflow front matter at {}: {e}",
+            path.display()
+        )
+    })
+}
+
+fn extract_front_matter(contents: &str) -> Option<&str> {
+    let rest = contents.strip_prefix("---\n")?;
+    let end = rest.find("\n---\n")?;
+    Some(&rest[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cfg = load_workflow_config(dir.path())?;
+        assert_eq!(cfg.issue_workflow.force_execute_label, "force-execute");
+        assert!(cfg.pr_feedback.enabled);
+        assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
+        assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
+        Ok(())
+    }
+
+    #[test]
+    fn load_workflow_config_reads_front_matter() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            r#"---
+issue_workflow:
+  force_execute_label: do-not-second-guess
+  auto_replan_on_plan_issue: false
+pr_feedback:
+  enabled: false
+  sweep_interval_secs: 15
+---
+
+Body
+"#,
+        )?;
+
+        let cfg = load_workflow_config(dir.path())?;
+        assert_eq!(
+            cfg.issue_workflow.force_execute_label,
+            "do-not-second-guess"
+        );
+        assert!(!cfg.issue_workflow.auto_replan_on_plan_issue);
+        assert!(!cfg.pr_feedback.enabled);
+        assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
+        Ok(())
+    }
+}

--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -81,6 +81,39 @@ pub fn plan_prompt(issue: u64, triage_assessment: &str) -> PromptParts {
     }
 }
 
+/// Build a replan prompt after an implementation attempt reports `PLAN_ISSUE=...`.
+///
+/// This is used when the current implementation plan proved incomplete or wrong
+/// during execution. The architect must produce a corrected plan rather than
+/// letting the executor silently diverge.
+pub fn replan_prompt(issue: u64, prior_plan: Option<&str>, plan_issue: &str) -> PromptParts {
+    let prior_plan_section = prior_plan
+        .map(wrap_external_data)
+        .map(|safe_plan| format!("Previous implementation plan:\n{safe_plan}\n\n"))
+        .unwrap_or_default();
+    let safe_plan_issue = wrap_external_data(plan_issue);
+    PromptParts {
+        static_instructions: format!(
+            "You are a Software Architect repairing the implementation plan for GitHub issue #{issue}.\n\n\
+             A previous implementation attempt refused to proceed because the current plan was incomplete or wrong.\n\n\
+             {prior_plan_section}\
+             Implementation concern raised by the executor:\n\
+             {safe_plan_issue}\n\n\
+             Produce a corrected implementation plan:\n\n\
+             1. **Files to modify** — list each file with a one-line rationale\n\
+             2. **Files to create** — only if truly needed\n\
+             3. **Key changes** — the 2-3 most important code changes\n\
+             4. **Test plan** — what to test and edge cases\n\
+             5. **Risk corrections** — what the previous plan missed and how this new plan fixes it\n\n\
+             Keep the plan actionable and minimal.\n\
+             Do NOT write code.\n\n\
+             On the LAST line, print: PLAN=READY"
+        ),
+        context: String::new(),
+        dynamic_payload: String::new(),
+    }
+}
+
 /// Build prompt parts: implement from a GitHub issue, create PR.
 ///
 /// When `plan` is provided, the engineer follows the plan instead of figuring
@@ -232,6 +265,14 @@ mod tests {
             p.contains("Closes #42"),
             "prompt must tell the agent to include `Closes #N` in the body"
         );
+    }
+
+    #[test]
+    fn test_replan_prompt() {
+        let p = replan_prompt(42, Some("old plan"), "missed auth bypass").to_prompt_string();
+        assert!(p.contains("repairing the implementation plan"));
+        assert!(p.contains("missed auth bypass"));
+        assert!(p.contains("PLAN=READY"));
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -17,8 +17,8 @@ pub use contract::{
     test_gate_failure_prompt, validation_retry_prompt,
 };
 pub use issue::{
-    gc_adopt_prompt, implement_from_issue, implement_from_prompt, plan_prompt, triage_prompt,
-    wrap_external_data,
+    gc_adopt_prompt, implement_from_issue, implement_from_prompt, plan_prompt, replan_prompt,
+    triage_prompt, wrap_external_data,
 };
 pub use parsing::{
     extract_pr_number, extract_review_issues, is_lgtm, is_quota_exhausted, is_waiting,

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -330,6 +330,7 @@ pub async fn gc_adopt(
                                 state.concurrency.workspace_mgr.clone(),
                                 permit,
                                 None,
+                                state.core.issue_workflow_store.clone(),
                             )
                             .await;
                             Ok(Some(tid.0))

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -235,10 +235,154 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                         state.concurrency.workspace_mgr.clone(),
                         permit,
                         state.intake.completion_callback.clone(),
+                        state.core.issue_workflow_store.clone(),
                         None,
                     )
                     .await;
                 });
+            }
+        }
+    });
+}
+
+/// Spawn a background sweeper that turns `pr_open` / `awaiting_feedback`
+/// issue workflows into `pr:N` review tasks.
+///
+/// This reuses the existing PR review loop instead of adding another GitHub API
+/// interpretation layer in the server. The workflow store decides *which* PRs
+/// need attention; the existing `pr:N` task path decides *what* to do.
+pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
+    if state.core.issue_workflow_store.is_none() {
+        tracing::debug!("workflow feedback sweeper disabled: issue workflow store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let state = match weak_state.upgrade() {
+                Some(s) => s,
+                None => break,
+            };
+            let workflow_cfg =
+                harness_core::config::workflow::load_workflow_config(&state.core.project_root)
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "workflow feedback sweeper: failed to load WORKFLOW.md, using default config: {e}"
+                        );
+                        harness_core::config::workflow::WorkflowConfig::default()
+                    });
+            let interval =
+                std::time::Duration::from_secs(workflow_cfg.pr_feedback.sweep_interval_secs);
+            tokio::time::sleep(interval).await;
+
+            if !workflow_cfg.pr_feedback.enabled {
+                tracing::debug!("workflow feedback sweeper: disabled by WORKFLOW.md");
+                continue;
+            }
+
+            let Some(issue_workflows) = state.core.issue_workflow_store.as_ref() else {
+                continue;
+            };
+
+            let candidates = match issue_workflows.list_feedback_candidates().await {
+                Ok(candidates) => candidates,
+                Err(e) => {
+                    tracing::warn!("workflow feedback sweep: failed to list candidates: {e}");
+                    continue;
+                }
+            };
+            if candidates.is_empty() {
+                continue;
+            }
+
+            let mut touched_projects = std::collections::HashSet::new();
+            for workflow in candidates {
+                let Some(pr_number) = workflow.pr_number else {
+                    continue;
+                };
+                if touched_projects.insert((workflow.project_id.clone(), workflow.repo.clone())) {
+                    if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                        if let Err(e) = project_store
+                            .record_feedback_sweep_started(
+                                &workflow.project_id,
+                                workflow.repo.as_deref(),
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                project_id = %workflow.project_id,
+                                "workflow feedback sweep: failed to mark project sweep start: {e}"
+                            );
+                        }
+                    }
+                }
+
+                let req = crate::task_runner::CreateTaskRequest {
+                    pr: Some(pr_number),
+                    project: Some(std::path::PathBuf::from(&workflow.project_id)),
+                    repo: workflow.repo.clone(),
+                    source: Some("workflow_feedback".to_string()),
+                    ..Default::default()
+                };
+
+                match task_routes::enqueue_task_background(state.clone(), req, None).await {
+                    Ok(task_id) => {
+                        tracing::info!(
+                            project_id = %workflow.project_id,
+                            pr = pr_number,
+                            task_id = %task_id.0,
+                            "workflow feedback sweep: PR task enqueued"
+                        );
+                    }
+                    Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
+                        retry_after_secs,
+                    }) => {
+                        if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                            let _ = project_store
+                                .record_paused(
+                                    &workflow.project_id,
+                                    workflow.repo.as_deref(),
+                                    &format!(
+                                        "feedback sweep paused by maintenance window; retry after {retry_after_secs}s"
+                                    ),
+                                )
+                                .await;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            project_id = %workflow.project_id,
+                            pr = pr_number,
+                            "workflow feedback sweep: failed to enqueue PR task: {e}"
+                        );
+                        if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                            let _ = project_store
+                                .record_degraded(
+                                    &workflow.project_id,
+                                    workflow.repo.as_deref(),
+                                    &format!(
+                                        "feedback sweep enqueue failed for pr:{pr_number}: {e}"
+                                    ),
+                                )
+                                .await;
+                        }
+                    }
+                }
+            }
+
+            if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                for (project_id, repo) in touched_projects {
+                    if let Err(e) = project_store
+                        .record_feedback_sweep_completed(&project_id, repo.as_deref())
+                        .await
+                    {
+                        tracing::warn!(
+                            project_id = %project_id,
+                            "workflow feedback sweep: failed to mark project sweep completion: {e}"
+                        );
+                    }
+                }
             }
         }
     });
@@ -471,6 +615,7 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
                     state.concurrency.workspace_mgr.clone(),
                     permit,
                     state.intake.completion_callback.clone(),
+                    state.core.issue_workflow_store.clone(),
                     None,
                 )
                 .await;
@@ -715,6 +860,7 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     state.concurrency.workspace_mgr.clone(),
                     permit,
                     state.intake.completion_callback.clone(),
+                    state.core.issue_workflow_store.clone(),
                     None,
                 )
                 .await;

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -297,11 +297,13 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
             }
 
             let mut touched_projects = std::collections::HashSet::new();
+            let mut incomplete_projects = std::collections::HashSet::new();
             for workflow in candidates {
                 let Some(pr_number) = workflow.pr_number else {
                     continue;
                 };
-                if touched_projects.insert((workflow.project_id.clone(), workflow.repo.clone())) {
+                let project_key = (workflow.project_id.clone(), workflow.repo.clone());
+                if touched_projects.insert(project_key.clone()) {
                     if let Some(project_store) = state.core.project_workflow_store.as_ref() {
                         if let Err(e) = project_store
                             .record_feedback_sweep_started(
@@ -338,6 +340,7 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                     Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
                         retry_after_secs,
                     }) => {
+                        incomplete_projects.insert(project_key.clone());
                         if let Some(project_store) = state.core.project_workflow_store.as_ref() {
                             let _ = project_store
                                 .record_paused(
@@ -351,6 +354,7 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                         }
                     }
                     Err(e) => {
+                        incomplete_projects.insert(project_key.clone());
                         tracing::warn!(
                             project_id = %workflow.project_id,
                             pr = pr_number,
@@ -373,6 +377,9 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
 
             if let Some(project_store) = state.core.project_workflow_store.as_ref() {
                 for (project_id, repo) in touched_projects {
+                    if incomplete_projects.contains(&(project_id.clone(), repo.clone())) {
+                        continue;
+                    }
                     if let Err(e) = project_store
                         .record_feedback_sweep_completed(&project_id, repo.as_deref())
                         .await

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -170,6 +170,7 @@ pub(crate) async fn build_intake(
         server.config.agents.review.clone(),
         Some(quality_trigger),
         server.config.server.github_token.clone(),
+        registry.issue_workflow_store.clone(),
     );
 
     // Wrap completion callback to record Q-value pipeline events and apply

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -9,6 +9,9 @@ pub(crate) struct RegistryBundle {
     pub thread_db: crate::thread_db::ThreadDb,
     pub plan_db: crate::plan_db::PlanDb,
     pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    pub issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
+    pub project_workflow_store:
+        Option<Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>>,
     pub project_registry: Arc<crate::project_registry::ProjectRegistry>,
     pub runtime_state_store: Option<Arc<crate::runtime_state_store::RuntimeStateStore>>,
     pub workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
@@ -73,6 +76,48 @@ pub(crate) async fn build_registry(
         }
         Err(e) => tracing::warn!("plan cache: failed to load plans on startup: {e}"),
     }
+
+    // ── Issue workflow store ──────────────────────────────────────────────────
+    let issue_workflow_store = {
+        let issue_workflows_db_path =
+            harness_core::config::dirs::default_db_path(data_dir, "issue_workflows");
+        match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
+            &issue_workflows_db_path,
+            configured_database_url,
+        )
+        .await
+        {
+            Ok(store) => Some(Arc::new(store)),
+            Err(e) => {
+                tracing::warn!(
+                    path = %issue_workflows_db_path.display(),
+                    "issue workflow store init failed, issue lifecycle state will not persist: {e}"
+                );
+                None
+            }
+        }
+    };
+
+    // ── Project workflow store ────────────────────────────────────────────────
+    let project_workflow_store = {
+        let project_workflows_db_path =
+            harness_core::config::dirs::default_db_path(data_dir, "project_workflows");
+        match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url(
+            &project_workflows_db_path,
+            configured_database_url,
+        )
+        .await
+        {
+            Ok(store) => Some(Arc::new(store)),
+            Err(e) => {
+                tracing::warn!(
+                    path = %project_workflows_db_path.display(),
+                    "project workflow store init failed, project lifecycle state will not persist: {e}"
+                );
+                None
+            }
+        }
+    };
 
     // ── Project registry ──────────────────────────────────────────────────────
     let project_registry = crate::project_registry::ProjectRegistry::open_with_database_url(
@@ -206,6 +251,8 @@ pub(crate) async fn build_registry(
         thread_db,
         plan_db,
         plan_cache,
+        issue_workflow_store,
+        project_workflow_store,
         project_registry,
         runtime_state_store,
         workspace_mgr,

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -71,6 +71,7 @@ pub(crate) async fn build_services(
         registry.workspace_mgr.clone(),
         intake.task_queue.clone(),
         intake.completion_callback.clone(),
+        registry.issue_workflow_store.clone(),
         Some(registry.project_registry.clone()),
         server.config.server.allowed_project_roots.clone(),
     );

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -7,7 +7,8 @@ use axum::{
 use std::sync::Arc;
 
 use super::{
-    auth, get_task, get_task_artifacts, get_task_prompts, github_webhook, handle_rpc, health_check,
+    auth, get_issue_workflow_by_issue, get_issue_workflow_by_pr, get_project_workflow_by_project,
+    get_task, get_task_artifacts, get_task_prompts, github_webhook, handle_rpc, health_check,
     ingest_signal, intake_status, list_tasks, password_reset, project_queue_stats, state::AppState,
     stream_task_sse, task_routes,
 };
@@ -51,6 +52,15 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             get(crate::handlers::operator_snapshot::operator_snapshot),
         )
         .route("/api/intake", get(intake_status))
+        .route(
+            "/api/workflows/issues/by-issue",
+            get(get_issue_workflow_by_issue),
+        )
+        .route("/api/workflows/issues/by-pr", get(get_issue_workflow_by_pr))
+        .route(
+            "/api/workflows/projects/by-project",
+            get(get_project_workflow_by_project),
+        )
         .route(
             "/api/runtime-hosts",
             get(crate::handlers::runtime_hosts::list_runtime_hosts),

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -389,6 +389,7 @@ pub(crate) fn build_completion_callback(
                         if let Err(e) = workflows
                             .record_terminal_for_issue(
                                 &project_id,
+                                task.repo.as_deref(),
                                 issue_number,
                                 final_state,
                                 task_error,
@@ -416,7 +417,14 @@ pub(crate) fn build_completion_callback(
                             | task_runner::TaskStatus::Cancelled
                     ) {
                         if let Err(e) = workflows
-                            .record_terminal_for_pr(&project_id, pr_number, success, task_error)
+                            .record_terminal_for_pr(
+                                &project_id,
+                                task.repo.as_deref(),
+                                pr_number,
+                                success,
+                                matches!(task.status, task_runner::TaskStatus::Cancelled),
+                                task_error,
+                            )
                             .await
                         {
                             tracing::warn!(

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -44,6 +44,11 @@ pub(super) fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
     path.to_path_buf()
 }
 
+fn parse_external_id_number(prefix: &str, external_id: Option<&str>) -> Option<u64> {
+    let value = external_id?;
+    value.strip_prefix(prefix)?.parse::<u64>().ok()
+}
+
 /// Build an AppState with all stores. Used by both HTTP and stdio transports.
 ///
 /// Initialization is split into five ordered phases — each phase's outputs
@@ -185,6 +190,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             thread_db: Some(registry.thread_db),
             plan_db: Some(registry.plan_db),
             plan_cache: registry.plan_cache,
+            issue_workflow_store: registry.issue_workflow_store,
+            project_workflow_store: registry.project_workflow_store,
             project_registry: Some(registry.project_registry),
             runtime_state_store: registry.runtime_state_store,
             q_values: storage.q_values,
@@ -242,6 +249,7 @@ pub(crate) fn build_completion_callback(
     review_config: harness_core::config::agents::AgentReviewConfig,
     quality_trigger: Option<Arc<crate::quality_trigger::QualityTrigger>>,
     config_github_token: Option<String>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
 ) -> Option<task_runner::CompletionCallback> {
     let mut sources: std::collections::HashMap<String, Arc<dyn crate::intake::IntakeSource>> =
         std::collections::HashMap::new();
@@ -268,6 +276,7 @@ pub(crate) fn build_completion_callback(
         let review_config = review_config.clone();
         let quality_trigger = quality_trigger.clone();
         let github_token = config_github_token.clone();
+        let issue_workflow_store = issue_workflow_store.clone();
         Box::pin(async move {
             // Grade recent events and auto-trigger GC if quality is poor.
             if let Some(qt) = quality_trigger {
@@ -346,6 +355,75 @@ pub(crate) fn build_completion_callback(
                                     );
                                 }
                             }
+                        }
+                    }
+                }
+            }
+
+            if let (Some(workflows), Some(project_root)) =
+                (issue_workflow_store.as_ref(), task.project_root.as_ref())
+            {
+                let project_id = project_root.to_string_lossy().into_owned();
+                let task_error = task.error.as_deref();
+                if let Some(issue_number) = task
+                    .issue
+                    .or_else(|| parse_external_id_number("issue:", task.external_id.as_deref()))
+                {
+                    let final_state = match task.status {
+                        task_runner::TaskStatus::Done => {
+                            if task.pr_url.is_none() {
+                                Some(harness_workflow::issue_lifecycle::IssueLifecycleState::Done)
+                            } else {
+                                None
+                            }
+                        }
+                        task_runner::TaskStatus::Failed => {
+                            Some(harness_workflow::issue_lifecycle::IssueLifecycleState::Failed)
+                        }
+                        task_runner::TaskStatus::Cancelled => {
+                            Some(harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled)
+                        }
+                        _ => None,
+                    };
+                    if let Some(final_state) = final_state {
+                        if let Err(e) = workflows
+                            .record_terminal_for_issue(
+                                &project_id,
+                                issue_number,
+                                final_state,
+                                task_error,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                issue = issue_number,
+                                task_id = ?task.id,
+                                "issue workflow terminal update failed: {e}"
+                            );
+                        }
+                    }
+                } else if let Some(pr_number) = task
+                    .pr_url
+                    .as_deref()
+                    .and_then(crate::http::parse_pr_num_from_url)
+                    .or_else(|| parse_external_id_number("pr:", task.external_id.as_deref()))
+                {
+                    let success = matches!(task.status, task_runner::TaskStatus::Done);
+                    if matches!(
+                        task.status,
+                        task_runner::TaskStatus::Done
+                            | task_runner::TaskStatus::Failed
+                            | task_runner::TaskStatus::Cancelled
+                    ) {
+                        if let Err(e) = workflows
+                            .record_terminal_for_pr(&project_id, pr_number, success, task_error)
+                            .await
+                        {
+                            tracing::warn!(
+                                pr = pr_number,
+                                task_id = ?task.id,
+                                "issue workflow PR terminal update failed: {e}"
+                            );
                         }
                     }
                 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -64,18 +64,21 @@ pub(crate) async fn project_queue_stats(
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct IssueWorkflowByIssueQuery {
     pub project_id: String,
+    pub repo: Option<String>,
     pub issue: u64,
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct IssueWorkflowByPrQuery {
     pub project_id: String,
+    pub repo: Option<String>,
     pub pr: u64,
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct ProjectWorkflowByProjectQuery {
     pub project_id: String,
+    pub repo: Option<String>,
 }
 
 pub(crate) async fn get_issue_workflow_by_issue(
@@ -89,7 +92,10 @@ pub(crate) async fn get_issue_workflow_by_issue(
         )
             .into_response();
     };
-    match store.get_by_issue(&query.project_id, query.issue).await {
+    match store
+        .get_by_issue(&query.project_id, query.repo.as_deref(), query.issue)
+        .await
+    {
         Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -115,7 +121,10 @@ pub(crate) async fn get_issue_workflow_by_pr(
         )
             .into_response();
     };
-    match store.get_by_pr(&query.project_id, query.pr).await {
+    match store
+        .get_by_pr(&query.project_id, query.repo.as_deref(), query.pr)
+        .await
+    {
         Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -141,7 +150,10 @@ pub(crate) async fn get_project_workflow_by_project(
         )
             .into_response();
     };
-    match store.get_by_project(&query.project_id).await {
+    match store
+        .get_by_project(&query.project_id, query.repo.as_deref())
+        .await
+    {
         Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -485,12 +497,12 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                         });
                     summary.workflow = match (by_issue, by_pr) {
                         (Some(issue), _) => workflow_store
-                            .get_by_issue(project_id, issue)
+                            .get_by_issue(project_id, summary.repo.as_deref(), issue)
                             .await
                             .ok()
                             .flatten(),
                         (None, Some(pr)) => workflow_store
-                            .get_by_pr(project_id, pr)
+                            .get_by_pr(project_id, summary.repo.as_deref(), pr)
                             .await
                             .ok()
                             .flatten(),

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Bytes,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
@@ -59,6 +59,101 @@ pub(crate) async fn project_queue_stats(
         },
         "projects": projects,
     }))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct IssueWorkflowByIssueQuery {
+    pub project_id: String,
+    pub issue: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct IssueWorkflowByPrQuery {
+    pub project_id: String,
+    pub pr: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct ProjectWorkflowByProjectQuery {
+    pub project_id: String,
+}
+
+pub(crate) async fn get_issue_workflow_by_issue(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<IssueWorkflowByIssueQuery>,
+) -> Response {
+    let Some(store) = state.core.issue_workflow_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "issue workflow store unavailable" })),
+        )
+            .into_response();
+    };
+    match store.get_by_issue(&query.project_id, query.issue).await {
+        Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "issue workflow not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+pub(crate) async fn get_issue_workflow_by_pr(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<IssueWorkflowByPrQuery>,
+) -> Response {
+    let Some(store) = state.core.issue_workflow_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "issue workflow store unavailable" })),
+        )
+            .into_response();
+    };
+    match store.get_by_pr(&query.project_id, query.pr).await {
+        Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "issue workflow not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+pub(crate) async fn get_project_workflow_by_project(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ProjectWorkflowByProjectQuery>,
+) -> Response {
+    let Some(store) = state.core.project_workflow_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "project workflow store unavailable" })),
+        )
+            .into_response();
+    };
+    match store.get_by_project(&query.project_id).await {
+        Ok(Some(workflow)) => (StatusCode::OK, Json(json!(workflow))).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "project workflow not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
 }
 
 pub(crate) async fn handle_rpc(
@@ -366,7 +461,45 @@ pub(crate) async fn github_webhook(
 
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
-        Ok(summaries) => Json(summaries).into_response(),
+        Ok(mut summaries) => {
+            if let Some(workflow_store) = state.core.issue_workflow_store.as_ref() {
+                for summary in &mut summaries {
+                    let Some(project_id) = summary.project.as_deref() else {
+                        continue;
+                    };
+                    let by_issue = summary
+                        .external_id
+                        .as_deref()
+                        .and_then(|id| id.strip_prefix("issue:"))
+                        .and_then(|n| n.parse::<u64>().ok());
+                    let by_pr = summary
+                        .external_id
+                        .as_deref()
+                        .and_then(|id| id.strip_prefix("pr:"))
+                        .and_then(|n| n.parse::<u64>().ok())
+                        .or_else(|| {
+                            summary
+                                .pr_url
+                                .as_deref()
+                                .and_then(crate::http::parse_pr_num_from_url)
+                        });
+                    summary.workflow = match (by_issue, by_pr) {
+                        (Some(issue), _) => workflow_store
+                            .get_by_issue(project_id, issue)
+                            .await
+                            .ok()
+                            .flatten(),
+                        (None, Some(pr)) => workflow_store
+                            .get_by_pr(project_id, pr)
+                            .await
+                            .ok()
+                            .flatten(),
+                        (None, None) => None,
+                    };
+                }
+            }
+            Json(summaries).into_response()
+        }
         Err(e) => {
             tracing::error!("list_tasks: database error: {e}");
             (

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -41,6 +41,7 @@ pub use state::{
 
 // Handler re-exports — moved to focused submodules, kept accessible via `crate::http::`.
 pub(crate) use misc_routes::{
+    get_issue_workflow_by_issue, get_issue_workflow_by_pr, get_project_workflow_by_project,
     get_task, get_task_artifacts, get_task_prompts, github_webhook, handle_rpc, health_check,
     ingest_signal, intake_status, list_tasks, password_reset, project_queue_stats,
 };
@@ -144,6 +145,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
 
     // Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
     background::spawn_checkpoint_recovery(&state).await;
+
+    // Periodically sweep issue workflows with attached PRs and automatically
+    // enqueue `pr:N` tasks so PR feedback is handled without manual resubmission.
+    background::spawn_issue_workflow_feedback_sweeper(&state);
 
     let initial_grade = {
         let events = state

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -20,6 +20,9 @@ pub struct CoreServices {
     /// In-memory plan cache hydrated from `plan_db` on startup.
     /// Write-through: every mutation must also persist via `plan_db`.
     pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    pub issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
+    pub project_workflow_store:
+        Option<Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>>,
     pub project_registry: Option<std::sync::Arc<crate::project_registry::ProjectRegistry>>,
     pub runtime_state_store: Option<Arc<crate::runtime_state_store::RuntimeStateStore>>,
     /// Q-value store for MemRL rule utility tracking. None when unavailable.

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -153,6 +153,49 @@ async fn check_pr_duplicate(
     Some(existing_id)
 }
 
+async fn track_issue_workflow_enqueue(
+    state: &Arc<AppState>,
+    project_id: &str,
+    req: &task_runner::CreateTaskRequest,
+    task_id: &task_runner::TaskId,
+) {
+    let Some(workflows) = state.core.issue_workflow_store.as_ref() else {
+        return;
+    };
+    if let Some(issue_number) = req.issue {
+        if let Err(e) = workflows
+            .record_issue_scheduled(
+                project_id,
+                req.repo.as_deref(),
+                issue_number,
+                &task_id.0,
+                &req.labels,
+                req.force_execute,
+            )
+            .await
+        {
+            tracing::warn!(
+                issue = issue_number,
+                task_id = %task_id.0,
+                "issue workflow enqueue tracking failed: {e}"
+            );
+        }
+        return;
+    }
+    if let Some(pr_number) = req.pr {
+        if let Err(e) = workflows
+            .record_feedback_task_scheduled(project_id, pr_number, &task_id.0)
+            .await
+        {
+            tracing::warn!(
+                pr = pr_number,
+                task_id = %task_id.0,
+                "issue workflow PR enqueue tracking failed: {e}"
+            );
+        }
+    }
+}
+
 /// Three-tier agent selection: request override > project default > complexity dispatch.
 ///
 /// Tier 1: `req.agent` is `Some` — use the named agent directly (unchanged behaviour).
@@ -315,9 +358,11 @@ pub(crate) async fn enqueue_task_in_domain(
             }
         }
         if !all_deps_done {
+            let workflow_req = req.clone();
             let task_id = task_runner::spawn_task_awaiting_deps(state.core.tasks.clone(), req)
                 .await
                 .map_err(|e| EnqueueTaskError::BadRequest(e.to_string()))?;
+            track_issue_workflow_enqueue(state, &project_id, &workflow_req, &task_id).await;
             return Ok(task_id);
         }
         // All deps satisfied — clear the list so the normal spawn path
@@ -352,6 +397,7 @@ pub(crate) async fn enqueue_task_in_domain(
         agent.name(),
     );
 
+    let workflow_req = req.clone();
     let task_id = task_runner::spawn_task(
         state.core.tasks.clone(),
         agent,
@@ -364,8 +410,11 @@ pub(crate) async fn enqueue_task_in_domain(
         state.concurrency.workspace_mgr.clone(),
         permit,
         state.intake.completion_callback.clone(),
+        state.core.issue_workflow_store.clone(),
     )
     .await;
+
+    track_issue_workflow_enqueue(state, &project_id, &workflow_req, &task_id).await;
 
     Ok(task_id)
 }
@@ -556,6 +605,7 @@ pub(crate) async fn enqueue_task_background_in_domain(
 
     // Register the task immediately so the caller gets an ID without blocking.
     let task_id = task_runner::register_pending_task(state.core.tasks.clone(), &req).await;
+    track_issue_workflow_enqueue(&state, &project_id, &req, &task_id).await;
 
     // Spawn a background tokio task that waits for a concurrency slot then executes.
     // The HTTP handler returns the task_id before this future completes.
@@ -589,6 +639,7 @@ pub(crate) async fn enqueue_task_background_in_domain(
                         state.concurrency.workspace_mgr.clone(),
                         permit,
                         state.intake.completion_callback.clone(),
+                        state.core.issue_workflow_store.clone(),
                         group_permit,
                     )
                     .await;

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -164,10 +164,10 @@ async fn track_issue_workflow_enqueue(
     };
     if let Some(issue_number) = req.issue {
         if let Err(e) = workflows
-                .record_issue_scheduled(
-                    project_id,
-                    req.repo.as_deref(),
-                    issue_number,
+            .record_issue_scheduled(
+                project_id,
+                req.repo.as_deref(),
+                issue_number,
                 &task_id.0,
                 &req.labels,
                 req.force_execute,
@@ -182,11 +182,11 @@ async fn track_issue_workflow_enqueue(
         }
         return;
     }
-        if let Some(pr_number) = req.pr {
-            if let Err(e) = workflows
-                .record_feedback_task_scheduled(project_id, req.repo.as_deref(), pr_number, &task_id.0)
-                .await
-            {
+    if let Some(pr_number) = req.pr {
+        if let Err(e) = workflows
+            .record_feedback_task_scheduled(project_id, req.repo.as_deref(), pr_number, &task_id.0)
+            .await
+        {
             tracing::warn!(
                 pr = pr_number,
                 task_id = %task_id.0,

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -164,10 +164,10 @@ async fn track_issue_workflow_enqueue(
     };
     if let Some(issue_number) = req.issue {
         if let Err(e) = workflows
-            .record_issue_scheduled(
-                project_id,
-                req.repo.as_deref(),
-                issue_number,
+                .record_issue_scheduled(
+                    project_id,
+                    req.repo.as_deref(),
+                    issue_number,
                 &task_id.0,
                 &req.labels,
                 req.force_execute,
@@ -182,11 +182,11 @@ async fn track_issue_workflow_enqueue(
         }
         return;
     }
-    if let Some(pr_number) = req.pr {
-        if let Err(e) = workflows
-            .record_feedback_task_scheduled(project_id, pr_number, &task_id.0)
-            .await
-        {
+        if let Some(pr_number) = req.pr {
+            if let Err(e) = workflows
+                .record_feedback_task_scheduled(project_id, req.repo.as_deref(), pr_number, &task_id.0)
+                .await
+            {
             tracing::warn!(
                 pr = pr_number,
                 task_id = %task_id.0,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -113,6 +113,7 @@ async fn make_test_state_with(
         Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
         None,
         None,
+        None,
         vec![],
     );
     Ok(Arc::new(AppState {
@@ -126,6 +127,8 @@ async fn make_test_state_with(
             thread_db: Some(thread_db),
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+            issue_workflow_store: None,
+            project_workflow_store: None,
             project_registry: None,
             runtime_state_store: None,
             q_values: None,

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -165,6 +165,26 @@ impl IntakeOrchestrator {
         // 2. Run a separate sprint planner per repo, all in parallel.
         let mut handles = Vec::new();
         for (repo, issues) in by_repo {
+            let project_root = issues
+                .first()
+                .and_then(|(_, i)| i.project_root.clone())
+                .unwrap_or_else(|| state.core.project_root.clone());
+            let project_id =
+                match crate::task_runner::resolve_canonical_project(Some(project_root)).await {
+                    Ok(path) => path.to_string_lossy().into_owned(),
+                    Err(_) => state.core.project_root.to_string_lossy().into_owned(),
+                };
+            if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_poll_started(&project_id, Some(&repo))
+                    .await
+                {
+                    tracing::warn!(
+                        repo,
+                        "intake: failed to mark project workflow poll state: {e}"
+                    );
+                }
+            }
             let state = Arc::clone(state);
             let planner_agent = self.planner_agent.clone();
             let sprint_timeout = self.sprint_timeout;
@@ -303,16 +323,40 @@ async fn run_repo_sprint(
     retry_backoff_base: Duration,
     retry_backoff_max: Duration,
 ) {
+    let project_root = issues
+        .first()
+        .and_then(|(_, i)| i.project_root.clone())
+        .unwrap_or_else(|| state.core.project_root.clone());
+    let project_id = match crate::task_runner::resolve_canonical_project(Some(project_root.clone()))
+        .await
+    {
+        Ok(path) => path.to_string_lossy().into_owned(),
+        Err(e) => {
+            tracing::warn!(
+                repo,
+                "intake: failed to canonicalize project root for workflow lookup, using raw path: {e}"
+            );
+            project_root.to_string_lossy().into_owned()
+        }
+    };
+
+    if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+        if let Err(e) = workflows
+            .record_planning_started(&project_id, Some(repo))
+            .await
+        {
+            tracing::warn!(
+                repo,
+                "intake: failed to mark project workflow planning state: {e}"
+            );
+        }
+    }
+
     tracing::info!(
         repo,
         count = issues.len(),
         "intake: planning sprint for repo"
     );
-
-    let project_root = issues
-        .first()
-        .and_then(|(_, i)| i.project_root.clone())
-        .unwrap_or_else(|| state.core.project_root.clone());
 
     // 1. Run sprint planner.
     let issue_summary = build_issue_summary(&issues);
@@ -328,10 +372,37 @@ async fn run_repo_sprint(
 
     let planner_task_id = match crate::http::task_routes::enqueue_task(state, planner_req).await {
         Ok(id) => {
+            if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_planner_enqueued(&project_id, Some(repo), &id.0)
+                    .await
+                {
+                    tracing::warn!(
+                        repo,
+                        task_id = %id,
+                        "intake: failed to record planner enqueue on project workflow: {e}"
+                    );
+                }
+            }
             tracing::info!(repo, task_id = %id, "intake: sprint planner enqueued");
             id
         }
         Err(e) => {
+            if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+                if let Err(track_err) = workflows
+                    .record_degraded(
+                        &project_id,
+                        Some(repo),
+                        &format!("failed to enqueue sprint planner: {e:?}"),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        repo,
+                        "intake: failed to record degraded project workflow state: {track_err}"
+                    );
+                }
+            }
             tracing::error!(repo, "intake: failed to enqueue sprint planner: {e:?}");
             return;
         }
@@ -340,11 +411,33 @@ async fn run_repo_sprint(
     let Some(planner_output) =
         poll_task_output(&state.core.tasks, &planner_task_id, sprint_timeout).await
     else {
+        if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+            if let Err(e) = workflows
+                .record_degraded(&project_id, Some(repo), "sprint planner failed")
+                .await
+            {
+                tracing::warn!(
+                    repo,
+                    "intake: failed to record degraded project workflow state: {e}"
+                );
+            }
+        }
         tracing::error!(repo, task_id = %planner_task_id, "intake: sprint planner failed");
         return;
     };
 
     let Some(plan) = harness_core::prompts::parse_sprint_plan(&planner_output) else {
+        if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+            if let Err(e) = workflows
+                .record_degraded(&project_id, Some(repo), "failed to parse sprint plan")
+                .await
+            {
+                tracing::warn!(
+                    repo,
+                    "intake: failed to record degraded project workflow state: {e}"
+                );
+            }
+        }
         tracing::error!(repo, task_id = %planner_task_id, "intake: failed to parse sprint plan");
         return;
     };
@@ -407,20 +500,9 @@ async fn run_repo_sprint(
         return;
     }
 
-    let project_id = match crate::task_runner::resolve_canonical_project(Some(project_root.clone()))
-        .await
-    {
-        Ok(path) => path.to_string_lossy().into_owned(),
-        Err(e) => {
-            tracing::warn!(
-                repo,
-                "intake: failed to canonicalize project root for slot limit lookup, using raw path: {e}"
-            );
-            project_root.to_string_lossy().into_owned()
-        }
-    };
     let start = tokio::time::Instant::now();
     let mut transient_retry_count = 0u32;
+    let mut project_workflow_monitoring_started = false;
 
     'sprint: loop {
         // All done?
@@ -447,6 +529,19 @@ async fn run_repo_sprint(
         // Fill available slots.
         let available =
             sprint_available_slots(&state.concurrency.task_queue.diagnostics(&project_id));
+        if available > 0 {
+            if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_dispatch_started(&project_id, Some(repo))
+                    .await
+                {
+                    tracing::warn!(
+                        repo,
+                        "intake: failed to mark project workflow dispatching state: {e}"
+                    );
+                }
+            }
+        }
         for &issue_num in ready.iter().take(available) {
             let ext_id = issue_num.to_string();
             let Some((source, issue)) = issue_map.get(&ext_id) else {
@@ -463,6 +558,15 @@ async fn run_repo_sprint(
             }
 
             let req = crate::task_runner::CreateTaskRequest {
+                force_execute: {
+                    let workflow_cfg =
+                        harness_core::config::workflow::load_workflow_config(&project_root)
+                            .unwrap_or_default();
+                    issue
+                        .labels
+                        .iter()
+                        .any(|label| label == &workflow_cfg.issue_workflow.force_execute_label)
+                },
                 issue: issue.external_id.parse().ok(),
                 project: issue
                     .project_root
@@ -471,6 +575,7 @@ async fn run_repo_sprint(
                 source: Some(source.name().to_string()),
                 external_id: Some(issue.external_id.clone()),
                 repo: Some(repo.to_string()),
+                labels: issue.labels.clone(),
                 ..Default::default()
             };
 
@@ -556,6 +661,20 @@ async fn run_repo_sprint(
         }
 
         // Wait for any running task to complete.
+        if !running.is_empty() && !project_workflow_monitoring_started {
+            if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_monitoring_started(&project_id, Some(repo))
+                    .await
+                {
+                    tracing::warn!(
+                        repo,
+                        "intake: failed to mark project workflow monitoring state: {e}"
+                    );
+                }
+            }
+            project_workflow_monitoring_started = true;
+        }
         tokio::time::sleep(TASK_POLL_INTERVAL).await;
         let mut newly_done = Vec::new();
         let mut cancelled = Vec::new();
@@ -612,6 +731,29 @@ async fn run_repo_sprint(
         elapsed_secs = start.elapsed().as_secs(),
         "intake: repo sprint complete"
     );
+
+    if let Some(workflows) = state.core.project_workflow_store.as_ref() {
+        let result = if stranded.is_empty() {
+            workflows.record_idle(&project_id, Some(repo)).await
+        } else {
+            workflows
+                .record_degraded(
+                    &project_id,
+                    Some(repo),
+                    &format!(
+                        "repo sprint ended with unresolved tasks: {}",
+                        stranded.len()
+                    ),
+                )
+                .await
+        };
+        if let Err(e) = result {
+            tracing::warn!(
+                repo,
+                "intake: failed to finalize project workflow state: {e}"
+            );
+        }
+    }
 
     if !stranded.is_empty() {
         tracing::error!(

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -60,6 +60,7 @@ async fn make_test_state_with_config_and_registry(
         Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
         None,
         None,
+        None,
         vec![],
     );
     Ok(AppState {
@@ -73,6 +74,8 @@ async fn make_test_state_with_config_and_registry(
             thread_db: Some(thread_db),
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+            issue_workflow_store: None,
+            project_workflow_store: None,
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
@@ -1385,6 +1388,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
         None,
         None,
+        None,
         vec![],
     );
     Ok(AppState {
@@ -1398,6 +1402,8 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             thread_db: Some(thread_db),
             plan_db: Some(plan_db),
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+            issue_workflow_store: None,
+            project_workflow_store: None,
             project_registry: None,
             runtime_state_store: None,
             q_values: None,

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -220,7 +220,12 @@ impl DefaultExecutionService {
         }
         if let Some(pr_number) = req.pr {
             if let Err(e) = workflows
-                .record_feedback_task_scheduled(project_id, req.repo.as_deref(), pr_number, &task_id.0)
+                .record_feedback_task_scheduled(
+                    project_id,
+                    req.repo.as_deref(),
+                    pr_number,
+                    &task_id.0,
+                )
                 .await
             {
                 tracing::warn!(

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -220,7 +220,7 @@ impl DefaultExecutionService {
         }
         if let Some(pr_number) = req.pr {
             if let Err(e) = workflows
-                .record_feedback_task_scheduled(project_id, pr_number, &task_id.0)
+                .record_feedback_task_scheduled(project_id, req.repo.as_deref(), pr_number, &task_id.0)
                 .await
             {
                 tracing::warn!(

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -80,6 +80,7 @@ pub struct DefaultExecutionService {
     workspace_mgr: Option<Arc<WorkspaceManager>>,
     task_queue: Arc<TaskQueue>,
     completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     project_registry: Option<Arc<ProjectRegistry>>,
     allowed_project_roots: Vec<PathBuf>,
 }
@@ -96,6 +97,7 @@ impl DefaultExecutionService {
         workspace_mgr: Option<Arc<WorkspaceManager>>,
         task_queue: Arc<TaskQueue>,
         completion_callback: Option<CompletionCallback>,
+        issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
         project_registry: Option<Arc<ProjectRegistry>>,
         allowed_project_roots: Vec<PathBuf>,
     ) -> Arc<Self> {
@@ -109,6 +111,7 @@ impl DefaultExecutionService {
             workspace_mgr,
             task_queue,
             completion_callback,
+            issue_workflow_store,
             project_registry,
             allowed_project_roots,
         })
@@ -185,6 +188,49 @@ impl DefaultExecutionService {
                 .map_err(|e| EnqueueTaskError::Internal(e.to_string()))
         }
     }
+
+    async fn track_issue_workflow(
+        &self,
+        project_id: &str,
+        req: &CreateTaskRequest,
+        task_id: &TaskId,
+    ) {
+        let Some(workflows) = self.issue_workflow_store.as_ref() else {
+            return;
+        };
+        if let Some(issue_number) = req.issue {
+            if let Err(e) = workflows
+                .record_issue_scheduled(
+                    project_id,
+                    req.repo.as_deref(),
+                    issue_number,
+                    &task_id.0,
+                    &req.labels,
+                    req.force_execute,
+                )
+                .await
+            {
+                tracing::warn!(
+                    issue = issue_number,
+                    task_id = %task_id.0,
+                    "issue workflow enqueue tracking failed: {e}"
+                );
+            }
+            return;
+        }
+        if let Some(pr_number) = req.pr {
+            if let Err(e) = workflows
+                .record_feedback_task_scheduled(project_id, pr_number, &task_id.0)
+                .await
+            {
+                tracing::warn!(
+                    pr = pr_number,
+                    task_id = %task_id.0,
+                    "issue workflow PR enqueue tracking failed: {e}"
+                );
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -215,6 +261,7 @@ impl ExecutionService for DefaultExecutionService {
             agent.name(),
         );
 
+        let workflow_req = req.clone();
         let task_id = task_runner::spawn_task(
             self.tasks.clone(),
             agent,
@@ -227,8 +274,12 @@ impl ExecutionService for DefaultExecutionService {
             self.workspace_mgr.clone(),
             permit,
             self.completion_callback.clone(),
+            self.issue_workflow_store.clone(),
         )
         .await;
+
+        self.track_issue_workflow(&project_id, &workflow_req, &task_id)
+            .await;
 
         Ok(task_id)
     }
@@ -271,7 +322,9 @@ impl ExecutionService for DefaultExecutionService {
         let workspace_mgr = self.workspace_mgr.clone();
         let task_queue = self.task_queue.clone();
         let completion_callback = self.completion_callback.clone();
+        let issue_workflow_store = self.issue_workflow_store.clone();
         let task_id2 = task_id.clone();
+        self.track_issue_workflow(&project_id, &req, &task_id).await;
         tokio::spawn(async move {
             match task_queue.acquire(&project_id, req.priority).await {
                 Ok(permit) => {
@@ -288,6 +341,7 @@ impl ExecutionService for DefaultExecutionService {
                         workspace_mgr,
                         permit,
                         completion_callback,
+                        issue_workflow_store,
                         None,
                     )
                     .await;
@@ -511,6 +565,7 @@ mod tests {
             None,
             make_task_queue(),
             None,
+            None,
             registry,
             vec![],
         )
@@ -531,6 +586,7 @@ mod tests {
             vec![],
             None,
             make_task_queue(),
+            None,
             None,
             None,
             allowed,

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -175,6 +175,7 @@ mod tests {
             Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             None,
             None,
+            None,
             vec![],
         );
 
@@ -189,6 +190,8 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+                issue_workflow_store: None,
+                project_workflow_store: None,
                 project_registry: None,
                 runtime_state_store: None,
                 q_values: None,

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -270,6 +270,7 @@ impl TaskSummaryRow {
             depends_on,
             subtask_ids: Vec::new(),
             project: self.project,
+            workflow: None,
         })
     }
 }

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -76,6 +76,13 @@ pub(crate) fn task_needs_pr_url(req: &CreateTaskRequest) -> bool {
 pub(crate) enum ImplementOutcome {
     /// Task is fully complete (success or failure already persisted) — caller returns Ok(()).
     Done,
+    /// Implementation reported that the current plan is incomplete and the
+    /// caller should choose between replan or force-execute retry.
+    Replan {
+        issue: u64,
+        plan_issue: String,
+        prior_plan: Option<String>,
+    },
     /// Implementation succeeded — proceed to conflict resolution and review.
     Proceed {
         pr_url: Option<String>,
@@ -112,6 +119,7 @@ pub(crate) async fn run_implement_phase(
     project: &Path,
     plan_output: Option<String>,
     resumed_pr_url: Option<String>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     turn_timeout: Duration,
     effective_max_turns: Option<u32>,
     turns_used: &mut u32,
@@ -600,6 +608,34 @@ pub(crate) async fn run_implement_phase(
 
         let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
             ImplementationOutcome::PlanIssue(plan_issue) => {
+                if let (Some(workflows), Some(issue_number)) =
+                    (issue_workflow_store.as_ref(), req.issue)
+                {
+                    let project_id = project.to_string_lossy().into_owned();
+                    if let Err(e) = workflows
+                        .record_plan_issue_detected(
+                            &project_id,
+                            req.repo.as_deref(),
+                            issue_number,
+                            &task_id.0,
+                            &plan_issue,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            issue = issue_number,
+                            task_id = %task_id.0,
+                            "issue workflow PLAN_ISSUE tracking failed: {e}"
+                        );
+                    }
+                }
+                if let Some(issue_number) = req.issue {
+                    return Ok(ImplementOutcome::Replan {
+                        issue: issue_number,
+                        plan_issue,
+                        prior_plan: plan_output.clone(),
+                    });
+                }
                 tracing::error!(
                     task_id = %task_id,
                     plan_issue = %plan_issue,
@@ -688,6 +724,29 @@ pub(crate) async fn run_implement_phase(
 
         // Emit PrDetected event so crash recovery can reconstruct pr_url.
         if let Some(pr_url_str) = pr_url.as_deref() {
+            if let (Some(workflows), Some(issue_number), Some(pr_number)) =
+                (issue_workflow_store.as_ref(), req.issue, pr_num)
+            {
+                let project_id = project.to_string_lossy().into_owned();
+                if let Err(e) = workflows
+                    .record_pr_detected(
+                        &project_id,
+                        req.repo.as_deref(),
+                        issue_number,
+                        &task_id.0,
+                        pr_number,
+                        pr_url_str,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        issue = issue_number,
+                        pr = pr_number,
+                        task_id = %task_id.0,
+                        "issue workflow PR binding failed: {e}"
+                    );
+                }
+            }
             store.log_event(crate::event_replay::TaskEvent::PrDetected {
                 task_id: task_id.0.clone(),
                 ts: crate::event_replay::now_ts(),

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -171,6 +171,7 @@ pub(crate) async fn run_task(
     req: &CreateTaskRequest,
     project: PathBuf,
     server_config: &harness_core::config::HarnessConfig,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     // Accumulated turn count from previous transient-retry attempts.
     // Ensures the max_turns budget is global across the full task lifecycle,
     // not reset on each retry (fix for budget-reset-on-retry bug).
@@ -335,40 +336,126 @@ pub(crate) async fn run_task(
 
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
 
-    // Run the implement phase (prompt construction + agent execution + PR detection).
-    let outcome = implement_pipeline::run_implement_phase(
-        store,
-        task_id,
-        agent,
-        req,
-        server_config,
-        &project_config,
-        review_config,
-        &interceptors,
-        &events,
-        &skills,
-        &cargo_env,
-        git,
-        &repo_slug,
-        &project,
-        plan_output,
-        resumed_pr_url,
-        turn_timeout,
-        effective_max_turns,
-        &mut turns_used,
-        turns_used_acc,
-        task_start,
-    )
-    .await?;
+    if let (Some(workflows), Some(issue_number)) = (issue_workflow_store.as_ref(), req.issue) {
+        let project_id = project.to_string_lossy().into_owned();
+        if let Err(e) = workflows
+            .record_implement_started(&project_id, req.repo.as_deref(), issue_number, &task_id.0)
+            .await
+        {
+            tracing::warn!(
+                issue = issue_number,
+                task_id = %task_id.0,
+                "issue workflow implement-start tracking failed: {e}"
+            );
+        }
+    }
 
-    let (pr_url, pr_num, context_items) = match outcome {
-        implement_pipeline::ImplementOutcome::Done => return Ok(()),
-        implement_pipeline::ImplementOutcome::Proceed {
-            pr_url,
-            pr_num,
-            context_items,
-            ..
-        } => (pr_url, pr_num, context_items),
+    let mut current_plan_output = plan_output;
+    let mut replan_attempted = false;
+    let (pr_url, pr_num, context_items) = loop {
+        let outcome = implement_pipeline::run_implement_phase(
+            store,
+            task_id,
+            agent,
+            req,
+            server_config,
+            &project_config,
+            review_config,
+            &interceptors,
+            &events,
+            &skills,
+            &cargo_env,
+            git,
+            &repo_slug,
+            &project,
+            current_plan_output.clone(),
+            resumed_pr_url.clone(),
+            issue_workflow_store.clone(),
+            turn_timeout,
+            effective_max_turns,
+            &mut turns_used,
+            turns_used_acc,
+            task_start,
+        )
+        .await?;
+
+        match outcome {
+            implement_pipeline::ImplementOutcome::Done => return Ok(()),
+            implement_pipeline::ImplementOutcome::Proceed {
+                pr_url,
+                pr_num,
+                context_items,
+                ..
+            } => break (pr_url, pr_num, context_items),
+            implement_pipeline::ImplementOutcome::Replan {
+                issue,
+                plan_issue,
+                prior_plan,
+            } => {
+                if replan_attempted {
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.error = Some(format!("PLAN_ISSUE persisted after replan: {plan_issue}"));
+                    })
+                    .await?;
+                    return Ok(());
+                }
+
+                let workflow_cfg = harness_core::config::workflow::load_workflow_config(&project)
+                    .unwrap_or_default();
+
+                if req.force_execute {
+                    let forced_plan = match prior_plan.or(current_plan_output.clone()) {
+                        Some(plan) => format!(
+                            "{plan}\n\nExecution override: this issue is force_execute.\n\
+                             Previous plan concern:\n{}",
+                            prompts::wrap_external_data(&plan_issue)
+                        ),
+                        None => format!(
+                            "Execution override: this issue is force_execute.\n\
+                             Previous plan concern:\n{}",
+                            prompts::wrap_external_data(&plan_issue)
+                        ),
+                    };
+                    current_plan_output = Some(forced_plan);
+                } else if workflow_cfg.issue_workflow.auto_replan_on_plan_issue {
+                    if let Some(max) = effective_max_turns {
+                        if turns_used >= max {
+                            return Err(anyhow::anyhow!(
+                                "Turn budget exhausted before replan: used {} of {} allowed turns",
+                                turns_used,
+                                max
+                            ));
+                        }
+                    }
+                    let new_plan = triage_pipeline::run_replan_for_issue(
+                        agent,
+                        store,
+                        task_id,
+                        issue,
+                        prior_plan.as_deref().or(current_plan_output.as_deref()),
+                        &plan_issue,
+                        &cargo_env,
+                        &project,
+                        req,
+                    )
+                    .await?;
+                    turns_used += 1;
+                    *turns_used_acc = turns_used;
+                    current_plan_output = Some(new_plan);
+                } else {
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.error = Some(format!(
+                            "PLAN_ISSUE encountered and auto_replan_on_plan_issue=false: {plan_issue}"
+                        ));
+                    })
+                    .await?;
+                    return Ok(());
+                }
+                replan_attempted = true;
+            }
+        }
     };
 
     // Gate A: require pr_url when the implement phase extracted a pr_num.

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -73,6 +73,10 @@ pub(crate) struct TaskContext {
     pub project: std::path::PathBuf,
 }
 
+fn should_run_issue_triage(skip_triage: bool, has_existing_pr: bool) -> bool {
+    !skip_triage && !has_existing_pr
+}
+
 /// Run the project's test commands as a hard gate before accepting LGTM.
 ///
 /// When `custom_cmds` is non-empty (from `validation.pre_push` in project config),
@@ -265,15 +269,22 @@ pub(crate) async fn run_task(
             .ok()
             .flatten()
             .is_some();
-        if !has_existing_pr {
+        if has_existing_pr {
+            // Fresh issue task reusing an existing PR — treat as resumed for conflict gating.
+            was_resumed_pr = true;
+            (None, prompts::TriageComplexity::Medium, 0u32)
+        } else if !should_run_issue_triage(req.skip_triage, has_existing_pr) {
+            tracing::info!(
+                task_id = %task_id,
+                issue,
+                "issue request opted to skip triage/plan pipeline"
+            );
+            (None, prompts::TriageComplexity::Medium, 0u32)
+        } else {
             triage_pipeline::run_triage_plan_pipeline(
                 agent, store, task_id, issue, &cargo_env, &project, req,
             )
             .await?
-        } else {
-            // Fresh issue task reusing an existing PR — treat as resumed for conflict gating.
-            was_resumed_pr = true;
-            (None, prompts::TriageComplexity::Medium, 0u32)
         }
     } else {
         // Planning gate (task_runner) may have forced TaskPhase::Plan for a
@@ -720,6 +731,13 @@ mod tests {
             implement_pipeline::task_needs_pr_url(&req),
             "issue task must require PR_URL"
         );
+    }
+
+    #[test]
+    fn issue_triage_runs_only_when_not_skipped_and_no_existing_pr() {
+        assert!(should_run_issue_triage(false, false));
+        assert!(!should_run_issue_triage(true, false));
+        assert!(!should_run_issue_triage(false, true));
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1,5 +1,7 @@
 use super::helpers::run_agent_streaming;
-use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskPhase, TaskStore};
+use crate::task_runner::{
+    mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStore,
+};
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::prompts;
 use harness_core::types::ExecutionPhase;
@@ -189,6 +191,66 @@ pub(crate) async fn run_triage_plan_pipeline(
 
     tracing::info!(task_id = %task_id, plan_len = plan_text.len(), "plan phase complete");
     Ok((Some(plan_text), complexity, 2))
+}
+
+/// Run a repair-plan step after an implementation attempt emitted `PLAN_ISSUE=...`.
+///
+/// Returns the corrected plan text and advances the task phase back to
+/// `Implement`. The caller decides whether to retry implementation or fail.
+pub(crate) async fn run_replan_for_issue(
+    agent: &dyn CodeAgent,
+    store: &TaskStore,
+    task_id: &TaskId,
+    issue: u64,
+    prior_plan: Option<&str>,
+    plan_issue: &str,
+    cargo_env: &HashMap<String, String>,
+    project: &Path,
+    req: &CreateTaskRequest,
+) -> anyhow::Result<String> {
+    tracing::info!(task_id = %task_id, issue, "pipeline: starting replan phase");
+    mutate_and_persist(store, task_id, |state| {
+        state.phase = TaskPhase::Plan;
+    })
+    .await?;
+
+    let prompt = prompts::replan_prompt(issue, prior_plan, plan_issue).to_prompt_string();
+    let plan_req = AgentRequest {
+        prompt,
+        project_root: project.to_path_buf(),
+        env_vars: cargo_env.clone(),
+        execution_phase: Some(ExecutionPhase::Planning),
+        ..Default::default()
+    };
+
+    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
+    let plan_resp = tokio::time::timeout(turn_timeout, agent.execute(plan_req))
+        .await
+        .map_err(|_| anyhow::anyhow!("replan phase timed out after {}s", req.turn_timeout_secs))?
+        .map_err(|e| anyhow::anyhow!("replan phase agent error: {e}"))?;
+
+    let plan_text = plan_resp.output.clone();
+    mutate_and_persist(store, task_id, |state| {
+        state.plan_output = Some(plan_text.clone());
+        state.phase = TaskPhase::Implement;
+        state.rounds.push(RoundResult {
+            turn: state.turn,
+            action: "replan".into(),
+            result: "plan_ready".into(),
+            detail: Some(plan_text.clone()),
+            first_token_latency_ms: None,
+        });
+    })
+    .await?;
+    if let Err(e) = store
+        .write_checkpoint(task_id, None, Some(&plan_text), None, "replan_done")
+        .await
+    {
+        tracing::warn!(task_id = %task_id, "failed to write replan checkpoint: {e}");
+    }
+
+    tracing::info!(task_id = %task_id, plan_len = plan_text.len(), "replan phase complete");
+    Ok(plan_text)
 }
 
 /// Fire a single agent turn to rebase a conflicting PR onto `origin/main`.

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -14,6 +14,10 @@ pub struct CreateTaskRequest {
     pub prompt: Option<String>,
     /// GitHub issue number to implement from.
     pub issue: Option<u64>,
+    /// When true, issue-backed tasks bypass the triage/plan pipeline and go
+    /// straight to implementation using the legacy direct-implement path.
+    #[serde(default)]
+    pub skip_triage: bool,
     /// GitHub PR number to review/fix.
     pub pr: Option<u64>,
     /// Explicit agent name; if omitted, uses the default agent.
@@ -82,6 +86,8 @@ pub struct PersistedRequestSettings {
     pub max_rounds: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_turns: Option<u32>,
+    #[serde(default)]
+    pub skip_triage: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_budget_usd: Option<f64>,
     pub wait_secs: u64,
@@ -117,6 +123,7 @@ impl PersistedRequestSettings {
             agent: req.agent.clone(),
             max_rounds: req.max_rounds,
             max_turns: req.max_turns,
+            skip_triage: req.skip_triage,
             max_budget_usd: req.max_budget_usd,
             wait_secs: req.wait_secs,
             retry_base_backoff_ms: req.retry_base_backoff_ms,
@@ -146,6 +153,7 @@ impl PersistedRequestSettings {
         req.agent = self.agent.clone();
         req.max_rounds = self.max_rounds;
         req.max_turns = self.max_turns;
+        req.skip_triage = self.skip_triage;
         req.max_budget_usd = self.max_budget_usd;
         req.wait_secs = self.wait_secs;
         req.retry_base_backoff_ms = self.retry_base_backoff_ms;
@@ -168,6 +176,7 @@ impl Default for CreateTaskRequest {
         Self {
             prompt: None,
             issue: None,
+            skip_triage: false,
             pr: None,
             agent: None,
             project: None,
@@ -261,4 +270,38 @@ pub(super) fn default_turn_timeout() -> u64 {
 
 pub(super) fn default_stall_timeout() -> u64 {
     300
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_task_request_deserializes_skip_triage() {
+        let req: CreateTaskRequest =
+            serde_json::from_str(r#"{"issue": 749, "skip_triage": true}"#).expect("deserialize");
+        assert_eq!(req.issue, Some(749));
+        assert!(req.skip_triage);
+    }
+
+    #[test]
+    fn create_task_request_default_skip_triage_is_false() {
+        let req = CreateTaskRequest::default();
+        assert!(!req.skip_triage);
+    }
+
+    #[test]
+    fn persisted_request_settings_roundtrip_preserves_skip_triage() {
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            skip_triage: true,
+            ..CreateTaskRequest::default()
+        };
+        let settings = PersistedRequestSettings::from_req(&req);
+        assert!(settings.skip_triage);
+
+        let mut restored = CreateTaskRequest::default();
+        settings.apply_to_req(&mut restored);
+        assert!(restored.skip_triage);
+    }
 }

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -18,6 +18,10 @@ pub struct CreateTaskRequest {
     /// straight to implementation using the legacy direct-implement path.
     #[serde(default)]
     pub skip_triage: bool,
+    /// When true, agent-raised plan concerns must not block implementation.
+    /// The concern is recorded, but the issue contract remains authoritative.
+    #[serde(default)]
+    pub force_execute: bool,
     /// GitHub PR number to review/fix.
     pub pr: Option<u64>,
     /// Explicit agent name; if omitted, uses the default agent.
@@ -61,6 +65,9 @@ pub struct CreateTaskRequest {
     /// Repository slug (e.g. "owner/repo"). Stored in TaskState for traceability.
     #[serde(default)]
     pub repo: Option<String>,
+    /// Snapshot of source labels for workflow policy decisions.
+    #[serde(default)]
+    pub labels: Vec<String>,
     /// Explicit parent task ID.
     #[serde(default)]
     pub parent_task_id: Option<TaskId>,
@@ -88,6 +95,10 @@ pub struct PersistedRequestSettings {
     pub max_turns: Option<u32>,
     #[serde(default)]
     pub skip_triage: bool,
+    #[serde(default)]
+    pub force_execute: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_budget_usd: Option<f64>,
     pub wait_secs: u64,
@@ -124,6 +135,8 @@ impl PersistedRequestSettings {
             max_rounds: req.max_rounds,
             max_turns: req.max_turns,
             skip_triage: req.skip_triage,
+            force_execute: req.force_execute,
+            labels: req.labels.clone(),
             max_budget_usd: req.max_budget_usd,
             wait_secs: req.wait_secs,
             retry_base_backoff_ms: req.retry_base_backoff_ms,
@@ -154,6 +167,8 @@ impl PersistedRequestSettings {
         req.max_rounds = self.max_rounds;
         req.max_turns = self.max_turns;
         req.skip_triage = self.skip_triage;
+        req.force_execute = self.force_execute;
+        req.labels = self.labels.clone();
         req.max_budget_usd = self.max_budget_usd;
         req.wait_secs = self.wait_secs;
         req.retry_base_backoff_ms = self.retry_base_backoff_ms;
@@ -177,6 +192,7 @@ impl Default for CreateTaskRequest {
             prompt: None,
             issue: None,
             skip_triage: false,
+            force_execute: false,
             pr: None,
             agent: None,
             project: None,
@@ -191,6 +207,7 @@ impl Default for CreateTaskRequest {
             source: None,
             external_id: None,
             repo: None,
+            labels: Vec::new(),
             parent_task_id: None,
             depends_on: Vec::new(),
             priority: 0,
@@ -288,6 +305,7 @@ mod tests {
     fn create_task_request_default_skip_triage_is_false() {
         let req = CreateTaskRequest::default();
         assert!(!req.skip_triage);
+        assert!(!req.force_execute);
     }
 
     #[test]
@@ -295,13 +313,16 @@ mod tests {
         let req = CreateTaskRequest {
             issue: Some(42),
             skip_triage: true,
+            force_execute: true,
             ..CreateTaskRequest::default()
         };
         let settings = PersistedRequestSettings::from_req(&req);
         assert!(settings.skip_triage);
+        assert!(settings.force_execute);
 
         let mut restored = CreateTaskRequest::default();
         settings.apply_to_req(&mut restored);
         assert!(restored.skip_triage);
+        assert!(restored.force_execute);
     }
 }

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -241,6 +241,7 @@ pub async fn spawn_task(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
 ) -> TaskId {
     spawn_task_with_worktree_detector(
         store,
@@ -255,6 +256,7 @@ pub async fn spawn_task(
         workspace_mgr,
         permit,
         completion_callback,
+        issue_workflow_store,
         None,
         None,
     )
@@ -299,6 +301,7 @@ pub async fn spawn_preregistered_task(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     group_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 ) {
     spawn_task_with_worktree_detector(
@@ -314,6 +317,7 @@ pub async fn spawn_preregistered_task(
         workspace_mgr,
         permit,
         completion_callback,
+        issue_workflow_store,
         Some(task_id),
         group_permit,
     )
@@ -333,6 +337,7 @@ pub(super) async fn spawn_task_with_worktree_detector<F>(
     workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
     permit: crate::task_queue::TaskPermit,
     completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     preregistered_id: Option<TaskId>,
     group_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 ) -> TaskId
@@ -618,6 +623,7 @@ where
                 &req,
                 run_project.clone(),
                 server_config.as_ref(),
+                issue_workflow_store.clone(),
                 &mut total_turns_used,
             )
             .await;
@@ -997,6 +1003,7 @@ mod tests {
             None,
             permit,
             None,
+            None,
         )
         .await;
 
@@ -1070,6 +1077,7 @@ mod tests {
             req,
             None,
             permit,
+            None,
             None,
         )
         .await;
@@ -1162,6 +1170,7 @@ mod tests {
             },
             None,
             permit,
+            None,
             None,
             None,
             None,
@@ -1341,6 +1350,7 @@ mod tests {
             None,
             permit,
             None,
+            None,
         )
         .await;
 
@@ -1397,6 +1407,7 @@ mod tests {
             req,
             None,
             permit,
+            None,
             None,
         )
         .await;

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -116,6 +116,9 @@ pub struct TaskSummary {
     /// Resolved project root path. Persisted to the database for observability.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
+    /// Issue workflow state summary, when this task belongs to an issue workflow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
 }
 
 /// Lightweight recent-failure row used by the operator snapshot.
@@ -179,6 +182,7 @@ impl TaskState {
                 .project_root
                 .as_ref()
                 .map(|p| p.to_string_lossy().into_owned()),
+            workflow: None,
         }
     }
 }

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -197,6 +197,7 @@ async fn make_state_inner(
         task_queue.clone(),
         None,
         None,
+        None,
         vec![],
     );
 
@@ -211,6 +212,8 @@ async fn make_state_inner(
             thread_db: Some(thread_db),
             plan_db: None,
             plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+            issue_workflow_store: None,
+            project_workflow_store: None,
             project_registry: None,
             runtime_state_store: None,
             q_values: None,

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -316,6 +316,7 @@ mod tests {
             Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
             None,
             None,
+            None,
             vec![],
         );
         Ok(AppState {
@@ -329,6 +330,8 @@ mod tests {
                 thread_db: Some(thread_db),
                 plan_db: None,
                 plan_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+                issue_workflow_store: None,
+                project_workflow_store: None,
                 project_registry: None,
                 runtime_state_store: None,
                 q_values: None,

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -221,7 +221,10 @@ fn repo_key(repo: Option<&str>) -> &str {
 }
 
 pub fn workflow_id(project_id: &str, repo: Option<&str>, issue_number: u64) -> String {
-    format!("{project_id}::repo:{}::issue:{issue_number}", repo_key(repo))
+    format!(
+        "{project_id}::repo:{}::issue:{issue_number}",
+        repo_key(repo)
+    )
 }
 
 pub struct IssueWorkflowStore {

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -1,0 +1,621 @@
+use chrono::{DateTime, Utc};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::postgres::PgPool;
+use std::path::Path;
+
+const ISSUE_WORKFLOW_SCHEMA_VERSION: u32 = 1;
+
+static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create issue_workflows table",
+        sql: "CREATE TABLE IF NOT EXISTS issue_workflows (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "index issue workflow lookups by project and issue",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_issue
+              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'issue_number')::bigint))",
+    },
+    Migration {
+        version: 3,
+        description: "index issue workflow lookups by project and pr",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_pr
+              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'pr_number')::bigint))",
+    },
+];
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueLifecycleState {
+    Discovered,
+    Scheduled,
+    Implementing,
+    PrOpen,
+    AwaitingFeedback,
+    AddressingFeedback,
+    ReadyToMerge,
+    Blocked,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueLifecycleEventKind {
+    IssueScheduled,
+    ImplementStarted,
+    PlanIssueDetected,
+    PrDetected,
+    FeedbackTaskScheduled,
+    FeedbackSweepCompleted,
+    FeedbackFound,
+    NoFeedbackFound,
+    Mergeable,
+    WorkflowFailed,
+    WorkflowCancelled,
+    WorkflowDone,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IssueLifecycleEvent {
+    pub kind: IssueLifecycleEventKind,
+    pub at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+}
+
+impl IssueLifecycleEvent {
+    fn new(kind: IssueLifecycleEventKind) -> Self {
+        Self {
+            kind,
+            at: Utc::now(),
+            task_id: None,
+            detail: None,
+            pr_number: None,
+            pr_url: None,
+        }
+    }
+
+    fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
+        self.task_id = Some(task_id.into());
+        self
+    }
+
+    fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    fn with_pr(mut self, pr_number: u64, pr_url: impl Into<String>) -> Self {
+        self.pr_number = Some(pr_number);
+        self.pr_url = Some(pr_url.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IssueWorkflowInstance {
+    pub id: String,
+    pub schema_version: u32,
+    pub project_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    pub issue_number: u64,
+    pub state: IssueLifecycleState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    #[serde(default)]
+    pub labels_snapshot: Vec<String>,
+    #[serde(default)]
+    pub force_execute: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_concern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event: Option<IssueLifecycleEvent>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl IssueWorkflowInstance {
+    pub fn new(project_id: impl Into<String>, repo: Option<String>, issue_number: u64) -> Self {
+        let project_id = project_id.into();
+        let id = workflow_id(&project_id, issue_number);
+        let now = Utc::now();
+        Self {
+            id,
+            schema_version: ISSUE_WORKFLOW_SCHEMA_VERSION,
+            project_id,
+            repo,
+            issue_number,
+            state: IssueLifecycleState::Discovered,
+            active_task_id: None,
+            pr_number: None,
+            pr_url: None,
+            labels_snapshot: Vec::new(),
+            force_execute: false,
+            plan_concern: None,
+            last_event: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn apply_event(&mut self, event: IssueLifecycleEvent) {
+        match event.kind {
+            IssueLifecycleEventKind::IssueScheduled => {
+                self.state = IssueLifecycleState::Scheduled;
+                self.active_task_id = event.task_id.clone();
+            }
+            IssueLifecycleEventKind::ImplementStarted => {
+                self.state = IssueLifecycleState::Implementing;
+                self.active_task_id = event.task_id.clone();
+            }
+            IssueLifecycleEventKind::PlanIssueDetected => {
+                self.state = IssueLifecycleState::Implementing;
+                self.active_task_id = event.task_id.clone();
+                self.plan_concern = event.detail.clone();
+            }
+            IssueLifecycleEventKind::PrDetected => {
+                self.state = IssueLifecycleState::PrOpen;
+                self.active_task_id = event.task_id.clone();
+                self.pr_number = event.pr_number;
+                self.pr_url = event.pr_url.clone();
+            }
+            IssueLifecycleEventKind::FeedbackTaskScheduled
+            | IssueLifecycleEventKind::FeedbackFound => {
+                self.state = IssueLifecycleState::AddressingFeedback;
+                self.active_task_id = event.task_id.clone();
+                if event.pr_number.is_some() {
+                    self.pr_number = event.pr_number;
+                }
+                if event.pr_url.is_some() {
+                    self.pr_url = event.pr_url.clone();
+                }
+            }
+            IssueLifecycleEventKind::FeedbackSweepCompleted
+            | IssueLifecycleEventKind::NoFeedbackFound => {
+                self.state = IssueLifecycleState::AwaitingFeedback;
+            }
+            IssueLifecycleEventKind::Mergeable => {
+                self.state = IssueLifecycleState::ReadyToMerge;
+            }
+            IssueLifecycleEventKind::WorkflowFailed => {
+                self.state = IssueLifecycleState::Failed;
+            }
+            IssueLifecycleEventKind::WorkflowCancelled => {
+                self.state = IssueLifecycleState::Cancelled;
+            }
+            IssueLifecycleEventKind::WorkflowDone => {
+                self.state = IssueLifecycleState::Done;
+            }
+        }
+        self.last_event = Some(event);
+        self.updated_at = Utc::now();
+    }
+}
+
+pub fn workflow_id(project_id: &str, issue_number: u64) -> String {
+    format!("{project_id}::issue:{issue_number}")
+}
+
+pub struct IssueWorkflowStore {
+    pool: PgPool,
+    update_lock: tokio::sync::Mutex<()>,
+}
+
+impl IssueWorkflowStore {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let path_utf8 = path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
+        let digest = Sha256::digest(path_utf8.as_bytes());
+        let mut schema_bytes = [0u8; 8];
+        schema_bytes.copy_from_slice(&digest[..8]);
+        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
+        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self {
+            pool,
+            update_lock: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    pub async fn upsert(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+                 updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&workflow.id)
+        .bind(&data)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_by_issue(
+        &self,
+        project_id: &str,
+        issue_number: u64,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'project_id' = $1
+               AND (data::jsonb->>'issue_number')::bigint = $2
+             ORDER BY updated_at DESC
+             LIMIT 1",
+        )
+        .bind(project_id)
+        .bind(issue_number as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn get_by_pr(
+        &self,
+        project_id: &str,
+        pr_number: u64,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'project_id' = $1
+               AND (data::jsonb->>'pr_number')::bigint = $2
+             ORDER BY updated_at DESC
+             LIMIT 1",
+        )
+        .bind(project_id)
+        .bind(pr_number as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn record_issue_scheduled(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        labels_snapshot: &[String],
+        force_execute: bool,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.labels_snapshot = labels_snapshot.to_vec();
+            workflow.force_execute = force_execute;
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::IssueScheduled)
+                    .with_task_id(task_id.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_implement_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::ImplementStarted)
+                    .with_task_id(task_id.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_plan_issue_detected(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        concern: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::PlanIssueDetected)
+                    .with_task_id(task_id.to_string())
+                    .with_detail(concern.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_pr_detected(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        pr_number: u64,
+        pr_url: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::PrDetected)
+                    .with_task_id(task_id.to_string())
+                    .with_pr(pr_number, pr_url.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_feedback_task_scheduled(
+        &self,
+        project_id: &str,
+        pr_number: u64,
+        task_id: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, pr_number, |workflow| {
+            let mut event =
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
+                    .with_task_id(task_id.to_string());
+            if let Some(pr_url) = workflow.pr_url.clone() {
+                event = event.with_pr(pr_number, pr_url);
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    pub async fn record_terminal_for_issue(
+        &self,
+        project_id: &str,
+        issue_number: u64,
+        final_state: IssueLifecycleState,
+        detail: Option<&str>,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_existing_issue(project_id, issue_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(match final_state {
+                IssueLifecycleState::Done => IssueLifecycleEventKind::WorkflowDone,
+                IssueLifecycleState::Cancelled => IssueLifecycleEventKind::WorkflowCancelled,
+                _ => IssueLifecycleEventKind::WorkflowFailed,
+            });
+            if let Some(detail) = detail {
+                event = event.with_detail(detail.to_string());
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    pub async fn record_terminal_for_pr(
+        &self,
+        project_id: &str,
+        pr_number: u64,
+        success: bool,
+        detail: Option<&str>,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, pr_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(if success {
+                IssueLifecycleEventKind::Mergeable
+            } else {
+                IssueLifecycleEventKind::WorkflowFailed
+            });
+            if let Some(detail) = detail {
+                event = event.with_detail(detail.to_string());
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    pub async fn list_feedback_candidates(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+               AND data::jsonb->>'pr_number' IS NOT NULL
+             ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    async fn update_issue<F>(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        f: F,
+    ) -> anyhow::Result<IssueWorkflowInstance>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let _guard = self.update_lock.lock().await;
+        let mut workflow = self
+            .get_by_issue(project_id, issue_number)
+            .await?
+            .unwrap_or_else(|| {
+                IssueWorkflowInstance::new(
+                    project_id.to_string(),
+                    repo.map(|r| r.to_string()),
+                    issue_number,
+                )
+            });
+        if workflow.repo.is_none() {
+            workflow.repo = repo.map(|r| r.to_string());
+        }
+        f(&mut workflow);
+        self.upsert(&workflow).await?;
+        Ok(workflow)
+    }
+
+    async fn update_existing_issue<F>(
+        &self,
+        project_id: &str,
+        issue_number: u64,
+        f: F,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let _guard = self.update_lock.lock().await;
+        let Some(mut workflow) = self.get_by_issue(project_id, issue_number).await? else {
+            return Ok(None);
+        };
+        f(&mut workflow);
+        self.upsert(&workflow).await?;
+        Ok(Some(workflow))
+    }
+
+    async fn update_by_pr<F>(
+        &self,
+        project_id: &str,
+        pr_number: u64,
+        f: F,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let _guard = self.update_lock.lock().await;
+        let Some(mut workflow) = self.get_by_pr(project_id, pr_number).await? else {
+            return Ok(None);
+        };
+        f(&mut workflow);
+        self.upsert(&workflow).await?;
+        Ok(Some(workflow))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_test_store() -> anyhow::Result<Option<IssueWorkflowStore>> {
+        if std::env::var("DATABASE_URL").is_err() {
+            return Ok(None);
+        }
+        let dir = tempfile::tempdir()?;
+        match IssueWorkflowStore::open(&dir.path().join("issue_workflows.db")).await {
+            Ok(store) => Ok(Some(store)),
+            Err(e) => {
+                tracing::warn!("issue workflow store test skipped: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn issue_workflow_store_binds_pr_to_issue_instance() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-a";
+        store
+            .record_issue_scheduled(
+                project_id,
+                Some("owner/repo"),
+                882,
+                "task-1",
+                &["force-execute".to_string()],
+                true,
+            )
+            .await?;
+        store
+            .record_pr_detected(
+                project_id,
+                Some("owner/repo"),
+                882,
+                "task-1",
+                909,
+                "https://github.com/owner/repo/pull/909",
+            )
+            .await?;
+
+        let by_issue = store
+            .get_by_issue(project_id, 882)
+            .await?
+            .expect("workflow by issue");
+        let by_pr = store
+            .get_by_pr(project_id, 909)
+            .await?
+            .expect("workflow by pr");
+
+        assert_eq!(by_issue.id, by_pr.id);
+        assert_eq!(by_issue.state, IssueLifecycleState::PrOpen);
+        assert_eq!(by_issue.pr_number, Some(909));
+        assert!(by_issue.force_execute);
+        assert_eq!(by_issue.labels_snapshot, vec!["force-execute".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_workflow_store_records_plan_issue_as_non_terminal_event() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-b";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo"), 883, "task-2", &[], false)
+            .await?;
+        let workflow = store
+            .record_plan_issue_detected(
+                project_id,
+                Some("owner/repo"),
+                883,
+                "task-2",
+                "The plan is incomplete.",
+            )
+            .await?;
+
+        assert_eq!(workflow.state, IssueLifecycleState::Implementing);
+        assert_eq!(
+            workflow.plan_concern.as_deref(),
+            Some("The plan is incomplete.")
+        );
+        assert_eq!(
+            workflow.last_event.as_ref().map(|e| &e.kind),
+            Some(&IssueLifecycleEventKind::PlanIssueDetected)
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -141,7 +141,7 @@ pub struct IssueWorkflowInstance {
 impl IssueWorkflowInstance {
     pub fn new(project_id: impl Into<String>, repo: Option<String>, issue_number: u64) -> Self {
         let project_id = project_id.into();
-        let id = workflow_id(&project_id, issue_number);
+        let id = workflow_id(&project_id, repo.as_deref(), issue_number);
         let now = Utc::now();
         Self {
             id,
@@ -216,8 +216,12 @@ impl IssueWorkflowInstance {
     }
 }
 
-pub fn workflow_id(project_id: &str, issue_number: u64) -> String {
-    format!("{project_id}::issue:{issue_number}")
+fn repo_key(repo: Option<&str>) -> &str {
+    repo.unwrap_or("<none>")
+}
+
+pub fn workflow_id(project_id: &str, repo: Option<&str>, issue_number: u64) -> String {
+    format!("{project_id}::repo:{}::issue:{issue_number}", repo_key(repo))
 }
 
 pub struct IssueWorkflowStore {
@@ -274,19 +278,37 @@ impl IssueWorkflowStore {
     pub async fn get_by_issue(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         issue_number: u64,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT data FROM issue_workflows
-             WHERE data::jsonb->>'project_id' = $1
-               AND (data::jsonb->>'issue_number')::bigint = $2
-             ORDER BY updated_at DESC
-             LIMIT 1",
-        )
-        .bind(project_id)
-        .bind(issue_number as i64)
-        .fetch_optional(&self.pool)
-        .await?;
+        let row: Option<(String,)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'issue_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(issue_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'issue_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(issue_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        };
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
@@ -295,19 +317,37 @@ impl IssueWorkflowStore {
     pub async fn get_by_pr(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         pr_number: u64,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT data FROM issue_workflows
-             WHERE data::jsonb->>'project_id' = $1
-               AND (data::jsonb->>'pr_number')::bigint = $2
-             ORDER BY updated_at DESC
-             LIMIT 1",
-        )
-        .bind(project_id)
-        .bind(pr_number as i64)
-        .fetch_optional(&self.pool)
-        .await?;
+        let row: Option<(String,)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'pr_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(pr_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'pr_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(pr_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        };
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
@@ -389,10 +429,11 @@ impl IssueWorkflowStore {
     pub async fn record_feedback_task_scheduled(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         pr_number: u64,
         task_id: &str,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_by_pr(project_id, pr_number, |workflow| {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
             let mut event =
                 IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
                     .with_task_id(task_id.to_string());
@@ -407,11 +448,12 @@ impl IssueWorkflowStore {
     pub async fn record_terminal_for_issue(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         issue_number: u64,
         final_state: IssueLifecycleState,
         detail: Option<&str>,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_existing_issue(project_id, issue_number, |workflow| {
+        self.update_existing_issue(project_id, repo, issue_number, |workflow| {
             let mut event = IssueLifecycleEvent::new(match final_state {
                 IssueLifecycleState::Done => IssueLifecycleEventKind::WorkflowDone,
                 IssueLifecycleState::Cancelled => IssueLifecycleEventKind::WorkflowCancelled,
@@ -428,12 +470,16 @@ impl IssueWorkflowStore {
     pub async fn record_terminal_for_pr(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         pr_number: u64,
         success: bool,
+        cancelled: bool,
         detail: Option<&str>,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_by_pr(project_id, pr_number, |workflow| {
-            let mut event = IssueLifecycleEvent::new(if success {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(if cancelled {
+                IssueLifecycleEventKind::WorkflowCancelled
+            } else if success {
                 IssueLifecycleEventKind::Mergeable
             } else {
                 IssueLifecycleEventKind::WorkflowFailed
@@ -472,7 +518,7 @@ impl IssueWorkflowStore {
     {
         let _guard = self.update_lock.lock().await;
         let mut workflow = self
-            .get_by_issue(project_id, issue_number)
+            .get_by_issue(project_id, repo, issue_number)
             .await?
             .unwrap_or_else(|| {
                 IssueWorkflowInstance::new(
@@ -492,6 +538,7 @@ impl IssueWorkflowStore {
     async fn update_existing_issue<F>(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         issue_number: u64,
         f: F,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>>
@@ -499,7 +546,7 @@ impl IssueWorkflowStore {
         F: FnOnce(&mut IssueWorkflowInstance),
     {
         let _guard = self.update_lock.lock().await;
-        let Some(mut workflow) = self.get_by_issue(project_id, issue_number).await? else {
+        let Some(mut workflow) = self.get_by_issue(project_id, repo, issue_number).await? else {
             return Ok(None);
         };
         f(&mut workflow);
@@ -510,6 +557,7 @@ impl IssueWorkflowStore {
     async fn update_by_pr<F>(
         &self,
         project_id: &str,
+        repo: Option<&str>,
         pr_number: u64,
         f: F,
     ) -> anyhow::Result<Option<IssueWorkflowInstance>>
@@ -517,7 +565,7 @@ impl IssueWorkflowStore {
         F: FnOnce(&mut IssueWorkflowInstance),
     {
         let _guard = self.update_lock.lock().await;
-        let Some(mut workflow) = self.get_by_pr(project_id, pr_number).await? else {
+        let Some(mut workflow) = self.get_by_pr(project_id, repo, pr_number).await? else {
             return Ok(None);
         };
         f(&mut workflow);
@@ -572,11 +620,11 @@ mod tests {
             .await?;
 
         let by_issue = store
-            .get_by_issue(project_id, 882)
+            .get_by_issue(project_id, Some("owner/repo"), 882)
             .await?
             .expect("workflow by issue");
         let by_pr = store
-            .get_by_pr(project_id, 909)
+            .get_by_pr(project_id, Some("owner/repo"), 909)
             .await?
             .expect("workflow by pr");
 
@@ -616,6 +664,59 @@ mod tests {
             workflow.last_event.as_ref().map(|e| &e.kind),
             Some(&IssueLifecycleEventKind::PlanIssueDetected)
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_workflow_store_scopes_identity_by_repo() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/shared-project";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo-a"), 42, "task-a", &[], false)
+            .await?;
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo-b"), 42, "task-b", &[], false)
+            .await?;
+
+        let a = store
+            .get_by_issue(project_id, Some("owner/repo-a"), 42)
+            .await?
+            .expect("repo-a workflow");
+        let b = store
+            .get_by_issue(project_id, Some("owner/repo-b"), 42)
+            .await?
+            .expect("repo-b workflow");
+
+        assert_ne!(a.id, b.id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_workflow_store_records_cancelled_pr_tasks_as_cancelled() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-cancel";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo"), 7, "task-1", &[], false)
+            .await?;
+        store
+            .record_pr_detected(
+                project_id,
+                Some("owner/repo"),
+                7,
+                "task-1",
+                55,
+                "https://github.com/owner/repo/pull/55",
+            )
+            .await?;
+        let workflow = store
+            .record_terminal_for_pr(project_id, Some("owner/repo"), 55, false, true, None)
+            .await?
+            .expect("workflow");
+        assert_eq!(workflow.state, IssueLifecycleState::Cancelled);
         Ok(())
     }
 }

--- a/crates/harness-workflow/src/lib.rs
+++ b/crates/harness-workflow/src/lib.rs
@@ -5,5 +5,7 @@
 
 pub mod checkpoint;
 pub mod circuit_breaker;
+pub mod issue_lifecycle;
 pub mod plan_db;
+pub mod project_lifecycle;
 pub mod task_queue;

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -412,8 +412,8 @@ impl ProjectWorkflowStore {
             .get_by_project(project_id, repo)
             .await?
             .unwrap_or_else(|| {
-            ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string))
-        });
+                ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string))
+            });
         if workflow.repo.is_none() {
             workflow.repo = repo.map(str::to_string);
         }
@@ -478,8 +478,12 @@ mod tests {
             return Ok(());
         };
         let project_id = "/tmp/shared-project";
-        store.record_poll_started(project_id, Some("owner/repo-a")).await?;
-        store.record_poll_started(project_id, Some("owner/repo-b")).await?;
+        store
+            .record_poll_started(project_id, Some("owner/repo-a"))
+            .await?;
+        store
+            .record_poll_started(project_id, Some("owner/repo-b"))
+            .await?;
 
         let a = store
             .get_by_project(project_id, Some("owner/repo-a"))

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -1,0 +1,451 @@
+use chrono::{DateTime, Utc};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::postgres::PgPool;
+use std::path::Path;
+
+const PROJECT_WORKFLOW_SCHEMA_VERSION: u32 = 1;
+
+static PROJECT_WORKFLOW_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create project_workflows table",
+        sql: "CREATE TABLE IF NOT EXISTS project_workflows (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "index project workflow lookups by project",
+        sql: "CREATE INDEX IF NOT EXISTS idx_project_workflows_project
+              ON project_workflows ((data::jsonb->>'project_id'))",
+    },
+];
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectWorkflowState {
+    Idle,
+    PollingIntake,
+    PlanningBatch,
+    Dispatching,
+    Monitoring,
+    SweepingFeedback,
+    Paused,
+    Degraded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectWorkflowEventKind {
+    PollStarted,
+    PollCompleted,
+    SprintPlanningStarted,
+    SprintPlannerEnqueued,
+    DispatchStarted,
+    DispatchCompleted,
+    MonitoringStarted,
+    FeedbackSweepStarted,
+    FeedbackSweepCompleted,
+    RepoPaused,
+    RepoDegraded,
+    RepoIdle,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectWorkflowEvent {
+    pub kind: ProjectWorkflowEventKind,
+    pub at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl ProjectWorkflowEvent {
+    fn new(kind: ProjectWorkflowEventKind) -> Self {
+        Self {
+            kind,
+            at: Utc::now(),
+            task_id: None,
+            detail: None,
+        }
+    }
+
+    fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
+        self.task_id = Some(task_id.into());
+        self
+    }
+
+    fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectWorkflowInstance {
+    pub id: String,
+    pub schema_version: u32,
+    pub project_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    pub state: ProjectWorkflowState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_planner_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event: Option<ProjectWorkflowEvent>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ProjectWorkflowInstance {
+    pub fn new(project_id: impl Into<String>, repo: Option<String>) -> Self {
+        let project_id = project_id.into();
+        let now = Utc::now();
+        Self {
+            id: workflow_id(&project_id),
+            schema_version: PROJECT_WORKFLOW_SCHEMA_VERSION,
+            project_id,
+            repo,
+            state: ProjectWorkflowState::Idle,
+            active_planner_task_id: None,
+            degraded_reason: None,
+            last_event: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn apply_event(&mut self, event: ProjectWorkflowEvent) {
+        match event.kind {
+            ProjectWorkflowEventKind::PollStarted => {
+                self.state = ProjectWorkflowState::PollingIntake;
+            }
+            ProjectWorkflowEventKind::PollCompleted => {
+                self.state = ProjectWorkflowState::Idle;
+            }
+            ProjectWorkflowEventKind::SprintPlanningStarted => {
+                self.state = ProjectWorkflowState::PlanningBatch;
+            }
+            ProjectWorkflowEventKind::SprintPlannerEnqueued => {
+                self.state = ProjectWorkflowState::PlanningBatch;
+                self.active_planner_task_id = event.task_id.clone();
+            }
+            ProjectWorkflowEventKind::DispatchStarted
+            | ProjectWorkflowEventKind::DispatchCompleted => {
+                self.state = ProjectWorkflowState::Dispatching;
+            }
+            ProjectWorkflowEventKind::MonitoringStarted => {
+                self.state = ProjectWorkflowState::Monitoring;
+            }
+            ProjectWorkflowEventKind::FeedbackSweepStarted => {
+                self.state = ProjectWorkflowState::SweepingFeedback;
+            }
+            ProjectWorkflowEventKind::FeedbackSweepCompleted
+            | ProjectWorkflowEventKind::RepoIdle => {
+                self.state = ProjectWorkflowState::Idle;
+                self.degraded_reason = None;
+            }
+            ProjectWorkflowEventKind::RepoPaused => {
+                self.state = ProjectWorkflowState::Paused;
+            }
+            ProjectWorkflowEventKind::RepoDegraded => {
+                self.state = ProjectWorkflowState::Degraded;
+                self.degraded_reason = event.detail.clone();
+            }
+        }
+        self.last_event = Some(event);
+        self.updated_at = Utc::now();
+    }
+}
+
+pub fn workflow_id(project_id: &str) -> String {
+    format!("{project_id}::project")
+}
+
+pub struct ProjectWorkflowStore {
+    pool: PgPool,
+    update_lock: tokio::sync::Mutex<()>,
+}
+
+impl ProjectWorkflowStore {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let path_utf8 = path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
+        let digest = Sha256::digest(path_utf8.as_bytes());
+        let mut schema_bytes = [0u8; 8];
+        schema_bytes.copy_from_slice(&digest[..8]);
+        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
+        PgMigrator::new(&pool, PROJECT_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self {
+            pool,
+            update_lock: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    pub async fn upsert(&self, workflow: &ProjectWorkflowInstance) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO project_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+                 updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&workflow.id)
+        .bind(&data)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_by_project(
+        &self,
+        project_id: &str,
+    ) -> anyhow::Result<Option<ProjectWorkflowInstance>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data FROM project_workflows
+             WHERE data::jsonb->>'project_id' = $1
+             ORDER BY updated_at DESC
+             LIMIT 1",
+        )
+        .bind(project_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn record_poll_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::PollStarted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_planning_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::SprintPlanningStarted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_planner_enqueued(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        task_id: &str,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(
+                ProjectWorkflowEvent::new(ProjectWorkflowEventKind::SprintPlannerEnqueued)
+                    .with_task_id(task_id.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_dispatch_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::DispatchStarted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_monitoring_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::MonitoringStarted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_feedback_sweep_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::FeedbackSweepStarted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_feedback_sweep_completed(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::FeedbackSweepCompleted,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_idle(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(ProjectWorkflowEvent::new(
+                ProjectWorkflowEventKind::RepoIdle,
+            ));
+        })
+        .await
+    }
+
+    pub async fn record_paused(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        detail: &str,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(
+                ProjectWorkflowEvent::new(ProjectWorkflowEventKind::RepoPaused)
+                    .with_detail(detail.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_degraded(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        detail: &str,
+    ) -> anyhow::Result<ProjectWorkflowInstance> {
+        self.update(project_id, repo, |workflow| {
+            workflow.apply_event(
+                ProjectWorkflowEvent::new(ProjectWorkflowEventKind::RepoDegraded)
+                    .with_detail(detail.to_string()),
+            );
+        })
+        .await
+    }
+
+    async fn update<F>(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        f: F,
+    ) -> anyhow::Result<ProjectWorkflowInstance>
+    where
+        F: FnOnce(&mut ProjectWorkflowInstance),
+    {
+        let _guard = self.update_lock.lock().await;
+        let mut workflow = self.get_by_project(project_id).await?.unwrap_or_else(|| {
+            ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string))
+        });
+        if workflow.repo.is_none() {
+            workflow.repo = repo.map(str::to_string);
+        }
+        f(&mut workflow);
+        self.upsert(&workflow).await?;
+        Ok(workflow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_test_store() -> anyhow::Result<Option<ProjectWorkflowStore>> {
+        if std::env::var("DATABASE_URL").is_err() {
+            return Ok(None);
+        }
+        let dir = tempfile::tempdir()?;
+        match ProjectWorkflowStore::open(&dir.path().join("project_workflows.db")).await {
+            Ok(store) => Ok(Some(store)),
+            Err(e) => {
+                tracing::warn!("project workflow store test skipped: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn project_workflow_store_tracks_repo_state_transitions() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-c";
+        store
+            .record_poll_started(project_id, Some("owner/repo"))
+            .await?;
+        store
+            .record_planning_started(project_id, Some("owner/repo"))
+            .await?;
+        store
+            .record_planner_enqueued(project_id, Some("owner/repo"), "planner-1")
+            .await?;
+        store
+            .record_monitoring_started(project_id, Some("owner/repo"))
+            .await?;
+
+        let workflow = store
+            .get_by_project(project_id)
+            .await?
+            .expect("project workflow");
+        assert_eq!(workflow.state, ProjectWorkflowState::Monitoring);
+        assert_eq!(
+            workflow.active_planner_task_id.as_deref(),
+            Some("planner-1")
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -113,7 +113,7 @@ impl ProjectWorkflowInstance {
         let project_id = project_id.into();
         let now = Utc::now();
         Self {
-            id: workflow_id(&project_id),
+            id: workflow_id(&project_id, repo.as_deref()),
             schema_version: PROJECT_WORKFLOW_SCHEMA_VERSION,
             project_id,
             repo,
@@ -169,8 +169,12 @@ impl ProjectWorkflowInstance {
     }
 }
 
-pub fn workflow_id(project_id: &str) -> String {
-    format!("{project_id}::project")
+fn repo_key(repo: Option<&str>) -> &str {
+    repo.unwrap_or("<none>")
+}
+
+pub fn workflow_id(project_id: &str, repo: Option<&str>) -> String {
+    format!("{project_id}::repo:{}::project", repo_key(repo))
 }
 
 pub struct ProjectWorkflowStore {
@@ -227,16 +231,32 @@ impl ProjectWorkflowStore {
     pub async fn get_by_project(
         &self,
         project_id: &str,
+        repo: Option<&str>,
     ) -> anyhow::Result<Option<ProjectWorkflowInstance>> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT data FROM project_workflows
-             WHERE data::jsonb->>'project_id' = $1
-             ORDER BY updated_at DESC
-             LIMIT 1",
-        )
-        .bind(project_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let row: Option<(String,)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT data FROM project_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT data FROM project_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .fetch_optional(&self.pool)
+            .await?
+        };
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
@@ -388,7 +408,10 @@ impl ProjectWorkflowStore {
         F: FnOnce(&mut ProjectWorkflowInstance),
     {
         let _guard = self.update_lock.lock().await;
-        let mut workflow = self.get_by_project(project_id).await?.unwrap_or_else(|| {
+        let mut workflow = self
+            .get_by_project(project_id, repo)
+            .await?
+            .unwrap_or_else(|| {
             ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string))
         });
         if workflow.repo.is_none() {
@@ -438,7 +461,7 @@ mod tests {
             .await?;
 
         let workflow = store
-            .get_by_project(project_id)
+            .get_by_project(project_id, Some("owner/repo"))
             .await?
             .expect("project workflow");
         assert_eq!(workflow.state, ProjectWorkflowState::Monitoring);
@@ -446,6 +469,28 @@ mod tests {
             workflow.active_planner_task_id.as_deref(),
             Some("planner-1")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn project_workflow_store_scopes_rows_by_repo() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/shared-project";
+        store.record_poll_started(project_id, Some("owner/repo-a")).await?;
+        store.record_poll_started(project_id, Some("owner/repo-b")).await?;
+
+        let a = store
+            .get_by_project(project_id, Some("owner/repo-a"))
+            .await?
+            .expect("repo-a workflow");
+        let b = store
+            .get_by_project(project_id, Some("owner/repo-b"))
+            .await?
+            .expect("repo-b workflow");
+
+        assert_ne!(a.id, b.id);
         Ok(())
     }
 }

--- a/docs/issue-lifecycle-workflow-spec.md
+++ b/docs/issue-lifecycle-workflow-spec.md
@@ -1,0 +1,609 @@
+# Workflow-First Orchestration Spec
+
+## Goal
+
+Define a workflow-first orchestration model with two authoritative layers:
+
+- `ProjectWorkflow` for repo-level orchestration
+- `IssueWorkflow` for a single GitHub issue lifecycle
+
+The combined model must own the full lifecycle of a GitHub issue:
+
+- intake
+- optional triage and planning
+- implementation
+- PR creation
+- PR feedback handling
+- merge readiness
+- completion
+
+This design must replace the current split-brain behavior where:
+
+- `issue:N` and `pr:M` become independent task lines
+- PR feedback handling depends on ad hoc webhook/task injection
+- `PLAN_ISSUE` is treated as terminal failure instead of structured workflow feedback
+- repo orchestration status is inferred from scattered queue/task state instead of explicit workflow state
+
+The design must be workflow-driven, not hard-coded as a large nest of executor conditionals.
+
+## Non-goals
+
+- Replacing the existing agent execution pipeline in one step
+- Rewriting `TaskPhase` or `TaskStatus` into a new enum family immediately
+- Implementing a generic external workflow DSL before proving the shape in-process
+
+## Design principles
+
+1. The issue is the primary unit of orchestration.
+2. A PR is an artifact of the issue workflow, not a separate top-level lifecycle.
+3. `Triage`, `Plan`, `Implement`, and `Review` remain execution activities, not top-level business states.
+4. Agent disagreement is evidence, not authority.
+5. PR feedback must be swept automatically as part of workflow progression.
+6. A user-controlled label must be able to force execution even when the agent raises a plan concern.
+
+## Current gap
+
+Today the system has:
+
+- task execution phases: `Triage`, `Plan`, `Implement`, `Review`, `Terminal`
+- task runtime statuses: `Pending`, `Implementing`, `Waiting`, `Reviewing`, `Done`, `Failed`, ...
+
+These are useful executor-level mechanics, but they do not form a full issue lifecycle because they do not model:
+
+- issue discovery vs scheduling
+- issue to PR binding as a first-class relation
+- PR feedback waiting vs PR feedback addressing
+- replan as a non-terminal branch
+- merge readiness
+- force-execute label overrides
+
+## Compatibility stance
+
+This spec intentionally does **not** preserve the old “task-first as source of truth” model.
+
+The authoritative state after this redesign is:
+
+1. `ProjectWorkflow`
+2. `IssueWorkflow`
+3. executor task state only as an implementation detail
+
+`TaskPhase` and `TaskStatus` may continue to exist during migration, but they are no longer the product-facing lifecycle contract.
+
+## Proposed architecture
+
+Introduce a workflow layer in `harness-workflow` with three concepts:
+
+1. `WorkflowSpec`
+2. `WorkflowInstance`
+3. `WorkflowActivity`
+
+The workflow layer owns business-state transitions.
+The existing executor pipeline continues to own task execution details.
+
+### Layer split
+
+#### Workflow layer
+
+Owns:
+
+- project orchestration state
+- issue lifecycle state
+- event handling
+- transition decisions
+- PR binding
+- feedback sweep policy
+- replan policy
+
+Does not own:
+
+- prompt text
+- agent process spawning
+- checkpoint content format
+- review loop implementation details
+
+#### Executor layer
+
+Owns:
+
+- triage activity
+- planning activity
+- implementation activity
+- review/fix activity
+- checkpoint persistence
+- PR detection
+
+## Canonical workflow: `project_workflow`
+
+### States
+
+```text
+idle
+polling_intake
+planning_batch
+dispatching
+monitoring
+sweeping_feedback
+paused
+degraded
+```
+
+### State semantics
+
+- `idle`
+  - The repo has no active orchestration action in progress.
+
+- `polling_intake`
+  - Intake is actively discovering new issue or PR signals for the repo.
+
+- `planning_batch`
+  - The repo is building or running a batch/sprint plan for discovered issues.
+
+- `dispatching`
+  - The repo is actively creating or admitting issue workflows into execution.
+
+- `monitoring`
+  - The repo has active issue workflows and is waiting on progress/terminal signals.
+
+- `sweeping_feedback`
+  - The repo is sweeping open PR feedback and converting it into issue workflow signals.
+
+- `paused`
+  - Orchestration is intentionally paused, for example by maintenance windows.
+
+- `degraded`
+  - The repo workflow is alive but blocked by orchestration/runtime problems.
+
+### Events
+
+- `poll_started`
+- `poll_completed`
+- `sprint_planning_started`
+- `sprint_planner_enqueued`
+- `dispatch_started`
+- `dispatch_completed`
+- `monitoring_started`
+- `feedback_sweep_started`
+- `feedback_sweep_completed`
+- `repo_paused`
+- `repo_degraded`
+- `repo_idle`
+
+### Activities
+
+- `poll_intake`
+- `build_sprint_plan`
+- `dispatch_issue_workflows`
+- `monitor_issue_workflows`
+- `sweep_repo_feedback`
+- `reconcile_repo_state`
+
+## Canonical workflow: `issue_workflow`
+
+### States
+
+```text
+discovered
+scheduled
+implementing
+pr_open
+awaiting_feedback
+addressing_feedback
+ready_to_merge
+blocked
+done
+failed
+cancelled
+```
+
+### State semantics
+
+- `discovered`
+  - The issue is known to the system but not yet admitted for work.
+
+- `scheduled`
+  - The issue has been selected for execution and can claim runtime capacity.
+
+- `implementing`
+  - The issue is in active implementation, including optional triage/plan/replan work.
+
+- `pr_open`
+  - A PR is bound to this issue workflow instance.
+
+- `awaiting_feedback`
+  - The PR exists and the workflow is waiting for new actionable feedback or mergeability.
+
+- `addressing_feedback`
+  - Actionable PR feedback has been detected and a fix round is active.
+
+- `ready_to_merge`
+  - The PR is green, no actionable feedback remains, and merge preconditions are satisfied.
+
+- `blocked`
+  - The workflow cannot proceed without external input, conflict resolution, or policy override.
+
+- `done`
+  - The issue is resolved and merged or otherwise completed successfully.
+
+- `failed`
+  - The workflow terminated unsuccessfully.
+
+- `cancelled`
+  - The workflow was intentionally cancelled.
+
+## Events
+
+### Intake and scheduling
+
+- `issue_discovered`
+- `issue_scheduled`
+- `capacity_denied`
+
+### Execution
+
+- `triage_completed`
+- `plan_completed`
+- `implement_started`
+- `implement_completed`
+- `pr_detected`
+- `implement_failed`
+- `plan_issue_detected`
+
+### PR feedback
+
+- `feedback_sweep_completed`
+- `feedback_found`
+- `no_feedback_found`
+- `changes_requested`
+- `approved`
+- `mergeable`
+- `conflicting`
+- `ci_failed`
+- `ci_green`
+
+### Terminal
+
+- `merged`
+- `workflow_failed`
+- `workflow_cancelled`
+
+## Activities
+
+These are named workflow actions. They map to existing or incremental code paths.
+
+- `run_triage`
+- `run_plan`
+- `run_replan`
+- `run_implement`
+- `bind_pr`
+- `sweep_pr_feedback`
+- `run_fix_round`
+- `check_mergeability`
+- `mark_blocked`
+- `mark_failed`
+- `mark_done`
+
+## Transition table
+
+### Discovery and admission
+
+```text
+discovered --issue_scheduled--> scheduled
+scheduled --implement_started--> implementing
+scheduled --capacity_denied--> scheduled
+```
+
+### Implementation path
+
+```text
+implementing --pr_detected--> pr_open
+implementing --implement_failed--> failed
+implementing --workflow_cancelled--> cancelled
+```
+
+### `PLAN_ISSUE` handling
+
+```text
+implementing --plan_issue_detected--> implementing
+```
+
+This event does not directly fail the workflow.
+Instead it triggers a policy decision:
+
+- if force-execute label is absent:
+  - run `run_replan`
+  - then run `run_implement`
+- if force-execute label is present:
+  - record a plan concern artifact
+  - continue with `run_implement`
+
+### PR-open path
+
+```text
+pr_open --feedback_sweep_completed--> awaiting_feedback
+awaiting_feedback --feedback_found--> addressing_feedback
+awaiting_feedback --mergeable--> ready_to_merge
+awaiting_feedback --conflicting--> blocked
+awaiting_feedback --ci_failed--> awaiting_feedback
+awaiting_feedback --no_feedback_found--> awaiting_feedback
+```
+
+### Feedback loop
+
+```text
+addressing_feedback --implement_started--> addressing_feedback
+addressing_feedback --pr_detected--> pr_open
+addressing_feedback --implement_failed--> failed
+```
+
+### Completion
+
+```text
+ready_to_merge --merged--> done
+blocked --workflow_failed--> failed
+blocked --workflow_cancelled--> cancelled
+```
+
+## Authority model
+
+### ProjectWorkflow owns
+
+- repo intake progress
+- repo planning progress
+- repo dispatch progress
+- repo monitoring / feedback sweep posture
+
+### IssueWorkflow owns
+
+- issue admission
+- triage/planning/implementation branches
+- issue-to-PR binding
+- feedback addressing
+- merge readiness
+- terminal issue outcome
+
+### Executor task state owns
+
+- current turn execution details
+- retry counters
+- tool/process lifecycle
+- implementation/review sub-phase execution
+
+## Mapping rules
+
+- One `ProjectWorkflow` exists per canonical project root / repo.
+- One `IssueWorkflow` exists per `(project_id, issue_number)`.
+- `pr:M` is never a top-level lifecycle; it routes into the already-bound `IssueWorkflow`.
+- A single `ProjectWorkflow` may coordinate many `IssueWorkflow`s.
+
+## Product-facing implications
+
+After this redesign, dashboards and operator APIs should prefer:
+
+1. `ProjectWorkflow.state`
+2. `IssueWorkflow.state`
+
+and only use `TaskStatus` / `TaskPhase` for drill-down diagnostics.
+
+## Force-execute label policy
+
+Introduce a label contract:
+
+- `force-execute`
+
+Semantics:
+
+- When present on the GitHub issue, agent-raised `PLAN_ISSUE` cannot block progression.
+- The system records the concern but must continue execution against the issue contract.
+- This label does not override:
+  - merge conflicts
+  - missing repository access
+  - missing workspace path
+  - missing required runtime resources
+
+This keeps product authority with the operator while still preserving agent evidence.
+
+## PR binding model
+
+Introduce a durable issue-to-PR binding record:
+
+```text
+issue_key -> pr_number
+issue_key -> pr_url
+issue_key -> workflow_instance_id
+```
+
+Rules:
+
+1. Once `issue:N` detects `pr:M`, that PR becomes the canonical PR for the issue workflow.
+2. A later `pr:M` signal must route into the same workflow instance instead of creating a new top-level lifecycle.
+3. A later issue retry for the same `issue:N` must reuse the existing PR binding when possible.
+
+This is the main fix for the current `issue:N` vs `pr:M` split.
+
+## PR feedback sweep
+
+This must be a first-class activity, not an incidental webhook side effect.
+
+### Inputs
+
+- PR top-level comments
+- review summaries
+- inline review comments
+- review state
+- CI state
+- mergeability state
+
+### Outputs
+
+- structured actionable feedback list
+- workflow events:
+  - `feedback_found`
+  - `no_feedback_found`
+  - `approved`
+  - `changes_requested`
+  - `ci_failed`
+  - `ci_green`
+  - `conflicting`
+  - `mergeable`
+
+### Triggering
+
+Trigger the sweep from both:
+
+1. webhook signals, when configured
+2. periodic reconciliation polling, as a backstop
+
+This avoids relying on webhook correctness as the sole orchestration path.
+
+## Persistence model
+
+Add a workflow state store in `harness-workflow`.
+
+Suggested minimal persisted fields:
+
+```text
+workflow_id
+workflow_type
+state
+issue_repo
+issue_number
+pr_number
+pr_url
+task_id
+last_event
+last_transition_at
+labels_snapshot
+attempt_count
+blocked_reason
+plan_concern
+```
+
+This is intentionally issue-centric, not task-centric.
+
+## Relationship to existing `TaskPhase`
+
+`TaskPhase` remains valid but moves down one layer.
+
+Example mapping:
+
+- workflow state `implementing`
+  - activity may run:
+    - `TaskPhase::Triage`
+    - `TaskPhase::Plan`
+    - `TaskPhase::Implement`
+
+- workflow state `addressing_feedback`
+  - activity may run:
+    - `TaskPhase::Implement`
+    - `TaskPhase::Review`
+
+This avoids conflict between the new workflow and current phase enums.
+
+## Relationship to existing `TaskStatus`
+
+`TaskStatus` remains an execution status for the currently attached task.
+It should not be treated as the full business-state source of truth for the issue.
+
+The workflow state becomes authoritative for lifecycle reporting.
+
+## Suggested implementation plan
+
+### Phase 1: internal workflow engine, static spec
+
+Add to `harness-workflow`:
+
+- `workflow_spec.rs`
+- `workflow_runtime.rs`
+- `workflow_state_store.rs`
+
+Use a static Rust table for the `issue_lifecycle` workflow first.
+Do not introduce YAML parsing yet.
+
+### Phase 2: bind issue and PR to one workflow instance
+
+Replace current independent lifecycle handling with:
+
+- issue admission creates workflow instance
+- PR detection updates workflow instance
+- PR webhook/poll events route into the same workflow instance
+
+### Phase 3: move `PLAN_ISSUE` into workflow event handling
+
+Replace:
+
+- `PLAN_ISSUE -> TaskStatus::Failed`
+
+With:
+
+- `PLAN_ISSUE -> workflow event`
+- policy branch:
+  - replan
+  - or force-execute continue
+
+### Phase 4: add PR feedback sweep polling
+
+Add periodic PR reconciliation so the system can progress even when webhook delivery is missing or incomplete.
+
+### Phase 5: optional declarative spec files
+
+Once the runtime shape is stable, move the static spec into:
+
+- `workflows/issue_lifecycle.yaml`
+
+The runtime stays generic; only the spec moves out of code.
+
+## Why static spec before YAML
+
+The current repository does not yet contain a generic workflow runtime.
+Jumping straight to an external DSL would increase implementation risk.
+
+A static internal spec:
+
+- keeps the first change set smaller
+- makes debugging easier
+- proves the state/event/activity boundaries
+- avoids inventing configuration syntax too early
+
+The long-term goal can still be a file-driven workflow.
+
+## Operator-facing behavior after this change
+
+After this workflow exists, the operator experience should become:
+
+1. Submit issue once.
+2. The system owns the issue lifecycle.
+3. If a PR is created, feedback handling stays attached to the same issue workflow.
+4. If the agent raises a plan concern:
+   - default: the system replans
+   - with `force-execute`: the system continues anyway
+5. The operator no longer needs to manually resubmit PR tasks one by one.
+
+## Acceptance criteria
+
+1. `issue:N` and `pr:M` no longer create two independent top-level lifecycles when they refer to the same work.
+2. `PLAN_ISSUE` no longer directly maps to terminal task failure.
+3. PR feedback is processed without requiring manual resubmission of the PR as a new task.
+4. A `force-execute` label prevents agent-raised plan concerns from blocking implementation.
+5. Workflow state survives restart independently from ephemeral executor state.
+6. Dashboard views can report workflow lifecycle state separately from task execution status.
+
+## Open questions
+
+1. Should merge be performed automatically from `ready_to_merge`, or remain manual?
+2. Should `approved` immediately imply `ready_to_merge`, or must CI and mergeability be revalidated every time?
+3. Should `blocked` split into:
+   - `blocked_on_conflict`
+   - `blocked_on_policy`
+   - `blocked_on_external_input`
+4. Should `force-execute` live on the issue, the PR, or both?
+
+## Recommended next step
+
+Implement Phase 1 only:
+
+- internal workflow runtime
+- issue lifecycle state store
+- issue-to-PR binding
+- `PLAN_ISSUE` as workflow event
+
+Do not attempt full YAML-driven workflows in the first patch.

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Active } from "./Active";
 import type { Task } from "@/types";
@@ -24,6 +24,7 @@ function makeTask(id: string, project: string | null, status = "running"): Task 
     error: null,
     source: null,
     parent_id: null,
+    external_id: null,
     repo: null,
     description: id,
     created_at: null,
@@ -31,7 +32,14 @@ function makeTask(id: string, project: string | null, status = "running"): Task 
     depends_on: [],
     subtask_ids: [],
     project,
+    workflow: null,
   };
+}
+
+function columnCount(label: string): string {
+  const header = screen.getByText(label).parentElement;
+  if (!header) throw new Error(`missing ${label} column header`);
+  return within(header).getAllByText(/\d+/)[0].textContent ?? "";
 }
 
 function wrap(ui: React.ReactElement) {
@@ -80,5 +88,25 @@ describe("<Active>", () => {
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
     const dashes = screen.getAllByText("—");
     expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("groups tasks by workflow state before falling back to task status", () => {
+    const ready = {
+      ...makeTask("ready-task", "harness", "implementing"),
+      workflow: { state: "ready_to_merge", pr_number: 123 },
+    };
+    const feedback = {
+      ...makeTask("feedback-task", "harness", "pending"),
+      workflow: { state: "addressing_feedback", pr_number: 124 },
+    };
+    mockUseTasks.mockReturnValue({ data: [ready, feedback], isLoading: false, isError: false });
+    wrap(<Active projectFilter="harness" />);
+
+    expect(screen.getByText("wf Ready To Merge")).toBeInTheDocument();
+    expect(screen.getByText("wf Addressing Feedback")).toBeInTheDocument();
+    expect(columnCount("Ready")).toBe("1");
+    expect(columnCount("Feedback")).toBe("1");
+    expect(columnCount("Implementing")).toBe("0");
+    expect(columnCount("Pending")).toBe("0");
   });
 });

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,46 +1,145 @@
 import { useTasks, useDashboard } from "@/lib/queries";
-import type { Task } from "@/types";
+import type { Task, WorkflowSummary } from "@/types";
 
 interface Column {
   key: string;
   label: string;
-  /** Status strings from `GET /tasks` that belong in this column. */
-  statuses: string[];
+  workflowStates: string[];
+  fallbackTaskStatuses: string[];
 }
 
 /**
- * Columns used by the dashboard kanban. Keep in sync with harness-core's
- * `TaskStatus` enum — any status not listed here is collected under the
- * catch-all "Other" column so operators always see every task.
+ * Columns used by the dashboard task page.
+ *
+ * Workflow state is authoritative when present. Task status remains the
+ * fallback while older tasks or partially migrated flows lack workflow data.
  */
 const COLUMNS: Column[] = [
-  { key: "pending", label: "Pending", statuses: ["pending", "queued"] },
-  { key: "implementing", label: "Implementing", statuses: ["implementing", "running", "triage", "plan"] },
-  { key: "agent_review", label: "Agent Review", statuses: ["agent_review", "reviewing_agent"] },
-  { key: "waiting", label: "Waiting", statuses: ["waiting"] },
-  { key: "reviewing", label: "Reviewing", statuses: ["reviewing"] },
+  {
+    key: "pending",
+    label: "Pending",
+    workflowStates: ["discovered", "scheduled"],
+    fallbackTaskStatuses: ["pending", "queued", "awaiting_deps"],
+  },
+  {
+    key: "implementing",
+    label: "Implementing",
+    workflowStates: ["implementing"],
+    fallbackTaskStatuses: ["implementing", "running", "triage", "plan"],
+  },
+  {
+    key: "feedback",
+    label: "Feedback",
+    workflowStates: ["pr_open", "awaiting_feedback", "addressing_feedback"],
+    fallbackTaskStatuses: ["agent_review", "reviewing_agent", "waiting", "reviewing"],
+  },
+  {
+    key: "ready",
+    label: "Ready",
+    workflowStates: ["ready_to_merge"],
+    fallbackTaskStatuses: [],
+  },
+  {
+    key: "blocked",
+    label: "Blocked",
+    workflowStates: ["blocked", "degraded", "paused"],
+    fallbackTaskStatuses: [],
+  },
 ];
 
 const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
 
-function columnOf(status: string): string {
+function columnOf(taskStatus: string, workflowState?: string | null): string {
+  if (workflowState) {
+    for (const c of COLUMNS) {
+      if (c.workflowStates.includes(workflowState)) return c.key;
+    }
+  }
   for (const c of COLUMNS) {
-    if (c.statuses.includes(status)) return c.key;
+    if (c.fallbackTaskStatuses.includes(taskStatus)) return c.key;
   }
   return "other";
 }
 
-function TaskCard({ task }: { task: Task }) {
+function workflowLabel(state: string): string {
+  switch (state) {
+    case "discovered":
+      return "Discovered";
+    case "scheduled":
+      return "Scheduled";
+    case "implementing":
+      return "Implementing";
+    case "pr_open":
+      return "PR Open";
+    case "awaiting_feedback":
+      return "Awaiting Feedback";
+    case "addressing_feedback":
+      return "Addressing Feedback";
+    case "ready_to_merge":
+      return "Ready To Merge";
+    case "blocked":
+      return "Blocked";
+    case "done":
+      return "Done";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    case "idle":
+      return "Idle";
+    case "polling_intake":
+      return "Polling Intake";
+    case "planning_batch":
+      return "Planning Batch";
+    case "dispatching":
+      return "Dispatching";
+    case "monitoring":
+      return "Monitoring";
+    case "sweeping_feedback":
+      return "Sweeping Feedback";
+    case "paused":
+      return "Paused";
+    case "degraded":
+      return "Degraded";
+    default:
+      return state;
+  }
+}
+
+function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary | null }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
     <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
         {title}
       </div>
+      {workflow && (
+        <div className="mt-1 flex flex-wrap items-center gap-1">
+          <span className="border border-line bg-bg-1 px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
+            wf {workflowLabel(workflow.state)}
+          </span>
+          {workflow.pr_number ? (
+            <span className="font-mono text-[10px] text-ink-3">PR #{workflow.pr_number}</span>
+          ) : null}
+          {workflow.force_execute ? (
+            <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
+              force-execute
+            </span>
+          ) : null}
+        </div>
+      )}
       <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
         <span className="truncate">{task.repo ?? "—"}</span>
         {task.turn > 0 && <span>turn {task.turn}</span>}
       </div>
+      {workflow?.plan_concern && (
+        <div
+          className="mt-1 block font-mono text-[10px] text-rust truncate"
+          title={workflow.plan_concern}
+        >
+          concern: {workflow.plan_concern}
+        </div>
+      )}
       {task.pr_url && (
         <a
           href={task.pr_url}
@@ -75,7 +174,8 @@ export function Active({ projectFilter }: Props) {
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];
   for (const t of active) {
-    const col = columnOf(t.status);
+    const workflow = t.workflow ?? null;
+    const col = columnOf(t.status, workflow?.state ?? null);
     if (col === "other") other.push(t);
     else grouped[col].push(t);
   }
@@ -101,7 +201,7 @@ export function Active({ projectFilter }: Props) {
                 </div>
               )}
               {rows.map((t) => (
-                <TaskCard key={t.id} task={t} />
+                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
               ))}
             </div>
           </div>
@@ -113,12 +213,12 @@ export function Active({ projectFilter }: Props) {
             <span>Other</span>
             <span className="text-ink-2">{other.length}</span>
           </div>
-          <div className="p-2 flex-1 overflow-auto">
-            {other.map((t) => (
-              <TaskCard key={t.id} task={t} />
-            ))}
+            <div className="p-2 flex-1 overflow-auto">
+              {other.map((t) => (
+                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+              ))}
+            </div>
           </div>
-        </div>
       )}
     </div>
   );

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -10,6 +10,7 @@ export interface Task {
   error: string | null;
   source: string | null;
   parent_id: string | null;
+  external_id: string | null;
   repo: string | null;
   description: string | null;
   created_at: string | null;
@@ -17,4 +18,13 @@ export interface Task {
   depends_on: string[];
   subtask_ids: string[];
   project: string | null;
+  workflow?: WorkflowSummary | null;
+}
+
+export interface WorkflowSummary {
+  state: string;
+  issue_number?: number | null;
+  pr_number?: number | null;
+  force_execute?: boolean;
+  plan_concern?: string | null;
 }


### PR DESCRIPTION
## Summary
- Introduce project and issue workflow state stores as the orchestration authority for issue/PR lifecycle.
- Bind issue workflows to PRs, route PR feedback back through the same lifecycle, and automatically enqueue PR feedback sweeps.
- Convert PLAN_ISSUE into a workflow event with replan/force-execute handling.
- Add WORKFLOW.md policy front matter for force-execute and PR feedback sweep behavior.
- Inline workflow summaries into /tasks and show workflow-first columns on the existing task page.

## Validation
- cargo fmt --all
- cargo check -p harness-core -p harness-workflow -p harness-server
- RUSTFLAGS='-Dwarnings' cargo check -p harness-core -p harness-workflow -p harness-server --all-targets
- cargo test -p harness-workflow issue_workflow_store -- --test-threads=1
- cargo test -p harness-workflow project_workflow_store -- --test-threads=1
- cargo test -p harness-core replan_prompt -- --test-threads=1
- cd web && bun run typecheck
- cd web && bun run test -- src/routes/dashboard/Active.test.tsx

## Notes
- Full cargo test --workspace was not completed locally: the pre-commit full suite hit unrelated harness_observe failures/hangs in this environment.
- Uncommitted Rust version docs/config changes in CONTRIBUTING.md, Cargo.toml, and README.md are intentionally not included.