### PR TITLE
Move workflow coordination under database authority

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -5,6 +5,7 @@ issue_workflow:
 pr_feedback:
   enabled: true
   sweep_interval_secs: 60
+  claim_stale_after_secs: 300
 storage:
   schema_namespace: workflow
 ---
@@ -26,6 +27,10 @@ Current externally configurable rules:
 
 - `pr_feedback.enabled`
   - Enables or disables automatic background PR feedback sweeping.
+
+- `pr_feedback.claim_stale_after_secs`
+  - Maximum age for a claimed feedback workflow before the sweeper reclaims it
+    after an interrupted enqueue path.
 
 - `storage.schema_namespace`
   - Stable namespace used for workflow persistence in Postgres so multiple instances do not split by local `data_dir` path.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -5,6 +5,8 @@ issue_workflow:
 pr_feedback:
   enabled: true
   sweep_interval_secs: 60
+storage:
+  schema_namespace: workflow
 ---
 
 # Harness Workflow
@@ -24,3 +26,6 @@ Current externally configurable rules:
 
 - `pr_feedback.enabled`
   - Enables or disables automatic background PR feedback sweeping.
+
+- `storage.schema_namespace`
+  - Stable namespace used for workflow persistence in Postgres so multiple instances do not split by local `data_dir` path.

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -23,6 +23,14 @@ pub struct WorkflowConfig {
     pub issue_workflow: IssueWorkflowPolicy,
     #[serde(default)]
     pub pr_feedback: PrFeedbackPolicy,
+    #[serde(default)]
+    pub storage: WorkflowStoragePolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStoragePolicy {
+    #[serde(default = "default_workflow_schema_namespace")]
+    pub schema_namespace: String,
 }
 
 impl Default for IssueWorkflowPolicy {
@@ -43,12 +51,24 @@ impl Default for PrFeedbackPolicy {
     }
 }
 
+impl Default for WorkflowStoragePolicy {
+    fn default() -> Self {
+        Self {
+            schema_namespace: default_workflow_schema_namespace(),
+        }
+    }
+}
+
 fn default_force_execute_label() -> String {
     "force-execute".to_string()
 }
 
 fn default_feedback_sweep_interval_secs() -> u64 {
     60
+}
+
+fn default_workflow_schema_namespace() -> String {
+    "workflow".to_string()
 }
 
 fn default_true() -> bool {
@@ -100,6 +120,7 @@ mod tests {
         assert!(cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
         assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
+        assert_eq!(cfg.storage.schema_namespace, "workflow");
         Ok(())
     }
 
@@ -115,6 +136,8 @@ issue_workflow:
 pr_feedback:
   enabled: false
   sweep_interval_secs: 15
+storage:
+  schema_namespace: orchestration
 ---
 
 Body
@@ -129,6 +152,7 @@ Body
         assert!(!cfg.issue_workflow.auto_replan_on_plan_issue);
         assert!(!cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
+        assert_eq!(cfg.storage.schema_namespace, "orchestration");
         Ok(())
     }
 }

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -15,6 +15,8 @@ pub struct PrFeedbackPolicy {
     pub enabled: bool,
     #[serde(default = "default_feedback_sweep_interval_secs")]
     pub sweep_interval_secs: u64,
+    #[serde(default = "default_feedback_claim_stale_after_secs")]
+    pub claim_stale_after_secs: u64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -47,6 +49,7 @@ impl Default for PrFeedbackPolicy {
         Self {
             enabled: default_true(),
             sweep_interval_secs: default_feedback_sweep_interval_secs(),
+            claim_stale_after_secs: default_feedback_claim_stale_after_secs(),
         }
     }
 }
@@ -65,6 +68,10 @@ fn default_force_execute_label() -> String {
 
 fn default_feedback_sweep_interval_secs() -> u64 {
     60
+}
+
+fn default_feedback_claim_stale_after_secs() -> u64 {
+    300
 }
 
 fn default_workflow_schema_namespace() -> String {
@@ -119,6 +126,7 @@ mod tests {
         assert_eq!(cfg.issue_workflow.force_execute_label, "force-execute");
         assert!(cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
+        assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 300);
         assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
         assert_eq!(cfg.storage.schema_namespace, "workflow");
         Ok(())
@@ -136,6 +144,7 @@ issue_workflow:
 pr_feedback:
   enabled: false
   sweep_interval_secs: 15
+  claim_stale_after_secs: 45
 storage:
   schema_namespace: orchestration
 ---
@@ -152,6 +161,7 @@ Body
         assert!(!cfg.issue_workflow.auto_replan_on_plan_issue);
         assert!(!cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
+        assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 45);
         assert_eq!(cfg.storage.schema_namespace, "orchestration");
         Ok(())
     }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -285,7 +285,12 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                 continue;
             };
 
-            let candidates = match issue_workflows.claim_feedback_candidates(128).await {
+            let stale_before = chrono::Utc::now()
+                - chrono::Duration::seconds(workflow_cfg.pr_feedback.claim_stale_after_secs as i64);
+            let candidates = match issue_workflows
+                .claim_feedback_candidates(128, stale_before)
+                .await
+            {
                 Ok(candidates) => candidates,
                 Err(e) => {
                     tracing::warn!("workflow feedback sweep: failed to claim candidates: {e}");

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -285,10 +285,10 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                 continue;
             };
 
-            let candidates = match issue_workflows.list_feedback_candidates().await {
+            let candidates = match issue_workflows.claim_feedback_candidates(128).await {
                 Ok(candidates) => candidates,
                 Err(e) => {
-                    tracing::warn!("workflow feedback sweep: failed to list candidates: {e}");
+                    tracing::warn!("workflow feedback sweep: failed to claim candidates: {e}");
                     continue;
                 }
             };
@@ -341,6 +341,16 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                         retry_after_secs,
                     }) => {
                         incomplete_projects.insert(project_key.clone());
+                        let _ = issue_workflows
+                            .release_feedback_claim(
+                                &workflow.project_id,
+                                workflow.repo.as_deref(),
+                                pr_number,
+                                &format!(
+                                    "feedback sweep deferred by maintenance window; retry after {retry_after_secs}s"
+                                ),
+                            )
+                            .await;
                         if let Some(project_store) = state.core.project_workflow_store.as_ref() {
                             let _ = project_store
                                 .record_paused(
@@ -355,6 +365,14 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                     }
                     Err(e) => {
                         incomplete_projects.insert(project_key.clone());
+                        let _ = issue_workflows
+                            .release_feedback_claim(
+                                &workflow.project_id,
+                                workflow.repo.as_deref(),
+                                pr_number,
+                                &format!("feedback sweep enqueue failed: {e}"),
+                            )
+                            .await;
                         tracing::warn!(
                             project_id = %workflow.project_id,
                             pr = pr_number,

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::task_runner;
+use harness_workflow::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
 
 /// Spawn background watcher for AwaitingDeps tasks.
 /// Uses Weak<AppState> to avoid a reference cycle; the loop exits when AppState is dropped.
@@ -426,18 +427,15 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
 /// acquisition never blocks serve() — if more tasks exist than available
 /// concurrency slots, the background futures will simply wait in queue.
 pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
-    let recovered: Vec<_> = state
-        .core
-        .tasks
-        .list_all()
-        .into_iter()
-        .filter(|t| matches!(t.status, task_runner::TaskStatus::Pending) && t.pr_url.is_some())
-        .collect();
-    if !recovered.is_empty() {
-        tracing::info!(
-            count = recovered.len(),
-            "startup: re-dispatching recovered pending task(s) with PRs"
-        );
+    let state = state.clone();
+    tokio::spawn(async move {
+        let recovered = collect_pr_recovery_tasks(&state).await;
+        if !recovered.is_empty() {
+            tracing::info!(
+                count = recovered.len(),
+                "startup: re-dispatching recovered pending task(s) with PRs"
+            );
+        }
         for task in recovered {
             let state = state.clone();
             tokio::spawn(async move {
@@ -651,7 +649,66 @@ pub(super) fn spawn_pr_recovery(state: &Arc<AppState>) {
                 .await;
             });
         }
+    });
+}
+
+fn workflow_state_needs_pr_recovery(state: IssueLifecycleState) -> bool {
+    matches!(state, IssueLifecycleState::AddressingFeedback)
+}
+
+fn task_is_pr_recovery_candidate(task: &task_runner::TaskState) -> bool {
+    matches!(task.status, task_runner::TaskStatus::Pending) && task.pr_url.is_some()
+}
+
+fn workflow_recovery_task_ids(
+    workflows: &[IssueWorkflowInstance],
+) -> std::collections::HashSet<task_runner::TaskId> {
+    workflows
+        .iter()
+        .filter(|workflow| workflow_state_needs_pr_recovery(workflow.state))
+        .filter_map(|workflow| {
+            workflow
+                .active_task_id
+                .as_deref()
+                .map(|task_id| harness_core::types::TaskId(task_id.to_string()))
+        })
+        .collect()
+}
+
+async fn collect_pr_recovery_tasks(state: &Arc<AppState>) -> Vec<task_runner::TaskState> {
+    let tasks = state.core.tasks.list_all();
+    let mut recovered = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    if let Some(workflows) = state.core.issue_workflow_store.as_ref() {
+        match workflows.list().await {
+            Ok(workflows) => {
+                let workflow_task_ids = workflow_recovery_task_ids(&workflows);
+                for task in &tasks {
+                    if workflow_task_ids.contains(&task.id) && task_is_pr_recovery_candidate(task) {
+                        seen.insert(task.id.clone());
+                        recovered.push(task.clone());
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "startup: failed to list issue workflows for PR recovery, falling back to task-only recovery: {e}"
+                );
+            }
+        }
     }
+
+    for task in tasks {
+        if seen.contains(&task.id) {
+            continue;
+        }
+        if task_is_pr_recovery_candidate(&task) {
+            recovered.push(task);
+        }
+    }
+
+    recovered
 }
 
 /// Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
@@ -896,5 +953,56 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                 .await;
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_recovery_task_ids_only_uses_active_addressing_feedback_rows() {
+        let mut addressing = IssueWorkflowInstance::new(
+            "/tmp/project".to_string(),
+            Some("owner/repo".to_string()),
+            1,
+        );
+        addressing.state = IssueLifecycleState::AddressingFeedback;
+        addressing.active_task_id = Some("task-1".to_string());
+
+        let mut waiting = IssueWorkflowInstance::new(
+            "/tmp/project".to_string(),
+            Some("owner/repo".to_string()),
+            2,
+        );
+        waiting.state = IssueLifecycleState::AwaitingFeedback;
+        waiting.active_task_id = Some("task-2".to_string());
+
+        let mut no_task = IssueWorkflowInstance::new(
+            "/tmp/project".to_string(),
+            Some("owner/repo".to_string()),
+            3,
+        );
+        no_task.state = IssueLifecycleState::AddressingFeedback;
+
+        let ids = workflow_recovery_task_ids(&[addressing, waiting, no_task]);
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains(&harness_core::types::TaskId("task-1".to_string())));
+    }
+
+    #[test]
+    fn task_is_pr_recovery_candidate_requires_pending_with_pr_url() {
+        let mut pending_with_pr = task_runner::TaskState::new(task_runner::TaskId::new());
+        pending_with_pr.status = task_runner::TaskStatus::Pending;
+        pending_with_pr.pr_url = Some("https://github.com/owner/repo/pull/1".to_string());
+        assert!(task_is_pr_recovery_candidate(&pending_with_pr));
+
+        let mut waiting_with_pr = pending_with_pr.clone();
+        waiting_with_pr.status = task_runner::TaskStatus::Waiting;
+        assert!(!task_is_pr_recovery_candidate(&waiting_with_pr));
+
+        let mut pending_without_pr = pending_with_pr;
+        pending_without_pr.pr_url = None;
+        assert!(!task_is_pr_recovery_candidate(&pending_without_pr));
     }
 }

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -81,6 +81,8 @@ pub(crate) async fn build_registry(
     }
 
     // ── Issue workflow store ──────────────────────────────────────────────────
+    let issue_workflows_db_path =
+        harness_core::config::dirs::default_db_path(data_dir, "issue_workflows");
     let issue_workflow_store = {
         let schema = format!("{workflow_ns}_issue");
         match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url_and_schema(
@@ -89,7 +91,22 @@ pub(crate) async fn build_registry(
         )
         .await
         {
-            Ok(store) => Some(Arc::new(store)),
+            Ok(store) => {
+                if let Err(e) = migrate_issue_workflows_if_needed(
+                    configured_database_url,
+                    &issue_workflows_db_path,
+                    &schema,
+                    &store,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        schema = %schema,
+                        "issue workflow migration check failed: {e}"
+                    );
+                }
+                Some(Arc::new(store))
+            }
             Err(e) => {
                 tracing::warn!(
                     schema = %schema,
@@ -101,6 +118,8 @@ pub(crate) async fn build_registry(
     };
 
     // ── Project workflow store ────────────────────────────────────────────────
+    let project_workflows_db_path =
+        harness_core::config::dirs::default_db_path(data_dir, "project_workflows");
     let project_workflow_store = {
         let schema = format!("{workflow_ns}_project");
         match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url_and_schema(
@@ -109,7 +128,22 @@ pub(crate) async fn build_registry(
         )
         .await
         {
-            Ok(store) => Some(Arc::new(store)),
+            Ok(store) => {
+                if let Err(e) = migrate_project_workflows_if_needed(
+                    configured_database_url,
+                    &project_workflows_db_path,
+                    &schema,
+                    &store,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        schema = %schema,
+                        "project workflow migration check failed: {e}"
+                    );
+                }
+                Some(Arc::new(store))
+            }
             Err(e) => {
                 tracing::warn!(
                     schema = %schema,
@@ -258,6 +292,74 @@ pub(crate) async fn build_registry(
         runtime_state_store,
         workspace_mgr,
     })
+}
+
+async fn migrate_issue_workflows_if_needed(
+    configured_database_url: Option<&str>,
+    legacy_path: &Path,
+    target_schema: &str,
+    target_store: &harness_workflow::issue_lifecycle::IssueWorkflowStore,
+) -> anyhow::Result<()> {
+    let legacy_schema = harness_workflow::issue_lifecycle::legacy_schema_for_path(legacy_path)?;
+    if legacy_schema == target_schema || target_store.row_count().await? > 0 {
+        return Ok(());
+    }
+
+    let legacy_store =
+        harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
+            legacy_path,
+            configured_database_url,
+        )
+        .await?;
+    let legacy_rows = legacy_store.list().await?;
+    if legacy_rows.is_empty() {
+        return Ok(());
+    }
+
+    for workflow in &legacy_rows {
+        target_store.upsert(workflow).await?;
+    }
+    tracing::info!(
+        count = legacy_rows.len(),
+        legacy_schema = %legacy_schema,
+        target_schema = %target_schema,
+        "workflow migration: copied legacy issue workflow rows into namespaced schema"
+    );
+    Ok(())
+}
+
+async fn migrate_project_workflows_if_needed(
+    configured_database_url: Option<&str>,
+    legacy_path: &Path,
+    target_schema: &str,
+    target_store: &harness_workflow::project_lifecycle::ProjectWorkflowStore,
+) -> anyhow::Result<()> {
+    let legacy_schema = harness_workflow::project_lifecycle::legacy_schema_for_path(legacy_path)?;
+    if legacy_schema == target_schema || target_store.row_count().await? > 0 {
+        return Ok(());
+    }
+
+    let legacy_store =
+        harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url(
+            legacy_path,
+            configured_database_url,
+        )
+        .await?;
+    let legacy_rows = legacy_store.list().await?;
+    if legacy_rows.is_empty() {
+        return Ok(());
+    }
+
+    for workflow in &legacy_rows {
+        target_store.upsert(workflow).await?;
+    }
+    tracing::info!(
+        count = legacy_rows.len(),
+        legacy_schema = %legacy_schema,
+        target_schema = %target_schema,
+        "workflow migration: copied legacy project workflow rows into namespaced schema"
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -29,6 +29,9 @@ pub(crate) async fn build_registry(
     tasks: &Arc<crate::task_runner::TaskStore>,
 ) -> anyhow::Result<RegistryBundle> {
     let configured_database_url = server.config.server.database_url.as_deref();
+    let workflow_config =
+        harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_default();
+    let workflow_ns = workflow_config.storage.schema_namespace;
     // ── Thread DB ─────────────────────────────────────────────────────────────
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
     let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
@@ -79,18 +82,17 @@ pub(crate) async fn build_registry(
 
     // ── Issue workflow store ──────────────────────────────────────────────────
     let issue_workflow_store = {
-        let issue_workflows_db_path =
-            harness_core::config::dirs::default_db_path(data_dir, "issue_workflows");
-        match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
-            &issue_workflows_db_path,
+        let schema = format!("{workflow_ns}_issue");
+        match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url_and_schema(
             configured_database_url,
+            &schema,
         )
         .await
         {
             Ok(store) => Some(Arc::new(store)),
             Err(e) => {
                 tracing::warn!(
-                    path = %issue_workflows_db_path.display(),
+                    schema = %schema,
                     "issue workflow store init failed, issue lifecycle state will not persist: {e}"
                 );
                 None
@@ -100,18 +102,17 @@ pub(crate) async fn build_registry(
 
     // ── Project workflow store ────────────────────────────────────────────────
     let project_workflow_store = {
-        let project_workflows_db_path =
-            harness_core::config::dirs::default_db_path(data_dir, "project_workflows");
-        match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url(
-            &project_workflows_db_path,
+        let schema = format!("{workflow_ns}_project");
+        match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url_and_schema(
             configured_database_url,
+            &schema,
         )
         .await
         {
             Ok(store) => Some(Arc::new(store)),
             Err(e) => {
                 tracing::warn!(
-                    path = %project_workflows_db_path.display(),
+                    schema = %schema,
                     "project workflow store init failed, project lifecycle state will not persist: {e}"
                 );
                 None

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -629,16 +629,42 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
     let intake_config = &state.core.server.config.intake;
     let all_tasks = state.core.tasks.list_all();
 
-    let github_active: u64 = all_tasks
-        .iter()
-        .filter(|t| {
-            t.source.as_deref() == Some("github")
-                && !matches!(
-                    t.status,
-                    task_runner::TaskStatus::Done | task_runner::TaskStatus::Failed
-                )
-        })
-        .count() as u64;
+    let github_active: u64 = if let Some(store) = state.core.issue_workflow_store.as_ref() {
+        match store.list().await {
+            Ok(workflows) => workflows
+                .into_iter()
+                .filter(|workflow| {
+                    !matches!(
+                        workflow.state,
+                        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+                            | harness_workflow::issue_lifecycle::IssueLifecycleState::Failed
+                            | harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
+                    )
+                })
+                .count() as u64,
+            Err(_) => all_tasks
+                .iter()
+                .filter(|t| {
+                    t.source.as_deref() == Some("github")
+                        && !matches!(
+                            t.status,
+                            task_runner::TaskStatus::Done | task_runner::TaskStatus::Failed
+                        )
+                })
+                .count() as u64,
+        }
+    } else {
+        all_tasks
+            .iter()
+            .filter(|t| {
+                t.source.as_deref() == Some("github")
+                    && !matches!(
+                        t.status,
+                        task_runner::TaskStatus::Done | task_runner::TaskStatus::Failed
+                    )
+            })
+            .count() as u64
+    };
 
     let feishu_active: u64 = all_tasks
         .iter()

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -3,9 +3,9 @@ use crate::{
     project_registry::check_allowed_roots, services::execution::EnqueueTaskError, task_runner,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Response, Json};
-use harness_workflow::issue_lifecycle::IssueWorkflowInstance;
-use harness_workflow::issue_lifecycle::IssueLifecycleState;
 use harness_core::agent::CodeAgent;
+use harness_workflow::issue_lifecycle::IssueLifecycleState;
+use harness_workflow::issue_lifecycle::IssueWorkflowInstance;
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -3,6 +3,8 @@ use crate::{
     project_registry::check_allowed_roots, services::execution::EnqueueTaskError, task_runner,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Response, Json};
+use harness_workflow::issue_lifecycle::IssueWorkflowInstance;
+use harness_workflow::issue_lifecycle::IssueLifecycleState;
 use harness_core::agent::CodeAgent;
 use serde::Deserialize;
 use serde_json::json;
@@ -116,6 +118,90 @@ fn populate_external_id(req: &mut task_runner::CreateTaskRequest) {
             }
         }
     }
+}
+
+fn workflow_state_allows_reuse(state: IssueLifecycleState) -> bool {
+    !matches!(
+        state,
+        IssueLifecycleState::Failed | IssueLifecycleState::Cancelled
+    )
+}
+
+enum WorkflowReuseStrategy {
+    ActiveTask(task_runner::TaskId),
+    PrExternalId(String),
+    None,
+}
+
+fn workflow_reuse_strategy(workflow: &IssueWorkflowInstance) -> WorkflowReuseStrategy {
+    if !workflow_state_allows_reuse(workflow.state) {
+        return WorkflowReuseStrategy::None;
+    }
+    if let Some(task_id) = workflow.active_task_id.as_ref() {
+        return WorkflowReuseStrategy::ActiveTask(harness_core::types::TaskId(task_id.clone()));
+    }
+    if let Some(pr_number) = workflow.pr_number {
+        return WorkflowReuseStrategy::PrExternalId(format!("pr:{pr_number}"));
+    }
+    WorkflowReuseStrategy::None
+}
+
+async fn check_workflow_duplicate(
+    state: &Arc<AppState>,
+    project_id: &str,
+    req: &task_runner::CreateTaskRequest,
+) -> Option<task_runner::TaskId> {
+    let workflows = state.core.issue_workflow_store.as_ref()?;
+    let workflow = if let Some(issue_number) = req.issue {
+        workflows
+            .get_by_issue(project_id, req.repo.as_deref(), issue_number)
+            .await
+            .ok()
+            .flatten()
+    } else if let Some(pr_number) = req.pr {
+        workflows
+            .get_by_pr(project_id, req.repo.as_deref(), pr_number)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    }?;
+
+    match workflow_reuse_strategy(&workflow) {
+        WorkflowReuseStrategy::ActiveTask(task_id) => {
+            if state
+                .core
+                .tasks
+                .exists_with_db_fallback(&task_id)
+                .await
+                .unwrap_or(false)
+            {
+                return Some(task_id);
+            }
+        }
+        WorkflowReuseStrategy::PrExternalId(pr_ext_id) => {
+            if let Some(task_id) = state
+                .core
+                .tasks
+                .find_active_duplicate(project_id, &pr_ext_id)
+                .await
+            {
+                return Some(task_id);
+            }
+            if let Some((task_id, _)) = state
+                .core
+                .tasks
+                .find_terminal_pr_duplicate(project_id, &pr_ext_id)
+                .await
+            {
+                return Some(task_id);
+            }
+        }
+        WorkflowReuseStrategy::None => {}
+    }
+
+    None
 }
 
 /// Return existing active TaskId if one matches project + external_id.
@@ -335,6 +421,9 @@ pub(crate) async fn enqueue_task_in_domain(
     // Auto-populate external_id and check for duplicates before acquiring
     // a concurrency permit (same dedup as enqueue_task_background).
     populate_external_id(&mut req);
+    if let Some(existing_id) = check_workflow_duplicate(state, &project_id, &req).await {
+        return Ok(existing_id);
+    }
     if let Some(existing_id) = check_duplicate(&state.core.tasks, &project_id, &req).await {
         return Ok(existing_id);
     }
@@ -589,6 +678,9 @@ pub(crate) async fn enqueue_task_background_in_domain(
 
     // Auto-populate external_id and check for duplicates.
     populate_external_id(&mut req);
+    if let Some(existing_id) = check_workflow_duplicate(&state, &project_id, &req).await {
+        return Ok(existing_id);
+    }
     if let Some(existing_id) = check_duplicate(&state.core.tasks, &project_id, &req).await {
         return Ok(existing_id);
     }

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -228,8 +228,11 @@ fn conflict_groups_single_task() {
 
 #[test]
 fn workflow_reuse_strategy_prefers_active_task() {
-    let mut workflow =
-        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 42);
+    let mut workflow = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        42,
+    );
     workflow.state = IssueLifecycleState::Implementing;
     workflow.active_task_id = Some("task-123".to_string());
     workflow.pr_number = Some(7);
@@ -241,8 +244,11 @@ fn workflow_reuse_strategy_prefers_active_task() {
 
 #[test]
 fn workflow_reuse_strategy_falls_back_to_pr_when_active_task_missing() {
-    let mut workflow =
-        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 42);
+    let mut workflow = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        42,
+    );
     workflow.state = IssueLifecycleState::AwaitingFeedback;
     workflow.pr_number = Some(99);
     match workflow_reuse_strategy(&workflow) {
@@ -253,8 +259,11 @@ fn workflow_reuse_strategy_falls_back_to_pr_when_active_task_missing() {
 
 #[test]
 fn workflow_reuse_strategy_rejects_failed_and_cancelled_workflows() {
-    let mut failed =
-        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 1);
+    let mut failed = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        1,
+    );
     failed.state = IssueLifecycleState::Failed;
     failed.active_task_id = Some("task-failed".to_string());
     assert!(matches!(
@@ -262,8 +271,11 @@ fn workflow_reuse_strategy_rejects_failed_and_cancelled_workflows() {
         WorkflowReuseStrategy::None
     ));
 
-    let mut cancelled =
-        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 2);
+    let mut cancelled = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        2,
+    );
     cancelled.state = IssueLifecycleState::Cancelled;
     cancelled.pr_number = Some(88);
     assert!(matches!(

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use harness_workflow::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
 
 #[test]
 fn batch_request_deserializes_issues_format() {
@@ -223,6 +224,52 @@ fn conflict_groups_single_task() {
     let groups = build_conflict_groups(&refs);
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0], vec![0]);
+}
+
+#[test]
+fn workflow_reuse_strategy_prefers_active_task() {
+    let mut workflow =
+        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 42);
+    workflow.state = IssueLifecycleState::Implementing;
+    workflow.active_task_id = Some("task-123".to_string());
+    workflow.pr_number = Some(7);
+    match workflow_reuse_strategy(&workflow) {
+        WorkflowReuseStrategy::ActiveTask(task_id) => assert_eq!(task_id.0, "task-123"),
+        _ => panic!("expected active-task reuse strategy"),
+    }
+}
+
+#[test]
+fn workflow_reuse_strategy_falls_back_to_pr_when_active_task_missing() {
+    let mut workflow =
+        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 42);
+    workflow.state = IssueLifecycleState::AwaitingFeedback;
+    workflow.pr_number = Some(99);
+    match workflow_reuse_strategy(&workflow) {
+        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:99"),
+        _ => panic!("expected pr-external-id reuse strategy"),
+    }
+}
+
+#[test]
+fn workflow_reuse_strategy_rejects_failed_and_cancelled_workflows() {
+    let mut failed =
+        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 1);
+    failed.state = IssueLifecycleState::Failed;
+    failed.active_task_id = Some("task-failed".to_string());
+    assert!(matches!(
+        workflow_reuse_strategy(&failed),
+        WorkflowReuseStrategy::None
+    ));
+
+    let mut cancelled =
+        IssueWorkflowInstance::new("/tmp/project".to_string(), Some("owner/repo".to_string()), 2);
+    cancelled.state = IssueLifecycleState::Cancelled;
+    cancelled.pr_number = Some(88);
+    assert!(matches!(
+        workflow_reuse_strategy(&cancelled),
+        WorkflowReuseStrategy::None
+    ));
 }
 
 // ── select_agent three-tier precedence tests ─────────────────────────────

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -679,6 +679,27 @@ async fn run_repo_sprint(
         let mut newly_done = Vec::new();
         let mut cancelled = Vec::new();
         for (&issue_num, task_id) in &running {
+            if let Some(outcome) = workflow_sprint_issue_outcome(
+                state.core.issue_workflow_store.as_deref(),
+                &project_id,
+                repo,
+                issue_num,
+            )
+            .await
+            {
+                tracing::info!(
+                    repo,
+                    external_id = issue_num,
+                    task_id = %task_id,
+                    workflow_outcome = outcome.as_str(),
+                    "intake: workflow state resolved running issue outcome"
+                );
+                match outcome {
+                    SprintIssueOutcome::UnblocksDependents => newly_done.push(issue_num),
+                    SprintIssueOutcome::Cancelled => cancelled.push(issue_num),
+                }
+                continue;
+            }
             if let Some(task) = state.core.tasks.get(task_id) {
                 if task.status.is_terminal() {
                     tracing::info!(
@@ -786,6 +807,63 @@ fn build_issue_summary(issues: &[(Arc<dyn IntakeSource>, IncomingIssue)]) -> Str
 
 fn status_unblocks_dependents(status: &TaskStatus) -> bool {
     matches!(status, TaskStatus::Done | TaskStatus::Failed)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SprintIssueOutcome {
+    UnblocksDependents,
+    Cancelled,
+}
+
+impl SprintIssueOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::UnblocksDependents => "unblocks_dependents",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+fn workflow_state_unblocks_dependents(
+    state: harness_workflow::issue_lifecycle::IssueLifecycleState,
+) -> bool {
+    matches!(
+        state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::ReadyToMerge
+            | harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+            | harness_workflow::issue_lifecycle::IssueLifecycleState::Failed
+    )
+}
+
+async fn workflow_sprint_issue_outcome(
+    store: Option<&harness_workflow::issue_lifecycle::IssueWorkflowStore>,
+    project_id: &str,
+    repo: &str,
+    issue_num: u64,
+) -> Option<SprintIssueOutcome> {
+    let store = store?;
+    let workflow = match store.get_by_issue(project_id, Some(repo), issue_num).await {
+        Ok(workflow) => workflow,
+        Err(e) => {
+            tracing::warn!(
+                repo,
+                issue = issue_num,
+                "intake: failed to load workflow state for running issue: {e}"
+            );
+            return None;
+        }
+    }?;
+
+    if workflow_state_unblocks_dependents(workflow.state) {
+        Some(SprintIssueOutcome::UnblocksDependents)
+    } else if matches!(
+        workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
+    ) {
+        Some(SprintIssueOutcome::Cancelled)
+    } else {
+        None
+    }
 }
 
 /// Poll a task until terminal state, return its output.
@@ -1086,6 +1164,36 @@ mod tests {
     fn done_and_failed_tasks_still_count_as_completed_dependencies() {
         assert!(status_unblocks_dependents(&TaskStatus::Done));
         assert!(status_unblocks_dependents(&TaskStatus::Failed));
+    }
+
+    #[test]
+    fn workflow_ready_to_merge_and_terminals_unblock_dependents() {
+        use harness_workflow::issue_lifecycle::IssueLifecycleState;
+
+        assert!(workflow_state_unblocks_dependents(
+            IssueLifecycleState::ReadyToMerge
+        ));
+        assert!(workflow_state_unblocks_dependents(
+            IssueLifecycleState::Done
+        ));
+        assert!(workflow_state_unblocks_dependents(
+            IssueLifecycleState::Failed
+        ));
+        assert!(!workflow_state_unblocks_dependents(
+            IssueLifecycleState::Cancelled
+        ));
+        assert!(!workflow_state_unblocks_dependents(
+            IssueLifecycleState::AddressingFeedback
+        ));
+    }
+
+    #[test]
+    fn sprint_issue_outcome_labels_are_stable() {
+        assert_eq!(
+            SprintIssueOutcome::UnblocksDependents.as_str(),
+            "unblocks_dependents"
+        );
+        assert_eq!(SprintIssueOutcome::Cancelled.as_str(), "cancelled");
     }
 
     #[test]

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -34,6 +34,13 @@ static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_pr
               ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'pr_number')::bigint))",
     },
+    Migration {
+        version: 4,
+        description: "index issue workflow feedback sweep candidates",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_feedback_candidates
+              ON issue_workflows (((data::jsonb->>'state')), updated_at DESC)
+              WHERE data::jsonb->>'pr_number' IS NOT NULL",
+    },
 ];
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -238,6 +245,16 @@ pub fn workflow_id(project_id: &str, repo: Option<&str>, issue_number: u64) -> S
     )
 }
 
+pub fn legacy_schema_for_path(path: &Path) -> anyhow::Result<String> {
+    let path_utf8 = path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
+    let digest = Sha256::digest(path_utf8.as_bytes());
+    let mut schema_bytes = [0u8; 8];
+    schema_bytes.copy_from_slice(&digest[..8]);
+    Ok(format!("h{:016x}", u64::from_le_bytes(schema_bytes)))
+}
+
 pub struct IssueWorkflowStore {
     pool: PgPool,
 }
@@ -252,13 +269,7 @@ impl IssueWorkflowStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let database_url = resolve_database_url(configured_database_url)?;
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let schema = legacy_schema_for_path(path)?;
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
@@ -387,6 +398,13 @@ impl IssueWorkflowStore {
         rows.into_iter()
             .map(|(data,)| Ok(serde_json::from_str(&data)?))
             .collect()
+    }
+
+    pub async fn row_count(&self) -> anyhow::Result<i64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM issue_workflows")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count)
     }
 
     pub async fn record_issue_scheduled(
@@ -545,23 +563,40 @@ impl IssueWorkflowStore {
     pub async fn claim_feedback_candidates(
         &self,
         limit: i64,
+        stale_before: DateTime<Utc>,
     ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
         let mut tx = self.pool.begin().await?;
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT id, data FROM issue_workflows
-             WHERE data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
-               AND data::jsonb->>'pr_number' IS NOT NULL
+             WHERE data::jsonb->>'pr_number' IS NOT NULL
+               AND (
+                    data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+                    OR (
+                        data::jsonb->>'state' = 'addressing_feedback'
+                        AND updated_at <= $2
+                    )
+               )
              ORDER BY updated_at DESC
              LIMIT $1
              FOR UPDATE SKIP LOCKED",
         )
         .bind(limit)
+        .bind(stale_before)
         .fetch_all(&mut *tx)
         .await?;
 
         let mut claimed = Vec::with_capacity(rows.len());
         for (workflow_id, data) in rows {
-            let mut workflow: IssueWorkflowInstance = serde_json::from_str(&data)?;
+            let mut workflow: IssueWorkflowInstance = match serde_json::from_str(&data) {
+                Ok(workflow) => workflow,
+                Err(e) => {
+                    tracing::warn!(
+                        workflow_id = %workflow_id,
+                        "workflow feedback sweep: skipping malformed workflow row while claiming candidates: {e}"
+                    );
+                    continue;
+                }
+            };
             let claim_id = format!("claim:{}", workflow.id);
             if let Some(pr_number) = workflow.pr_number {
                 let pr_url = workflow.pr_url.clone().unwrap_or_default();
@@ -913,6 +948,89 @@ mod tests {
             .await?
             .expect("workflow");
         assert_eq!(workflow.state, IssueLifecycleState::Cancelled);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-stale-claim";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo"), 9, "task-1", &[], false)
+            .await?;
+        store
+            .record_pr_detected(
+                project_id,
+                Some("owner/repo"),
+                9,
+                "task-1",
+                77,
+                "https://github.com/owner/repo/pull/77",
+            )
+            .await?;
+        store
+            .record_feedback_task_scheduled(project_id, Some("owner/repo"), 77, "task-2")
+            .await?;
+
+        let mut workflow = store
+            .get_by_pr(project_id, Some("owner/repo"), 77)
+            .await?
+            .expect("workflow");
+        workflow.feedback_claimed_at = Some(Utc::now() - chrono::Duration::minutes(10));
+        store.upsert(&workflow).await?;
+        sqlx::query(
+            "UPDATE issue_workflows
+             SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
+             WHERE id = $1",
+        )
+        .bind(&workflow.id)
+        .execute(&store.pool)
+        .await?;
+
+        let claimed = store
+            .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+            .await?;
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].pr_number, Some(77));
+        assert_eq!(claimed[0].state, IssueLifecycleState::AddressingFeedback);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_feedback_candidates_skips_malformed_rows() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-malformed";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo"), 10, "task-1", &[], false)
+            .await?;
+        store
+            .record_pr_detected(
+                project_id,
+                Some("owner/repo"),
+                10,
+                "task-1",
+                88,
+                "https://github.com/owner/repo/pull/88",
+            )
+            .await?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
+        )
+        .bind("malformed-workflow")
+        .bind(r#"{"project_id":"/tmp/project-malformed","repo":"owner/repo","state":"pr_open","pr_number":999}"#)
+        .execute(&store.pool)
+        .await?;
+
+        let claimed = store
+            .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+            .await?;
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].pr_number, Some(88));
         Ok(())
     }
 }

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -6,6 +6,7 @@ use harness_core::db::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgPool;
+use sqlx::Postgres;
 use std::path::Path;
 
 const ISSUE_WORKFLOW_SCHEMA_VERSION: u32 = 1;
@@ -133,6 +134,8 @@ pub struct IssueWorkflowInstance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_concern: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub feedback_claimed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_event: Option<IssueLifecycleEvent>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -156,6 +159,7 @@ impl IssueWorkflowInstance {
             labels_snapshot: Vec::new(),
             force_execute: false,
             plan_concern: None,
+            feedback_claimed_at: None,
             last_event: None,
             created_at: now,
             updated_at: now,
@@ -187,6 +191,7 @@ impl IssueWorkflowInstance {
             | IssueLifecycleEventKind::FeedbackFound => {
                 self.state = IssueLifecycleState::AddressingFeedback;
                 self.active_task_id = event.task_id.clone();
+                self.feedback_claimed_at = Some(Utc::now());
                 if event.pr_number.is_some() {
                     self.pr_number = event.pr_number;
                 }
@@ -197,18 +202,24 @@ impl IssueWorkflowInstance {
             IssueLifecycleEventKind::FeedbackSweepCompleted
             | IssueLifecycleEventKind::NoFeedbackFound => {
                 self.state = IssueLifecycleState::AwaitingFeedback;
+                self.active_task_id = None;
+                self.feedback_claimed_at = None;
             }
             IssueLifecycleEventKind::Mergeable => {
                 self.state = IssueLifecycleState::ReadyToMerge;
+                self.feedback_claimed_at = None;
             }
             IssueLifecycleEventKind::WorkflowFailed => {
                 self.state = IssueLifecycleState::Failed;
+                self.feedback_claimed_at = None;
             }
             IssueLifecycleEventKind::WorkflowCancelled => {
                 self.state = IssueLifecycleState::Cancelled;
+                self.feedback_claimed_at = None;
             }
             IssueLifecycleEventKind::WorkflowDone => {
                 self.state = IssueLifecycleState::Done;
+                self.feedback_claimed_at = None;
             }
         }
         self.last_event = Some(event);
@@ -229,7 +240,6 @@ pub fn workflow_id(project_id: &str, repo: Option<&str>, issue_number: u64) -> S
 
 pub struct IssueWorkflowStore {
     pool: PgPool,
-    update_lock: tokio::sync::Mutex<()>,
 }
 
 impl IssueWorkflowStore {
@@ -258,10 +268,23 @@ impl IssueWorkflowStore {
         PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
             .run()
             .await?;
-        Ok(Self {
-            pool,
-            update_lock: tokio::sync::Mutex::new(()),
-        })
+        Ok(Self { pool })
+    }
+
+    pub async fn open_with_database_url_and_schema(
+        configured_database_url: Option<&str>,
+        schema: &str,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, schema).await?;
+        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self { pool })
     }
 
     pub async fn upsert(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<()> {
@@ -509,6 +532,59 @@ impl IssueWorkflowStore {
             .collect()
     }
 
+    pub async fn claim_feedback_candidates(
+        &self,
+        limit: i64,
+    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let mut tx = self.pool.begin().await?;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, data FROM issue_workflows
+             WHERE data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+               AND data::jsonb->>'pr_number' IS NOT NULL
+             ORDER BY updated_at DESC
+             LIMIT $1
+             FOR UPDATE SKIP LOCKED",
+        )
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut claimed = Vec::with_capacity(rows.len());
+        for (workflow_id, data) in rows {
+            let mut workflow: IssueWorkflowInstance = serde_json::from_str(&data)?;
+            let claim_id = format!("claim:{}", workflow.id);
+            if let Some(pr_number) = workflow.pr_number {
+                let pr_url = workflow.pr_url.clone().unwrap_or_default();
+                workflow.apply_event(
+                    IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
+                        .with_task_id(claim_id)
+                        .with_pr(pr_number, pr_url),
+                );
+                self.upsert_in_tx(&mut tx, &workflow).await?;
+                debug_assert_eq!(workflow.id, workflow_id);
+                claimed.push(workflow);
+            }
+        }
+        tx.commit().await?;
+        Ok(claimed)
+    }
+
+    pub async fn release_feedback_claim(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        detail: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::NoFeedbackFound)
+                    .with_detail(detail.to_string()),
+            );
+        })
+        .await
+    }
+
     async fn update_issue<F>(
         &self,
         project_id: &str,
@@ -519,22 +595,25 @@ impl IssueWorkflowStore {
     where
         F: FnOnce(&mut IssueWorkflowInstance),
     {
-        let _guard = self.update_lock.lock().await;
+        let workflow_id = workflow_id(project_id, repo, issue_number);
+        let placeholder = IssueWorkflowInstance::new(
+            project_id.to_string(),
+            repo.map(|r| r.to_string()),
+            issue_number,
+        );
+        let mut tx = self.pool.begin().await?;
+        self.insert_placeholder(&mut tx, &workflow_id, &placeholder)
+            .await?;
         let mut workflow = self
-            .get_by_issue(project_id, repo, issue_number)
+            .load_for_update_by_id(&mut tx, &workflow_id)
             .await?
-            .unwrap_or_else(|| {
-                IssueWorkflowInstance::new(
-                    project_id.to_string(),
-                    repo.map(|r| r.to_string()),
-                    issue_number,
-                )
-            });
+            .ok_or_else(|| anyhow::anyhow!("workflow row disappeared after placeholder insert"))?;
         if workflow.repo.is_none() {
             workflow.repo = repo.map(|r| r.to_string());
         }
         f(&mut workflow);
-        self.upsert(&workflow).await?;
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
         Ok(workflow)
     }
 
@@ -548,12 +627,14 @@ impl IssueWorkflowStore {
     where
         F: FnOnce(&mut IssueWorkflowInstance),
     {
-        let _guard = self.update_lock.lock().await;
-        let Some(mut workflow) = self.get_by_issue(project_id, repo, issue_number).await? else {
+        let mut tx = self.pool.begin().await?;
+        let workflow_id = workflow_id(project_id, repo, issue_number);
+        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, &workflow_id).await? else {
             return Ok(None);
         };
         f(&mut workflow);
-        self.upsert(&workflow).await?;
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
         Ok(Some(workflow))
     }
 
@@ -567,13 +648,115 @@ impl IssueWorkflowStore {
     where
         F: FnOnce(&mut IssueWorkflowInstance),
     {
-        let _guard = self.update_lock.lock().await;
-        let Some(mut workflow) = self.get_by_pr(project_id, repo, pr_number).await? else {
+        let mut tx = self.pool.begin().await?;
+        let Some((workflow_id, mut workflow)) = self
+            .load_for_update_by_pr(&mut tx, project_id, repo, pr_number)
+            .await?
+        else {
             return Ok(None);
         };
         f(&mut workflow);
-        self.upsert(&workflow).await?;
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        debug_assert_eq!(workflow.id, workflow_id);
+        tx.commit().await?;
         Ok(Some(workflow))
+    }
+
+    async fn insert_placeholder(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+        workflow: &IssueWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(workflow_id)
+        .bind(&data)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    async fn load_for_update_by_id(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM issue_workflows WHERE id = $1 FOR UPDATE")
+                .bind(workflow_id)
+                .fetch_optional(&mut **tx)
+                .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn load_for_update_by_pr(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+    ) -> anyhow::Result<Option<(String, IssueWorkflowInstance)>> {
+        let row: Option<(String, String)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT id, data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'pr_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                 FOR UPDATE",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(pr_number as i64)
+            .fetch_optional(&mut **tx)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT id, data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'pr_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                 FOR UPDATE",
+            )
+            .bind(project_id)
+            .bind(pr_number as i64)
+            .fetch_optional(&mut **tx)
+            .await?
+        };
+        match row {
+            Some((id, data)) => {
+                let workflow = serde_json::from_str(&data)?;
+                Ok(Some((id, workflow)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn upsert_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow: &IssueWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "UPDATE issue_workflows
+             SET data = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(&data)
+        .bind(&workflow.id)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
     }
 }
 

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -379,6 +379,16 @@ impl IssueWorkflowStore {
             .map_err(Into::into)
     }
 
+    pub async fn list(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT data FROM issue_workflows ORDER BY updated_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
     pub async fn record_issue_scheduled(
         &self,
         project_id: &str,

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -6,6 +6,7 @@ use harness_core::db::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgPool;
+use sqlx::Postgres;
 use std::path::Path;
 
 const PROJECT_WORKFLOW_SCHEMA_VERSION: u32 = 1;
@@ -179,7 +180,6 @@ pub fn workflow_id(project_id: &str, repo: Option<&str>) -> String {
 
 pub struct ProjectWorkflowStore {
     pool: PgPool,
-    update_lock: tokio::sync::Mutex<()>,
 }
 
 impl ProjectWorkflowStore {
@@ -208,10 +208,23 @@ impl ProjectWorkflowStore {
         PgMigrator::new(&pool, PROJECT_WORKFLOW_MIGRATIONS)
             .run()
             .await?;
-        Ok(Self {
-            pool,
-            update_lock: tokio::sync::Mutex::new(()),
-        })
+        Ok(Self { pool })
+    }
+
+    pub async fn open_with_database_url_and_schema(
+        configured_database_url: Option<&str>,
+        schema: &str,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, schema).await?;
+        PgMigrator::new(&pool, PROJECT_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self { pool })
     }
 
     pub async fn upsert(&self, workflow: &ProjectWorkflowInstance) -> anyhow::Result<()> {
@@ -407,19 +420,73 @@ impl ProjectWorkflowStore {
     where
         F: FnOnce(&mut ProjectWorkflowInstance),
     {
-        let _guard = self.update_lock.lock().await;
+        let workflow_id = workflow_id(project_id, repo);
+        let placeholder = ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string));
+        let mut tx = self.pool.begin().await?;
+        self.insert_placeholder(&mut tx, &workflow_id, &placeholder)
+            .await?;
         let mut workflow = self
-            .get_by_project(project_id, repo)
+            .load_for_update_by_id(&mut tx, &workflow_id)
             .await?
-            .unwrap_or_else(|| {
-                ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string))
-            });
+            .ok_or_else(|| anyhow::anyhow!("project workflow row disappeared after placeholder insert"))?;
         if workflow.repo.is_none() {
             workflow.repo = repo.map(str::to_string);
         }
         f(&mut workflow);
-        self.upsert(&workflow).await?;
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
         Ok(workflow)
+    }
+
+    async fn insert_placeholder(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+        workflow: &ProjectWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO project_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(workflow_id)
+        .bind(&data)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    async fn load_for_update_by_id(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+    ) -> anyhow::Result<Option<ProjectWorkflowInstance>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM project_workflows WHERE id = $1 FOR UPDATE")
+                .bind(workflow_id)
+                .fetch_optional(&mut **tx)
+                .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn upsert_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow: &ProjectWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "UPDATE project_workflows
+             SET data = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(&data)
+        .bind(&workflow.id)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
     }
 }
 

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -178,6 +178,16 @@ pub fn workflow_id(project_id: &str, repo: Option<&str>) -> String {
     format!("{project_id}::repo:{}::project", repo_key(repo))
 }
 
+pub fn legacy_schema_for_path(path: &Path) -> anyhow::Result<String> {
+    let path_utf8 = path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
+    let digest = Sha256::digest(path_utf8.as_bytes());
+    let mut schema_bytes = [0u8; 8];
+    schema_bytes.copy_from_slice(&digest[..8]);
+    Ok(format!("h{:016x}", u64::from_le_bytes(schema_bytes)))
+}
+
 pub struct ProjectWorkflowStore {
     pool: PgPool,
 }
@@ -192,13 +202,7 @@ impl ProjectWorkflowStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let database_url = resolve_database_url(configured_database_url)?;
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let schema = legacy_schema_for_path(path)?;
 
         let setup = pg_open_pool(&database_url).await?;
         pg_create_schema_if_not_exists(&setup, &schema).await?;
@@ -273,6 +277,23 @@ impl ProjectWorkflowStore {
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
+    }
+
+    pub async fn list(&self) -> anyhow::Result<Vec<ProjectWorkflowInstance>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT data FROM project_workflows ORDER BY updated_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    pub async fn row_count(&self) -> anyhow::Result<i64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM project_workflows")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count)
     }
 
     pub async fn record_poll_started(
@@ -421,14 +442,17 @@ impl ProjectWorkflowStore {
         F: FnOnce(&mut ProjectWorkflowInstance),
     {
         let workflow_id = workflow_id(project_id, repo);
-        let placeholder = ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string));
+        let placeholder =
+            ProjectWorkflowInstance::new(project_id.to_string(), repo.map(str::to_string));
         let mut tx = self.pool.begin().await?;
         self.insert_placeholder(&mut tx, &workflow_id, &placeholder)
             .await?;
         let mut workflow = self
             .load_for_update_by_id(&mut tx, &workflow_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("project workflow row disappeared after placeholder insert"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("project workflow row disappeared after placeholder insert")
+            })?;
         if workflow.repo.is_none() {
             workflow.repo = repo.map(str::to_string);
         }


### PR DESCRIPTION
## Summary\n- replace workflow-store process-local serialization with DB transaction + row-lock update paths\n- use stable WORKFLOW.md schema namespaces for workflow persistence instead of local path-derived schemas\n- add workflow-level feedback claim/release semantics to reduce duplicate PR feedback task enqueue\n\n## Validation\n- cargo check -p harness-workflow -p harness-server\n- cargo test -p harness-workflow issue_workflow_store -- --test-threads=1\n- cargo test -p harness-workflow project_workflow_store -- --test-threads=1\n- cargo test -p harness-core load_workflow_config -- --test-threads=1\n\n## Notes\n- This PR will continue to receive follow-up commits for the next workflow migration step (TaskStatus/TaskPhase second-truth cleanup).