### PR TITLE
fix(workflow): use canonical project root for IssueWorkflowInstance project_id

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -317,7 +317,7 @@ pub(crate) async fn build_registry(
 async fn repair_corrupt_project_ids(
     store: &harness_workflow::issue_lifecycle::IssueWorkflowStore,
     canonical_root: &std::path::Path,
-) -> (u32, u32, u32) {
+) -> (u64, u64, u64) {
     let corrupt_rows = match store.list_with_worktree_project_ids().await {
         Ok(rows) => rows,
         Err(e) => {
@@ -328,8 +328,8 @@ async fn repair_corrupt_project_ids(
     let total_count = store.row_count().await.unwrap_or(0);
 
     let new_project_id = canonical_root.to_string_lossy().into_owned();
-    let (mut rewritten, mut failed) = (0u32, 0u32);
-    let skipped = (total_count as u32).saturating_sub(corrupt_rows.len() as u32);
+    let (mut rewritten, mut failed) = (0u64, 0u64);
+    let skipped = (total_count as u64).saturating_sub(corrupt_rows.len() as u64);
 
     for workflow in corrupt_rows {
         tracing::info!(
@@ -348,7 +348,7 @@ async fn repair_corrupt_project_ids(
                 if let Err(e2) = store
                     .mark_workflow_failed_with_reason(
                         &workflow.id,
-                        "project root not found during startup repair",
+                        "failed to repair project_id during startup",
                     )
                     .await
                 {

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -105,6 +105,14 @@ pub(crate) async fn build_registry(
                         "issue workflow migration check failed: {e}"
                     );
                 }
+                let (rewritten, failed, skipped) =
+                    repair_corrupt_project_ids(&store, project_root).await;
+                tracing::info!(
+                    rewritten,
+                    failed,
+                    skipped,
+                    "startup repair of corrupt issue workflow project_ids complete"
+                );
                 Some(Arc::new(store))
             }
             Err(e) => {
@@ -303,6 +311,62 @@ pub(crate) async fn build_registry(
     })
 }
 
+/// Walk all `issue_workflows` rows. For each row whose `project_id` contains
+/// `/workspaces/` (a corrupt worktree path), replace it with `canonical_root`.
+/// Returns `(rewritten, failed, skipped)` counts.
+async fn repair_corrupt_project_ids(
+    store: &harness_workflow::issue_lifecycle::IssueWorkflowStore,
+    canonical_root: &std::path::Path,
+) -> (u32, u32, u32) {
+    let all_rows = match store.list().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("startup repair: failed to list issue workflows: {e}");
+            return (0, 0, 0);
+        }
+    };
+
+    let new_project_id = canonical_root.to_string_lossy().into_owned();
+    let (mut rewritten, mut failed, mut skipped) = (0u32, 0u32, 0u32);
+
+    for workflow in all_rows {
+        if !workflow.project_id.contains("/workspaces/") {
+            skipped += 1;
+            continue;
+        }
+        tracing::info!(
+            row_id = %workflow.id,
+            old_project_id = %workflow.project_id,
+            new_project_id = %new_project_id,
+            "startup repair: rewriting corrupt workflow project_id"
+        );
+        match store.repair_project_id(&workflow.id, &new_project_id).await {
+            Ok(()) => rewritten += 1,
+            Err(e) => {
+                tracing::error!(
+                    row_id = %workflow.id,
+                    "startup repair: failed to rewrite project_id: {e}; marking workflow failed"
+                );
+                if let Err(e2) = store
+                    .mark_workflow_failed_with_reason(
+                        &workflow.id,
+                        "project root not found during startup repair",
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        row_id = %workflow.id,
+                        "startup repair: also failed to mark workflow as failed: {e2}"
+                    );
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    (rewritten, failed, skipped)
+}
+
 async fn migrate_issue_workflows_if_needed(
     configured_database_url: Option<&str>,
     legacy_path: &Path,
@@ -436,5 +500,119 @@ mod tests {
             bundle.plan_cache.contains_key(&plan_id),
             "plan should be hydrated into cache"
         );
+    }
+
+    async fn open_test_issue_store(
+    ) -> anyhow::Result<Option<harness_workflow::issue_lifecycle::IssueWorkflowStore>> {
+        if std::env::var("DATABASE_URL").is_err() {
+            return Ok(None);
+        }
+        let dir = tempfile::tempdir()?;
+        match harness_workflow::issue_lifecycle::IssueWorkflowStore::open(
+            &dir.path().join("issue_workflows.db"),
+        )
+        .await
+        {
+            Ok(store) => Ok(Some(store)),
+            Err(e) => {
+                tracing::warn!("issue workflow store test skipped: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn migration_rewrites_worktree_paths() -> anyhow::Result<()> {
+        let Some(store) = open_test_issue_store().await? else {
+            return Ok(());
+        };
+        let corrupt = "/data/workspaces/abc-uuid-reg-test";
+        let canonical = std::path::Path::new("/real/canonical/reg-root");
+
+        store
+            .record_issue_scheduled(corrupt, Some("owner/repo"), 8001, "task-reg1", &[], false)
+            .await?;
+        store
+            .record_issue_scheduled(corrupt, Some("owner/repo"), 8002, "task-reg2", &[], false)
+            .await?;
+
+        let (rewritten, failed, skipped) = repair_corrupt_project_ids(&store, canonical).await;
+        assert_eq!(rewritten, 2, "both worktree rows should be rewritten");
+        assert_eq!(failed, 0);
+        assert_eq!(skipped, 0);
+
+        let canonical_str = canonical.to_string_lossy();
+        let r1 = store
+            .get_by_issue(&canonical_str, Some("owner/repo"), 8001)
+            .await?;
+        assert!(r1.is_some(), "row 8001 should have canonical project_id");
+        let r2 = store
+            .get_by_issue(&canonical_str, Some("owner/repo"), 8002)
+            .await?;
+        assert!(r2.is_some(), "row 8002 should have canonical project_id");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn migration_skips_canonical_rows() -> anyhow::Result<()> {
+        let Some(store) = open_test_issue_store().await? else {
+            return Ok(());
+        };
+        let canonical_id = "/tmp/already-canonical-skip-test";
+        let canonical_root = std::path::Path::new("/any/root");
+
+        store
+            .record_issue_scheduled(
+                canonical_id,
+                Some("owner/repo"),
+                8003,
+                "task-skip1",
+                &[],
+                false,
+            )
+            .await?;
+
+        let (rewritten, failed, skipped) = repair_corrupt_project_ids(&store, canonical_root).await;
+        assert_eq!(skipped, 1, "canonical row should be skipped");
+        assert_eq!(rewritten, 0);
+        assert_eq!(failed, 0);
+
+        // Row untouched: project_id unchanged
+        let row = store
+            .get_by_issue(canonical_id, Some("owner/repo"), 8003)
+            .await?
+            .expect("row should still exist");
+        assert_eq!(row.project_id, canonical_id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn migration_counts_all_categories() -> anyhow::Result<()> {
+        let Some(store) = open_test_issue_store().await? else {
+            return Ok(());
+        };
+        let corrupt = "/data/workspaces/mix-uuid-reg-test";
+        let canonical_id = "/tmp/canonical-mix-test";
+        let canonical_root = std::path::Path::new("/real/mix-root");
+
+        store
+            .record_issue_scheduled(corrupt, Some("owner/repo"), 8010, "task-mix1", &[], false)
+            .await?;
+        store
+            .record_issue_scheduled(
+                canonical_id,
+                Some("owner/repo"),
+                8011,
+                "task-mix2",
+                &[],
+                false,
+            )
+            .await?;
+
+        let (rewritten, failed, skipped) = repair_corrupt_project_ids(&store, canonical_root).await;
+        assert_eq!(rewritten, 1);
+        assert_eq!(failed, 0);
+        assert_eq!(skipped, 1);
+        Ok(())
     }
 }

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -318,22 +318,20 @@ async fn repair_corrupt_project_ids(
     store: &harness_workflow::issue_lifecycle::IssueWorkflowStore,
     canonical_root: &std::path::Path,
 ) -> (u32, u32, u32) {
-    let all_rows = match store.list().await {
+    let corrupt_rows = match store.list_with_worktree_project_ids().await {
         Ok(rows) => rows,
         Err(e) => {
-            tracing::error!("startup repair: failed to list issue workflows: {e}");
+            tracing::error!("startup repair: failed to list corrupt issue workflows: {e}");
             return (0, 0, 0);
         }
     };
+    let total_count = store.row_count().await.unwrap_or(0);
 
     let new_project_id = canonical_root.to_string_lossy().into_owned();
-    let (mut rewritten, mut failed, mut skipped) = (0u32, 0u32, 0u32);
+    let (mut rewritten, mut failed) = (0u32, 0u32);
+    let skipped = (total_count as u32).saturating_sub(corrupt_rows.len() as u32);
 
-    for workflow in all_rows {
-        if !workflow.project_id.contains("/workspaces/") {
-            skipped += 1;
-            continue;
-        }
+    for workflow in corrupt_rows {
         tracing::info!(
             row_id = %workflow.id,
             old_project_id = %workflow.project_id,

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -119,6 +119,9 @@ pub(crate) async fn run_implement_phase(
     git: Option<&harness_core::config::project::GitConfig>,
     repo_slug: &str,
     project: &Path,
+    // Canonical project root for project_id derivation. Separate from `project`
+    // because workspace isolation makes `project` a worktree path, not the canonical root.
+    project_root: &Path,
     plan_output: Option<String>,
     resumed_pr_url: Option<String>,
     issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
@@ -542,7 +545,7 @@ pub(crate) async fn run_implement_phase(
                 if let (Some(workflows), Some(issue_number)) =
                     (issue_workflow_store.as_ref(), req.issue)
                 {
-                    let project_id = project.to_string_lossy().into_owned();
+                    let project_id = project_root.to_string_lossy().into_owned();
                     if let Err(e) = workflows
                         .record_plan_issue_detected(
                             &project_id,

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -391,6 +391,9 @@ pub(crate) async fn run_task(
     interceptors: Arc<Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
     req: &CreateTaskRequest,
     project: PathBuf,
+    // Canonical project root used for project_id derivation in issue workflow records.
+    // Distinct from `project` when workspace isolation is active (worktree != canonical root).
+    project_root: PathBuf,
     server_config: &harness_core::config::HarnessConfig,
     issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     // Accumulated turn count from previous transient-retry attempts.
@@ -586,7 +589,7 @@ pub(crate) async fn run_task(
     let turn_timeout = crate::task_runner::effective_turn_timeout(req.turn_timeout_secs);
 
     if let (Some(workflows), Some(issue_number)) = (issue_workflow_store.as_ref(), req.issue) {
-        let project_id = project.to_string_lossy().into_owned();
+        let project_id = project_root.to_string_lossy().into_owned();
         if let Err(e) = workflows
             .record_implement_started(&project_id, req.repo.as_deref(), issue_number, &task_id.0)
             .await
@@ -617,6 +620,7 @@ pub(crate) async fn run_task(
             git,
             &repo_slug,
             &project,
+            &project_root,
             current_plan_output.clone(),
             resumed_pr_url.clone(),
             issue_workflow_store.clone(),

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -633,6 +633,8 @@ where
         }
 
         // If workspace isolation is configured, create a per-task git worktree.
+        // Save the canonical root before it may be moved into run_project.
+        let canonical_project_root = project_root.clone();
         let run_project = if let Some(ref wmgr) = workspace_mgr {
             let project_config = harness_core::config::project::load_project_config(&project_root)
                 .map_err(|e| {
@@ -715,6 +717,7 @@ where
                 interceptors.clone(),
                 &req,
                 run_project.clone(),
+                canonical_project_root.clone(),
                 server_config.as_ref(),
                 issue_workflow_store.clone(),
                 &mut total_turns_used,

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -846,16 +846,22 @@ impl IssueWorkflowStore {
             new_workflow.repo.as_deref(),
             new_workflow.issue_number,
         );
+
+        if new_workflow.id == old_row_id {
+            return Ok(());
+        }
+
         new_workflow.updated_at = chrono::Utc::now();
 
         let new_data = serde_json::to_string(&new_workflow)?;
         sqlx::query(
-            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+            "INSERT INTO issue_workflows (id, data, created_at) VALUES ($1, $2, $3)
              ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
                  updated_at = CURRENT_TIMESTAMP",
         )
         .bind(&new_workflow.id)
         .bind(&new_data)
+        .bind(old_workflow.created_at)
         .execute(&mut *tx)
         .await?;
 

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -809,6 +809,91 @@ impl IssueWorkflowStore {
         }
     }
 
+    /// List all workflow rows whose `project_id` contains `/workspaces/`,
+    /// indicating a corrupt worktree path was stored instead of the canonical root.
+    pub async fn list_with_worktree_project_ids(
+        &self,
+    ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM issue_workflows
+             WHERE data::jsonb->>'project_id' LIKE '%/workspaces/%'
+             ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
+    /// Replace a workflow row's `project_id` with `new_project_id`, rekeying the
+    /// primary key (which embeds the project_id). Old row is deleted; new row is inserted.
+    pub async fn repair_project_id(
+        &self,
+        old_row_id: &str,
+        new_project_id: &str,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        let old_workflow = self
+            .load_for_update_by_id(&mut tx, old_row_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("workflow row '{old_row_id}' not found"))?;
+
+        let mut new_workflow = old_workflow.clone();
+        new_workflow.project_id = new_project_id.to_string();
+        new_workflow.id = workflow_id(
+            &new_workflow.project_id,
+            new_workflow.repo.as_deref(),
+            new_workflow.issue_number,
+        );
+        new_workflow.updated_at = chrono::Utc::now();
+
+        let new_data = serde_json::to_string(&new_workflow)?;
+        sqlx::query(
+            "INSERT INTO issue_workflows (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+                 updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&new_workflow.id)
+        .bind(&new_data)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("DELETE FROM issue_workflows WHERE id = $1")
+            .bind(old_row_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        tracing::info!(
+            old_row_id,
+            old_project_id = %old_workflow.project_id,
+            new_project_id,
+            new_row_id = %new_workflow.id,
+            "repaired corrupt workflow project_id"
+        );
+        Ok(())
+    }
+
+    /// Mark a workflow row as `Failed` with the given reason detail.
+    pub async fn mark_workflow_failed_with_reason(
+        &self,
+        row_id: &str,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        let Some(mut workflow) = self.load_for_update_by_id(&mut tx, row_id).await? else {
+            return Ok(());
+        };
+        workflow.apply_event(
+            IssueLifecycleEvent::new(IssueLifecycleEventKind::WorkflowFailed)
+                .with_detail(reason.to_string()),
+        );
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn upsert_in_tx(
         &self,
         tx: &mut sqlx::Transaction<'_, Postgres>,
@@ -1101,6 +1186,101 @@ mod tests {
         store
             .update_project_path("nonexistent-workflow-id", "/tmp/any-path")
             .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repair_project_id_rekeyes_row() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let corrupt_id = "/data/workspaces/abc-uuid-repair-test";
+        store
+            .record_issue_scheduled(corrupt_id, Some("owner/repo"), 9001, "task-r1", &[], false)
+            .await?;
+
+        let workflow = store
+            .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
+            .await?
+            .expect("row should exist");
+        let old_row_id = workflow.id.clone();
+
+        let canonical = "/real/canonical/root";
+        store.repair_project_id(&old_row_id, canonical).await?;
+
+        // Old row gone, new row present with correct project_id
+        let old = store
+            .get_by_issue(corrupt_id, Some("owner/repo"), 9001)
+            .await?;
+        assert!(old.is_none(), "old row should be removed");
+
+        let new = store
+            .get_by_issue(canonical, Some("owner/repo"), 9001)
+            .await?
+            .expect("new row should exist");
+        assert_eq!(new.project_id, canonical);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mark_workflow_failed_with_reason_sets_state() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let project_id = "/tmp/project-mark-failed-test";
+        store
+            .record_issue_scheduled(project_id, Some("owner/repo"), 9002, "task-mf1", &[], false)
+            .await?;
+
+        let workflow = store
+            .get_by_issue(project_id, Some("owner/repo"), 9002)
+            .await?
+            .expect("row should exist");
+
+        store
+            .mark_workflow_failed_with_reason(&workflow.id, "project root not found")
+            .await?;
+
+        let updated = store
+            .get_by_issue(project_id, Some("owner/repo"), 9002)
+            .await?
+            .expect("row should still exist");
+        assert_eq!(updated.state, IssueLifecycleState::Failed);
+        assert!(
+            updated
+                .last_event
+                .as_ref()
+                .and_then(|e| e.detail.as_deref())
+                == Some("project root not found"),
+            "detail should be recorded"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_with_worktree_project_ids_filters_correctly() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let corrupt = "/data/workspaces/xyz-uuid-list-test";
+        let canonical = "/tmp/canonical-list-test";
+
+        store
+            .record_issue_scheduled(corrupt, Some("owner/repo"), 9003, "task-l1", &[], false)
+            .await?;
+        store
+            .record_issue_scheduled(canonical, Some("owner/repo"), 9004, "task-l2", &[], false)
+            .await?;
+
+        let corrupt_rows = store.list_with_worktree_project_ids().await?;
+        assert!(
+            corrupt_rows.iter().any(|w| w.project_id == corrupt),
+            "worktree row should appear"
+        );
+        assert!(
+            !corrupt_rows.iter().any(|w| w.project_id == canonical),
+            "canonical row should not appear"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- **Part A (source fix)**: Extended `run_task()` and `run_implement_phase()` with an explicit `project_root: PathBuf` parameter (canonical root, distinct from the working directory). `spawn.rs` captures the canonical root before workspace assignment and passes it through. All `project_id` derivations in `task_executor/` now use `project_root` instead of `project` (the worktree path).
- **Part B (startup migration)**: Added `repair_corrupt_project_ids()` wired into `build_registry()` at startup. It detects `issue_workflows` rows where `project_id` contains `/workspaces/`, rewrites them transactionally to the canonical root (rekeying the primary key via delete+insert), and marks unresolvable rows as Failed. Logs `(rewritten, failed, skipped)` counts at `info` level.
- Added tests: 3 in `issue_lifecycle.rs` (`repair_project_id_rekeyes_row`, `mark_workflow_failed_with_reason_sets_state`, `list_with_worktree_project_ids_filters_correctly`) and 3 in `registry.rs` (`migration_rewrites_worktree_paths`, `migration_skips_canonical_rows`, `migration_counts_all_categories`).

Closes #950

## Test plan

- [ ] `cargo check --workspace --all-targets` passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` passes (no dead code / unused imports)
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets` passes
- [ ] `cargo test -p harness-workflow --lib` passes (3 new tests)
- [ ] `cargo test -p harness-server --lib` passes (3 new tests in registry)
- [ ] Manual: start server against a DB with corrupt rows, verify startup log shows `rewritten > 0` and subsequent workflow lookups use canonical paths