### PR TITLE
feat: guide the first-run operator flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 ### Prerequisites
 
 - Rust 1.88+
+- Postgres 14+
 - At least one agent runtime:
   - [`codex`](https://github.com/openai/codex) CLI
   - [`claude`](https://docs.anthropic.com/en/docs/claude-code) CLI
@@ -74,6 +75,36 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 git clone https://github.com/majiayu000/harness.git
 cd harness
 cargo build
+```
+
+### First Successful Run
+
+1. Start Postgres and set `server.database_url` in your config.
+2. Start the HTTP server:
+
+```bash
+cargo run -p harness-cli -- serve --transport http --port 9800
+```
+
+3. Open the web UI at `http://127.0.0.1:9800/`.
+4. In the dashboard, register a repository root with the guided setup flow.
+5. Submit one focused task, let the UI redirect into `/?task=<id>`, and watch the live stream.
+6. Reopen the completed task from History to inspect the PR, prompts, artifacts, and checkpoint summary.
+
+If you prefer the raw HTTP control plane, the same loop is:
+
+```bash
+curl -X POST http://127.0.0.1:9800/projects/validate \
+  -H "Content-Type: application/json" \
+  -d '{"root": "/absolute/path/to/repo"}'
+
+curl -X POST http://127.0.0.1:9800/projects \
+  -H "Content-Type: application/json" \
+  -d '{"root": "/absolute/path/to/repo"}'
+
+curl -X POST http://127.0.0.1:9800/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"project": "/absolute/path/to/repo", "prompt": "Add a focused regression test for the latest failing behavior"}'
 ```
 
 ### Rust API Facade
@@ -150,6 +181,10 @@ cargo run -p harness-cli -- serve --transport http --port 9800
 curl http://127.0.0.1:9800/health
 ```
 
+Open `http://127.0.0.1:9800/` for the operator dashboard. The first-run flow
+validates a repository root, registers it, submits a task, and redirects into
+the live task detail view.
+
 **Stdio (for MCP integration):**
 
 ```bash
@@ -165,10 +200,19 @@ cargo run -p harness-cli -- exec "Fix the failing test in src/lib.rs"
 ### Common Workflows
 
 ```bash
-# Task management
+# Validate + register a project for the operator control plane
+curl -X POST http://127.0.0.1:9800/projects/validate \
+  -H "Content-Type: application/json" \
+  -d '{"root": "/absolute/path/to/repo"}'
+
+curl -X POST http://127.0.0.1:9800/projects \
+  -H "Content-Type: application/json" \
+  -d '{"root": "/absolute/path/to/repo"}'
+
+# Submit a task
 curl -X POST http://127.0.0.1:9800/tasks \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "Add input validation to the API handler"}'
+  -d '{"project": "/absolute/path/to/repo", "prompt": "Add input validation to the API handler"}'
 
 # Rule engine
 cargo run -p harness-cli -- rule load .

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -543,28 +543,25 @@ mod tests {
             state.observability.events.log(&event).await?;
         }
 
-        let app = Router::new()
-            .route("/api/dashboard", get(dashboard))
-            .with_state(state);
+        for _ in 0..50 {
+            let (_status, Json(body)) = dashboard(State(state.clone())).await;
+            if body["first_run"] == false {
+                assert_eq!(body["onboarding"]["phase"], "complete");
+                assert_eq!(body["onboarding"]["has_registered_project"], true);
+                assert_eq!(body["onboarding"]["has_submitted_task"], true);
+                assert_eq!(body["onboarding"]["has_live_output"], true);
+                assert_eq!(body["onboarding"]["has_completion_evidence"], true);
+                assert!(body["funnel"]["project_registered_at"].is_string());
+                assert!(body["funnel"]["task_submitted_at"].is_string());
+                assert!(body["funnel"]["live_output_at"].is_string());
+                assert!(body["funnel"]["completion_evidence_at"].is_string());
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
-        let req = axum::http::Request::builder()
-            .uri("/api/dashboard")
-            .body(axum::body::Body::empty())?;
-
-        let resp = tower::ServiceExt::oneshot(app, req).await?;
-        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
-        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
-
+        let (_status, Json(body)) = dashboard(State(state)).await;
         assert_eq!(body["first_run"], false);
-        assert_eq!(body["onboarding"]["phase"], "complete");
-        assert_eq!(body["onboarding"]["has_registered_project"], true);
-        assert_eq!(body["onboarding"]["has_submitted_task"], true);
-        assert_eq!(body["onboarding"]["has_live_output"], true);
-        assert_eq!(body["onboarding"]["has_completion_evidence"], true);
-        assert!(body["funnel"]["project_registered_at"].is_string());
-        assert!(body["funnel"]["task_submitted_at"].is_string());
-        assert!(body["funnel"]["live_output_at"].is_string());
-        assert!(body["funnel"]["completion_evidence_at"].is_string());
         Ok(())
     }
 }

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -1,7 +1,4 @@
-use crate::{
-    http::AppState,
-    task_runner::{DashboardCounts, TaskStatus, TaskSummary},
-};
+use crate::{http::AppState, task_runner::DashboardCounts};
 use axum::{extract::State, http::StatusCode, Json};
 use harness_core::types::{Event, EventFilters};
 use harness_observe::{quality::QualityGrader, stats};
@@ -59,24 +56,34 @@ fn parse_operator_funnel_milestone(event: &Event) -> Option<String> {
     })
 }
 
