### PR TITLE
Give review and planner tasks a dedicated lifecycle

### DIFF
--- a/crates/harness-server/src/handlers/operator_snapshot.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot.rs
@@ -274,6 +274,7 @@ mod tests {
     fn missing_timestamps_serialize_as_null() {
         let stalled_task = crate::task_runner::TaskState {
             id: harness_core::types::TaskId("stalled-task".to_string()),
+            task_kind: crate::task_runner::TaskKind::Issue,
             status: crate::task_runner::TaskStatus::Implementing,
             turn: 1,
             pr_url: None,
@@ -295,6 +296,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
+            system_input: None,
         };
         let stalled_json = stalled_task_json(&stalled_task);
 
@@ -398,6 +400,7 @@ mod tests {
         for i in 0..25u32 {
             let mut task = crate::task_runner::TaskState {
                 id: harness_core::types::TaskId(format!("fail-task-{i}")),
+                task_kind: crate::task_runner::TaskKind::Issue,
                 status: crate::task_runner::TaskStatus::Failed,
                 turn: 1,
                 pr_url: None,
@@ -419,6 +422,7 @@ mod tests {
                 triage_output: None,
                 plan_output: None,
                 request_settings: None,
+                system_input: None,
             };
             task.status = crate::task_runner::TaskStatus::Failed;
             state.core.tasks.insert(&task).await;
@@ -453,6 +457,7 @@ mod tests {
         let long_error = "x".repeat(500);
         let task = crate::task_runner::TaskState {
             id: harness_core::types::TaskId("trunc-task".to_string()),
+            task_kind: crate::task_runner::TaskKind::Issue,
             status: crate::task_runner::TaskStatus::Failed,
             turn: 1,
             pr_url: None,
@@ -474,6 +479,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
+            system_input: None,
         };
         state.core.tasks.insert(&task).await;
 
@@ -512,6 +518,7 @@ mod tests {
         let unicode_error = "€".repeat(100); // 300 bytes total
         let task = crate::task_runner::TaskState {
             id: harness_core::types::TaskId("unicode-task".to_string()),
+            task_kind: crate::task_runner::TaskKind::Issue,
             status: crate::task_runner::TaskStatus::Failed,
             turn: 1,
             pr_url: None,
@@ -533,6 +540,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
+            system_input: None,
         };
         state.core.tasks.insert(&task).await;
 

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -89,6 +89,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
     };
     let task = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
         status: crate::task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -110,6 +111,7 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -182,6 +184,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
 
     let task_a = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
         status: crate::task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -203,9 +206,11 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     let task_b = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
         status: crate::task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -227,6 +232,7 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     let task_b_id = task_b.id.clone();
 
@@ -283,6 +289,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
     };
     let task = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
         status: crate::task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -304,6 +311,7 @@ async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> 
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);
@@ -351,6 +359,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
     };
     let task = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
         status: crate::task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -372,6 +381,7 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     state.core.tasks.insert(&task).await;
     let app = runtime_hosts_app(state);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -3,6 +3,50 @@ use std::sync::Arc;
 use super::{state::AppState, task_routes};
 use crate::task_runner;
 
+fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
+    task.external_id
+        .as_deref()
+        .map(|eid| {
+            if let Some(n) = eid.strip_prefix("issue:") {
+                (n.parse::<u64>().ok(), None)
+            } else if let Some(n) = eid.strip_prefix("pr:") {
+                (None, n.parse::<u64>().ok())
+            } else {
+                (None, None)
+            }
+        })
+        .unwrap_or((None, None))
+}
+
+fn build_recovered_request(
+    task: &task_runner::TaskState,
+    canonical: std::path::PathBuf,
+    issue: Option<u64>,
+    pr: Option<u64>,
+) -> task_runner::CreateTaskRequest {
+    let mut req = task_runner::CreateTaskRequest {
+        issue,
+        pr,
+        project: Some(canonical),
+        repo: task.repo.clone(),
+        source: task.source.clone(),
+        external_id: task.external_id.clone(),
+        parent_task_id: task.parent_id.clone(),
+        priority: task.priority,
+        system_input: task.system_input.clone(),
+        ..Default::default()
+    };
+    if let Some(ref settings) = task.request_settings {
+        settings.apply_to_req(&mut req);
+    }
+    if req.prompt.is_none() {
+        if let Some(system_input) = req.system_input.as_ref() {
+            req.prompt = Some(system_input.prompt().to_string());
+        }
+    }
+    req
+}
+
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
 pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
@@ -94,36 +138,8 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                     };
                     let project_id = canonical.to_string_lossy().into_owned();
 
-                    // Reconstruct the CreateTaskRequest from persisted task fields.
-                    // Parse issue/pr numbers from the canonical external_id (e.g. "issue:42").
-                    let (issue, pr) = task
-                        .external_id
-                        .as_deref()
-                        .map(|eid| {
-                            if let Some(n) = eid.strip_prefix("issue:") {
-                                (n.parse::<u64>().ok(), None)
-                            } else if let Some(n) = eid.strip_prefix("pr:") {
-                                (None, n.parse::<u64>().ok())
-                            } else {
-                                (None, None)
-                            }
-                        })
-                        .unwrap_or((None, None));
-                    let mut req = task_runner::CreateTaskRequest {
-                        issue,
-                        pr,
-                        project: Some(canonical),
-                        repo: task.repo.clone(),
-                        source: task.source.clone(),
-                        external_id: task.external_id.clone(),
-                        parent_task_id: task.parent_id.clone(),
-                        priority: task.priority,
-                        ..Default::default()
-                    };
-                    // Restore execution limits and prompt from persisted settings.
-                    if let Some(ref settings) = task.request_settings {
-                        settings.apply_to_req(&mut req);
-                    }
+                    let (issue, pr) = parse_issue_pr(&task);
+                    let req = build_recovered_request(&task, canonical, issue, pr);
 
                     // Guard: prompt-only tasks store their prompt in memory only
                     // (#[serde(skip)]). After a server restart the prompt field is
@@ -131,9 +147,11 @@ pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
                     // call implement_from_prompt("") — a silent mis-execution.
                     // Fail the task explicitly so the caller can re-submit.
                     if req.prompt.is_none() && req.issue.is_none() && req.pr.is_none() {
-                        let reason = "dep-watcher: prompt-only task has no persisted \
-                            prompt after server restart; please re-submit the task"
-                            .to_string();
+                        let reason = format!(
+                            "dep-watcher: {} task has no restart-safe input after server restart; \
+                             please re-submit the task",
+                            task.task_kind.as_ref()
+                        );
                         tracing::error!(task_id = ?task.id, "{reason}");
                         if let Err(pe) =
                             task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
@@ -408,7 +426,11 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
         .tasks
         .list_all()
         .into_iter()
-        .filter(|t| matches!(t.status, task_runner::TaskStatus::Pending) && t.pr_url.is_some())
+        .filter(|t| {
+            matches!(t.status, task_runner::TaskStatus::Pending)
+                && t.task_kind.requires_pr_url()
+                && t.pr_url.is_some()
+        })
         .collect();
     if !recovered.is_empty() {
         tracing::info!(
@@ -555,19 +577,7 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
                     }
                 };
 
-                let mut req = task_runner::CreateTaskRequest {
-                    pr: Some(pr_num),
-                    project: Some(canonical),
-                    repo: task.repo.clone(),
-                    source: task.source.clone(),
-                    external_id: task.external_id.clone(),
-                    ..Default::default()
-                };
-                // Restore persisted execution limits so the recovered task resumes
-                // with the same budget / timeout guardrails as originally requested.
-                if let Some(ref settings) = task.request_settings {
-                    settings.apply_to_req(&mut req);
-                }
+                let req = build_recovered_request(&task, canonical, None, Some(pr_num));
                 // Use the three-tier select_agent() so that an explicit agent
                 // pin stored in request_settings (Tier 1) and project-level
                 // defaults (Tier 2a) are honoured, not bypassed by a raw
@@ -631,6 +641,184 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
     }
 }
 
