### PR TITLE
feat(workflow): add Ready-for-Merge human gate (#935)

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -7,6 +7,11 @@ pub struct IssueWorkflowPolicy {
     pub force_execute_label: String,
     #[serde(default = "default_true")]
     pub auto_replan_on_plan_issue: bool,
+    /// When true, the review loop pauses at `ready_to_merge` and requires a
+    /// human to call `POST /tasks/:id/merge` before the workflow advances to
+    /// `done`.  Defaults to `false` to preserve the legacy auto-merge flow.
+    #[serde(default)]
+    pub require_human_gate_before_merge: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,6 +45,7 @@ impl Default for IssueWorkflowPolicy {
         Self {
             force_execute_label: default_force_execute_label(),
             auto_replan_on_plan_issue: default_true(),
+            require_human_gate_before_merge: false,
         }
     }
 }
@@ -129,6 +135,7 @@ mod tests {
         assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 300);
         assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
         assert_eq!(cfg.storage.schema_namespace, "workflow");
+        assert!(!cfg.issue_workflow.require_human_gate_before_merge);
         Ok(())
     }
 
@@ -141,6 +148,7 @@ mod tests {
 issue_workflow:
   force_execute_label: do-not-second-guess
   auto_replan_on_plan_issue: false
+  require_human_gate_before_merge: true
 pr_feedback:
   enabled: false
   sweep_interval_secs: 15
@@ -159,6 +167,7 @@ Body
             "do-not-second-guess"
         );
         assert!(!cfg.issue_workflow.auto_replan_on_plan_issue);
+        assert!(cfg.issue_workflow.require_human_gate_before_merge);
         assert!(!cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
         assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 45);

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -10,7 +10,7 @@ use super::{
     auth, get_issue_workflow_by_issue, get_issue_workflow_by_pr, get_project_workflow_by_project,
     get_task, get_task_artifacts, get_task_prompts, github_webhook, handle_rpc, health_check,
     ingest_signal, intake_status, list_tasks, password_reset, project_queue_stats, state::AppState,
-    stream_task_sse, task_routes,
+    stream_task_sse, task_mutation_routes, task_routes,
 };
 
 pub(super) fn build_router(state: Arc<AppState>) -> Router {
@@ -31,6 +31,7 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
         .route("/tasks/batch", post(task_routes::create_tasks_batch))
         .route("/tasks/{id}", get(get_task))
         .route("/tasks/{id}/cancel", post(task_routes::cancel_task))
+        .route("/tasks/{id}/merge", post(task_mutation_routes::merge_task))
         .route("/tasks/{id}/artifacts", get(get_task_artifacts))
         .route("/tasks/{id}/prompts", get(get_task_prompts))
         .route("/tasks/{id}/stream", get(stream_task_sse))

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod misc_routes;
 pub(crate) mod rate_limit;
 pub(crate) mod sse_routes;
 pub(crate) mod state;
+pub(crate) mod task_mutation_routes;
 pub(crate) mod task_query_routes;
 pub(crate) mod task_routes;
 

--- a/crates/harness-server/src/http/task_mutation_routes.rs
+++ b/crates/harness-server/src/http/task_mutation_routes.rs
@@ -1,0 +1,119 @@
+use super::AppState;
+use axum::{extract::State, http::StatusCode, Json};
+use harness_workflow::issue_lifecycle::IssueLifecycleState;
+use serde_json::json;
+use std::sync::Arc;
+
+/// POST /tasks/{id}/merge — human-gate approval to transition a `ready_to_merge`
+/// workflow to `done`.
+///
+/// Returns 202 on success, 404 if the task or workflow is not found, and 409
+/// if prerequisites are not met (no PR URL, workflow store unavailable, PR URL
+/// unparseable, or workflow not in `ready_to_merge` state).
+pub(super) async fn merge_task(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let task_id = harness_core::types::TaskId(id);
+
+    let task = match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "task not found" })),
+            );
+        }
+        Err(e) => {
+            tracing::error!("merge_task: DB lookup failed for {task_id:?}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "internal server error" })),
+            );
+        }
+    };
+
+    let pr_url = match task.pr_url.as_deref() {
+        Some(url) => url.to_owned(),
+        None => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({ "error": "no PR associated with task" })),
+            );
+        }
+    };
+
+    let workflows = match state.core.issue_workflow_store.as_ref() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({ "error": "workflow tracking not available" })),
+            );
+        }
+    };
+
+    let pr_num = match super::parse_pr_num_from_url(&pr_url) {
+        Some(n) => n,
+        None => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({ "error": "could not parse PR number from task pr_url" })),
+            );
+        }
+    };
+
+    let project_id = match task.project_root.as_ref() {
+        Some(p) => p.to_string_lossy().into_owned(),
+        None => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({ "error": "task has no project_root" })),
+            );
+        }
+    };
+
+    let workflow = match workflows
+        .get_by_pr(&project_id, task.repo.as_deref(), pr_num)
+        .await
+    {
+        Ok(Some(wf)) => wf,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "workflow not found for PR" })),
+            );
+        }
+        Err(e) => {
+            tracing::error!("merge_task: workflow lookup failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "internal server error" })),
+            );
+        }
+    };
+
+    if workflow.state != IssueLifecycleState::ReadyToMerge {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "workflow not in ready_to_merge state" })),
+        );
+    }
+
+    match workflows
+        .record_merge_approved(&project_id, task.repo.as_deref(), pr_num)
+        .await
+    {
+        Ok(_) => (
+            StatusCode::ACCEPTED,
+            Json(json!({ "status": "merge_approved" })),
+        ),
+        Err(e) => {
+            tracing::error!("merge_task: record_merge_approved failed: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to record merge approval" })),
+            )
+        }
+    }
+}

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -1,47 +1,13 @@
 use chrono::{DateTime, Utc};
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sqlx::postgres::PgPool;
-use sqlx::Postgres;
 use std::path::Path;
 
-const ISSUE_WORKFLOW_SCHEMA_VERSION: u32 = 1;
+/// Re-exported to preserve the `harness_workflow::issue_lifecycle::IssueWorkflowStore` path
+/// used by callers outside this crate.
+pub use crate::issue_workflow_store::IssueWorkflowStore;
 
