### PR TITLE
feat(task-runner): model task semantics explicitly with TaskKind and RecoveryStrategy

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -53,7 +53,8 @@ pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_ro
         task_runner::TaskKind::Issue
         | task_runner::TaskKind::Pr
         | task_runner::TaskKind::Prompt
-        | task_runner::TaskKind::Planner => task_routes::QueueDomain::Primary,
+        | task_runner::TaskKind::Planner
+        | task_runner::TaskKind::PlannerTask => task_routes::QueueDomain::Primary,
     }
 }
 
@@ -867,7 +868,8 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                     task_runner::TaskKind::Prompt => None,
                     task_runner::TaskKind::Pr
                     | task_runner::TaskKind::Review
-                    | task_runner::TaskKind::Planner => None,
+                    | task_runner::TaskKind::Planner
+                    | task_runner::TaskKind::PlannerTask => None,
                 };
 
                 if issue_num.is_none() {

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -15,6 +15,7 @@ use harness_core::db::Migration;
 /// v18 – add version column for optimistic locking.
 /// v19 – add task_kind column for first-class task lifecycle dispatch.
 /// v20 – add system_input column for restart-safe trusted system prompt bundles.
+/// v21 – add recovery_strategy column for explicit restart recovery dispatch.
 pub(super) static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -144,5 +145,11 @@ pub(super) static TASK_MIGRATIONS: &[Migration] = &[
         version: 20,
         description: "add system_input column for restart-safe system prompt bundles",
         sql: "ALTER TABLE tasks ADD COLUMN system_input TEXT",
+    },
+    Migration {
+        version: 21,
+        description: "add recovery_strategy column for explicit restart recovery dispatch",
+        sql:
+            "ALTER TABLE tasks ADD COLUMN recovery_strategy TEXT NOT NULL DEFAULT 'non_recoverable'",
     },
 ];

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -1,5 +1,5 @@
 use crate::http::parse_pr_num_from_url;
-use crate::task_runner::{TaskState, TaskStatus};
+use crate::task_runner::{RecoveryStrategy, TaskState, TaskStatus};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
@@ -28,15 +28,17 @@ impl TaskDb {
             .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&Utc));
+        let recovery_strategy = state.task_kind.recovery_strategy();
         sqlx::query(
-            "INSERT INTO tasks (id, task_kind, status, turn, pr_url, rounds, error, source, \
-             external_id, parent_id, created_at, repo, depends_on, project, priority, phase, \
-             description, request_settings, system_input) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, \
-                     COALESCE($11, CURRENT_TIMESTAMP), $12, $13, $14, $15, $16, $17, $18, $19)",
+            "INSERT INTO tasks (id, task_kind, recovery_strategy, status, turn, pr_url, rounds, \
+             error, source, external_id, parent_id, created_at, repo, depends_on, project, \
+             priority, phase, description, request_settings, system_input) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, \
+                     COALESCE($12, CURRENT_TIMESTAMP), $13, $14, $15, $16, $17, $18, $19, $20)",
         )
         .bind(&state.id.0)
         .bind(task_kind)
+        .bind(recovery_strategy.as_ref())
         .bind(status)
         .bind(state.turn as i64)
         .bind(&state.pr_url)
