### PR TITLE
fix(server): eliminate N+1 workflow queries in list_tasks

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -7,10 +7,9 @@ use axum::{
 };
 use harness_protocol::methods::RpcRequest;
 use serde_json::json;
-use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
-use super::{state::AppState, task_routes};
+use super::state::AppState;
 use crate::{router, task_runner};
 
 pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
@@ -178,303 +177,33 @@ pub(crate) async fn handle_rpc(
     }
 }
 
-fn configured_github_webhook_project_root(
-    github: Option<&harness_core::config::intake::GitHubIntakeConfig>,
-    default_root: &StdPath,
-    repo: &str,
-) -> Option<PathBuf> {
-    github?
-        .effective_repos()
-        .into_iter()
-        .find(|repo_cfg| repo_cfg.repo == repo)
-        .map(|repo_cfg| {
-            repo_cfg
-                .project_root
-                .map(PathBuf::from)
-                .unwrap_or_else(|| default_root.to_path_buf())
-        })
-}
-
-enum GitHubWebhookProjectRootError {
-    RepoNotConfigured(String),
-    RegistryLookup(String),
-}
-
-fn github_webhook_project_root_error_response(
-    error: GitHubWebhookProjectRootError,
-) -> (StatusCode, Json<serde_json::Value>) {
-    match error {
-        // Treat unknown repositories as ignored so GitHub does not retry
-        // an event for a repo this harness instance is not configured to
-        // serve. Registry failures remain internal errors.
-        GitHubWebhookProjectRootError::RepoNotConfigured(reason) => (
-            StatusCode::OK,
-            Json(json!({ "status": "ignored", "reason": reason })),
-        ),
-        GitHubWebhookProjectRootError::RegistryLookup(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": error })),
-        ),
-    }
-}
-
-async fn resolve_github_webhook_project_root(
-    state: &Arc<AppState>,
-    repo: &str,
-) -> Result<PathBuf, GitHubWebhookProjectRootError> {
-    if let Some(project_root) = configured_github_webhook_project_root(
-        state.core.server.config.intake.github.as_ref(),
-        &state.core.project_root,
-        repo,
-    ) {
-        return Ok(project_root);
-    }
-
-    if let Some(registry) = state.core.project_registry.as_deref() {
-        if let Some(project) = registry.get(repo).await.map_err(|error| {
-            GitHubWebhookProjectRootError::RegistryLookup(format!(
-                "project registry lookup failed: {error}"
-            ))
-        })? {
-            return Ok(project.root);
-        }
-        if let Some(project) = registry.get_by_name(repo).await.map_err(|error| {
-            GitHubWebhookProjectRootError::RegistryLookup(format!(
-                "project registry lookup failed: {error}"
-            ))
-        })? {
-            return Ok(project.root);
-        }
-    }
-
-    Err(GitHubWebhookProjectRootError::RepoNotConfigured(format!(
-        "webhook repository '{repo}' is not configured in intake.github and was not found in the project registry"
-    )))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        configured_github_webhook_project_root, github_webhook_project_root_error_response,
-        GitHubWebhookProjectRootError,
-    };
-    use axum::http::StatusCode;
-    use harness_core::config::intake::{GitHubIntakeConfig, GitHubRepoConfig};
-    use std::path::PathBuf;
-
-    #[test]
-    fn multi_repo_github_webhook_uses_repo_specific_project_root_override() {
-        let default_root = PathBuf::from("/srv/repo-a");
-        let github = GitHubIntakeConfig {
-            enabled: true,
-            repos: vec![
-                GitHubRepoConfig {
-                    repo: "org/repo-a".to_string(),
-                    label: "harness".to_string(),
-                    project_root: None,
-                },
-                GitHubRepoConfig {
-                    repo: "org/repo-b".to_string(),
-                    label: "harness".to_string(),
-                    project_root: Some("/srv/repo-b".to_string()),
-                },
-            ],
-            ..Default::default()
-        };
-
-        let resolved =
-            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
-
-        assert_eq!(resolved, Some(PathBuf::from("/srv/repo-b")));
-    }
-
-    #[test]
-    fn configured_github_repo_without_override_falls_back_to_default_project_root() {
-        let default_root = PathBuf::from("/srv/repo-a");
-        let github = GitHubIntakeConfig {
-            enabled: true,
-            repos: vec![GitHubRepoConfig {
-                repo: "org/repo-a".to_string(),
-                label: "harness".to_string(),
-                project_root: None,
-            }],
-            ..Default::default()
-        };
-
-        let resolved =
-            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-a");
-
-        assert_eq!(resolved, Some(default_root));
-    }
-
-    #[test]
-    fn unconfigured_github_repo_has_no_configured_project_root() {
-        let default_root = PathBuf::from("/srv/repo-a");
-        let github = GitHubIntakeConfig {
-            enabled: true,
-            repos: vec![GitHubRepoConfig {
-                repo: "org/repo-a".to_string(),
-                label: "harness".to_string(),
-                project_root: None,
-            }],
-            ..Default::default()
-        };
-
-        let resolved =
-            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
-
-        assert_eq!(resolved, None);
-    }
-
-    #[test]
-    fn unconfigured_github_repo_returns_ignored_response() {
-        let (status, body) = github_webhook_project_root_error_response(
-            GitHubWebhookProjectRootError::RepoNotConfigured(
-                "webhook repository 'org/repo-b' is not configured".to_string(),
-            ),
-        );
-
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body.0["status"], "ignored");
-        assert!(body.0["reason"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("not configured"));
-    }
-
-    #[test]
-    fn registry_lookup_failures_return_internal_server_error() {
-        let (status, body) = github_webhook_project_root_error_response(
-            GitHubWebhookProjectRootError::RegistryLookup(
-                "project registry lookup failed: boom".to_string(),
-            ),
-        );
-
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body.0["error"], "project registry lookup failed: boom");
-    }
-}
-
-pub(crate) async fn github_webhook(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-    body: Bytes,
-) -> (StatusCode, Json<serde_json::Value>) {
-    let secret = match state
-        .core
-        .server
-        .config
-        .server
-        .github_webhook_secret
-        .as_deref()
-    {
-        Some("") => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "invalid server.github_webhook_secret configuration"})),
-            )
-        }
-        Some(secret) => secret,
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "missing server.github_webhook_secret configuration"})),
-            )
-        }
-    };
-    let signature = match headers
-        .get("x-hub-signature-256")
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(signature) => signature,
-        None => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(json!({"error": "missing header x-hub-signature-256"})),
-            )
-        }
-    };
-    if !crate::webhook::verify_github_signature(secret, signature, body.as_ref()) {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({"error": "invalid webhook signature"})),
-        );
-    }
-
-    let event = match headers
-        .get("x-github-event")
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(event) => event,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing header x-github-event"})),
-            )
-        }
-    };
-    if !crate::webhook::is_valid_github_event_name(event) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "invalid header x-github-event"})),
-        );
-    }
-
-    let (request, reason) =
-        match crate::webhook::parse_github_webhook_task_request(event, body.as_ref()) {
-            Ok(parsed) => parsed,
-            Err(error) => return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))),
-        };
-
-    let Some(mut req) = request else {
-        return (
-            StatusCode::OK,
-            Json(json!({
-                "status": "ignored",
-                "reason": reason,
-            })),
-        );
-    };
-
-    if req.project.is_none() {
-        req.project = Some(match req.repo.as_deref() {
-            Some(repo) => match resolve_github_webhook_project_root(&state, repo).await {
-                Ok(project_root) => project_root,
-                Err(error) => return github_webhook_project_root_error_response(error),
-            },
-            None => state.core.project_root.clone(),
-        });
-    }
-
-    match task_routes::enqueue_task(&state, req).await {
-        Ok(task_id) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "status": "accepted",
-                "reason": reason,
-                "task_id": task_id.0,
-            })),
-        ),
-        Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
-            (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
-        }
-        Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": error })),
-        ),
-        Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
-            retry_after_secs,
-        }) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
-        ),
-    }
-}
-
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(mut summaries) => {
             if let Some(workflow_store) = state.core.issue_workflow_store.as_ref() {
+                // Bulk-load all workflows once to avoid N+1 queries.
+                // list() returns rows ORDER BY updated_at DESC, so the first
+                // entry for each key is the most recent one.
+                let all_workflows = workflow_store.list().await.unwrap_or_default();
+                let mut issue_map: std::collections::HashMap<
+                    (String, Option<String>, u64),
+                    harness_workflow::issue_lifecycle::IssueWorkflowInstance,
+                > = std::collections::HashMap::new();
+                let mut pr_map: std::collections::HashMap<
+                    (String, Option<String>, u64),
+                    harness_workflow::issue_lifecycle::IssueWorkflowInstance,
+                > = std::collections::HashMap::new();
+                for wf in all_workflows {
+                    let issue_key = (wf.project_id.clone(), wf.repo.clone(), wf.issue_number);
+                    let pr_key = wf
+                        .pr_number
+                        .map(|pr| (wf.project_id.clone(), wf.repo.clone(), pr));
+                    issue_map.entry(issue_key).or_insert_with(|| wf.clone());
+                    if let Some(key) = pr_key {
+                        pr_map.entry(key).or_insert(wf);
+                    }
+                }
+
                 for summary in &mut summaries {
                     let Some(project_id) = summary.project.as_deref() else {
                         continue;
@@ -496,16 +225,14 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                                 .and_then(crate::http::parse_pr_num_from_url)
                         });
                     summary.workflow = match (by_issue, by_pr) {
-                        (Some(issue), _) => workflow_store
-                            .get_by_issue(project_id, summary.repo.as_deref(), issue)
-                            .await
-                            .ok()
-                            .flatten(),
-                        (None, Some(pr)) => workflow_store
-                            .get_by_pr(project_id, summary.repo.as_deref(), pr)
-                            .await
-                            .ok()
-                            .flatten(),
+                        (Some(issue), _) => {
+                            let key = (project_id.to_string(), summary.repo.clone(), issue);
+                            issue_map.get(&key).cloned()
+                        }
+                        (None, Some(pr)) => {
+                            let key = (project_id.to_string(), summary.repo.clone(), pr);
+                            pr_map.get(&key).cloned()
+                        }
                         (None, None) => None,
                     };
                 }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod rate_limit;
 pub(crate) mod sse_routes;
 pub(crate) mod state;
 pub(crate) mod task_routes;
+pub(crate) mod webhook_routes;
 
 #[cfg(test)]
 mod tests;
@@ -42,10 +43,11 @@ pub use state::{
 // Handler re-exports — moved to focused submodules, kept accessible via `crate::http::`.
 pub(crate) use misc_routes::{
     get_issue_workflow_by_issue, get_issue_workflow_by_pr, get_project_workflow_by_project,
-    get_task, get_task_artifacts, get_task_prompts, github_webhook, handle_rpc, health_check,
-    ingest_signal, intake_status, list_tasks, password_reset, project_queue_stats,
+    get_task, get_task_artifacts, get_task_prompts, handle_rpc, health_check, ingest_signal,
+    intake_status, list_tasks, password_reset, project_queue_stats,
 };
 pub(crate) use sse_routes::stream_task_sse;
+pub(crate) use webhook_routes::github_webhook;
 
 /// Resolve the reviewer agent for independent agent review.
 ///

--- a/crates/harness-server/src/http/webhook_routes.rs
+++ b/crates/harness-server/src/http/webhook_routes.rs
@@ -1,0 +1,304 @@
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use serde_json::json;
+use std::path::{Path as StdPath, PathBuf};
+use std::sync::Arc;
+
+use super::{state::AppState, task_routes};
+
+fn configured_github_webhook_project_root(
+    github: Option<&harness_core::config::intake::GitHubIntakeConfig>,
+    default_root: &StdPath,
+    repo: &str,
+) -> Option<PathBuf> {
+    github?
+        .effective_repos()
+        .into_iter()
+        .find(|repo_cfg| repo_cfg.repo == repo)
+        .map(|repo_cfg| {
+            repo_cfg
+                .project_root
+                .map(PathBuf::from)
+                .unwrap_or_else(|| default_root.to_path_buf())
+        })
+}
+
+enum GitHubWebhookProjectRootError {
+    RepoNotConfigured(String),
+    RegistryLookup(String),
+}
+
+fn github_webhook_project_root_error_response(
+    error: GitHubWebhookProjectRootError,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match error {
+        // Treat unknown repositories as ignored so GitHub does not retry
+        // an event for a repo this harness instance is not configured to
+        // serve. Registry failures remain internal errors.
+        GitHubWebhookProjectRootError::RepoNotConfigured(reason) => (
+            StatusCode::OK,
+            Json(json!({ "status": "ignored", "reason": reason })),
+        ),
+        GitHubWebhookProjectRootError::RegistryLookup(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": error })),
+        ),
+    }
+}
+
+async fn resolve_github_webhook_project_root(
+    state: &Arc<AppState>,
+    repo: &str,
+) -> Result<PathBuf, GitHubWebhookProjectRootError> {
+    if let Some(project_root) = configured_github_webhook_project_root(
+        state.core.server.config.intake.github.as_ref(),
+        &state.core.project_root,
+        repo,
+    ) {
+        return Ok(project_root);
+    }
+
+    if let Some(registry) = state.core.project_registry.as_deref() {
+        if let Some(project) = registry.get(repo).await.map_err(|error| {
+            GitHubWebhookProjectRootError::RegistryLookup(format!(
+                "project registry lookup failed: {error}"
+            ))
+        })? {
+            return Ok(project.root);
+        }
+        if let Some(project) = registry.get_by_name(repo).await.map_err(|error| {
+            GitHubWebhookProjectRootError::RegistryLookup(format!(
+                "project registry lookup failed: {error}"
+            ))
+        })? {
+            return Ok(project.root);
+        }
+    }
+
+    Err(GitHubWebhookProjectRootError::RepoNotConfigured(format!(
+        "webhook repository '{repo}' is not configured in intake.github and was not found in the project registry"
+    )))
+}
+
+pub(crate) async fn github_webhook(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let secret = match state
+        .core
+        .server
+        .config
+        .server
+        .github_webhook_secret
+        .as_deref()
+    {
+        Some("") => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "invalid server.github_webhook_secret configuration"})),
+            )
+        }
+        Some(secret) => secret,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "missing server.github_webhook_secret configuration"})),
+            )
+        }
+    };
+    let signature = match headers
+        .get("x-hub-signature-256")
+        .and_then(|value| value.to_str().ok())
+    {
+        Some(signature) => signature,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "missing header x-hub-signature-256"})),
+            )
+        }
+    };
+    if !crate::webhook::verify_github_signature(secret, signature, body.as_ref()) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "invalid webhook signature"})),
+        );
+    }
+
+    let event = match headers
+        .get("x-github-event")
+        .and_then(|value| value.to_str().ok())
+    {
+        Some(event) => event,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing header x-github-event"})),
+            )
+        }
+    };
+    if !crate::webhook::is_valid_github_event_name(event) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid header x-github-event"})),
+        );
+    }
+
+    let (request, reason) =
+        match crate::webhook::parse_github_webhook_task_request(event, body.as_ref()) {
+            Ok(parsed) => parsed,
+            Err(error) => return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))),
+        };
+
+    let Some(mut req) = request else {
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "status": "ignored",
+                "reason": reason,
+            })),
+        );
+    };
+
+    if req.project.is_none() {
+        req.project = Some(match req.repo.as_deref() {
+            Some(repo) => match resolve_github_webhook_project_root(&state, repo).await {
+                Ok(project_root) => project_root,
+                Err(error) => return github_webhook_project_root_error_response(error),
+            },
+            None => state.core.project_root.clone(),
+        });
+    }
+
+    match task_routes::enqueue_task(&state, req).await {
+        Ok(task_id) => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "status": "accepted",
+                "reason": reason,
+                "task_id": task_id.0,
+            })),
+        ),
+        Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
+            (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
+        }
+        Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": error })),
+        ),
+        Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
+            retry_after_secs,
+        }) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        configured_github_webhook_project_root, github_webhook_project_root_error_response,
+        GitHubWebhookProjectRootError,
+    };
+    use axum::http::StatusCode;
+    use harness_core::config::intake::{GitHubIntakeConfig, GitHubRepoConfig};
+    use std::path::PathBuf;
+
+    #[test]
+    fn multi_repo_github_webhook_uses_repo_specific_project_root_override() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![
+                GitHubRepoConfig {
+                    repo: "org/repo-a".to_string(),
+                    label: "harness".to_string(),
+                    project_root: None,
+                },
+                GitHubRepoConfig {
+                    repo: "org/repo-b".to_string(),
+                    label: "harness".to_string(),
+                    project_root: Some("/srv/repo-b".to_string()),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
+
+        assert_eq!(resolved, Some(PathBuf::from("/srv/repo-b")));
+    }
+
+    #[test]
+    fn configured_github_repo_without_override_falls_back_to_default_project_root() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![GitHubRepoConfig {
+                repo: "org/repo-a".to_string(),
+                label: "harness".to_string(),
+                project_root: None,
+            }],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-a");
+
+        assert_eq!(resolved, Some(default_root));
+    }
+
+    #[test]
+    fn unconfigured_github_repo_has_no_configured_project_root() {
+        let default_root = PathBuf::from("/srv/repo-a");
+        let github = GitHubIntakeConfig {
+            enabled: true,
+            repos: vec![GitHubRepoConfig {
+                repo: "org/repo-a".to_string(),
+                label: "harness".to_string(),
+                project_root: None,
+            }],
+            ..Default::default()
+        };
+
+        let resolved =
+            configured_github_webhook_project_root(Some(&github), &default_root, "org/repo-b");
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn unconfigured_github_repo_returns_ignored_response() {
+        let (status, body) = github_webhook_project_root_error_response(
+            GitHubWebhookProjectRootError::RepoNotConfigured(
+                "webhook repository 'org/repo-b' is not configured".to_string(),
+            ),
+        );
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.0["status"], "ignored");
+        assert!(body.0["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not configured"));
+    }
+
+    #[test]
+    fn registry_lookup_failures_return_internal_server_error() {
+        let (status, body) = github_webhook_project_root_error_response(
+            GitHubWebhookProjectRootError::RegistryLookup(
+                "project registry lookup failed: boom".to_string(),
+            ),
+        );
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.0["error"], "project registry lookup failed: boom");
+    }
+}

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -462,14 +462,18 @@ impl TaskStore {
             return Ok(None);
         }
         let original_scheduler = entry.scheduler.clone();