-static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
-    Migration {
-        version: 1,
-        description: "create issue_workflows table",
-        sql: "CREATE TABLE IF NOT EXISTS issue_workflows (
-            id         TEXT PRIMARY KEY,
-            data       TEXT NOT NULL,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        )",
-    },
-    Migration {
-        version: 2,
-        description: "index issue workflow lookups by project and issue",
-        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_issue
-              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'issue_number')::bigint))",
-    },
-    Migration {
-        version: 3,
-        description: "index issue workflow lookups by project and pr",
-        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_pr
-              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'pr_number')::bigint))",
-    },
-    Migration {
-        version: 4,
-        description: "index issue workflow feedback sweep candidates",
-        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_feedback_candidates
-              ON issue_workflows (((data::jsonb->>'state')), updated_at DESC)
-              WHERE data::jsonb->>'pr_number' IS NOT NULL",
-    },
-];
+const ISSUE_WORKFLOW_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -71,6 +37,8 @@ pub enum IssueLifecycleEventKind {
     FeedbackFound,
     NoFeedbackFound,
     Mergeable,
+    /// Human approved the merge after reviewing a `ReadyToMerge` workflow.
+    HumanMergeApproved,
     WorkflowFailed,
     WorkflowCancelled,
     WorkflowDone,
@@ -91,7 +59,7 @@ pub struct IssueLifecycleEvent {
 }
 
 impl IssueLifecycleEvent {
-    fn new(kind: IssueLifecycleEventKind) -> Self {
+    pub(crate) fn new(kind: IssueLifecycleEventKind) -> Self {
         Self {
             kind,
             at: Utc::now(),
@@ -102,17 +70,17 @@ impl IssueLifecycleEvent {
         }
     }
 
-    fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
+    pub(crate) fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
         self.task_id = Some(task_id.into());
         self
     }
 
-    fn with_detail(mut self, detail: impl Into<String>) -> Self {
+    pub(crate) fn with_detail(mut self, detail: impl Into<String>) -> Self {
         self.detail = Some(detail.into());
         self
     }
 
-    fn with_pr(mut self, pr_number: u64, pr_url: impl Into<String>) -> Self {
+    pub(crate) fn with_pr(mut self, pr_number: u64, pr_url: impl Into<String>) -> Self {
         self.pr_number = Some(pr_number);
         self.pr_url = Some(pr_url.into());
         self
@@ -216,6 +184,18 @@ impl IssueWorkflowInstance {
                 self.state = IssueLifecycleState::ReadyToMerge;
                 self.feedback_claimed_at = None;
             }
+            IssueLifecycleEventKind::HumanMergeApproved => {
+                if self.state != IssueLifecycleState::ReadyToMerge {
+                    tracing::warn!(
+                        workflow_id = %self.id,
+                        state = ?self.state,
+                        "HumanMergeApproved received in unexpected state, ignoring"
+                    );
+                    return;
+                }
+                self.state = IssueLifecycleState::Done;
+                self.feedback_claimed_at = None;
+            }
             IssueLifecycleEventKind::WorkflowFailed => {
                 self.state = IssueLifecycleState::Failed;
                 self.feedback_claimed_at = None;
@@ -255,1181 +235,65 @@ pub fn legacy_schema_for_path(path: &Path) -> anyhow::Result<String> {
     Ok(format!("h{:016x}", u64::from_le_bytes(schema_bytes)))
 }
 
-pub struct IssueWorkflowStore {
-    pool: PgPool,
-}
-
-impl IssueWorkflowStore {
-    pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        Self::open_with_database_url(path, None).await
-    }
-
-    pub async fn open_with_database_url(
-        path: &Path,
-        configured_database_url: Option<&str>,
-    ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let schema = legacy_schema_for_path(path)?;
-
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
-            .run()
-            .await?;
-        Ok(Self { pool })
-    }
-
-    pub async fn open_with_database_url_and_schema(
-        configured_database_url: Option<&str>,
-        schema: &str,
-    ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, schema).await?;
-        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
-            .run()
-            .await?;
-        Ok(Self { pool })
-    }
-
-    pub async fn upsert(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<()> {
-        let data = serde_json::to_string(workflow)?;
-        sqlx::query(
-            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
-             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
-                 updated_at = CURRENT_TIMESTAMP",
-        )
-        .bind(&workflow.id)
-        .bind(&data)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    pub async fn insert_if_absent(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<bool> {
-        let data = serde_json::to_string(workflow)?;
-        let result = sqlx::query(
-            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
-             ON CONFLICT(id) DO NOTHING",
-        )
-        .bind(&workflow.id)
-        .bind(&data)
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected() == 1)
-    }
-
-    pub async fn get_by_issue(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        let row: Option<(String,)> = if let Some(repo) = repo {
-            sqlx::query_as(
-                "SELECT data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' = $2
-                   AND (data::jsonb->>'issue_number')::bigint = $3
-                 ORDER BY updated_at DESC
-                 LIMIT 1",
-            )
-            .bind(project_id)
-            .bind(repo)
-            .bind(issue_number as i64)
-            .fetch_optional(&self.pool)
-            .await?
-        } else {
-            sqlx::query_as(
-                "SELECT data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' IS NULL
-                   AND (data::jsonb->>'issue_number')::bigint = $2
-                 ORDER BY updated_at DESC
-                 LIMIT 1",
-            )
-            .bind(project_id)
-            .bind(issue_number as i64)
-            .fetch_optional(&self.pool)
-            .await?
-        };
-        row.map(|(data,)| serde_json::from_str(&data))
-            .transpose()
-            .map_err(Into::into)
-    }
-
-    pub async fn get_by_pr(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        let row: Option<(String,)> = if let Some(repo) = repo {
-            sqlx::query_as(
-                "SELECT data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' = $2
-                   AND (data::jsonb->>'pr_number')::bigint = $3
-                 ORDER BY updated_at DESC
-                 LIMIT 1",
-            )
-            .bind(project_id)
-            .bind(repo)
-            .bind(pr_number as i64)
-            .fetch_optional(&self.pool)
-            .await?
-        } else {
-            sqlx::query_as(
-                "SELECT data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' IS NULL
-                   AND (data::jsonb->>'pr_number')::bigint = $2
-                 ORDER BY updated_at DESC
-                 LIMIT 1",
-            )
-            .bind(project_id)
-            .bind(pr_number as i64)
-            .fetch_optional(&self.pool)
-            .await?
-        };
-        row.map(|(data,)| serde_json::from_str(&data))
-            .transpose()
-            .map_err(Into::into)
-    }
-
-    pub async fn list(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
-        let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT data FROM issue_workflows ORDER BY updated_at DESC")
-                .fetch_all(&self.pool)
-                .await?;
-        rows.into_iter()
-            .map(|(data,)| Ok(serde_json::from_str(&data)?))
-            .collect()
-    }
-
-    pub async fn row_count(&self) -> anyhow::Result<i64> {
-        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM issue_workflows")
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(count)
-    }
-
-    pub async fn record_issue_scheduled(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        task_id: &str,
-        labels_snapshot: &[String],
-        force_execute: bool,
-    ) -> anyhow::Result<IssueWorkflowInstance> {
-        self.update_issue(project_id, repo, issue_number, |workflow| {
-            workflow.labels_snapshot = labels_snapshot.to_vec();
-            workflow.force_execute = force_execute;
-            workflow.apply_event(
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::IssueScheduled)
-                    .with_task_id(task_id.to_string()),
-            );
-        })
-        .await
-    }
-
-    pub async fn record_implement_started(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        task_id: &str,
-    ) -> anyhow::Result<IssueWorkflowInstance> {
-        self.update_issue(project_id, repo, issue_number, |workflow| {
-            workflow.apply_event(
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::ImplementStarted)
-                    .with_task_id(task_id.to_string()),
-            );
-        })
-        .await
-    }
-
-    pub async fn record_plan_issue_detected(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        task_id: &str,
-        concern: &str,
-    ) -> anyhow::Result<IssueWorkflowInstance> {
-        self.update_issue(project_id, repo, issue_number, |workflow| {
-            workflow.apply_event(
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::PlanIssueDetected)
-                    .with_task_id(task_id.to_string())
-                    .with_detail(concern.to_string()),
-            );
-        })
-        .await
-    }
-
-    pub async fn record_pr_detected(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        task_id: &str,
-        pr_number: u64,
-        pr_url: &str,
-    ) -> anyhow::Result<IssueWorkflowInstance> {
-        self.update_issue(project_id, repo, issue_number, |workflow| {
-            workflow.apply_event(
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::PrDetected)
-                    .with_task_id(task_id.to_string())
-                    .with_pr(pr_number, pr_url.to_string()),
-            );
-        })
-        .await
-    }
-
-    pub async fn record_feedback_task_scheduled(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-        task_id: &str,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_by_pr(project_id, repo, pr_number, |workflow| {
-            let mut event =
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
-                    .with_task_id(task_id.to_string());
-            if let Some(pr_url) = workflow.pr_url.clone() {
-                event = event.with_pr(pr_number, pr_url);
-            }
-            workflow.apply_event(event);
-        })
-        .await
-    }
-
-    pub async fn record_terminal_for_issue(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        final_state: IssueLifecycleState,
-        detail: Option<&str>,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_existing_issue(project_id, repo, issue_number, |workflow| {
-            let mut event = IssueLifecycleEvent::new(match final_state {
-                IssueLifecycleState::Done => IssueLifecycleEventKind::WorkflowDone,
-                IssueLifecycleState::Cancelled => IssueLifecycleEventKind::WorkflowCancelled,
-                _ => IssueLifecycleEventKind::WorkflowFailed,
-            });
-            if let Some(detail) = detail {
-                event = event.with_detail(detail.to_string());
-            }
-            workflow.apply_event(event);
-        })
-        .await
-    }
-
-    pub async fn record_terminal_for_pr(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-        success: bool,
-        cancelled: bool,
-        detail: Option<&str>,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_by_pr(project_id, repo, pr_number, |workflow| {
-            let mut event = IssueLifecycleEvent::new(if cancelled {
-                IssueLifecycleEventKind::WorkflowCancelled
-            } else if success {
-                IssueLifecycleEventKind::Mergeable
-            } else {
-                IssueLifecycleEventKind::WorkflowFailed
-            });
-            if let Some(detail) = detail {
-                event = event.with_detail(detail.to_string());
-            }
-            workflow.apply_event(event);
-        })
-        .await
-    }
-
-    pub async fn list_feedback_candidates(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
-        let rows: Vec<(String,)> = sqlx::query_as(
-            "SELECT data FROM issue_workflows
-             WHERE data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
-               AND data::jsonb->>'pr_number' IS NOT NULL
-             ORDER BY updated_at DESC",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        rows.into_iter()
-            .map(|(data,)| Ok(serde_json::from_str(&data)?))
-            .collect()
-    }
-
-    pub async fn claim_feedback_candidates(
-        &self,
-        limit: i64,
-        stale_before: DateTime<Utc>,
-    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
-        let mut tx = self.pool.begin().await?;
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT id, data FROM issue_workflows
-             WHERE data::jsonb->>'pr_number' IS NOT NULL
-               AND (
-                    data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
-                    OR (
-                        data::jsonb->>'state' = 'addressing_feedback'
-                        AND updated_at <= $2
-                    )
-               )
-             ORDER BY updated_at DESC
-             LIMIT $1
-             FOR UPDATE SKIP LOCKED",
-        )
-        .bind(limit)
-        .bind(stale_before)
-        .fetch_all(&mut *tx)
-        .await?;
-
-        let mut claimed = Vec::with_capacity(rows.len());
-        for (workflow_id, data) in rows {
-            let mut workflow: IssueWorkflowInstance = match serde_json::from_str(&data) {
-                Ok(workflow) => workflow,
-                Err(e) => {
-                    tracing::warn!(
-                        workflow_id = %workflow_id,
-                        "workflow feedback sweep: skipping malformed workflow row while claiming candidates: {e}"
-                    );
-                    continue;
-                }
-            };
-            let claim_id = format!("claim:{}", workflow.id);
-            if let Some(pr_number) = workflow.pr_number {
-                let pr_url = workflow.pr_url.clone().unwrap_or_default();
-                workflow.apply_event(
-                    IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
-                        .with_task_id(claim_id)
-                        .with_pr(pr_number, pr_url),
-                );
-                self.upsert_in_tx(&mut tx, &workflow).await?;
-                debug_assert_eq!(workflow.id, workflow_id);
-                claimed.push(workflow);
-            }
-        }
-        tx.commit().await?;
-        Ok(claimed)
-    }
-
-    pub async fn release_feedback_claim(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-        detail: &str,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        self.update_by_pr(project_id, repo, pr_number, |workflow| {
-            workflow.apply_event(
-                IssueLifecycleEvent::new(IssueLifecycleEventKind::NoFeedbackFound)
-                    .with_detail(detail.to_string()),
-            );
-        })
-        .await
-    }
-
-    /// Patches only the `project_id` field inside the JSONB blob without replacing the whole row.
-    ///
-    /// WARNING: the row primary key (`id`) is NOT updated by this function. The `id` column embeds
-    /// the project_id, so after this patch the primary key will be stale and diverge from the JSON
-    /// `project_id` field. Subsequent lookups via the canonical path will compute a different
-    /// `workflow_id`, causing `ON CONFLICT DO NOTHING` to create duplicate orphan rows.
-    ///
-    /// Callers that resolve a canonical path MUST use [`IssueWorkflowStore::repair_project_id`]
-    /// instead, which performs a correct delete-then-insert in a single transaction.
-    ///
-    /// Returns `Ok(())` even when no row matches `workflow_id` (zero rows affected is not an error).
-    pub async fn update_project_path(
-        &self,
-        workflow_id: &str,
-        new_path: &str,
-    ) -> anyhow::Result<()> {
-        sqlx::query(
-            "UPDATE issue_workflows
-             SET    data = jsonb_set(data::jsonb, '{project_id}', to_jsonb($2::text), false)::text,
-                    updated_at = CURRENT_TIMESTAMP
-             WHERE  id = $1",
-        )
-        .bind(workflow_id)
-        .bind(new_path)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    async fn update_issue<F>(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        f: F,
-    ) -> anyhow::Result<IssueWorkflowInstance>
-    where
-        F: FnOnce(&mut IssueWorkflowInstance),
-    {
-        let workflow_id = workflow_id(project_id, repo, issue_number);
-        let placeholder = IssueWorkflowInstance::new(
-            project_id.to_string(),
-            repo.map(|r| r.to_string()),
-            issue_number,
-        );
-        let mut tx = self.pool.begin().await?;
-        self.insert_placeholder(&mut tx, &workflow_id, &placeholder)
-            .await?;
-        let mut workflow = self
-            .load_for_update_by_id(&mut tx, &workflow_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("workflow row disappeared after placeholder insert"))?;
-        if workflow.repo.is_none() {
-            workflow.repo = repo.map(|r| r.to_string());
-        }
-        f(&mut workflow);
-        self.upsert_in_tx(&mut tx, &workflow).await?;
-        tx.commit().await?;
-        Ok(workflow)
-    }
-
-    async fn update_existing_issue<F>(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        issue_number: u64,
-        f: F,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
-    where
-        F: FnOnce(&mut IssueWorkflowInstance),
-    {
-        let mut tx = self.pool.begin().await?;
-        let workflow_id = workflow_id(project_id, repo, issue_number);
-        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, &workflow_id).await? else {
-            return Ok(None);
-        };
-        f(&mut workflow);
-        self.upsert_in_tx(&mut tx, &workflow).await?;
-        tx.commit().await?;
-        Ok(Some(workflow))
-    }
-
-    async fn update_by_pr<F>(
-        &self,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-        f: F,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
-    where
-        F: FnOnce(&mut IssueWorkflowInstance),
-    {
-        let mut tx = self.pool.begin().await?;
-        let Some((workflow_id, mut workflow)) = self
-            .load_for_update_by_pr(&mut tx, project_id, repo, pr_number)
-            .await?
-        else {
-            return Ok(None);
-        };
-        f(&mut workflow);
-        self.upsert_in_tx(&mut tx, &workflow).await?;
-        debug_assert_eq!(workflow.id, workflow_id);
-        tx.commit().await?;
-        Ok(Some(workflow))
-    }
-
-    async fn insert_placeholder(
-        &self,
-        tx: &mut sqlx::Transaction<'_, Postgres>,
-        workflow_id: &str,
-        workflow: &IssueWorkflowInstance,
-    ) -> anyhow::Result<()> {
-        let data = serde_json::to_string(workflow)?;
-        sqlx::query(
-            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
-             ON CONFLICT(id) DO NOTHING",
-        )
-        .bind(workflow_id)
-        .bind(&data)
-        .execute(&mut **tx)
-        .await?;
-        Ok(())
-    }
-
-    async fn load_for_update_by_id(
-        &self,
-        tx: &mut sqlx::Transaction<'_, Postgres>,
-        workflow_id: &str,
-    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT data FROM issue_workflows WHERE id = $1 FOR UPDATE")
-                .bind(workflow_id)
-                .fetch_optional(&mut **tx)
-                .await?;
-        row.map(|(data,)| serde_json::from_str(&data))
-            .transpose()
-            .map_err(Into::into)
-    }
-
-    async fn load_for_update_by_pr(
-        &self,
-        tx: &mut sqlx::Transaction<'_, Postgres>,
-        project_id: &str,
-        repo: Option<&str>,
-        pr_number: u64,
-    ) -> anyhow::Result<Option<(String, IssueWorkflowInstance)>> {
-        let row: Option<(String, String)> = if let Some(repo) = repo {
-            sqlx::query_as(
-                "SELECT id, data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' = $2
-                   AND (data::jsonb->>'pr_number')::bigint = $3
-                 ORDER BY updated_at DESC
-                 LIMIT 1
-                 FOR UPDATE",
-            )
-            .bind(project_id)
-            .bind(repo)
-            .bind(pr_number as i64)
-            .fetch_optional(&mut **tx)
-            .await?
-        } else {
-            sqlx::query_as(
-                "SELECT id, data FROM issue_workflows
-                 WHERE data::jsonb->>'project_id' = $1
-                   AND data::jsonb->>'repo' IS NULL
-                   AND (data::jsonb->>'pr_number')::bigint = $2
-                 ORDER BY updated_at DESC
-                 LIMIT 1
-                 FOR UPDATE",
-            )
-            .bind(project_id)
-            .bind(pr_number as i64)
-            .fetch_optional(&mut **tx)
-            .await?
-        };
-        match row {
-            Some((id, data)) => {
-                let workflow = serde_json::from_str(&data)?;
-                Ok(Some((id, workflow)))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// List all workflow rows whose `project_id` contains `/workspaces/`,
-    /// indicating a corrupt worktree path was stored instead of the canonical root.
-    pub async fn list_with_worktree_project_ids(
-        &self,
-    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
-        let rows: Vec<(String,)> = sqlx::query_as(
-            "SELECT data FROM issue_workflows
-             WHERE data::jsonb->>'project_id' LIKE '%/workspaces/%'
-             ORDER BY updated_at DESC",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        rows.into_iter()
-            .map(|(data,)| Ok(serde_json::from_str(&data)?))
-            .collect()
-    }
-
-    /// Replace a workflow row's `project_id` with `new_project_id`, rekeying the
-    /// primary key (which embeds the project_id). Old row is deleted; new row is inserted.
-    pub async fn repair_project_id(
-        &self,
-        old_row_id: &str,
-        new_project_id: &str,
-    ) -> anyhow::Result<()> {
-        let mut tx = self.pool.begin().await?;
-        let old_workflow = self
-            .load_for_update_by_id(&mut tx, old_row_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("workflow row '{old_row_id}' not found"))?;
-
-        let mut new_workflow = old_workflow.clone();
-        new_workflow.project_id = new_project_id.to_string();
-        new_workflow.id = workflow_id(
-            &new_workflow.project_id,
-            new_workflow.repo.as_deref(),
-            new_workflow.issue_number,
-        );
-
-        if new_workflow.id == old_row_id {
-            return Ok(());
-        }
-
-        if let Some(existing_workflow) = self
-            .load_for_update_by_id(&mut tx, &new_workflow.id)
-            .await?
-        {
-            anyhow::bail!(
-                "cannot repair workflow row '{old_row_id}' to canonical id '{}': canonical row already exists in state {:?} (updated_at {})",
-                new_workflow.id,
-                existing_workflow.state,
-                existing_workflow.updated_at,
-            );
-        }
-
-        new_workflow.updated_at = chrono::Utc::now();
-
-        let new_data = serde_json::to_string(&new_workflow)?;
-        let insert_result = sqlx::query(
-            "INSERT INTO issue_workflows (id, data, created_at) VALUES ($1, $2, $3)
-             ON CONFLICT(id) DO NOTHING",
-        )
-        .bind(&new_workflow.id)
-        .bind(&new_data)
-        .bind(old_workflow.created_at)
-        .execute(&mut *tx)
-        .await?;
-        if insert_result.rows_affected() != 1 {
-            anyhow::bail!(
-                "cannot repair workflow row '{old_row_id}' to canonical id '{}': canonical row appeared during repair",
-                new_workflow.id,
-            );
-        }
-
-        sqlx::query("DELETE FROM issue_workflows WHERE id = $1")
-            .bind(old_row_id)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        tracing::info!(
-            old_row_id,
-            old_project_id = %old_workflow.project_id,
-            new_project_id,
-            new_row_id = %new_workflow.id,
-            "repaired corrupt workflow project_id"
-        );
-        Ok(())
-    }
-
-    /// Mark a workflow row as `Failed` with the given reason detail.
-    pub async fn mark_workflow_failed_with_reason(
-        &self,
-        row_id: &str,
-        reason: &str,
-    ) -> anyhow::Result<()> {
-        let mut tx = self.pool.begin().await?;
-        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, row_id).await? else {
-            return Ok(());
-        };
-        workflow.apply_event(
-            IssueLifecycleEvent::new(IssueLifecycleEventKind::WorkflowFailed)
-                .with_detail(reason.to_string()),
-        );
-        self.upsert_in_tx(&mut tx, &workflow).await?;
-        tx.commit().await?;
-        Ok(())
-    }
-
-    async fn upsert_in_tx(
-        &self,
-        tx: &mut sqlx::Transaction<'_, Postgres>,
-        workflow: &IssueWorkflowInstance,
-    ) -> anyhow::Result<()> {
-        let data = serde_json::to_string(workflow)?;
-        sqlx::query(
-            "UPDATE issue_workflows
-             SET data = $1, updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
-        )
-        .bind(&data)
-        .bind(&workflow.id)
-        .execute(&mut **tx)
-        .await?;
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    async fn open_test_store() -> anyhow::Result<Option<IssueWorkflowStore>> {
-        if resolve_database_url(None).is_err() {
-            return Ok(None);
-        }
-        let dir = tempfile::tempdir()?;
-        match IssueWorkflowStore::open(&dir.path().join("issue_workflows.db")).await {
-            Ok(store) => Ok(Some(store)),
-            Err(e) => {
-                tracing::warn!("issue workflow store test skipped: {e}");
-                Ok(None)
-            }
-        }
-    }
+    #[test]
+    fn human_merge_approved_transitions_ready_to_done() {
+        let mut wf = IssueWorkflowInstance::new("/tmp/p", Some("owner/repo".to_string()), 1);
+        wf.apply_event(IssueLifecycleEvent::new(IssueLifecycleEventKind::Mergeable));
+        assert_eq!(wf.state, IssueLifecycleState::ReadyToMerge);
 
-    #[tokio::test]
-    async fn issue_workflow_store_binds_pr_to_issue_instance() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-a";
-        store
-            .record_issue_scheduled(
-                project_id,
-                Some("owner/repo"),
-                882,
-                "task-1",
-                &["force-execute".to_string()],
-                true,
-            )
-            .await?;
-        store
-            .record_pr_detected(
-                project_id,
-                Some("owner/repo"),
-                882,
-                "task-1",
-                909,
-                "https://github.com/owner/repo/pull/909",
-            )
-            .await?;
-
-        let by_issue = store
-            .get_by_issue(project_id, Some("owner/repo"), 882)
-            .await?
-            .expect("workflow by issue");
-        let by_pr = store
-            .get_by_pr(project_id, Some("owner/repo"), 909)
-            .await?
-            .expect("workflow by pr");
-
-        assert_eq!(by_issue.id, by_pr.id);
-        assert_eq!(by_issue.state, IssueLifecycleState::PrOpen);
-        assert_eq!(by_issue.pr_number, Some(909));
-        assert!(by_issue.force_execute);
-        assert_eq!(by_issue.labels_snapshot, vec!["force-execute".to_string()]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn issue_workflow_store_records_plan_issue_as_non_terminal_event() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-b";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo"), 883, "task-2", &[], false)
-            .await?;
-        let workflow = store
-            .record_plan_issue_detected(
-                project_id,
-                Some("owner/repo"),
-                883,
-                "task-2",
-                "The plan is incomplete.",
-            )
-            .await?;
-
-        assert_eq!(workflow.state, IssueLifecycleState::Implementing);
+        wf.apply_event(IssueLifecycleEvent::new(
+            IssueLifecycleEventKind::HumanMergeApproved,
+        ));
+        assert_eq!(wf.state, IssueLifecycleState::Done);
+        assert!(wf.feedback_claimed_at.is_none());
         assert_eq!(
-            workflow.plan_concern.as_deref(),
-            Some("The plan is incomplete.")
+            wf.last_event.as_ref().map(|e| &e.kind),
+            Some(&IssueLifecycleEventKind::HumanMergeApproved)
         );
+    }
+
+    #[test]
+    fn human_merge_approved_is_noop_from_non_ready_state() {
+        let mut wf = IssueWorkflowInstance::new("/tmp/p", Some("owner/repo".to_string()), 2);
+        wf.apply_event(
+            IssueLifecycleEvent::new(IssueLifecycleEventKind::IssueScheduled).with_task_id("t1"),
+        );
+        assert_eq!(wf.state, IssueLifecycleState::Scheduled);
+
+        let last_event_before = wf.last_event.as_ref().map(|e| e.kind.clone());
+        wf.apply_event(IssueLifecycleEvent::new(
+            IssueLifecycleEventKind::HumanMergeApproved,
+        ));
+        assert_eq!(wf.state, IssueLifecycleState::Scheduled, "state unchanged");
         assert_eq!(
-            workflow.last_event.as_ref().map(|e| &e.kind),
-            Some(&IssueLifecycleEventKind::PlanIssueDetected)
+            wf.last_event.as_ref().map(|e| e.kind.clone()),
+            last_event_before,
+            "last_event unchanged on early return"
         );
-        Ok(())
     }
 
-    #[tokio::test]
-    async fn issue_workflow_store_scopes_identity_by_repo() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/shared-project";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo-a"), 42, "task-a", &[], false)
-            .await?;
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo-b"), 42, "task-b", &[], false)
-            .await?;
+    #[test]
+    fn human_merge_approved_double_fire_is_safe() {
+        let mut wf = IssueWorkflowInstance::new("/tmp/p", Some("owner/repo".to_string()), 3);
+        wf.apply_event(IssueLifecycleEvent::new(IssueLifecycleEventKind::Mergeable));
+        wf.apply_event(IssueLifecycleEvent::new(
+            IssueLifecycleEventKind::HumanMergeApproved,
+        ));
+        assert_eq!(wf.state, IssueLifecycleState::Done);
 
-        let a = store
-            .get_by_issue(project_id, Some("owner/repo-a"), 42)
-            .await?
-            .expect("repo-a workflow");
-        let b = store
-            .get_by_issue(project_id, Some("owner/repo-b"), 42)
-            .await?
-            .expect("repo-b workflow");
-
-        assert_ne!(a.id, b.id);
-        Ok(())
+        wf.apply_event(IssueLifecycleEvent::new(
+            IssueLifecycleEventKind::HumanMergeApproved,
+        ));
+        assert_eq!(wf.state, IssueLifecycleState::Done, "second call is no-op");
     }
 
-    #[tokio::test]
-    async fn issue_workflow_store_records_cancelled_pr_tasks_as_cancelled() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-cancel";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo"), 7, "task-1", &[], false)
-            .await?;
-        store
-            .record_pr_detected(
-                project_id,
-                Some("owner/repo"),
-                7,
-                "task-1",
-                55,
-                "https://github.com/owner/repo/pull/55",
-            )
-            .await?;
-        let workflow = store
-            .record_terminal_for_pr(project_id, Some("owner/repo"), 55, false, true, None)
-            .await?
-            .expect("workflow");
-        assert_eq!(workflow.state, IssueLifecycleState::Cancelled);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-stale-claim";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo"), 9, "task-1", &[], false)
-            .await?;
-        store
-            .record_pr_detected(
-                project_id,
-                Some("owner/repo"),
-                9,
-                "task-1",
-                77,
-                "https://github.com/owner/repo/pull/77",
-            )
-            .await?;
-        store
-            .record_feedback_task_scheduled(project_id, Some("owner/repo"), 77, "task-2")
-            .await?;
-
-        let mut workflow = store
-            .get_by_pr(project_id, Some("owner/repo"), 77)
-            .await?
-            .expect("workflow");
-        workflow.feedback_claimed_at = Some(Utc::now() - chrono::Duration::minutes(10));
-        store.upsert(&workflow).await?;
-        sqlx::query(
-            "UPDATE issue_workflows
-             SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
-             WHERE id = $1",
-        )
-        .bind(&workflow.id)
-        .execute(&store.pool)
-        .await?;
-
-        let claimed = store
-            .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
-            .await?;
-        assert_eq!(claimed.len(), 1);
-        assert_eq!(claimed[0].pr_number, Some(77));
-        assert_eq!(claimed[0].state, IssueLifecycleState::AddressingFeedback);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_feedback_candidates_skips_malformed_rows() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-malformed";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo"), 10, "task-1", &[], false)
-            .await?;
-        store
-            .record_pr_detected(
-                project_id,
-                Some("owner/repo"),
-                10,
-                "task-1",
-                88,
-                "https://github.com/owner/repo/pull/88",
-            )
-            .await?;
-        sqlx::query(
-            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
-             ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
-        )
-        .bind("malformed-workflow")
-        .bind(r#"{"project_id":"/tmp/project-malformed","repo":"owner/repo","state":"pr_open","pr_number":999}"#)
-        .execute(&store.pool)
-        .await?;
-
-        let claimed = store
-            .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
-            .await?;
-        assert_eq!(claimed.len(), 1);
-        assert_eq!(claimed[0].pr_number, Some(88));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_project_path_patches_project_id_field() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let old_project_id = "/tmp/old-project-path-test";
-        store
-            .record_issue_scheduled(
-                old_project_id,
-                Some("owner/repo"),
-                101,
-                "task-path-1",
-                &[],
-                false,
-            )
-            .await?;
-        let before = store
-            .get_by_issue(old_project_id, Some("owner/repo"), 101)
-            .await?
-            .expect("workflow before update");
-        let before_state = before.state;
-
-        store
-            .update_project_path(&before.id, "/tmp/new-project-path-test")
-            .await?;
-
-        let after = store
-            .get_by_issue("/tmp/new-project-path-test", Some("owner/repo"), 101)
-            .await?
-            .expect("workflow after update");
-        assert_eq!(after.project_id, "/tmp/new-project-path-test");
-        assert_eq!(after.state, before_state);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_project_path_noop_on_missing_id() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        // Must not return an error when no row matches
-        store
-            .update_project_path("nonexistent-workflow-id", "/tmp/any-path")
-            .await?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn repair_project_id_rekeyes_row() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let corrupt_id = "/data/workspaces/abc-uuid-repair-test";
-        store
-            .record_issue_scheduled(corrupt_id, Some("owner/repo"), 9001, "task-r1", &[], false)
-            .await?;
-
-        let workflow = store
-            .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
-            .await?
-            .expect("row should exist");
-        let old_row_id = workflow.id.clone();
-
-        let canonical = "/real/canonical/root";
-        store.repair_project_id(&old_row_id, canonical).await?;
-
-        // Old row gone, new row present with correct project_id
-        let old = store
-            .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
-            .await?;
-        assert!(old.is_none(), "old row should be removed");
-
-        let new = store
-            .get_by_issue(canonical, Some("owner/repo"), 9001)
-            .await?
-            .expect("new row should exist");
-        assert_eq!(new.project_id, canonical);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn repair_project_id_refuses_to_overwrite_existing_canonical_row() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let corrupt_project_id = "/data/workspaces/abc-uuid-conflict-test";
-        let canonical_project_id = "/real/canonical/conflict-root";
-
-        store
-            .record_issue_scheduled(
-                corrupt_project_id,
-                Some("owner/repo"),
-                9005,
-                "task-corrupt",
-                &[],
-                false,
-            )
-            .await?;
-        store
-            .record_issue_scheduled(
-                canonical_project_id,
-                Some("owner/repo"),
-                9005,
-                "task-canonical",
-                &[],
-                false,
-            )
-            .await?;
-        store
-            .record_pr_detected(
-                canonical_project_id,
-                Some("owner/repo"),
-                9005,
-                "task-canonical",
-                45,
-                "https://github.com/owner/repo/pull/45",
-            )
-            .await?;
-
-        let corrupt_before = store
-            .get_by_issue(corrupt_project_id, Some("owner/repo"), 9005)
-            .await?
-            .expect("corrupt row should exist");
-        let canonical_before = store
-            .get_by_issue(canonical_project_id, Some("owner/repo"), 9005)
-            .await?
-            .expect("canonical row should exist");
-
-        let err = store
-            .repair_project_id(&corrupt_before.id, canonical_project_id)
-            .await
-            .expect_err("repair should fail when canonical row already exists");
-        assert!(
-            err.to_string().contains("canonical row already exists"),
-            "unexpected error: {err}",
-        );
-
-        let corrupt_after = store
-            .get_by_issue(corrupt_project_id, Some("owner/repo"), 9005)
-            .await?
-            .expect("corrupt row should remain for manual remediation");
-        let canonical_after = store
-            .get_by_issue(canonical_project_id, Some("owner/repo"), 9005)
-            .await?
-            .expect("canonical row should remain unchanged");
-
-        assert_eq!(store.row_count().await?, 2);
-        assert_eq!(corrupt_after, corrupt_before);
-        assert_eq!(canonical_after, canonical_before);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn mark_workflow_failed_with_reason_sets_state() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let project_id = "/tmp/project-mark-failed-test";
-        store
-            .record_issue_scheduled(project_id, Some("owner/repo"), 9002, "task-mf1", &[], false)
-            .await?;
-
-        let workflow = store
-            .get_by_issue(project_id, Some("owner/repo"), 9002)
-            .await?
-            .expect("row should exist");
-
-        store
-            .mark_workflow_failed_with_reason(&workflow.id, "project root not found")
-            .await?;
-
-        let updated = store
-            .get_by_issue(project_id, Some("owner/repo"), 9002)
-            .await?
-            .expect("row should still exist");
-        assert_eq!(updated.state, IssueLifecycleState::Failed);
-        assert!(
-            updated
-                .last_event
-                .as_ref()
-                .and_then(|e| e.detail.as_deref())
-                == Some("project root not found"),
-            "detail should be recorded"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn list_with_worktree_project_ids_filters_correctly() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let corrupt = "/data/workspaces/xyz-uuid-list-test";
-        let canonical = "/tmp/canonical-list-test";
-
-        store
-            .record_issue_scheduled(corrupt, Some("owner/repo"), 9003, "task-l1", &[], false)
-            .await?;
-        store
-            .record_issue_scheduled(canonical, Some("owner/repo"), 9004, "task-l2", &[], false)
-            .await?;
-
-        let corrupt_rows = store.list_with_worktree_project_ids().await?;
-        assert!(
-            corrupt_rows.iter().any(|w| w.project_id == corrupt),
-            "worktree row should appear"
-        );
-        assert!(
-            !corrupt_rows.iter().any(|w| w.project_id == canonical),
-            "canonical row should not appear"
-        );
-        Ok(())
-    }
-
-    // Surface 1 regression guard: after repair_project_id the stored project_id
-    // must never contain a UUID workspace path segment.
-    #[tokio::test]
-    async fn surface1_repaired_project_id_has_no_workspaces_path() -> anyhow::Result<()> {
-        let Some(store) = open_test_store().await? else {
-            return Ok(());
-        };
-        let uuid_path = "/data/workspaces/6b10f4d1-8381-4ceb-be46-9bcd13c08eb1/some-project-s1";
-        store
-            .record_issue_scheduled(uuid_path, Some("owner/repo"), 9101, "task-s1a", &[], false)
-            .await?;
-
-        let workflow = store
-            .get_by_issue(uuid_path, Some("owner/repo"), 9101)
-            .await?
-            .expect("row should exist before repair");
-        let row_id = workflow.id.clone();
-
-        let canonical = "/home/user/projects/some-project-s1";
-        store.repair_project_id(&row_id, canonical).await?;
-
-        let repaired = store
-            .get_by_issue(canonical, Some("owner/repo"), 9101)
-            .await?
-            .expect("repaired row should exist");
-
-        assert!(
-            !repaired.project_id.contains("/workspaces/"),
-            "repaired project_id must not contain a workspace path, got: {}",
-            repaired.project_id
-        );
-        assert_eq!(repaired.project_id, canonical);
-        Ok(())
+    #[test]
+    fn config_human_gate_flag_defaults_false() {
+        let policy = harness_core::config::workflow::IssueWorkflowPolicy::default();
+        assert!(!policy.require_human_gate_before_merge);
     }
 }

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -101,6 +101,19 @@ impl IssueWorkflowStore {
         Ok(())
     }
 
+    pub async fn insert_if_absent(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<bool> {
+        let data = serde_json::to_string(workflow)?;
+        let result = sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(&workflow.id)
+        .bind(&data)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
     pub async fn get_by_issue(
         &self,
         project_id: &str,
@@ -436,6 +449,112 @@ impl IssueWorkflowStore {
             );
         })
         .await
+    }
+
+    /// List workflow rows whose `project_id` still points at an isolated worktree.
+    pub async fn list_with_worktree_project_ids(
+        &self,
+    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'project_id' LIKE '%/workspaces/%'
+             ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    /// Replace a workflow row's `project_id` and rekey the primary key.
+    pub async fn repair_project_id(
+        &self,
+        old_row_id: &str,
+        new_project_id: &str,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        let old_workflow = self
+            .load_for_update_by_id(&mut tx, old_row_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("workflow row '{old_row_id}' not found"))?;
+
+        let mut new_workflow = old_workflow.clone();
+        new_workflow.project_id = new_project_id.to_string();
+        new_workflow.id = workflow_id(
+            &new_workflow.project_id,
+            new_workflow.repo.as_deref(),
+            new_workflow.issue_number,
+        );
+
+        if new_workflow.id == old_row_id {
+            return Ok(());
+        }
+
+        if let Some(existing_workflow) = self
+            .load_for_update_by_id(&mut tx, &new_workflow.id)
+            .await?
+        {
+            anyhow::bail!(
+                "cannot repair workflow row '{old_row_id}' to canonical id '{}': canonical row already exists in state {:?} (updated_at {})",
+                new_workflow.id,
+                existing_workflow.state,
+                existing_workflow.updated_at,
+            );
+        }
+
+        new_workflow.updated_at = Utc::now();
+
+        let new_data = serde_json::to_string(&new_workflow)?;
+        let insert_result = sqlx::query(
+            "INSERT INTO issue_workflows (id, data, created_at) VALUES ($1, $2, $3)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(&new_workflow.id)
+        .bind(&new_data)
+        .bind(old_workflow.created_at)
+        .execute(&mut *tx)
+        .await?;
+        if insert_result.rows_affected() != 1 {
+            anyhow::bail!(
+                "cannot repair workflow row '{old_row_id}' to canonical id '{}': canonical row appeared during repair",
+                new_workflow.id,
+            );
+        }
+
+        sqlx::query("DELETE FROM issue_workflows WHERE id = $1")
+            .bind(old_row_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        tracing::info!(
+            old_row_id,
+            old_project_id = %old_workflow.project_id,
+            new_project_id,
+            new_row_id = %new_workflow.id,
+            "repaired corrupt workflow project_id"
+        );
+        Ok(())
+    }
+
+    /// Mark a workflow row as `Failed` with the given reason detail.
+    pub async fn mark_workflow_failed_with_reason(
+        &self,
+        row_id: &str,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, row_id).await? else {
+            return Ok(());
+        };
+        workflow.apply_event(
+            IssueLifecycleEvent::new(IssueLifecycleEventKind::WorkflowFailed)
+                .with_detail(reason.to_string()),
+        );
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
+        Ok(())
     }
 
     async fn update_issue<F>(

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -1,0 +1,618 @@
+use chrono::{DateTime, Utc};
+use harness_core::db::{
+    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
+    Migration, PgMigrator,
+};
+use sqlx::postgres::PgPool;
+use sqlx::Postgres;
+use std::path::Path;
+
+use crate::issue_lifecycle::{
+    legacy_schema_for_path, workflow_id, IssueLifecycleEvent, IssueLifecycleEventKind,
+    IssueLifecycleState, IssueWorkflowInstance,
+};
+
+static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create issue_workflows table",
+        sql: "CREATE TABLE IF NOT EXISTS issue_workflows (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "index issue workflow lookups by project and issue",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_issue
+              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'issue_number')::bigint))",
+    },
+    Migration {
+        version: 3,
+        description: "index issue workflow lookups by project and pr",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_pr
+              ON issue_workflows ((data::jsonb->>'project_id'), ((data::jsonb->>'pr_number')::bigint))",
+    },
+    Migration {
+        version: 4,
+        description: "index issue workflow feedback sweep candidates",
+        sql: "CREATE INDEX IF NOT EXISTS idx_issue_workflows_feedback_candidates
+              ON issue_workflows (((data::jsonb->>'state')), updated_at DESC)
+              WHERE data::jsonb->>'pr_number' IS NOT NULL",
+    },
+];
+
+pub struct IssueWorkflowStore {
+    pool: PgPool,
+}
+
+impl IssueWorkflowStore {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let schema = legacy_schema_for_path(path)?;
+
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, &schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
+        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn open_with_database_url_and_schema(
+        configured_database_url: Option<&str>,
+        schema: &str,
+    ) -> anyhow::Result<Self> {
+        let database_url = resolve_database_url(configured_database_url)?;
+        let setup = pg_open_pool(&database_url).await?;
+        pg_create_schema_if_not_exists(&setup, schema).await?;
+        setup.close().await;
+
+        let pool = pg_open_pool_schematized(&database_url, schema).await?;
+        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
+            .run()
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn upsert(&self, workflow: &IssueWorkflowInstance) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+                 updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&workflow.id)
+        .bind(&data)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_by_issue(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'issue_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(issue_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'issue_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(issue_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        };
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn get_by_pr(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'pr_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(pr_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'pr_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1",
+            )
+            .bind(project_id)
+            .bind(pr_number as i64)
+            .fetch_optional(&self.pool)
+            .await?
+        };
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn list(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT data FROM issue_workflows ORDER BY updated_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    pub async fn row_count(&self) -> anyhow::Result<i64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM issue_workflows")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count)
+    }
+
+    pub async fn record_issue_scheduled(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        labels_snapshot: &[String],
+        force_execute: bool,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.labels_snapshot = labels_snapshot.to_vec();
+            workflow.force_execute = force_execute;
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::IssueScheduled)
+                    .with_task_id(task_id.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_implement_started(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::ImplementStarted)
+                    .with_task_id(task_id.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_plan_issue_detected(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        concern: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::PlanIssueDetected)
+                    .with_task_id(task_id.to_string())
+                    .with_detail(concern.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_pr_detected(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        task_id: &str,
+        pr_number: u64,
+        pr_url: &str,
+    ) -> anyhow::Result<IssueWorkflowInstance> {
+        self.update_issue(project_id, repo, issue_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::PrDetected)
+                    .with_task_id(task_id.to_string())
+                    .with_pr(pr_number, pr_url.to_string()),
+            );
+        })
+        .await
+    }
+
+    pub async fn record_feedback_task_scheduled(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        task_id: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            let mut event =
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
+                    .with_task_id(task_id.to_string());
+            if let Some(pr_url) = workflow.pr_url.clone() {
+                event = event.with_pr(pr_number, pr_url);
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    pub async fn record_terminal_for_issue(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        final_state: IssueLifecycleState,
+        detail: Option<&str>,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_existing_issue(project_id, repo, issue_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(match final_state {
+                IssueLifecycleState::Done => IssueLifecycleEventKind::WorkflowDone,
+                IssueLifecycleState::Cancelled => IssueLifecycleEventKind::WorkflowCancelled,
+                _ => IssueLifecycleEventKind::WorkflowFailed,
+            });
+            if let Some(detail) = detail {
+                event = event.with_detail(detail.to_string());
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    pub async fn record_terminal_for_pr(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        success: bool,
+        cancelled: bool,
+        detail: Option<&str>,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(if cancelled {
+                IssueLifecycleEventKind::WorkflowCancelled
+            } else if success {
+                IssueLifecycleEventKind::Mergeable
+            } else {
+                IssueLifecycleEventKind::WorkflowFailed
+            });
+            if let Some(detail) = detail {
+                event = event.with_detail(detail.to_string());
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
+    /// Transition a `ReadyToMerge` workflow to `Done` after human approval.
+    ///
+    /// Returns `None` if no workflow is found for the given PR.  The state
+    /// machine guard in `apply_event` silently discards the event when the
+    /// workflow is not in `ReadyToMerge` (e.g. already `Done`).
+    pub async fn record_merge_approved(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            workflow.apply_event(IssueLifecycleEvent::new(
+                IssueLifecycleEventKind::HumanMergeApproved,
+            ));
+        })
+        .await
+    }
+
+    pub async fn list_feedback_candidates(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+               AND data::jsonb->>'pr_number' IS NOT NULL
+             ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    pub async fn claim_feedback_candidates(
+        &self,
+        limit: i64,
+        stale_before: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let mut tx = self.pool.begin().await?;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, data FROM issue_workflows
+             WHERE data::jsonb->>'pr_number' IS NOT NULL
+               AND (
+                    data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+                    OR (
+                        data::jsonb->>'state' = 'addressing_feedback'
+                        AND updated_at <= $2
+                    )
+               )
+             ORDER BY updated_at DESC
+             LIMIT $1
+             FOR UPDATE SKIP LOCKED",
+        )
+        .bind(limit)
+        .bind(stale_before)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut claimed = Vec::with_capacity(rows.len());
+        for (workflow_id, data) in rows {
+            let mut workflow: IssueWorkflowInstance = match serde_json::from_str(&data) {
+                Ok(workflow) => workflow,
+                Err(e) => {
+                    tracing::warn!(
+                        workflow_id = %workflow_id,
+                        "workflow feedback sweep: skipping malformed workflow row while claiming candidates: {e}"
+                    );
+                    continue;
+                }
+            };
+            let claim_id = format!("claim:{}", workflow.id);
+            if let Some(pr_number) = workflow.pr_number {
+                let pr_url = workflow.pr_url.clone().unwrap_or_default();
+                workflow.apply_event(
+                    IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
+                        .with_task_id(claim_id)
+                        .with_pr(pr_number, pr_url),
+                );
+                self.upsert_in_tx(&mut tx, &workflow).await?;
+                debug_assert_eq!(workflow.id, workflow_id);
+                claimed.push(workflow);
+            }
+        }
+        tx.commit().await?;
+        Ok(claimed)
+    }
+
+    pub async fn release_feedback_claim(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        detail: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_by_pr(project_id, repo, pr_number, |workflow| {
+            workflow.apply_event(
+                IssueLifecycleEvent::new(IssueLifecycleEventKind::NoFeedbackFound)
+                    .with_detail(detail.to_string()),
+            );
+        })
+        .await
+    }
+
+    async fn update_issue<F>(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        f: F,
+    ) -> anyhow::Result<IssueWorkflowInstance>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let wf_id = workflow_id(project_id, repo, issue_number);
+        let placeholder = IssueWorkflowInstance::new(
+            project_id.to_string(),
+            repo.map(|r| r.to_string()),
+            issue_number,
+        );
+        let mut tx = self.pool.begin().await?;
+        self.insert_placeholder(&mut tx, &wf_id, &placeholder)
+            .await?;
+        let mut workflow = self
+            .load_for_update_by_id(&mut tx, &wf_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("workflow row disappeared after placeholder insert"))?;
+        if workflow.repo.is_none() {
+            workflow.repo = repo.map(|r| r.to_string());
+        }
+        f(&mut workflow);
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
+        Ok(workflow)
+    }
+
+    async fn update_existing_issue<F>(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        f: F,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let mut tx = self.pool.begin().await?;
+        let wf_id = workflow_id(project_id, repo, issue_number);
+        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, &wf_id).await? else {
+            return Ok(None);
+        };
+        f(&mut workflow);
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
+        Ok(Some(workflow))
+    }
+
+    pub(crate) async fn update_by_pr<F>(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        f: F,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>>
+    where
+        F: FnOnce(&mut IssueWorkflowInstance),
+    {
+        let mut tx = self.pool.begin().await?;
+        let Some((wf_id, mut workflow)) = self
+            .load_for_update_by_pr(&mut tx, project_id, repo, pr_number)
+            .await?
+        else {
+            return Ok(None);
+        };
+        f(&mut workflow);
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        debug_assert_eq!(workflow.id, wf_id);
+        tx.commit().await?;
+        Ok(Some(workflow))
+    }
+
+    async fn insert_placeholder(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+        workflow: &IssueWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(workflow_id)
+        .bind(&data)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    async fn load_for_update_by_id(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow_id: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM issue_workflows WHERE id = $1 FOR UPDATE")
+                .bind(workflow_id)
+                .fetch_optional(&mut **tx)
+                .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn load_for_update_by_pr(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+    ) -> anyhow::Result<Option<(String, IssueWorkflowInstance)>> {
+        let row: Option<(String, String)> = if let Some(repo) = repo {
+            sqlx::query_as(
+                "SELECT id, data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' = $2
+                   AND (data::jsonb->>'pr_number')::bigint = $3
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                 FOR UPDATE",
+            )
+            .bind(project_id)
+            .bind(repo)
+            .bind(pr_number as i64)
+            .fetch_optional(&mut **tx)
+            .await?
+        } else {
+            sqlx::query_as(
+                "SELECT id, data FROM issue_workflows
+                 WHERE data::jsonb->>'project_id' = $1
+                   AND data::jsonb->>'repo' IS NULL
+                   AND (data::jsonb->>'pr_number')::bigint = $2
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                 FOR UPDATE",
+            )
+            .bind(project_id)
+            .bind(pr_number as i64)
+            .fetch_optional(&mut **tx)
+            .await?
+        };
+        match row {
+            Some((id, data)) => {
+                let workflow = serde_json::from_str(&data)?;
+                Ok(Some((id, workflow)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn upsert_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+        workflow: &IssueWorkflowInstance,
+    ) -> anyhow::Result<()> {
+        let data = serde_json::to_string(workflow)?;
+        sqlx::query(
+            "UPDATE issue_workflows
+             SET data = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(&data)
+        .bind(&workflow.id)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "issue_workflow_store_tests.rs"]
+mod tests;

--- a/crates/harness-workflow/src/issue_workflow_store_tests.rs
+++ b/crates/harness-workflow/src/issue_workflow_store_tests.rs
@@ -259,3 +259,168 @@ async fn record_merge_approved_transitions_workflow_to_done() -> anyhow::Result<
     assert_eq!(updated.state, IssueLifecycleState::Done);
     Ok(())
 }
+
+#[tokio::test]
+async fn repair_project_id_rekeys_row() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let corrupt_id = "/data/workspaces/abc-uuid-repair-test";
+    store
+        .record_issue_scheduled(corrupt_id, Some("owner/repo"), 9001, "task-r1", &[], false)
+        .await?;
+
+    let workflow = store
+        .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
+        .await?
+        .expect("row should exist");
+    let old_row_id = workflow.id.clone();
+
+    let canonical = "/real/canonical/root";
+    store.repair_project_id(&old_row_id, canonical).await?;
+
+    let old = store
+        .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
+        .await?;
+    assert!(old.is_none(), "old row should be removed");
+
+    let new = store
+        .get_by_issue(canonical, Some("owner/repo"), 9001)
+        .await?
+        .expect("new row should exist");
+    assert_eq!(new.project_id, canonical);
+    Ok(())
+}
+
+#[tokio::test]
+async fn repair_project_id_refuses_to_overwrite_existing_canonical_row() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let corrupt_project_id = "/data/workspaces/abc-uuid-conflict-test";
+    let canonical_project_id = "/real/canonical/conflict-root";
+
+    store
+        .record_issue_scheduled(
+            corrupt_project_id,
+            Some("owner/repo"),
+            9005,
+            "task-corrupt",
+            &[],
+            false,
+        )
+        .await?;
+    store
+        .record_issue_scheduled(
+            canonical_project_id,
+            Some("owner/repo"),
+            9005,
+            "task-canonical",
+            &[],
+            false,
+        )
+        .await?;
+    store
+        .record_pr_detected(
+            canonical_project_id,
+            Some("owner/repo"),
+            9005,
+            "task-canonical",
+            45,
+            "https://github.com/owner/repo/pull/45",
+        )
+        .await?;
+
+    let corrupt_before = store
+        .get_by_issue(corrupt_project_id, Some("owner/repo"), 9005)
+        .await?
+        .expect("corrupt row should exist");
+    let canonical_before = store
+        .get_by_issue(canonical_project_id, Some("owner/repo"), 9005)
+        .await?
+        .expect("canonical row should exist");
+
+    let err = store
+        .repair_project_id(&corrupt_before.id, canonical_project_id)
+        .await
+        .expect_err("repair should fail when canonical row already exists");
+    assert!(
+        err.to_string().contains("canonical row already exists"),
+        "unexpected error: {err}",
+    );
+
+    let corrupt_after = store
+        .get_by_issue(corrupt_project_id, Some("owner/repo"), 9005)
+        .await?
+        .expect("corrupt row should remain for manual remediation");
+    let canonical_after = store
+        .get_by_issue(canonical_project_id, Some("owner/repo"), 9005)
+        .await?
+        .expect("canonical row should remain unchanged");
+
+    assert_eq!(store.row_count().await?, 2);
+    assert_eq!(corrupt_after, corrupt_before);
+    assert_eq!(canonical_after, canonical_before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mark_workflow_failed_with_reason_sets_state() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-mark-failed-test";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 9002, "task-mf1", &[], false)
+        .await?;
+
+    let workflow = store
+        .get_by_issue(project_id, Some("owner/repo"), 9002)
+        .await?
+        .expect("row should exist");
+
+    store
+        .mark_workflow_failed_with_reason(&workflow.id, "project root not found")
+        .await?;
+
+    let updated = store
+        .get_by_issue(project_id, Some("owner/repo"), 9002)
+        .await?
+        .expect("row should still exist");
+    assert_eq!(updated.state, IssueLifecycleState::Failed);
+    assert_eq!(
+        updated
+            .last_event
+            .as_ref()
+            .and_then(|e| e.detail.as_deref()),
+        Some("project root not found")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_with_worktree_project_ids_filters_correctly() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let corrupt = "/data/workspaces/xyz-uuid-list-test";
+    let canonical = "/tmp/canonical-list-test";
+
+    store
+        .record_issue_scheduled(corrupt, Some("owner/repo"), 9003, "task-l1", &[], false)
+        .await?;
+    store
+        .record_issue_scheduled(canonical, Some("owner/repo"), 9004, "task-l2", &[], false)
+        .await?;
+
+    let corrupt_rows = store.list_with_worktree_project_ids().await?;
+    assert!(
+        corrupt_rows.iter().any(|w| w.project_id == corrupt),
+        "worktree row should appear"
+    );
+    assert!(
+        !corrupt_rows.iter().any(|w| w.project_id == canonical),
+        "canonical row should not appear"
+    );
+    Ok(())
+}

--- a/crates/harness-workflow/src/issue_workflow_store_tests.rs
+++ b/crates/harness-workflow/src/issue_workflow_store_tests.rs
@@ -1,0 +1,264 @@
+use super::IssueWorkflowStore;
+use crate::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
+use chrono::Utc;
+
+async fn open_test_store() -> anyhow::Result<Option<IssueWorkflowStore>> {
+    if std::env::var("DATABASE_URL").is_err() {
+        return Ok(None);
+    }
+    let dir = tempfile::tempdir()?;
+    match IssueWorkflowStore::open(&dir.path().join("issue_workflows.db")).await {
+        Ok(store) => Ok(Some(store)),
+        Err(e) => {
+            tracing::warn!("issue workflow store test skipped: {e}");
+            Ok(None)
+        }
+    }
+}
+
+#[tokio::test]
+async fn issue_workflow_store_binds_pr_to_issue_instance() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-a";
+    store
+        .record_issue_scheduled(
+            project_id,
+            Some("owner/repo"),
+            882,
+            "task-1",
+            &["force-execute".to_string()],
+            true,
+        )
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            882,
+            "task-1",
+            909,
+            "https://github.com/owner/repo/pull/909",
+        )
+        .await?;
+
+    let by_issue = store
+        .get_by_issue(project_id, Some("owner/repo"), 882)
+        .await?
+        .expect("workflow by issue");
+    let by_pr = store
+        .get_by_pr(project_id, Some("owner/repo"), 909)
+        .await?
+        .expect("workflow by pr");
+
+    assert_eq!(by_issue.id, by_pr.id);
+    assert_eq!(by_issue.state, IssueLifecycleState::PrOpen);
+    assert_eq!(by_issue.pr_number, Some(909));
+    assert!(by_issue.force_execute);
+    assert_eq!(by_issue.labels_snapshot, vec!["force-execute".to_string()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn issue_workflow_store_records_plan_issue_as_non_terminal_event() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-b";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 883, "task-2", &[], false)
+        .await?;
+    let workflow = store
+        .record_plan_issue_detected(
+            project_id,
+            Some("owner/repo"),
+            883,
+            "task-2",
+            "The plan is incomplete.",
+        )
+        .await?;
+
+    assert_eq!(workflow.state, IssueLifecycleState::Implementing);
+    assert_eq!(
+        workflow.plan_concern.as_deref(),
+        Some("The plan is incomplete.")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn issue_workflow_store_scopes_identity_by_repo() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/shared-project";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo-a"), 42, "task-a", &[], false)
+        .await?;
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo-b"), 42, "task-b", &[], false)
+        .await?;
+
+    let a = store
+        .get_by_issue(project_id, Some("owner/repo-a"), 42)
+        .await?
+        .expect("repo-a workflow");
+    let b = store
+        .get_by_issue(project_id, Some("owner/repo-b"), 42)
+        .await?
+        .expect("repo-b workflow");
+
+    assert_ne!(a.id, b.id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn issue_workflow_store_records_cancelled_pr_tasks_as_cancelled() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-cancel";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 7, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            7,
+            "task-1",
+            55,
+            "https://github.com/owner/repo/pull/55",
+        )
+        .await?;
+    let workflow = store
+        .record_terminal_for_pr(project_id, Some("owner/repo"), 55, false, true, None)
+        .await?
+        .expect("workflow");
+    assert_eq!(workflow.state, IssueLifecycleState::Cancelled);
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-stale-claim";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 9, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            9,
+            "task-1",
+            77,
+            "https://github.com/owner/repo/pull/77",
+        )
+        .await?;
+    store
+        .record_feedback_task_scheduled(project_id, Some("owner/repo"), 77, "task-2")
+        .await?;
+
+    let mut workflow = store
+        .get_by_pr(project_id, Some("owner/repo"), 77)
+        .await?
+        .expect("workflow");
+    workflow.feedback_claimed_at = Some(Utc::now() - chrono::Duration::minutes(10));
+    store.upsert(&workflow).await?;
+    sqlx::query(
+        "UPDATE issue_workflows
+         SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
+         WHERE id = $1",
+    )
+    .bind(&workflow.id)
+    .execute(&store.pool)
+    .await?;
+
+    let claimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].pr_number, Some(77));
+    assert_eq!(claimed[0].state, IssueLifecycleState::AddressingFeedback);
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_feedback_candidates_skips_malformed_rows() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-malformed";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 10, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            10,
+            "task-1",
+            88,
+            "https://github.com/owner/repo/pull/88",
+        )
+        .await?;
+    sqlx::query(
+        "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+         ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
+    )
+    .bind("malformed-workflow")
+    .bind(r#"{"project_id":"/tmp/project-malformed","repo":"owner/repo","state":"pr_open","pr_number":999}"#)
+    .execute(&store.pool)
+    .await?;
+
+    let claimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].pr_number, Some(88));
+    Ok(())
+}
+
+#[tokio::test]
+async fn record_merge_approved_transitions_workflow_to_done() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-merge-approved";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 20, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            20,
+            "task-1",
+            120,
+            "https://github.com/owner/repo/pull/120",
+        )
+        .await?;
+    store
+        .record_terminal_for_pr(project_id, Some("owner/repo"), 120, true, false, None)
+        .await?;
+
+    let workflow = store
+        .get_by_pr(project_id, Some("owner/repo"), 120)
+        .await?
+        .expect("workflow should be ready_to_merge");
+    assert_eq!(workflow.state, IssueLifecycleState::ReadyToMerge);
+
+    let updated = store
+        .record_merge_approved(project_id, Some("owner/repo"), 120)
+        .await?
+        .expect("updated workflow");
+    assert_eq!(updated.state, IssueLifecycleState::Done);
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn _use_workflow_instance(_: &IssueWorkflowInstance) {}

--- a/crates/harness-workflow/src/issue_workflow_store_tests.rs
+++ b/crates/harness-workflow/src/issue_workflow_store_tests.rs
@@ -1,5 +1,5 @@
 use super::IssueWorkflowStore;
-use crate::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
+use crate::issue_lifecycle::IssueLifecycleState;
 use chrono::Utc;
 
 async fn open_test_store() -> anyhow::Result<Option<IssueWorkflowStore>> {
@@ -259,6 +259,3 @@ async fn record_merge_approved_transitions_workflow_to_done() -> anyhow::Result<
     assert_eq!(updated.state, IssueLifecycleState::Done);
     Ok(())
 }
-
-#[allow(dead_code)]
-fn _use_workflow_instance(_: &IssueWorkflowInstance) {}

--- a/crates/harness-workflow/src/lib.rs
+++ b/crates/harness-workflow/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod checkpoint;
 pub mod circuit_breaker;
 pub mod issue_lifecycle;
+pub mod issue_workflow_store;
 pub mod plan_db;
 pub mod project_lifecycle;
 pub mod task_queue;

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Active } from "./Active";
 import type { Task } from "@/types";
@@ -28,10 +28,16 @@ vi.mock("@/components/TaskDetailSlideover", () => ({
   },
 }));
 
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(() => Promise.resolve(undefined)),
+}));
+
 import { useTasks, useDashboard } from "@/lib/queries";
