### PR TITLE
fix(workflow): sweeper uses repair_project_id to fix stale PK on path correction

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -453,13 +453,13 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                             if resolved.as_path() != std::path::Path::new(&workflow.project_id) =>
                         {
                             if let Err(e) = issue_workflows
-                                .update_project_path(&workflow.id, &resolved.to_string_lossy())
+                                .repair_project_id(&workflow.id, &resolved.to_string_lossy())
                                 .await
                             {
                                 tracing::error!(
                                     workflow_id = %workflow.id,
                                     error = %e,
-                                    "sweeper: failed to update project path"
+                                    "sweeper: failed to repair project_id"
                                 );
                             }
                             warned_unresolvable.remove(&project_key);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::task_runner;
-use harness_workflow::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
+use harness_workflow::issue_lifecycle::{workflow_id, IssueLifecycleState, IssueWorkflowInstance};
 
 fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
     task.external_id
@@ -403,7 +403,7 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
 
             let mut touched_projects = std::collections::HashSet::new();
             let mut incomplete_projects = std::collections::HashSet::new();
-            for workflow in candidates {
+            for mut workflow in candidates {
                 let Some(pr_number) = workflow.pr_number else {
                     continue;
                 };
@@ -471,6 +471,13 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                                     .await;
                                 continue;
                             }
+                            let new_project_id = resolved.to_string_lossy().into_owned();
+                            workflow.id = workflow_id(
+                                &new_project_id,
+                                workflow.repo.as_deref(),
+                                workflow.issue_number,
+                            );
+                            workflow.project_id = new_project_id;
                             warned_unresolvable.remove(&project_key);
                             resolved
                         }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -461,6 +461,15 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                                     error = %e,
                                     "sweeper: failed to repair project_id"
                                 );
+                                let _ = issue_workflows
+                                    .release_feedback_claim(
+                                        &workflow.project_id,
+                                        workflow.repo.as_deref(),
+                                        pr_number,
+                                        &format!("sweeper: failed to repair project_id: {e}"),
+                                    )
+                                    .await;
+                                continue;
                             }
                             warned_unresolvable.remove(&project_key);
                             resolved

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -631,9 +631,15 @@ impl IssueWorkflowStore {
     }
 
     /// Patches only the `project_id` field inside the JSONB blob without replacing the whole row.
-    /// Note: the embedded `id` field inside the JSON may diverge from the stored `project_id` after
-    /// this patch. This is harmless because all sweep/claim queries select by
-    /// `data::jsonb->>'project_id'`, not the embedded `id`.
+    ///
+    /// WARNING: the row primary key (`id`) is NOT updated by this function. The `id` column embeds
+    /// the project_id, so after this patch the primary key will be stale and diverge from the JSON
+    /// `project_id` field. Subsequent lookups via the canonical path will compute a different
+    /// `workflow_id`, causing `ON CONFLICT DO NOTHING` to create duplicate orphan rows.
+    ///
+    /// Callers that resolve a canonical path MUST use [`IssueWorkflowStore::repair_project_id`]
+    /// instead, which performs a correct delete-then-insert in a single transaction.
+    ///
     /// Returns `Ok(())` even when no row matches `workflow_id` (zero rows affected is not an error).
     pub async fn update_project_path(
         &self,


### PR DESCRIPTION
## Summary
- Replace `update_project_path` with `repair_project_id` in the sweeper live path correction path
- `update_project_path` only patched the JSON `project_id` field, leaving the row primary key stale
- Subsequent calls via the canonical path computed a different `workflow_id`, creating duplicate orphan rows
- `repair_project_id` performs a correct delete-then-insert in a single transaction

## Root cause
`IssueWorkflowStore::update_project_path` patches only `data::jsonb->'project_id'` without updating the `id` column (the primary key). Any subsequent `update_issue(canonical_path, ...)` call computes `workflow_id(canonical_path, ...)` → a different key → `ON CONFLICT DO NOTHING` creates a fresh placeholder row, discarding all prior state.

Also updates the `update_project_path` docstring to replace the incorrect "This is harmless" note with a clear warning that the primary key is NOT updated and callers should prefer `repair_project_id`.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] Existing `repair_project_id_rekeyes_row` test covers the correct behavior
- [ ] No new duplicate rows in `issue_workflows` after sweeper path correction

Closes #960