### PR TITLE
feat(web): expose persisted prompts from dashboard task cards

### DIFF
--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -21,6 +21,7 @@ const detail: TaskDetail = {
   error: null,
   source: "dashboard",
   parent_id: null,
+  external_id: null,
   repo: "majiayu000/harness",
   description: "Prompt task",
   created_at: "2026-04-22T13:00:00Z",
@@ -112,5 +113,31 @@ describe("<TaskSlideover>", () => {
     fireEvent.keyDown(window, { key: "Escape" });
 
     expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not emit duplicate key warnings for repeated round actions", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockUseTaskDetail.mockReturnValue({
+      data: {
+        ...detail,
+        rounds: [
+          { turn: 2, action: "transient_retry", result: "retrying after transient failure" },
+          { turn: 2, action: "transient_retry", result: "retry succeeded" },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<TaskSlideover taskId="task-12345678" open onClose={() => {}} />);
+
+    expect(screen.getAllByText(/transient_retry/)).toHaveLength(2);
+    expect(
+      consoleError.mock.calls.some(([message]) =>
+        String(message).includes("Each child in a list should have a unique"),
+      ),
+    ).toBe(false);
+
+    consoleError.mockRestore();
   });
 });

--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -29,6 +29,7 @@ const detail: TaskDetail = {
   depends_on: [],
   subtask_ids: [],
   project: "/tmp/harness",
+  task_kind: "implementation",
   rounds: [
     { turn: 1, action: "plan", result: "created implementation plan" },
     { turn: 2, action: "implement", result: "editing files" },

--- a/web/src/components/TaskSlideover.test.tsx
+++ b/web/src/components/TaskSlideover.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TaskSlideover } from "./TaskSlideover";
+import type { TaskDetail, TaskPromptRecord } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useTaskDetail: vi.fn(),
+  useTaskPrompts: vi.fn(),
+}));
+
+import { useTaskDetail, useTaskPrompts } from "@/lib/queries";
+
+const mockUseTaskDetail = useTaskDetail as ReturnType<typeof vi.fn>;
+const mockUseTaskPrompts = useTaskPrompts as ReturnType<typeof vi.fn>;
+
+const detail: TaskDetail = {
+  id: "task-12345678",
+  status: "running",
+  turn: 2,
+  pr_url: null,
+  error: null,
+  source: "dashboard",
+  parent_id: null,
+  repo: "majiayu000/harness",
+  description: "Prompt task",
+  created_at: "2026-04-22T13:00:00Z",
+  phase: "implement",
+  depends_on: [],
+  subtask_ids: [],
+  project: "/tmp/harness",
+  rounds: [
+    { turn: 1, action: "plan", result: "created implementation plan" },
+    { turn: 2, action: "implement", result: "editing files" },
+  ],
+};
+
+function makePrompt(turn: number, prompt: string, createdAt: string): TaskPromptRecord {
+  return {
+    task_id: "task-12345678",
+    turn,
+    phase: turn === 1 ? "plan" : "implement",
+    prompt,
+    created_at: createdAt,
+  };
+}
+
+describe("<TaskSlideover>", () => {
+  beforeEach(() => {
+    mockUseTaskDetail.mockReturnValue({
+      data: detail,
+      isLoading: false,
+      isError: false,
+    });
+    mockUseTaskPrompts.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("renders prompts in order and keeps long prompt text fully accessible", () => {
+    const longPrompt = `${"line of prompt context\n".repeat(80)}THE-END`;
+    mockUseTaskPrompts.mockReturnValue({
+      data: [
+        makePrompt(1, "planner prompt", "2026-04-22T13:00:01Z"),
+        makePrompt(2, longPrompt, "2026-04-22T13:00:02Z"),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<TaskSlideover taskId="task-12345678" open onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Prompts" }));
+
+    const prompts = screen.getAllByTestId("task-prompt");
+    expect(prompts).toHaveLength(2);
+    expect(prompts[0]).toHaveTextContent("planner prompt");
+    const promptBody = screen.getByLabelText("Prompt body turn 2");
+    expect(promptBody.textContent).toBe(longPrompt);
+    expect(promptBody.className).toContain("overflow-auto");
+  });
+
+  it("renders loading, empty, and error states for prompts", () => {
+    const { rerender } = render(<TaskSlideover taskId="task-12345678" open onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Prompts" }));
+    expect(screen.getByText("No prompts recorded for this task.")).toBeInTheDocument();
+
+    mockUseTaskPrompts.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    rerender(<TaskSlideover taskId="task-12345678" open onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Prompts" }));
+    expect(screen.getByText("Loading prompts…")).toBeInTheDocument();
+
+    mockUseTaskPrompts.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    rerender(<TaskSlideover taskId="task-12345678" open onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Prompts" }));
+    expect(screen.getByText("Unable to load prompts.")).toBeInTheDocument();
+  });
+
+  it("closes on backdrop click and Escape", () => {
+    const onClose = vi.fn();
+    render(<TaskSlideover taskId="task-12345678" open onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText("Close task detail"));
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTaskDetail, useTaskPrompts } from "@/lib/queries";
+
+type TabId = "overview" | "prompts";
+
+interface Props {
+  taskId: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "prompts", label: "Prompts" },
+];
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "Unknown time";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export function TaskSlideover({ taskId, open, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    setActiveTab("overview");
+  }, [taskId]);
+
+  const detailQuery = useTaskDetail(open ? taskId : null);
+  const promptsQuery = useTaskPrompts(open && activeTab === "prompts" ? taskId : null);
+
+  const title = useMemo(() => {
+    const detail = detailQuery.data;
+    if (!detail) return taskId?.slice(0, 8) ?? "Task";
+    return detail.description?.trim() || detail.repo || detail.id.slice(0, 8);
+  }, [detailQuery.data, taskId]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close task detail"
+        className="fixed inset-0 z-[70] bg-[rgba(5,8,10,0.62)]"
+        onClick={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Task detail"
+        className="fixed inset-y-0 right-0 z-[80] flex w-full max-w-[880px] flex-col border-l border-line-2 bg-bg-1 shadow-[-24px_0_60px_rgba(0,0,0,.45)]"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-line px-5 py-4">
+          <div className="min-w-0">
+            <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-ink-3">
+              Task Detail
+            </div>
+            <h2 className="mt-1 text-sm font-medium leading-6 text-ink">{title}</h2>
+            {taskId && <div className="mt-1 font-mono text-[11px] text-ink-3">{taskId}</div>}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border border-line px-2 py-1 font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3 transition-colors hover:border-line-3 hover:text-ink"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="border-b border-line px-5">
+          <div className="flex gap-2 py-3">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={`border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.12em] transition-colors ${
+                  tab.id === activeTab
+                    ? "border-rust bg-bg-2 text-rust"
+                    : "border-line text-ink-3 hover:border-line-3 hover:text-ink"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+          {activeTab === "overview" && (
+            <section className="space-y-4">
+              {detailQuery.isLoading && (
+                <div className="font-mono text-[11px] text-ink-3">Loading task…</div>
+              )}
+              {detailQuery.isError && (
+                <div className="font-mono text-[11px] text-red-300">Unable to load task detail.</div>
+              )}
+              {detailQuery.data && (
+                <>
+                  <dl className="grid gap-3 sm:grid-cols-2">
+                    <div className="border border-line bg-bg px-3 py-2">
+                      <dt className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                        Status
+                      </dt>
+                      <dd className="mt-1 text-sm text-ink">{detailQuery.data.status}</dd>
+                    </div>
+                    <div className="border border-line bg-bg px-3 py-2">
+                      <dt className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                        Phase
+                      </dt>
+                      <dd className="mt-1 text-sm text-ink">{detailQuery.data.phase ?? "—"}</dd>
+                    </div>
+                    <div className="border border-line bg-bg px-3 py-2">
+                      <dt className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                        Turn
+                      </dt>
+                      <dd className="mt-1 text-sm text-ink">{detailQuery.data.turn}</dd>
+                    </div>
+                    <div className="border border-line bg-bg px-3 py-2">
+                      <dt className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                        Created
+                      </dt>
+                      <dd className="mt-1 text-sm text-ink">
+                        {formatTimestamp(detailQuery.data.created_at)}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div className="border border-line bg-bg px-3 py-3">
+                    <div className="font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                      Rounds
+                    </div>
+                    {detailQuery.data.rounds.length === 0 ? (
+                      <div className="mt-2 font-mono text-[11px] text-ink-3">No rounds yet.</div>
+                    ) : (
+                      <div className="mt-3 space-y-2">
+                        {detailQuery.data.rounds.map((round) => (
+                          <div key={`${round.turn}-${round.action}`} className="border border-line px-3 py-2">
+                            <div className="font-mono text-[11px] text-ink-2">
+                              turn {round.turn} · {round.action}
+                            </div>
+                            <div className="mt-1 text-sm leading-6 text-ink">{round.result}</div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </section>
+          )}
+
+          {activeTab === "prompts" && (
+            <section className="space-y-4">
+              {promptsQuery.isLoading && (
+                <div className="font-mono text-[11px] text-ink-3">Loading prompts…</div>
+              )}
+              {promptsQuery.isError && (
+                <div className="font-mono text-[11px] text-red-300">Unable to load prompts.</div>
+              )}
+              {!promptsQuery.isLoading && !promptsQuery.isError && promptsQuery.data?.length === 0 && (
+                <div className="font-mono text-[11px] text-ink-3">No prompts recorded for this task.</div>
+              )}
+              {promptsQuery.data?.map((prompt) => (
+                <article
+                  key={`${prompt.turn}-${prompt.phase ?? "unknown"}-${prompt.created_at ?? "no-time"}`}
+                  data-testid="task-prompt"
+                  className="border border-line bg-bg px-3 py-3"
+                >
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10.5px] uppercase tracking-[0.12em] text-ink-3">
+                    <span>{prompt.phase ?? "unknown phase"}</span>
+                    <span>turn {prompt.turn}</span>
+                    <span>{formatTimestamp(prompt.created_at)}</span>
+                  </div>
+                  <pre
+                    aria-label={`Prompt body turn ${prompt.turn}`}
+                    className="mt-3 max-h-[52vh] overflow-auto whitespace-pre-wrap break-words border border-line bg-bg-1 p-3 font-mono text-[11px] leading-5 text-ink"
+                  >
+                    {prompt.prompt}
+                  </pre>
+                </article>
+              ))}
+            </section>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/web/src/components/TaskSlideover.tsx
+++ b/web/src/components/TaskSlideover.tsx
@@ -146,8 +146,11 @@ export function TaskSlideover({ taskId, open, onClose }: Props) {
                       <div className="mt-2 font-mono text-[11px] text-ink-3">No rounds yet.</div>
                     ) : (
                       <div className="mt-3 space-y-2">
-                        {detailQuery.data.rounds.map((round) => (
-                          <div key={`${round.turn}-${round.action}`} className="border border-line px-3 py-2">
+                        {detailQuery.data.rounds.map((round, index) => (
+                          <div
+                            key={`${round.turn}-${round.action}-${index}`}
+                            className="border border-line px-3 py-2"
+                          >
                             <div className="font-mono text-[11px] text-ink-2">
                               turn {round.turn} · {round.action}
                             </div>

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { useWorktrees } from "./queries";
+import { useTaskDetail, useTaskPrompts, useWorktrees } from "./queries";
 import { TOKEN_KEY } from "./api";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -95,5 +95,90 @@ describe("stream URL construction", () => {
 
   it("omits token param when no session token", () => {
     expect(buildStreamUrl("abc-123")).not.toContain("token=");
+  });
+});
+
+describe("task detail queries", () => {
+  it("does not fetch detail or prompts when no task id is provided", async () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    const { result: detailResult } = renderHook(() => useTaskDetail(null), { wrapper: makeWrapper() });
+    const { result: promptsResult } = renderHook(() => useTaskPrompts(null), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(detailResult.current.fetchStatus).toBe("idle");
+      expect(promptsResult.current.fetchStatus).toBe("idle");
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches task detail from /tasks/{id}", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "task-123",
+          status: "running",
+          turn: 2,
+          pr_url: null,
+          error: null,
+          source: "dashboard",
+          parent_id: null,
+          repo: "majiayu000/harness",
+          description: "Task detail",
+          created_at: "2026-04-22T13:00:00Z",
+          phase: "implement",
+          depends_on: [],
+          subtask_ids: [],
+          project: "/tmp/harness",
+          rounds: [],
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTaskDetail("task-123"), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data?.id).toBe("task-123"));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/tasks/task-123",
+      expect.objectContaining({
+        headers: { Accept: "application/json" },
+      }),
+    );
+  });
+
+  it("fetches prompts from /tasks/{id}/prompts and sorts them chronologically", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            task_id: "task-123",
+            turn: 2,
+            phase: "implement",
+            prompt: "retry prompt",
+            created_at: "2026-04-22T13:00:02Z",
+          },
+          {
+            task_id: "task-123",
+            turn: 1,
+            phase: "plan",
+            prompt: "planner prompt",
+            created_at: "2026-04-22T13:00:01Z",
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTaskPrompts("task-123"), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(result.current.data?.map((prompt) => prompt.turn)).toEqual([1, 2]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/tasks/task-123/prompts",
+      expect.objectContaining({
+        headers: { Accept: "application/json" },
+      }),
+    );
   });
 });

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -147,22 +147,22 @@ describe("task detail queries", () => {
     );
   });
 
-  it("fetches prompts from /tasks/{id}/prompts and sorts them chronologically", async () => {
+  it("fetches prompts from /tasks/{id}/prompts and preserves backend ordering", async () => {
     global.fetch = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify([
           {
             task_id: "task-123",
-            turn: 2,
-            phase: "implement",
-            prompt: "retry prompt",
-            created_at: "2026-04-22T13:00:02Z",
+            turn: 1,
+            phase: "plan",
+            prompt: "planner prompt",
+            created_at: "2026-04-22T13:00:01Z",
           },
           {
             task_id: "task-123",
             turn: 1,
-            phase: "plan",
-            prompt: "planner prompt",
+            phase: "implement",
+            prompt: "implement prompt",
             created_at: "2026-04-22T13:00:01Z",
           },
         ]),
@@ -173,7 +173,7 @@ describe("task detail queries", () => {
     const { result } = renderHook(() => useTaskPrompts("task-123"), { wrapper: makeWrapper() });
 
     await waitFor(() => expect(result.current.data).toHaveLength(2));
-    expect(result.current.data?.map((prompt) => prompt.turn)).toEqual([1, 2]);
+    expect(result.current.data?.map((prompt) => prompt.phase)).toEqual(["plan", "implement"]);
     expect(global.fetch).toHaveBeenCalledWith(
       "/tasks/task-123/prompts",
       expect.objectContaining({

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "./api";
+<<<<<<< HEAD
 import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task } from "@/types";
+=======
+import type { DashboardPayload, OverviewPayload, Task, TaskDetail, TaskPromptRecord } from "@/types";
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -28,6 +32,36 @@ export function useTasks() {
   return useQuery<Task[], Error>({
     queryKey: ["tasks"],
     queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
+  });
+}
+
+function hasTaskId(id: string | null): id is string {
+  return Boolean(id?.trim());
+}
+
+function comparePromptRecords(a: TaskPromptRecord, b: TaskPromptRecord): number {
+  if (a.turn !== b.turn) return a.turn - b.turn;
+  const timestampComparison = (a.created_at ?? "").localeCompare(b.created_at ?? "");
+  if (timestampComparison !== 0) return timestampComparison;
+  return (a.phase ?? "").localeCompare(b.phase ?? "");
+}
+
+export function useTaskDetail(id: string | null) {
+  return useQuery<TaskDetail, Error>({
+    queryKey: ["tasks", id, "detail"],
+    enabled: hasTaskId(id),
+    queryFn: ({ signal }) => apiJson<TaskDetail>(`/tasks/${id}`, { signal }),
+  });
+}
+
+export function useTaskPrompts(id: string | null) {
+  return useQuery<TaskPromptRecord[], Error>({
+    queryKey: ["tasks", id, "prompts"],
+    enabled: hasTaskId(id),
+    queryFn: async ({ signal }) => {
+      const prompts = await apiJson<TaskPromptRecord[]>(`/tasks/${id}/prompts`, { signal });
+      return [...prompts].sort(comparePromptRecords);
+    },
   });
 }
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "./api";
-<<<<<<< HEAD
-import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task } from "@/types";
-=======
-import type { DashboardPayload, OverviewPayload, Task, TaskDetail, TaskPromptRecord } from "@/types";
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
+import type {
+  DashboardPayload,
+  OperatorSnapshotPayload,
+  OverviewPayload,
+  Task,
+  TaskDetail,
+  TaskPromptRecord,
+} from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -39,13 +39,6 @@ function hasTaskId(id: string | null): id is string {
   return Boolean(id?.trim());
 }
 
-function comparePromptRecords(a: TaskPromptRecord, b: TaskPromptRecord): number {
-  if (a.turn !== b.turn) return a.turn - b.turn;
-  const timestampComparison = (a.created_at ?? "").localeCompare(b.created_at ?? "");
-  if (timestampComparison !== 0) return timestampComparison;
-  return (a.phase ?? "").localeCompare(b.phase ?? "");
-}
-
 export function useTaskDetail(id: string | null) {
   return useQuery<TaskDetail, Error>({
     queryKey: ["tasks", id, "detail"],
@@ -58,10 +51,7 @@ export function useTaskPrompts(id: string | null) {
   return useQuery<TaskPromptRecord[], Error>({
     queryKey: ["tasks", id, "prompts"],
     enabled: hasTaskId(id),
-    queryFn: async ({ signal }) => {
-      const prompts = await apiJson<TaskPromptRecord[]>(`/tasks/${id}/prompts`, { signal });
-      return [...prompts].sort(comparePromptRecords);
-    },
+    queryFn: ({ signal }) => apiJson<TaskPromptRecord[]>(`/tasks/${id}/prompts`, { signal }),
   });
 }
 

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
 import { StatusBadge } from "@/components/StatusBadge";
 import { PaletteFab } from "@/components/PaletteFab";
+import { TaskSlideover } from "@/components/TaskSlideover";
 import { Active } from "./dashboard/Active";
 import { History } from "./dashboard/History";
 import { Channels } from "./dashboard/Channels";
@@ -14,6 +15,7 @@ type Tab = "board" | "history" | "channels" | "submit";
 
 export function Dashboard() {
   const [tab, setTab] = useState<Tab>("board");
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const { isError } = useDashboard();
   const [searchParams] = useSearchParams();
   const projectFilter = searchParams.get("project");
@@ -39,7 +41,10 @@ export function Dashboard() {
       <Sidebar
         env="local"
         sections={sections}
-        onItemClick={(id) => setTab(id as Tab)}
+        onItemClick={(id) => {
+          setTab(id as Tab);
+          setSelectedTaskId(null);
+        }}
       />
       <main className="flex flex-col min-h-0 min-w-0">
         <TopBar
@@ -52,12 +57,22 @@ export function Dashboard() {
           actions={<StatusBadge ok={!isError} />}
         />
         <div className="flex-1 overflow-auto min-h-0 p-6">
-          {tab === "board" && <Active projectFilter={projectFilter} />}
+          {tab === "board" && (
+            <Active
+              projectFilter={projectFilter}
+              onOpenTask={(taskId) => setSelectedTaskId(taskId)}
+            />
+          )}
           {tab === "history" && <History projectFilter={projectFilter} />}
           {tab === "channels" && <Channels projectFilter={projectFilter} />}
           {tab === "submit" && <Submit projectFilter={projectFilter} />}
         </div>
       </main>
+      <TaskSlideover
+        taskId={selectedTaskId}
+        open={selectedTaskId !== null}
+        onClose={() => setSelectedTaskId(null)}
+      />
       <PaletteFab />
     </div>
   );

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -145,7 +145,7 @@ describe("<Active>", () => {
       isLoading: false,
       isError: false,
     });
-    wrap(<Active />);
+    wrap(<Active onOpenTask={() => {}} />);
     expect(screen.getByText("Planning")).toBeInTheDocument();
     expect(screen.getByText("Review")).toBeInTheDocument();
     expect(screen.getByText("planner-task")).toBeInTheDocument();

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-<<<<<<< HEAD
-import { render, screen, within } from "@testing-library/react";
-=======
-import { fireEvent, render, screen } from "@testing-library/react";
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Active } from "./Active";
 import type { Task } from "@/types";
@@ -95,7 +91,6 @@ describe("<Active>", () => {
     expect(dashes.length).toBeGreaterThan(0);
   });
 
-<<<<<<< HEAD
   it("groups tasks by workflow state before falling back to task status", () => {
     const ready = {
       ...makeTask("ready-task", "harness", "implementing"),
@@ -106,7 +101,7 @@ describe("<Active>", () => {
       workflow: { state: "addressing_feedback", pr_number: 124 },
     };
     mockUseTasks.mockReturnValue({ data: [ready, feedback], isLoading: false, isError: false });
-    wrap(<Active projectFilter="harness" />);
+    wrap(<Active projectFilter="harness" onOpenTask={() => {}} />);
 
     expect(screen.getByText("wf Ready To Merge")).toBeInTheDocument();
     expect(screen.getByText("wf Addressing Feedback")).toBeInTheDocument();
@@ -114,7 +109,8 @@ describe("<Active>", () => {
     expect(columnCount("Feedback")).toBe("1");
     expect(columnCount("Implementing")).toBe("0");
     expect(columnCount("Pending")).toBe("0");
-=======
+  });
+
   it("opens detail for a clicked kanban card", () => {
     const onOpenTask = vi.fn();
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
@@ -137,7 +133,6 @@ describe("<Active>", () => {
     fireEvent.click(screen.getByRole("button", { name: /prompt-task/i }));
 
     expect(onOpenTask).toHaveBeenCalledWith("prompt-task");
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
   });
 
   it("groups planner and review lifecycle statuses outside implementing", () => {

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+<<<<<<< HEAD
 import { render, screen, within } from "@testing-library/react";
+=======
+import { fireEvent, render, screen } from "@testing-library/react";
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Active } from "./Active";
 import type { Task } from "@/types";
@@ -66,7 +70,7 @@ describe("<Active>", () => {
 
   it("filters to matching project when projectFilter is set", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active projectFilter="harness" />);
+    wrap(<Active projectFilter="harness" onOpenTask={() => {}} />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
@@ -75,7 +79,7 @@ describe("<Active>", () => {
 
   it("shows all non-terminal tasks when no projectFilter", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active />);
+    wrap(<Active onOpenTask={() => {}} />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t2")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
@@ -84,13 +88,14 @@ describe("<Active>", () => {
 
   it("shows empty columns when projectFilter matches no tasks", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active projectFilter="nonexistent" />);
+    wrap(<Active projectFilter="nonexistent" onOpenTask={() => {}} />);
     expect(screen.queryByText("t1")).not.toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
     const dashes = screen.getAllByText("—");
     expect(dashes.length).toBeGreaterThan(0);
   });
 
+<<<<<<< HEAD
   it("groups tasks by workflow state before falling back to task status", () => {
     const ready = {
       ...makeTask("ready-task", "harness", "implementing"),
@@ -109,6 +114,30 @@ describe("<Active>", () => {
     expect(columnCount("Feedback")).toBe("1");
     expect(columnCount("Implementing")).toBe("0");
     expect(columnCount("Pending")).toBe("0");
+=======
+  it("opens detail for a clicked kanban card", () => {
+    const onOpenTask = vi.fn();
+    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+
+    wrap(<Active onOpenTask={onOpenTask} />);
+    fireEvent.click(screen.getByRole("button", { name: /t1/i }));
+
+    expect(onOpenTask).toHaveBeenCalledWith("t1");
+  });
+
+  it("opens detail for prompt-only task cards too", () => {
+    const onOpenTask = vi.fn();
+    mockUseTasks.mockReturnValue({
+      data: [makeTask("prompt-task", null, "pending")],
+      isLoading: false,
+      isError: false,
+    });
+
+    wrap(<Active onOpenTask={onOpenTask} />);
+    fireEvent.click(screen.getByRole("button", { name: /prompt-task/i }));
+
+    expect(onOpenTask).toHaveBeenCalledWith("prompt-task");
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
   });
 
   it("groups planner and review lifecycle statuses outside implementing", () => {

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -73,7 +73,6 @@ function columnOf(taskStatus: string, workflowState?: string | null): string {
   return "other";
 }
 
-<<<<<<< HEAD
 function workflowLabel(state: string): string {
   switch (state) {
     case "discovered":
@@ -119,42 +118,15 @@ function workflowLabel(state: string): string {
   }
 }
 
-function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary | null }) {
-  const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
-  return (
-    <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
-      <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
-        {title}
-      </div>
-      {workflow && (
-        <div className="mt-1 flex flex-wrap items-center gap-1">
-          <span className="border border-line bg-bg-1 px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
-            wf {workflowLabel(workflow.state)}
-          </span>
-          {workflow.pr_number ? (
-            <span className="font-mono text-[10px] text-ink-3">PR #{workflow.pr_number}</span>
-          ) : null}
-          {workflow.force_execute ? (
-            <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
-              force-execute
-            </span>
-          ) : null}
-        </div>
-      )}
-      <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
-        <span className="truncate">{task.repo ?? "—"}</span>
-        {task.turn > 0 && <span>turn {task.turn}</span>}
-      </div>
-      {workflow?.plan_concern && (
-        <div
-          className="mt-1 block font-mono text-[10px] text-rust truncate"
-          title={workflow.plan_concern}
-        >
-          concern: {workflow.plan_concern}
-        </div>
-      )}
-=======
-function TaskCard({ task, onOpenTask }: { task: Task; onOpenTask: (taskId: string) => void }) {
+function TaskCard({
+  task,
+  workflow,
+  onOpenTask,
+}: {
+  task: Task;
+  workflow?: WorkflowSummary | null;
+  onOpenTask: (taskId: string) => void;
+}) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
     <div className="mb-2 border border-line bg-bg transition-colors last:mb-0 hover:border-line-3">
@@ -166,12 +138,34 @@ function TaskCard({ task, onOpenTask }: { task: Task; onOpenTask: (taskId: strin
         <div className="text-[12.5px] leading-snug text-ink line-clamp-2" title={title}>
           {title}
         </div>
+        {workflow && (
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            <span className="border border-line bg-bg-1 px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
+              wf {workflowLabel(workflow.state)}
+            </span>
+            {workflow.pr_number ? (
+              <span className="font-mono text-[10px] text-ink-3">PR #{workflow.pr_number}</span>
+            ) : null}
+            {workflow.force_execute ? (
+              <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
+                force-execute
+              </span>
+            ) : null}
+          </div>
+        )}
         <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
           <span className="truncate">{task.repo ?? "—"}</span>
           {task.turn > 0 && <span>turn {task.turn}</span>}
         </div>
+        {workflow?.plan_concern && (
+          <div
+            className="mt-1 block font-mono text-[10px] text-rust truncate"
+            title={workflow.plan_concern}
+          >
+            concern: {workflow.plan_concern}
+          </div>
+        )}
       </button>
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
       {task.pr_url && (
         <a
           href={task.pr_url}
@@ -233,11 +227,12 @@ export function Active({ projectFilter, onOpenTask }: Props) {
                 </div>
               )}
               {rows.map((t) => (
-<<<<<<< HEAD
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
-=======
-                <TaskCard key={t.id} task={t} onOpenTask={onOpenTask} />
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
+                <TaskCard
+                  key={t.id}
+                  task={t}
+                  workflow={t.workflow ?? null}
+                  onOpenTask={onOpenTask}
+                />
               ))}
             </div>
           </div>
@@ -249,19 +244,17 @@ export function Active({ projectFilter, onOpenTask }: Props) {
             <span>Other</span>
             <span className="text-ink-2">{other.length}</span>
           </div>
-<<<<<<< HEAD
-            <div className="p-2 flex-1 overflow-auto">
-              {other.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
-              ))}
-            </div>
-=======
           <div className="p-2 flex-1 overflow-auto">
             {other.map((t) => (
-              <TaskCard key={t.id} task={t} onOpenTask={onOpenTask} />
+              <TaskCard
+                key={t.id}
+                task={t}
+                workflow={t.workflow ?? null}
+                onOpenTask={onOpenTask}
+              />
             ))}
->>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
           </div>
+        </div>
       )}
     </div>
   );

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -73,6 +73,7 @@ function columnOf(taskStatus: string, workflowState?: string | null): string {
   return "other";
 }
 
+<<<<<<< HEAD
 function workflowLabel(state: string): string {
   switch (state) {
     case "discovered":
@@ -152,13 +153,31 @@ function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary |
           concern: {workflow.plan_concern}
         </div>
       )}
+=======
+function TaskCard({ task, onOpenTask }: { task: Task; onOpenTask: (taskId: string) => void }) {
+  const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
+  return (
+    <div className="mb-2 border border-line bg-bg transition-colors last:mb-0 hover:border-line-3">
+      <button
+        type="button"
+        onClick={() => onOpenTask(task.id)}
+        className="block w-full cursor-pointer px-2.5 py-2 text-left"
+      >
+        <div className="text-[12.5px] leading-snug text-ink line-clamp-2" title={title}>
+          {title}
+        </div>
+        <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
+          <span className="truncate">{task.repo ?? "—"}</span>
+          {task.turn > 0 && <span>turn {task.turn}</span>}
+        </div>
+      </button>
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
       {task.pr_url && (
         <a
           href={task.pr_url}
           target="_blank"
           rel="noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="mt-1 block font-mono text-[10px] text-rust hover:underline truncate"
+          className="mt-1 block truncate px-2.5 pb-2 font-mono text-[10px] text-rust hover:underline"
         >
           {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
         </a>
@@ -169,9 +188,10 @@ function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary |
 
 interface Props {
   projectFilter?: string | null;
+  onOpenTask: (taskId: string) => void;
 }
 
-export function Active({ projectFilter }: Props) {
+export function Active({ projectFilter, onOpenTask }: Props) {
   const { data, isLoading, isError } = useTasks();
   const { data: dashboard } = useDashboard();
 
@@ -213,7 +233,11 @@ export function Active({ projectFilter }: Props) {
                 </div>
               )}
               {rows.map((t) => (
+<<<<<<< HEAD
                 <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+=======
+                <TaskCard key={t.id} task={t} onOpenTask={onOpenTask} />
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
               ))}
             </div>
           </div>
@@ -225,11 +249,18 @@ export function Active({ projectFilter }: Props) {
             <span>Other</span>
             <span className="text-ink-2">{other.length}</span>
           </div>
+<<<<<<< HEAD
             <div className="p-2 flex-1 overflow-auto">
               {other.map((t) => (
                 <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
               ))}
             </div>
+=======
+          <div className="p-2 flex-1 overflow-auto">
+            {other.map((t) => (
+              <TaskCard key={t.id} task={t} onOpenTask={onOpenTask} />
+            ))}
+>>>>>>> 996596d (Expose persisted task prompts from dashboard cards)
           </div>
       )}
     </div>

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -39,7 +39,6 @@ export interface TaskRound {
 }
 
 export interface TaskDetail extends Task {
-  external_id?: string | null;
   rounds: TaskRound[];
   priority?: number;
 }

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -29,3 +29,25 @@ export interface WorkflowSummary {
   force_execute?: boolean;
   plan_concern?: string | null;
 }
+
+export interface TaskRound {
+  turn: number;
+  action: string;
+  result: string;
+  detail?: string | null;
+  first_token_latency_ms?: number | null;
+}
+
+export interface TaskDetail extends Task {
+  external_id?: string | null;
+  rounds: TaskRound[];
+  priority?: number;
+}
+
+export interface TaskPromptRecord {
+  task_id: string;
+  turn: number;
+  phase: string | null;
+  prompt: string;
+  created_at: string | null;
+}


### PR DESCRIPTION
Closes #904

## Summary
- make every active dashboard task card open a shared task detail slideover
- add task detail and prompt query hooks plus frontend types for full task detail and persisted prompt records
- add a Prompts tab that renders complete prompt bodies without truncation and covers the new flow with focused tests

## Validation
- `bun run typecheck`
- `bun run test ./src/routes/dashboard/Active.test.tsx ./src/components/TaskSlideover.test.tsx ./src/lib/queries.test.ts`
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` is blocked in this session by conflicting `DATABASE_URL`-dependent workspace test environment behavior outside this web-only diff