### PR TITLE
feat(task-status): surface Triaging and Planning status during agent execution

### DIFF
--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -735,7 +735,8 @@ impl TaskDb {
         let sql = if project.is_some() {
             format!(
                 "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
+                 WHERE status IN ('triaging', 'planning', 'implementing', \
+                                  'review_generating', 'review_waiting', \
                                   'planner_generating', 'planner_waiting', 'agent_review', \
                                   'waiting', 'reviewing') \
                  AND external_id IS NOT NULL \
@@ -745,7 +746,8 @@ impl TaskDb {
         } else {
             format!(
                 "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('implementing', 'review_generating', 'review_waiting', \
+                 WHERE status IN ('triaging', 'planning', 'implementing', \
+                                  'review_generating', 'review_waiting', \
                                   'planner_generating', 'planner_waiting', 'agent_review', \
                                   'waiting', 'reviewing') \
                  AND external_id IS NOT NULL \

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -547,11 +547,10 @@ pub(crate) async fn run_task(
             .map(|s| s.phase == crate::task_runner::TaskPhase::Plan)
             .unwrap_or(false);
         if forced_plan && req.issue.is_none() && req.pr.is_none() {
-            // Set to Implementing BEFORE the plan phase so that a crash during planning
-            // leaves the task in 'implementing' status. The startup recovery code will catch
-            // it and fail-close it (no pr_url → mark failed), rather than leaving it stuck
-            // as a plain 'pending' that is never re-dispatched.
-            update_status(store, task_id, TaskStatus::Implementing, 1).await?;
+            // Set to Planning so operators can see the agent is actively working.
+            // Planning is in resumable_statuses, so a crash here will be caught by
+            // startup recovery: no pr_url/plan checkpoint → mark failed, re-queue manually.
+            update_status(store, task_id, TaskStatus::Planning, 0).await?;
             triage_pipeline::run_plan_for_prompt(agent, store, task_id, &cargo_env, &project, req)
                 .await?
         } else {

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1,6 +1,6 @@
-use super::helpers::run_agent_streaming;
+use super::helpers::{run_agent_streaming, update_status};
 use crate::task_runner::{
-    mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStore,
+    mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStatus, TaskStore,
 };
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::prompts;
@@ -91,6 +91,7 @@ pub(crate) async fn run_triage_plan_pipeline(
         state.phase = TaskPhase::Triage;
     })
     .await?;
+    update_status(store, task_id, TaskStatus::Triaging, 0).await?;
 
     let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
     let triage_req = AgentRequest {
@@ -158,6 +159,7 @@ pub(crate) async fn run_triage_plan_pipeline(
         state.phase = TaskPhase::Plan;
     })
     .await?;
+    update_status(store, task_id, TaskStatus::Planning, 0).await?;
 
     let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
     let plan_req = AgentRequest {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -107,6 +107,8 @@ impl TaskStore {
         let active_statuses = &[
             "pending",
             "awaiting_deps",
+            "triaging",
+            "planning",
             "implementing",
             "review_generating",
             "review_waiting",
@@ -1577,6 +1579,8 @@ mod tests {
                 false,
                 false,
             ),
+            (TaskStatus::Triaging, false, true, true, false, false, false),
+            (TaskStatus::Planning, false, true, true, false, false, false),
             (
                 TaskStatus::Implementing,
                 false,
@@ -1674,6 +1678,8 @@ mod tests {
         assert_eq!(
             TaskStatus::resumable_statuses(),
             &[
+                "triaging",
+                "planning",
                 "implementing",
                 "review_generating",
                 "review_waiting",

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -134,6 +134,10 @@ pub enum TaskPhase {
 pub enum TaskStatus {
     Pending,
     AwaitingDeps,
+    /// Claude is actively running the triage agent for this task.
+    Triaging,
+    /// Claude is actively running the plan agent for this task.
+    Planning,
     Implementing,
     ReviewGenerating,
     ReviewWaiting,
@@ -156,6 +160,8 @@ pub enum TaskFailureKind {
 
 const TERMINAL_TASK_STATUSES: &[&str] = &["done", "failed", "cancelled"];
 const RESUMABLE_TASK_STATUSES: &[&str] = &[
+    "triaging",
+    "planning",
     "implementing",
     "review_generating",
     "review_waiting",
@@ -174,7 +180,9 @@ impl TaskStatus {
     pub fn is_inflight(&self) -> bool {
         matches!(
             self,
-            Self::Implementing
+            Self::Triaging
+                | Self::Planning
+                | Self::Implementing
                 | Self::ReviewGenerating
                 | Self::ReviewWaiting
                 | Self::PlannerGenerating
@@ -215,6 +223,8 @@ impl AsRef<str> for TaskStatus {
         match self {
             TaskStatus::Pending => "pending",
             TaskStatus::AwaitingDeps => "awaiting_deps",
+            TaskStatus::Triaging => "triaging",
+            TaskStatus::Planning => "planning",
             TaskStatus::Implementing => "implementing",
             TaskStatus::ReviewGenerating => "review_generating",
             TaskStatus::ReviewWaiting => "review_waiting",
@@ -237,6 +247,8 @@ impl std::str::FromStr for TaskStatus {
         match s {
             "pending" => Ok(TaskStatus::Pending),
             "awaiting_deps" => Ok(TaskStatus::AwaitingDeps),
+            "triaging" => Ok(TaskStatus::Triaging),
+            "planning" => Ok(TaskStatus::Planning),
             "implementing" => Ok(TaskStatus::Implementing),
             "review_generating" => Ok(TaskStatus::ReviewGenerating),
             "review_waiting" => Ok(TaskStatus::ReviewWaiting),


### PR DESCRIPTION
## Summary

Fixes the task visibility gap where triage/plan pipeline phases consumed real Claude capacity but tasks remained in `pending` status, making operator capacity metrics inaccurate.

- Add `Triaging` and `Planning` variants to the `TaskStatus` enum
- Include both in `RESUMABLE_TASK_STATUSES`, `is_inflight()`, `active_statuses` cache list, and `list_stalled_tasks` SQL
- Emit `Triaging` status before the triage agent runs and `Planning` before each plan agent run in `triage_pipeline.rs`
- Emit `Planning` (instead of `Implementing`) for the prompt-only forced-plan path in `task_executor/mod.rs`
- Extend `task_status_semantics_are_centralized` unit test to cover both new variants

Closes #883

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — all non-Postgres tests pass; Postgres tests verified individually
- [ ] `task_status_semantics_are_centralized` passes with both new variants covered
- [ ] `stalled_tasks_empty_on_fresh_server` and `periodic_retry::no_stalled_tasks_returns_empty` pass when Postgres is available (CI)