+import { apiFetch } from "@/lib/api";
 
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
 const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
 
 function makeTask(id: string, project: string | null, status = "running", task_kind = "issue"): Task {
   return {
@@ -79,6 +85,7 @@ const tasks = [
 
 describe("<Active>", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockUseDashboard.mockReturnValue({ data: undefined });
   });
 
@@ -127,6 +134,27 @@ describe("<Active>", () => {
     expect(columnCount("Feedback")).toBe("1");
     expect(columnCount("Implementing")).toBe("0");
     expect(columnCount("Pending")).toBe("0");
+  });
+
+  it("keeps ready-to-merge terminal tasks visible and mergeable", async () => {
+    const ready = {
+      ...makeTask("ready-task", "harness", "done"),
+      pr_url: "https://github.com/owner/repo/pull/123",
+      workflow: { state: "ready_to_merge", pr_number: 123 },
+    };
+    mockUseTasks.mockReturnValue({ data: [ready], isLoading: false, isError: false });
+
+    wrap(<Active projectFilter="harness" />);
+
+    expect(screen.getByText("wf Ready To Merge")).toBeInTheDocument();
+    expect(columnCount("Ready")).toBe("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/tasks/ready-task/merge", { method: "POST" });
+    });
+    expect(screen.queryByTestId("task-slideover")).not.toBeInTheDocument();
   });
 
   it("groups planner and review lifecycle statuses outside implementing", () => {

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTasks, useDashboard } from "@/lib/queries";
+import { apiFetch } from "@/lib/api";
 import { TaskDetailSlideover } from "@/components/TaskDetailSlideover";
 import { workflowLabel } from "@/lib/format";
 import type { Task, WorkflowSummary } from "@/types";
@@ -80,10 +82,14 @@ function TaskCard({
   task,
   workflow,
   onClick,
+  onMerge,
+  merging,
 }: {
   task: Task;
   workflow?: WorkflowSummary | null;
   onClick: () => void;
+  onMerge?: (taskId: string) => void;
+  merging?: boolean;
 }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
@@ -133,6 +139,19 @@ function TaskCard({
           {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
         </a>
       )}
+      {workflow?.state === "ready_to_merge" && onMerge && (
+        <button
+          type="button"
+          disabled={merging}
+          onClick={(e) => {
+            e.stopPropagation();
+            onMerge(task.id);
+          }}
+          className="mt-2 w-full border border-line bg-bg-1 px-2 py-1 font-mono text-[10px] text-ink-2 hover:border-line-3 hover:text-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {merging ? "Merging…" : "Merge"}
+        </button>
+      )}
     </button>
   );
 }
@@ -143,8 +162,24 @@ interface Props {
 
 export function Active({ projectFilter }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [merging, setMerging] = useState<Set<string>>(new Set());
   const { data, isLoading, isError } = useTasks();
   const { data: dashboard } = useDashboard();
+  const queryClient = useQueryClient();
+
+  const handleMerge = async (taskId: string) => {
+    setMerging((prev) => new Set(prev).add(taskId));
+    try {
+      await apiFetch(`/tasks/${taskId}/merge`, { method: "POST" });
+      await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    } finally {
+      setMerging((prev) => {
+        const next = new Set(prev);
+        next.delete(taskId);
+        return next;
+      });
+    }
+  };
 
   const resolvedRoot = projectFilter
     ? (dashboard?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
@@ -189,6 +224,8 @@ export function Active({ projectFilter }: Props) {
                   task={t}
                   workflow={t.workflow ?? null}
                   onClick={() => setSelectedTaskId(t.id)}
+                  onMerge={handleMerge}
+                  merging={merging.has(t.id)}
                 />
               ))}
             </div>

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -78,6 +78,11 @@ function columnOf(taskStatus: string, workflowState?: string | null): string {
   return "other";
 }
 
+function shouldShowTask(task: Task): boolean {
+  if (task.workflow?.state === "ready_to_merge") return true;
+  return !TERMINAL_STATUSES.has(task.status);
+}
+
 function TaskCard({
   task,
   workflow,
@@ -93,47 +98,46 @@ function TaskCard({
 }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
   return (
-    <button
-      type="button"
+    <div
       className="w-full text-left border border-line bg-bg px-2.5 py-2 mb-2 last:mb-0 hover:border-line-3 transition-colors cursor-pointer"
-      onClick={onClick}
     >
-      <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
-        {title}
-      </div>
-      {workflow && (
-        <div className="mt-1 flex flex-wrap items-center gap-1">
-          <span className="border border-line bg-bg-1 px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
-            wf {workflowLabel(workflow.state)}
-          </span>
-          {workflow.pr_number ? (
-            <span className="font-mono text-[10px] text-ink-3">PR #{workflow.pr_number}</span>
-          ) : null}
-          {workflow.force_execute ? (
-            <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
-              force-execute
+      <button type="button" className="block w-full text-left" onClick={onClick}>
+        <div className="text-[12.5px] text-ink leading-snug line-clamp-2" title={title}>
+          {title}
+        </div>
+        {workflow && (
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            <span className="border border-line bg-bg-1 px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
+              wf {workflowLabel(workflow.state)}
             </span>
-          ) : null}
+            {workflow.pr_number ? (
+              <span className="font-mono text-[10px] text-ink-3">PR #{workflow.pr_number}</span>
+            ) : null}
+            {workflow.force_execute ? (
+              <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
+                force-execute
+              </span>
+            ) : null}
+          </div>
+        )}
+        <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
+          <span className="truncate">{task.repo ?? "—"}</span>
+          {task.turn > 0 && <span>turn {task.turn}</span>}
         </div>
-      )}
-      <div className="mt-1.5 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-3">
-        <span className="truncate">{task.repo ?? "—"}</span>
-        {task.turn > 0 && <span>turn {task.turn}</span>}
-      </div>
-      {workflow?.plan_concern && (
-        <div
-          className="mt-1 block font-mono text-[10px] text-rust truncate"
-          title={workflow.plan_concern}
-        >
-          concern: {workflow.plan_concern}
-        </div>
-      )}
+        {workflow?.plan_concern && (
+          <div
+            className="mt-1 block font-mono text-[10px] text-rust truncate"
+            title={workflow.plan_concern}
+          >
+            concern: {workflow.plan_concern}
+          </div>
+        )}
+      </button>
       {task.pr_url && (
         <a
           href={task.pr_url}
           target="_blank"
           rel="noreferrer"
-          onClick={(e) => e.stopPropagation()}
           className="mt-1 block font-mono text-[10px] text-rust hover:underline truncate"
         >
           {task.pr_url.replace(/^https:\/\/github\.com\//, "")}
@@ -152,7 +156,7 @@ function TaskCard({
           {merging ? "Merging…" : "Merge"}
         </button>
       )}
-    </button>
+    </div>
   );
 }
 
@@ -186,7 +190,7 @@ export function Active({ projectFilter }: Props) {
     : null;
 
   const active = (data ?? [])
-    .filter((t) => !TERMINAL_STATUSES.has(t.status))
+    .filter(shouldShowTask)
     .filter((t) => !resolvedRoot || t.project === resolvedRoot);
   const grouped: Record<string, Task[]> = {};
   for (const c of COLUMNS) grouped[c.key] = [];


### PR DESCRIPTION
## Summary

- Wire `ready_to_merge` to an explicit `ReadyToMerge -> Done` transition via a `HumanMergeApproved` event and `record_merge_approved()`.
- Add `POST /tasks/{id}/merge` for human approval of ready workflows.
- Surface a dashboard Merge button for ready workflows, while keeping terminal `ready_to_merge` tasks visible and mergeable.
- Split the issue workflow store out of `issue_lifecycle.rs` and preserved the recent project-id repair helpers plus insert-only migration helper after the split.

## Notes

- Rebuilt this PR cleanly on current `main` after #1014 merged.
- Includes the dashboard fix from #1015, so #1015 is superseded by this PR.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --message-format short`
- [x] `bun run test src/routes/dashboard/Active.test.tsx`
- [x] `bun run typecheck`
- [x] `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness DATABASE_URL=postgres://harness:harness@localhost:5432/harness RUST_TEST_THREADS=1 cargo test --workspace`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Closes #935