+/// Re-dispatch review/planner tasks that were recovered into their kind-specific
+/// waiting states after a restart.
+pub(super) fn spawn_system_task_recovery(state: &Arc<AppState>) {
+    let recovered: Vec<_> = state
+        .core
+        .tasks
+        .list_all()
+        .into_iter()
+        .filter(|task| {
+            matches!(
+                task.status,
+                task_runner::TaskStatus::ReviewWaiting | task_runner::TaskStatus::PlannerWaiting
+            )
+        })
+        .collect();
+    if !recovered.is_empty() {
+        tracing::info!(
+            count = recovered.len(),
+            "startup: re-dispatching recovered review/planner task(s)"
+        );
+        for task in recovered {
+            let state = state.clone();
+            tokio::spawn(async move {
+                let project_path = task
+                    .project_root
+                    .clone()
+                    .or_else(|| task.repo.as_deref().map(std::path::PathBuf::from));
+                let canonical = match task_runner::resolve_canonical_project(project_path).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let reason =
+                            format!("startup recovery: failed to resolve project path: {e}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                };
+                let project_id = canonical.to_string_lossy().into_owned();
+
+                let permit = match state
+                    .concurrency
+                    .task_queue
+                    .acquire(&project_id, task.priority)
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let reason =
+                            format!("startup recovery: failed to acquire concurrency permit: {e}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                };
+
+                let req = build_recovered_request(&task, canonical, None, None);
+                if req.prompt.is_none() {
+                    let reason = format!(
+                        "startup recovery: {} task has no restart-safe input metadata",
+                        task.task_kind.as_ref()
+                    );
+                    tracing::error!(task_id = ?task.id, "{reason}");
+                    if let Err(pe) =
+                        task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                            s.status = task_runner::TaskStatus::Failed;
+                            s.error = Some(reason);
+                        })
+                        .await
+                    {
+                        tracing::error!(
+                            task_id = ?task.id,
+                            "startup recovery: failed to persist failed status: {pe}; \
+                             skipping completion callback to avoid state split"
+                        );
+                        return;
+                    }
+                    if let Some(cb) = &state.intake.completion_callback {
+                        if let Some(final_state) = state.core.tasks.get(&task.id) {
+                            cb(final_state).await;
+                        }
+                    }
+                    return;
+                }
+
+                let agent = match task_routes::select_agent(
+                    &req,
+                    &state.core.server.agent_registry,
+                    None,
+                ) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        let reason = format!("startup recovery: failed to select agent: {e}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                };
+                let (reviewer, _) = super::resolve_reviewer(
+                    &state.core.server.agent_registry,
+                    &state.core.server.config.agents.review,
+                    agent.name(),
+                );
+                state.core.tasks.register_task_stream(&task.id);
+                task_runner::spawn_preregistered_task(
+                    task.id,
+                    state.core.tasks.clone(),
+                    agent,
+                    reviewer,
+                    Arc::new(state.core.server.config.clone()),
+                    state.engines.skills.clone(),
+                    state.observability.events.clone(),
+                    state.interceptors.clone(),
+                    req,
+                    state.concurrency.workspace_mgr.clone(),
+                    permit,
+                    state.intake.completion_callback.clone(),
+                    None,
+                )
+                .await;
+            });
+        }
+    }
+}
+
 /// Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
 /// Source A (spawn_pr_recovery) handles tasks with `pr_url` set. Source B (this
 /// function) picks up remaining pending tasks that have a plan or triage
@@ -656,32 +844,29 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
         for (task, _checkpoint) in checkpoint_tasks {
             let state = state.clone();
             tokio::spawn(async move {
-                // Reconstruct request type: parse issue number from the
-                // authoritative external_id ("issue:<n>") first, then fall
-                // back to the human-readable description for older rows.
-                // PR tasks are handled by Source A and never appear here.
-                let issue_num = task
-                    .external_id
-                    .as_deref()
-                    .and_then(|eid| eid.strip_prefix("issue:"))
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .or_else(|| {
-                        task.description
-                            .as_deref()
-                            .and_then(|d| d.strip_prefix("issue #"))
-                            .and_then(|s| s.split_whitespace().next())
-                            .and_then(|s| s.parse::<u64>().ok())
-                    });
+                // Reconstruct request type using the persisted task kind.
+                let issue_num = match task.task_kind {
+                    task_runner::TaskKind::Issue => task
+                        .external_id
+                        .as_deref()
+                        .and_then(|eid| eid.strip_prefix("issue:"))
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .or_else(|| {
+                            task.description
+                                .as_deref()
+                                .and_then(|d| d.strip_prefix("issue #"))
+                                .and_then(|s| s.split_whitespace().next())
+                                .and_then(|s| s.parse::<u64>().ok())
+                        }),
+                    task_runner::TaskKind::Prompt => None,
+                    task_runner::TaskKind::Pr
+                    | task_runner::TaskKind::Review
+                    | task_runner::TaskKind::Planner => None,
+                };
 
                 if issue_num.is_none() {
-                    // Prompt tasks store the placeholder "prompt task" in description
-                    // by design — the original prompt text is never persisted for
-                    // privacy.  Re-dispatching with that placeholder would execute
-                    // against the wrong prompt, so mark the task failed instead to
-                    // prevent the same broken recovery on every subsequent restart.
-                    let reason = if task.description.as_deref() == Some("prompt task") {
-                        "prompt task cannot be recovered after restart: \
-                         original prompt text is not persisted"
+                    let reason = if matches!(task.task_kind, task_runner::TaskKind::Prompt) {
+                        "prompt task cannot be recovered after restart: original prompt text is not persisted"
                     } else {
                         "checkpoint task has no parseable issue number — skipping"
                     };
@@ -795,23 +980,8 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     }
                 };
 
-                // issue_num is always Some here — the None branch returned above.
                 let Some(issue) = issue_num else { return };
-                let mut req = task_runner::CreateTaskRequest {
-                    issue: Some(issue),
-                    project: Some(canonical),
-                    repo: task.repo.clone(),
-                    source: task.source.clone(),
-                    external_id: task.external_id.clone(),
-                    priority: task.priority,
-                    ..Default::default()
-                };
-                // Restore persisted execution limits and any additional prompt
-                // context so the recovered task resumes with the same settings
-                // and caller-supplied context as originally requested.
-                if let Some(ref settings) = task.request_settings {
-                    settings.apply_to_req(&mut req);
-                }
+                let req = build_recovered_request(&task, canonical, Some(issue), None);
 
                 // Use the three-tier select_agent() so that an explicit agent
                 // pin stored in request_settings (Tier 1) and project-level

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -816,6 +816,7 @@ pub(super) fn spawn_system_task_recovery(state: &Arc<AppState>) {
                     state.concurrency.workspace_mgr.clone(),
                     permit,
                     state.intake.completion_callback.clone(),
+                    state.core.issue_workflow_store.clone(),
                     None,
                 )
                 .await;

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -436,11 +436,7 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
         .tasks
         .list_all()
         .into_iter()
-        .filter(|t| {
-            matches!(t.status, task_runner::TaskStatus::Pending)
-                && t.task_kind.requires_pr_url()
-                && t.pr_url.is_some()
-        })
+        .filter(|t| matches!(t.status, task_runner::TaskStatus::Pending) && t.pr_url.is_some())
         .collect();
     if !recovered.is_empty() {
         tracing::info!(

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -47,6 +47,16 @@ fn build_recovered_request(
     req
 }
 
+pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_routes::QueueDomain {
+    match task_kind {
+        task_runner::TaskKind::Review => task_routes::QueueDomain::Review,
+        task_runner::TaskKind::Issue
+        | task_runner::TaskKind::Pr
+        | task_runner::TaskKind::Prompt
+        | task_runner::TaskKind::Planner => task_routes::QueueDomain::Primary,
+    }
+}
+
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
 pub(super) fn spawn_awaiting_deps_watcher(state: &Arc<AppState>) {
@@ -698,12 +708,11 @@ pub(super) fn spawn_system_task_recovery(state: &Arc<AppState>) {
                 };
                 let project_id = canonical.to_string_lossy().into_owned();
 
-                let permit = match state
-                    .concurrency
-                    .task_queue
-                    .acquire(&project_id, task.priority)
-                    .await
-                {
+                let queue = match recovery_queue_domain(task.task_kind) {
+                    task_routes::QueueDomain::Primary => state.concurrency.task_queue.clone(),
+                    task_routes::QueueDomain::Review => state.concurrency.review_task_queue.clone(),
+                };
+                let permit = match queue.acquire(&project_id, task.priority).await {
                     Ok(p) => p,
                     Err(e) => {
                         let reason =

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -143,6 +143,9 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // These had PRs when the server crashed and need their review loop re-started.
     background::spawn_pr_recovery(&state);
 
+    // Re-dispatch recovered review/planner tasks that have restart-safe input bundles.
+    background::spawn_system_task_recovery(&state);
+
     // Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
     background::spawn_checkpoint_recovery(&state).await;
 

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum QueueDomain {
     Primary,
     Review,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1981,6 +1981,76 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
 }
 
 #[tokio::test]
+async fn pr_recovery_redispatches_prompt_tasks_with_pr_urls() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
+        status: task_runner::TaskStatus::Pending,
+        turn: 0,
+        pr_url: Some("not-a-valid-pr-url".to_string()),
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        issue: None,
+        repo: None,
+        description: None,
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        system_input: None,
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_pr_recovery(&state);
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Some(t) = state.core.tasks.get(&task_id) {
+            if matches!(t.status, task_runner::TaskStatus::Failed) {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("prompt task was not re-dispatched within 5 seconds after pr_recovery");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let final_state = state
+        .core
+        .tasks
+        .get(&task_id)
+        .expect("task must still exist");
+    assert!(matches!(
+        final_state.status,
+        task_runner::TaskStatus::Failed
+    ));
+    assert!(
+        final_state
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unparseable pr_url"),
+        "error should mention unparseable pr_url, got: {:?}",
+        final_state.error
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1153,6 +1153,89 @@ async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn list_tasks_exposes_task_kind_and_non_implementation_statuses() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .with_state(state.clone());
+
+    let review_task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Review,
+        status: task_runner::TaskStatus::ReviewWaiting,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("periodic_review".to_string()),
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        issue: None,
+        repo: Some("owner/repo".to_string()),
+        description: Some("periodic review".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::Review,
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        system_input: Some(task_runner::SystemTaskInput::PeriodicReview {
+            prompt: "review prompt".to_string(),
+        }),
+    };
+    let planner_task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Planner,
+        status: task_runner::TaskStatus::PlannerGenerating,
+        turn: 1,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("sprint_planner".to_string()),
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        issue: None,
+        repo: Some("owner/repo".to_string()),
+        description: Some("sprint planner".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::Plan,
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        system_input: Some(task_runner::SystemTaskInput::SprintPlanner {
+            prompt: "planner prompt".to_string(),
+        }),
+    };
+    state.core.tasks.insert(&review_task).await;
+    state.core.tasks.insert(&planner_task).await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    let tasks: serde_json::Value = serde_json::from_slice(&body)?;
+    let tasks = tasks.as_array().expect("tasks array");
+    assert!(tasks
+        .iter()
+        .any(|task| { task["task_kind"] == "review" && task["status"] == "review_waiting" }));
+    assert!(tasks
+        .iter()
+        .any(|task| { task["task_kind"] == "planner" && task["status"] == "planner_generating" }));
+    Ok(())
+}
+
+#[tokio::test]
 async fn feishu_webhook_returns_service_unavailable_when_token_missing() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state_with_feishu(dir.path(), None).await?;
@@ -1789,6 +1872,7 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Pr,
         status: task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: Some("not-a-valid-pr-url".to_string()),
@@ -1810,6 +1894,7 @@ async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Resu
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;
@@ -1857,6 +1942,7 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
         status: task_runner::TaskStatus::Pending,
         turn: 0,
         pr_url: None,
@@ -1878,6 +1964,7 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
         triage_output: None,
         plan_output: None,
         request_settings: None,
+        system_input: None,
     };
     let task_id = task.id.clone();
     state.core.tasks.insert(&task).await;

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -923,6 +923,51 @@ async fn create_then_get_task_returns_state() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn get_task_hides_internal_system_input_metadata() -> anyhow::Result<()> {
+    use axum::response::IntoResponse;
+
+    let dir = tempfile::tempdir()?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Review,
+        status: task_runner::TaskStatus::ReviewWaiting,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("periodic_review".to_string()),
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        issue: None,
+        repo: Some("owner/repo".to_string()),
+        description: Some("periodic review".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::Review,
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        system_input: Some(task_runner::SystemTaskInput::PeriodicReview {
+            prompt: "review prompt".to_string(),
+        }),
+    };
+    let task_id = task.id.to_string();
+
+    let response = axum::Json(task).into_response();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    let task_json: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(task_json["id"], task_id);
+    assert!(task_json.get("system_input").is_none());
+    Ok(())
+}
+
+#[tokio::test]
 async fn intake_status_returns_three_channels() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2011,3 +2011,15 @@ async fn checkpoint_recovery_marks_prompt_task_failed() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn recovery_queue_domain_routes_review_tasks_to_review_capacity() {
+    assert_eq!(
+        super::background::recovery_queue_domain(task_runner::TaskKind::Review),
+        super::task_routes::QueueDomain::Review
+    );
+    assert_eq!(
+        super::background::recovery_queue_domain(task_runner::TaskKind::Planner),
+        super::task_routes::QueueDomain::Primary
+    );
+}

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -363,10 +363,13 @@ async fn run_repo_sprint(
     let planner_prompt = harness_core::prompts::sprint_plan_prompt(&issue_summary);
 
     let planner_req = crate::task_runner::CreateTaskRequest {
-        prompt: Some(planner_prompt),
+        prompt: Some(planner_prompt.clone()),
         agent: planner_agent.map(String::from),
         project: Some(project_root.clone()),
         source: Some("sprint_planner".to_string()),
+        system_input: Some(crate::task_runner::SystemTaskInput::SprintPlanner {
+            prompt: planner_prompt,
+        }),
         ..Default::default()
     };
 

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -491,6 +491,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn system_review_tasks_are_excluded_from_stalled_scan() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;
+        let mut task = stalled_task("t1", "issue:1", "/proj");
+        task.task_kind = crate::task_runner::TaskKind::Review;
+        task.status = TaskStatus::ReviewWaiting;
+        task.external_id = None;
+        db.insert(&task).await?;
+        sqlx::query("UPDATE tasks SET updated_at = NOW() - INTERVAL '120 minutes' WHERE id = 't1'")
+            .execute(db.pool_for_test())
+            .await?;
+
+        let results = db
+            .list_stalled_tasks(Duration::from_secs(60 * 60), None)
+            .await?;
+        assert!(results.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn project_filter_scopes_results() -> anyhow::Result<()> {
         let tmp = tempfile::tempdir()?;
         let db = TaskDb::open(&tmp.path().join("tasks.db")).await?;

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -386,6 +386,7 @@ mod tests {
     fn stalled_task(id: &str, external_id: &str, project: &str) -> TaskState {
         TaskState {
             id: TaskId(id.to_string()),
+            task_kind: crate::task_runner::TaskKind::Issue,
             status: TaskStatus::Implementing,
             turn: 1,
             pr_url: None,
@@ -407,6 +408,7 @@ mod tests {
             triage_output: None,
             plan_output: None,
             request_settings: None,
+            system_input: None,
         }
     }
 

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -852,6 +852,9 @@ async fn run_review_tick(
         turn_timeout_secs: config.timeout_secs,
         source: Some("periodic_review".to_string()),
         project: Some(project_root.clone()),
+        system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
+            prompt: base_prompt.clone(),
+        }),
         ..CreateTaskRequest::default()
     };
 
@@ -953,6 +956,9 @@ async fn run_review_tick(
                 turn_timeout_secs: timeout_secs,
                 source: Some("periodic_review".to_string()),
                 project: Some(project_root_for_poll.clone()),
+                system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
+                    prompt: base_prompt.clone(),
+                }),
                 ..CreateTaskRequest::default()
             };
             match task_routes::enqueue_task_in_domain(
@@ -1030,11 +1036,14 @@ async fn run_review_tick(
                     secondary_text,
                 );
                 let synth_req = CreateTaskRequest {
-                    prompt: Some(synthesis_prompt),
+                    prompt: Some(synthesis_prompt.clone()),
                     agent: Some(primary_agent_for_synthesis.clone()),
                     turn_timeout_secs: timeout_secs,
                     source: Some("periodic_review".to_string()),
                     project: Some(project_root_for_poll.clone()),
+                    system_input: Some(crate::task_runner::SystemTaskInput::PeriodicReview {
+                        prompt: synthesis_prompt,
+                    }),
                     ..CreateTaskRequest::default()
                 };
                 match task_routes::enqueue_task_in_domain(

--- a/crates/harness-server/src/services/task.rs
+++ b/crates/harness-server/src/services/task.rs
@@ -140,6 +140,7 @@ mod tests {
         let id = harness_core::types::TaskId("test-task".to_string());
         let mut state = crate::task_runner::TaskState {
             id: id.clone(),
+            task_kind: crate::task_runner::TaskKind::Prompt,
             status: TaskStatus::Pending,
             turn: 0,
             pr_url: None,
@@ -161,6 +162,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            system_input: None,
         };
         state.source = Some("github".to_string());
         store.insert(&state).await;
@@ -182,6 +184,7 @@ mod tests {
 
         let parent_state = crate::task_runner::TaskState {
             id: parent_id.clone(),
+            task_kind: crate::task_runner::TaskKind::Prompt,
             status: TaskStatus::Pending,
             turn: 0,
             pr_url: None,
@@ -203,11 +206,13 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            system_input: None,
         };
         store.insert(&parent_state).await;
 
         let child_state = crate::task_runner::TaskState {
             id: child_id.clone(),
+            task_kind: crate::task_runner::TaskKind::Prompt,
             status: TaskStatus::Pending,
             turn: 0,
             pr_url: None,
@@ -229,6 +234,7 @@ mod tests {
             plan_output: None,
             repo: None,
             request_settings: None,
+            system_input: None,
         };
         store.insert(&child_state).await;
 

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -13,6 +13,8 @@ use harness_core::db::Migration;
 /// v14 – add description column for task observability after restart.
 /// v15 – add (status, updated_at DESC) index for project-agnostic terminal queries.
 /// v18 – add version column for optimistic locking.
+/// v19 – add task_kind column for first-class task lifecycle dispatch.
+/// v20 – add system_input column for restart-safe trusted system prompt bundles.
 pub(super) static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -132,5 +134,15 @@ pub(super) static TASK_MIGRATIONS: &[Migration] = &[
         version: 18,
         description: "add version column for optimistic locking",
         sql: "ALTER TABLE tasks ADD COLUMN version INTEGER NOT NULL DEFAULT 0",
+    },
+    Migration {
+        version: 19,
+        description: "add task_kind column for explicit task lifecycle dispatch",
+        sql: "ALTER TABLE tasks ADD COLUMN task_kind TEXT NOT NULL DEFAULT 'legacy'",
+    },
+    Migration {
+        version: 20,
+        description: "add system_input column for restart-safe system prompt bundles",
+        sql: "ALTER TABLE tasks ADD COLUMN system_input TEXT",
     },
 ];

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -139,9 +139,10 @@ impl TaskDb {
         &self,
     ) -> anyhow::Result<Vec<(TaskState, TaskCheckpoint)>> {
         let rows = sqlx::query_as::<_, PendingCheckpointRow>(
-            "SELECT t.id, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
+            "SELECT t.id, t.task_kind, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
                     t.external_id, t.parent_id, t.created_at, t.updated_at, t.repo, t.depends_on, \
                     t.project, t.priority, t.phase, t.description, t.request_settings, \
+                    t.system_input, \
                     c.triage_output, c.plan_output, c.pr_url AS ck_pr_url, \
                     c.last_phase, \
                     TO_CHAR(c.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS ck_updated_at \
@@ -159,6 +160,7 @@ impl TaskDb {
             let task_id = row.id.clone();
             let task_row = TaskRow {
                 id: row.id,
+                task_kind: row.task_kind,
                 status: row.status,
                 turn: row.turn,
                 pr_url: row.pr_url,
@@ -176,6 +178,7 @@ impl TaskDb {
                 phase: row.phase,
                 description: row.description,
                 request_settings: row.request_settings,
+                system_input: row.system_input,
             };
             let task_state = match task_row.try_into_task_state() {
                 Ok(s) => s,

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -11,24 +11,30 @@ impl TaskDb {
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
+        let task_kind = state.task_kind.as_ref();
         let phase_json = serde_json::to_string(&state.phase)?;
         let settings_json = state
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
+        let system_input_json = state
+            .system_input
+            .as_ref()
+            .and_then(|input| serde_json::to_string(input).ok());
         let created_at_dt: Option<DateTime<Utc>> = state
             .created_at
             .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&Utc));
         sqlx::query(
-            "INSERT INTO tasks (id, status, turn, pr_url, rounds, error, source, external_id, \
-             parent_id, created_at, repo, depends_on, project, priority, phase, description, \
-             request_settings) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, \
-                     COALESCE($10, CURRENT_TIMESTAMP), $11, $12, $13, $14, $15, $16, $17)",
+            "INSERT INTO tasks (id, task_kind, status, turn, pr_url, rounds, error, source, \
+             external_id, parent_id, created_at, repo, depends_on, project, priority, phase, \
+             description, request_settings, system_input) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, \
+                     COALESCE($11, CURRENT_TIMESTAMP), $12, $13, $14, $15, $16, $17, $18, $19)",
         )
         .bind(&state.id.0)
+        .bind(task_kind)
         .bind(status)
         .bind(state.turn as i64)
         .bind(&state.pr_url)
@@ -50,6 +56,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
+        .bind(system_input_json.as_deref())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -60,17 +67,23 @@ impl TaskDb {
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let phase_json = serde_json::to_string(&state.phase)?;
         let status = state.status.as_ref();
+        let task_kind = state.task_kind.as_ref();
         let settings_json = state
             .request_settings
             .as_ref()
             .and_then(|s| serde_json::to_string(s).ok());
+        let system_input_json = state
+            .system_input
+            .as_ref()
+            .and_then(|input| serde_json::to_string(input).ok());
         sqlx::query(
-            "UPDATE tasks SET status = $1, turn = $2, pr_url = $3, rounds = $4, error = $5, \
-                    source = $6, external_id = $7, repo = $8, depends_on = $9, project = $10, \
-                    priority = $11, phase = $12, description = $13, request_settings = $14, \
-                    updated_at = CURRENT_TIMESTAMP, version = version + 1 \
-             WHERE id = $15",
+            "UPDATE tasks SET task_kind = $1, status = $2, turn = $3, pr_url = $4, rounds = $5, \
+                    error = $6, source = $7, external_id = $8, repo = $9, depends_on = $10, \
+                    project = $11, priority = $12, phase = $13, description = $14, \
+                    request_settings = $15, system_input = $16, updated_at = CURRENT_TIMESTAMP, \
+                    version = version + 1 WHERE id = $17",
         )
+        .bind(task_kind)
         .bind(status)
         .bind(state.turn as i64)
         .bind(&state.pr_url)
@@ -90,6 +103,7 @@ impl TaskDb {
         .bind(&phase_json)
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
+        .bind(system_input_json.as_deref())
         .bind(&state.id.0)
         .execute(&self.pool)
         .await?;
@@ -138,16 +152,22 @@ impl TaskDb {
         project: &str,
         external_id: &str,
     ) -> anyhow::Result<Option<String>> {
-        let row: Option<(String,)> = sqlx::query_as(
+        let active_statuses: Vec<&str> = std::iter::once(TaskStatus::Pending.as_ref())
+            .chain(std::iter::once(TaskStatus::AwaitingDeps.as_ref()))
+            .chain(TaskStatus::resumable_statuses().iter().copied())
+            .collect();
+        let placeholders = Self::numbered_placeholders(3, active_statuses.len());
+        let sql = format!(
             "SELECT id FROM tasks WHERE project = $1 AND external_id = $2 \
-             AND status IN ('pending', 'awaiting_deps', 'implementing', \
-                           'agent_review', 'waiting', 'reviewing') \
-             LIMIT 1",
-        )
-        .bind(project)
-        .bind(external_id)
-        .fetch_optional(&self.pool)
-        .await?;
+             AND status IN ({placeholders}) LIMIT 1"
+        );
+        let mut query = sqlx::query_as::<_, (String,)>(&sql)
+            .bind(project)
+            .bind(external_id);
+        for status in active_statuses {
+            query = query.bind(status);
+        }
+        let row = query.fetch_optional(&self.pool).await?;
         Ok(row.map(|r| r.0))
     }
 
@@ -213,7 +233,7 @@ impl TaskDb {
     /// Return all tasks as lightweight summaries, skipping the heavy `rounds` column.
     pub async fn list_summaries(&self) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
         let rows = sqlx::query_as::<_, TaskSummaryRow>(
-            "SELECT id, status, turn, pr_url, error, source, external_id, parent_id, \
+            "SELECT id, task_kind, status, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, phase, description \
              FROM tasks ORDER BY created_at DESC",
         )
@@ -345,7 +365,9 @@ impl TaskDb {
             let resumable = TaskStatus::resumable_statuses();
             let placeholders = Self::numbered_placeholders(1, resumable.len());
             let sql = format!(
-                "SELECT t.id, t.status, t.turn, t.pr_url AS task_pr_url, \
+                "SELECT t.id, t.task_kind, t.source, t.external_id, t.description, \
+                        t.status, t.turn, t.pr_url AS task_pr_url, \
+                        t.system_input, \
                         c.triage_output, c.plan_output, c.pr_url AS ck_pr_url \
                  FROM tasks t \
                  LEFT JOIN task_checkpoints c ON t.id = c.task_id \
@@ -363,6 +385,16 @@ impl TaskDb {
         let mut result = RecoveryResult::default();
 
         for row in rows {
+            let task_kind = crate::task_runner::TaskKind::from_persisted(
+                Some(&row.task_kind),
+                row.source.as_deref(),
+                row.external_id.as_deref(),
+                row.description.as_deref(),
+            )?;
+            let system_input: Option<crate::task_runner::SystemTaskInput> = row
+                .system_input
+                .as_deref()
+                .and_then(|value| serde_json::from_str(value).ok());
             let effective_pr_url = row
                 .task_pr_url
                 .as_deref()
@@ -375,6 +407,29 @@ impl TaskDb {
             let has_pr = effective_pr_url.is_some();
             let has_plan = row.plan_output.is_some();
             let has_triage = row.triage_output.is_some();
+
+            if task_kind.recovery_status().is_some() {
+                if let Some(recovery_status) = task_kind.recovery_status() {
+                    if system_input.is_some() {
+                        sqlx::query(
+                            "UPDATE tasks SET status = $1, error = NULL, \
+                             updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+                        )
+                        .bind(recovery_status.as_ref())
+                        .bind(&row.id)
+                        .execute(&self.pool)
+                        .await?;
+                        result.resumed += 1;
+                        tracing::info!(
+                            task_id = %row.id,
+                            task_kind = task_kind.as_ref(),
+                            was = %row.status,
+                            "startup recovery: resumed system task"
+                        );
+                        continue;
+                    }
+                }
+            }
 
             if has_pr || has_plan || has_triage {
                 let reason = if has_pr {
@@ -608,16 +663,20 @@ impl TaskDb {
         let sql = if project.is_some() {
             format!(
                 "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('implementing', 'agent_review', 'waiting', 'reviewing') \
-                 AND external_id IS NOT NULL \
+                 WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
+                                  'planner_generating', 'planner_waiting', 'agent_review', \
+                                  'waiting', 'reviewing') \
+                 AND (external_id IS NOT NULL OR task_kind IN ('review', 'planner')) \
                  AND updated_at < $1 AND project = $2 \
                  ORDER BY updated_at ASC LIMIT 100"
             )
         } else {
             format!(
                 "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('implementing', 'agent_review', 'waiting', 'reviewing') \
-                 AND external_id IS NOT NULL \
+                 WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
+                                  'planner_generating', 'planner_waiting', 'agent_review', \
+                                  'waiting', 'reviewing') \
+                 AND (external_id IS NOT NULL OR task_kind IN ('review', 'planner')) \
                  AND updated_at < $1 \
                  ORDER BY updated_at ASC LIMIT 100"
             )

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -666,7 +666,7 @@ impl TaskDb {
                  WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
                                   'planner_generating', 'planner_waiting', 'agent_review', \
                                   'waiting', 'reviewing') \
-                 AND (external_id IS NOT NULL OR task_kind IN ('review', 'planner')) \
+                 AND external_id IS NOT NULL \
                  AND updated_at < $1 AND project = $2 \
                  ORDER BY updated_at ASC LIMIT 100"
             )
@@ -676,7 +676,7 @@ impl TaskDb {
                  WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
                                   'planner_generating', 'planner_waiting', 'agent_review', \
                                   'waiting', 'reviewing') \
-                 AND (external_id IS NOT NULL OR task_kind IN ('review', 'planner')) \
+                 AND external_id IS NOT NULL \
                  AND updated_at < $1 \
                  ORDER BY updated_at ASC LIMIT 100"
             )

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -1,4 +1,4 @@
-use crate::task_runner::{TaskState, TaskStatus};
+use crate::task_runner::{SystemTaskInput, TaskKind, TaskState, TaskStatus};
 use chrono::{DateTime, Utc};
 use harness_core::error::TaskDbDecodeError;
 use serde::{Deserialize, Serialize};
@@ -63,9 +63,14 @@ pub struct RecoveryResult {
 #[derive(sqlx::FromRow)]
 pub(super) struct RecoveryRow {
     pub(super) id: String,
+    pub(super) task_kind: String,
+    pub(super) source: Option<String>,
+    pub(super) external_id: Option<String>,
+    pub(super) description: Option<String>,
     pub(super) status: String,
     pub(super) turn: i64,
     pub(super) task_pr_url: Option<String>,
+    pub(super) system_input: Option<String>,
     pub(super) triage_output: Option<String>,
     pub(super) plan_output: Option<String>,
     pub(super) ck_pr_url: Option<String>,
@@ -77,11 +82,12 @@ pub(super) struct RecoveryRow {
 /// When adding a field to `TaskRow`, add the column here once and all queries
 /// pick it up automatically.  The `task_row_columns_match_struct` test below
 /// will fail if this list drifts from the struct definition.
-pub(super) const TASK_ROW_COLUMNS: &str = "id, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, updated_at, repo, depends_on, project, priority, phase, description, request_settings";
+pub(super) const TASK_ROW_COLUMNS: &str = "id, task_kind, status, turn, pr_url, rounds, error, source, external_id, parent_id, created_at, updated_at, repo, depends_on, project, priority, phase, description, request_settings, system_input";
 
 #[derive(sqlx::FromRow)]
 pub(super) struct TaskRow {
     pub(super) id: String,
+    pub(super) task_kind: String,
     pub(super) status: String,
     pub(super) turn: i64,
     pub(super) pr_url: Option<String>,
@@ -99,6 +105,7 @@ pub(super) struct TaskRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
+    pub(super) system_input: Option<String>,
 }
 
 /// Combined row for the pending-tasks-with-checkpoint JOIN query.
@@ -109,6 +116,7 @@ pub(super) struct TaskRow {
 pub(super) struct PendingCheckpointRow {
     // Task columns
     pub(super) id: String,
+    pub(super) task_kind: String,
     pub(super) status: String,
     pub(super) turn: i64,
     pub(super) pr_url: Option<String>,
@@ -126,6 +134,7 @@ pub(super) struct PendingCheckpointRow {
     pub(super) phase: String,
     pub(super) description: Option<String>,
     pub(super) request_settings: Option<String>,
+    pub(super) system_input: Option<String>,
     // Checkpoint columns (aliased)
     pub(super) triage_output: Option<String>,
     pub(super) plan_output: Option<String>,
@@ -138,6 +147,7 @@ pub(super) struct PendingCheckpointRow {
 #[derive(sqlx::FromRow)]
 pub(super) struct TaskSummaryRow {
     pub(super) id: String,
+    pub(super) task_kind: String,
     pub(super) status: String,
     pub(super) turn: i64,
     pub(super) pr_url: Option<String>,
@@ -167,6 +177,7 @@ impl TaskRow {
     pub(super) fn try_into_task_state(self) -> anyhow::Result<TaskState> {
         let Self {
             id,
+            task_kind,
             status,
             turn,
             pr_url,
@@ -184,12 +195,22 @@ impl TaskRow {
             phase,
             description,
             request_settings,
+            system_input,
         } = self;
 
         let decoded_request_settings: Option<crate::task_runner::PersistedRequestSettings> =
             request_settings
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok());
+        let decoded_system_input: Option<SystemTaskInput> = system_input
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok());
+        let decoded_task_kind = TaskKind::from_persisted(
+            Some(&task_kind),
+            source.as_deref(),
+            external_id.as_deref(),
+            description.as_deref(),
+        )?;
 
         let decoded_rounds = serde_json::from_str(&rounds).map_err(|source| {
             TaskDbDecodeError::RoundsDeserialize {
@@ -213,6 +234,7 @@ impl TaskRow {
 
         Ok(TaskState {
             id: harness_core::types::TaskId(id),
+            task_kind: decoded_task_kind,
             status: status.parse::<TaskStatus>()?,
             turn: turn as u32,
             pr_url,
@@ -234,6 +256,7 @@ impl TaskRow {
             plan_output: None,
             repo,
             request_settings: decoded_request_settings,
+            system_input: decoded_system_input,
         })
     }
 }
@@ -254,8 +277,15 @@ impl TaskSummaryRow {
                     source,
                 },
             )?;
+        let decoded_task_kind = TaskKind::from_persisted(
+            Some(&self.task_kind),
+            self.source.as_deref(),
+            self.external_id.as_deref(),
+            self.description.as_deref(),
+        )?;
         Ok(crate::task_runner::TaskSummary {
             id: TaskId(self.id),
+            task_kind: decoded_task_kind,
             status: self.status.parse::<crate::task_runner::TaskStatus>()?,
             turn: self.turn as u32,
             pr_url: self.pr_url,

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -559,7 +559,7 @@ pub(crate) async fn run_agent_streaming(
     // and must not be written at rest (per the privacy contract in task_runner.rs).
     let is_prompt_only = store
         .get(task_id)
-        .map(|s| s.description.as_deref() == Some("prompt task"))
+        .map(|s| matches!(s.task_kind, crate::task_runner::TaskKind::Prompt))
         .unwrap_or(false);
     let phase_str = req
         .execution_phase

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -3,7 +3,9 @@ use super::helpers::{
     matched_skills_for_prompt, run_agent_streaming, run_on_error, run_post_execute,
     run_post_tool_use, run_pre_execute, update_status,
 };
-use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskStatus, TaskStore};
+use crate::task_runner::{
+    mutate_and_persist, CreateTaskRequest, TaskId, TaskKind, TaskStatus, TaskStore,
+};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::interceptor::ToolUseEvent;
 use harness_core::tool_isolation::validate_tool_usage;
@@ -65,10 +67,10 @@ pub(crate) fn prepend_constitution(prompt: String, enabled: bool) -> String {
 }
 
 /// Returns true when the task type requires the agent to emit a `PR_URL=…` line.
-/// Issue-backed tasks and `pr:N` review tasks must produce a PR URL; prompt-only
-/// tasks (periodic_review, etc.) may produce output without creating a PR.
+/// Issue-backed tasks and `pr:N` review tasks must produce a PR URL; generic
+/// prompt-only implementation tasks may complete without creating one.
 pub(crate) fn task_needs_pr_url(req: &CreateTaskRequest) -> bool {
-    req.issue.is_some() || req.pr.is_some()
+    TaskKind::classify(req.source.as_deref(), req.issue, req.pr).requires_pr_url()
 }
 
 /// Outcome of the implement phase.
@@ -127,16 +129,6 @@ pub(crate) async fn run_implement_phase(
     task_start: Instant,
 ) -> anyhow::Result<ImplementOutcome> {
     use crate::task_runner::RoundResult;
-    use harness_core::config::agents::CapabilityProfile;
-
-    fn restricted_tools(profile: CapabilityProfile) -> anyhow::Result<Vec<String>> {
-        profile.tools().ok_or_else(|| {
-            anyhow::anyhow!(
-                "capability profile {:?} returned None from tools() — misconfiguration",
-                profile
-            )
-        })
-    }
 
     // Resume normal flow — update status to Implementing for the main turn.
     update_status(store, task_id, TaskStatus::Implementing, 1).await?;
@@ -177,12 +169,6 @@ pub(crate) async fn run_implement_phase(
             &review_config.reviewer_name,
             false,
         )
-    } else if matches!(
-        req.source.as_deref(),
-        Some("periodic_review") | Some("sprint_planner")
-    ) {
-        // Review/planner tasks use their prompt as-is — no "create PR" wrapper.
-        req.prompt.clone().unwrap_or_default()
     } else {
         prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default(), git)
     };
@@ -275,23 +261,8 @@ pub(crate) async fn run_implement_phase(
 
     let context_items = collect_context_items(skills, project, &first_prompt).await;
 
-    // Periodic review tasks need Bash to run guard check commands but should
-    // not have unrestricted write access — use Standard profile. All other
-    // tasks (implementation) keep Full (None → --dangerously-skip-permissions).
-    //
-    // Some(tools) causes claude.rs to pass --allowedTools to the CLI (hard
-    // enforcement). None → --dangerously-skip-permissions (full access).
-    let (initial_allowed_tools, capability_prompt_note): (Option<Vec<String>>, _) = if matches!(
-        req.source.as_deref(),
-        Some("periodic_review") | Some("sprint_planner")
-    ) {
-        (
-            Some(restricted_tools(CapabilityProfile::Standard)?),
-            CapabilityProfile::Standard.prompt_note(),
-        )
-    } else {
-        (None, None)
-    };
+    let initial_allowed_tools: Option<Vec<String>> = None;
+    let capability_prompt_note: Option<&'static str> = None;
 
     // Prepend capability restriction note so the agent knows which tools are
     // permitted. This is the primary enforcement path now that --allowedTools
@@ -565,47 +536,6 @@ pub(crate) async fn run_implement_phase(
             return Ok(ImplementOutcome::Done);
         }
 
-        // Review-only tasks produce a report, not a PR.
-        // Persist the output and return immediately — no PR parsing or review loop.
-        let is_review_task = store.get(task_id).is_some_and(|s| {
-            matches!(
-                s.source.as_deref(),
-                Some("periodic_review") | Some("sprint_planner")
-            )
-        });
-
-        if is_review_task {
-            mutate_and_persist(store, task_id, |s| {
-                s.status = TaskStatus::Done;
-                s.turn = 1;
-                s.rounds.push(RoundResult {
-                    turn: 1,
-                    action: "review".into(),
-                    result: "completed".into(),
-                    detail: if output.is_empty() {
-                        None
-                    } else {
-                        Some(output.clone())
-                    },
-                    first_token_latency_ms: impl_first_token_ms,
-                });
-            })
-            .await?;
-            store.log_event(crate::event_replay::TaskEvent::Completed {
-                task_id: task_id.0.clone(),
-                ts: crate::event_replay::now_ts(),
-            });
-            tracing::info!(
-                task_id = %task_id,
-                status = "done",
-                turns = 1,
-                pr_url = tracing::field::Empty,
-                total_elapsed_secs = task_start.elapsed().as_secs(),
-                "task_completed"
-            );
-            return Ok(ImplementOutcome::Done);
-        }
-
         let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
             ImplementationOutcome::PlanIssue(plan_issue) => {
                 if let (Some(workflows), Some(issue_number)) =
@@ -805,8 +735,7 @@ pub(crate) async fn run_implement_phase(
             }
             // Issue tasks and pr:N tasks must produce a PR URL. Mark Failed so the issue
             // is removed from the dispatched set by on_task_complete and can be re-queued.
-            // Prompt-only tasks (periodic_review, etc.) may legitimately produce output
-            // without a PR — Done is correct there.
+            // Generic prompt-only implementation tasks may legitimately finish without a PR.
             if task_needs_pr_url(req) {
                 tracing::warn!(
                     task_id = %task_id,

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -3,9 +3,7 @@ use super::helpers::{
     matched_skills_for_prompt, run_agent_streaming, run_on_error, run_post_execute,
     run_post_tool_use, run_pre_execute, update_status,
 };
-use crate::task_runner::{
-    mutate_and_persist, CreateTaskRequest, TaskId, TaskKind, TaskStatus, TaskStore,
-};
+use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskStatus, TaskStore};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::interceptor::ToolUseEvent;
 use harness_core::tool_isolation::validate_tool_usage;
@@ -70,7 +68,7 @@ pub(crate) fn prepend_constitution(prompt: String, enabled: bool) -> String {
 /// Issue-backed tasks and `pr:N` review tasks must produce a PR URL; generic
 /// prompt-only implementation tasks may complete without creating one.
 pub(crate) fn task_needs_pr_url(req: &CreateTaskRequest) -> bool {
-    TaskKind::classify(req.source.as_deref(), req.issue, req.pr).requires_pr_url()
+    req.task_kind().requires_pr_url()
 }
 
 /// Outcome of the implement phase.

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -436,7 +436,7 @@ pub(crate) async fn run_task(
     let task_kind = store
         .get(task_id)
         .map(|state| state.task_kind)
-        .unwrap_or_else(|| TaskKind::classify(req.source.as_deref(), req.issue, req.pr));
+        .unwrap_or_else(|| req.task_kind());
     let effective_max_turns: Option<u32> = req.max_turns.or(server_config.concurrency.max_turns);
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
 

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -7,23 +7,24 @@ pub(crate) mod review_loop;
 pub(crate) mod triage_pipeline;
 pub(crate) mod turn_lifecycle;
 
-use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskStatus, TaskStore};
+use crate::task_runner::{
+    mutate_and_persist, CreateTaskRequest, TaskId, TaskKind, TaskStatus, TaskStore,
+};
 use anyhow::Context;
-use harness_core::agent::CodeAgent;
+use harness_core::agent::{AgentRequest, CodeAgent};
+use harness_core::config::agents::CapabilityProfile;
+use harness_core::tool_isolation::validate_tool_usage;
 use harness_core::{config::project::load_project_config, lang_detect, prompts};
 use std::collections::HashMap;
 
 use helpers::update_status;
 
-#[cfg(test)]
-use harness_core::config::agents::CapabilityProfile;
 /// Extract tool list from a capability profile, returning an error if the
 /// profile unexpectedly returns `None` (which means Full/unrestricted).
 /// A misconfigured profile causes a hard failure rather than silent degradation,
 /// per U-23 (no silent capability downgrade).
 // Re-export so existing call sites in handlers/ don't need updating.
 pub(crate) use turn_lifecycle::run_turn_lifecycle;
-#[cfg(test)]
 fn restricted_tools(profile: CapabilityProfile) -> anyhow::Result<Vec<String>> {
     profile.tools().ok_or_else(|| {
         anyhow::anyhow!(
@@ -160,6 +161,226 @@ async fn run_test_gate(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn run_non_implementation_task(
+    store: &TaskStore,
+    task_id: &TaskId,
+    task_kind: TaskKind,
+    agent: &dyn CodeAgent,
+    req: &CreateTaskRequest,
+    project: &std::path::Path,
+    server_config: &harness_core::config::HarnessConfig,
+    interceptors: &Arc<Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
+    events: &Arc<harness_observe::event_store::EventStore>,
+    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
+    cargo_env: &HashMap<String, String>,
+    turn_timeout: Duration,
+    effective_max_turns: Option<u32>,
+    turns_used: &mut u32,
+    turns_used_acc: &mut u32,
+    task_start: Instant,
+) -> anyhow::Result<()> {
+    let Some(system_input) = store.get(task_id).and_then(|state| state.system_input) else {
+        anyhow::bail!(
+            "{} task is missing restart-safe input metadata",
+            task_kind.as_ref()
+        );
+    };
+
+    update_status(store, task_id, task_kind.execution_status(), 1).await?;
+
+    let mut prompt = implement_pipeline::prepend_constitution(
+        system_input.prompt().to_string(),
+        server_config.server.constitution_enabled,
+    );
+    let skill_additions = helpers::inject_skills_into_prompt(skills, &prompt).await;
+    if !skill_additions.is_empty() {
+        prompt.push_str(&skill_additions);
+    }
+    let context_items = helpers::collect_context_items(skills, project, &prompt).await;
+    let allowed_tools = Some(restricted_tools(CapabilityProfile::Standard)?);
+    if let Some(note) = CapabilityProfile::Standard.prompt_note() {
+        prompt = format!("{note}\n\n{prompt}");
+    }
+
+    let initial_req = AgentRequest {
+        prompt,
+        project_root: project.to_path_buf(),
+        context: context_items,
+        max_budget_usd: req.max_budget_usd,
+        execution_phase: Some(harness_core::types::ExecutionPhase::Planning),
+        allowed_tools: allowed_tools.clone(),
+        env_vars: cargo_env.clone(),
+        ..Default::default()
+    };
+    let first_req = helpers::run_pre_execute(interceptors, initial_req).await?;
+    let max_validation_retries: u32 = interceptors
+        .iter()
+        .filter_map(|i| i.max_validation_retries())
+        .max()
+        .unwrap_or(2);
+    let mut validation_attempt = 0u32;
+    let mut turn_req = first_req.clone();
+
+    let (resp, first_token_latency_ms) = loop {
+        if let Some(max) = effective_max_turns {
+            if *turns_used >= max {
+                anyhow::bail!(
+                    "Turn budget exhausted: used {} of {} allowed turns",
+                    turns_used,
+                    max
+                );
+            }
+        }
+        let raw = tokio::time::timeout(
+            turn_timeout,
+            helpers::run_agent_streaming(agent, turn_req.clone(), task_id, store, 1),
+        )
+        .await;
+        *turns_used += 1;
+        *turns_used_acc = *turns_used;
+        match raw {
+            Ok(Ok((response, latency_ms))) => {
+                let turn_tools = turn_req.allowed_tools.as_deref().unwrap_or(&[]);
+                let tool_violations = validate_tool_usage(&response.output, turn_tools);
+                let violation_err: Option<String> = if tool_violations.is_empty() {
+                    None
+                } else {
+                    Some(format!(
+                        "[VALIDATION ERROR] Tool isolation violation: agent used disallowed tools: [{}]. Only [{}] are permitted.",
+                        tool_violations.join(", "),
+                        turn_tools.join(", ")
+                    ))
+                };
+                let hook_err = {
+                    let modified = helpers::detect_modified_files(project).await;
+                    if modified.is_empty() {
+                        None
+                    } else {
+                        let hook_event = harness_core::interceptor::ToolUseEvent {
+                            tool_name: "file_write".to_string(),
+                            affected_files: modified,
+                            session_id: None,
+                        };
+                        helpers::run_post_tool_use(interceptors, &hook_event, project).await
+                    }
+                };
+                let post_err = helpers::run_post_execute(interceptors, &turn_req, &response).await;
+                if let Some(err) = violation_err.or(hook_err).or(post_err) {
+                    if validation_attempt < max_validation_retries {
+                        validation_attempt += 1;
+                        let backoff_ms = implement_pipeline::compute_backoff_ms(
+                            req.retry_base_backoff_ms,
+                            req.retry_max_backoff_ms,
+                            validation_attempt,
+                        );
+                        let truncated = helpers::truncate_validation_error(&err, 2000);
+                        turn_req.prompt = prompts::validation_retry_prompt(
+                            &first_req.prompt,
+                            validation_attempt,
+                            max_validation_retries,
+                            &truncated,
+                        );
+                        sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
+                    helpers::run_on_error(interceptors, &turn_req, &err).await;
+                    anyhow::bail!(
+                        "Post-execution validation failed after {} attempts: {}",
+                        max_validation_retries,
+                        err
+                    );
+                }
+                break (response, latency_ms);
+            }
+            Ok(Err(err)) => {
+                helpers::run_on_error(interceptors, &turn_req, &err.to_string()).await;
+                return Err(err.into());
+            }
+            Err(_) => {
+                let msg = format!(
+                    "{} timed out after {}s",
+                    task_kind.as_ref(),
+                    turn_timeout.as_secs()
+                );
+                helpers::run_on_error(interceptors, &turn_req, &msg).await;
+                anyhow::bail!(msg);
+            }
+        }
+    };
+
+    if implement_pipeline::contains_worktree_collision_sentinel(&resp.output) {
+        mutate_and_persist(store, task_id, |s| {
+            s.status = TaskStatus::Failed;
+            s.turn = 1;
+            s.error = Some(
+                "WorktreeCollision: agent observed worktree managed by another harness session"
+                    .into(),
+            );
+            s.rounds.push(crate::task_runner::RoundResult {
+                turn: 1,
+                action: task_kind.as_ref().to_string(),
+                result: "worktree_collision".into(),
+                detail: if resp.output.is_empty() {
+                    None
+                } else {
+                    Some(resp.output.clone())
+                },
+                first_token_latency_ms,
+            });
+        })
+        .await?;
+        tracing::info!(
+            task_id = %task_id,
+            task_kind = task_kind.as_ref(),
+            status = "failed",
+            total_elapsed_secs = task_start.elapsed().as_secs(),
+            "task_completed"
+        );
+        return Ok(());
+    }
+
+    mutate_and_persist(store, task_id, |s| {
+        s.status = TaskStatus::Done;
+        s.turn = 1;
+        s.rounds.push(crate::task_runner::RoundResult {
+            turn: 1,
+            action: task_kind.as_ref().to_string(),
+            result: "completed".into(),
+            detail: if resp.output.is_empty() {
+                None
+            } else {
+                Some(resp.output.clone())
+            },
+            first_token_latency_ms,
+        });
+    })
+    .await?;
+    store.log_event(crate::event_replay::TaskEvent::Completed {
+        task_id: task_id.0.clone(),
+        ts: crate::event_replay::now_ts(),
+    });
+    let event_name = format!("task_{}", task_kind.as_ref());
+    let mut ev = harness_core::types::Event::new(
+        harness_core::types::SessionId::new(),
+        &event_name,
+        "task_runner",
+        harness_core::types::Decision::Complete,
+    );
+    ev.detail = Some(format!("task_id={}", task_id.as_str()));
+    if let Err(err) = events.log(&ev).await {
+        tracing::warn!("failed to log {} event: {err}", task_kind.as_ref());
+    }
+    tracing::info!(
+        task_id = %task_id,
+        task_kind = task_kind.as_ref(),
+        status = "done",
+        total_elapsed_secs = task_start.elapsed().as_secs(),
+        "task_completed"
+    );
+    Ok(())
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
@@ -212,6 +433,36 @@ pub(crate) async fn run_task(
     let repo_slug = detect_repo_slug(&project)
         .await
         .unwrap_or_else(|| "{owner}/{repo}".to_string());
+    let task_kind = store
+        .get(task_id)
+        .map(|state| state.task_kind)
+        .unwrap_or_else(|| TaskKind::classify(req.source.as_deref(), req.issue, req.pr));
+    let effective_max_turns: Option<u32> = req.max_turns.or(server_config.concurrency.max_turns);
+    let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
+
+    if matches!(task_kind, TaskKind::Review | TaskKind::Planner) {
+        let mut turns_used = *turns_used_acc;
+        run_non_implementation_task(
+            store,
+            task_id,
+            task_kind,
+            agent,
+            req,
+            &project,
+            server_config,
+            &interceptors,
+            &events,
+            &skills,
+            &cargo_env,
+            turn_timeout,
+            effective_max_turns,
+            &mut turns_used,
+            turns_used_acc,
+            task_start,
+        )
+        .await?;
+        return Ok(());
+    }
 
     // --- Checkpoint-based resume detection ---
     // Load checkpoint and task state to determine if we can skip phases.
@@ -319,7 +570,6 @@ pub(crate) async fn run_task(
     let effective_max_rounds = req.max_rounds.unwrap_or(triage_default_rounds);
     // max_turns: per-request override wins; global config is the fallback.
     // Counts every agent API call (impl + validation retries + review rounds).
-    let effective_max_turns: Option<u32> = req.max_turns.or(server_config.concurrency.max_turns);
     // Start from accumulated turns (prior transient-retry attempts + pipeline phases)
     // so the budget is global across the full task lifecycle.
     let mut turns_used: u32 = *turns_used_acc + pipeline_turns;

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -16,7 +16,8 @@ pub type CompletionCallback =
 // Re-export everything that was previously public from the flat task_runner.rs.
 pub use metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
 pub use request::{
-    fill_missing_repo_from_project, CreateTaskRequest, PersistedRequestSettings, MAX_TASK_PRIORITY,
+    fill_missing_repo_from_project, CreateTaskRequest, PersistedRequestSettings, SystemTaskInput,
+    MAX_TASK_PRIORITY,
 };
 pub use spawn::{
     check_awaiting_deps, effective_turn_timeout, prompt_requires_plan, register_pending_task,
@@ -24,7 +25,7 @@ pub use spawn::{
 };
 pub use state::{RecentFailureTask, RoundResult, TaskState, TaskSummary};
 pub use store::{mutate_and_persist, update_status, TaskStore};
-pub use types::{TaskId, TaskPhase, TaskStatus};
+pub use types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 
 impl TaskStore {
     /// Return the most recent `limit` failed tasks, newest first.

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -84,6 +84,21 @@ pub struct CreateTaskRequest {
     pub system_input: Option<SystemTaskInput>,
 }
 
+impl CreateTaskRequest {
+    /// Classify task kind using only trusted internal metadata for system tasks.
+    ///
+    /// External callers may set `source`, but they cannot populate `system_input`
+    /// because the field is `#[serde(skip)]`. That makes `system_input` the trust
+    /// boundary for review/planner lifecycle selection.
+    pub fn task_kind(&self) -> TaskKind {
+        match self.system_input.as_ref() {
+            Some(SystemTaskInput::PeriodicReview { .. }) => TaskKind::Review,
+            Some(SystemTaskInput::SprintPlanner { .. }) => TaskKind::Planner,
+            None => TaskKind::classify(None, self.issue, self.pr),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SystemTaskInput {
@@ -92,15 +107,6 @@ pub enum SystemTaskInput {
 }
 
 impl SystemTaskInput {
-    pub fn from_request(task_kind: TaskKind, req: &CreateTaskRequest) -> Option<Self> {
-        let prompt = req.prompt.as_ref()?.clone();
-        match task_kind {
-            TaskKind::Review => Some(Self::PeriodicReview { prompt }),
-            TaskKind::Planner => Some(Self::SprintPlanner { prompt }),
-            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => None,
-        }
-    }
-
     pub fn prompt(&self) -> &str {
         match self {
             Self::PeriodicReview { prompt } | Self::SprintPlanner { prompt } => prompt,
@@ -245,7 +251,7 @@ impl Default for CreateTaskRequest {
 }
 
 pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<String> {
-    let task_kind = TaskKind::classify(req.source.as_deref(), req.issue, req.pr);
+    let task_kind = req.task_kind();
     // Only persist structured safe labels — never raw prompt text, which may contain
     // credentials or customer data.
     if let Some(n) = req.issue {

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use super::types::TaskId;
+use super::types::{TaskId, TaskKind};
 
 /// Maximum allowed scheduling priority. Values above this are rejected at the
 /// API boundary to prevent scheduler-level starvation of normal-priority tasks.
@@ -78,6 +78,34 @@ pub struct CreateTaskRequest {
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
     pub priority: u8,
+    /// Restart-safe metadata for trusted system-generated prompt tasks.
+    /// Never accepted from or exposed to external HTTP callers.
+    #[serde(skip)]
+    pub system_input: Option<SystemTaskInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SystemTaskInput {
+    PeriodicReview { prompt: String },
+    SprintPlanner { prompt: String },
+}
+
+impl SystemTaskInput {
+    pub fn from_request(task_kind: TaskKind, req: &CreateTaskRequest) -> Option<Self> {
+        let prompt = req.prompt.as_ref()?.clone();
+        match task_kind {
+            TaskKind::Review => Some(Self::PeriodicReview { prompt }),
+            TaskKind::Planner => Some(Self::SprintPlanner { prompt }),
+            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => None,
+        }
+    }
+
+    pub fn prompt(&self) -> &str {
+        match self {
+            Self::PeriodicReview { prompt } | Self::SprintPlanner { prompt } => prompt,
+        }
+    }
 }
 
 /// Execution limits that survive a server restart.
@@ -211,11 +239,13 @@ impl Default for CreateTaskRequest {
             parent_task_id: None,
             depends_on: Vec::new(),
             priority: 0,
+            system_input: None,
         }
     }
 }
 
 pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<String> {
+    let task_kind = TaskKind::classify(req.source.as_deref(), req.issue, req.pr);
     // Only persist structured safe labels — never raw prompt text, which may contain
     // credentials or customer data.
     if let Some(n) = req.issue {
@@ -224,12 +254,12 @@ pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<S
     if let Some(n) = req.pr {
         return Some(format!("PR #{n}"));
     }
-    // Prompt-only tasks: store a generic label so that:
-    //   (a) sibling-awareness can include them (prevents parallel agents stomping the same files),
-    //   (b) operators can identify crashed tasks in the DB/dashboard after a restart.
-    // The prompt itself is deliberately not stored.
     if req.prompt.is_some() {
-        return Some("prompt task".to_string());
+        return Some(match task_kind {
+            TaskKind::Review => "periodic review".to_string(),
+            TaskKind::Planner => "sprint planner".to_string(),
+            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => "prompt task".to_string(),
+        });
     }
     None
 }

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -89,6 +89,24 @@ fn system_input_for_request(req: &CreateTaskRequest) -> Option<SystemTaskInput> 
     req.system_input.clone()
 }
 
+fn refresh_preregistered_task_metadata(
+    entry: &mut TaskState,
+    req: &CreateTaskRequest,
+    project_root: PathBuf,
+    description: Option<String>,
+) {
+    entry.task_kind = classify_task_kind(req);
+    entry.source = req.source.clone();
+    entry.external_id = req.external_id.clone();
+    entry.repo = req.repo.clone();
+    entry.parent_id = req.parent_task_id.clone();
+    entry.depends_on = req.depends_on.clone();
+    entry.project_root = Some(project_root);
+    entry.issue = req.issue;
+    entry.description = description;
+    entry.system_input = system_input_for_request(req);
+}
+
 #[cfg(test)]
 pub(super) fn is_non_decomposable_prompt_source(source: Option<&str>) -> bool {
     TaskKind::classify(source, None, None).is_non_decomposable_prompt()
@@ -408,17 +426,12 @@ where
         }
         let description = summarize_request_description(&req);
         if let Some(mut entry) = store.cache.get_mut(&id) {
-            entry.task_kind = classify_task_kind(&req);
-            entry.source = req.source.clone();
-            entry.external_id = req.external_id.clone();
-            entry.repo = req.repo.clone();
-            entry.parent_id = req.parent_task_id.clone();
-            entry.depends_on = req.depends_on.clone();
-            entry.project_root = Some(project_root.clone());
-            entry.issue = req.issue;
-            entry.phase = entry.task_kind.default_phase();
-            entry.description = description;
-            entry.system_input = system_input_for_request(&req);
+            refresh_preregistered_task_metadata(
+                &mut entry,
+                &req,
+                project_root.clone(),
+                description,
+            );
         }
 
         // Parallel dispatch for Complex+ prompt-only tasks when workspace isolation is active.
@@ -1485,6 +1498,30 @@ mod tests {
             "review loop turn must use Execution phase (agent needs write access to fix bot comments)"
         );
         Ok(())
+    }
+
+    #[test]
+    fn preregistered_metadata_refresh_preserves_persisted_phase() {
+        let mut state = TaskState::new(TaskId::new());
+        state.phase = TaskPhase::Plan;
+
+        let req = CreateTaskRequest {
+            prompt: Some("small prompt".into()),
+            project: Some(PathBuf::from("/tmp/recovered-project")),
+            repo: Some("owner/repo".into()),
+            ..Default::default()
+        };
+
+        refresh_preregistered_task_metadata(
+            &mut state,
+            &req,
+            PathBuf::from("/tmp/recovered-project"),
+            Some("small prompt".into()),
+        );
+
+        assert_eq!(state.phase, TaskPhase::Plan);
+        assert_eq!(state.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(state.description.as_deref(), Some("small prompt"));
     }
 
     #[test]

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -82,11 +82,11 @@ pub fn prompt_requires_plan(prompt: &str) -> bool {
 }
 
 fn classify_task_kind(req: &CreateTaskRequest) -> TaskKind {
-    TaskKind::classify(req.source.as_deref(), req.issue, req.pr)
+    req.task_kind()
 }
 
 fn system_input_for_request(req: &CreateTaskRequest) -> Option<SystemTaskInput> {
-    SystemTaskInput::from_request(classify_task_kind(req), req)
+    req.system_input.clone()
 }
 
 #[cfg(test)]
@@ -1610,6 +1610,51 @@ mod tests {
         assert!(is_non_decomposable_prompt_source(Some("sprint_planner")));
         assert!(!is_non_decomposable_prompt_source(Some("github")));
         assert!(!is_non_decomposable_prompt_source(None));
+    }
+
+    #[test]
+    fn request_task_kind_trusts_only_internal_system_input() {
+        let spoofed = CreateTaskRequest {
+            prompt: Some("review this".to_string()),
+            source: Some("periodic_review".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(spoofed.task_kind(), TaskKind::Prompt);
+
+        let trusted = CreateTaskRequest {
+            prompt: Some("review this".to_string()),
+            source: Some("periodic_review".to_string()),
+            system_input: Some(SystemTaskInput::PeriodicReview {
+                prompt: "review this".to_string(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(trusted.task_kind(), TaskKind::Review);
+    }
+
+    #[test]
+    fn system_input_for_request_clones_only_explicit_internal_metadata() {
+        let spoofed = CreateTaskRequest {
+            prompt: Some("review this".to_string()),
+            source: Some("periodic_review".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(system_input_for_request(&spoofed), None);
+
+        let trusted = CreateTaskRequest {
+            prompt: Some("review this".to_string()),
+            source: Some("periodic_review".to_string()),
+            system_input: Some(SystemTaskInput::PeriodicReview {
+                prompt: "review this".to_string(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            system_input_for_request(&trusted),
+            Some(SystemTaskInput::PeriodicReview {
+                prompt: "review this".to_string(),
+            })
+        );
     }
 
     // --- dependency scheduling tests ---

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -6,11 +6,11 @@ use tokio::sync::RwLock;
 
 use super::request::{
     detect_main_worktree, summarize_request_description, CreateTaskRequest,
-    PersistedRequestSettings,
+    PersistedRequestSettings, SystemTaskInput,
 };
 use super::state::{RoundResult, TaskState};
 use super::store::{mutate_and_persist, TaskStore};
-use super::types::{TaskId, TaskPhase, TaskStatus};
+use super::types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 use super::CompletionCallback;
 
 /// Patterns that indicate a transient (retryable) failure rather than a permanent one.
@@ -81,8 +81,17 @@ pub fn prompt_requires_plan(prompt: &str) -> bool {
     file_path_count >= 3
 }
 
+fn classify_task_kind(req: &CreateTaskRequest) -> TaskKind {
+    TaskKind::classify(req.source.as_deref(), req.issue, req.pr)
+}
+
+fn system_input_for_request(req: &CreateTaskRequest) -> Option<SystemTaskInput> {
+    SystemTaskInput::from_request(classify_task_kind(req), req)
+}
+
+#[cfg(test)]
 pub(super) fn is_non_decomposable_prompt_source(source: Option<&str>) -> bool {
-    matches!(source, Some("periodic_review") | Some("sprint_planner"))
+    TaskKind::classify(source, None, None).is_non_decomposable_prompt()
 }
 
 /// Check if an error message indicates a transient failure that may succeed on retry.
@@ -269,6 +278,7 @@ pub async fn spawn_task(
 pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskRequest) -> TaskId {
     let task_id = TaskId::new();
     let mut state = TaskState::new(task_id.clone());
+    state.task_kind = classify_task_kind(req);
     state.source = req.source.clone();
     state.external_id = req.external_id.clone();
     state.repo = req.repo.clone();
@@ -276,8 +286,10 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.depends_on = req.depends_on.clone();
     state.priority = req.priority;
     state.issue = req.issue;
+    state.phase = state.task_kind.default_phase();
     state.description = summarize_request_description(req);
     state.request_settings = Some(PersistedRequestSettings::from_req(req));
+    state.system_input = system_input_for_request(req);
     store.insert(&state).await;
     // Register stream channel now so SSE clients can subscribe before execution begins.
     store.register_task_stream(&task_id);
@@ -351,11 +363,14 @@ where
     } else {
         let task_id = TaskId::new();
         let mut state = TaskState::new(task_id.clone());
+        state.task_kind = classify_task_kind(&req);
         state.source = req.source.clone();
         state.external_id = req.external_id.clone();
         state.repo = req.repo.clone();
         state.priority = req.priority;
+        state.phase = state.task_kind.default_phase();
         state.request_settings = Some(PersistedRequestSettings::from_req(&req));
+        state.system_input = system_input_for_request(&req);
         store.insert(&state).await;
         // Register stream channel before spawning so SSE clients can subscribe immediately.
         store.register_task_stream(&task_id);
@@ -393,6 +408,7 @@ where
         }
         let description = summarize_request_description(&req);
         if let Some(mut entry) = store.cache.get_mut(&id) {
+            entry.task_kind = classify_task_kind(&req);
             entry.source = req.source.clone();
             entry.external_id = req.external_id.clone();
             entry.repo = req.repo.clone();
@@ -400,7 +416,9 @@ where
             entry.depends_on = req.depends_on.clone();
             entry.project_root = Some(project_root.clone());
             entry.issue = req.issue;
+            entry.phase = entry.task_kind.default_phase();
             entry.description = description;
+            entry.system_input = system_input_for_request(&req);
         }
 
         // Parallel dispatch for Complex+ prompt-only tasks when workspace isolation is active.
@@ -415,8 +433,12 @@ where
             harness_core::agent::TaskComplexity::Complex
                 | harness_core::agent::TaskComplexity::Critical
         );
-        let is_non_decomposable_source = is_non_decomposable_prompt_source(req.source.as_deref());
-        if req.issue.is_none() && req.pr.is_none() && is_complex && !is_non_decomposable_source {
+        let task_kind = classify_task_kind(&req);
+        if req.issue.is_none()
+            && req.pr.is_none()
+            && is_complex
+            && !task_kind.is_non_decomposable_prompt()
+        {
             if let Some(ref wmgr) = workspace_mgr {
                 let mut subtask_specs = match crate::parallel_dispatch::decompose(
                     req.prompt.as_deref().unwrap_or_default(),
@@ -562,10 +584,7 @@ where
         // Planning gate: complex prompt-only tasks must go through the Plan phase
         // before implementation to reduce drift.
         // Heuristic: prompt longer than 200 words OR containing 3+ file path tokens.
-        if req.issue.is_none()
-            && req.pr.is_none()
-            && !is_non_decomposable_prompt_source(req.source.as_deref())
-        {
+        if req.issue.is_none() && req.pr.is_none() && !task_kind.is_non_decomposable_prompt() {
             if let Some(ref prompt) = req.prompt {
                 if prompt_requires_plan(prompt) {
                     mutate_and_persist(&store, &id, |s| {
@@ -771,14 +790,17 @@ pub async fn spawn_task_awaiting_deps(
     }
 
     let mut state = TaskState::new(task_id.clone());
+    state.task_kind = classify_task_kind(&req);
     state.depends_on = depends_on;
     state.source = req.source.clone();
     state.external_id = req.external_id.clone();
     state.repo = req.repo.clone();
     state.priority = req.priority;
     state.issue = req.issue;
+    state.phase = state.task_kind.default_phase();
     state.description = summarize_request_description(&req);
     state.request_settings = Some(PersistedRequestSettings::from_req(&req));
+    state.system_input = system_input_for_request(&req);
     // Persist the caller's resolved project root so that duplicate detection
     // (which keys on project_root + external_id) and the dep-watcher's project
     // path resolution both work correctly for waiting tasks.

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use super::request::PersistedRequestSettings;
-use super::types::{TaskId, TaskPhase, TaskStatus};
+use super::request::{PersistedRequestSettings, SystemTaskInput};
+use super::types::{TaskId, TaskKind, TaskPhase, TaskStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoundResult {
@@ -20,6 +20,7 @@ pub struct RoundResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskState {
     pub id: TaskId,
+    pub task_kind: TaskKind,
     pub status: TaskStatus,
     pub turn: u32,
     pub pr_url: Option<String>,
@@ -78,12 +79,16 @@ pub struct TaskState {
     /// requested rather than silently falling back to server defaults.
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
+    /// Restart-safe prompt snapshot for trusted system-generated prompt tasks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_input: Option<SystemTaskInput>,
 }
 
 /// Lightweight task summary returned by the list endpoint (excludes `rounds` history).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskSummary {
     pub id: TaskId,
+    pub task_kind: TaskKind,
     pub status: TaskStatus,
     pub turn: u32,
     pub pr_url: Option<String>,
@@ -138,6 +143,7 @@ impl TaskState {
     pub(crate) fn new(id: TaskId) -> Self {
         Self {
             id,
+            task_kind: TaskKind::default(),
             status: TaskStatus::Pending,
             turn: 0,
             pr_url: None,
@@ -159,12 +165,14 @@ impl TaskState {
             plan_output: None,
             repo: None,
             request_settings: None,
+            system_input: None,
         }
     }
 
     pub fn summary(&self) -> TaskSummary {
         TaskSummary {
             id: self.id.clone(),
+            task_kind: self.task_kind,
             status: self.status.clone(),
             turn: self.turn,
             pr_url: self.pr_url.clone(),

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -80,7 +80,8 @@ pub struct TaskState {
     #[serde(skip)]
     pub request_settings: Option<PersistedRequestSettings>,
     /// Restart-safe prompt snapshot for trusted system-generated prompt tasks.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Persisted internally for recovery only; never expose it via the public task API.
+    #[serde(skip)]
     pub system_input: Option<SystemTaskInput>,
 }
 

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -107,6 +107,10 @@ impl TaskStore {
             "pending",
             "awaiting_deps",
             "implementing",
+            "review_generating",
+            "review_waiting",
+            "planner_generating",
+            "planner_waiting",
             "agent_review",
             "waiting",
             "reviewing",
@@ -1344,6 +1348,42 @@ mod tests {
                 false,
             ),
             (
+                TaskStatus::ReviewGenerating,
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+            ),
+            (
+                TaskStatus::ReviewWaiting,
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+            ),
+            (
+                TaskStatus::PlannerGenerating,
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+            ),
+            (
+                TaskStatus::PlannerWaiting,
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+            ),
+            (
                 TaskStatus::AgentReview,
                 false,
                 true,
@@ -1394,7 +1434,16 @@ mod tests {
         );
         assert_eq!(
             TaskStatus::resumable_statuses(),
-            &["implementing", "agent_review", "waiting", "reviewing"]
+            &[
+                "implementing",
+                "review_generating",
+                "review_waiting",
+                "planner_generating",
+                "planner_waiting",
+                "agent_review",
+                "waiting",
+                "reviewing",
+            ]
         );
     }
 

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -47,21 +47,19 @@ impl TaskKind {
         external_id: Option<&str>,
         description: Option<&str>,
     ) -> Self {
-        match source {
-            Some("periodic_review") => Self::Review,
-            Some("sprint_planner") => Self::Planner,
-            _ => {
-                if external_id.is_some_and(|id| id.starts_with("issue:"))
-                    || description.is_some_and(|desc| desc.starts_with("issue #"))
-                {
-                    Self::Issue
-                } else if external_id.is_some_and(|id| id.starts_with("pr:"))
-                    || description.is_some_and(|desc| desc.starts_with("PR #"))
-                {
-                    Self::Pr
-                } else {
-                    Self::Prompt
-                }
+        if external_id.is_some_and(|id| id.starts_with("issue:"))
+            || description.is_some_and(|desc| desc.starts_with("issue #"))
+        {
+            Self::Issue
+        } else if external_id.is_some_and(|id| id.starts_with("pr:"))
+            || description.is_some_and(|desc| desc.starts_with("PR #"))
+        {
+            Self::Pr
+        } else {
+            match source {
+                Some("periodic_review") => Self::Review,
+                Some("sprint_planner") => Self::Planner,
+                _ => Self::Prompt,
             }
         }
     }
@@ -245,5 +243,57 @@ impl std::str::FromStr for TaskStatus {
             "cancelled" => Ok(TaskStatus::Cancelled),
             _ => anyhow::bail!("unknown task status `{s}`"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskKind;
+
+    #[test]
+    fn legacy_issue_markers_override_review_source() {
+        let kind = TaskKind::from_persisted(
+            None,
+            Some("periodic_review"),
+            Some("issue:42"),
+            Some("issue #42"),
+        )
+        .expect("legacy task kind should decode");
+
+        assert_eq!(kind, TaskKind::Issue);
+    }
+
+    #[test]
+    fn legacy_pr_markers_override_planner_source() {
+        let kind = TaskKind::from_persisted(
+            Some("legacy"),
+            Some("sprint_planner"),
+            Some("pr:7"),
+            Some("PR #7"),
+        )
+        .expect("legacy task kind should decode");
+
+        assert_eq!(kind, TaskKind::Pr);
+    }
+
+    #[test]
+    fn legacy_system_sources_still_decode_when_no_issue_or_pr_markers_exist() {
+        let review = TaskKind::from_persisted(
+            Some("legacy"),
+            Some("periodic_review"),
+            Some("legacy:review"),
+            Some("periodic review"),
+        )
+        .expect("legacy review task kind should decode");
+        let planner = TaskKind::from_persisted(
+            Some("legacy"),
+            Some("sprint_planner"),
+            Some("legacy:planner"),
+            Some("sprint planner"),
+        )
+        .expect("legacy planner task kind should decode");
+
+        assert_eq!(review, TaskKind::Review);
+        assert_eq!(planner, TaskKind::Planner);
     }
 }

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -3,6 +3,114 @@ use serde::{Deserialize, Serialize};
 
 pub type TaskId = CoreTaskId;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskKind {
+    Issue,
+    Pr,
+    #[default]
+    Prompt,
+    Review,
+    Planner,
+}
+
+impl TaskKind {
+    pub fn classify(source: Option<&str>, issue: Option<u64>, pr: Option<u64>) -> Self {
+        match source {
+            Some("periodic_review") => Self::Review,
+            Some("sprint_planner") => Self::Planner,
+            _ if issue.is_some() => Self::Issue,
+            _ if pr.is_some() => Self::Pr,
+            _ => Self::Prompt,
+        }
+    }
+
+    pub fn from_persisted(
+        persisted: Option<&str>,
+        source: Option<&str>,
+        external_id: Option<&str>,
+        description: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        match persisted {
+            Some("legacy") | None => Ok(Self::infer_legacy(source, external_id, description)),
+            Some("issue") => Ok(Self::Issue),
+            Some("pr") => Ok(Self::Pr),
+            Some("prompt") => Ok(Self::Prompt),
+            Some("review") => Ok(Self::Review),
+            Some("planner") => Ok(Self::Planner),
+            Some(other) => anyhow::bail!("unknown task kind `{other}`"),
+        }
+    }
+
+    fn infer_legacy(
+        source: Option<&str>,
+        external_id: Option<&str>,
+        description: Option<&str>,
+    ) -> Self {
+        match source {
+            Some("periodic_review") => Self::Review,
+            Some("sprint_planner") => Self::Planner,
+            _ => {
+                if external_id.is_some_and(|id| id.starts_with("issue:"))
+                    || description.is_some_and(|desc| desc.starts_with("issue #"))
+                {
+                    Self::Issue
+                } else if external_id.is_some_and(|id| id.starts_with("pr:"))
+                    || description.is_some_and(|desc| desc.starts_with("PR #"))
+                {
+                    Self::Pr
+                } else {
+                    Self::Prompt
+                }
+            }
+        }
+    }
+
+    pub fn default_phase(&self) -> TaskPhase {
+        match self {
+            Self::Planner => TaskPhase::Plan,
+            Self::Review => TaskPhase::Review,
+            Self::Issue | Self::Pr | Self::Prompt => TaskPhase::Implement,
+        }
+    }
+
+    pub fn execution_status(&self) -> TaskStatus {
+        match self {
+            Self::Review => TaskStatus::ReviewGenerating,
+            Self::Planner => TaskStatus::PlannerGenerating,
+            Self::Issue | Self::Pr | Self::Prompt => TaskStatus::Implementing,
+        }
+    }
+
+    pub fn recovery_status(&self) -> Option<TaskStatus> {
+        match self {
+            Self::Review => Some(TaskStatus::ReviewWaiting),
+            Self::Planner => Some(TaskStatus::PlannerWaiting),
+            Self::Issue | Self::Pr | Self::Prompt => None,
+        }
+    }
+
+    pub fn requires_pr_url(&self) -> bool {
+        matches!(self, Self::Issue | Self::Pr)
+    }
+
+    pub fn is_non_decomposable_prompt(&self) -> bool {
+        matches!(self, Self::Review | Self::Planner)
+    }
+}
+
+impl AsRef<str> for TaskKind {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Issue => "issue",
+            Self::Pr => "pr",
+            Self::Prompt => "prompt",
+            Self::Review => "review",
+            Self::Planner => "planner",
+        }
+    }
+}
+
 /// Current phase in the task pipeline.
 ///
 /// Tasks progress through phases sequentially. Simple tasks may skip
@@ -29,6 +137,10 @@ pub enum TaskStatus {
     Pending,
     AwaitingDeps,
     Implementing,
+    ReviewGenerating,
+    ReviewWaiting,
+    PlannerGenerating,
+    PlannerWaiting,
     AgentReview,
     Waiting,
     Reviewing,
@@ -38,7 +150,16 @@ pub enum TaskStatus {
 }
 
 const TERMINAL_TASK_STATUSES: &[&str] = &["done", "failed", "cancelled"];
-const RESUMABLE_TASK_STATUSES: &[&str] = &["implementing", "agent_review", "waiting", "reviewing"];
+const RESUMABLE_TASK_STATUSES: &[&str] = &[
+    "implementing",
+    "review_generating",
+    "review_waiting",
+    "planner_generating",
+    "planner_waiting",
+    "agent_review",
+    "waiting",
+    "reviewing",
+];
 
 impl TaskStatus {
     pub fn is_terminal(&self) -> bool {
@@ -48,7 +169,14 @@ impl TaskStatus {
     pub fn is_inflight(&self) -> bool {
         matches!(
             self,
-            Self::Implementing | Self::AgentReview | Self::Waiting | Self::Reviewing
+            Self::Implementing
+                | Self::ReviewGenerating
+                | Self::ReviewWaiting
+                | Self::PlannerGenerating
+                | Self::PlannerWaiting
+                | Self::AgentReview
+                | Self::Waiting
+                | Self::Reviewing
         )
     }
 
@@ -83,6 +211,10 @@ impl AsRef<str> for TaskStatus {
             TaskStatus::Pending => "pending",
             TaskStatus::AwaitingDeps => "awaiting_deps",
             TaskStatus::Implementing => "implementing",
+            TaskStatus::ReviewGenerating => "review_generating",
+            TaskStatus::ReviewWaiting => "review_waiting",
+            TaskStatus::PlannerGenerating => "planner_generating",
+            TaskStatus::PlannerWaiting => "planner_waiting",
             TaskStatus::AgentReview => "agent_review",
             TaskStatus::Waiting => "waiting",
             TaskStatus::Reviewing => "reviewing",
@@ -101,6 +233,10 @@ impl std::str::FromStr for TaskStatus {
             "pending" => Ok(TaskStatus::Pending),
             "awaiting_deps" => Ok(TaskStatus::AwaitingDeps),
             "implementing" => Ok(TaskStatus::Implementing),
+            "review_generating" => Ok(TaskStatus::ReviewGenerating),
+            "review_waiting" => Ok(TaskStatus::ReviewWaiting),
+            "planner_generating" => Ok(TaskStatus::PlannerGenerating),
+            "planner_waiting" => Ok(TaskStatus::PlannerWaiting),
             "agent_review" => Ok(TaskStatus::AgentReview),
             "waiting" => Ok(TaskStatus::Waiting),
             "reviewing" => Ok(TaskStatus::Reviewing),

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -8,11 +8,12 @@
 
 use harness_core::types::TaskId as CoreTaskId;
 use harness_server::task_db::TaskDb;
-use harness_server::task_runner::{TaskPhase, TaskState, TaskStatus, TaskStore};
+use harness_server::task_runner::{TaskKind, TaskPhase, TaskState, TaskStatus, TaskStore};
 
 fn make_task(id: &str, status: TaskStatus) -> TaskState {
     TaskState {
         id: CoreTaskId(id.to_string()),
+        task_kind: TaskKind::Prompt,
         status,
         turn: 0,
         pr_url: None,
@@ -34,6 +35,7 @@ fn make_task(id: &str, status: TaskStatus) -> TaskState {
         plan_output: None,
         repo: None,
         request_settings: None,
+        system_input: None,
     }
 }
 
@@ -259,6 +261,85 @@ async fn restart_with_triage_checkpoint_resumes_task() -> anyhow::Result<()> {
         task.error
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn restart_with_review_system_input_resumes_task() -> anyhow::Result<()> {
+    let store = setup_store(|db| async move {
+        let mut task = make_task("t-review-system", TaskStatus::ReviewGenerating);
+        task.task_kind = TaskKind::Review;
+        task.system_input = Some(
+            harness_server::task_runner::SystemTaskInput::PeriodicReview {
+                prompt: "review prompt".to_string(),
+            },
+        );
+        db.insert(&task).await?;
+        Ok(())
+    })
+    .await?;
+
+    let task = store
+        .get(&CoreTaskId("t-review-system".into()))
+        .expect("task must exist");
+    assert!(
+        matches!(task.status, TaskStatus::ReviewWaiting),
+        "review task with persisted input should resume to review_waiting, got {:?}",
+        task.status
+    );
+    assert_eq!(task.task_kind, TaskKind::Review);
+    assert!(task.system_input.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn restart_with_planner_system_input_resumes_task() -> anyhow::Result<()> {
+    let store = setup_store(|db| async move {
+        let mut task = make_task("t-planner-system", TaskStatus::PlannerGenerating);
+        task.task_kind = TaskKind::Planner;
+        task.system_input = Some(
+            harness_server::task_runner::SystemTaskInput::SprintPlanner {
+                prompt: "planner prompt".to_string(),
+            },
+        );
+        db.insert(&task).await?;
+        Ok(())
+    })
+    .await?;
+
+    let task = store
+        .get(&CoreTaskId("t-planner-system".into()))
+        .expect("task must exist");
+    assert!(
+        matches!(task.status, TaskStatus::PlannerWaiting),
+        "planner task with persisted input should resume to planner_waiting, got {:?}",
+        task.status
+    );
+    assert_eq!(task.task_kind, TaskKind::Planner);
+    assert!(task.system_input.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn restart_review_task_without_system_input_fails() -> anyhow::Result<()> {
+    let store = setup_store(|db| async move {
+        let mut task = make_task("t-review-missing-input", TaskStatus::ReviewGenerating);
+        task.task_kind = TaskKind::Review;
+        db.insert(&task).await?;
+        Ok(())
+    })
+    .await?;
+
+    let task = store
+        .get_with_db_fallback(&CoreTaskId("t-review-missing-input".into()))
+        .await?
+        .expect("task should be fetchable from DB");
+    assert!(
+        matches!(task.status, TaskStatus::Failed),
+        "review task without persisted input should fail on restart, got {:?}",
+        task.status
+    );
+    assert!(task.error.is_some());
     Ok(())
 }
 

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -18,7 +18,12 @@ function fmtBytes(v: number | null): string {
 function statusColor(status: string): string {
   switch (status) {
     case "implementing":
+    case "planner_generating":
       return "text-ok border-ok/40";
+    case "review_generating":
+      return "text-rust border-rust/40";
+    case "review_waiting":
+    case "planner_waiting":
     case "pending":
     case "awaiting_deps":
     case "waiting":

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -15,9 +15,10 @@ import { useTasks, useDashboard } from "@/lib/queries";
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
 const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
 
-function makeTask(id: string, project: string | null, status = "running"): Task {
+function makeTask(id: string, project: string | null, status = "running", task_kind = "issue"): Task {
   return {
     id,
+    task_kind,
     status,
     turn: 1,
     pr_url: null,
@@ -108,5 +109,23 @@ describe("<Active>", () => {
     expect(columnCount("Feedback")).toBe("1");
     expect(columnCount("Implementing")).toBe("0");
     expect(columnCount("Pending")).toBe("0");
+  });
+
+  it("groups planner and review lifecycle statuses outside implementing", () => {
+    mockUseTasks.mockReturnValue({
+      data: [
+        makeTask("planner-task", "harness", "planner_waiting", "planner"),
+        makeTask("review-task", "harness", "review_generating", "review"),
+        makeTask("impl-task", "harness", "implementing", "issue"),
+      ],
+      isLoading: false,
+      isError: false,
+    });
+    wrap(<Active />);
+    expect(screen.getByText("Planning")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("planner-task")).toBeInTheDocument();
+    expect(screen.getByText("review-task")).toBeInTheDocument();
+    expect(screen.getByText("impl-task")).toBeInTheDocument();
   });
 });

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -28,6 +28,18 @@ const COLUMNS: Column[] = [
     fallbackTaskStatuses: ["implementing", "running", "triage", "plan"],
   },
   {
+    key: "planning",
+    label: "Planning",
+    workflowStates: [],
+    fallbackTaskStatuses: ["planner_generating", "planner_waiting"],
+  },
+  {
+    key: "review",
+    label: "Review",
+    workflowStates: [],
+    fallbackTaskStatuses: ["review_generating", "review_waiting"],
+  },
+  {
     key: "feedback",
     label: "Feedback",
     workflowStates: ["pr_open", "awaiting_feedback", "addressing_feedback"],

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -4,6 +4,7 @@
  */
 export interface Task {
   id: string;
+  task_kind: string;
   status: string;
   turn: number;
   pr_url: string | null;


### PR DESCRIPTION
Closes #897

## Summary
- persist first-class task kinds and restart-safe system input for trusted review/planner prompt tasks
- dispatch review/planner work through dedicated non-implementation lifecycles and recover them into kind-specific waiting states
- expose task kind and new statuses through the task APIs and dashboard/worktree UI

## Verification
- cargo check
- cargo test (with DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55439/postgres against local Postgres)
- bun run typecheck
- bun run test -- src/routes/dashboard/Active.test.tsx