### PR TITLE
Restore restart recovery for system-generated prompt tasks

### DIFF
--- a/crates/harness-server/src/handlers/operator_snapshot.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot.rs
@@ -296,7 +296,6 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
-            system_input: None,
         };
         let stalled_json = stalled_task_json(&stalled_task);
 
@@ -422,7 +421,6 @@ mod tests {
                 triage_output: None,
                 plan_output: None,
                 request_settings: None,
-                system_input: None,
             };
             task.status = crate::task_runner::TaskStatus::Failed;
             state.core.tasks.insert(&task).await;
@@ -479,7 +477,6 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
-            system_input: None,
         };
         state.core.tasks.insert(&task).await;
 
@@ -540,7 +537,6 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
-            system_input: None,
         };
         state.core.tasks.insert(&task).await;
 

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -111,7 +111,6 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -206,7 +205,6 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
@@ -232,7 +230,6 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -311,7 +308,6 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -381,7 +377,6 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -4,58 +4,17 @@ use super::{state::AppState, task_routes};
 use crate::task_runner;
 use harness_workflow::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
 
-fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
-    task.external_id
-        .as_deref()
-        .map(|eid| {
-            if let Some(n) = eid.strip_prefix("issue:") {
-                (n.parse::<u64>().ok(), None)
-            } else if let Some(n) = eid.strip_prefix("pr:") {
-                (None, n.parse::<u64>().ok())
-            } else {
-                (None, None)
-            }
-        })
-        .unwrap_or((None, None))
-}
-
-fn build_recovered_request(
-    task: &task_runner::TaskState,
-    canonical: std::path::PathBuf,
-    issue: Option<u64>,
-    pr: Option<u64>,
-) -> task_runner::CreateTaskRequest {
-    let mut req = task_runner::CreateTaskRequest {
-        issue,
-        pr,
-        project: Some(canonical),
-        repo: task.repo.clone(),
-        source: task.source.clone(),
-        external_id: task.external_id.clone(),
-        parent_task_id: task.parent_id.clone(),
-        priority: task.priority,
-        system_input: task.system_input.clone(),
-        ..Default::default()
-    };
-    if let Some(ref settings) = task.request_settings {
-        settings.apply_to_req(&mut req);
-    }
+fn apply_recovered_request_settings(
+    req: &mut task_runner::CreateTaskRequest,
+    settings: &task_runner::PersistedRequestSettings,
+) -> Result<(), String> {
+    settings.apply_to_req(req);
     if req.prompt.is_none() {
-        if let Some(system_input) = req.system_input.as_ref() {
-            req.prompt = Some(system_input.prompt().to_string());
+        if let Some(prompt) = settings.rebuild_system_prompt()? {
+            req.prompt = Some(prompt);
         }
     }
-    req
-}
-
-pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_routes::QueueDomain {
-    match task_kind {
-        task_runner::TaskKind::Review => task_routes::QueueDomain::Review,
-        task_runner::TaskKind::Issue
-        | task_runner::TaskKind::Pr
-        | task_runner::TaskKind::Prompt
-        | task_runner::TaskKind::Planner => task_routes::QueueDomain::Primary,
-    }
+    Ok(())
 }
 
 /// Spawn background watcher for AwaitingDeps tasks.
@@ -149,20 +108,75 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                     };
                     let project_id = canonical.to_string_lossy().into_owned();
 
-                    let (issue, pr) = parse_issue_pr(&task);
-                    let req = build_recovered_request(&task, canonical, issue, pr);
+                    // Reconstruct the CreateTaskRequest from persisted task fields.
+                    // Parse issue/pr numbers from the canonical external_id (e.g. "issue:42").
+                    let (issue, pr) = task
+                        .external_id
+                        .as_deref()
+                        .map(|eid| {
+                            if let Some(n) = eid.strip_prefix("issue:") {
+                                (n.parse::<u64>().ok(), None)
+                            } else if let Some(n) = eid.strip_prefix("pr:") {
+                                (None, n.parse::<u64>().ok())
+                            } else {
+                                (None, None)
+                            }
+                        })
+                        .unwrap_or((None, None));
+                    let mut req = task_runner::CreateTaskRequest {
+                        issue,
+                        pr,
+                        project: Some(canonical),
+                        repo: task.repo.clone(),
+                        source: task.source.clone(),
+                        external_id: task.external_id.clone(),
+                        parent_task_id: task.parent_id.clone(),
+                        priority: task.priority,
+                        ..Default::default()
+                    };
+                    // Restore execution limits and prompt from persisted settings.
+                    if let Some(ref settings) = task.request_settings {
+                        if let Err(err) = apply_recovered_request_settings(&mut req, settings) {
+                            let reason =
+                                format!("dep-watcher: failed to rebuild system prompt: {err}");
+                            tracing::error!(task_id = ?task.id, "{reason}");
+                            if let Err(pe) = task_runner::mutate_and_persist(
+                                &state.core.tasks,
+                                &task.id,
+                                move |s| {
+                                    s.status = task_runner::TaskStatus::Failed;
+                                    s.error = Some(reason);
+                                },
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    task_id = ?task.id,
+                                    "dep-watcher: failed to persist failed status: {pe}"
+                                );
+                            }
+                            return;
+                        }
+                    }
 
-                    // Guard: prompt-only tasks store their prompt in memory only
-                    // (#[serde(skip)]). After a server restart the prompt field is
-                    // absent. If no issue/pr is present either, dispatching would
-                    // call implement_from_prompt("") — a silent mis-execution.
-                    // Fail the task explicitly so the caller can re-submit.
+                    // Guard: manual prompt-only tasks keep their prompt in
+                    // memory only. If restart recovery cannot rebuild a
+                    // system-generated prompt either, fail explicitly instead
+                    // of silently executing with an empty prompt.
                     if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
-                        let reason = format!(
-                            "dep-watcher: {} task has no restart-safe input after server restart; \
-                             please re-submit the task",
-                            task.task_kind.as_ref()
-                        );
+                        let reason = if task
+                            .request_settings
+                            .as_ref()
+                            .is_some_and(|settings| settings.is_manual_prompt_only())
+                        {
+                            "dep-watcher: manual prompt-only task has no persisted \
+                             prompt after server restart; please re-submit the task"
+                                .to_string()
+                        } else {
+                            "dep-watcher: task has no recoverable issue, PR, or prompt \
+                             after server restart"
+                                .to_string()
+                        };
                         tracing::error!(task_id = ?task.id, "{reason}");
                         if let Err(pe) =
                             task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
@@ -604,7 +618,42 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
                     }
                 };
 