@@ -78,14 +80,16 @@ impl TaskDb {
             .system_input
             .as_ref()
             .and_then(|input| serde_json::to_string(input).ok());
+        let recovery_strategy = state.task_kind.recovery_strategy();
         sqlx::query(
-            "UPDATE tasks SET task_kind = $1, status = $2, turn = $3, pr_url = $4, rounds = $5, \
-                    error = $6, source = $7, external_id = $8, repo = $9, depends_on = $10, \
-                    project = $11, priority = $12, phase = $13, description = $14, \
-                    request_settings = $15, system_input = $16, updated_at = CURRENT_TIMESTAMP, \
-                    version = version + 1 WHERE id = $17",
+            "UPDATE tasks SET task_kind = $1, recovery_strategy = $2, status = $3, turn = $4, \
+                    pr_url = $5, rounds = $6, error = $7, source = $8, external_id = $9, \
+                    repo = $10, depends_on = $11, project = $12, priority = $13, phase = $14, \
+                    description = $15, request_settings = $16, system_input = $17, \
+                    updated_at = CURRENT_TIMESTAMP, version = version + 1 WHERE id = $18",
         )
         .bind(task_kind)
+        .bind(recovery_strategy.as_ref())
         .bind(status)
         .bind(state.turn as i64)
         .bind(&state.pr_url)
@@ -401,13 +405,16 @@ impl TaskDb {
     }
 
     /// Recovery on server restart: resume or fail interrupted tasks.
+    ///
+    /// Dispatches by the persisted `recovery_strategy` column instead of
+    /// inferring behaviour from description/source strings.
     pub async fn recover_in_progress(&self) -> anyhow::Result<RecoveryResult> {
         let rows = {
             let resumable = TaskStatus::resumable_statuses();
             let placeholders = Self::numbered_placeholders(1, resumable.len());
             let sql = format!(
-                "SELECT t.id, t.task_kind, t.source, t.external_id, t.description, \
-                        t.status, t.turn, t.pr_url AS task_pr_url, \
+                "SELECT t.id, t.task_kind, t.recovery_strategy, t.source, t.external_id, \
+                        t.description, t.status, t.turn, t.pr_url AS task_pr_url, \
                         t.system_input, \
                         c.triage_output, c.plan_output, c.pr_url AS ck_pr_url \
                  FROM tasks t \
@@ -417,25 +424,22 @@ impl TaskDb {
             );
             let query = resumable
                 .iter()
-                .fold(sqlx::query_as::<_, RecoveryRow>(&sql), |q, status| {
-                    q.bind(*status)
-                });
+                .fold(sqlx::query_as::<_, RecoveryRow>(&sql), |q, s| q.bind(*s));
             query.fetch_all(&self.pool).await?
         };
 
         let mut result = RecoveryResult::default();
 
         for row in rows {
+            let strategy = RecoveryStrategy::from_persisted(&row.recovery_strategy);
             let task_kind = crate::task_runner::TaskKind::from_persisted(
                 Some(&row.task_kind),
                 row.source.as_deref(),
                 row.external_id.as_deref(),
                 row.description.as_deref(),
             )?;
-            let system_input: Option<crate::task_runner::SystemTaskInput> = row
-                .system_input
-                .as_deref()
-                .and_then(|value| serde_json::from_str(value).ok());
+
+            // Resolve effective PR URL (task column takes priority over checkpoint).
             let effective_pr_url = row
                 .task_pr_url
                 .as_deref()
@@ -445,88 +449,86 @@ impl TaskDb {
                         .as_deref()
                         .filter(|u| parse_pr_num_from_url(u).is_some())
                 });
-            let has_pr = effective_pr_url.is_some();
-            let has_plan = row.plan_output.is_some();
-            let has_triage = row.triage_output.is_some();
 
-            if task_kind.recovery_status().is_some() {
-                if let Some(recovery_status) = task_kind.recovery_status() {
-                    if system_input.is_some() {
-                        sqlx::query(
-                            "UPDATE tasks SET status = $1, error = NULL, \
-                             updated_at = CURRENT_TIMESTAMP WHERE id = $2",
-                        )
-                        .bind(recovery_status.as_ref())
-                        .bind(&row.id)
-                        .execute(&self.pool)
-                        .await?;
-                        result.resumed += 1;
-                        tracing::info!(
-                            task_id = %row.id,
-                            task_kind = task_kind.as_ref(),
-                            was = %row.status,
-                            "startup recovery: resumed system task"
-                        );
-                        continue;
+            let resume_status: Option<String> = match strategy {
+                RecoveryStrategy::RecoverByPromptSnapshot => {
+                    let has_input = row
+                        .system_input
+                        .as_deref()
+                        .and_then(|v| {
+                            serde_json::from_str::<crate::task_runner::SystemTaskInput>(v).ok()
+                        })
+                        .is_some();
+                    if has_input {
+                        let s = match task_kind {
+                            crate::task_runner::TaskKind::Review => {
+                                TaskStatus::ReviewWaiting.as_ref()
+                            }
+                            crate::task_runner::TaskKind::Planner => {
+                                TaskStatus::PlannerWaiting.as_ref()
+                            }
+                            _ => TaskStatus::Implementing.as_ref(),
+                        };
+                        Some(s.to_owned())
+                    } else {
+                        None
                     }
                 }
-            }
+                RecoveryStrategy::RecoverByIssue => {
+                    row.external_id.as_deref().map(|_| "pending".to_owned())
+                }
+                RecoveryStrategy::RecoverByPr => effective_pr_url.map(|_| "pending".to_owned()),
+                RecoveryStrategy::RecoverByDerivedMetadata => {
+                    let any = effective_pr_url.is_some()
+                        || row.plan_output.is_some()
+                        || row.triage_output.is_some();
+                    any.then(|| "pending".to_owned())
+                }
+                RecoveryStrategy::NonRecoverable => None,
+            };
 
-            if has_pr || has_plan || has_triage {
-                let reason = if has_pr {
-                    format!(
-                        "resumed after restart (was: {}, pr: {})",
-                        row.status,
-                        effective_pr_url.unwrap_or("checkpoint")
-                    )
-                } else if has_plan {
-                    format!(
-                        "resumed after restart (was: {}, plan checkpoint)",
-                        row.status
-                    )
-                } else {
-                    format!(
-                        "resumed after restart (was: {}, triage checkpoint)",
-                        row.status
-                    )
-                };
-                let task_pr_url_valid = row
+            if let Some(status) = resume_status {
+                // Write back checkpoint PR URL to task row if needed.
+                let task_pr_valid = row
                     .task_pr_url
                     .as_deref()
                     .map(|u| parse_pr_num_from_url(u).is_some())
                     .unwrap_or(false);
-                let needs_pr_url_writeback = !task_pr_url_valid && effective_pr_url.is_some();
-                if needs_pr_url_writeback {
+                let pr_writeback = matches!(
+                    strategy,
+                    RecoveryStrategy::RecoverByPr | RecoveryStrategy::RecoverByDerivedMetadata
+                ) && !task_pr_valid
+                    && effective_pr_url.is_some();
+
+                if pr_writeback {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', error = NULL, pr_url = $1, \
-                         updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+                        "UPDATE tasks SET status = $1, error = NULL, pr_url = $2, \
+                         updated_at = CURRENT_TIMESTAMP WHERE id = $3",
                     )
+                    .bind(&status)
                     .bind(effective_pr_url)
                     .bind(&row.id)
                     .execute(&self.pool)
                     .await?;
                     tracing::info!(
-                        task_id = %row.id,
-                        was = %row.status,
-                        pr_url = ?effective_pr_url,
-                        "startup recovery: wrote back pr_url from checkpoint"
+                        task_id = %row.id, was = %row.status,
+                        "startup recovery: resumed task (pr_url written back)"
                     );
                 } else {
                     sqlx::query(
-                        "UPDATE tasks SET status = 'pending', error = NULL, \
-                         updated_at = CURRENT_TIMESTAMP WHERE id = $1",
+                        "UPDATE tasks SET status = $1, error = NULL, \
+                         updated_at = CURRENT_TIMESTAMP WHERE id = $2",
                     )
+                    .bind(&status)
                     .bind(&row.id)
                     .execute(&self.pool)
                     .await?;
+                    tracing::info!(
+                        task_id = %row.id, was = %row.status, strategy = strategy.as_ref(),
+                        "startup recovery: resumed task to {status}"
+                    );
                 }
                 result.resumed += 1;
-                tracing::info!(
-                    task_id = %row.id,
-                    was = %row.status,
-                    reason = %reason,
-                    "startup recovery: resumed task"
-                );
             } else {
                 let err = format!(
                     "recovered after restart (was: {}, round: {}, pr: {})",

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -64,6 +64,7 @@ pub struct RecoveryResult {
 pub(super) struct RecoveryRow {
     pub(super) id: String,
     pub(super) task_kind: String,
+    pub(super) recovery_strategy: String,
     pub(super) source: Option<String>,
     pub(super) external_id: Option<String>,
     pub(super) description: Option<String>,

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -25,7 +25,7 @@ pub use spawn::{
 };
 pub use state::{RecentFailureTask, RoundResult, TaskState, TaskSummary};
 pub use store::{mutate_and_persist, update_status, TaskStore};
-pub use types::{TaskId, TaskKind, TaskPhase, TaskStatus};
+pub use types::{RecoveryStrategy, TaskId, TaskKind, TaskPhase, TaskStatus};
 
 impl TaskStore {
     /// Return the most recent `limit` failed tasks, newest first.

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -264,7 +264,9 @@ pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<S
         return Some(match task_kind {
             TaskKind::Review => "periodic review".to_string(),
             TaskKind::Planner => "sprint planner".to_string(),
-            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => "prompt task".to_string(),
+            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt | TaskKind::PlannerTask => {
+                "prompt task".to_string()
+            }
         });
     }
     None

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -3,6 +3,51 @@ use serde::{Deserialize, Serialize};
 
 pub type TaskId = CoreTaskId;
 
+/// Explicit recovery contract for a task.
+///
+/// Each variant defines what data the recovery path needs and what outcome it
+/// produces. Persisted in the `recovery_strategy` column so that future changes
+/// to `TaskKind::recovery_strategy()` do not retroactively affect existing rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryStrategy {
+    /// Resume to `Pending` when a valid `pr_url` is present (task or checkpoint).
+    RecoverByPr,
+    /// Resume to `Pending` when `external_id` is present.
+    RecoverByIssue,
+    /// Resume to `ReviewWaiting`/`PlannerWaiting` when `system_input` is present.
+    RecoverByPromptSnapshot,
+    /// Resume to `Pending` when any checkpoint (pr, plan, triage) is present.
+    RecoverByDerivedMetadata,
+    /// Always transition to `Failed`; the task cannot be safely re-queued.
+    #[default]
+    NonRecoverable,
+}
+
+impl RecoveryStrategy {
+    pub fn from_persisted(s: &str) -> Self {
+        match s {
+            "recover_by_pr" => Self::RecoverByPr,
+            "recover_by_issue" => Self::RecoverByIssue,
+            "recover_by_prompt_snapshot" => Self::RecoverByPromptSnapshot,
+            "recover_by_derived_metadata" => Self::RecoverByDerivedMetadata,
+            _ => Self::NonRecoverable,
+        }
+    }
+}
+
+impl AsRef<str> for RecoveryStrategy {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::RecoverByPr => "recover_by_pr",
+            Self::RecoverByIssue => "recover_by_issue",
+            Self::RecoverByPromptSnapshot => "recover_by_prompt_snapshot",
+            Self::RecoverByDerivedMetadata => "recover_by_derived_metadata",
+            Self::NonRecoverable => "non_recoverable",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
@@ -12,6 +57,10 @@ pub enum TaskKind {
     Prompt,
     Review,
     Planner,
+    /// A concrete implementation task spawned from a sprint-planner run.
+    /// Unlike `Planner` (which generates the plan), `PlannerTask` executes
+    /// a single item from that plan and is backed by a GitHub issue.
+    PlannerTask,
 }
 
 impl TaskKind {
@@ -38,6 +87,7 @@ impl TaskKind {
             Some("prompt") => Ok(Self::Prompt),
             Some("review") => Ok(Self::Review),
             Some("planner") => Ok(Self::Planner),
+            Some("planner_task") => Ok(Self::PlannerTask),
             Some(other) => anyhow::bail!("unknown task kind `{other}`"),
         }
     }
@@ -68,7 +118,7 @@ impl TaskKind {
         match self {
             Self::Planner => TaskPhase::Plan,
             Self::Review => TaskPhase::Review,
-            Self::Issue | Self::Pr | Self::Prompt => TaskPhase::Implement,
+            Self::Issue | Self::Pr | Self::Prompt | Self::PlannerTask => TaskPhase::Implement,
         }
     }
 
@@ -76,15 +126,23 @@ impl TaskKind {
         match self {
             Self::Review => TaskStatus::ReviewGenerating,
             Self::Planner => TaskStatus::PlannerGenerating,
-            Self::Issue | Self::Pr | Self::Prompt => TaskStatus::Implementing,
+            Self::Issue | Self::Pr | Self::Prompt | Self::PlannerTask => TaskStatus::Implementing,
         }
     }
 
-    pub fn recovery_status(&self) -> Option<TaskStatus> {
+    /// Map each task kind to its explicit recovery contract.
+    ///
+    /// This replaces the old `recovery_status()` heuristic. The returned
+    /// strategy is persisted in `tasks.recovery_strategy` so existing rows
+    /// keep their original contract even if this mapping changes later.
+    pub fn recovery_strategy(&self) -> RecoveryStrategy {
         match self {
-            Self::Review => Some(TaskStatus::ReviewWaiting),
-            Self::Planner => Some(TaskStatus::PlannerWaiting),
-            Self::Issue | Self::Pr | Self::Prompt => None,
+            Self::Issue => RecoveryStrategy::RecoverByIssue,
+            Self::Pr => RecoveryStrategy::RecoverByPr,
+            Self::Prompt => RecoveryStrategy::RecoverByDerivedMetadata,
+            Self::Review => RecoveryStrategy::RecoverByPromptSnapshot,
+            Self::Planner => RecoveryStrategy::RecoverByPromptSnapshot,
+            Self::PlannerTask => RecoveryStrategy::RecoverByIssue,
         }
     }
 
@@ -105,6 +163,7 @@ impl AsRef<str> for TaskKind {
             Self::Prompt => "prompt",
             Self::Review => "review",
             Self::Planner => "planner",
+            Self::PlannerTask => "planner_task",
         }
     }
 }
@@ -248,7 +307,7 @@ impl std::str::FromStr for TaskStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::TaskKind;
+    use super::{RecoveryStrategy, TaskKind};
 
     #[test]
     fn legacy_issue_markers_override_review_source() {
@@ -295,5 +354,71 @@ mod tests {
 
         assert_eq!(review, TaskKind::Review);
         assert_eq!(planner, TaskKind::Planner);
+    }
+
+    #[test]
+    fn task_kind_recovery_strategy_mappings() {
+        assert_eq!(
+            TaskKind::Issue.recovery_strategy(),
+            RecoveryStrategy::RecoverByIssue
+        );
+        assert_eq!(
+            TaskKind::Pr.recovery_strategy(),
+            RecoveryStrategy::RecoverByPr
+        );
+        assert_eq!(
+            TaskKind::Prompt.recovery_strategy(),
+            RecoveryStrategy::RecoverByDerivedMetadata
+        );
+        assert_eq!(
+            TaskKind::Review.recovery_strategy(),
+            RecoveryStrategy::RecoverByPromptSnapshot
+        );
+        assert_eq!(
+            TaskKind::Planner.recovery_strategy(),
+            RecoveryStrategy::RecoverByPromptSnapshot
+        );
+        assert_eq!(
+            TaskKind::PlannerTask.recovery_strategy(),
+            RecoveryStrategy::RecoverByIssue
+        );
+    }
+
+    #[test]
+    fn recovery_strategy_as_ref_roundtrips() {
+        let cases = [
+            (RecoveryStrategy::RecoverByPr, "recover_by_pr"),
+            (RecoveryStrategy::RecoverByIssue, "recover_by_issue"),
+            (
+                RecoveryStrategy::RecoverByPromptSnapshot,
+                "recover_by_prompt_snapshot",
+            ),
+            (
+                RecoveryStrategy::RecoverByDerivedMetadata,
+                "recover_by_derived_metadata",
+            ),
+            (RecoveryStrategy::NonRecoverable, "non_recoverable"),
+        ];
+        for (variant, s) in cases {
+            assert_eq!(variant.as_ref(), s);
+            assert_eq!(RecoveryStrategy::from_persisted(s), variant);
+        }
+    }
+
+    #[test]
+    fn recovery_strategy_unknown_string_defaults_to_non_recoverable() {
+        assert_eq!(
+            RecoveryStrategy::from_persisted("bogus_value"),
+            RecoveryStrategy::NonRecoverable
+        );
+    }
+
+    #[test]
+    fn recovery_strategy_serde_roundtrip() {
+        let s = RecoveryStrategy::RecoverByPromptSnapshot;
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(json, r#""recover_by_prompt_snapshot""#);
+        let back: RecoveryStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
     }
 }


### PR DESCRIPTION
## Summary

- Add `PlannerTask` variant to `TaskKind` for sprint-planner-spawned implementation tasks
- Introduce first-class `RecoveryStrategy` enum with 5 variants: `RecoverByPr`, `RecoverByIssue`, `RecoverByPromptSnapshot`, `RecoverByDerivedMetadata`, `NonRecoverable`
- Add `TaskKind::recovery_strategy()` method mapping each kind to its explicit recovery contract
- Persist `recovery_strategy` in new `tasks.recovery_strategy` column (DB migration v21)
- Rewrite `recover_in_progress()` to dispatch by `RecoveryStrategy` enum instead of string heuristics, eliminating the fragile `recovery_status()` method

Closes #895

## Test plan

- [ ] All new unit tests pass: `TaskKind::recovery_strategy()` mappings, `RecoveryStrategy::as_ref` / `from_persisted` roundtrips, serde roundtrip, unknown-string fallback
- [ ] Existing `task_runner::types` tests still pass (legacy inference logic unchanged)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes clean
- [ ] `cargo fmt --all -- --check` passes