### PR TITLE
fix(workflow): sweeper path recovery and warn deduplication

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -357,6 +357,8 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
 
     let weak_state = Arc::downgrade(state);
     tokio::spawn(async move {
+        let mut warned_unresolvable: std::collections::HashSet<(String, Option<String>)> =
+            std::collections::HashSet::new();
         loop {
             let state = match weak_state.upgrade() {
                 Some(s) => s,
@@ -423,9 +425,50 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                     }
                 }
 
+                // Short-circuit if path is healthy (avoids a registry DB query on every tick).
+                let project_path = if std::path::Path::new(&workflow.project_id).exists() {
+                    std::path::PathBuf::from(&workflow.project_id)
+                } else if let Some(registry) = state.core.project_registry.as_deref() {
+                    match registry.resolve_path(&workflow.project_id).await {
+                        Ok(None) | Err(_) => {
+                            if warned_unresolvable.insert(project_key.clone()) {
+                                tracing::warn!(
+                                    project_id = %workflow.project_id,
+                                    "sweeper: project path unresolvable, skipping"
+                                );
+                            }
+                            incomplete_projects.insert(project_key.clone());
+                            let _ = issue_workflows
+                                .release_feedback_claim(
+                                    &workflow.project_id,
+                                    workflow.repo.as_deref(),
+                                    pr_number,
+                                    "sweeper: project path unresolvable",
+                                )
+                                .await;
+                            continue;
+                        }
+                        Ok(Some(resolved))
+                            if resolved.as_path() != std::path::Path::new(&workflow.project_id) =>
+                        {
+                            let _ = issue_workflows
+                                .update_project_path(
+                                    &workflow.id,
+                                    resolved.to_str().unwrap_or_default(),
+                                )
+                                .await;
+                            warned_unresolvable.remove(&project_key);
+                            resolved
+                        }
+                        Ok(Some(resolved)) => resolved,
+                    }
+                } else {
+                    std::path::PathBuf::from(&workflow.project_id)
+                };
+
                 let req = crate::task_runner::CreateTaskRequest {
                     pr: Some(pr_number),
-                    project: Some(std::path::PathBuf::from(&workflow.project_id)),
+                    project: Some(project_path),
                     repo: workflow.repo.clone(),
                     source: Some("workflow_feedback".to_string()),
                     ..Default::default()
@@ -1262,5 +1305,25 @@ mod tests {
         let mut pending_without_pr = pending_with_pr;
         pending_without_pr.pr_url = None;
         assert!(!task_is_pr_recovery_candidate(&pending_without_pr));
+    }
+
+    #[test]
+    fn warn_dedup_insert_returns_true_first_time_only() {
+        let mut warned: std::collections::HashSet<(String, Option<String>)> =
+            std::collections::HashSet::new();
+        let key = ("/dead/path".to_string(), Some("owner/repo".to_string()));
+        assert!(
+            warned.insert(key.clone()),
+            "first insert should return true (first tick should warn)"
+        );
+        assert!(
+            !warned.insert(key.clone()),
+            "second insert should return false (dedup suppresses warn)"
+        );
+        warned.remove(&key);
+        assert!(
+            warned.insert(key.clone()),
+            "after removal (path recovered), insert returns true again"
+        );
     }
 }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -426,7 +426,8 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                 }
 
                 // Short-circuit if path is healthy (avoids a registry DB query on every tick).
-                let project_path = if std::path::Path::new(&workflow.project_id).exists() {
+                let project_path = if tokio::fs::metadata(&workflow.project_id).await.is_ok() {
+                    warned_unresolvable.remove(&project_key);
                     std::path::PathBuf::from(&workflow.project_id)
                 } else if let Some(registry) = state.core.project_registry.as_deref() {
                     match registry.resolve_path(&workflow.project_id).await {
@@ -451,12 +452,16 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                         Ok(Some(resolved))
                             if resolved.as_path() != std::path::Path::new(&workflow.project_id) =>
                         {
-                            let _ = issue_workflows
-                                .update_project_path(
-                                    &workflow.id,
-                                    resolved.to_str().unwrap_or_default(),
-                                )
-                                .await;
+                            if let Err(e) = issue_workflows
+                                .update_project_path(&workflow.id, &resolved.to_string_lossy())
+                                .await
+                            {
+                                tracing::error!(
+                                    workflow_id = %workflow.id,
+                                    error = %e,
+                                    "sweeper: failed to update project path"
+                                );
+                            }
                             warned_unresolvable.remove(&project_key);
                             resolved
                         }

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -630,6 +630,29 @@ impl IssueWorkflowStore {
         .await
     }
 
+    /// Patches only the `project_id` field inside the JSONB blob without replacing the whole row.
+    /// Note: the embedded `id` field inside the JSON may diverge from the stored `project_id` after
+    /// this patch. This is harmless because all sweep/claim queries select by
+    /// `data::jsonb->>'project_id'`, not the embedded `id`.
+    /// Returns `Ok(())` even when no row matches `workflow_id` (zero rows affected is not an error).
+    pub async fn update_project_path(
+        &self,
+        workflow_id: &str,
+        new_path: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE issue_workflows
+             SET    data = jsonb_set(data::jsonb, '{project_id}', to_jsonb($2::text), false)::text,
+                    updated_at = CURRENT_TIMESTAMP
+             WHERE  id = $1",
+        )
+        .bind(workflow_id)
+        .bind(new_path)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn update_issue<F>(
         &self,
         project_id: &str,
@@ -1031,6 +1054,53 @@ mod tests {
             .await?;
         assert_eq!(claimed.len(), 1);
         assert_eq!(claimed[0].pr_number, Some(88));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_project_path_patches_project_id_field() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let old_project_id = "/tmp/old-project-path-test";
+        store
+            .record_issue_scheduled(
+                old_project_id,
+                Some("owner/repo"),
+                101,
+                "task-path-1",
+                &[],
+                false,
+            )
+            .await?;
+        let before = store
+            .get_by_issue(old_project_id, Some("owner/repo"), 101)
+            .await?
+            .expect("workflow before update");
+        let before_state = before.state;
+
+        store
+            .update_project_path(&before.id, "/tmp/new-project-path-test")
+            .await?;
+
+        let after = store
+            .get_by_issue("/tmp/new-project-path-test", Some("owner/repo"), 101)
+            .await?
+            .expect("workflow after update");
+        assert_eq!(after.project_id, "/tmp/new-project-path-test");
+        assert_eq!(after.state, before_state);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_project_path_noop_on_missing_id() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        // Must not return an error when no row matches
+        store
+            .update_project_path("nonexistent-workflow-id", "/tmp/any-path")
+            .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add `IssueWorkflowStore::update_project_path` — targeted JSONB patch updating only `project_id` without replacing the full row, preserving `state`, `pr_number`, and event history
- Add `warned_unresolvable` `HashSet` declared before the sweeper `loop {}` so each unresolvable project emits at most one `warn` per server lifetime (not one per tick)
- Add per-candidate path resolution guard: `Path::exists()` fast-path avoids registry DB queries for healthy paths; on dead path falls back to `registry.resolve_path()`; unresolvable → deduplicated warn + release claim + skip enqueue; recovered → persist canonical path + clear dedup entry

Closes #949

## Test plan

- [ ] `cargo test --package harness-workflow -- update_project_path` — DB-backed: verifies `project_id` field patched, `state` unchanged; verifies no-op on missing id
- [ ] `cargo test --package harness-server -- warn_dedup` — unit test: verifies HashSet dedup insert/remove cycle
- [ ] CI green on all non-DB tests (harness-server DB tests require live Postgres)