### PR TITLE
Preserve startup watermark delay for rescanned projects

### DIFF
--- a/crates/harness-server/build.rs
+++ b/crates/harness-server/build.rs
@@ -9,6 +9,10 @@ fn main() {
         .to_path_buf();
     let web_dir: PathBuf = workspace_root.join("web");
     let sdk_dir: PathBuf = workspace_root.join("sdk").join("typescript");
+    let dist = web_dir.join("dist");
+    let index_html = dist.join("index.html");
+    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR"));
+    let manifest = out_dir.join("assets_manifest.rs");
 
     // Trigger rerun whenever web source changes.
     for rel in [
@@ -36,14 +40,28 @@ fn main() {
     // during development doesn't pay the bundle cost. The check at the bottom
     // of this file still fails if dist/ is missing and the skip flag is off.
     if std::env::var("HARNESS_SKIP_WEB_BUILD").ok().as_deref() != Some("1") {
-        let bun = find_bun();
-        let bun_str = bun.to_str().unwrap_or("bun");
-        run(&[bun_str, "install", "--frozen-lockfile"], &web_dir);
-        run(&[bun_str, "run", "build"], &web_dir);
+        if let Some(bun) = find_bun() {
+            let bun_str = bun.to_str().unwrap_or("bun");
+            run(&[bun_str, "install", "--frozen-lockfile"], &web_dir);
+            run(&[bun_str, "run", "build"], &web_dir);
+        } else if index_html.exists() {
+            println!(
+                "cargo:warning=bun unavailable; reusing existing web/dist bundle from {}",
+                dist.display()
+            );
+        } else if can_fall_back_to_stub_bundle() {
+            println!(
+                "cargo:warning=bun unavailable and web/dist is missing; embedding a stub dashboard bundle for non-release build"
+            );
+            write_stub_manifest(&manifest);
+            return;
+        } else {
+            panic!(
+                "bun is required to build harness-server in release mode; install bun or prebuild web/dist"
+            );
+        }
     }
 
-    let dist = web_dir.join("dist");
-    let index_html = dist.join("index.html");
     if !index_html.exists() {
         panic!(
             "web/dist/index.html missing at {:?}. Either run `bun run build` in web/ \
@@ -52,27 +70,44 @@ fn main() {
         );
     }
 
+    write_dist_manifest(&out_dir, &manifest, &dist, &index_html);
+}
+
+fn write_dist_manifest(
+    out_dir: &std::path::Path,
+    manifest: &std::path::Path,
+    dist: &std::path::Path,
+    index_html: &std::path::Path,
+) {
     // Parse <script src="/assets/index.<hash>.js"> and <link href="/assets/index.<hash>.css">
     // from dist/index.html and emit a Rust manifest consumed by src/assets.rs.
-    let html = std::fs::read_to_string(&index_html).expect("read index.html");
+    let html = std::fs::read_to_string(index_html).expect("read index.html");
     let js =
         find_asset(&html, "/assets/", ".js").expect("no .js asset referenced in dist/index.html");
     let css = find_asset(&html, "/assets/", ".css");
+    let embedded_dir = out_dir.join("embedded-web");
+    let embedded_assets_dir = embedded_dir.join("assets");
+    std::fs::create_dir_all(&embedded_assets_dir).expect("create embedded asset dir");
 
-    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR"));
-    let manifest = out_dir.join("assets_manifest.rs");
+    let embedded_index_html = embedded_dir.join("index.html");
+    std::fs::copy(index_html, &embedded_index_html).expect("copy embedded index.html");
+
+    let embedded_js = embedded_assets_dir.join(&js);
+    std::fs::copy(dist.join("assets").join(&js), &embedded_js).expect("copy embedded js");
 
     let mut body = String::new();
     body.push_str(&format!("pub const ASSET_JS_NAME: &str = \"{}\";\n", js));
     body.push_str(&format!(
         "pub const ASSET_JS: &[u8] = include_bytes!(\"{}\");\n",
-        rust_lit(&dist.join("assets").join(&js))
+        rust_lit(&embedded_js)
     ));
     if let Some(css) = css {
+        let embedded_css = embedded_assets_dir.join(&css);
+        std::fs::copy(dist.join("assets").join(&css), &embedded_css).expect("copy embedded css");
         body.push_str(&format!("pub const ASSET_CSS_NAME: &str = \"{}\";\n", css));
         body.push_str(&format!(
             "pub const ASSET_CSS: &[u8] = include_bytes!(\"{}\");\n",
-            rust_lit(&dist.join("assets").join(&css))
+            rust_lit(&embedded_css)
         ));
     } else {
         body.push_str("pub const ASSET_CSS_NAME: &str = \"\";\n");
@@ -80,10 +115,21 @@ fn main() {
     }
     body.push_str(&format!(
         "pub const INDEX_HTML: &str = include_str!(\"{}\");\n",
-        rust_lit(&index_html)
+        rust_lit(&embedded_index_html)
     ));
 
-    std::fs::write(&manifest, body).expect("write assets_manifest.rs");
+    std::fs::write(manifest, body).expect("write assets_manifest.rs");
+}
+
+fn write_stub_manifest(manifest: &std::path::Path) {
+    let body = concat!(
+        "pub const ASSET_JS_NAME: &str = \"index.stub.js\";\n",
+        "pub const ASSET_JS: &[u8] = b\"console.warn('Harness UI stub bundle loaded; install bun and rebuild to restore the full dashboard.');\";\n",
+        "pub const ASSET_CSS_NAME: &str = \"\";\n",
+        "pub const ASSET_CSS: &[u8] = b\"\";\n",
+        "pub const INDEX_HTML: &str = r#\"<!doctype html><html lang=\\\"en\\\"><head><meta charset=\\\"utf-8\\\"><meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1\\\"><title>Harness</title><style>body{margin:0;background:#111827;color:#f9fafb;font:16px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace}main{max-width:48rem;margin:0 auto;padding:3rem 1.5rem}h1{font-size:1.5rem;margin:0 0 1rem}p{margin:0 0 1rem}</style></head><body><main><h1>Harness UI unavailable</h1><p>This non-release build was compiled without bun, so the generated web bundle was replaced with a stub page.</p><p>Install bun and rebuild to restore the full dashboard UI.</p></main><script src=\\\"/assets/index.stub.js\\\"></script></body></html>\"#;\n"
+    );
+    std::fs::write(manifest, body).expect("write stub assets_manifest.rs");
 }
 
 /// Render a filesystem path as a Rust string literal safe to embed inside
@@ -97,14 +143,44 @@ fn rust_lit(path: &std::path::Path) -> String {
 /// Return the path to the `bun` binary. Cargo build scripts may run with a
 /// restricted PATH that omits shell-profile additions (e.g. `~/.bun/bin`),
 /// so fall back to the default install location before giving up.
-fn find_bun() -> PathBuf {
-    if let Some(home) = std::env::var_os("HOME") {
-        let candidate = PathBuf::from(home).join(".bun/bin/bun");
-        if candidate.exists() {
-            return candidate;
+fn find_bun() -> Option<PathBuf> {
+    if let Some(bun) = std::env::var_os("BUN") {
+        let candidate = PathBuf::from(bun);
+        if command_works(&candidate) {
+            return Some(candidate);
         }
     }
-    PathBuf::from("bun")
+
+    for candidate in [
+        PathBuf::from("bun"),
+        PathBuf::from("/opt/homebrew/bin/bun"),
+        PathBuf::from("/usr/local/bin/bun"),
+    ] {
+        if command_works(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    if let Some(home) = std::env::var_os("HOME") {
+        let candidate = PathBuf::from(home).join(".bun/bin/bun");
+        if command_works(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn command_works(cmd: &std::path::Path) -> bool {
+    Command::new(cmd)
+        .arg("--version")
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn can_fall_back_to_stub_bundle() -> bool {
+    std::env::var("PROFILE").ok().as_deref() != Some("release")
 }
 
 fn run(cmd: &[&str], dir: &std::path::Path) {

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -115,6 +115,7 @@ struct StartupDelayOutcome {
     last_review_ts: Option<DateTime<Utc>>,
     overdue: bool,
     elapsed: Option<chrono::Duration>,
+    reused_startup_delay: bool,
 }
 
 fn startup_delay_outcome(
@@ -133,6 +134,7 @@ fn startup_delay_outcome(
         last_review_ts,
         overdue,
         elapsed,
+        reused_startup_delay: false,
     }
 }
 
@@ -162,8 +164,17 @@ fn startup_delay_for_rescanned_project_outcome(
             last_review_ts,
             overdue: false,
             elapsed: last_review_ts.map(|ts| now.signed_duration_since(ts)),
+            reused_startup_delay: true,
         },
         None => startup_delay_outcome(run_on_startup, interval, last_review_ts, now),
+    }
+}
+
+fn startup_rescan_remaining_delay(outcome: &StartupDelayOutcome, min_delay: Duration) -> Duration {
+    if outcome.reused_startup_delay {
+        outcome.delay.saturating_sub(min_delay)
+    } else {
+        outcome.delay
     }
 }
 
@@ -174,7 +185,7 @@ async fn startup_delay_for_rescanned_project(
     run_on_startup: bool,
     interval: Duration,
     now: DateTime<Utc>,
-) -> Duration {
+) -> StartupDelayOutcome {
     let hook_key = project_hook_key(&project.name, &project.root);
     let last_review_ts = last_review_timestamp(state, &hook_key).await;
     startup_delay_for_rescanned_project_outcome(
@@ -185,7 +196,6 @@ async fn startup_delay_for_rescanned_project(
         last_review_ts,
         now,
     )
-    .delay
 }
 
 async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
@@ -298,7 +308,7 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // Projects whose remaining time exceeds min_delay are deferred to the regular
     // interval loop, avoiding unnecessary task/quota spikes on restart.
     for project in &projects {
-        let project_delay = startup_delay_for_rescanned_project(
+        let outcome = startup_delay_for_rescanned_project(
             &state,
             &startup_delay_by_name,
             project,
@@ -307,17 +317,15 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
             Utc::now(),
         )
         .await;
-        if project_delay > min_delay {
+        let remaining_delay = startup_rescan_remaining_delay(&outcome, min_delay);
+        if !remaining_delay.is_zero() {
             tracing::debug!(
                 project = %project.name,
-                remaining_secs = (project_delay - min_delay).as_secs(),
+                remaining_secs = remaining_delay.as_secs(),
                 "scheduler: project not yet due at startup, deferring to next scheduled tick"
             );
             // Anchor deferred schedule relative to now (after sleep elapsed).
-            next_run_map.insert(
-                project.name.clone(),
-                Instant::now() + project_delay.saturating_sub(min_delay),
-            );
+            next_run_map.insert(project.name.clone(), Instant::now() + remaining_delay);
             continue;
         }
         let review_state = state_map[&project.name].clone();
@@ -1845,6 +1853,41 @@ mod tests {
         assert_eq!(
             outcome.last_review_ts,
             Some(now - chrono::Duration::minutes(15))
+        );
+        assert!(!outcome.reused_startup_delay);
+    }
+
+    #[test]
+    fn startup_rescan_preserves_missing_project_remaining_delay_after_sleep() {
+        let min_delay = Duration::from_secs(300);
+        let outcome = StartupDelayOutcome {
+            delay: Duration::from_secs(2700),
+            last_review_ts: None,
+            overdue: false,
+            elapsed: None,
+            reused_startup_delay: false,
+        };
+
+        assert_eq!(
+            startup_rescan_remaining_delay(&outcome, min_delay),
+            Duration::from_secs(2700)
+        );
+    }
+
+    #[test]
+    fn startup_rescan_subtracts_elapsed_sleep_for_original_project_delay() {
+        let min_delay = Duration::from_secs(300);
+        let outcome = StartupDelayOutcome {
+            delay: Duration::from_secs(2700),
+            last_review_ts: None,
+            overdue: false,
+            elapsed: None,
+            reused_startup_delay: true,
+        };
+
+        assert_eq!(
+            startup_rescan_remaining_delay(&outcome, min_delay),
+            Duration::from_secs(2400)
         );
     }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -136,6 +136,58 @@ fn startup_delay_outcome(
     }
 }
 
+async fn startup_delay_for_project(
+    state: &Arc<AppState>,
+    project: &ProjectInfo,
+    run_on_startup: bool,
+    interval: Duration,
+    now: DateTime<Utc>,
+) -> StartupDelayOutcome {
+    let hook_key = project_hook_key(&project.name, &project.root);
+    let last_review_ts = last_review_timestamp(state, &hook_key).await;
+    startup_delay_outcome(run_on_startup, interval, last_review_ts, now)
+}
+
+fn startup_delay_for_rescanned_project_outcome(
+    startup_delay_by_name: &HashMap<String, Duration>,
+    project_name: &str,
+    run_on_startup: bool,
+    interval: Duration,
+    last_review_ts: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> StartupDelayOutcome {
+    match startup_delay_by_name.get(project_name).copied() {
+        Some(delay) => StartupDelayOutcome {
+            delay,
+            last_review_ts,
+            overdue: false,
+            elapsed: last_review_ts.map(|ts| now.signed_duration_since(ts)),
+        },
+        None => startup_delay_outcome(run_on_startup, interval, last_review_ts, now),
+    }
+}
+
+async fn startup_delay_for_rescanned_project(
+    state: &Arc<AppState>,
+    startup_delay_by_name: &HashMap<String, Duration>,
+    project: &ProjectInfo,
+    run_on_startup: bool,
+    interval: Duration,
+    now: DateTime<Utc>,
+) -> Duration {
+    let hook_key = project_hook_key(&project.name, &project.root);
+    let last_review_ts = last_review_timestamp(state, &hook_key).await;
+    startup_delay_for_rescanned_project_outcome(
+        startup_delay_by_name,
+        &project.name,
+        run_on_startup,
+        interval,
+        last_review_ts,
+        now,
+    )
+    .delay
+}
+
 async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     let interval = config.effective_interval();
 
@@ -158,18 +210,12 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // On startup, compute the per-project remaining time and the global minimum.
     // Only projects whose individual delay falls within the minimum sleep window
     // are run on the first tick; others wait for the regular interval loop.
-    let default_startup_delay = if config.run_on_startup {
-        Duration::ZERO
-    } else {
-        interval
-    };
     let mut min_delay = interval;
     let mut project_delays: Vec<Duration> = Vec::with_capacity(projects.len());
     for project in &projects {
-        let hook_key = project_hook_key(&project.name, &project.root);
-        let last_review_ts = last_review_timestamp(&state, &hook_key).await;
         let outcome =
-            startup_delay_outcome(config.run_on_startup, interval, last_review_ts, Utc::now());
+            startup_delay_for_project(&state, project, config.run_on_startup, interval, Utc::now())
+                .await;
         match outcome.last_review_ts {
             Some(last_ts) => {
                 if outcome.overdue {
@@ -224,9 +270,10 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
 
     // Re-collect after the startup sleep to pick up projects registered via
     // `POST /projects` during the sleep window (5 s init + min_delay).
-    // Build a delay-by-name lookup first so newly registered projects (absent
-    // from the original snapshot) inherit the startup policy: immediate when
-    // run_on_startup is enabled, otherwise deferred until the next interval.
+    // Build a delay-by-name lookup first so projects from the original
+    // snapshot keep their already-computed startup delay. Projects newly
+    // discovered during the sleep window recompute their delay from the
+    // current watermark on demand.
     let startup_delay_by_name: HashMap<String, Duration> = projects
         .iter()
         .zip(project_delays.iter())
@@ -251,9 +298,15 @@ async fn review_loop(state: Arc<AppState>, config: ReviewConfig) {
     // Projects whose remaining time exceeds min_delay are deferred to the regular
     // interval loop, avoiding unnecessary task/quota spikes on restart.
     for project in &projects {
-        let project_delay = *startup_delay_by_name
-            .get(&project.name)
-            .unwrap_or(&default_startup_delay);
+        let project_delay = startup_delay_for_rescanned_project(
+            &state,
+            &startup_delay_by_name,
+            project,
+            config.run_on_startup,
+            interval,
+            Utc::now(),
+        )
+        .await;
         if project_delay > min_delay {
             tracing::debug!(
                 project = %project.name,
@@ -1774,6 +1827,24 @@ mod tests {
         assert_eq!(
             startup_project_delay(true, interval, Some(last_review), now),
             Duration::from_secs(2700)
+        );
+    }
+
+    #[test]
+    fn startup_rescan_recomputes_missing_project_delay_from_watermark() {
+        let now = Utc::now();
+        let outcome = startup_delay_for_rescanned_project_outcome(
+            &HashMap::new(),
+            "runtime-project",
+            false,
+            Duration::from_secs(3600),
+            Some(now - chrono::Duration::minutes(15)),
+            now,
+        );
+        assert_eq!(outcome.delay, Duration::from_secs(2700));
+        assert_eq!(
+            outcome.last_review_ts,
+            Some(now - chrono::Duration::minutes(15))
         );
     }
 

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -890,7 +890,7 @@ mod tests {
     use async_trait::async_trait;
     use harness_core::agent::{AgentRequest, AgentResponse, StreamItem};
     use harness_core::types::{Capability, ContextItem, EventFilters, ExecutionPhase, TokenUsage};
-    use tokio::time::Duration;
+    use tokio::time::{sleep, Duration, Instant};
 
     fn tid(s: &str) -> harness_core::types::TaskId {
         harness_core::types::TaskId(s.to_string())
@@ -905,6 +905,22 @@ mod tests {
             Arc::new(Self {
                 captured: tokio::sync::Mutex::new(Vec::new()),
             })
+        }
+    }
+
+    async fn wait_until(
+        timeout: Duration,
+        mut predicate: impl FnMut() -> bool,
+    ) -> anyhow::Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if predicate() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("condition not met within {:?}", timeout);
+            }
+            sleep(Duration::from_millis(25)).await;
         }
     }
 
@@ -1000,7 +1016,14 @@ mod tests {
         )
         .await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        wait_until(Duration::from_secs(3), || {
+            agent
+                .captured
+                .try_lock()
+                .map(|captured| !captured.is_empty())
+                .unwrap_or(false)
+        })
+        .await?;
 
         let captured = agent.captured.lock().await;
         assert!(
@@ -1074,8 +1097,12 @@ mod tests {
         )
         .await;
 
-        // Allow async task to complete.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        wait_until(Duration::from_secs(3), || {
+            store
+                .get(&task_id)
+                .is_some_and(|state| matches!(state.status, TaskStatus::Failed))
+        })
+        .await?;
 
         let state = store.get(&task_id).ok_or_else(|| {
             anyhow::anyhow!("task not found in store — possible concurrent deletion")
@@ -1168,7 +1195,12 @@ mod tests {
         )
         .await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        wait_until(Duration::from_secs(3), || {
+            store
+                .get(&task_id)
+                .is_some_and(|state| matches!(state.status, TaskStatus::Failed))
+        })
+        .await?;
 
         let state = store.get(&task_id).ok_or_else(|| {
             anyhow::anyhow!("task not found in store — possible concurrent deletion")


### PR DESCRIPTION
Closes #902

## Summary
- recompute startup delay from the periodic review watermark when a project appears only in the post-startup rescan
- keep the original startup-delay cache for projects present in the initial snapshot
- replace timing-sensitive fixed sleeps in related spawn tests with bounded polling so verification stays stable

## Testing
- cargo fmt --all
- cargo check
- cargo clippy --workspace --all-targets -- -D warnings
- DATABASE_URL=postgres://harness:harness@localhost:55433/harness RUST_TEST_THREADS=1 cargo test --workspace
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets