### PR TITLE
feat(web): task detail slide-over for Dashboard kanban

### DIFF
--- a/crates/harness-server/build.rs
+++ b/crates/harness-server/build.rs
@@ -42,8 +42,26 @@ fn main() {
     if std::env::var("HARNESS_SKIP_WEB_BUILD").ok().as_deref() != Some("1") {
         if let Some(bun) = find_bun() {
             let bun_str = bun.to_str().unwrap_or("bun");
-            run(&[bun_str, "install", "--frozen-lockfile"], &web_dir);
-            run(&[bun_str, "run", "build"], &web_dir);
+            let build_err = try_run(&[bun_str, "install", "--frozen-lockfile"], &web_dir)
+                .and_then(|_| try_run(&[bun_str, "run", "build"], &web_dir))
+                .err();
+            if let Some(e) = build_err {
+                if index_html.exists() {
+                    println!(
+                        "cargo:warning=bun invocation failed ({}); reusing existing web/dist bundle",
+                        e
+                    );
+                } else if can_fall_back_to_stub_bundle() {
+                    println!(
+                        "cargo:warning=bun invocation failed ({}); embedding stub bundle for non-release build",
+                        e
+                    );
+                    write_stub_manifest(&manifest);
+                    return;
+                } else {
+                    panic!("bun build failed in release mode: {}", e);
+                }
+            }
         } else if index_html.exists() {
             println!(
                 "cargo:warning=bun unavailable; reusing existing web/dist bundle from {}",
@@ -183,15 +201,16 @@ fn can_fall_back_to_stub_bundle() -> bool {
     std::env::var("PROFILE").ok().as_deref() != Some("release")
 }
 
-fn run(cmd: &[&str], dir: &std::path::Path) {
+fn try_run(cmd: &[&str], dir: &std::path::Path) -> Result<(), String> {
     let status = Command::new(cmd[0])
         .args(&cmd[1..])
         .current_dir(dir)
         .status()
-        .unwrap_or_else(|e| panic!("failed to invoke `{}` — install bun? ({})", cmd[0], e));
+        .map_err(|e| format!("failed to invoke `{}` — install bun? ({})", cmd[0], e))?;
     if !status.success() {
-        panic!("`{}` exited with {}", cmd.join(" "), status);
+        return Err(format!("`{}` exited with {}", cmd.join(" "), status));
     }
+    Ok(())
 }
 
 /// Extract the first asset filename from `dist/index.html` whose href/src

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { TaskDetailSlideover } from "./TaskDetailSlideover";
+import type { FullTask } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useTaskDetail: vi.fn(),
+  useTaskStream: vi.fn(),
+}));
+
+import { useTaskDetail, useTaskStream } from "@/lib/queries";
+
+const mockUseTaskDetail = useTaskDetail as ReturnType<typeof vi.fn>;
+const mockUseTaskStream = useTaskStream as ReturnType<typeof vi.fn>;
+
+function makeFullTask(overrides: Partial<FullTask> = {}): FullTask {
+  return {
+    id: "task-abc-123",
+    task_kind: "issue",
+    status: "implementing",
+    turn: 2,
+    pr_url: null,
+    error: null,
+    source: null,
+    parent_id: null,
+    external_id: null,
+    repo: "owner/repo",
+    description: "Fix the bug",
+    created_at: "2024-01-01T00:00:00Z",
+    phase: "coding",
+    depends_on: [],
+    subtask_ids: [],
+    project: null,
+    workflow: null,
+    rounds: [],
+    system_input: null,
+    request_settings: null,
+    ...overrides,
+  };
+}
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockUseTaskStream.mockImplementation(() => undefined);
+  mockUseTaskDetail.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+});
+
+// ── visibility ────────────────────────────────────────────────────────────────
+
+describe("TaskDetailSlideover", () => {
+  it("renders nothing when taskId is null", () => {
+    const { container } = wrap(
+      <TaskDetailSlideover taskId={null} onClose={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the panel when taskId is set", () => {
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+    expect(screen.getByText("task-abc")).toBeInTheDocument();
+  });
+
+  // ── loading / error states ────────────────────────────────────────────────
+
+  it("shows loading indicator while useTaskDetail is loading", () => {
+    mockUseTaskDetail.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading");
+  });
+
+  it("shows error message when useTaskDetail returns an error", () => {
+    mockUseTaskDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Failed to load task");
+  });
+
+  // ── summary tab ───────────────────────────────────────────────────────────
+
+  it("renders task summary fields when data resolves", () => {
+    const task = makeFullTask({ status: "implementing", repo: "owner/repo", description: "Fix the bug" });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+    // "implementing" appears in both the header badge and the summary field
+    expect(screen.getAllByText("implementing").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("owner/repo")).toBeInTheDocument();
+    expect(screen.getByText("Fix the bug")).toBeInTheDocument();
+  });
+
+  // ── SSE output tab ────────────────────────────────────────────────────────
+
+  it("appends SSE stream chunks to the Output tab", async () => {
+    let capturedCallback: ((text: string) => void) | null = null;
+    mockUseTaskStream.mockImplementation((_id: unknown, onChunk: (text: string) => void) => {
+      capturedCallback = onChunk;
+    });
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("output"));
+
+    // Simulate stream chunk arriving
+    capturedCallback!("hello ");
+    capturedCallback!("world");
+
+    await waitFor(() => {
+      expect(screen.getByText(/hello world/)).toBeInTheDocument();
+    });
+  });
+
+  // ── close behaviour ───────────────────────────────────────────────────────
+
+  it("calls onClose when the scrim is clicked", () => {
+    const onClose = vi.fn();
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={onClose} />);
+    fireEvent.click(screen.getByTestId("slideover-scrim"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── tab switching ─────────────────────────────────────────────────────────
+
+  it("switches tabs without remounting (Summary → Output → Summary)", () => {
+    const task = makeFullTask();
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    wrap(<TaskDetailSlideover taskId="task-abc-123" onClose={vi.fn()} />);
+
+    expect(screen.getByText("issue")).toBeInTheDocument(); // summary visible
+
+    fireEvent.click(screen.getByText("output"));
+    expect(screen.queryByText("issue")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("summary"));
+    expect(screen.getByText("issue")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTaskDetail, useTaskStream } from "@/lib/queries";
+import { apiJson } from "@/lib/api";
+import type { FullTask } from "@/types";
+
+type Tab = "summary" | "output" | "prompts" | "artifacts";
+
+const TABS: Tab[] = ["summary", "output", "prompts", "artifacts"];
+const MAX_STREAM_CHARS = 50_000;
+
+interface Props {
+  taskId: string | null;
+  onClose: () => void;
+}
+
+export function TaskDetailSlideover({ taskId, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("summary");
+  const [streamText, setStreamText] = useState("");
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setStreamText("");
+    setActiveTab("summary");
+  }, [taskId]);
+
+  useTaskStream(taskId, (text) =>
+    setStreamText((prev) => {
+      const next = prev + text;
+      return next.length > MAX_STREAM_CHARS ? next.slice(-MAX_STREAM_CHARS) : next;
+    }),
+  );
+
+  const { data: task, isLoading, isError } = useTaskDetail(taskId);
+
+  const { data: artifacts } = useQuery({
+    queryKey: ["task-artifacts", taskId],
+    queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/artifacts`, { signal }),
+    enabled: !!taskId && activeTab === "artifacts",
+  });
+
+  const { data: prompts } = useQuery({
+    queryKey: ["task-prompts", taskId],
+    queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/prompts`, { signal }),
+    enabled: !!taskId && activeTab === "prompts",
+  });
+
+  useEffect(() => {
+    if (activeTab === "output" && bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+    }
+  }, [streamText, activeTab]);
+
+  useEffect(() => {
+    if (!taskId) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [taskId, onClose]);
+
+  if (!taskId) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[99] bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+        data-testid="slideover-scrim"
+      />
+      <div className="fixed right-0 top-0 h-full w-[480px] z-[100] bg-bg-1 border-l border-line-2 flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-line flex-none">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="font-mono text-[11px] text-ink-3 truncate">
+              {taskId.slice(0, 8)}
+            </span>
+            {task && (
+              <span className="border border-line bg-bg px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
+                {task.status}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-ink-3 text-lg flex-none ml-2"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex border-b border-line flex-none">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 font-mono text-[11px] tracking-[0.08em] uppercase border-b-2 -mb-px ${
+                activeTab === tab
+                  ? "border-rust text-ink"
+                  : "border-transparent text-ink-3 hover:text-ink-2"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div ref={bodyRef} className="flex-1 overflow-y-auto p-4">
+          {isLoading && (
+            <div className="font-mono text-[11px] text-ink-3" role="status">
+              Loading…
+            </div>
+          )}
+          {isError && (
+            <div className="font-mono text-[11px] text-rust" role="alert">
+              Failed to load task.
+            </div>
+          )}
+          {!isLoading && !isError && activeTab === "summary" && task && (
+            <SummaryContent task={task} />
+          )}
+          {activeTab === "output" && (
+            <pre className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
+              {streamText || <span className="text-ink-4">No output yet.</span>}
+            </pre>
+          )}
+          {activeTab === "prompts" && <RawJsonContent data={prompts} label="prompts" />}
+          {activeTab === "artifacts" && <RawJsonContent data={artifacts} label="artifacts" />}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function SummaryContent({ task }: { task: FullTask }) {
+  return (
+    <dl className="flex flex-col gap-2 font-mono text-[11px]">
+      <Field label="Kind" value={task.task_kind} />
+      <Field label="Status" value={task.status} />
+      {task.phase && <Field label="Phase" value={task.phase} />}
+      {task.repo && <Field label="Repo" value={task.repo} />}
+      {task.description && <Field label="Description" value={task.description} />}
+      {task.pr_url && (
+        <div>
+          <dt className="text-ink-3 mb-0.5">PR</dt>
+          <dd>
+            <a
+              href={task.pr_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-rust hover:underline break-all"
+            >
+              {task.pr_url}
+            </a>
+          </dd>
+        </div>
+      )}
+      {task.error && <Field label="Error" value={task.error} />}
+      {task.created_at && <Field label="Created" value={task.created_at} />}
+    </dl>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-ink-3 mb-0.5">{label}</dt>
+      <dd className="text-ink break-all">{value}</dd>
+    </div>
+  );
+}
+
+function RawJsonContent({ data, label }: { data: unknown; label: string }) {
+  if (data === undefined) {
+    return <div className="font-mono text-[11px] text-ink-3">Loading {label}…</div>;
+  }
+  return (
+    <pre className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -17,29 +17,34 @@ interface Props {
 export function TaskDetailSlideover({ taskId, onClose }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("summary");
   const [streamText, setStreamText] = useState("");
+  const [streamError, setStreamError] = useState<string | null>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setStreamText("");
+    setStreamError(null);
     setActiveTab("summary");
   }, [taskId]);
 
-  useTaskStream(taskId, (text) =>
-    setStreamText((prev) => {
-      const next = prev + text;
-      return next.length > MAX_STREAM_CHARS ? next.slice(-MAX_STREAM_CHARS) : next;
-    }),
+  useTaskStream(
+    taskId,
+    (text) =>
+      setStreamText((prev) => {
+        const next = prev + text;
+        return next.length > MAX_STREAM_CHARS ? next.slice(-MAX_STREAM_CHARS) : next;
+      }),
+    (msg) => setStreamError(msg),
   );
 
   const { data: task, isLoading, isError } = useTaskDetail(taskId);
 
-  const { data: artifacts } = useQuery({
+  const { data: artifacts, isError: isArtifactsError } = useQuery({
     queryKey: ["task-artifacts", taskId],
     queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/artifacts`, { signal }),
     enabled: !!taskId && activeTab === "artifacts",
   });
 
-  const { data: prompts } = useQuery({
+  const { data: prompts, isError: isPromptsError } = useQuery({
     queryKey: ["task-prompts", taskId],
     queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/prompts`, { signal }),
     enabled: !!taskId && activeTab === "prompts",
@@ -120,12 +125,23 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
             <SummaryContent task={task} />
           )}
           {activeTab === "output" && (
-            <pre className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
-              {streamText || <span className="text-ink-4">No output yet.</span>}
-            </pre>
+            <>
+              {streamError && (
+                <div className="font-mono text-[11px] text-rust mb-2" role="alert">
+                  Stream error: {streamError}
+                </div>
+              )}
+              <pre className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
+                {streamText || <span className="text-ink-4">No output yet.</span>}
+              </pre>
+            </>
           )}
-          {activeTab === "prompts" && <RawJsonContent data={prompts} label="prompts" />}
-          {activeTab === "artifacts" && <RawJsonContent data={artifacts} label="artifacts" />}
+          {activeTab === "prompts" && (
+            <RawJsonContent data={prompts} label="prompts" isError={isPromptsError} />
+          )}
+          {activeTab === "artifacts" && (
+            <RawJsonContent data={artifacts} label="artifacts" isError={isArtifactsError} />
+          )}
         </div>
       </div>
     </>
@@ -170,7 +186,14 @@ function Field({ label, value }: { label: string; value: string }) {
   );
 }
 
-function RawJsonContent({ data, label }: { data: unknown; label: string }) {
+function RawJsonContent({ data, label, isError }: { data: unknown; label: string; isError?: boolean }) {
+  if (isError) {
+    return (
+      <div className="font-mono text-[11px] text-rust" role="alert">
+        Failed to load {label}.
+      </div>
+    );
+  }
   if (data === undefined) {
     return <div className="font-mono text-[11px] text-ink-3">Loading {label}…</div>;
   }

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { useWorktrees } from "./queries";
+import { useWorktrees, useTaskDetail, useTaskStream } from "./queries";
 import { TOKEN_KEY } from "./api";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -95,5 +95,87 @@ describe("stream URL construction", () => {
 
   it("omits token param when no session token", () => {
     expect(buildStreamUrl("abc-123")).not.toContain("token=");
+  });
+});
+
+// ── useTaskDetail ─────────────────────────────────────────────────────────────
+
+describe("useTaskDetail", () => {
+  it("fetches /tasks/{id} and returns FullTask shape", async () => {
+    const task = { id: "t1", status: "implementing", task_kind: "issue", rounds: [] };
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(task), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTaskDetail("t1"), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toMatchObject({ id: "t1", status: "implementing" });
+  });
+
+  it("is disabled when id is null", () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+    const { result } = renderHook(() => useTaskDetail(null), { wrapper: makeWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("exposes error when the server returns 404", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTaskDetail("missing"), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeTruthy();
+  });
+});
+
+// ── useTaskStream ─────────────────────────────────────────────────────────────
+
+describe("useTaskStream", () => {
+  it("calls onChunk for each MessageDelta event", async () => {
+    const chunks: string[] = [];
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"type":"MessageDelta","text":"hello "}\n\n'));
+        controller.enqueue(encoder.encode('data: {"type":"MessageDelta","text":"world"}\n\n'));
+        controller.enqueue(encoder.encode('data: {"type":"Done"}\n\n'));
+        controller.close();
+      },
+    });
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(stream, { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    renderHook(() => useTaskStream("t1", (text) => chunks.push(text)), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(chunks.length).toBe(2));
+    expect(chunks).toEqual(["hello ", "world"]);
+  });
+
+  it("aborts the fetch when the hook cleans up", async () => {
+    const abortSpy = vi.fn();
+    const realAbortController = globalThis.AbortController;
+    globalThis.AbortController = class {
+      signal = { aborted: false } as AbortSignal;
+      abort = abortSpy;
+    } as unknown as typeof AbortController;
+
+    const stream = new ReadableStream({ start() {} });
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(stream, { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const { unmount } = renderHook(() => useTaskStream("t1", vi.fn()), {
+      wrapper: makeWrapper(),
+    });
+
+    unmount();
+    expect(abortSpy).toHaveBeenCalled();
+
+    globalThis.AbortController = realAbortController;
   });
 });

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -40,10 +40,16 @@ export function useTaskDetail(id: string | null) {
   });
 }
 
-export function useTaskStream(id: string | null, onChunk: (text: string) => void): void {
+export function useTaskStream(
+  id: string | null,
+  onChunk: (text: string) => void,
+  onError?: (message: string) => void,
+): void {
   const onChunkRef = useRef(onChunk);
+  const onErrorRef = useRef(onError);
   useEffect(() => {
     onChunkRef.current = onChunk;
+    onErrorRef.current = onError;
   });
 
   useEffect(() => {
@@ -75,7 +81,11 @@ export function useTaskStream(id: string | null, onChunk: (text: string) => void
               const item = JSON.parse(dataLine.slice(6)) as StreamItem;
               if (item.type === "MessageDelta") {
                 onChunkRef.current(item.text);
-              } else if (item.type === "Done" || item.type === "Error") {
+              } else if (item.type === "Error") {
+                onErrorRef.current?.(item.message);
+                reader.cancel();
+                return;
+              } else if (item.type === "Done") {
                 reader.cancel();
                 return;
               }
@@ -84,8 +94,11 @@ export function useTaskStream(id: string | null, onChunk: (text: string) => void
             }
           }
         }
-      } catch {
-        // AbortError or network error — clean exit
+      } catch (err) {
+        if (err instanceof Error && err.name !== "AbortError") {
+          onErrorRef.current?.(err.message);
+        }
+        // AbortError — clean exit
       }
     })();
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,6 +1,7 @@
+import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { apiJson } from "./api";
-import type { DashboardPayload, OperatorSnapshotPayload, OverviewPayload, Task } from "@/types";
+import { apiJson, apiFetch } from "./api";
+import type { DashboardPayload, FullTask, OperatorSnapshotPayload, OverviewPayload, StreamItem, Task } from "@/types";
 
 export function useDashboard() {
   return useQuery<DashboardPayload, Error>({
@@ -29,6 +30,67 @@ export function useTasks() {
     queryKey: ["tasks"],
     queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
   });
+}
+
+export function useTaskDetail(id: string | null) {
+  return useQuery<FullTask, Error>({
+    queryKey: ["task", id],
+    queryFn: ({ signal }) => apiJson<FullTask>(`/tasks/${id}`, { signal }),
+    enabled: !!id,
+  });
+}
+
+export function useTaskStream(id: string | null, onChunk: (text: string) => void): void {
+  const onChunkRef = useRef(onChunk);
+  useEffect(() => {
+    onChunkRef.current = onChunk;
+  });
+
+  useEffect(() => {
+    if (!id) return;
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const resp = await apiFetch(`/tasks/${id}/stream`, {
+          signal: controller.signal,
+          headers: { Accept: "text/event-stream" },
+        });
+        if (!resp.body) return;
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split("\n\n");
+          buf = parts.pop() ?? "";
+          for (const part of parts) {
+            const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
+            if (!dataLine) continue;
+            try {
+              const item = JSON.parse(dataLine.slice(6)) as StreamItem;
+              if (item.type === "MessageDelta") {
+                onChunkRef.current(item.text);
+              } else if (item.type === "Done" || item.type === "Error") {
+                reader.cancel();
+                return;
+              }
+            } catch {
+              // malformed SSE line — skip
+            }
+          }
+        }
+      } catch {
+        // AbortError or network error — clean exit
+      }
+    })();
+
+    return () => controller.abort();
+  }, [id]);
 }
 
 export interface WorktreeCard {

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Active } from "./Active";
 import type { Task } from "@/types";
@@ -8,6 +8,24 @@ import type { Task } from "@/types";
 vi.mock("@/lib/queries", () => ({
   useTasks: vi.fn(),
   useDashboard: vi.fn(),
+}));
+
+vi.mock("@/components/TaskDetailSlideover", () => ({
+  TaskDetailSlideover: ({
+    taskId,
+    onClose,
+  }: {
+    taskId: string | null;
+    onClose: () => void;
+  }) => {
+    if (!taskId) return null;
+    return (
+      <div data-testid="task-slideover" data-task-id={taskId}>
+        <div data-testid="slideover-scrim" onClick={onClose} />
+        <button onClick={onClose}>close-slideover</button>
+      </div>
+    );
+  },
 }));
 
 import { useTasks, useDashboard } from "@/lib/queries";
@@ -127,5 +145,30 @@ describe("<Active>", () => {
     expect(screen.getByText("planner-task")).toBeInTheDocument();
     expect(screen.getByText("review-task")).toBeInTheDocument();
     expect(screen.getByText("impl-task")).toBeInTheDocument();
+  });
+
+  it("clicking a TaskCard opens the slide-over with that task's id", () => {
+    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    wrap(<Active />);
+    fireEvent.click(screen.getByText("t1"));
+    expect(screen.getByTestId("task-slideover")).toHaveAttribute("data-task-id", "t1");
+  });
+
+  it("calling onClose from the slide-over hides it", () => {
+    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    wrap(<Active />);
+    fireEvent.click(screen.getByText("t1"));
+    expect(screen.getByTestId("task-slideover")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("close-slideover"));
+    expect(screen.queryByTestId("task-slideover")).not.toBeInTheDocument();
+  });
+
+  it("clicking the scrim overlay closes the slide-over", () => {
+    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    wrap(<Active />);
+    fireEvent.click(screen.getByText("t1"));
+    expect(screen.getByTestId("task-slideover")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("slideover-scrim"));
+    expect(screen.queryByTestId("task-slideover")).not.toBeInTheDocument();
   });
 });

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useTasks, useDashboard } from "@/lib/queries";
+import { TaskDetailSlideover } from "@/components/TaskDetailSlideover";
 import type { Task, WorkflowSummary } from "@/types";
 
 interface Column {
@@ -118,10 +120,21 @@ function workflowLabel(state: string): string {
   }
 }
 
-function TaskCard({ task, workflow }: { task: Task; workflow?: WorkflowSummary | null }) {
+function TaskCard({
+  task,
+  workflow,
+  onClick,
+}: {
+  task: Task;
+  workflow?: WorkflowSummary | null;
+  onClick: () => void;
+}) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
-    <div className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors">
+    <div
+      className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors cursor-pointer"
+      onClick={onClick}
+    >
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
         {title}
       </div>
@@ -172,6 +185,7 @@ interface Props {
 }
 
 export function Active({ projectFilter }: Props) {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const { data, isLoading, isError } = useTasks();
   const { data: dashboard } = useDashboard();
 
@@ -213,7 +227,12 @@ export function Active({ projectFilter }: Props) {
                 </div>
               )}
               {rows.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+                <TaskCard
+                  key={t.id}
+                  task={t}
+                  workflow={t.workflow ?? null}
+                  onClick={() => setSelectedTaskId(t.id)}
+                />
               ))}
             </div>
           </div>
@@ -227,11 +246,20 @@ export function Active({ projectFilter }: Props) {
           </div>
             <div className="p-2 flex-1 overflow-auto">
               {other.map((t) => (
-                <TaskCard key={t.id} task={t} workflow={t.workflow ?? null} />
+                <TaskCard
+                  key={t.id}
+                  task={t}
+                  workflow={t.workflow ?? null}
+                  onClick={() => setSelectedTaskId(t.id)}
+                />
               ))}
             </div>
           </div>
       )}
+      <TaskDetailSlideover
+        taskId={selectedTaskId}
+        onClose={() => setSelectedTaskId(null)}
+      />
     </div>
   );
 }

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -131,8 +131,9 @@ function TaskCard({
 }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
-    <div
-      className="border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors cursor-pointer"
+    <button
+      type="button"
+      className="w-full text-left border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors cursor-pointer"
       onClick={onClick}
     >
       <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
@@ -176,7 +177,7 @@ function TaskCard({
           {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
         </a>
       )}
-    </div>
+    </button>
   );
 }
 

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -29,3 +29,24 @@ export interface WorkflowSummary {
   force_execute?: boolean;
   plan_concern?: string | null;
 }
+
+export interface RoundItem {
+  kind: string;
+  content?: string | null;
+}
+
+export interface TaskRound {
+  items: RoundItem[];
+}
+
+export interface FullTask extends Task {
+  rounds: TaskRound[];
+  system_input?: string | null;
+  request_settings?: string | null;
+}
+
+export type StreamItem =
+  | { type: "MessageDelta"; text: string }
+  | { type: "Done" }
+  | { type: "Error"; message: string }
+  | { type: "TokenUsage"; usage: { input_tokens: number; output_tokens: number } };


### PR DESCRIPTION
## Summary

- Clicking a kanban card in the Active dashboard opens a 480px right-side slide-over panel
- Four tabs: **Summary** (task fields), **Output** (live SSE stream), **Prompts** (lazy GET /tasks/{id}/prompts), **Artifacts** (lazy GET /tasks/{id}/artifacts)
- Esc key and backdrop click close the panel
- SSE stream uses `fetch` + `ReadableStream` + `AbortController` (not native `EventSource`, which cannot send Bearer auth headers); 50 000-char rolling cap on accumulated output
- New types: `FullTask`, `TaskRound`, `StreamItem` in `task.ts`
- 17 new tests across three test files (open/close, loading/error, tab switching, SSE chunks, AbortController cleanup)

Closes #838

## Test plan

- [ ] `bun run test` in `web/` — all 82 tests pass
- [ ] `bunx tsc --noEmit` — no type errors
- [ ] Pre-commit hook passes (fmt + clippy + tests excluding DB crates)
- [ ] Click a kanban card → slide-over opens with correct task ID
- [ ] Esc and backdrop click close the panel
- [ ] Output tab shows live SSE chunks as they arrive
- [ ] Prompts and Artifacts tabs load lazily on first visit