-fn task_has_started(summary: &TaskSummary) -> bool {
-    matches!(
-        summary.status,
-        TaskStatus::Implementing
-            | TaskStatus::AgentReview
-            | TaskStatus::Waiting
-            | TaskStatus::Reviewing
-            | TaskStatus::Done
-            | TaskStatus::Failed
-    ) || summary.turn > 0
-}
-
 async fn build_onboarding_summary(
     state: &AppState,
-    dashboard_events: &[Event],
 ) -> (bool, DashboardOnboarding, DashboardFunnel) {
     let mut funnel = DashboardFunnel::default();
-    for event in dashboard_events {
+
+    // Query operator_funnel events with content so milestone values can be parsed.
+    // This is a targeted query for a small event subset rather than loading the full
+    // content column for the entire rolling-window event history.
+    let events_since = chrono::Utc::now() - chrono::Duration::days(DASHBOARD_EVENT_WINDOW_DAYS);
+    let funnel_events = match state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("operator_funnel".to_string()),
+            since: Some(events_since),
+            include_content: true,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::warn!("dashboard: failed to query operator_funnel events: {e}");
+            Vec::new()
+        }
+    };
+
+    for event in &funnel_events {
         match parse_operator_funnel_milestone(event).as_deref() {
             Some("project_registered") => {
                 record_first_timestamp(&mut funnel.project_registered_at, &event.ts)
@@ -95,27 +102,9 @@ async fn build_onboarding_summary(
     }
 
     if funnel.live_output_at.is_none() {
-        let task_summaries = match state.core.tasks.list_all_summaries_with_terminal().await {
-            Ok(summaries) => summaries,
-            Err(e) => {
-                tracing::warn!("dashboard: failed to list task summaries for onboarding: {e}");
-                Vec::new()
-            }
-        };
-
-        for summary in task_summaries
-            .iter()
-            .filter(|summary| task_has_started(summary))
-        {
-            if let Some(created_at) = &summary.created_at {
-                if funnel
-                    .live_output_at
-                    .as_ref()
-                    .is_none_or(|existing| created_at < existing)
-                {
-                    funnel.live_output_at = Some(created_at.clone());
-                }
-            }
+        // Fallback: use a single MIN aggregate query instead of loading all summaries.
+        if let Some(ts) = state.core.tasks.earliest_started_task_created_at().await {
+            funnel.live_output_at = Some(ts);
         }
     }
 
@@ -344,7 +333,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         .iter()
         .filter(|host| host["online"].as_bool().unwrap_or(false))
         .count() as u64;
-    let (first_run, onboarding, funnel) = build_onboarding_summary(&state, &dashboard_events).await;
+    let (first_run, onboarding, funnel) = build_onboarding_summary(&state).await;
 
     let body = json!({
         "projects": projects,

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -1,7 +1,11 @@
-use crate::{http::AppState, task_runner::DashboardCounts};
+use crate::{
+    http::AppState,
+    task_runner::{DashboardCounts, TaskStatus, TaskSummary},
+};
 use axum::{extract::State, http::StatusCode, Json};
-use harness_core::types::EventFilters;
+use harness_core::types::{Event, EventFilters};
 use harness_observe::{quality::QualityGrader, stats};
+use serde::Serialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
@@ -14,6 +18,136 @@ const DASHBOARD_EVENT_WINDOW_DAYS: i64 = 30;
 /// so `uptime_secs` reflects true server uptime rather than time since first dashboard hit.
 pub(crate) static SERVER_START: std::sync::OnceLock<std::time::Instant> =
     std::sync::OnceLock::new();
+
+#[derive(Debug, Default, Serialize)]
+struct DashboardFunnel {
+    project_registered_at: Option<String>,
+    task_submitted_at: Option<String>,
+    live_output_at: Option<String>,
+    completion_evidence_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DashboardOnboarding {
+    phase: &'static str,
+    has_registered_project: bool,
+    has_submitted_task: bool,
+    has_live_output: bool,
+    has_completion_evidence: bool,
+}
+
+fn record_first_timestamp(slot: &mut Option<String>, ts: &chrono::DateTime<chrono::Utc>) {
+    let ts = ts.to_rfc3339();
+    if slot.as_ref().is_none_or(|existing| ts < *existing) {
+        *slot = Some(ts);
+    }
+}
+
+fn parse_operator_funnel_milestone(event: &Event) -> Option<String> {
+    if event.hook != "operator_funnel" {
+        return None;
+    }
+    event.content.as_deref().and_then(|content| {
+        serde_json::from_str::<serde_json::Value>(content)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("milestone")
+                    .and_then(|value| value.as_str())
+                    .map(ToString::to_string)
+            })
+    })
+}
+
+fn task_has_started(summary: &TaskSummary) -> bool {
+    matches!(
+        summary.status,
+        TaskStatus::Implementing
+            | TaskStatus::AgentReview
+            | TaskStatus::Waiting
+            | TaskStatus::Reviewing
+            | TaskStatus::Done
+            | TaskStatus::Failed
+    ) || summary.turn > 0
+}
+
+async fn build_onboarding_summary(
+    state: &AppState,
+    dashboard_events: &[Event],
+) -> (bool, DashboardOnboarding, DashboardFunnel) {
+    let mut funnel = DashboardFunnel::default();
+    for event in dashboard_events {
+        match parse_operator_funnel_milestone(event).as_deref() {
+            Some("project_registered") => {
+                record_first_timestamp(&mut funnel.project_registered_at, &event.ts)
+            }
+            Some("task_submitted") => {
+                record_first_timestamp(&mut funnel.task_submitted_at, &event.ts)
+            }
+            Some("live_output_available") => {
+                record_first_timestamp(&mut funnel.live_output_at, &event.ts)
+            }
+            Some("completion_evidence_available") => {
+                record_first_timestamp(&mut funnel.completion_evidence_at, &event.ts)
+            }
+            _ => {}
+        }
+    }
+
+    let task_summaries = match state.core.tasks.list_all_summaries_with_terminal().await {
+        Ok(summaries) => summaries,
+        Err(e) => {
+            tracing::warn!("dashboard: failed to list task summaries for onboarding: {e}");
+            Vec::new()
+        }
+    };
+
+    if funnel.live_output_at.is_none() {
+        for summary in task_summaries
+            .iter()
+            .filter(|summary| task_has_started(summary))
+        {
+            if let Some(created_at) = &summary.created_at {
+                if funnel
+                    .live_output_at
+                    .as_ref()
+                    .is_none_or(|existing| created_at < existing)
+                {
+                    funnel.live_output_at = Some(created_at.clone());
+                }
+            }
+        }
+    }
+
+    let has_registered_project = funnel.project_registered_at.is_some();
+    let has_submitted_task = funnel.task_submitted_at.is_some();
+    let has_live_output = funnel.live_output_at.is_some();
+    let has_completion_evidence = funnel.completion_evidence_at.is_some();
+
+    let phase = if !has_registered_project {
+        "register_project"
+    } else if !has_submitted_task {
+        "submit_task"
+    } else if !has_live_output {
+        "watch_live_output"
+    } else if !has_completion_evidence {
+        "inspect_completion"
+    } else {
+        "complete"
+    };
+
+    (
+        phase != "complete",
+        DashboardOnboarding {
+            phase,
+            has_registered_project,
+            has_submitted_task,
+            has_live_output,
+            has_completion_evidence,
+        },
+        funnel,
+    )
+}
 
 /// GET /api/dashboard — JSON summary of all registered projects and global concurrency.
 ///
@@ -44,7 +178,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     // Derive violation_count from the most recent rule_scan session so we don't
     // permanently depress the grade with historical violations from old scans.
     let events_since = chrono::Utc::now() - chrono::Duration::days(DASHBOARD_EVENT_WINDOW_DAYS);
-    let grade: Option<Value> = match state
+    let dashboard_events = match state
         .observability
         .events
         .query(&EventFilters {
@@ -53,7 +187,18 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         })
         .await
     {
-        Ok(events) => {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::warn!("dashboard: failed to query events: {e}");
+            Vec::new()
+        }
+    };
+
+    let grade: Option<Value> = {
+        let events = &dashboard_events;
+        if events.is_empty() {
+            None
+        } else {
             // Return None when the rolling window contains no events rather than
             // computing a false perfect grade from an empty set.  Operators should
             // see null (unknown) instead of an inflated A when the project has been
@@ -72,13 +217,9 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                             .count()
                     })
                     .unwrap_or(0);
-                let report = QualityGrader::grade(&events, violation_count);
+                let report = QualityGrader::grade(events, violation_count);
                 serde_json::to_value(report.grade).ok()
             }
-        }
-        Err(e) => {
-            tracing::warn!("dashboard: failed to query events for grade: {e}");
-            None
         }
     };
 
@@ -203,11 +344,15 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
         .iter()
         .filter(|host| host["online"].as_bool().unwrap_or(false))
         .count() as u64;
+    let (first_run, onboarding, funnel) = build_onboarding_summary(&state, &dashboard_events).await;
 
     let body = json!({
         "projects": projects,
         "runtime_hosts": runtime_hosts,
         "llm_metrics": llm_metrics,
+        "first_run": first_run,
+        "onboarding": onboarding,
+        "funnel": funnel,
         "global": {
             "running": tq.running_count(),
             "queued": tq.queued_count(),
@@ -272,6 +417,9 @@ mod tests {
 
         // Must have top-level "projects" array and "global" object.
         assert!(body.get("projects").and_then(|v| v.as_array()).is_some());
+        assert!(body.get("first_run").is_some());
+        assert!(body.get("onboarding").is_some());
+        assert!(body.get("funnel").is_some());
         let global = body.get("global").expect("missing global key");
         assert!(global.get("running").is_some());
         assert!(global.get("queued").is_some());
@@ -367,6 +515,56 @@ mod tests {
             host["assignment_pressure"], 0.0,
             "idle host must have 0.0 assignment_pressure"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dashboard_aggregates_operator_funnel_milestones() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-dashboard-")?;
+        let state = Arc::new(make_test_state(dir.path()).await?);
+
+        for milestone in [
+            "project_registered",
+            "task_submitted",
+            "live_output_available",
+            "completion_evidence_available",
+        ] {
+            let mut event = harness_core::types::Event::new(
+                harness_core::types::SessionId::new(),
+                "operator_funnel",
+                "test",
+                harness_core::types::Decision::Complete,
+            );
+            event.content = Some(serde_json::json!({ "milestone": milestone }).to_string());
+            state.observability.events.log(&event).await?;
+        }
+
+        let app = Router::new()
+            .route("/api/dashboard", get(dashboard))
+            .with_state(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/api/dashboard")
+            .body(axum::body::Body::empty())?;
+
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        assert_eq!(body["first_run"], false);
+        assert_eq!(body["onboarding"]["phase"], "complete");
+        assert_eq!(body["onboarding"]["has_registered_project"], true);
+        assert_eq!(body["onboarding"]["has_submitted_task"], true);
+        assert_eq!(body["onboarding"]["has_live_output"], true);
+        assert_eq!(body["onboarding"]["has_completion_evidence"], true);
+        assert!(body["funnel"]["project_registered_at"].is_string());
+        assert!(body["funnel"]["task_submitted_at"].is_string());
+        assert!(body["funnel"]["live_output_at"].is_string());
+        assert!(body["funnel"]["completion_evidence_at"].is_string());
         Ok(())
     }
 }

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -94,15 +94,15 @@ async fn build_onboarding_summary(
         }
     }
 
-    let task_summaries = match state.core.tasks.list_all_summaries_with_terminal().await {
-        Ok(summaries) => summaries,
-        Err(e) => {
-            tracing::warn!("dashboard: failed to list task summaries for onboarding: {e}");
-            Vec::new()
-        }
-    };
-
     if funnel.live_output_at.is_none() {
+        let task_summaries = match state.core.tasks.list_all_summaries_with_terminal().await {
+            Ok(summaries) => summaries,
+            Err(e) => {
+                tracing::warn!("dashboard: failed to list task summaries for onboarding: {e}");
+                Vec::new()
+            }
+        };
+
         for summary in task_summaries
             .iter()
             .filter(|summary| task_has_started(summary))

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -462,10 +462,11 @@ mod tests {
         if !crate::test_helpers::db_tests_enabled().await {
             return Ok(());
         }
+        let startup_root = crate::test_helpers::tempdir_in_home("projects-startup-root-")?;
         let repo = crate::test_helpers::tempdir_in_home("projects-register-")?;
         init_git_repo(repo.path(), None)?;
         let data_dir = tempfile::tempdir()?;
-        let state = make_test_state(repo.path(), data_dir.path()).await?;
+        let state = make_test_state(startup_root.path(), data_dir.path()).await?;
         let root = repo.path().to_path_buf();
 
         let (first_status, Json(first_body)) = register_project(

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -1,18 +1,19 @@
 use crate::http::AppState;
-use crate::project_registry::{validate_project_root, Project};
+use crate::project_registry::{check_allowed_roots, validate_project_root, Project};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
-use tracing;
+use tracing::{self, warn};
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterProjectRequest {
-    pub id: String,
+    #[serde(default)]
+    pub id: Option<String>,
     pub root: std::path::PathBuf,
     #[serde(default)]
     pub max_concurrent: Option<u32>,
@@ -20,45 +21,122 @@ pub struct RegisterProjectRequest {
     pub default_agent: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ValidateProjectRequest {
+    pub root: std::path::PathBuf,
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectValidationResponse {
+    pub canonical_root: std::path::PathBuf,
+    pub project_id: String,
+    pub display_name: String,
+    pub repo: Option<String>,
+    pub errors: Vec<String>,
+}
+
+fn validation_error(
+    status: StatusCode,
+    message: impl Into<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let message = message.into();
+    (
+        status,
+        Json(json!({ "error": message, "errors": [message] })),
+    )
+}
+
+fn normalize_requested_project_id(id: Option<String>) -> Option<String> {
+    id.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn infer_display_name(root: &std::path::Path, repo: Option<&str>) -> String {
+    if let Some(slug) = repo {
+        if let Some(name) = slug.rsplit('/').next() {
+            let trimmed = name.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    root.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("project")
+        .to_string()
+}
+
+async fn validate_project_request(
+    state: &AppState,
+    root: std::path::PathBuf,
+    requested_id: Option<String>,
+) -> Result<ProjectValidationResponse, (StatusCode, Json<serde_json::Value>)> {
+    let canonical_root = root.canonicalize().map_err(|e| {
+        validation_error(StatusCode::BAD_REQUEST, format!("invalid root path: {e}"))
+    })?;
+
+    validate_project_root(&canonical_root)
+        .map_err(|message| validation_error(StatusCode::BAD_REQUEST, message))?;
+
+    check_allowed_roots(
+        &canonical_root,
+        &state.core.server.config.server.allowed_project_roots,
+    )
+    .map_err(|message| validation_error(StatusCode::FORBIDDEN, message))?;
+
+    let repo = crate::task_executor::pr_detection::detect_repo_slug(&canonical_root).await;
+    let project_id = normalize_requested_project_id(requested_id)
+        .unwrap_or_else(|| canonical_root.to_string_lossy().into_owned());
+    let display_name = infer_display_name(&canonical_root, repo.as_deref());
+
+    Ok(ProjectValidationResponse {
+        canonical_root,
+        project_id,
+        display_name,
+        repo,
+        errors: Vec::new(),
+    })
+}
+
+pub async fn validate_project(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ValidateProjectRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match validate_project_request(&state, req.root, req.id).await {
+        Ok(validation) => (StatusCode::OK, Json(json!(validation))),
+        Err(error) => error,
+    }
+}
+
 pub async fn register_project(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RegisterProjectRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let root = match req.root.canonicalize() {
-        Ok(p) => p,
+    let validation = match validate_project_request(&state, req.root, req.id).await {
+        Ok(validation) => validation,
+        Err(error) => return error,
+    };
+
+    let already_registered = match state.project_svc.get(&validation.project_id).await {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
         Err(e) => {
             return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": format!("invalid root path: {e}")})),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
             )
         }
     };
 
-    if let Err(msg) = validate_project_root(&root) {
-        return (StatusCode::BAD_REQUEST, Json(json!({"error": msg})));
-    }
-
-    let allowed = &state.core.server.config.server.allowed_project_roots;
-    if !allowed.is_empty() {
-        let permitted = allowed.iter().any(|base| match base.canonicalize() {
-            Ok(canonical_base) => root.starts_with(&canonical_base),
-            Err(e) => {
-                tracing::error!("failed to canonicalize allowed root {:?}: {}", base, e);
-                false
-            }
-        });
-        if !permitted {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "project root is not under an allowed base directory"})),
-            );
-        }
-    }
-
     let project = Project {
-        id: req.id,
-        root,
-        name: None,
+        id: validation.project_id.clone(),
+        root: validation.canonical_root.clone(),
+        name: Some(validation.display_name.clone()),
         max_concurrent: req.max_concurrent,
         default_agent: req.default_agent,
         active: true,
@@ -66,7 +144,40 @@ pub async fn register_project(
     };
 
     match state.project_svc.register(project.clone()).await {
-        Ok(()) => (StatusCode::CREATED, Json(json!(project))),
+        Ok(()) => {
+            let mut event = harness_core::types::Event::new(
+                harness_core::types::SessionId::new(),
+                "operator_funnel",
+                "projects",
+                harness_core::types::Decision::Complete,
+            );
+            event.detail = Some("project_registered".to_string());
+            event.content = Some(
+                json!({
+                    "milestone": "project_registered",
+                    "project_id": validation.project_id,
+                    "root": validation.canonical_root,
+                    "status": if already_registered { "existing" } else { "created" },
+                })
+                .to_string(),
+            );
+            if let Err(e) = state.observability.events.log(&event).await {
+                warn!("failed to log operator_funnel project_registered event: {e}");
+            }
+
+            (
+                if already_registered {
+                    StatusCode::OK
+                } else {
+                    StatusCode::CREATED
+                },
+                Json(json!({
+                    "status": if already_registered { "existing" } else { "created" },
+                    "project": project,
+                    "validation": validation,
+                })),
+            )
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": e.to_string()})),
@@ -198,6 +309,22 @@ mod tests {
         Ok(Arc::new(build_app_state(server).await?))
     }
 
+    fn init_git_repo(path: &std::path::Path, remote: Option<&str>) -> anyhow::Result<()> {
+        let status = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .status()?;
+        anyhow::ensure!(status.success(), "git init must succeed");
+        if let Some(remote) = remote {
+            let status = std::process::Command::new("git")
+                .args(["remote", "add", "origin", remote])
+                .current_dir(path)
+                .status()?;
+            anyhow::ensure!(status.success(), "git remote add must succeed");
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn list_projects_includes_task_count_and_project_identity() -> anyhow::Result<()> {
         let _lock = crate::test_helpers::HOME_LOCK.lock().await;
@@ -229,6 +356,148 @@ mod tests {
             );
             assert_eq!(project.get("task_count"), Some(&json!(0)));
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validate_project_returns_detected_metadata() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let repo = crate::test_helpers::tempdir_in_home("projects-validate-")?;
+        init_git_repo(repo.path(), Some("https://github.com/acme/harness.git"))?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(repo.path(), data_dir.path()).await?;
+
+        let (status, Json(body)) = validate_project(
+            State(state),
+            Json(ValidateProjectRequest {
+                root: repo.path().to_path_buf(),
+                id: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["project_id"],
+            json!(repo.path().canonicalize()?.to_string_lossy().to_string())
+        );
+        assert_eq!(body["display_name"], "harness");
+        assert_eq!(body["repo"], "acme/harness");
+        assert_eq!(body["errors"], json!([]));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validate_project_rejects_non_git_root() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let repo = crate::test_helpers::tempdir_in_home("projects-not-git-")?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(repo.path(), data_dir.path()).await?;
+
+        let (status, Json(body)) = validate_project(
+            State(state),
+            Json(ValidateProjectRequest {
+                root: repo.path().to_path_buf(),
+                id: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not a git repository"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validate_project_rejects_disallowed_root() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let allowed = crate::test_helpers::tempdir_in_home("projects-allowed-")?;
+        let repo = crate::test_helpers::tempdir_in_home("projects-outside-")?;
+        init_git_repo(repo.path(), None)?;
+        let data_dir = tempfile::tempdir()?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = repo.path().to_path_buf();
+        config.server.data_dir = data_dir.path().to_path_buf();
+        config.server.allowed_project_roots = vec![allowed.path().to_path_buf()];
+        let server = Arc::new(HarnessServer::new(
+            config,
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        ));
+        let state = Arc::new(build_app_state(server).await?);
+
+        let (status, Json(body)) = validate_project(
+            State(state),
+            Json(ValidateProjectRequest {
+                root: repo.path().to_path_buf(),
+                id: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            body["error"],
+            "project root is not under an allowed base directory"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_project_returns_existing_status_for_duplicate_root() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let repo = crate::test_helpers::tempdir_in_home("projects-register-")?;
+        init_git_repo(repo.path(), None)?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(repo.path(), data_dir.path()).await?;
+        let root = repo.path().to_path_buf();
+
+        let (first_status, Json(first_body)) = register_project(
+            State(state.clone()),
+            Json(RegisterProjectRequest {
+                id: None,
+                root: root.clone(),
+                max_concurrent: None,
+                default_agent: None,
+            }),
+        )
+        .await;
+        assert_eq!(first_status, StatusCode::CREATED);
+        assert_eq!(first_body["status"], "created");
+
+        let (second_status, Json(second_body)) = register_project(
+            State(state.clone()),
+            Json(RegisterProjectRequest {
+                id: None,
+                root,
+                max_concurrent: Some(3),
+                default_agent: Some("auto".to_string()),
+            }),
+        )
+        .await;
+
+        assert_eq!(second_status, StatusCode::OK);
+        assert_eq!(second_body["status"], "existing");
+        assert_eq!(
+            second_body["project"]["id"], first_body["project"]["id"],
+            "duplicate registration must resolve to the same canonical project id"
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -40,6 +40,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
                 .get(crate::handlers::projects::list_projects),
         )
         .route(
+            "/projects/validate",
+            post(crate::handlers::projects::validate_project),
+        )
+        .route(
             "/projects/{id}",
             get(crate::handlers::projects::get_project)
                 .delete(crate::handlers::projects::delete_project),

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -544,8 +544,14 @@ pub(crate) async fn github_webhook(
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(mut summaries) => {
-            for summary in &mut summaries {
-                summary.workflow = load_issue_workflow_for_summary(&state, summary).await;
+            let workflows = futures::future::join_all(
+                summaries
+                    .iter()
+                    .map(|s| load_issue_workflow_for_summary(&state, s)),
+            )
+            .await;
+            for (summary, workflow) in summaries.iter_mut().zip(workflows) {
+                summary.workflow = workflow;
             }
             Json(summaries).into_response()
         }
@@ -572,9 +578,15 @@ pub(crate) async fn get_task(
     {
         Ok(Some(task)) => {
             let summary = task.summary();
-            let workflow = load_issue_workflow_for_summary(&state, &summary).await;
             let task_id = task.id.clone();
-            let prompts = match state.core.tasks.get_prompts(&task_id).await {
+            // Run independent DB lookups concurrently to reduce response latency.
+            let (workflow, prompts_result, artifacts_result, checkpoint_result) = tokio::join!(
+                load_issue_workflow_for_summary(&state, &summary),
+                state.core.tasks.get_prompts(&task_id),
+                state.core.tasks.list_artifacts(&task_id),
+                state.core.tasks.load_checkpoint(&task_id),
+            );
+            let prompts = match prompts_result {
                 Ok(prompts) => prompts,
                 Err(e) => {
                     tracing::error!("get_task: prompt query failed: {e}");
@@ -585,7 +597,7 @@ pub(crate) async fn get_task(
                         .into_response();
                 }
             };
-            let artifacts = match state.core.tasks.list_artifacts(&task_id).await {
+            let artifacts = match artifacts_result {
                 Ok(artifacts) => artifacts,
                 Err(e) => {
                     tracing::error!("get_task: artifact query failed: {e}");
@@ -596,7 +608,7 @@ pub(crate) async fn get_task(
                         .into_response();
                 }
             };
-            let checkpoint = match state.core.tasks.load_checkpoint(&task_id).await {
+            let checkpoint = match checkpoint_result {
                 Ok(checkpoint) => checkpoint.map(|checkpoint| TaskDetailCheckpoint {
                     triage_output: checkpoint.triage_output,
                     plan_output: checkpoint.plan_output,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -6,12 +6,82 @@ use axum::{
     Json,
 };
 use harness_protocol::methods::RpcRequest;
+use serde::Serialize;
 use serde_json::json;
 use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::{router, task_runner};
+
+#[derive(Debug, Serialize)]
+struct TaskDetailCheckpoint {
+    triage_output: Option<String>,
+    plan_output: Option<String>,
+    pr_url: Option<String>,
+    last_phase: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskCompletionSummary {
+    is_terminal: bool,
+    status: String,
+    has_pr: bool,
+    has_artifacts: bool,
+    has_prompts: bool,
+    pr_url: Option<String>,
+    latest_artifact_at: Option<String>,
+    latest_prompt_at: Option<String>,
+    checkpoint: Option<TaskDetailCheckpoint>,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskDetailResponse {
+    #[serde(flatten)]
+    task: task_runner::TaskState,
+    workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
+    prompts: Vec<crate::task_db::TaskPrompt>,
+    artifacts: Vec<crate::task_db::TaskArtifact>,
+    completion: TaskCompletionSummary,
+}
+
+async fn load_issue_workflow_for_summary(
+    state: &AppState,
+    summary: &task_runner::TaskSummary,
+) -> Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance> {
+    let workflow_store = state.core.issue_workflow_store.as_ref()?;
+    let project_id = summary.project.as_deref()?;
+    let by_issue = summary
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("issue:"))
+        .and_then(|n| n.parse::<u64>().ok());
+    let by_pr = summary
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("pr:"))
+        .and_then(|n| n.parse::<u64>().ok())
+        .or_else(|| {
+            summary
+                .pr_url
+                .as_deref()
+                .and_then(crate::http::parse_pr_num_from_url)
+        });
+    match (by_issue, by_pr) {
+        (Some(issue), _) => workflow_store
+            .get_by_issue(project_id, summary.repo.as_deref(), issue)
+            .await
+            .ok()
+            .flatten(),
+        (None, Some(pr)) => workflow_store
+            .get_by_pr(project_id, summary.repo.as_deref(), pr)
+            .await
+            .ok()
+            .flatten(),
+        (None, None) => None,
+    }
+}
 
 pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let count = state.core.tasks.count();
@@ -474,41 +544,8 @@ pub(crate) async fn github_webhook(
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(mut summaries) => {
-            if let Some(workflow_store) = state.core.issue_workflow_store.as_ref() {
-                for summary in &mut summaries {
-                    let Some(project_id) = summary.project.as_deref() else {
-                        continue;
-                    };
-                    let by_issue = summary
-                        .external_id
-                        .as_deref()
-                        .and_then(|id| id.strip_prefix("issue:"))
-                        .and_then(|n| n.parse::<u64>().ok());
-                    let by_pr = summary
-                        .external_id
-                        .as_deref()
-                        .and_then(|id| id.strip_prefix("pr:"))
-                        .and_then(|n| n.parse::<u64>().ok())
-                        .or_else(|| {
-                            summary
-                                .pr_url
-                                .as_deref()
-                                .and_then(crate::http::parse_pr_num_from_url)
-                        });
-                    summary.workflow = match (by_issue, by_pr) {
-                        (Some(issue), _) => workflow_store
-                            .get_by_issue(project_id, summary.repo.as_deref(), issue)
-                            .await
-                            .ok()
-                            .flatten(),
-                        (None, Some(pr)) => workflow_store
-                            .get_by_pr(project_id, summary.repo.as_deref(), pr)
-                            .await
-                            .ok()
-                            .flatten(),
-                        (None, None) => None,
-                    };
-                }
+            for summary in &mut summaries {
+                summary.workflow = load_issue_workflow_for_summary(&state, summary).await;
             }
             Json(summaries).into_response()
         }
@@ -533,7 +570,77 @@ pub(crate) async fn get_task(
         .get_with_db_fallback(&harness_core::types::TaskId(id))
         .await
     {
-        Ok(Some(task)) => Json(task).into_response(),
+        Ok(Some(task)) => {
+            let summary = task.summary();
+            let workflow = load_issue_workflow_for_summary(&state, &summary).await;
+            let task_id = task.id.clone();
+            let prompts = match state.core.tasks.get_prompts(&task_id).await {
+                Ok(prompts) => prompts,
+                Err(e) => {
+                    tracing::error!("get_task: prompt query failed: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            };
+            let artifacts = match state.core.tasks.list_artifacts(&task_id).await {
+                Ok(artifacts) => artifacts,
+                Err(e) => {
+                    tracing::error!("get_task: artifact query failed: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            };
+            let checkpoint = match state.core.tasks.load_checkpoint(&task_id).await {
+                Ok(checkpoint) => checkpoint.map(|checkpoint| TaskDetailCheckpoint {
+                    triage_output: checkpoint.triage_output,
+                    plan_output: checkpoint.plan_output,
+                    pr_url: checkpoint.pr_url,
+                    last_phase: checkpoint.last_phase,
+                    updated_at: checkpoint.updated_at,
+                }),
+                Err(e) => {
+                    tracing::error!("get_task: checkpoint query failed: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            };
+            let completion = TaskCompletionSummary {
+                is_terminal: task.status.is_terminal(),
+                status: task.status.as_ref().to_string(),
+                has_pr: task.pr_url.is_some()
+                    || checkpoint
+                        .as_ref()
+                        .is_some_and(|checkpoint| checkpoint.pr_url.is_some()),
+                has_artifacts: !artifacts.is_empty(),
+                has_prompts: !prompts.is_empty(),
+                pr_url: task.pr_url.clone().or_else(|| {
+                    checkpoint
+                        .as_ref()
+                        .and_then(|checkpoint| checkpoint.pr_url.clone())
+                }),
+                latest_artifact_at: artifacts.last().map(|artifact| artifact.created_at.clone()),
+                latest_prompt_at: prompts.last().map(|prompt| prompt.created_at.clone()),
+                checkpoint,
+            };
+
+            Json(TaskDetailResponse {
+                task,
+                workflow,
+                prompts,
+                artifacts,
+                completion,
+            })
+            .into_response()
+        }
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Response, Json};
 use harness_core::agent::CodeAgent;
+use harness_core::types::{Decision, Event, SessionId};
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
@@ -21,6 +22,12 @@ impl QueueDomain {
             Self::Review => "review",
         }
     }
+}
+
+#[derive(Clone)]
+struct EnqueueTaskResult {
+    task_id: task_runner::TaskId,
+    deduped: bool,
 }
 
 fn queue_timeout_message(
@@ -264,14 +271,33 @@ pub(crate) async fn enqueue_task(
     state: &Arc<AppState>,
     req: task_runner::CreateTaskRequest,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
-    enqueue_task_in_domain(state, req, QueueDomain::Primary).await
+    enqueue_task_with_result(state, req)
+        .await
+        .map(|result| result.task_id)
 }
 
 pub(crate) async fn enqueue_task_in_domain(
     state: &Arc<AppState>,
-    mut req: task_runner::CreateTaskRequest,
+    req: task_runner::CreateTaskRequest,
     queue_domain: QueueDomain,
 ) -> Result<task_runner::TaskId, EnqueueTaskError> {
+    enqueue_task_in_domain_with_result(state, req, queue_domain)
+        .await
+        .map(|result| result.task_id)
+}
+
+async fn enqueue_task_with_result(
+    state: &Arc<AppState>,
+    req: task_runner::CreateTaskRequest,
+) -> Result<EnqueueTaskResult, EnqueueTaskError> {
+    enqueue_task_in_domain_with_result(state, req, QueueDomain::Primary).await
+}
+
+async fn enqueue_task_in_domain_with_result(
+    state: &Arc<AppState>,
+    mut req: task_runner::CreateTaskRequest,
+    queue_domain: QueueDomain,
+) -> Result<EnqueueTaskResult, EnqueueTaskError> {
     let now = chrono::Utc::now();
     if state
         .core
@@ -336,10 +362,16 @@ pub(crate) async fn enqueue_task_in_domain(
     // a concurrency permit (same dedup as enqueue_task_background).
     populate_external_id(&mut req);
     if let Some(existing_id) = check_duplicate(&state.core.tasks, &project_id, &req).await {
-        return Ok(existing_id);
+        return Ok(EnqueueTaskResult {
+            task_id: existing_id,
+            deduped: true,
+        });
     }
     if let Some(existing_id) = check_pr_duplicate(&state.core.tasks, &project_id, &req).await {
-        return Ok(existing_id);
+        return Ok(EnqueueTaskResult {
+            task_id: existing_id,
+            deduped: true,
+        });
     }
 
     // Tasks with unresolved dependencies are registered as AwaitingDeps without
@@ -363,7 +395,10 @@ pub(crate) async fn enqueue_task_in_domain(
                 .await
                 .map_err(|e| EnqueueTaskError::BadRequest(e.to_string()))?;
             track_issue_workflow_enqueue(state, &project_id, &workflow_req, &task_id).await;
-            return Ok(task_id);
+            return Ok(EnqueueTaskResult {
+                task_id,
+                deduped: false,
+            });
         }
         // All deps satisfied — clear the list so the normal spawn path
         // does not re-enter the AwaitingDeps branch.
@@ -416,7 +451,10 @@ pub(crate) async fn enqueue_task_in_domain(
 
     track_issue_workflow_enqueue(state, &project_id, &workflow_req, &task_id).await;
 
-    Ok(task_id)
+    Ok(EnqueueTaskResult {
+        task_id,
+        deduped: false,
+    })
 }
 
 /// A single task entry in the detailed batch format.
@@ -835,15 +873,60 @@ pub(super) async fn create_task(
     State(state): State<Arc<AppState>>,
     Json(req): Json<task_runner::CreateTaskRequest>,
 ) -> Response {
-    match enqueue_task(&state, req).await {
-        Ok(task_id) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "task_id": task_id.0,
-                "status": "running"
-            })),
-        )
-            .into_response(),
+    match enqueue_task_with_result(&state, req).await {
+        Ok(result) => {
+            let task_id = result.task_id.0.clone();
+            let task_state = match state.core.tasks.get_with_db_fallback(&result.task_id).await {
+                Ok(task) => task,
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        "failed to load task after enqueue for operator_funnel logging: {e}"
+                    );
+                    None
+                }
+            };
+            let task_status = task_state
+                .as_ref()
+                .map(|task| task.status.as_ref().to_string())
+                .unwrap_or_else(|| "running".to_string());
+            let project_id = task_state
+                .as_ref()
+                .and_then(|task| task.project_root.as_ref())
+                .map(|root| root.to_string_lossy().into_owned());
+
+            let mut event = Event::new(
+                SessionId::new(),
+                "operator_funnel",
+                "tasks",
+                Decision::Complete,
+            );
+            event.detail = Some("task_submitted".to_string());
+            event.content = Some(
+                json!({
+                    "milestone": "task_submitted",
+                    "task_id": task_id,
+                    "project_id": project_id,
+                    "deduped": result.deduped,
+                    "status": task_status.clone(),
+                })
+                .to_string(),
+            );
+            if let Err(e) = state.observability.events.log(&event).await {
+                tracing::warn!("failed to log operator_funnel task_submitted event: {e}");
+            }
+
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "task_id": task_id,
+                    "status": task_status.clone(),
+                    "deduped": result.deduped,
+                    "task_url": format!("/?task={}", result.task_id.0),
+                })),
+            )
+                .into_response()
+        }
         Err(EnqueueTaskError::BadRequest(error)) => {
             (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
         }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -984,30 +984,37 @@ async fn create_task_records_operator_funnel_submission_event() -> anyhow::Resul
         .await?;
     assert_eq!(response.status(), StatusCode::ACCEPTED);
 
-    let events = state
-        .observability
-        .events
-        .query(&harness_core::types::EventFilters {
-            hook: Some("operator_funnel".to_string()),
-            ..Default::default()
-        })
-        .await?;
-
-    assert!(events.iter().any(|event| {
-        event
-            .content
-            .as_deref()
-            .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
-            .and_then(|value| {
-                value
-                    .get("milestone")
-                    .and_then(|value| value.as_str())
-                    .map(ToString::to_string)
+    for _ in 0..50 {
+        let events = state
+            .observability
+            .events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("operator_funnel".to_string()),
+                ..Default::default()
             })
-            .as_deref()
-            == Some("task_submitted")
-    }));
-    Ok(())
+            .await?;
+
+        if events.iter().any(|event| {
+            event
+                .content
+                .as_deref()
+                .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
+                .and_then(|value| {
+                    value
+                        .get("milestone")
+                        .and_then(|value| value.as_str())
+                        .map(ToString::to_string)
+                })
+                .as_deref()
+                == Some("task_submitted")
+        }) {
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    anyhow::bail!("task_submitted operator_funnel event was not persisted in time")
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -968,6 +968,114 @@ async fn get_task_hides_internal_system_input_metadata() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn create_task_records_operator_funnel_submission_event() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
+
+    let create_body = serde_json::json!({ "prompt": "add tests" });
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let events = state
+        .observability
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("operator_funnel".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    assert!(events.iter().any(|event| {
+        event
+            .content
+            .as_deref()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
+            .and_then(|value| {
+                value
+                    .get("milestone")
+                    .and_then(|value| value.as_str())
+                    .map(ToString::to_string)
+            })
+            .as_deref()
+            == Some("task_submitted")
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_task_returns_joined_detail_payload() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
+
+    let create_body = serde_json::json!({ "prompt": "add tests" });
+    let create_resp = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(create_resp.status(), StatusCode::ACCEPTED);
+
+    use http_body_util::BodyExt;
+    let create_body = create_resp.into_body().collect().await?.to_bytes();
+    let create_json: serde_json::Value = serde_json::from_slice(&create_body)?;
+    let task_id = harness_core::types::TaskId(
+        create_json["task_id"]
+            .as_str()
+            .expect("task_id should be string")
+            .to_string(),
+    );
+
+    state
+        .core
+        .tasks
+        .save_prompt(&task_id, 1, "implement", "redacted prompt")
+        .await?;
+    state
+        .core
+        .tasks
+        .insert_artifact(&task_id, 1, "stdout", "artifact content")
+        .await;
+    state
+        .core
+        .tasks
+        .write_checkpoint(&task_id, Some("triage"), Some("plan"), None, "plan_done")
+        .await?;
+
+    let get_resp = task_app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{}", task_id.0))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(get_resp.status(), StatusCode::OK);
+
+    let get_body = get_resp.into_body().collect().await?.to_bytes();
+    let task_json: serde_json::Value = serde_json::from_slice(&get_body)?;
+    assert_eq!(task_json["id"], task_id.0);
+    assert_eq!(task_json["prompts"][0]["prompt"], "redacted prompt");
+    assert_eq!(task_json["artifacts"][0]["content"], "artifact content");
+    assert_eq!(task_json["completion"]["has_artifacts"], true);
+    assert_eq!(task_json["completion"]["has_prompts"], true);
+    assert_eq!(
+        task_json["completion"]["checkpoint"]["last_phase"],
+        "plan_done"
+    );    Ok(())
+}
+
+#[tokio::test]
 async fn intake_status_returns_three_channels() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -990,6 +990,7 @@ async fn create_task_records_operator_funnel_submission_event() -> anyhow::Resul
             .events
             .query(&harness_core::types::EventFilters {
                 hook: Some("operator_funnel".to_string()),
+                include_content: true,
                 ..Default::default()
             })
             .await?;
@@ -1079,7 +1080,8 @@ async fn get_task_returns_joined_detail_payload() -> anyhow::Result<()> {
     assert_eq!(
         task_json["completion"]["checkpoint"]["last_phase"],
         "plan_done"
-    );    Ok(())
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -93,6 +93,15 @@ impl TaskDb {
         Ok(rows)
     }
 
+    pub async fn count_artifacts(&self, task_id: &str) -> anyhow::Result<u64> {
+        let count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM task_artifacts WHERE task_id = $1")
+                .bind(task_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(count as u64)
+    }
+
     pub async fn save_task_prompt(
         &self,
         task_id: &str,
@@ -133,6 +142,15 @@ impl TaskDb {
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
+    }
+
+    pub async fn count_task_prompts(&self, task_id: &str) -> anyhow::Result<u64> {
+        let count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM task_prompts WHERE task_id = $1")
+                .bind(task_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(count as u64)
     }
 
     pub async fn pending_tasks_with_checkpoint(

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -749,6 +749,20 @@ impl TaskDb {
             .collect())
     }
 
+    /// Return the `created_at` of the earliest task that has started
+    /// (status in active/terminal set, or turn > 0), as an RFC-3339 string.
+    /// Returns `None` when no such task exists.
+    pub async fn earliest_started_created_at(&self) -> anyhow::Result<Option<String>> {
+        let dt: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
+            "SELECT MIN(created_at) FROM tasks \
+             WHERE status IN ('implementing', 'agent_review', 'waiting', 'reviewing', 'done', 'failed') \
+                OR turn > 0",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(dt.map(|t| t.to_rfc3339()))
+    }
+
     /// Expose the raw pool for test-only SQL setup (e.g. back-dating `updated_at`).
     #[cfg(test)]
     pub(crate) fn pool_for_test(&self) -> &sqlx::PgPool {

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -4,7 +4,8 @@ use harness_core::error::HarnessError;
 use harness_core::interceptor::{ToolUseEvent, TurnInterceptor};
 use harness_core::prompts;
 use harness_core::types::{
-    ContextItem, Decision, Item, SkillId, ThreadId, TokenUsage, TurnId, TurnStatus,
+    ContextItem, Decision, Event, Item, SessionId, SkillId, ThreadId, TokenUsage, TurnId,
+    TurnStatus,
 };
 use harness_protocol::{notifications::Notification, notifications::RpcNotification};
 use std::path::Path;
@@ -550,6 +551,7 @@ pub(crate) async fn run_agent_streaming(
     req: AgentRequest,
     task_id: &TaskId,
     store: &TaskStore,
+    events: &harness_observe::event_store::EventStore,
     turn: u32,
 ) -> harness_core::error::Result<(AgentResponse, Option<u64>)> {
     let turn_start = Instant::now();
@@ -594,6 +596,7 @@ pub(crate) async fn run_agent_streaming(
     let is_auto_fix_task = store
         .get(task_id)
         .is_some_and(|s| s.source.as_deref() == Some("auto-fix"));
+    let mut live_output_logged = false;
 
     loop {
         tokio::select! {
@@ -609,6 +612,31 @@ pub(crate) async fn run_agent_streaming(
                                 if first_token_latency_ms.is_none() {
                                     first_token_latency_ms =
                                         Some(turn_start.elapsed().as_millis() as u64);
+                                }
+                                if !live_output_logged && !text.trim().is_empty() {
+                                    let mut event = Event::new(
+                                        SessionId::new(),
+                                        "operator_funnel",
+                                        "task_runner",
+                                        Decision::Complete,
+                                    );
+                                    event.detail = Some("live_output_available".to_string());
+                                    event.content = Some(
+                                        serde_json::json!({
+                                            "milestone": "live_output_available",
+                                            "task_id": task_id.0,
+                                            "turn": turn,
+                                        })
+                                        .to_string(),
+                                    );
+                                    if let Err(e) = events.log(&event).await {
+                                        tracing::warn!(
+                                            task_id = %task_id,
+                                            turn,
+                                            "failed to log operator_funnel live_output_available event: {e}"
+                                        );
+                                    }
+                                    live_output_logged = true;
                                 }
                                 output.push_str(text);
 
@@ -669,6 +697,31 @@ pub(crate) async fn run_agent_streaming(
                                         task_id,
                                     )
                                     .await;
+                                }
+                                if !live_output_logged && !content.trim().is_empty() {
+                                    let mut event = Event::new(
+                                        SessionId::new(),
+                                        "operator_funnel",
+                                        "task_runner",
+                                        Decision::Complete,
+                                    );
+                                    event.detail = Some("live_output_available".to_string());
+                                    event.content = Some(
+                                        serde_json::json!({
+                                            "milestone": "live_output_available",
+                                            "task_id": task_id.0,
+                                            "turn": turn,
+                                        })
+                                        .to_string(),
+                                    );
+                                    if let Err(e) = events.log(&event).await {
+                                        tracing::warn!(
+                                            task_id = %task_id,
+                                            turn,
+                                            "failed to log operator_funnel live_output_available event: {e}"
+                                        );
+                                    }
+                                    live_output_logged = true;
                                 }
                             }
                             StreamItem::ItemCompleted { item: completed_item } => {

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -358,7 +358,7 @@ pub(crate) async fn run_implement_phase(
             }
             let raw = tokio::time::timeout(
                 turn_timeout,
-                run_agent_streaming(agent, impl_req.clone(), task_id, store, 1),
+                run_agent_streaming(agent, impl_req.clone(), task_id, store, events, 1),
             )
             .await;
             *turns_used += 1;

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -234,7 +234,7 @@ async fn run_non_implementation_task(
         }
         let raw = tokio::time::timeout(
             turn_timeout,
-            helpers::run_agent_streaming(agent, turn_req.clone(), task_id, store, 1),
+            helpers::run_agent_streaming(agent, turn_req.clone(), task_id, store, events, 1),
         )
         .await;
         *turns_used += 1;

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -534,7 +534,7 @@ pub(crate) async fn run_task(
             (None, prompts::TriageComplexity::Medium, 0u32)
         } else {
             triage_pipeline::run_triage_plan_pipeline(
-                agent, store, task_id, issue, &cargo_env, &project, req,
+                agent, store, task_id, &events, issue, &cargo_env, &project, req,
             )
             .await?
         }

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -80,6 +80,7 @@ pub(crate) async fn run_triage_plan_pipeline(
     agent: &dyn CodeAgent,
     store: &TaskStore,
     task_id: &TaskId,
+    events: &harness_observe::event_store::EventStore,
     issue: u64,
     cargo_env: &HashMap<String, String>,
     project: &Path,
@@ -104,7 +105,7 @@ pub(crate) async fn run_triage_plan_pipeline(
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
     let (triage_resp, _) = tokio::time::timeout(
         turn_timeout,
-        run_agent_streaming(agent, triage_req, task_id, store, 0),
+        run_agent_streaming(agent, triage_req, task_id, store, events, 0),
     )
     .await
     .map_err(|_| anyhow::anyhow!("triage phase timed out after {}s", req.turn_timeout_secs))?
@@ -170,7 +171,7 @@ pub(crate) async fn run_triage_plan_pipeline(
 
     let (plan_resp, _) = tokio::time::timeout(
         turn_timeout,
-        run_agent_streaming(agent, plan_req, task_id, store, 0),
+        run_agent_streaming(agent, plan_req, task_id, store, events, 0),
     )
     .await
     .map_err(|_| anyhow::anyhow!("plan phase timed out after {}s", req.turn_timeout_secs))?

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -3,6 +3,7 @@ mod request;
 pub(super) mod spawn;
 mod state;
 mod store;
+mod store_ext;
 mod types;
 
 // CompletionCallback references TaskState (state.rs) which depends on types.rs.

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -766,7 +766,59 @@ where
         store_watcher.close_task_stream(&id_watcher);
         if let Some(cb) = completion_callback {
             match store_watcher.get(&id_watcher) {
-                Some(final_state) => cb(final_state).await,
+                Some(final_state) => {
+                    let artifact_count = store_watcher
+                        .list_artifacts(&id_watcher)
+                        .await
+                        .map(|artifacts| artifacts.len())
+                        .unwrap_or(0);
+                    let prompt_count = store_watcher
+                        .get_prompts(&id_watcher)
+                        .await
+                        .map(|prompts| prompts.len())
+                        .unwrap_or(0);
+                    let checkpoint = store_watcher
+                        .load_checkpoint(&id_watcher)
+                        .await
+                        .ok()
+                        .flatten();
+                    let has_completion_evidence = final_state.pr_url.is_some()
+                        || artifact_count > 0
+                        || prompt_count > 0
+                        || checkpoint.as_ref().is_some_and(|checkpoint| {
+                            checkpoint.pr_url.is_some()
+                                || checkpoint.plan_output.is_some()
+                                || checkpoint.triage_output.is_some()
+                        });
+                    if has_completion_evidence {
+                        let task_id_value = id_watcher.0.clone();
+                        let mut event = Event::new(
+                            SessionId::new(),
+                            "operator_funnel",
+                            "task_runner",
+                            Decision::Complete,
+                        );
+                        event.detail = Some("completion_evidence_available".to_string());
+                        event.content = Some(
+                            serde_json::json!({
+                                "milestone": "completion_evidence_available",
+                                "task_id": task_id_value,
+                                "status": final_state.status.as_ref(),
+                                "pr_url": final_state.pr_url.clone(),
+                                "artifact_count": artifact_count,
+                                "prompt_count": prompt_count,
+                            })
+                            .to_string(),
+                        );
+                        if let Err(e) = events_watcher.log(&event).await {
+                            tracing::warn!(
+                                task_id = %id_watcher.0,
+                                "failed to log operator_funnel completion_evidence_available event: {e}"
+                            );
+                        }
+                    }
+                    cb(final_state).await
+                }
                 None => tracing::warn!(
                     "completion_callback: task {:?} not found in store after completion",
                     id_watcher

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -768,15 +768,10 @@ where
             match store_watcher.get(&id_watcher) {
                 Some(final_state) => {
                     let artifact_count = store_watcher
-                        .list_artifacts(&id_watcher)
+                        .count_artifacts(&id_watcher)
                         .await
-                        .map(|artifacts| artifacts.len())
                         .unwrap_or(0);
-                    let prompt_count = store_watcher
-                        .get_prompts(&id_watcher)
-                        .await
-                        .map(|prompts| prompts.len())
-                        .unwrap_or(0);
+                    let prompt_count = store_watcher.count_prompts(&id_watcher).await.unwrap_or(0);
                     let checkpoint = store_watcher
                         .load_checkpoint(&id_watcher)
                         .await
@@ -817,6 +812,7 @@ where
                             );
                         }
                     }
+
                     cb(final_state).await
                 }
                 None => tracing::warn!(

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -777,6 +777,11 @@ impl TaskStore {
         self.db.list_artifacts(&task_id.0).await
     }
 
+    /// Return the number of persisted artifacts for a task without loading them.
+    pub async fn count_artifacts(&self, task_id: &TaskId) -> anyhow::Result<u64> {
+        self.db.count_artifacts(&task_id.0).await
+    }
+
     /// Persist a redacted agent prompt for a task turn (fire-and-forget wrapper).
     pub(crate) async fn save_prompt(
         &self,
@@ -796,6 +801,11 @@ impl TaskStore {
         task_id: &TaskId,
     ) -> anyhow::Result<Vec<crate::task_db::TaskPrompt>> {
         self.db.get_task_prompts(&task_id.0).await
+    }
+
+    /// Return the number of persisted prompts for a task without loading them.
+    pub async fn count_prompts(&self, task_id: &TaskId) -> anyhow::Result<u64> {
+        self.db.count_task_prompts(&task_id.0).await
     }
 
     /// Append a [`TaskEvent`] to the event log. No-op when the log is not open.
@@ -1599,6 +1609,26 @@ mod tests {
         let key = root.to_string_lossy().into_owned();
         assert_eq!(counts.by_project[&key].done, 1);
         assert_eq!(counts.by_project[&key].failed, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prompt_and_artifact_counts_use_persisted_rows() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let task_id = harness_core::types::TaskId("counted".to_string());
+
+        store
+            .insert_artifact(&task_id, 1, "log", "artifact-one")
+            .await;
+        store
+            .insert_artifact(&task_id, 2, "log", "artifact-two")
+            .await;
+        store.save_prompt(&task_id, 1, "plan", "prompt-one").await?;
+        store.save_prompt(&task_id, 2, "impl", "prompt-two").await?;
+
+        assert_eq!(store.count_artifacts(&task_id).await?, 2);
+        assert_eq!(store.count_prompts(&task_id).await?, 2);
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner/store_ext.rs
+++ b/crates/harness-server/src/task_runner/store_ext.rs
@@ -1,0 +1,38 @@
+use super::{store::TaskStore, types::TaskStatus};
+
+impl TaskStore {
+    /// Return the earliest `created_at` (RFC-3339) of any task that has started
+    /// (active/terminal status or turn > 0). Checks both the DB and the live cache.
+    /// Returns `None` when no started task exists yet.
+    pub async fn earliest_started_task_created_at(&self) -> Option<String> {
+        let cache_min = self
+            .cache
+            .iter()
+            .filter(|entry| {
+                let v = entry.value();
+                matches!(
+                    v.status,
+                    TaskStatus::Implementing
+                        | TaskStatus::AgentReview
+                        | TaskStatus::Waiting
+                        | TaskStatus::Reviewing
+                        | TaskStatus::Done
+                        | TaskStatus::Failed
+                ) || v.turn > 0
+            })
+            .filter_map(|entry| entry.value().created_at.clone())
+            .min();
+        let db_min = match self.db.earliest_started_created_at().await {
+            Ok(min) => min,
+            Err(e) => {
+                tracing::warn!("failed to query earliest started task: {e}");
+                None
+            }
+        };
+        match (cache_min, db_min) {
+            (Some(a), Some(b)) => Some(if a <= b { a } else { b }),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        }
+    }
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -22,6 +22,7 @@ observes results. The following capabilities are **only available over HTTP**:
 | `POST /tasks/batch` | batch create | Enqueue multiple tasks at once |
 | `GET  /tasks/{id}` | get | Fetch task details |
 | `GET  /tasks/{id}/stream` | stream | Server-Sent Events live output |
+| `POST /projects/validate` | validate | Validate a project root and preview canonical metadata |
 | `POST /projects` | register | Register a project root |
 | `GET  /projects` | list | List registered projects |
 | `GET  /projects/{id}` | get | Get project details |
@@ -43,6 +44,46 @@ clients that cannot set `Authorization` headers on WebSocket upgrades or
 top-level navigation requests, `/ws` and `/` additionally accept a
 `?token=<value>` query parameter as a fallback; all other routes only accept
 `Authorization: Bearer <token>`.
+
+### Operator first-run flow
+
+The web product uses the HTTP control plane for a single guided loop:
+
+1. `POST /projects/validate` previews the canonical root, detected project id,
+   inferred display name, and detected repo slug before registration.
+2. `POST /projects` reuses the same validation path and persists the project
+   record. Re-registering the same root is idempotent and returns the existing
+   canonical project id.
+3. `POST /tasks` returns a UI-friendly payload with `task_id`, `deduped`, and
+   `task_url`, so the operator can navigate straight into `/?task=<id>`.
+4. `GET /tasks/{id}` returns one joined payload for the task state, workflow
+   state, prompts, artifacts, and completion summary.
+5. `GET /tasks/{id}/stream` remains the live SSE channel for in-flight output.
+6. `GET /api/dashboard` now includes `first_run`, `onboarding`, and `funnel`
+   so the client does not infer onboarding state on its own.
+
+Example validation response:
+
+```json
+{
+  "canonical_root": "/srv/repos/harness",
+  "project_id": "/srv/repos/harness",
+  "display_name": "harness",
+  "repo": "majiayu000/harness",
+  "errors": []
+}
+```
+
+Example task-create response:
+
+```json
+{
+  "task_id": "7d4f0f4f-5e94-4df2-a8d2-6d3374cce936",
+  "status": "pending",
+  "deduped": false,
+  "task_url": "/?task=7d4f0f4f-5e94-4df2-a8d2-6d3374cce936"
+}
+```
 
 ### JSON-RPC 2.0 — agent-facing (data plane)
 
@@ -132,6 +173,7 @@ The design is intentional:
 |---|---|
 | Submit a task from a CI script | `POST /tasks` (HTTP) |
 | Stream live output from a running task | `GET /tasks/{id}/stream` (HTTP SSE) |
+| Validate a repository root before registration | `POST /projects/validate` (HTTP) |
 | Register a new project | `POST /projects` (HTTP) |
 | Run an agent thread interactively | `turn/start` (JSON-RPC) |
 | Inspect or cancel a running turn | `turn/status` / `turn/cancel` (JSON-RPC) |

--- a/web/src/components/ProjectsTable.tsx
+++ b/web/src/components/ProjectsTable.tsx
@@ -28,8 +28,27 @@ export function ProjectsTable({ projects }: Props) {
 
   if (!projects.length) {
     return (
-      <div className="px-5 py-5 text-ink-4 font-mono text-[11px]">
-        no projects registered yet — register one via POST /projects
+      <div className="px-5 py-5">
+        <div className="text-[13px] text-ink">No projects registered yet.</div>
+        <div className="mt-2 text-ink-3 text-[12px] max-w-[560px]">
+          Start with the guided setup flow, validate the repository root, then launch a sample operator task from the dashboard.
+        </div>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={() => nav("/")}
+            className="px-3 py-1.5 bg-rust text-white font-mono text-[12px]"
+          >
+            Register a project
+          </button>
+          <button
+            type="button"
+            onClick={() => nav("/")}
+            className="px-3 py-1.5 border border-line-2 bg-bg text-ink font-mono text-[12px]"
+          >
+            Try a sample task
+          </button>
+        </div>
       </div>
     );
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,7 @@ export class ApiError extends Error {
   constructor(
     public readonly status: number,
     message: string,
+    public readonly details?: unknown,
   ) {
     super(message);
     this.name = "ApiError";
@@ -43,7 +44,23 @@ export async function apiFetch(
     throw new ApiError(401, `${path} → 401`);
   }
   if (!resp.ok) {
-    throw new ApiError(resp.status, `${path} → HTTP ${resp.status}`);
+    let body: unknown = null;
+    let message = `${path} → HTTP ${resp.status}`;
+    try {
+      body = await resp.clone().json();
+      if (body && typeof body === "object") {
+        const error = "error" in body ? body.error : undefined;
+        const errors = "errors" in body ? body.errors : undefined;
+        if (typeof error === "string" && error.trim()) {
+          message = error;
+        } else if (Array.isArray(errors) && typeof errors[0] === "string") {
+          message = errors[0];
+        }
+      }
+    } catch {
+      // Non-JSON error bodies fall back to the HTTP status message above.
+    }
+    throw new ApiError(resp.status, message, body);
   }
   return resp;
 }

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiJson } from "./api";
-import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task } from "@/types";
+import type {
+  CreateTaskResponse,
+  DashboardPayload,
+  OperatorSnapshotPayload,
+  OverviewPayload,
+  ProjectValidationResult,
+  RegisterProjectResponse,
+  RegisteredProject,
+  Task,
+  TaskArtifactRecord,
+  TaskDetail,
+  TaskPromptRecord,
+} from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -28,6 +40,85 @@ export function useTasks() {
   return useQuery<Task[], Error>({
     queryKey: ["tasks"],
     queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
+  });
+}
+
+export function useProjects() {
+  return useQuery<RegisteredProject[], Error>({
+    queryKey: ["projects"],
+    queryFn: ({ signal }) => apiJson<RegisteredProject[]>("/projects", { signal }),
+  });
+}
+
+export function useTaskDetail(taskId: string | null) {
+  return useQuery<TaskDetail, Error>({
+    queryKey: ["task-detail", taskId],
+    queryFn: ({ signal }) => apiJson<TaskDetail>(`/tasks/${taskId}`, { signal }),
+    enabled: Boolean(taskId),
+  });
+}
+
+export function useTaskArtifacts(taskId: string | null) {
+  return useQuery<TaskArtifactRecord[], Error>({
+    queryKey: ["task-artifacts", taskId],
+    queryFn: ({ signal }) => apiJson<TaskArtifactRecord[]>(`/tasks/${taskId}/artifacts`, { signal }),
+    enabled: Boolean(taskId),
+  });
+}
+
+export function useTaskPrompts(taskId: string | null) {
+  return useQuery<TaskPromptRecord[], Error>({
+    queryKey: ["task-prompts", taskId],
+    queryFn: ({ signal }) => apiJson<TaskPromptRecord[]>(`/tasks/${taskId}/prompts`, { signal }),
+    enabled: Boolean(taskId),
+  });
+}
+
+export function useValidateProject() {
+  return useMutation<ProjectValidationResult, Error, { root: string }>({
+    mutationFn: async ({ root }) =>
+      apiJson<ProjectValidationResult>("/projects/validate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ root }),
+      }),
+  });
+}
+
+export function useRegisterProject() {
+  const queryClient = useQueryClient();
+  return useMutation<RegisterProjectResponse, Error, { root: string }>({
+    mutationFn: async ({ root }) =>
+      apiJson<RegisterProjectResponse>("/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ root }),
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+        queryClient.invalidateQueries({ queryKey: ["overview"] }),
+      ]);
+    },
+  });
+}
+
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+  return useMutation<CreateTaskResponse, Error, { prompt: string; project?: string }>({
+    mutationFn: async ({ prompt, project }) =>
+      apiJson<CreateTaskResponse>("/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt, project }),
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["tasks"] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+      ]);
+    },
   });
 }
 

--- a/web/src/routes/Dashboard.test.tsx
+++ b/web/src/routes/Dashboard.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { Dashboard } from "./Dashboard";
+import { PaletteProvider } from "@/lib/palette";
+
+vi.mock("@/lib/queries", () => ({
+  useDashboard: vi.fn(),
+  useTasks: vi.fn(),
+}));
+
+vi.mock("./dashboard/Active", () => ({
+  Active: ({ selectedTaskId }: { selectedTaskId: string | null }) => <div>active {selectedTaskId}</div>,
+}));
+
+vi.mock("./dashboard/History", () => ({
+  History: ({ selectedTaskId }: { selectedTaskId: string | null }) => <div>history {selectedTaskId}</div>,
+}));
+
+vi.mock("./dashboard/Channels", () => ({
+  Channels: () => <div>channels</div>,
+}));
+
+vi.mock("./dashboard/Submit", () => ({
+  Submit: () => <div>submit</div>,
+}));
+
+import { useDashboard, useTasks } from "@/lib/queries";
+
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
+const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+
+describe("<Dashboard>", () => {
+  beforeEach(() => {
+    mockUseDashboard.mockReturnValue({
+      data: {
+        onboarding: { phase: "complete" },
+      },
+      isError: false,
+    });
+    mockUseTasks.mockReturnValue({ data: [] });
+  });
+
+  it("routes first-run users into the guided submit flow", () => {
+    mockUseDashboard.mockReturnValue({
+      data: {
+        onboarding: { phase: "register_project" },
+      },
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <PaletteProvider>
+          <Dashboard />
+        </PaletteProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("submit")).toBeInTheDocument();
+  });
+
+  it("opens the live board for ?task deep links", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", status: "implementing" }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/?task=task-1"]}>
+        <PaletteProvider>
+          <Dashboard />
+        </PaletteProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("active task-1")).toBeInTheDocument();
+  });
+
+  it("routes terminal deep links to history", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-2", status: "done" }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/?task=task-2"]}>
+        <PaletteProvider>
+          <Dashboard />
+        </PaletteProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("history task-2")).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -8,15 +8,36 @@ import { Active } from "./dashboard/Active";
 import { History } from "./dashboard/History";
 import { Channels } from "./dashboard/Channels";
 import { Submit } from "./dashboard/Submit";
-import { useDashboard } from "@/lib/queries";
+import { useDashboard, useTasks } from "@/lib/queries";
 
 type Tab = "board" | "history" | "channels" | "submit";
 
 export function Dashboard() {
-  const [tab, setTab] = useState<Tab>("board");
-  const { isError } = useDashboard();
-  const [searchParams] = useSearchParams();
+  const [manualTab, setManualTab] = useState<Tab | null>(null);
+  const { data: dashboard, isError } = useDashboard();
+  const { data: tasks } = useTasks();
+  const [searchParams, setSearchParams] = useSearchParams();
   const projectFilter = searchParams.get("project");
+  const selectedTaskId = searchParams.get("task");
+  const selectedTask = (tasks ?? []).find((task) => task.id === selectedTaskId) ?? null;
+  const selectedTaskTerminal = selectedTask
+    ? ["done", "failed", "cancelled"].includes(selectedTask.status)
+    : false;
+  const derivedTab: Tab = selectedTaskId
+    ? selectedTaskTerminal
+      ? "history"
+      : "board"
+    : dashboard?.onboarding.phase === "register_project" ||
+        dashboard?.onboarding.phase === "submit_task"
+      ? "submit"
+      : "board";
+  const tab = manualTab ?? derivedTab;
+
+  function handleSelectTask(taskId: string) {
+    const next = new URLSearchParams(searchParams);
+    next.set("task", taskId);
+    setSearchParams(next);
+  }
 
   const sections: SidebarSection[] = [
     {
@@ -39,7 +60,7 @@ export function Dashboard() {
       <Sidebar
         env="local"
         sections={sections}
-        onItemClick={(id) => setTab(id as Tab)}
+        onItemClick={(id) => setManualTab(id as Tab)}
       />
       <main className="flex flex-col min-h-0 min-w-0">
         <TopBar
@@ -52,8 +73,20 @@ export function Dashboard() {
           actions={<StatusBadge ok={!isError} />}
         />
         <div className="flex-1 overflow-auto min-h-0 p-6">
-          {tab === "board" && <Active projectFilter={projectFilter} />}
-          {tab === "history" && <History projectFilter={projectFilter} />}
+          {tab === "board" && (
+            <Active
+              projectFilter={projectFilter}
+              selectedTaskId={selectedTaskId}
+              onSelectTask={handleSelectTask}
+            />
+          )}
+          {tab === "history" && (
+            <History
+              projectFilter={projectFilter}
+              selectedTaskId={selectedTaskId}
+              onSelectTask={handleSelectTask}
+            />
+          )}
           {tab === "channels" && <Channels projectFilter={projectFilter} />}
           {tab === "submit" && <Submit projectFilter={projectFilter} />}
         </div>

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -7,12 +7,14 @@ import { PaletteProvider } from "@/lib/palette";
 import type { OperatorSnapshotPayload, OverviewPayload } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
+  useDashboard: vi.fn(),
   useOverview: vi.fn(),
   useOperatorSnapshot: vi.fn(),
 }));
 
-import { useOperatorSnapshot, useOverview } from "@/lib/queries";
+import { useDashboard, useOperatorSnapshot, useOverview } from "@/lib/queries";
 
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
 const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
 const mockUseOperatorSnapshot = useOperatorSnapshot as ReturnType<typeof vi.fn>;
 
@@ -99,6 +101,7 @@ function makeSnapshot(): OperatorSnapshotPayload {
 
 describe("<Overview>", () => {
   it("shows a degraded status badge when operator snapshot fails even if overview succeeds", () => {
+    mockUseDashboard.mockReturnValue({ data: { first_run: false } });
     mockUseOverview.mockReturnValue({
       data: makeOverview(),
       isError: false,
@@ -115,6 +118,7 @@ describe("<Overview>", () => {
   });
 
   it("shows a healthy status badge only when both overview and operator snapshot succeed", () => {
+    mockUseDashboard.mockReturnValue({ data: { first_run: false } });
     mockUseOverview.mockReturnValue({
       data: makeOverview(),
       isError: false,

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -10,7 +10,7 @@ import { Feed } from "@/components/Feed";
 import { AlertList } from "@/components/AlertList";
 import { StatusBadge } from "@/components/StatusBadge";
 import { PaletteFab } from "@/components/PaletteFab";
-import { useOperatorSnapshot, useOverview } from "@/lib/queries";
+import { useDashboard, useOperatorSnapshot, useOverview } from "@/lib/queries";
 import { OperatorPanel } from "./overview/OperatorPanel";
 import { fmtInt, fmtPct, fmtScore } from "@/lib/format";
 
@@ -25,6 +25,7 @@ const SERIES_COLORS = [
 
 export function Overview() {
   const { data, isError } = useOverview();
+  const { data: dashboard } = useDashboard();
   const { isError: isOperatorSnapshotError } = useOperatorSnapshot();
   const isSystemHealthy = !isError && !isOperatorSnapshotError;
 
@@ -79,6 +80,19 @@ export function Overview() {
           </div>
 
           <div className="grid grid-cols-6 border-b border-line">
+            {dashboard?.first_run ? (
+              <div className="col-span-6 border-b border-line bg-rust/8 px-6 py-5">
+                <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-rust">
+                  First run
+                </div>
+                <div className="mt-2 text-[18px] text-ink">
+                  Register a project, submit one focused task, then inspect the proof of work.
+                </div>
+                <div className="mt-2 text-[13px] text-ink-2 max-w-[760px]">
+                  The control-plane metrics below are most useful after you complete the first operator loop. Use the dashboard setup flow first if you have not seen a live run yet.
+                </div>
+              </div>
+            ) : null}
             <KpiCard label="Active tasks" value={fmtInt(data?.kpi.active_tasks)} delta={`window ${data?.window.hours ?? 24}h`} />
             <KpiCard label="Merged · 24h" value={fmtInt(data?.kpi.merged_24h)} delta="in window" />
             <KpiCard

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -125,7 +125,7 @@ describe("<Active>", () => {
       isLoading: false,
       isError: false,
     });
-    wrap(<Active />);
+    wrap(<Active selectedTaskId={null} onSelectTask={vi.fn()} />);
     expect(screen.getByText("Planning")).toBeInTheDocument();
     expect(screen.getByText("Review")).toBeInTheDocument();
     expect(screen.getByText("planner-task")).toBeInTheDocument();

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/lib/queries", () => ({
   useDashboard: vi.fn(),
 }));
 
+vi.mock("./TaskDetailPanel", () => ({
+  TaskDetailPanel: () => <div>task detail</div>,
+}));
+
 import { useTasks, useDashboard } from "@/lib/queries";
 
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
@@ -66,7 +70,7 @@ describe("<Active>", () => {
 
   it("filters to matching project when projectFilter is set", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active projectFilter="harness" />);
+    wrap(<Active projectFilter="harness" selectedTaskId={null} onSelectTask={vi.fn()} />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
@@ -75,7 +79,7 @@ describe("<Active>", () => {
 
   it("shows all non-terminal tasks when no projectFilter", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active />);
+    wrap(<Active selectedTaskId={null} onSelectTask={vi.fn()} />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t2")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
@@ -84,7 +88,7 @@ describe("<Active>", () => {
 
   it("shows empty columns when projectFilter matches no tasks", () => {
     mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
-    wrap(<Active projectFilter="nonexistent" />);
+    wrap(<Active projectFilter="nonexistent" selectedTaskId={null} onSelectTask={vi.fn()} />);
     expect(screen.queryByText("t1")).not.toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
     const dashes = screen.getAllByText("—");
@@ -101,7 +105,7 @@ describe("<Active>", () => {
       workflow: { state: "addressing_feedback", pr_number: 124 },
     };
     mockUseTasks.mockReturnValue({ data: [ready, feedback], isLoading: false, isError: false });
-    wrap(<Active projectFilter="harness" />);
+    wrap(<Active projectFilter="harness" selectedTaskId={null} onSelectTask={vi.fn()} />);
 
     expect(screen.getByText("wf Ready To Merge")).toBeInTheDocument();
     expect(screen.getByText("wf Addressing Feedback")).toBeInTheDocument();

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,5 +1,6 @@
 import { useTasks, useDashboard } from "@/lib/queries";
 import type { Task, WorkflowSummary } from "@/types";
+import { TaskDetailPanel } from "./TaskDetailPanel";
 
 interface Column {
   key: string;
@@ -118,10 +119,26 @@ function workflowLabel(state: string): string {
   }
 }
 
-function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary | null }) {
+function TaskCard({
+  task,
+  workflow,
+  selected,
+  onSelect,
+}: {
+  task: Task;
+  workflow?: WorkflowSummary | null;
+  selected: boolean;
+  onSelect: (taskId: string) => void;
+}) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
-    <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
+    <button
+      type="button"
+      onClick={() => onSelect(task.id)}
+      className={`w-full border bg-bg px-2.5 py-2 mb-2 last:mb-0 text-left transition-colors ${
+        selected ? "border-rust" : "border-line hover:border-line-3"
+      }`}
+    >
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
         {title}
       </div>
@@ -163,15 +180,17 @@ function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary |
           {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
         </a>
       )}
-    </div>
+    </button>
   );
 }
 
 interface Props {
   projectFilter?: string | null;
+  selectedTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
 }
 
-export function Active({ projectFilter }: Props) {
+export function Active({ projectFilter, selectedTaskId, onSelectTask }: Props) {
   const { data, isLoading, isError } = useTasks();
   const { data: dashboard } = useDashboard();
 
@@ -194,44 +213,59 @@ export function Active({ projectFilter }: Props) {
   const showOther = other.length > 0;
 
   return (
-    <div
-      className="grid gap-3"
-      style={{ gridTemplateColumns: `repeat(${COLUMNS.length + (showOther ? 1 : 0)}, 1fr)` }}
-    >
-      {COLUMNS.map((col) => {
-        const rows = grouped[col.key];
-        return (
-          <div key={col.key} className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_380px]">
+      <div
+        className="grid gap-3"
+        style={{ gridTemplateColumns: `repeat(${COLUMNS.length + (showOther ? 1 : 0)}, minmax(180px, 1fr))` }}
+      >
+        {COLUMNS.map((col) => {
+          const rows = grouped[col.key];
+          return (
+            <div key={col.key} className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
+              <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
+                <span>{col.label}</span>
+                <span className="text-ink-2">{rows.length}</span>
+              </div>
+              <div className="p-2 flex-1 overflow-auto">
+                {rows.length === 0 && (
+                  <div className="text-ink-4 font-mono text-[11px] p-1">
+                    {isLoading ? "loading…" : isError ? "error" : "—"}
+                  </div>
+                )}
+                {rows.map((t) => (
+                  <TaskCard
+                    key={t.id}
+                    task={t}
+                    workflow={t.workflow ?? null}
+                    selected={selectedTaskId === t.id}
+                    onSelect={onSelectTask}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {showOther && (
+          <div className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
             <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
-              <span>{col.label}</span>
-              <span className="text-ink-2">{rows.length}</span>
+              <span>Other</span>
+              <span className="text-ink-2">{other.length}</span>
             </div>
-            <div className="p-2 flex-1 overflow-auto">
-              {rows.length === 0 && (
-                <div className="text-ink-4 font-mono text-[11px] p-1">
-                  {isLoading ? "loading…" : isError ? "error" : "—"}
-                </div>
-              )}
-              {rows.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
-              ))}
-            </div>
-          </div>
-        );
-      })}
-      {showOther && (
-        <div className="border border-line bg-bg-1 min-h-[200px] flex flex-col">
-          <div className="px-3 py-2 border-b border-line font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 flex justify-between flex-none">
-            <span>Other</span>
-            <span className="text-ink-2">{other.length}</span>
-          </div>
             <div className="p-2 flex-1 overflow-auto">
               {other.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+                <TaskCard
+                  key={t.id}
+                  task={t}
+                  workflow={t.workflow ?? null}
+                  selected={selectedTaskId === t.id}
+                  onSelect={onSelectTask}
+                />
               ))}
             </div>
           </div>
-      )}
+        )}
+      </div>
+      <TaskDetailPanel taskId={selectedTaskId} />
     </div>
   );
 }

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { History } from "./History";
+
+vi.mock("@/lib/queries", () => ({
+  useTasks: vi.fn(),
+  useTaskDetail: vi.fn(),
+  useTaskArtifacts: vi.fn(),
+  useTaskPrompts: vi.fn(),
+}));
+
+import { useTaskArtifacts, useTaskDetail, useTaskPrompts, useTasks } from "@/lib/queries";
+
+const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+const mockUseTaskDetail = useTaskDetail as ReturnType<typeof vi.fn>;
+const mockUseTaskArtifacts = useTaskArtifacts as ReturnType<typeof vi.fn>;
+const mockUseTaskPrompts = useTaskPrompts as ReturnType<typeof vi.fn>;
+
+function renderHistory(selectedTaskId: string | null, onSelectTask = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <History selectedTaskId={selectedTaskId} onSelectTask={onSelectTask} />
+    </MemoryRouter>,
+  );
+}
+
+describe("<History>", () => {
+  beforeEach(() => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", status: "done", description: "Ship docs", project: "/srv/repos/harness", pr_url: null }],
+      isLoading: false,
+      isError: false,
+    });
+    mockUseTaskArtifacts.mockReturnValue({ data: [] });
+    mockUseTaskPrompts.mockReturnValue({ data: [] });
+    mockUseTaskDetail.mockReturnValue({
+      isLoading: false,
+      data: {
+        id: "task-1",
+        status: "done",
+        turn: 1,
+        pr_url: null,
+        error: null,
+        source: null,
+        parent_id: null,
+        external_id: null,
+        repo: null,
+        description: "Ship docs",
+        created_at: null,
+        phase: "terminal",
+        depends_on: [],
+        subtask_ids: [],
+        project: "/srv/repos/harness",
+        rounds: [],
+        prompts: [],
+        artifacts: [],
+        completion: {
+          is_terminal: true,
+          status: "done",
+          has_pr: false,
+          has_artifacts: false,
+          has_prompts: false,
+          pr_url: null,
+          latest_artifact_at: null,
+          latest_prompt_at: null,
+          checkpoint: null,
+        },
+        workflow: null,
+      },
+    });
+  });
+
+  it("reopens completed tasks through the shared detail panel", () => {
+    const onSelectTask = vi.fn();
+    renderHistory(null, onSelectTask);
+
+    fireEvent.click(screen.getByRole("button", { name: /ship docs/i }));
+    expect(onSelectTask).toHaveBeenCalledWith("task-1");
+  });
+
+  it("renders explicit not-available states when completion evidence is missing", () => {
+    renderHistory("task-1");
+    expect(screen.getAllByText("Not available yet").length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,47 +1,88 @@
 import { useState } from "react";
-import { useDashboard } from "@/lib/queries";
+import { useTasks } from "@/lib/queries";
+import { TaskDetailPanel } from "./TaskDetailPanel";
 
 interface Props {
   projectFilter?: string | null;
+  selectedTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
 }
 
-export function History({ projectFilter }: Props) {
-  const { data } = useDashboard();
+const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
+
+export function History({ projectFilter, selectedTaskId, onSelectTask }: Props) {
+  const { data, isLoading, isError } = useTasks();
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
-  const scopedProject = projectFilter ? (data?.projects.find((p) => p.id === projectFilter) ?? null) : null;
-  const totalDone = projectFilter
-    ? (scopedProject?.tasks.done ?? 0)
-    : (data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0);
-  const totalFailed = projectFilter
-    ? (scopedProject?.tasks.failed ?? 0)
-    : (data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0);
+  const normalizedQuery = query.trim().toLowerCase();
+  const rows = (data ?? [])
+    .filter((task) => TERMINAL_STATUSES.has(task.status))
+    .filter((task) => !projectFilter || task.project === projectFilter)
+    .filter((task) => filter === "all" || task.status === filter)
+    .filter((task) => {
+      if (!normalizedQuery) return true;
+      const haystack = `${task.description ?? ""} ${task.repo ?? ""} ${task.id}`.toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
 
   return (
-    <div>
-      <div className="flex gap-2 mb-4">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search history…"
-          className="flex-1 h-[30px] bg-bg-1 border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-        <select
-          value={filter}
-          onChange={(e) => setFilter(e.target.value as "all" | "done" | "failed")}
-          className="h-[30px] bg-bg-1 border border-line-2 text-ink font-mono text-[12px] px-2 rounded-[3px]"
-        >
-          <option value="all">All</option>
-          <option value="done">Done</option>
-          <option value="failed">Failed</option>
-        </select>
-      </div>
-      <div className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">
-        done {totalDone} · failed {totalFailed} · filter {filter} · query {query || "(none)"}
-        <div className="mt-3 text-ink-4 text-[11px]">
-          Task list endpoint is /tasks; cursor-based pagination TBD in a separate PR.
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+      <div>
+        <div className="flex gap-2 mb-4">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search history…"
+            className="flex-1 h-[30px] bg-bg-1 border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+          />
+          <select
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as "all" | "done" | "failed")}
+            className="h-[30px] bg-bg-1 border border-line-2 text-ink font-mono text-[12px] px-2 rounded-[3px]"
+          >
+            <option value="all">All</option>
+            <option value="done">Done</option>
+            <option value="failed">Failed</option>
+          </select>
+        </div>
+        <div className="border border-line bg-bg-1">
+          {isLoading ? (
+            <div className="p-4 font-mono text-[12px] text-ink-3">Loading recent tasks…</div>
+          ) : isError ? (
+            <div className="p-4 font-mono text-[12px] text-rust">Failed to load recent tasks.</div>
+          ) : rows.length === 0 ? (
+            <div className="p-4 font-mono text-[12px] text-ink-3">No completed tasks yet.</div>
+          ) : (
+            <div className="divide-y divide-line">
+              {rows.map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => onSelectTask(task.id)}
+                  className={`w-full px-4 py-3 text-left transition-colors ${
+                    selectedTaskId === task.id ? "bg-rust/10" : "hover:bg-bg"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="text-[13px] text-ink">
+                        {task.description?.trim() || task.repo || task.id}
+                      </div>
+                      <div className="mt-1 font-mono text-[11px] text-ink-3">
+                        {task.status} · {task.project ?? "no project"}
+                      </div>
+                    </div>
+                    {task.pr_url ? (
+                      <span className="font-mono text-[11px] text-rust">PR</span>
+                    ) : null}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
+      <TaskDetailPanel taskId={selectedTaskId} />
     </div>
   );
 }

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Submit } from "./Submit";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/lib/queries", () => ({
+  useDashboard: vi.fn(),
+  useProjects: vi.fn(),
+  useValidateProject: vi.fn(),
+  useRegisterProject: vi.fn(),
+  useCreateTask: vi.fn(),
+}));
+
+import {
+  useCreateTask,
+  useDashboard,
+  useProjects,
+  useRegisterProject,
+  useValidateProject,
+} from "@/lib/queries";
+
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
+const mockUseProjects = useProjects as ReturnType<typeof vi.fn>;
+const mockUseValidateProject = useValidateProject as ReturnType<typeof vi.fn>;
+const mockUseRegisterProject = useRegisterProject as ReturnType<typeof vi.fn>;
+const mockUseCreateTask = useCreateTask as ReturnType<typeof vi.fn>;
+
+function renderSubmit() {
+  return render(
+    <MemoryRouter>
+      <Submit />
+    </MemoryRouter>,
+  );
+}
+
+describe("<Submit>", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockUseDashboard.mockReturnValue({ data: { onboarding: { phase: "submit_task" } } });
+    mockUseProjects.mockReturnValue({
+      data: [{ id: "project-1", root: "/srv/repos/harness", name: "harness" }],
+    });
+    mockUseValidateProject.mockReturnValue({
+      isPending: false,
+      data: undefined,
+      variables: undefined,
+      mutateAsync: vi.fn(),
+    });
+    mockUseRegisterProject.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    mockUseCreateTask.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        task_id: "task-1",
+        status: "running",
+        deduped: false,
+        task_url: "/?task=task-1",
+      }),
+    });
+  });
+
+  it("renders a project picker when projects exist", () => {
+    renderSubmit();
+    expect(screen.getByDisplayValue("harness")).toBeInTheDocument();
+  });
+
+  it("applies starter templates to the form", () => {
+    renderSubmit();
+    fireEvent.click(screen.getByRole("button", { name: "Polish README" }));
+    expect(screen.getByDisplayValue("Improve the onboarding docs")).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/first-run documentation/i)).toBeInTheDocument();
+  });
+
+  it("renders validation failures from the server", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error("root is not a git repository"));
+    mockUseValidateProject.mockReturnValue({
+      isPending: false,
+      data: undefined,
+      variables: undefined,
+      mutateAsync,
+    });
+
+    renderSubmit();
+    fireEvent.change(screen.getByPlaceholderText("/absolute/path/to/your/repository"), {
+      target: { value: "/tmp/not-a-repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("root is not a git repository")).toBeInTheDocument(),
+    );
+  });
+
+  it("submits a task and redirects into the selected task", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({
+      task_id: "task-7",
+      status: "running",
+      deduped: false,
+      task_url: "/?task=task-7",
+    });
+    mockUseCreateTask.mockReturnValue({
+      isPending: false,
+      mutateAsync,
+    });
+
+    renderSubmit();
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Investigate a failure" },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Find the root cause and add coverage." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit task" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledOnce());
+    expect(mockNavigate).toHaveBeenCalledWith("/?task=task-7");
+  });
+});

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -1,84 +1,300 @@
-import { useState, useEffect } from "react";
-import { apiFetch } from "@/lib/api";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  useCreateTask,
+  useDashboard,
+  useProjects,
+  useRegisterProject,
+  useValidateProject,
+} from "@/lib/queries";
 
 interface Props {
   projectFilter?: string | null;
 }
 
+interface StarterTemplate {
+  id: string;
+  label: string;
+  title: string;
+  description: string;
+}
+
+const STARTER_TEMPLATES: StarterTemplate[] = [
+  {
+    id: "readme",
+    label: "Polish README",
+    title: "Improve the onboarding docs",
+    description: "Tighten the first-run documentation, keep the scope minimal, and verify the operator flow still matches the product.",
+  },
+  {
+    id: "test",
+    label: "Add coverage",
+    title: "Add focused regression coverage",
+    description: "Find the smallest missing test for a recent behavior change, implement it, and keep the rest of the code untouched.",
+  },
+  {
+    id: "bugfix",
+    label: "Fix a bug",
+    title: "Investigate and fix a concrete bug",
+    description: "Diagnose the root cause first, then apply the smallest safe fix and validate it with the relevant tests.",
+  },
+];
+
+function projectLabel(project: { id: string; name?: string | null; root: string }): string {
+  return project.name?.trim() || project.root.split("/").filter(Boolean).at(-1) || project.id;
+}
+
 export function Submit({ projectFilter }: Props) {
+  const navigate = useNavigate();
+  const dashboard = useDashboard();
+  const projects = useProjects();
+  const validateProject = useValidateProject();
+  const registerProject = useRegisterProject();
+  const createTask = useCreateTask();
+
+  const [root, setRoot] = useState("");
+  const [selectedProject, setSelectedProject] = useState("");
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
-  const [project, setProject] = useState(projectFilter ?? "");
-  const [msg, setMsg] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const availableProjects = projects.data ?? [];
+  const canSubmit = selectedProject.trim() && title.trim() && desc.trim();
+  const activeValidation =
+    validateProject.data && root.trim() === validateProject.variables?.root ? validateProject.data : null;
 
   useEffect(() => {
-    setProject(projectFilter ?? "");
-  }, [projectFilter]);
+    if (!availableProjects.length) {
+      setSelectedProject("");
+      return;
+    }
+    if (projectFilter) {
+      const match = availableProjects.find(
+        (project) => project.id === projectFilter || project.root === projectFilter,
+      );
+      if (match) {
+        setSelectedProject(match.id);
+        return;
+      }
+    }
+    setSelectedProject((current) => current || availableProjects[0].id);
+  }, [availableProjects, projectFilter]);
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!title.trim() || !desc.trim()) return;
-    setBusy(true);
-    setMsg(null);
+  const onboardingCopy = useMemo(() => {
+    const phase = dashboard.data?.onboarding.phase;
+    if (phase === "register_project") {
+      return "Register the repository you want Harness to operate on.";
+    }
+    if (phase === "submit_task") {
+      return "Pick a registered project and start with one focused task.";
+    }
+    if (phase === "watch_live_output") {
+      return "Your first task is queued. Open it and watch the live output.";
+    }
+    if (phase === "inspect_completion") {
+      return "The run produced output. Reopen it from history to inspect the evidence.";
+    }
+    return "Compose the next operator task.";
+  }, [dashboard.data?.onboarding.phase]);
+
+  async function handleValidateProject() {
+    setNotice(null);
     try {
-      const prompt = title.trim() + (desc.trim() ? `\n\n${desc.trim()}` : "");
-      const body = JSON.stringify({ prompt, project: project.trim() || undefined });
-      const resp = await apiFetch("/tasks", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body,
-      });
-      const json = await resp.json();
-      setMsg(`created task ${json.id ?? "?"}`);
-      setTitle("");
-      setDesc("");
-      setProject(projectFilter ?? "");
-    } catch (e) {
-      setMsg((e as Error).message);
-    } finally {
-      setBusy(false);
+      await validateProject.mutateAsync({ root: root.trim() });
+    } catch (error) {
+      setNotice((error as Error).message);
     }
   }
 
+  async function handleRegisterProject() {
+    setNotice(null);
+    try {
+      const response = await registerProject.mutateAsync({ root: root.trim() });
+      setSelectedProject(response.project.id);
+      setNotice(
+        response.status === "existing"
+          ? "Project already existed. Using the registered record."
+          : "Project registered. You can submit a task now.",
+      );
+    } catch (error) {
+      setNotice((error as Error).message);
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setNotice(null);
+    try {
+      const prompt = title.trim() + (desc.trim() ? `\n\n${desc.trim()}` : "");
+      const response = await createTask.mutateAsync({
+        prompt,
+        project: selectedProject || undefined,
+      });
+      setTitle("");
+      setDesc("");
+      navigate(`/?task=${encodeURIComponent(response.task_id)}`);
+    } catch (error) {
+      setNotice((error as Error).message);
+    }
+  }
+
+  function applyTemplate(template: StarterTemplate) {
+    setTitle(template.title);
+    setDesc(template.description);
+  }
+
   return (
-    <form onSubmit={submit} className="max-w-[640px] border border-line bg-bg-1 p-5 space-y-4">
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Project</label>
-        <input
-          value={project}
-          onChange={(e) => setProject(e.target.value)}
-          placeholder="project id (optional)"
-          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-      </div>
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Title</label>
-        <input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          required
-          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-      </div>
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Description</label>
-        <textarea
-          value={desc}
-          onChange={(e) => setDesc(e.target.value)}
-          required
-          rows={4}
-          className="w-full bg-bg border border-line-2 px-2.5 py-2 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-      </div>
-      <button
-        disabled={busy}
-        type="submit"
-        className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
-      >
-        {busy ? "Submitting…" : "Submit Task"}
-      </button>
-      {msg && <div className="font-mono text-[11px] text-ink-2">{msg}</div>}
-    </form>
+    <div className="space-y-5">
+      <section className="border border-line bg-bg-1 p-5 space-y-4">
+        <div>
+          <div className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3">
+            First run
+          </div>
+          <h2 className="mt-2 text-[18px] text-ink">Setup and submit</h2>
+          <p className="mt-2 text-[13px] text-ink-2 max-w-[720px]">{onboardingCopy}</p>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto]">
+          <input
+            value={root}
+            onChange={(event) => setRoot(event.target.value)}
+            placeholder="/absolute/path/to/your/repository"
+            className="h-[34px] bg-bg border border-line-2 px-3 text-ink font-mono text-[12px] rounded-[3px]"
+          />
+          <button
+            type="button"
+            onClick={handleValidateProject}
+            disabled={!root.trim() || validateProject.isPending}
+            className="px-3 py-1.5 border border-line-2 bg-bg text-ink font-mono text-[12px] disabled:opacity-60"
+          >
+            {validateProject.isPending ? "Validating…" : "Validate"}
+          </button>
+          <button
+            type="button"
+            onClick={handleRegisterProject}
+            disabled={!root.trim() || registerProject.isPending}
+            className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
+          >
+            {registerProject.isPending ? "Registering…" : "Register project"}
+          </button>
+        </div>
+
+        {activeValidation ? (
+          <div className="grid gap-3 rounded-[4px] border border-line bg-bg px-4 py-3 text-[12px] text-ink-2 md:grid-cols-3">
+            <div>
+              <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Detected id</div>
+              <div className="mt-1 break-all">{activeValidation.project_id}</div>
+            </div>
+            <div>
+              <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Canonical root</div>
+              <div className="mt-1 break-all">{activeValidation.canonical_root}</div>
+            </div>
+            <div>
+              <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Detected repo</div>
+              <div className="mt-1">{activeValidation.repo ?? activeValidation.display_name}</div>
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <form onSubmit={handleSubmit} className="border border-line bg-bg-1 p-5 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3">
+              Guided submit
+            </div>
+            <p className="mt-2 text-[13px] text-ink-2">
+              Use a registered project, start with one focused task, then jump straight into the live task view.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {STARTER_TEMPLATES.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => applyTemplate(template)}
+                className="px-2.5 py-1 border border-line-2 bg-bg text-ink font-mono text-[11px]"
+              >
+                {template.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+            Project
+          </label>
+          <select
+            aria-label="Project"
+            value={selectedProject}
+            onChange={(event) => setSelectedProject(event.target.value)}
+            disabled={!availableProjects.length}
+            className="w-full h-[34px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px] disabled:opacity-60"
+          >
+            {!availableProjects.length ? (
+              <option value="">Register a project first</option>
+            ) : null}
+            {availableProjects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {projectLabel(project)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <div className="space-y-4">
+            <div>
+              <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+                Title
+              </label>
+              <input
+                aria-label="Title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                required
+                className="w-full h-[34px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+              />
+            </div>
+            <div>
+              <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+                Description
+              </label>
+              <textarea
+                aria-label="Description"
+                value={desc}
+                onChange={(event) => setDesc(event.target.value)}
+                required
+                rows={5}
+                className="w-full bg-bg border border-line-2 px-2.5 py-2 text-ink font-mono text-[12px] rounded-[3px]"
+              />
+            </div>
+          </div>
+
+          <div className="border border-line-2 bg-bg p-3">
+            <div className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3">
+              Preflight hints
+            </div>
+            <div className="mt-2 space-y-2 text-[12px] text-ink-2">
+              <div>Anchor the task to one concrete outcome.</div>
+              <div>Call out the failing behavior or missing evidence.</div>
+              <div>Keep the first run narrow enough to finish in one sitting.</div>
+            </div>
+          </div>
+        </div>
+
+        <button
+          disabled={!canSubmit || createTask.isPending}
+          type="submit"
+          className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
+        >
+          {createTask.isPending ? "Submitting…" : "Submit task"}
+        </button>
+      </form>
+
+      {notice ? <div className="font-mono text-[11px] text-ink-2">{notice}</div> : null}
+    </div>
   );
 }

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -247,11 +247,11 @@ export function Submit({ projectFilter }: Props) {
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
           <div className="space-y-4">
             <div>
-              <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+              <label htmlFor="task-title" className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
                 Title
               </label>
               <input
-                aria-label="Title"
+                id="task-title"
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
                 required
@@ -259,11 +259,11 @@ export function Submit({ projectFilter }: Props) {
               />
             </div>
             <div>
-              <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+              <label htmlFor="task-description" className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
                 Description
               </label>
               <textarea
-                aria-label="Description"
+                id="task-description"
                 value={desc}
                 onChange={(event) => setDesc(event.target.value)}
                 required

--- a/web/src/routes/dashboard/TaskDetailPanel.tsx
+++ b/web/src/routes/dashboard/TaskDetailPanel.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { TOKEN_KEY } from "@/lib/api";
+import { useTaskArtifacts, useTaskDetail, useTaskPrompts } from "@/lib/queries";
+
+interface Props {
+  taskId: string | null;
+}
+
+function buildStreamUrl(taskId: string): string {
+  const tok = (globalThis.sessionStorage?.getItem?.(TOKEN_KEY) ?? "").trim();
+  const base = `/tasks/${taskId}/stream`;
+  return tok ? `${base}?token=${encodeURIComponent(tok)}` : base;
+}
+
+function titleForTask(taskId: string, description?: string | null, repo?: string | null): string {
+  return description?.trim() || repo || taskId;
+}
+
+export function TaskDetailPanel({ taskId }: Props) {
+  const detail = useTaskDetail(taskId);
+  const artifactsQuery = useTaskArtifacts(taskId);
+  const promptsQuery = useTaskPrompts(taskId);
+  const [streamText, setStreamText] = useState("");
+
+  const task = detail.data;
+  const prompts = promptsQuery.data ?? task?.prompts ?? [];
+  const artifacts = artifactsQuery.data ?? task?.artifacts ?? [];
+
+  useEffect(() => {
+    setStreamText("");
+  }, [taskId]);
+
+  useEffect(() => {
+    if (!taskId || !task || task.completion.is_terminal || typeof EventSource !== "function") {
+      return;
+    }
+    const source = new EventSource(buildStreamUrl(taskId));
+    source.onmessage = (event) => {
+      try {
+        const item = JSON.parse(event.data) as { type?: string; text?: string; message?: string };
+        if (item.type === "message_delta" && item.text) {
+          setStreamText((current) => current + item.text);
+        } else if (item.type === "error" && item.message) {
+          setStreamText((current) => `${current}\n[error] ${item.message}`.trim());
+        }
+      } catch {
+        setStreamText((current) => `${current}\n${event.data}`.trim());
+      }
+    };
+    return () => source.close();
+  }, [task, taskId]);
+
+  if (!taskId) {
+    return (
+      <aside className="border border-line bg-bg-1 p-4 text-[12px] text-ink-3">
+        Select a task to inspect its live output and completion evidence.
+      </aside>
+    );
+  }
+
+  if (detail.isLoading) {
+    return <aside className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">Loading task…</aside>;
+  }
+
+  if (detail.error || !task) {
+    return (
+      <aside className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-rust">
+        {detail.error?.message ?? "Task not found"}
+      </aside>
+    );
+  }
+
+  const latestPrompt = prompts.at(-1) ?? null;
+  const latestArtifact = artifacts.at(-1) ?? null;
+
+  return (
+    <aside className="border border-line bg-bg-1 min-h-[320px]">
+      <div className="border-b border-line px-4 py-3">
+        <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">
+          Task detail
+        </div>
+        <h2 className="mt-2 text-[16px] leading-snug text-ink">
+          {titleForTask(task.id, task.description, task.repo)}
+        </h2>
+        <div className="mt-2 flex flex-wrap gap-2 font-mono text-[11px] text-ink-3">
+          <span>{task.status}</span>
+          {task.workflow?.state ? <span>workflow {task.workflow.state}</span> : null}
+          {task.project ? <span>{task.project}</span> : null}
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <section>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">
+            {task.completion.is_terminal ? "Completion" : "Live output"}
+          </div>
+          {task.completion.is_terminal ? (
+            <div className="mt-2 grid gap-2 text-[12px] text-ink-2">
+              <div>
+                PR:{" "}
+                {task.completion.pr_url ? (
+                  <a href={task.completion.pr_url} target="_blank" rel="noreferrer" className="text-rust hover:underline">
+                    {task.completion.pr_url}
+                  </a>
+                ) : (
+                  <span>Not available yet</span>
+                )}
+              </div>
+              <div>Prompts: {task.completion.has_prompts ? `${prompts.length} saved` : "Not available yet"}</div>
+              <div>Artifacts: {task.completion.has_artifacts ? `${artifacts.length} saved` : "Not available yet"}</div>
+              <div>
+                Checkpoint: {task.completion.checkpoint?.last_phase ?? "Not available yet"}
+              </div>
+            </div>
+          ) : (
+            <pre className="mt-2 max-h-[320px] overflow-auto whitespace-pre-wrap border border-line-2 bg-bg px-3 py-2 text-[12px] text-ink">
+              {streamText || "Waiting for live output…"}
+            </pre>
+          )}
+        </section>
+
+        <section>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Latest prompt</div>
+          <div className="mt-2 border border-line-2 bg-bg px-3 py-2 text-[12px] text-ink-2 whitespace-pre-wrap">
+            {latestPrompt?.prompt || "Not available yet"}
+          </div>
+        </section>
+
+        <section>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Latest artifact</div>
+          <div className="mt-2 border border-line-2 bg-bg px-3 py-2 text-[12px] text-ink-2 whitespace-pre-wrap">
+            {latestArtifact?.content || "Not available yet"}
+          </div>
+        </section>
+
+        <section>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-ink-3">Plan checkpoint</div>
+          <div className="mt-2 border border-line-2 bg-bg px-3 py-2 text-[12px] text-ink-2 whitespace-pre-wrap">
+            {task.completion.checkpoint?.plan_output ||
+              task.completion.checkpoint?.triage_output ||
+              "Not available yet"}
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/routes/dashboard/TaskDetailPanel.tsx
+++ b/web/src/routes/dashboard/TaskDetailPanel.tsx
@@ -48,8 +48,12 @@ export function TaskDetailPanel({ taskId }: Props) {
         setStreamText((current) => `${current}\n${event.data}`.trim());
       }
     };
+    source.onerror = () => {
+      setStreamText((current) => `${current}\n[stream disconnected]`.trim());
+      source.close();
+    };
     return () => source.close();
-  }, [isTerminal, taskId]);
+  }, [taskId, isTerminal]);
 
   if (!taskId) {
     return (

--- a/web/src/routes/dashboard/TaskDetailPanel.tsx
+++ b/web/src/routes/dashboard/TaskDetailPanel.tsx
@@ -23,6 +23,7 @@ export function TaskDetailPanel({ taskId }: Props) {
   const [streamText, setStreamText] = useState("");
 
   const task = detail.data;
+  const isTerminal = task?.completion.is_terminal ?? false;
   const prompts = promptsQuery.data ?? task?.prompts ?? [];
   const artifacts = artifactsQuery.data ?? task?.artifacts ?? [];
 
@@ -31,7 +32,7 @@ export function TaskDetailPanel({ taskId }: Props) {
   }, [taskId]);
 
   useEffect(() => {
-    if (!taskId || !task || task.completion.is_terminal || typeof EventSource !== "function") {
+    if (!taskId || isTerminal || typeof EventSource !== "function") {
       return;
     }
     const source = new EventSource(buildStreamUrl(taskId));
@@ -48,7 +49,7 @@ export function TaskDetailPanel({ taskId }: Props) {
       }
     };
     return () => source.close();
-  }, [task, taskId]);
+  }, [isTerminal, taskId]);
 
   if (!taskId) {
     return (

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -44,9 +44,27 @@ export interface DashboardGlobal {
   runtime_hosts_online: number;
 }
 
+export interface DashboardOnboarding {
+  phase: "register_project" | "submit_task" | "watch_live_output" | "inspect_completion" | "complete";
+  has_registered_project: boolean;
+  has_submitted_task: boolean;
+  has_live_output: boolean;
+  has_completion_evidence: boolean;
+}
+
+export interface DashboardFunnel {
+  project_registered_at: string | null;
+  task_submitted_at: string | null;
+  live_output_at: string | null;
+  completion_evidence_at: string | null;
+}
+
 export interface DashboardPayload {
   projects: DashboardProject[];
   runtime_hosts: DashboardRuntimeHost[];
   llm_metrics: DashboardLlmMetrics;
+  first_run: boolean;
+  onboarding: DashboardOnboarding;
+  funnel: DashboardFunnel;
   global: DashboardGlobal;
 }

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -15,6 +15,7 @@ export interface Task {
   repo: string | null;
   description: string | null;
   created_at: string | null;
+  updated_at?: string | null;
   phase: string | null;
   depends_on: string[];
   subtask_ids: string[];
@@ -28,4 +29,88 @@ export interface WorkflowSummary {
   pr_number?: number | null;
   force_execute?: boolean;
   plan_concern?: string | null;
+}
+
+export interface RegisteredProject {
+  id: string;
+  root: string;
+  name?: string | null;
+  max_concurrent?: number | null;
+  default_agent?: string | null;
+  active?: boolean;
+  created_at?: string | null;
+  task_count?: number;
+}
+
+export interface ProjectValidationResult {
+  canonical_root: string;
+  project_id: string;
+  display_name: string;
+  repo: string | null;
+  errors: string[];
+}
+
+export interface RegisterProjectResponse {
+  status: "created" | "existing";
+  project: RegisteredProject;
+  validation: ProjectValidationResult;
+}
+
+export interface CreateTaskResponse {
+  task_id: string;
+  status: string;
+  deduped: boolean;
+  task_url: string;
+}
+
+export interface TaskRound {
+  turn: number;
+  action: string;
+  result: string;
+  detail?: string | null;
+  first_token_latency_ms?: number | null;
+}
+
+export interface TaskPromptRecord {
+  task_id: string;
+  turn: number;
+  phase: string;
+  prompt: string;
+  created_at: string;
+}
+
+export interface TaskArtifactRecord {
+  task_id: string;
+  turn: number;
+  artifact_type: string;
+  content: string;
+  created_at: string;
+}
+
+export interface TaskCheckpointSummary {
+  triage_output: string | null;
+  plan_output: string | null;
+  pr_url: string | null;
+  last_phase: string;
+  updated_at: string;
+}
+
+export interface TaskCompletionSummary {
+  is_terminal: boolean;
+  status: string;
+  has_pr: boolean;
+  has_artifacts: boolean;
+  has_prompts: boolean;
+  pr_url: string | null;
+  latest_artifact_at: string | null;
+  latest_prompt_at: string | null;
+  checkpoint: TaskCheckpointSummary | null;
+}
+
+export interface TaskDetail extends Task {
+  rounds: TaskRound[];
+  prompts: TaskPromptRecord[];
+  artifacts: TaskArtifactRecord[];
+  completion: TaskCompletionSummary;
+  workflow: WorkflowSummary | null;
 }


### PR DESCRIPTION
Closes #930

## Summary
- add server-backed project validation, operator funnel milestones, onboarding data, and joined task detail responses
- replace the day-one dashboard submit/history/live flows with guided project setup, task deep links, and shared completion evidence surfaces
- update README and API contract to document the first successful operator loop and cover the new route/test matrix