### PR TITLE
Handle stdio stdout flush failures

### DIFF
--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -1,7 +1,7 @@
 use crate::http::AppState;
 use crate::router;
 use harness_protocol::{codec, methods::RpcResponse};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
 
 async fn process_line(state: &AppState, line: &str) -> anyhow::Result<Option<String>> {
@@ -50,15 +50,7 @@ pub async fn serve(mut state: AppState) -> anyhow::Result<()> {
     // Stdout writer: single task owns stdout to prevent concurrent writes.
     tokio::spawn(async move {
         let mut stdout = tokio::io::stdout();
-        while let Some(line) = out_rx.recv().await {
-            if stdout.write_all(line.as_bytes()).await.is_err() {
-                break;
-            }
-            if stdout.write_all(b"\n").await.is_err() {
-                break;
-            }
-            let _ = stdout.flush().await;
-        }
+        write_output_lines(&mut stdout, &mut out_rx).await;
     });
 
     tracing::info!("harness: stdio server started");
@@ -95,6 +87,26 @@ pub async fn serve(mut state: AppState) -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn write_output_lines<W>(stdout: &mut W, out_rx: &mut mpsc::Receiver<String>)
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(line) = out_rx.recv().await {
+        if let Err(e) = stdout.write_all(line.as_bytes()).await {
+            tracing::error!(transport = "stdio", stream = "stdout", error = %e, "stdio stdout write failed");
+            break;
+        }
+        if let Err(e) = stdout.write_all(b"\n").await {
+            tracing::error!(transport = "stdio", stream = "stdout", error = %e, "stdio stdout newline write failed");
+            break;
+        }
+        if let Err(e) = stdout.flush().await {
+            tracing::error!(transport = "stdio", stream = "stdout", error = %e, "stdio stdout flush failed");
+            break;
+        }
+    }
+}
+
 async fn shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
@@ -126,8 +138,42 @@ mod tests {
     use harness_agents::registry::AgentRegistry;
     use harness_core::config::HarnessConfig;
     use harness_protocol::{methods::Method, methods::RpcRequest};
-    use std::sync::Arc;
+    use std::{
+        io,
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll},
+    };
     use tokio::sync::RwLock;
+
+    #[derive(Default)]
+    struct FlushFailWriter {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    impl AsyncWrite for FlushFailWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.flushes += 1;
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "flush failed",
+            )))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
 
     async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
         let server = Arc::new(HarnessServer::new(
@@ -290,6 +336,22 @@ mod tests {
             initialized_out.is_none(),
             "initialized notification (id=None) should produce no response"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stdout_writer_stops_on_flush_error() -> anyhow::Result<()> {
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send("first".to_string()).await?;
+        tx.send("second".to_string()).await?;
+        drop(tx);
+
+        let mut writer = FlushFailWriter::default();
+        write_output_lines(&mut writer, &mut rx).await;
+
+        assert_eq!(writer.bytes, b"first\n");
+        assert_eq!(writer.flushes, 1);
+        assert_eq!(rx.try_recv()?, "second");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Log stdio stdout write, newline, and flush failures with transport context.
- Stop the stdout writer loop when flush fails so queued responses are not silently drained after delivery failure.
- Add deterministic coverage with a test writer that fails on flush.

Closes #922

## Validation
- cargo check
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p harness-server stdout_writer_stops_on_flush_error
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

## Notes
- cargo test --workspace was run twice and failed outside this change in DB-backed EventStore tests against the shared Supabase DATABASE_URL: first `set_then_get_watermark_roundtrip` with `unexpected response from SSLRequest: 0x00`, then `log_external_signal_and_query_roundtrip` with the same SSLRequest error. A targeted stdio run later also hit `EMAXCONNSESSION` from the same shared pooler for pre-existing stdio DB setup tests; the new flush-failure test passed.