### PR TITLE
Align declared Rust toolchain with workspace requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing.
 
 ## Development Setup
 
-1. Install Rust `1.75+`.
+1. Install Rust `1.88+`.
 2. Clone the repository.
 3. Build the workspace:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 version = "0.6.33"
 edition = "2021"
 license = "MIT"
-rust-version = "1.75"
+rust-version = "1.88"
 
 [workspace.dependencies]
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **An orchestration layer for AI coding agents — govern, observe, and improve agent workflows at scale.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/Rust-1.75+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/Rust-1.88+-orange.svg)](https://www.rust-lang.org)
 [![CI](https://img.shields.io/github/actions/workflow/status/majiayu000/harness/ci.yml?branch=main&label=CI)](https://github.com/majiayu000/harness/actions/workflows/ci.yml)
 
 [Documentation](docs/) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
@@ -62,7 +62,7 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 
 ### Prerequisites
 
-- Rust 1.75+
+- Rust 1.88+
 - At least one agent runtime:
   - [`codex`](https://github.com/openai/codex) CLI
   - [`claude`](https://docs.anthropic.com/en/docs/claude-code) CLI


### PR DESCRIPTION
## Summary
- Raise the declared workspace rust-version from 1.75 to 1.88.
- Update README and CONTRIBUTING setup guidance to match.

## Validation
- Not run; metadata/documentation-only change.

## Notes
- This is intentionally separate from #913 so workflow lifecycle changes stay isolated.