### PR TITLE
fix(task-runner): make Scheduler-owner protection explicit in claim_for_runtime_host

### DIFF
--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -462,14 +462,16 @@ impl TaskStore {
             return Ok(None);
         }
         let original_scheduler = entry.scheduler.clone();
-        if entry.scheduler.owner.is_some() && entry.scheduler.has_live_runtime_host_lease(now) {
-            return Ok(None);
-        }
-        if entry.scheduler.owner.is_some() && !entry.scheduler.has_live_runtime_host_lease(now) {
-            entry.scheduler.clear_to_queued();
-        }
         if entry.scheduler.owner.is_some() {
-            return Ok(None);
+            // Scheduler owner: never allow a runtime host to steal the task.
+            // RuntimeHost with live lease: the claim is still active.
+            if entry.scheduler.runtime_host_id().is_none()
+                || entry.scheduler.has_live_runtime_host_lease(now)
+            {
+                return Ok(None);
+            }
+            // RuntimeHost with a stale lease: safe to clear and re-claim.
+            entry.scheduler.clear_to_queued();
         }
 
         entry.scheduler.claim_runtime_host(host_id, expires_at);


### PR DESCRIPTION
## Summary

- **Bug**: In `claim_for_runtime_host` (added in #910), the third guard `if entry.scheduler.owner.is_some() { return Ok(None) }` was dead code. The preceding `clear_to_queued()` call unconditionally sets `owner = None`, so this guard never fires.
- **Hidden regression**: The stale-lease branch matched on _any_ owner (including `Scheduler` kind) because `has_live_runtime_host_lease` returns `false` for Scheduler entries. This allowed a runtime host to silently steal tasks owned by the local scheduler, enabling split-brain execution.
- **Fix**: Replace the three-block chain with a single `if` block using `runtime_host_id()` as a discriminator (it returns `None` for non-RuntimeHost owners), making all three cases explicit and future-safe.

## Invariants now enforced

| Owner state | Action |
|---|---|
| No owner | Proceed to claim |
| Scheduler owner | `return Ok(None)` — never steal |
| RuntimeHost with live lease | `return Ok(None)` — active claim |
| RuntimeHost with stale lease | `clear_to_queued()`, then claim |

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — all non-Postgres-flaky tests pass; Postgres pool exhaustion failures in `harness-observe` are pre-existing (pool is shared across parallel test runs, see hook comment)