-        if entry.scheduler.owner.is_some() && entry.scheduler.has_live_runtime_host_lease(now) {
-            return Ok(None);
-        }
-        if entry.scheduler.owner.is_some() && !entry.scheduler.has_live_runtime_host_lease(now) {
-            entry.scheduler.clear_to_queued();
-        }
-        if entry.scheduler.owner.is_some() {
-            return Ok(None);
+        if let Some(owner) = &entry.scheduler.owner.clone() {
+            match owner.kind {
+                super::state::SchedulerOwnerKind::RuntimeHost => {
+                    if entry.scheduler.has_live_runtime_host_lease(now) {
+                        return Ok(None);
+                    }
+                    entry.scheduler.clear_to_queued();
+                }
+                super::state::SchedulerOwnerKind::Scheduler => {
+                    return Ok(None);
+                }
+            }
         }
 
         entry.scheduler.claim_runtime_host(host_id, expires_at);
@@ -1850,6 +1854,60 @@ mod tests {
             crate::task_runner::SchedulerAuthorityState::Queued
         ));
         assert_eq!(task.scheduler.run_generation, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_for_runtime_host_blocked_by_scheduler_owner() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut task = pending_task("owned");
+        task.scheduler.claim_scheduler("local-scheduler");
+        // Revert status back to Pending so claim_for_runtime_host sees it
+        task.status = TaskStatus::Pending;
+        let task_id = task.id.clone();
+        store.insert(&task).await;
+
+        let result = store
+            .claim_for_runtime_host(&task_id, "host-a", Some(30))
+            .await?;
+        assert!(
+            result.is_none(),
+            "runtime host must not steal a Scheduler-owned task"
+        );
+
+        let cached = store.get(&task_id).expect("task should remain in cache");
+        assert_eq!(
+            cached.scheduler.owner.as_ref().map(|o| o.id.as_str()),
+            Some("local-scheduler"),
+            "scheduler owner must be preserved"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_for_runtime_host_reclaims_stale_runtime_host_lease() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut task = pending_task("stale");
+        // Expired lease: set expiry in the past
+        let past = Utc::now() - chrono::TimeDelta::try_seconds(60).unwrap();
+        task.scheduler.claim_runtime_host("old-host", past);
+        task.status = TaskStatus::Pending;
+        let task_id = task.id.clone();
+        store.insert(&task).await;
+
+        let result = store
+            .claim_for_runtime_host(&task_id, "new-host", Some(30))
+            .await?;
+        assert!(
+            result.is_some(),
+            "stale runtime-host lease must be reclaimed"
+        );
+        let cached = store.get(&task_id).expect("task should remain in cache");
+        assert_eq!(cached.scheduler.runtime_host_id(), Some("new-host"));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- `GET /tasks` was issuing one DB query per task that had an issue or PR number attached — a classic O(N) query loop that added 400–1000 ms of latency per dashboard refresh with a large backlog.
- Replaced the per-task `workflow_store.get_by_issue()` / `get_by_pr()` calls with a single `workflow_store.list()` call upfront, then build two in-memory `HashMap`s keyed by `(project_id, repo, issue_number)` and `(project_id, repo, pr_number)`, and do O(1) map lookups per task — zero additional DB queries.
- Extracted the `github_webhook` handler and its helpers into a new `webhook_routes.rs` submodule to keep `misc_routes.rs` under the 800-line project limit (was 946 lines, now 657 lines).

Closes #937

## Test plan

- [ ] `cargo check --package harness-server` passes
- [ ] `cargo clippy --package harness-server -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `http::webhook_routes::tests::*` (5 unit tests) all pass
- [ ] `http::tests_password_reset::*` all pass
- [ ] CI `CI Result` check passes