-                let req = build_recovered_request(&task, canonical, None, Some(pr_num));
+                let mut req = task_runner::CreateTaskRequest {
+                    pr: Some(pr_num),
+                    project: Some(canonical),
+                    repo: task.repo.clone(),
+                    source: task.source.clone(),
+                    external_id: task.external_id.clone(),
+                    priority: task.priority,
+                    ..Default::default()
+                };
+                if let Some(ref settings) = task.request_settings {
+                    if let Err(err) = apply_recovered_request_settings(&mut req, settings) {
+                        let reason =
+                            format!("startup recovery: failed to rebuild system prompt: {err}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                }
                 // Use the three-tier select_agent() so that an explicit agent
                 // pin stored in request_settings (Tier 1) and project-level
                 // defaults (Tier 2a) are honoured, not bypassed by a raw
@@ -784,9 +833,10 @@ pub(super) fn spawn_system_task_recovery(state: &Arc<AppState>) {
                 };
                 let project_id = canonical.to_string_lossy().into_owned();
 
-                let queue = match recovery_queue_domain(task.task_kind) {
-                    task_routes::QueueDomain::Primary => state.concurrency.task_queue.clone(),
-                    task_routes::QueueDomain::Review => state.concurrency.review_task_queue.clone(),
+                let queue = if task.task_kind == task_runner::TaskKind::Review {
+                    state.concurrency.review_task_queue.clone()
+                } else {
+                    state.concurrency.task_queue.clone()
                 };
                 let permit = match queue.acquire(&project_id, task.priority).await {
                     Ok(p) => p,
@@ -817,7 +867,41 @@ pub(super) fn spawn_system_task_recovery(state: &Arc<AppState>) {
                     }
                 };
 
-                let req = build_recovered_request(&task, canonical, None, None);
+                let mut req = task_runner::CreateTaskRequest {
+                    project: Some(canonical),
+                    repo: task.repo.clone(),
+                    source: task.source.clone(),
+                    external_id: task.external_id.clone(),
+                    priority: task.priority,
+                    ..Default::default()
+                };
+                if let Some(ref settings) = task.request_settings {
+                    if let Err(err) = apply_recovered_request_settings(&mut req, settings) {
+                        let reason =
+                            format!("startup recovery: failed to rebuild system prompt: {err}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                }
                 if req.prompt.is_none() {
                     let reason = format!(
                         "startup recovery: {} task has no restart-safe input metadata",
@@ -950,31 +1034,6 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     | task_runner::TaskKind::Planner => None,
                 };
 
-                if issue_num.is_none() {
-                    let reason = if matches!(task.task_kind, task_runner::TaskKind::Prompt) {
-                        "prompt task cannot be recovered after restart: original prompt text is not persisted"
-                    } else {
-                        "checkpoint task has no parseable issue number — skipping"
-                    };
-                    tracing::warn!(task_id = ?task.id, "{reason}");
-                    let mut failed = task.clone();
-                    failed.status = task_runner::TaskStatus::Failed;
-                    failed.error = Some(reason.to_string());
-                    state.core.tasks.cache.insert(failed.id.clone(), failed);
-                    if let Err(e) = state.core.tasks.persist(&task.id).await {
-                        tracing::warn!(
-                            task_id = ?task.id,
-                            "startup recovery: failed to persist failed status: {e}"
-                        );
-                    }
-                    if let Some(cb) = &state.intake.completion_callback {
-                        if let Some(final_state) = state.core.tasks.get(&task.id) {
-                            cb(final_state).await;
-                        }
-                    }
-                    return;
-                }
-
                 let project_path = if let Some(root) = task.project_root.clone() {
                     Some(root)
                 } else {
@@ -1066,8 +1125,75 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     }
                 };
 
-                let Some(issue) = issue_num else { return };
-                let req = build_recovered_request(&task, canonical, Some(issue), None);
+                let mut req = task_runner::CreateTaskRequest {
+                    issue: issue_num,
+                    project: Some(canonical),
+                    repo: task.repo.clone(),
+                    source: task.source.clone(),
+                    external_id: task.external_id.clone(),
+                    priority: task.priority,
+                    ..Default::default()
+                };
+                // Restore persisted execution limits and any additional prompt
+                // context so the recovered task resumes with the same settings
+                // and caller-supplied context as originally requested.
+                if let Some(ref settings) = task.request_settings {
+                    if let Err(err) = apply_recovered_request_settings(&mut req, settings) {
+                        let reason =
+                            format!("startup recovery: failed to rebuild system prompt: {err}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                }
+
+                if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
+                    let reason = if task
+                        .request_settings
+                        .as_ref()
+                        .is_some_and(|settings| settings.is_manual_prompt_only())
+                    {
+                        "manual prompt-only task cannot be recovered after restart: \
+                         original prompt text is not persisted"
+                    } else {
+                        "checkpoint task has no parseable issue number or restart bundle — skipping"
+                    };
+                    tracing::warn!(task_id = ?task.id, "{reason}");
+                    let mut failed = task.clone();
+                    failed.status = task_runner::TaskStatus::Failed;
+                    failed.error = Some(reason.to_string());
+                    state.core.tasks.cache.insert(failed.id.clone(), failed);
+                    if let Err(e) = state.core.tasks.persist(&task.id).await {
+                        tracing::warn!(
+                            task_id = ?task.id,
+                            "startup recovery: failed to persist failed status: {e}"
+                        );
+                    }
+                    if let Some(cb) = &state.intake.completion_callback {
+                        if let Some(final_state) = state.core.tasks.get(&task.id) {
+                            cb(final_state).await;
+                        }
+                    }
+                    return;
+                }
 
                 // Use the three-tier select_agent() so that an explicit agent
                 // pin stored in request_settings (Tier 1) and project-level

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1214,12 +1214,8 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                 // Only wait for a permit once recovery has proven the task can
                 // actually be re-dispatched. Otherwise guaranteed-failure
                 // tasks sit behind unrelated work and delay intake cleanup.
-                let permit = match state
-                    .concurrency
-                    .task_queue
-                    .acquire(&project_id, task.priority)
-                    .await
-                {
+                let queue = recovered_task_queue(&state, &task);
+                let permit = match queue.acquire(&project_id, task.priority).await {
                     Ok(p) => p,
                     Err(e) => {
                         let reason =

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -75,6 +75,31 @@ fn awaiting_deps_recovery_failure_reason(
     }
 }
 
+fn recovered_queue_domain(task: &task_runner::TaskState) -> task_routes::QueueDomain {
+    let is_periodic_review = matches!(task.source.as_deref(), Some("periodic_review"))
+        || task
+            .request_settings
+            .as_ref()
+            .and_then(|settings| settings.system_prompt_restart_bundle.as_ref())
+            .is_some_and(|bundle| bundle.kind == "periodic_review");
+
+    if is_periodic_review {
+        task_routes::QueueDomain::Review
+    } else {
+        task_routes::QueueDomain::Primary
+    }
+}
+
+fn recovered_task_queue(
+    state: &AppState,
+    task: &task_runner::TaskState,
+) -> Arc<crate::task_queue::TaskQueue> {
+    match recovered_queue_domain(task) {
+        task_routes::QueueDomain::Primary => state.concurrency.task_queue.clone(),
+        task_routes::QueueDomain::Review => state.concurrency.review_task_queue.clone(),
+    }
+}
+
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
 pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
@@ -245,12 +270,8 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                         return;
                     }
 
-                    let permit = match state
-                        .concurrency
-                        .task_queue
-                        .acquire(&project_id, task.priority)
-                        .await
-                    {
+                    let queue = recovered_task_queue(&state, &task);
+                    let permit = match queue.acquire(&project_id, task.priority).await {
                         Ok(p) => p,
                         Err(e) => {
                             let reason =
@@ -627,12 +648,8 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
 
                 // Issue 1: acquire permit here inside the spawned future so serve()
                 // is never blocked waiting for a concurrency slot.
-                let permit = match state
-                    .concurrency
-                    .task_queue
-                    .acquire(&project_id, task.priority)
-                    .await
-                {
+                let queue = recovered_task_queue(&state, &task);
+                let permit = match queue.acquire(&project_id, task.priority).await {
                     Ok(p) => p,
                     Err(e) => {
                         let reason =
@@ -1387,6 +1404,16 @@ mod tests {
         }
     }
 
+    fn task_with_source_and_settings(
+        source: Option<&str>,
+        settings: task_runner::PersistedRequestSettings,
+    ) -> task_runner::TaskState {
+        task_runner::TaskState {
+            source: source.map(ToString::to_string),
+            ..task_with_settings(settings)
+        }
+    }
+
     #[test]
     fn checkpoint_recovery_fails_closed_when_issue_identity_is_lost() {
         let task = task_with_settings(issue_task_settings("extra context"));
@@ -1429,5 +1456,40 @@ mod tests {
                 "manual prompt-only task cannot be recovered after restart: original prompt text is not persisted",
             )
         );
+    }
+
+    #[test]
+    fn recovered_queue_domain_uses_review_queue_for_periodic_review_bundle_without_source() {
+        let task = task_with_settings(task_runner::PersistedRequestSettings {
+            system_prompt_restart_bundle: Some(
+                task_runner::SystemPromptRestartBundle::periodic_review(
+                    task_runner::PeriodicReviewPromptInputs {
+                        project_root: "/tmp/project".to_string(),
+                        since_arg: "2026-04-20T00:00:00Z".to_string(),
+                        review_type: "mixed".to_string(),
+                        guard_scan_output: None,
+                    },
+                ),
+            ),
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            recovered_queue_domain(&task),
+            crate::http::task_routes::QueueDomain::Review
+        ));
+    }
+
+    #[test]
+    fn recovered_queue_domain_uses_primary_queue_for_non_review_tasks() {
+        let task = task_with_source_and_settings(
+            Some("github"),
+            task_runner::PersistedRequestSettings::default(),
+        );
+
+        assert!(matches!(
+            recovered_queue_domain(&task),
+            crate::http::task_routes::QueueDomain::Primary
+        ));
     }
 }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -17,6 +17,35 @@ fn apply_recovered_request_settings(
     Ok(())
 }
 
+fn checkpoint_recovery_failure_reason(
+    task: &task_runner::TaskState,
+    req: &task_runner::CreateTaskRequest,
+    recovered_issue_num: Option<u64>,
+) -> Option<&'static str> {
+    if recovered_issue_num.is_none()
+        && task
+            .request_settings
+            .as_ref()
+            .is_some_and(|settings| settings.additional_prompt.is_some())
+    {
+        Some("checkpoint task lost parseable issue number during restart recovery — skipping")
+    } else if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
+        if task
+            .request_settings
+            .as_ref()
+            .is_some_and(|settings| settings.is_manual_prompt_only())
+        {
+            Some(
+                "manual prompt-only task cannot be recovered after restart: original prompt text is not persisted",
+            )
+        } else {
+            Some("checkpoint task has no parseable issue number or restart bundle — skipping")
+        }
+    } else {
+        None
+    }
+}
+
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
 pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
@@ -1165,17 +1194,7 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     }
                 }
 
-                if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
-                    let reason = if task
-                        .request_settings
-                        .as_ref()
-                        .is_some_and(|settings| settings.is_manual_prompt_only())
-                    {
-                        "manual prompt-only task cannot be recovered after restart: \
-                         original prompt text is not persisted"
-                    } else {
-                        "checkpoint task has no parseable issue number or restart bundle — skipping"
-                    };
+                if let Some(reason) = checkpoint_recovery_failure_reason(&task, &req, issue_num) {
                     tracing::warn!(task_id = ?task.id, "{reason}");
                     let mut failed = task.clone();
                     failed.status = task_runner::TaskStatus::Failed;
@@ -1306,5 +1325,92 @@ mod tests {
         let mut pending_without_pr = pending_with_pr;
         pending_without_pr.pr_url = None;
         assert!(!task_is_pr_recovery_candidate(&pending_without_pr));
+    }
+
+    fn issue_task_settings(additional_prompt: &str) -> task_runner::PersistedRequestSettings {
+        task_runner::PersistedRequestSettings {
+            additional_prompt: Some(additional_prompt.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn manual_prompt_only_settings() -> task_runner::PersistedRequestSettings {
+        task_runner::PersistedRequestSettings {
+            prompt_task_origin: Some(task_runner::PromptTaskOrigin::Manual),
+            ..Default::default()
+        }
+    }
+
+    fn task_with_settings(
+        settings: task_runner::PersistedRequestSettings,
+    ) -> task_runner::TaskState {
+        task_runner::TaskState {
+            id: task_runner::TaskId::new(),
+            status: task_runner::TaskStatus::Pending,
+            turn: 0,
+            pr_url: None,
+            rounds: vec![],
+            error: None,
+            source: None,
+            external_id: None,
+            parent_id: None,
+            depends_on: vec![],
+            subtask_ids: vec![],
+            project_root: None,
+            issue: None,
+            repo: None,
+            description: None,
+            created_at: None,
+            updated_at: None,
+            priority: 0,
+            phase: task_runner::TaskPhase::default(),
+            triage_output: None,
+            plan_output: None,
+            request_settings: Some(settings),
+        }
+    }
+
+    #[test]
+    fn checkpoint_recovery_fails_closed_when_issue_identity_is_lost() {
+        let task = task_with_settings(issue_task_settings("extra context"));
+        let req = task_runner::CreateTaskRequest {
+            prompt: Some("extra context".to_string()),
+            ..Default::default()
+        };
+
+        let reason = checkpoint_recovery_failure_reason(&task, &req, None);
+
+        assert_eq!(
+            reason,
+            Some("checkpoint task lost parseable issue number during restart recovery — skipping")
+        );
+    }
+
+    #[test]
+    fn checkpoint_recovery_allows_system_prompt_only_recovery() {
+        let task = task_with_settings(task_runner::PersistedRequestSettings::default());
+        let req = task_runner::CreateTaskRequest {
+            prompt: Some("rebuilt system prompt".to_string()),
+            ..Default::default()
+        };
+
+        let reason = checkpoint_recovery_failure_reason(&task, &req, None);
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn checkpoint_recovery_rejects_manual_prompt_only_tasks_without_prompt() {
+        let task = task_with_settings(manual_prompt_only_settings());
+        let req = task_runner::CreateTaskRequest::default();
+
+        let reason = checkpoint_recovery_failure_reason(&task, &req, None);
+
+        assert_eq!(
+            reason,
+            Some(
+                "manual prompt-only task cannot be recovered after restart: original prompt text is not persisted",
+            )
+        );
     }
 }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1377,6 +1377,7 @@ mod tests {
         task_runner::TaskState {
             id: task_runner::TaskId::new(),
             status: task_runner::TaskStatus::Pending,
+            task_kind: task_runner::TaskKind::default(),
             turn: 0,
             pr_url: None,
             rounds: vec![],

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -46,6 +46,35 @@ fn checkpoint_recovery_failure_reason(
     }
 }
 
+fn awaiting_deps_recovery_failure_reason(
+    task: &task_runner::TaskState,
+    req: &task_runner::CreateTaskRequest,
+    recovered_issue_num: Option<u64>,
+) -> Option<&'static str> {
+    if recovered_issue_num.is_none()
+        && task
+            .request_settings
+            .as_ref()
+            .is_some_and(|settings| settings.additional_prompt.is_some())
+    {
+        Some("dep-watcher: issue-backed task lost parseable issue number after restart; skipping")
+    } else if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
+        if task
+            .request_settings
+            .as_ref()
+            .is_some_and(|settings| settings.is_manual_prompt_only())
+        {
+            Some(
+                "dep-watcher: manual prompt-only task has no persisted prompt after server restart; please re-submit the task",
+            )
+        } else {
+            Some("dep-watcher: task has no recoverable issue, PR, or prompt after server restart")
+        }
+    } else {
+        None
+    }
+}
+
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
 pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
@@ -188,24 +217,9 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                         }
                     }
 
-                    // Guard: manual prompt-only tasks keep their prompt in
-                    // memory only. If restart recovery cannot rebuild a
-                    // system-generated prompt either, fail explicitly instead
-                    // of silently executing with an empty prompt.
-                    if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
-                        let reason = if task
-                            .request_settings
-                            .as_ref()
-                            .is_some_and(|settings| settings.is_manual_prompt_only())
-                        {
-                            "dep-watcher: manual prompt-only task has no persisted \
-                             prompt after server restart; please re-submit the task"
-                                .to_string()
-                        } else {
-                            "dep-watcher: task has no recoverable issue, PR, or prompt \
-                             after server restart"
-                                .to_string()
-                        };
+                    if let Some(reason) = awaiting_deps_recovery_failure_reason(&task, &req, issue)
+                    {
+                        let reason = reason.to_string();
                         tracing::error!(task_id = ?task.id, "{reason}");
                         if let Err(pe) =
                             task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
@@ -1120,40 +1134,6 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                 };
                 let project_id = canonical.to_string_lossy().into_owned();
 
-                let permit = match state
-                    .concurrency
-                    .task_queue
-                    .acquire(&project_id, task.priority)
-                    .await
-                {
-                    Ok(p) => p,
-                    Err(e) => {
-                        let reason =
-                            format!("startup recovery: failed to acquire concurrency permit: {e}");
-                        tracing::error!(task_id = ?task.id, "{reason}");
-                        if let Err(pe) =
-                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
-                                s.status = task_runner::TaskStatus::Failed;
-                                s.error = Some(reason);
-                            })
-                            .await
-                        {
-                            tracing::error!(
-                                task_id = ?task.id,
-                                "startup recovery: failed to persist failed status: {pe}; \
-                                 skipping completion callback to avoid state split"
-                            );
-                            return;
-                        }
-                        if let Some(cb) = &state.intake.completion_callback {
-                            if let Some(final_state) = state.core.tasks.get(&task.id) {
-                                cb(final_state).await;
-                            }
-                        }
-                        return;
-                    }
-                };
-
                 let mut req = task_runner::CreateTaskRequest {
                     issue: issue_num,
                     project: Some(canonical),
@@ -1213,6 +1193,43 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     }
                     return;
                 }
+
+                // Only wait for a permit once recovery has proven the task can
+                // actually be re-dispatched. Otherwise guaranteed-failure
+                // tasks sit behind unrelated work and delay intake cleanup.
+                let permit = match state
+                    .concurrency
+                    .task_queue
+                    .acquire(&project_id, task.priority)
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let reason =
+                            format!("startup recovery: failed to acquire concurrency permit: {e}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                };
 
                 // Use the three-tier select_agent() so that an explicit agent
                 // pin stored in request_settings (Tier 1) and project-level

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -54,9 +54,10 @@ impl CodeAgent for CapturingAgent {
 
     async fn execute_stream(
         &self,
-        _req: AgentRequest,
+        req: AgentRequest,
         _tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::error::Result<()> {
+        self.prompts.lock().await.push(req.prompt);
         Ok(())
     }
 }
@@ -279,6 +280,34 @@ async fn build_test_state_with_agent(
 fn init_fake_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(root.join(".git"))?;
     Ok(())
+}
+
+fn system_prompt_settings(
+    bundle: task_runner::SystemPromptRestartBundle,
+) -> task_runner::PersistedRequestSettings {
+    task_runner::PersistedRequestSettings {
+        wait_secs: 120,
+        retry_base_backoff_ms: 10_000,
+        retry_max_backoff_ms: 300_000,
+        stall_timeout_secs: 300,
+        turn_timeout_secs: 3_600,
+        agent: Some("test".to_string()),
+        prompt_task_origin: Some(task_runner::PromptTaskOrigin::SystemGenerated),
+        system_prompt_restart_bundle: Some(bundle),
+        ..Default::default()
+    }
+}
+
+fn manual_prompt_only_settings() -> task_runner::PersistedRequestSettings {
+    task_runner::PersistedRequestSettings {
+        wait_secs: 120,
+        retry_base_backoff_ms: 10_000,
+        retry_max_backoff_ms: 300_000,
+        stall_timeout_secs: 300,
+        turn_timeout_secs: 3_600,
+        prompt_task_origin: Some(task_runner::PromptTaskOrigin::Manual),
+        ..Default::default()
+    }
 }
 
 fn task_app(state: Arc<AppState>) -> Router {
@@ -951,9 +980,18 @@ async fn get_task_hides_internal_system_input_metadata() -> anyhow::Result<()> {
         phase: task_runner::TaskPhase::Review,
         triage_output: None,
         plan_output: None,
-        request_settings: None,
-        system_input: Some(task_runner::SystemTaskInput::PeriodicReview {
-            prompt: "review prompt".to_string(),
+        request_settings: Some(task_runner::PersistedRequestSettings {
+            system_prompt_restart_bundle: Some(
+                task_runner::SystemPromptRestartBundle::periodic_review(
+                    task_runner::PeriodicReviewPromptInputs {
+                        project_root: "/tmp/proj".to_string(),
+                        since_arg: "2024-01-01T00:00:00Z".to_string(),
+                        review_type: "standard".to_string(),
+                        guard_scan_output: None,
+                    },
+                ),
+            ),
+            ..Default::default()
         }),
     };
     let task_id = task.id.to_string();
@@ -963,7 +1001,7 @@ async fn get_task_hides_internal_system_input_metadata() -> anyhow::Result<()> {
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
     let task_json: serde_json::Value = serde_json::from_slice(&body)?;
     assert_eq!(task_json["id"], task_id);
-    assert!(task_json.get("system_input").is_none());
+    assert!(task_json.get("request_settings").is_none());
     Ok(())
 }
 
@@ -1229,9 +1267,6 @@ async fn list_tasks_exposes_task_kind_and_non_implementation_statuses() -> anyho
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: Some(task_runner::SystemTaskInput::PeriodicReview {
-            prompt: "review prompt".to_string(),
-        }),
     };
     let planner_task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
@@ -1257,9 +1292,6 @@ async fn list_tasks_exposes_task_kind_and_non_implementation_statuses() -> anyho
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: Some(task_runner::SystemTaskInput::SprintPlanner {
-            prompt: "planner prompt".to_string(),
-        }),
     };
     state.core.tasks.insert(&review_task).await;
     state.core.tasks.insert(&planner_task).await;
@@ -1939,7 +1971,6 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
         triage_output: None,
         plan_output: None,
         request_settings: None,
-        system_input: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -1981,16 +2012,23 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
 }
 
 #[tokio::test]
-async fn pr_recovery_redispatches_prompt_tasks_with_pr_urls() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let state = make_test_state(dir.path()).await?;
+async fn checkpoint_recovery_redispatches_periodic_review_prompt_task() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("harness-http-test-")?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), None).await?;
+    let expected_prompt = harness_core::prompts::periodic_review_prompt_with_guard_scan(
+        &dir.path().display().to_string(),
+        "2026-04-20T00:00:00Z",
+        "mixed",
+        Some("guard findings"),
+    );
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
         task_kind: task_runner::TaskKind::Prompt,
         status: task_runner::TaskStatus::Pending,
         turn: 0,
-        pr_url: Some("not-a-valid-pr-url".to_string()),
+        pr_url: None,
         rounds: vec![],
         error: None,
         source: None,
@@ -1998,60 +2036,150 @@ async fn pr_recovery_redispatches_prompt_tasks_with_pr_urls() -> anyhow::Result<
         parent_id: None,
         depends_on: vec![],
         subtask_ids: vec![],
-        project_root: None,
+        project_root: Some(dir.path().to_path_buf()),
         issue: None,
         repo: None,
-        description: None,
+        description: Some("prompt task".to_string()),
         created_at: None,
         updated_at: None,
         priority: 0,
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
-        system_input: None,
+        request_settings: Some(system_prompt_settings(
+            task_runner::SystemPromptRestartBundle::periodic_review(
+                task_runner::PeriodicReviewPromptInputs {
+                    project_root: dir.path().display().to_string(),
+                    since_arg: "2026-04-20T00:00:00Z".to_string(),
+                    review_type: "mixed".to_string(),
+                    guard_scan_output: Some("guard findings".to_string()),
+                },
+            ),
+        )),
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
+    // Write a checkpoint so the task appears in pending_tasks_with_checkpoint().
+    state
+        .core
+        .tasks
+        .write_checkpoint(&task_id, Some("triage output"), None, None, "triage_done")
+        .await?;
 
-    super::background::spawn_pr_recovery(&state);
+    super::background::spawn_checkpoint_recovery(&state).await;
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
-        if let Some(t) = state.core.tasks.get(&task_id) {
-            if matches!(t.status, task_runner::TaskStatus::Failed) {
-                break;
-            }
+        let prompts = agent.prompts.lock().await.clone();
+        if prompts.iter().any(|prompt| !prompt.is_empty()) {
+            break;
         }
         if tokio::time::Instant::now() >= deadline {
-            panic!("prompt task was not re-dispatched within 5 seconds after pr_recovery");
+            panic!("periodic_review prompt was not redispatched within 5 seconds");
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 
-    let final_state = state
-        .core
-        .tasks
-        .get(&task_id)
-        .expect("task must still exist");
-    assert!(matches!(
-        final_state.status,
-        task_runner::TaskStatus::Failed
-    ));
+    let prompts = agent.prompts.lock().await.clone();
+    assert!(prompts.iter().any(|prompt| !prompt.is_empty()));
+    assert!(prompts
+        .iter()
+        .any(|prompt| prompt.contains(expected_prompt.as_str())));
     assert!(
-        final_state
-            .error
-            .as_deref()
-            .unwrap_or("")
-            .contains("unparseable pr_url"),
-        "error should mention unparseable pr_url, got: {:?}",
-        final_state.error
+        state.core.tasks.get(&task_id).is_some(),
+        "task must still exist"
     );
     Ok(())
 }
 
 #[tokio::test]
-async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
+async fn checkpoint_recovery_redispatches_sprint_planner_prompt_task() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("harness-http-test-")?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), None).await?;
+    let issue_summary = "- #42: Fix login [p1, bug] (owner/repo)\n- #77: Tighten auth ()";
+    let expected_prompt = harness_core::prompts::sprint_plan_prompt(issue_summary);
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
+        status: task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("sprint_planner".to_string()),
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        issue: None,
+        repo: None,
+        description: Some("prompt task".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: Some(system_prompt_settings(
+            task_runner::SystemPromptRestartBundle::sprint_planner(
+                task_runner::SprintPlannerPromptInputs {
+                    issues: vec![
+                        task_runner::SprintPlannerIssueSummaryInput {
+                            external_id: "42".to_string(),
+                            title: "Fix login".to_string(),
+                            labels: vec!["p1".to_string(), "bug".to_string()],
+                            repo: Some("owner/repo".to_string()),
+                        },
+                        task_runner::SprintPlannerIssueSummaryInput {
+                            external_id: "77".to_string(),
+                            title: "Tighten auth".to_string(),
+                            labels: vec![],
+                            repo: None,
+                        },
+                    ],
+                },
+            ),
+        )),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+    state
+        .core
+        .tasks
+        .write_checkpoint(&task_id, Some("triage output"), None, None, "triage_done")
+        .await?;
+
+    super::background::spawn_checkpoint_recovery(&state).await;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let prompts = agent.prompts.lock().await.clone();
+        if prompts.iter().any(|prompt| !prompt.is_empty()) {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("sprint_planner prompt was not redispatched within 5 seconds");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let prompts = agent.prompts.lock().await.clone();
+    assert!(prompts.iter().any(|prompt| !prompt.is_empty()));
+    assert!(prompts
+        .iter()
+        .any(|prompt| prompt.contains(expected_prompt.as_str())));
+    assert!(
+        state.core.tasks.get(&task_id).is_some(),
+        "task must still exist"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn checkpoint_recovery_marks_manual_prompt_task_failed() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
 
@@ -2078,21 +2206,18 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
-        system_input: None,
+        request_settings: Some(manual_prompt_only_settings()),
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
-    // Write a checkpoint so the task appears in pending_tasks_with_checkpoint().
     state
         .core
         .tasks
-        .write_checkpoint(&task_id, None, Some("plan output"), None, "plan")
+        .write_checkpoint(&task_id, Some("triage output"), None, None, "triage_done")
         .await?;
 
     super::background::spawn_checkpoint_recovery(&state).await;
 
-    // The spawned tokio task updates the cache; give it a moment to complete.
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         if let Some(t) = state.core.tasks.get(&task_id) {
@@ -2101,7 +2226,7 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
             }
         }
         if tokio::time::Instant::now() >= deadline {
-            panic!("prompt task was not marked Failed within 5 seconds after checkpoint_recovery");
+            panic!("manual prompt task was not marked Failed within 5 seconds after checkpoint_recovery");
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
@@ -2120,21 +2245,93 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
             .error
             .as_deref()
             .unwrap_or("")
-            .contains("prompt task"),
-        "error should mention prompt task recovery failure, got: {:?}",
+            .contains("manual prompt-only task"),
+        "error should mention manual prompt-only recovery failure, got: {:?}",
         final_state.error
     );
     Ok(())
 }
 
-#[test]
-fn recovery_queue_domain_routes_review_tasks_to_review_capacity() {
-    assert_eq!(
-        super::background::recovery_queue_domain(task_runner::TaskKind::Review),
-        super::task_routes::QueueDomain::Review
+#[tokio::test]
+async fn checkpoint_recovery_fails_closed_on_invalid_system_prompt_bundle() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
+        status: task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("periodic_review".to_string()),
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        issue: None,
+        repo: None,
+        description: Some("prompt task".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: Some(system_prompt_settings(
+            task_runner::SystemPromptRestartBundle {
+                version: 99,
+                kind: "periodic_review".to_string(),
+                data: serde_json::json!({
+                    "project_root": dir.path().display().to_string(),
+                    "since_arg": "2026-04-20T00:00:00Z",
+                    "review_type": "mixed"
+                }),
+            },
+        )),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+    state
+        .core
+        .tasks
+        .write_checkpoint(&task_id, Some("triage output"), None, None, "triage_done")
+        .await?;
+
+    super::background::spawn_checkpoint_recovery(&state).await;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Some(t) = state.core.tasks.get(&task_id) {
+            if matches!(t.status, task_runner::TaskStatus::Failed) {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("invalid bundle task was not marked Failed within 5 seconds after checkpoint_recovery");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let final_state = state
+        .core
+        .tasks
+        .get(&task_id)
+        .expect("task must still exist");
+    assert!(matches!(
+        final_state.status,
+        task_runner::TaskStatus::Failed
+    ));
+    assert!(
+        final_state
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unsupported system prompt restart bundle"),
+        "error should mention prompt task recovery failure, got: {:?}",
+        final_state.error
     );
-    assert_eq!(
-        super::background::recovery_queue_domain(task_runner::TaskKind::Planner),
-        super::task_routes::QueueDomain::Primary
-    );
+    Ok(())
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2102,7 +2102,7 @@ async fn checkpoint_recovery_redispatches_sprint_planner_prompt_task() -> anyhow
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
-        task_kind: task_runner::TaskKind::Prompt,
+        task_kind: task_runner::TaskKind::Planner,
         status: task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::http::AppState;
-use crate::task_runner::{TaskId, TaskStatus};
+use crate::task_runner::{
+    CreateTaskRequest, SprintPlannerIssueSummaryInput, SprintPlannerPromptInputs,
+    SystemPromptRestartBundle, TaskId, TaskStatus,
+};
 
 pub mod feishu;
 pub mod github_issues;
@@ -522,14 +525,12 @@ async fn run_repo_sprint(
     let issue_summary = build_issue_summary(&issues);
     let planner_prompt = harness_core::prompts::sprint_plan_prompt(&issue_summary);
 
-    let planner_req = crate::task_runner::CreateTaskRequest {
-        prompt: Some(planner_prompt.clone()),
+    let planner_req = CreateTaskRequest {
+        prompt: Some(planner_prompt),
         agent: planner_agent.map(String::from),
         project: Some(project_root.clone()),
         source: Some("sprint_planner".to_string()),
-        system_input: Some(crate::task_runner::SystemTaskInput::SprintPlanner {
-            prompt: planner_prompt,
-        }),
+        system_prompt_restart_bundle: Some(build_sprint_planner_restart_bundle(&issues)),
         ..Default::default()
     };
 
@@ -997,6 +998,28 @@ fn build_issue_summary(issues: &[(Arc<dyn IntakeSource>, IncomingIssue)]) -> Str
         .join("\n")
 }
 
+fn build_sprint_planner_prompt_inputs(
+    issues: &[(Arc<dyn IntakeSource>, IncomingIssue)],
+) -> SprintPlannerPromptInputs {
+    SprintPlannerPromptInputs {
+        issues: issues
+            .iter()
+            .map(|(_, issue)| SprintPlannerIssueSummaryInput {
+                external_id: issue.external_id.clone(),
+                title: issue.title.clone(),
+                labels: issue.labels.clone(),
+                repo: issue.repo.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn build_sprint_planner_restart_bundle(
+    issues: &[(Arc<dyn IntakeSource>, IncomingIssue)],
+) -> SystemPromptRestartBundle {
+    SystemPromptRestartBundle::sprint_planner(build_sprint_planner_prompt_inputs(issues))
+}
+
 fn status_unblocks_dependents(status: &TaskStatus) -> bool {
     matches!(status, TaskStatus::Done | TaskStatus::Failed)
 }
@@ -1208,6 +1231,62 @@ pub(crate) fn build_prompt_from_issue(issue: &IncomingIssue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    struct TestSource;
+
+    #[async_trait]
+    impl IntakeSource for TestSource {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        async fn poll(&self) -> anyhow::Result<Vec<IncomingIssue>> {
+            Ok(Vec::new())
+        }
+
+        async fn mark_dispatched(
+            &self,
+            _external_id: &str,
+            _task_id: &TaskId,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn unmark_dispatched(&self, _external_id: &str) {}
+
+        async fn on_task_complete(
+            &self,
+            _external_id: &str,
+            _result: &TaskCompletionResult,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn planner_issue(
+        external_id: &str,
+        title: &str,
+        labels: &[&str],
+        repo: Option<&str>,
+    ) -> (Arc<dyn IntakeSource>, IncomingIssue) {
+        (
+            Arc::new(TestSource),
+            IncomingIssue {
+                source: "github".to_string(),
+                external_id: external_id.to_string(),
+                identifier: format!("#{external_id}"),
+                title: title.to_string(),
+                description: None,
+                repo: repo.map(ToOwned::to_owned),
+                url: None,
+                priority: None,
+                labels: labels.iter().map(|label| (*label).to_string()).collect(),
+                created_at: None,
+                project_root: None,
+            },
+        )
+    }
 
     fn make_deps(pairs: &[(u64, &[u64])]) -> std::collections::HashMap<u64, Vec<u64>> {
         pairs
@@ -1651,6 +1730,39 @@ mod tests {
         let prompt = build_prompt_from_issue(&issue);
         assert!(prompt.contains("URL: N/A"));
         assert!(prompt.contains("No description."));
+    }
+
+    #[test]
+    fn sprint_planner_restart_bundle_serializes_minimal_issue_summary_inputs() {
+        let issues = vec![
+            planner_issue("42", "Fix login", &["p1", "bug"], Some("owner/repo")),
+            planner_issue("77", "Tighten auth", &[], None),
+        ];
+
+        let inputs = build_sprint_planner_prompt_inputs(&issues);
+
+        assert_eq!(inputs.issues.len(), 2);
+        assert_eq!(inputs.issues[0].external_id, "42");
+        assert_eq!(inputs.issues[0].title, "Fix login");
+        assert_eq!(inputs.issues[0].labels, vec!["p1", "bug"]);
+        assert_eq!(inputs.issues[0].repo.as_deref(), Some("owner/repo"));
+        assert_eq!(inputs.issues[1].external_id, "77");
+        assert_eq!(inputs.issues[1].labels, Vec::<String>::new());
+        assert_eq!(inputs.issues[1].repo, None);
+    }
+
+    #[test]
+    fn sprint_planner_restart_bundle_rebuilds_current_prompt() {
+        let issues = vec![
+            planner_issue("42", "Fix login", &["p1", "bug"], Some("owner/repo")),
+            planner_issue("77", "Tighten auth", &[], None),
+        ];
+
+        let bundle = build_sprint_planner_restart_bundle(&issues);
+        let prompt = bundle.rebuild_prompt().expect("bundle rebuilds prompt");
+        let expected = harness_core::prompts::sprint_plan_prompt(&build_issue_summary(&issues));
+
+        assert_eq!(prompt, expected);
     }
 
     #[test]

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -408,7 +408,6 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
-            system_input: None,
         }
     }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -1,6 +1,8 @@
 use crate::http::task_routes;
 use crate::http::AppState;
-use crate::task_runner::CreateTaskRequest;
+use crate::task_runner::{
+    CreateTaskRequest, PeriodicReviewPromptInputs, SystemPromptRestartBundle,
+};
 use chrono::{DateTime, Utc};
 use harness_core::{
     config::misc::ReviewConfig,
@@ -725,6 +727,20 @@ fn ensure_review_queue_limit(state: &Arc<AppState>, project_root: &std::path::Pa
         .set_project_limit(&canonical, 1);
 }
 
+fn build_periodic_review_restart_bundle(
+    project_root: &std::path::Path,
+    since_arg: &str,
+    review_type: ReviewType,
+    guard_scan_output: Option<&str>,
+) -> SystemPromptRestartBundle {
+    SystemPromptRestartBundle::periodic_review(PeriodicReviewPromptInputs {
+        project_root: project_root.display().to_string(),
+        since_arg: since_arg.to_string(),
+        review_type: review_type.as_str().to_string(),
+        guard_scan_output: guard_scan_output.map(ToOwned::to_owned),
+    })
+}
+
 async fn run_review_tick(
     state: &Arc<AppState>,
     config: &ReviewConfig,
@@ -852,9 +868,12 @@ async fn run_review_tick(
         turn_timeout_secs: config.timeout_secs,
         source: Some("periodic_review".to_string()),
         project: Some(project_root.clone()),
-        system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
-            prompt: base_prompt.clone(),
-        }),
+        system_prompt_restart_bundle: Some(build_periodic_review_restart_bundle(
+            project_root,
+            &since_arg,
+            project.review_type,
+            guard_scan_output.as_deref(),
+        )),
         ..CreateTaskRequest::default()
     };
 
@@ -906,6 +925,7 @@ async fn run_review_tick(
     // correct repository — without this they fall back to main-worktree
     // detection and can execute against the wrong project.
     let project_root_for_poll = project_root.clone();
+    let review_type_for_poll = project.review_type;
     // Capture the scan boundary before the review agents run. Using this
     // timestamp (rather than Utc::now() after synthesis completes) as the
     // watermark ensures that commits arriving while secondary/synthesis agents
@@ -956,9 +976,12 @@ async fn run_review_tick(
                 turn_timeout_secs: timeout_secs,
                 source: Some("periodic_review".to_string()),
                 project: Some(project_root_for_poll.clone()),
-                system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
-                    prompt: base_prompt.clone(),
-                }),
+                system_prompt_restart_bundle: Some(build_periodic_review_restart_bundle(
+                    &project_root_for_poll,
+                    &since_arg,
+                    review_type_for_poll,
+                    guard_scan_output.as_deref(),
+                )),
                 ..CreateTaskRequest::default()
             };
             match task_routes::enqueue_task_in_domain(
@@ -1036,14 +1059,11 @@ async fn run_review_tick(
                     secondary_text,
                 );
                 let synth_req = CreateTaskRequest {
-                    prompt: Some(synthesis_prompt.clone()),
+                    prompt: Some(synthesis_prompt),
                     agent: Some(primary_agent_for_synthesis.clone()),
                     turn_timeout_secs: timeout_secs,
                     source: Some("periodic_review".to_string()),
                     project: Some(project_root_for_poll.clone()),
-                    system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
-                        prompt: synthesis_prompt,
-                    }),
                     ..CreateTaskRequest::default()
                 };
                 match task_routes::enqueue_task_in_domain(
@@ -2207,6 +2227,45 @@ mod tests {
         };
         assert_eq!(req.source.as_deref(), Some("periodic_review"));
         assert_eq!(req.project.as_deref(), Some(root.as_path()));
+    }
+
+    #[test]
+    fn periodic_review_restart_bundle_captures_enqueue_inputs() {
+        let root = std::path::PathBuf::from("/tmp/project");
+        let bundle = build_periodic_review_restart_bundle(
+            &root,
+            "2026-04-20T00:00:00Z",
+            ReviewType::Rust,
+            Some("guard findings"),
+        );
+        let inputs: PeriodicReviewPromptInputs =
+            serde_json::from_value(bundle.data).expect("bundle payload decodes");
+
+        assert_eq!(inputs.project_root, root.display().to_string());
+        assert_eq!(inputs.since_arg, "2026-04-20T00:00:00Z");
+        assert_eq!(inputs.review_type, "rust");
+        assert_eq!(inputs.guard_scan_output.as_deref(), Some("guard findings"));
+    }
+
+    #[test]
+    fn periodic_review_restart_bundle_rebuilds_current_prompt() {
+        let root = std::path::PathBuf::from("/tmp/project");
+        let bundle = build_periodic_review_restart_bundle(
+            &root,
+            "2026-04-20T00:00:00Z",
+            ReviewType::Mixed,
+            Some("guard findings"),
+        );
+
+        let prompt = bundle.rebuild_prompt().expect("bundle rebuilds prompt");
+        let expected = harness_core::prompts::periodic_review_prompt_with_guard_scan(
+            &root.display().to_string(),
+            "2026-04-20T00:00:00Z",
+            "mixed",
+            Some("guard findings"),
+        );
+
+        assert_eq!(prompt, expected);
     }
 
     // --- build_fix_prompt tests (SEC-01 / issue #612) ---

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -162,7 +162,6 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
-            system_input: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -206,7 +205,6 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
-            system_input: None,
         };
         store.insert(&parent_state).await;
 
@@ -234,7 +232,6 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
-            system_input: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -142,7 +142,6 @@ impl TaskDb {
             "SELECT t.id, t.task_kind, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
                     t.external_id, t.parent_id, t.created_at, t.updated_at, t.repo, t.depends_on, \
                     t.project, t.priority, t.phase, t.description, t.request_settings, \
-                    t.system_input, \
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
                     c.last_phase, \
                     TO_CHAR(c.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS ck_updated_at \
@@ -178,7 +177,6 @@ impl TaskDb {
                 phase: row.phase,
                 description: row.description,
                 request_settings: row.request_settings,
-                system_input: row.system_input,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -19,10 +19,6 @@ impl TaskDb {
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
-        let system_input_json = state
-            .system_input
-            .as_ref()
-            .and_then(|input| serde_json::to_string(input).ok());
         let created_at_dt: Option<DateTime<Utc>> = state
             .created_at
             .as_deref()
@@ -58,7 +54,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
-        .bind(system_input_json.as_deref())
+        .bind(None::<&str>)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -74,10 +70,6 @@ impl TaskDb {
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
-        let system_input_json = state
-            .system_input
-            .as_ref()
-            .and_then(|input| serde_json::to_string(input).ok());
         sqlx::query(
             "UPDATE tasks SET task_kind = $1, status = $2, turn = $3, pr_url = $4, rounds = $5, \
                     error = $6, source = $7, external_id = $8, repo = $9, depends_on = $10, \
@@ -105,7 +97,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
-        .bind(system_input_json.as_deref())
+        .bind(None::<&str>)
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -408,7 +400,7 @@ impl TaskDb {
             let sql = format!(
                 "SELECT t.id, t.task_kind, t.source, t.external_id, t.description, \
                         t.status, t.turn, t.pr_url AS task_pr_url, \
-                        t.system_input, \
+                        t.system_input, t.request_settings, \
                         c.triage_output, c.plan_output, c.pr_url AS ck_pr_url \
                  FROM tasks t \
                  LEFT JOIN task_checkpoints c ON t.id = c.task_id \
@@ -432,10 +424,15 @@ impl TaskDb {
                 row.external_id.as_deref(),
                 row.description.as_deref(),
             )?;
-            let system_input: Option<crate::task_runner::SystemTaskInput> = row
-                .system_input
-                .as_deref()
-                .and_then(|value| serde_json::from_str(value).ok());
+            let has_restart_data = row.system_input.is_some()
+                || row
+                    .request_settings
+                    .as_deref()
+                    .and_then(|s| {
+                        serde_json::from_str::<crate::task_runner::PersistedRequestSettings>(s).ok()
+                    })
+                    .map(|s| s.system_prompt_restart_bundle.is_some())
+                    .unwrap_or(false);
             let effective_pr_url = row
                 .task_pr_url
                 .as_deref()
@@ -451,7 +448,7 @@ impl TaskDb {
 
             if task_kind.recovery_status().is_some() {
                 if let Some(recovery_status) = task_kind.recovery_status() {
-                    if system_input.is_some() {
+                    if has_restart_data {
                         sqlx::query(
                             "UPDATE tasks SET status = $1, error = NULL, \
                              updated_at = CURRENT_TIMESTAMP WHERE id = $2",

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -1,4 +1,4 @@
-use crate::task_runner::{SystemTaskInput, TaskKind, TaskState, TaskStatus};
+use crate::task_runner::{TaskKind, TaskState, TaskStatus};
 use chrono::{DateTime, Utc};
 use harness_core::error::TaskDbDecodeError;
 use serde::{Deserialize, Serialize};
@@ -71,6 +71,7 @@ pub(super) struct RecoveryRow {
     pub(super) turn: i64,
     pub(super) task_pr_url: Option<String>,
     pub(super) system_input: Option<String>,
+    pub(super) request_settings: Option<String>,
     pub(super) triage_output: Option<String>,
     pub(super) plan_output: Option<String>,
     pub(super) ck_pr_url: Option<String>,
@@ -82,7 +83,7 @@ pub(super) struct RecoveryRow {
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-pub(super) const TASK_ROW_COLUMNS: &str = "id, task_kind, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, updated_at, repo, depends_on, project, priority, phase, description, request_settings, system_input";
+pub(super) const TASK_ROW_COLUMNS: &str = "id, task_kind, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, updated_at, repo, depends_on, project, priority, phase, description, request_settings";
 
 #[derive(sqlx::FromRow)]
 pub(super) struct TaskRow {
@@ -105,7 +106,6 @@ pub(super) struct TaskRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
-    pub(super) system_input: Option<String>,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -134,7 +134,6 @@ pub(super) struct PendingCheckpointRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
-    pub(super) system_input: Option<String>,
     // Checkpoint columns (aliased)
     pub(super) triage_output: Option<String>,
     pub(super) plan_output: Option<String>,
@@ -202,16 +201,12 @@ impl TaskRow {
             phase,
             description,
             request_settings,
-            system_input,
         } = self;
 
         let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
             request_settings
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok());
-        let decoded_system_input: Option<SystemTaskInput> = system_input
-            .as_deref()
-            .and_then(|s| serde_json::from_str(s).ok());
         let decoded_task_kind = TaskKind::from_persisted(
             Some(&task_kind),
             source.as_deref(),
@@ -263,7 +258,6 @@ impl TaskRow {
             plan_output: None,
             repo,
             request_settings: decoded_request_settings,
-            system_input: decoded_system_input,
         })
     }
 }

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -12,6 +12,26 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Instant;
 
+fn should_skip_prompt_persistence(task: Option<&crate::task_runner::TaskState>) -> bool {
+    let Some(task) = task else {
+        return false;
+    };
+    let Some(settings) = task.request_settings.as_ref() else {
+        return false;
+    };
+
+    if settings.is_manual_prompt_only() {
+        return true;
+    }
+
+    // Legacy prompt-only rows predate prompt_task_origin. Preserve the old
+    // description-based privacy fallback unless a restart bundle proves the
+    // prompt is system-generated and safe to reconstruct.
+    settings.prompt_task_origin.is_none()
+        && settings.system_prompt_restart_bundle.is_none()
+        && task.description.as_deref() == Some("prompt task")
+}
+
 /// Truncate validation error output to `max_chars` to avoid bloating agent prompts.
 /// Preserves the first portion which typically contains the most actionable info.
 pub(crate) fn truncate_validation_error(error: &str, max_chars: usize) -> String {
@@ -557,16 +577,12 @@ pub(crate) async fn run_agent_streaming(
     // Persist redacted prompt before req is consumed by execute_stream.
     // Skip only true manual prompt-only tasks: system-generated prompt tasks
     // are typed in request_settings and may be durably reconstructed.
-    let is_manual_prompt_only = store
-        .get(task_id)
-        .and_then(|s| s.request_settings)
-        .is_some_and(|settings| settings.is_manual_prompt_only());
-    let is_prompt_only = is_manual_prompt_only;
+    let skip_prompt_persistence = should_skip_prompt_persistence(store.get(task_id).as_ref());
     let phase_str = req
         .execution_phase
         .map(|p| format!("{p:?}").to_lowercase())
         .unwrap_or_else(|| "unknown".into());
-    if !is_prompt_only {
+    if !skip_prompt_persistence {
         let redacted_prompt = crate::redact::redact_secrets(&req.prompt, &req.env_vars);
         if let Err(e) = store
             .save_prompt(task_id, turn, &phase_str, &redacted_prompt)

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -555,12 +555,13 @@ pub(crate) async fn run_agent_streaming(
     let turn_start = Instant::now();
 
     // Persist redacted prompt before req is consumed by execute_stream.
-    // Skip prompt-only tasks: their prompts may contain user-supplied credentials
-    // and must not be written at rest (per the privacy contract in task_runner.rs).
-    let is_prompt_only = store
+    // Skip only true manual prompt-only tasks: system-generated prompt tasks
+    // are typed in request_settings and may be durably reconstructed.
+    let is_manual_prompt_only = store
         .get(task_id)
-        .map(|s| matches!(s.task_kind, crate::task_runner::TaskKind::Prompt))
-        .unwrap_or(false);
+        .and_then(|s| s.request_settings)
+        .is_some_and(|settings| settings.is_manual_prompt_only());
+    let is_prompt_only = is_manual_prompt_only;
     let phase_str = req
         .execution_phase
         .map(|p| format!("{p:?}").to_lowercase())

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -17,7 +17,7 @@ fn should_skip_prompt_persistence(task: Option<&crate::task_runner::TaskState>) 
         return false;
     };
     let Some(settings) = task.request_settings.as_ref() else {
-        return false;
+        return task.description.as_deref() == Some("prompt task");
     };
 
     if settings.is_manual_prompt_only() {

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -291,6 +291,19 @@ fn legacy_manual_prompt_only_tasks_still_skip_prompt_persistence() {
 }
 
 #[test]
+fn prompt_task_description_still_skips_prompt_persistence_without_request_settings() {
+    let mut task = task_with_prompt_settings(
+        "prompt task",
+        crate::task_runner::PersistedRequestSettings::default(),
+    );
+    task.request_settings = None;
+    assert!(
+        should_skip_prompt_persistence(Some(&task)),
+        "legacy prompt-only rows without request settings must not persist prompt text"
+    );
+}
+
+#[test]
 fn restart_bundle_keeps_system_prompt_tasks_persistable_without_origin_flag() {
     let dir = tempfile::tempdir().unwrap();
     let task = task_with_prompt_settings(

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -193,6 +193,7 @@ fn task_with_prompt_settings(
     crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
         status: crate::task_runner::TaskStatus::Pending,
+        task_kind: crate::task_runner::TaskKind::default(),
         turn: 0,
         pr_url: None,
         rounds: vec![],

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -186,6 +186,36 @@ fn wrap<T: TurnInterceptor + 'static>(t: T) -> Arc<dyn TurnInterceptor> {
     Arc::new(t)
 }
 
+fn task_with_prompt_settings(
+    description: &str,
+    settings: crate::task_runner::PersistedRequestSettings,
+) -> crate::task_runner::TaskState {
+    crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        status: crate::task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        issue: None,
+        repo: None,
+        description: Some(description.to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: Some(settings),
+    }
+}
+
 // ── run_pre_execute ───────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -245,6 +275,43 @@ async fn run_pre_execute_stops_chain_at_first_block() {
     assert!(
         !second_called.load(Ordering::SeqCst),
         "interceptor after block must not be called"
+    );
+}
+
+#[test]
+fn legacy_manual_prompt_only_tasks_still_skip_prompt_persistence() {
+    let task = task_with_prompt_settings(
+        "prompt task",
+        crate::task_runner::PersistedRequestSettings::default(),
+    );
+    assert!(
+        should_skip_prompt_persistence(Some(&task)),
+        "legacy manual prompt-only tasks must not persist prompt text"
+    );
+}
+
+#[test]
+fn restart_bundle_keeps_system_prompt_tasks_persistable_without_origin_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let task = task_with_prompt_settings(
+        "prompt task",
+        crate::task_runner::PersistedRequestSettings {
+            system_prompt_restart_bundle: Some(
+                crate::task_runner::SystemPromptRestartBundle::periodic_review(
+                    crate::task_runner::PeriodicReviewPromptInputs {
+                        project_root: dir.path().display().to_string(),
+                        since_arg: "2026-04-20T00:00:00Z".to_string(),
+                        review_type: "mixed".to_string(),
+                        guard_scan_output: None,
+                    },
+                ),
+            ),
+            ..Default::default()
+        },
+    );
+    assert!(
+        !should_skip_prompt_persistence(Some(&task)),
+        "restart bundles must keep system-generated prompt tasks eligible for prompt persistence"
     );
 }
 

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -180,7 +180,7 @@ async fn run_non_implementation_task(
     turns_used_acc: &mut u32,
     task_start: Instant,
 ) -> anyhow::Result<()> {
-    let Some(system_input) = store.get(task_id).and_then(|state| state.system_input) else {
+    let Some(ref prompt_str) = req.prompt else {
         anyhow::bail!(
             "{} task is missing restart-safe input metadata",
             task_kind.as_ref()
@@ -190,7 +190,7 @@ async fn run_non_implementation_task(
     update_status(store, task_id, task_kind.execution_status(), 1).await?;
 
     let mut prompt = implement_pipeline::prepend_constitution(
-        system_input.prompt().to_string(),
+        prompt_str.clone(),
         server_config.server.constitution_enabled,
     );
     let skill_additions = helpers::inject_skills_into_prompt(skills, &prompt).await;

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -16,8 +16,9 @@ pub type CompletionCallback =
 // Re-export everything that was previously public from the flat task_runner.rs.
 pub use metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
 pub use request::{
-    fill_missing_repo_from_project, CreateTaskRequest, PersistedRequestSettings, SystemTaskInput,
-    MAX_TASK_PRIORITY,
+    fill_missing_repo_from_project, CreateTaskRequest, PeriodicReviewPromptInputs,
+    PersistedRequestSettings, PromptTaskOrigin, SprintPlannerIssueSummaryInput,
+    SprintPlannerPromptInputs, SystemPromptRestartBundle, MAX_TASK_PRIORITY,
 };
 pub use spawn::{
     check_awaiting_deps, effective_turn_timeout, prompt_requires_plan, register_pending_task,

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -8,6 +8,98 @@ use super::types::{TaskId, TaskKind};
 /// `0` = normal (default), `1` = high, `2` = critical.
 pub const MAX_TASK_PRIORITY: u8 = 2;
 
+const SYSTEM_PROMPT_RESTART_BUNDLE_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptTaskOrigin {
+    Manual,
+    SystemGenerated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PeriodicReviewPromptInputs {
+    pub project_root: String,
+    pub since_arg: String,
+    pub review_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guard_scan_output: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SprintPlannerIssueSummaryInput {
+    pub external_id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SprintPlannerPromptInputs {
+    pub issues: Vec<SprintPlannerIssueSummaryInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SystemPromptRestartBundle {
+    pub version: u8,
+    pub kind: String,
+    pub data: serde_json::Value,
+}
+
+impl SystemPromptRestartBundle {
+    pub fn periodic_review(inputs: PeriodicReviewPromptInputs) -> Self {
+        Self {
+            version: SYSTEM_PROMPT_RESTART_BUNDLE_VERSION,
+            kind: "periodic_review".to_string(),
+            data: serde_json::json!({
+                "project_root": inputs.project_root,
+                "since_arg": inputs.since_arg,
+                "review_type": inputs.review_type,
+                "guard_scan_output": inputs.guard_scan_output,
+            }),
+        }
+    }
+
+    pub fn sprint_planner(inputs: SprintPlannerPromptInputs) -> Self {
+        Self {
+            version: SYSTEM_PROMPT_RESTART_BUNDLE_VERSION,
+            kind: "sprint_planner".to_string(),
+            data: serde_json::json!({ "issues": inputs.issues }),
+        }
+    }
+
+    pub(crate) fn rebuild_prompt(&self) -> Result<String, String> {
+        match (self.version, self.kind.as_str()) {
+            (SYSTEM_PROMPT_RESTART_BUNDLE_VERSION, "periodic_review") => {
+                let inputs: PeriodicReviewPromptInputs =
+                    serde_json::from_value(self.data.clone()).map_err(|err| {
+                        format!("invalid periodic_review restart bundle payload: {err}")
+                    })?;
+                Ok(harness_core::prompts::periodic_review_prompt_with_guard_scan(
+                    &inputs.project_root,
+                    &inputs.since_arg,
+                    &inputs.review_type,
+                    inputs.guard_scan_output.as_deref(),
+                ))
+            }
+            (SYSTEM_PROMPT_RESTART_BUNDLE_VERSION, "sprint_planner") => {
+                let inputs: SprintPlannerPromptInputs =
+                    serde_json::from_value(self.data.clone()).map_err(|err| {
+                        format!("invalid sprint_planner restart bundle payload: {err}")
+                    })?;
+                Ok(harness_core::prompts::sprint_plan_prompt(
+                    &build_sprint_issue_summary(&inputs),
+                ))
+            }
+            (version, kind) => Err(format!(
+                "unsupported system prompt restart bundle version/kind: version={version}, kind={kind}"
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateTaskRequest {
     /// Free-text task description (prompt, issue URL, etc.).
@@ -78,39 +170,17 @@ pub struct CreateTaskRequest {
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
     pub priority: u8,
-    /// Restart-safe metadata for trusted system-generated prompt tasks.
-    /// Never accepted from or exposed to external HTTP callers.
+    /// Structured restart-safe inputs for system-generated prompt-only tasks.
+    ///
+    /// Internal-only: arbitrary API callers must not inject raw prompt recovery
+    /// metadata. Scheduler-created tasks attach a bundle explicitly in Rust code.
     #[serde(skip)]
-    pub system_input: Option<SystemTaskInput>,
+    pub system_prompt_restart_bundle: Option<SystemPromptRestartBundle>,
 }
 
 impl CreateTaskRequest {
-    /// Classify task kind using only trusted internal metadata for system tasks.
-    ///
-    /// External callers may set `source`, but they cannot populate `system_input`
-    /// because the field is `#[serde(skip)]`. That makes `system_input` the trust
-    /// boundary for review/planner lifecycle selection.
     pub fn task_kind(&self) -> TaskKind {
-        match self.system_input.as_ref() {
-            Some(SystemTaskInput::PeriodicReview { .. }) => TaskKind::Review,
-            Some(SystemTaskInput::SprintPlanner { .. }) => TaskKind::Planner,
-            None => TaskKind::classify(None, self.issue, self.pr),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum SystemTaskInput {
-    PeriodicReview { prompt: String },
-    SprintPlanner { prompt: String },
-}
-
-impl SystemTaskInput {
-    pub fn prompt(&self) -> &str {
-        match self {
-            Self::PeriodicReview { prompt } | Self::SprintPlanner { prompt } => prompt,
-        }
+        TaskKind::classify(None, self.issue, self.pr)
     }
 }
 
@@ -148,6 +218,13 @@ pub struct PersistedRequestSettings {
     /// Pure prompt tasks and PR tasks leave this `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_prompt: Option<String>,
+    /// Typed classification for prompt-only tasks so privacy and restart logic
+    /// no longer depend on the `"prompt task"` description placeholder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_task_origin: Option<PromptTaskOrigin>,
+    /// Restart-safe structured inputs for system-generated prompt-only tasks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt_restart_bundle: Option<SystemPromptRestartBundle>,
     /// Primary prompt for prompt-only tasks (no issue or pr).
     ///
     /// Kept in memory so that `AwaitingDeps` tasks can reconstruct the original
@@ -164,6 +241,17 @@ pub struct PersistedRequestSettings {
 
 impl PersistedRequestSettings {
     pub(crate) fn from_req(req: &CreateTaskRequest) -> Self {
+        let prompt_task_origin = if req.issue.is_none() && req.pr.is_none() && req.prompt.is_some()
+        {
+            Some(if req.system_prompt_restart_bundle.is_some() {
+                PromptTaskOrigin::SystemGenerated
+            } else {
+                PromptTaskOrigin::Manual
+            })
+        } else {
+            None
+        };
+
         Self {
             agent: req.agent.clone(),
             max_rounds: req.max_rounds,
@@ -186,6 +274,8 @@ impl PersistedRequestSettings {
             } else {
                 None
             },
+            prompt_task_origin,
+            system_prompt_restart_bundle: req.system_prompt_restart_bundle.clone(),
             // For prompt-only tasks (no issue/pr), store the prompt so that
             // AwaitingDeps tasks can reconstruct the original request when deps resolve.
             prompt: if req.issue.is_none() && req.pr.is_none() {
@@ -209,6 +299,7 @@ impl PersistedRequestSettings {
         req.retry_max_backoff_ms = self.retry_max_backoff_ms;
         req.stall_timeout_secs = self.stall_timeout_secs;
         req.turn_timeout_secs = self.turn_timeout_secs;
+        req.system_prompt_restart_bundle = self.system_prompt_restart_bundle.clone();
         // Restore the additional prompt context for recovered issue tasks.
         if self.additional_prompt.is_some() {
             req.prompt = self.additional_prompt.clone();
@@ -217,6 +308,25 @@ impl PersistedRequestSettings {
         if self.prompt.is_some() {
             req.prompt = self.prompt.clone();
         }
+    }
+
+    pub(crate) fn is_manual_prompt_only(&self) -> bool {
+        self.prompt_task_origin == Some(PromptTaskOrigin::Manual)
+    }
+
+    pub(crate) fn is_system_generated_prompt_only(&self) -> bool {
+        self.prompt_task_origin == Some(PromptTaskOrigin::SystemGenerated)
+    }
+
+    pub(crate) fn rebuild_system_prompt(&self) -> Result<Option<String>, String> {
+        if !self.is_system_generated_prompt_only() {
+            return Ok(None);
+        }
+        let bundle = self
+            .system_prompt_restart_bundle
+            .as_ref()
+            .ok_or_else(|| "system-generated prompt task is missing restart bundle".to_string())?;
+        bundle.rebuild_prompt().map(Some)
     }
 }
 
@@ -245,13 +355,12 @@ impl Default for CreateTaskRequest {
             parent_task_id: None,
             depends_on: Vec::new(),
             priority: 0,
-            system_input: None,
+            system_prompt_restart_bundle: None,
         }
     }
 }
 
 pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<String> {
-    let task_kind = req.task_kind();
     // Only persist structured safe labels — never raw prompt text, which may contain
     // credentials or customer data.
     if let Some(n) = req.issue {
@@ -260,14 +369,34 @@ pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<S
     if let Some(n) = req.pr {
         return Some(format!("PR #{n}"));
     }
-    if req.prompt.is_some() {
-        return Some(match task_kind {
-            TaskKind::Review => "periodic review".to_string(),
-            TaskKind::Planner => "sprint planner".to_string(),
-            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => "prompt task".to_string(),
-        });
+    // Prompt-only tasks: store a generic label so that:
+    //   (a) sibling-awareness can include them (prevents parallel agents stomping the same files),
+    //   (b) operators can identify crashed tasks in the DB/dashboard after a restart.
+    // The prompt itself is deliberately not stored.
+    if req.prompt.is_some() || req.system_prompt_restart_bundle.is_some() {
+        return Some("prompt task".to_string());
     }
     None
+}
+
+fn build_sprint_issue_summary(inputs: &SprintPlannerPromptInputs) -> String {
+    inputs
+        .issues
+        .iter()
+        .map(|issue| {
+            let labels = if issue.labels.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", issue.labels.join(", "))
+            };
+            let repo = issue.repo.as_deref().unwrap_or("");
+            format!(
+                "- #{}: {}{} ({})",
+                issue.external_id, issue.title, labels, repo
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub async fn fill_missing_repo_from_project(req: &mut CreateTaskRequest) {
@@ -360,5 +489,63 @@ mod tests {
         settings.apply_to_req(&mut restored);
         assert!(restored.skip_triage);
         assert!(restored.force_execute);
+    }
+
+    #[test]
+    fn request_settings_roundtrip_preserves_system_prompt_bundle() {
+        let settings = PersistedRequestSettings {
+            wait_secs: 120,
+            retry_base_backoff_ms: 10_000,
+            retry_max_backoff_ms: 300_000,
+            stall_timeout_secs: 300,
+            turn_timeout_secs: 3_600,
+            prompt_task_origin: Some(PromptTaskOrigin::SystemGenerated),
+            system_prompt_restart_bundle: Some(SystemPromptRestartBundle::periodic_review(
+                PeriodicReviewPromptInputs {
+                    project_root: "/tmp/project".to_string(),
+                    since_arg: "2026-04-20T00:00:00Z".to_string(),
+                    review_type: "mixed".to_string(),
+                    guard_scan_output: Some("guard output".to_string()),
+                },
+            )),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&settings).expect("settings serialize");
+        let decoded: PersistedRequestSettings =
+            serde_json::from_str(&json).expect("settings deserialize");
+
+        assert_eq!(decoded.prompt_task_origin, settings.prompt_task_origin);
+        assert_eq!(
+            decoded.system_prompt_restart_bundle,
+            settings.system_prompt_restart_bundle
+        );
+    }
+
+    #[test]
+    fn rebuild_system_prompt_fails_closed_on_unsupported_bundle_version() {
+        let settings = PersistedRequestSettings {
+            wait_secs: 120,
+            retry_base_backoff_ms: 10_000,
+            retry_max_backoff_ms: 300_000,
+            stall_timeout_secs: 300,
+            turn_timeout_secs: 3_600,
+            prompt_task_origin: Some(PromptTaskOrigin::SystemGenerated),
+            system_prompt_restart_bundle: Some(SystemPromptRestartBundle {
+                version: 99,
+                kind: "periodic_review".to_string(),
+                data: serde_json::json!({
+                    "project_root": "/tmp/project",
+                    "since_arg": "2026-04-20T00:00:00Z",
+                    "review_type": "mixed"
+                }),
+            }),
+            ..Default::default()
+        };
+
+        let err = settings
+            .rebuild_system_prompt()
+            .expect_err("unsupported bundle must fail");
+        assert!(err.contains("unsupported system prompt restart bundle"));
     }
 }

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -6,7 +6,7 @@ use tokio::sync::RwLock;
 
 use super::request::{
     detect_main_worktree, summarize_request_description, CreateTaskRequest,
-    PersistedRequestSettings, SystemTaskInput,
+    PersistedRequestSettings,
 };
 use super::state::{RoundResult, TaskState};
 use super::store::{mutate_and_persist, TaskStore};
@@ -85,10 +85,6 @@ fn classify_task_kind(req: &CreateTaskRequest) -> TaskKind {
     req.task_kind()
 }
 
-fn system_input_for_request(req: &CreateTaskRequest) -> Option<SystemTaskInput> {
-    req.system_input.clone()
-}
-
 fn refresh_preregistered_task_metadata(
     entry: &mut TaskState,
     req: &CreateTaskRequest,
@@ -104,7 +100,6 @@ fn refresh_preregistered_task_metadata(
     entry.project_root = Some(project_root);
     entry.issue = req.issue;
     entry.description = description;
-    entry.system_input = system_input_for_request(req);
 }
 
 #[cfg(test)]
@@ -307,7 +302,6 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.phase = state.task_kind.default_phase();
     state.description = summarize_request_description(req);
     state.request_settings = Some(PersistedRequestSettings::from_req(req));
-    state.system_input = system_input_for_request(req);
     store.insert(&state).await;
     // Register stream channel now so SSE clients can subscribe before execution begins.
     store.register_task_stream(&task_id);
@@ -388,7 +382,6 @@ where
         state.priority = req.priority;
         state.phase = state.task_kind.default_phase();
         state.request_settings = Some(PersistedRequestSettings::from_req(&req));
-        state.system_input = system_input_for_request(&req);
         store.insert(&state).await;
         // Register stream channel before spawning so SSE clients can subscribe immediately.
         store.register_task_stream(&task_id);
@@ -813,7 +806,6 @@ pub async fn spawn_task_awaiting_deps(
     state.phase = state.task_kind.default_phase();
     state.description = summarize_request_description(&req);
     state.request_settings = Some(PersistedRequestSettings::from_req(&req));
-    state.system_input = system_input_for_request(&req);
     // Persist the caller's resolved project root so that duplicate detection
     // (which keys on project_root + external_id) and the dep-watcher's project
     // path resolution both work correctly for waiting tasks.
@@ -1647,51 +1639,6 @@ mod tests {
         assert!(is_non_decomposable_prompt_source(Some("sprint_planner")));
         assert!(!is_non_decomposable_prompt_source(Some("github")));
         assert!(!is_non_decomposable_prompt_source(None));
-    }
-
-    #[test]
-    fn request_task_kind_trusts_only_internal_system_input() {
-        let spoofed = CreateTaskRequest {
-            prompt: Some("review this".to_string()),
-            source: Some("periodic_review".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(spoofed.task_kind(), TaskKind::Prompt);
-
-        let trusted = CreateTaskRequest {
-            prompt: Some("review this".to_string()),
-            source: Some("periodic_review".to_string()),
-            system_input: Some(SystemTaskInput::PeriodicReview {
-                prompt: "review this".to_string(),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(trusted.task_kind(), TaskKind::Review);
-    }
-
-    #[test]
-    fn system_input_for_request_clones_only_explicit_internal_metadata() {
-        let spoofed = CreateTaskRequest {
-            prompt: Some("review this".to_string()),
-            source: Some("periodic_review".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(system_input_for_request(&spoofed), None);
-
-        let trusted = CreateTaskRequest {
-            prompt: Some("review this".to_string()),
-            source: Some("periodic_review".to_string()),
-            system_input: Some(SystemTaskInput::PeriodicReview {
-                prompt: "review this".to_string(),
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            system_input_for_request(&trusted),
-            Some(SystemTaskInput::PeriodicReview {
-                prompt: "review this".to_string(),
-            })
-        );
     }
 
     // --- dependency scheduling tests ---

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use super::request::{PersistedRequestSettings, SystemTaskInput};
+use super::request::PersistedRequestSettings;
 use super::types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,10 +79,6 @@ pub struct TaskState {
     /// requested rather than silently falling back to server defaults.
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
-    /// Restart-safe prompt snapshot for trusted system-generated prompt tasks.
-    /// Persisted internally for recovery only; never expose it via the public task API.
-    #[serde(skip)]
-    pub system_input: Option<SystemTaskInput>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
@@ -166,7 +162,6 @@ impl TaskState {
             plan_output: None,
             repo: None,
             request_settings: None,
-            system_input: None,
         }
     }
 

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -35,7 +35,6 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         plan_output: None,
         repo: None,
         request_settings: None,
-        system_input: None,
     }
 }
 
@@ -266,14 +265,23 @@ async fn restart_with_triage_checkpoint_resumes_task() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn restart_with_review_system_input_resumes_task() -> anyhow::Result<()> {
+    use harness_server::task_runner::{
+        PeriodicReviewPromptInputs, PersistedRequestSettings, SystemPromptRestartBundle,
+    };
     let store = setup_store(|db| async move {
         let mut task = make_task("t-review-system", TaskStatus::ReviewGenerating);
         task.task_kind = TaskKind::Review;
-        task.system_input = Some(
-            harness_server::task_runner::SystemTaskInput::PeriodicReview {
-                prompt: "review prompt".to_string(),
-            },
-        );
+        task.request_settings = Some(PersistedRequestSettings {
+            system_prompt_restart_bundle: Some(SystemPromptRestartBundle::periodic_review(
+                PeriodicReviewPromptInputs {
+                    project_root: "/tmp/proj".to_string(),
+                    since_arg: "2024-01-01T00:00:00Z".to_string(),
+                    review_type: "standard".to_string(),
+                    guard_scan_output: None,
+                },
+            )),
+            ..Default::default()
+        });
         db.insert(&task).await?;
         Ok(())
     })
@@ -288,20 +296,31 @@ async fn restart_with_review_system_input_resumes_task() -> anyhow::Result<()> {
         task.status
     );
     assert_eq!(task.task_kind, TaskKind::Review);
-    assert!(task.system_input.is_some());
     Ok(())
 }
 
 #[tokio::test]
 async fn restart_with_planner_system_input_resumes_task() -> anyhow::Result<()> {
+    use harness_server::task_runner::{
+        PersistedRequestSettings, SprintPlannerIssueSummaryInput, SprintPlannerPromptInputs,
+        SystemPromptRestartBundle,
+    };
     let store = setup_store(|db| async move {
         let mut task = make_task("t-planner-system", TaskStatus::PlannerGenerating);
         task.task_kind = TaskKind::Planner;
-        task.system_input = Some(
-            harness_server::task_runner::SystemTaskInput::SprintPlanner {
-                prompt: "planner prompt".to_string(),
-            },
-        );
+        task.request_settings = Some(PersistedRequestSettings {
+            system_prompt_restart_bundle: Some(SystemPromptRestartBundle::sprint_planner(
+                SprintPlannerPromptInputs {
+                    issues: vec![SprintPlannerIssueSummaryInput {
+                        external_id: "issue:1".to_string(),
+                        title: "Test issue".to_string(),
+                        labels: vec![],
+                        repo: None,
+                    }],
+                },
+            )),
+            ..Default::default()
+        });
         db.insert(&task).await?;
         Ok(())
     })
@@ -316,7 +335,6 @@ async fn restart_with_planner_system_input_resumes_task() -> anyhow::Result<()> 
         task.status
     );
     assert_eq!(task.task_kind, TaskKind::Planner);
-    assert!(task.system_input.is_some());
     Ok(())
 }
 


### PR DESCRIPTION
Closes #896

## Summary
- persist versioned restart bundles for periodic review and sprint planner prompt-only tasks in tasks.request_settings
- rebuild system-generated prompts during dependency and checkpoint recovery while keeping manual prompt-only tasks fail-closed
- replace description-based prompt privacy checks with typed prompt-origin handling and add restart coverage tests

## Validation
- DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo clippy --workspace --all-targets -- -D warnings
- DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace -- --test-threads=1
- RUSTFLAGS='-Dwarnings' DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo check --workspace --all-targets