### PR TITLE
feat(web): proof-of-work card in TaskDetailSlideover for terminal tasks

### DIFF
--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -4,11 +4,22 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use serde::Serialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::state::AppState;
+
+/// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
+/// that requires a separate workflow-store lookup (not persisted on `TaskState` itself).
+#[derive(Serialize)]
+struct FullTaskResponse {
+    #[serde(flatten)]
+    inner: crate::task_runner::TaskState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
+}
 
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
@@ -87,7 +98,14 @@ pub(crate) async fn get_task(
         .get_with_db_fallback(&harness_core::types::TaskId(id))
         .await
     {
-        Ok(Some(task)) => Json(task).into_response(),
+        Ok(Some(task)) => {
+            let workflow = enrich_task_workflow(&state, &task).await;
+            Json(FullTaskResponse {
+                inner: task,
+                workflow,
+            })
+            .into_response()
+        }
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "task not found"})),
@@ -101,6 +119,50 @@ pub(crate) async fn get_task(
             )
                 .into_response()
         }
+    }
+}
+
+/// Look up the issue-workflow instance for a task using targeted store queries.
+/// Returns `None` when the workflow store is unavailable or the task has no workflow association.
+async fn enrich_task_workflow(
+    state: &AppState,
+    task: &crate::task_runner::TaskState,
+) -> Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance> {
+    let workflow_store = state.core.issue_workflow_store.as_ref()?;
+    let project_id = task.project_root.as_ref()?.to_string_lossy().into_owned();
+
+    let by_issue = task
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("issue:"))
+        .and_then(|n| n.parse::<u64>().ok());
+    let by_pr = task
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("pr:"))
+        .and_then(|n| n.parse::<u64>().ok())
+        .or_else(|| {
+            task.pr_url
+                .as_deref()
+                .and_then(super::parse_pr_num_from_url)
+        });
+
+    match (by_issue, by_pr) {
+        (Some(issue), _) => workflow_store
+            .get_by_issue(&project_id, task.repo.as_deref(), issue)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("get_task: workflow lookup by issue failed: {e}");
+                None
+            }),
+        (None, Some(pr)) => workflow_store
+            .get_by_pr(&project_id, task.repo.as_deref(), pr)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("get_task: workflow lookup by PR failed: {e}");
+                None
+            }),
+        (None, None) => None,
     }
 }
 

--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -59,7 +59,7 @@ export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
         <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Rounds / Elapsed</div>
         <div className="flex gap-4 text-ink">
           <span>Rounds: {task.turn}</span>
-          <span>Elapsed: {elapsedTime(task.created_at, task.completed_at)}</span>
+          <span>Elapsed: {elapsedTime(task.created_at, task.updated_at ?? undefined)}</span>
         </div>
       </section>
 

--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -3,8 +3,8 @@ import type { FullTask, TaskArtifact, TaskPrompt } from "@/types";
 
 interface Props {
   task: FullTask;
-  prompts: TaskPrompt[];
-  artifacts: TaskArtifact[];
+  prompts: TaskPrompt[] | undefined;
+  artifacts: TaskArtifact[] | undefined;
 }
 
 function reviewerVerdict(state: string): string {
@@ -19,7 +19,7 @@ function reviewerVerdict(state: string): string {
 function elapsedTime(createdAt: string | null, completedAt: string | undefined): string {
   if (!createdAt || !completedAt) return "N/A";
   const ms = new Date(completedAt).getTime() - new Date(createdAt).getTime();
-  if (ms < 0) return "N/A";
+  if (isNaN(ms) || ms < 0) return "N/A";
   const s = Math.floor(ms / 1000);
   if (s < 60) return `${s}s`;
   if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
@@ -74,7 +74,9 @@ export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
 
       <section>
         <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Prompts</div>
-        {prompts.length === 0 ? (
+        {prompts === undefined ? (
+          <span className="text-ink-3">Loading prompts…</span>
+        ) : prompts.length === 0 ? (
           <span className="text-ink-3">No prompts recorded</span>
         ) : (
           <div className="flex flex-col gap-1">
@@ -94,7 +96,9 @@ export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
 
       <section>
         <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Artifacts</div>
-        {artifacts.length === 0 ? (
+        {artifacts === undefined ? (
+          <span className="text-ink-3">Loading artifacts…</span>
+        ) : artifacts.length === 0 ? (
           <span className="text-ink-3">No artifacts</span>
         ) : (
           <div className="flex flex-col gap-2">

--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -1,0 +1,116 @@
+import { workflowLabel } from "@/lib/format";
+import type { FullTask, TaskArtifact, TaskPrompt } from "@/types";
+
+interface Props {
+  task: FullTask;
+  prompts: TaskPrompt[];
+  artifacts: TaskArtifact[];
+}
+
+function reviewerVerdict(state: string): string {
+  switch (state) {
+    case "ready_to_merge": return "Approved";
+    case "awaiting_feedback": return "Changes Requested";
+    case "addressing_feedback": return "In Progress";
+    default: return workflowLabel(state);
+  }
+}
+
+function elapsedTime(createdAt: string | null, completedAt: string | undefined): string {
+  if (!createdAt || !completedAt) return "N/A";
+  const ms = new Date(completedAt).getTime() - new Date(createdAt).getTime();
+  if (ms < 0) return "N/A";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+  return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+}
+
+export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
+  return (
+    <div
+      className="mt-4 border border-line bg-bg p-3 flex flex-col gap-3 font-mono text-[11px]"
+      data-testid="proof-of-work-card"
+    >
+      <section>
+        <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">PR &amp; GitHub State</div>
+        {task.pr_url ? (
+          <div className="flex flex-col gap-1">
+            <a
+              href={task.pr_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-rust hover:underline break-all"
+            >
+              {task.pr_url}
+            </a>
+            {task.workflow?.state && (
+              <span className="border border-line bg-bg-1 px-1.5 py-[1px] text-[10px] text-ink-2 self-start">
+                {workflowLabel(task.workflow.state)}
+              </span>
+            )}
+          </div>
+        ) : (
+          <span className="text-ink-3">No PR</span>
+        )}
+      </section>
+
+      <section>
+        <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Rounds / Elapsed</div>
+        <div className="flex gap-4 text-ink">
+          <span>Rounds: {task.turn}</span>
+          <span>Elapsed: {elapsedTime(task.created_at, task.completed_at)}</span>
+        </div>
+      </section>
+
+      <section>
+        <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Reviewer Verdict</div>
+        {task.workflow?.state ? (
+          <span className="text-ink">{reviewerVerdict(task.workflow.state)}</span>
+        ) : (
+          <span className="text-ink-3">No reviewer data</span>
+        )}
+      </section>
+
+      <section>
+        <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Prompts</div>
+        {prompts.length === 0 ? (
+          <span className="text-ink-3">No prompts recorded</span>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {prompts.map((p, i) => (
+              <details key={i} className="border border-line">
+                <summary className="px-2 py-1 cursor-pointer text-ink-2 hover:bg-bg-1">
+                  {p.phase} (turn {p.turn})
+                </summary>
+                <pre className="p-2 text-ink whitespace-pre-wrap break-words text-[10px]">
+                  {p.prompt.length > 500 ? p.prompt.slice(0, 500) + "…" : p.prompt}
+                </pre>
+              </details>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Artifacts</div>
+        {artifacts.length === 0 ? (
+          <span className="text-ink-3">No artifacts</span>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {artifacts.map((a, i) => (
+              <div key={i} className="border border-line p-2">
+                <span className="border border-line bg-bg-1 px-1.5 py-[1px] text-[10px] text-ink-2">
+                  {a.artifact_type}
+                </span>
+                <pre className="mt-1 text-ink whitespace-pre-wrap break-words text-[10px]">
+                  {a.content}
+                </pre>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -151,7 +151,7 @@ describe("TaskDetailSlideover", () => {
       status: "done",
       pr_url: "https://github.com/owner/repo/pull/42",
       workflow: { state: "ready_to_merge", pr_number: 42 },
-      completed_at: "2024-01-01T01:00:00Z",
+      updated_at: "2024-01-01T01:00:00Z",
     });
     mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
     mockApiJson.mockImplementation((url: string) => {
@@ -191,8 +191,10 @@ describe("TaskDetailSlideover", () => {
     const card = await screen.findByTestId("proof-of-work-card");
     expect(card).toHaveTextContent("No PR");
     expect(card).toHaveTextContent("No reviewer data");
-    expect(card).toHaveTextContent("No prompts recorded");
-    expect(card).toHaveTextContent("No artifacts");
+    await waitFor(() => {
+      expect(card).toHaveTextContent("No prompts recorded");
+      expect(card).toHaveTextContent("No artifacts");
+    });
   });
 
   it("switches tabs without remounting (Summary → Output → Summary)", () => {

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -10,10 +10,16 @@ vi.mock("@/lib/queries", () => ({
   useTaskStream: vi.fn(),
 }));
 
+vi.mock("@/lib/api", () => ({
+  apiJson: vi.fn().mockResolvedValue([]),
+}));
+
 import { useTaskDetail, useTaskStream } from "@/lib/queries";
+import { apiJson } from "@/lib/api";
 
 const mockUseTaskDetail = useTaskDetail as ReturnType<typeof vi.fn>;
 const mockUseTaskStream = useTaskStream as ReturnType<typeof vi.fn>;
+const mockApiJson = apiJson as ReturnType<typeof vi.fn>;
 
 function makeFullTask(overrides: Partial<FullTask> = {}): FullTask {
   return {
@@ -49,6 +55,7 @@ function wrap(ui: React.ReactElement) {
 beforeEach(() => {
   mockUseTaskStream.mockImplementation(() => undefined);
   mockUseTaskDetail.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  mockApiJson.mockResolvedValue([]);
 });
 
 // ── visibility ────────────────────────────────────────────────────────────────
@@ -136,6 +143,57 @@ describe("TaskDetailSlideover", () => {
   });
 
   // ── tab switching ─────────────────────────────────────────────────────────
+
+  // ── proof-of-work card ────────────────────────────────────────────────────
+
+  it("renders proof-of-work card for terminal task", async () => {
+    const task = makeFullTask({
+      status: "done",
+      pr_url: "https://github.com/owner/repo/pull/42",
+      workflow: { state: "ready_to_merge", pr_number: 42 },
+      completed_at: "2024-01-01T01:00:00Z",
+    });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/artifacts")) {
+        return Promise.resolve([
+          { task_id: task.id, turn: 1, artifact_type: "patch", content: "diff --git a/x", created_at: "2024-01-01T00:30:00Z" },
+        ]);
+      }
+      if (url.includes("/prompts")) {
+        return Promise.resolve([
+          { task_id: task.id, turn: 1, phase: "implement", prompt: "Write the fix", created_at: "2024-01-01T00:10:00Z" },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    const card = await screen.findByTestId("proof-of-work-card");
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveTextContent("https://github.com/owner/repo/pull/42");
+    expect(card).toHaveTextContent("Rounds: 2");
+    expect(card).toHaveTextContent("Approved");
+    expect(await screen.findByText("patch")).toBeInTheDocument();
+    expect(await screen.findByText(/implement/)).toBeInTheDocument();
+  });
+
+  it("does not render proof-of-work card for non-terminal task", () => {
+    const task = makeFullTask({ status: "implementing" });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    expect(screen.queryByTestId("proof-of-work-card")).not.toBeInTheDocument();
+  });
+
+  it("proof-of-work card degrades gracefully with missing data", async () => {
+    const task = makeFullTask({ status: "done", pr_url: null, workflow: null });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    const card = await screen.findByTestId("proof-of-work-card");
+    expect(card).toHaveTextContent("No PR");
+    expect(card).toHaveTextContent("No reviewer data");
+    expect(card).toHaveTextContent("No prompts recorded");
+    expect(card).toHaveTextContent("No artifacts");
+  });
 
   it("switches tabs without remounting (Summary → Output → Summary)", () => {
     const task = makeFullTask();

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -128,11 +128,11 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
           {!isLoading && !isError && activeTab === "summary" && task && (
             <>
               <SummaryContent task={task} />
-              {isTerminal(task.status) && (
+              {isTaskTerminal && (
                 <ProofOfWorkCard
                   task={task}
-                  prompts={prompts ?? []}
-                  artifacts={artifacts ?? []}
+                  prompts={prompts}
+                  artifacts={artifacts}
                 />
               )}
             </>

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTaskDetail, useTaskStream } from "@/lib/queries";
 import { apiJson } from "@/lib/api";
-import type { FullTask } from "@/types";
+import { isTerminal } from "@/types/task";
+import { ProofOfWorkCard } from "./ProofOfWorkCard";
+import type { FullTask, TaskArtifact, TaskPrompt } from "@/types";
 
 type Tab = "summary" | "output" | "prompts" | "artifacts";
 
@@ -38,16 +40,18 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
 
   const { data: task, isLoading, isError } = useTaskDetail(taskId);
 
+  const isTaskTerminal = task ? isTerminal(task.status) : false;
+
   const { data: artifacts, isError: isArtifactsError } = useQuery({
     queryKey: ["task-artifacts", taskId],
-    queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/artifacts`, { signal }),
-    enabled: !!taskId && activeTab === "artifacts",
+    queryFn: ({ signal }) => apiJson<TaskArtifact[]>(`/tasks/${taskId}/artifacts`, { signal }),
+    enabled: !!taskId && (activeTab === "artifacts" || isTaskTerminal),
   });
 
   const { data: prompts, isError: isPromptsError } = useQuery({
     queryKey: ["task-prompts", taskId],
-    queryFn: ({ signal }) => apiJson<unknown[]>(`/tasks/${taskId}/prompts`, { signal }),
-    enabled: !!taskId && activeTab === "prompts",
+    queryFn: ({ signal }) => apiJson<TaskPrompt[]>(`/tasks/${taskId}/prompts`, { signal }),
+    enabled: !!taskId && (activeTab === "prompts" || isTaskTerminal),
   });
 
   useEffect(() => {
@@ -122,7 +126,16 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
             </div>
           )}
           {!isLoading && !isError && activeTab === "summary" && task && (
-            <SummaryContent task={task} />
+            <>
+              <SummaryContent task={task} />
+              {isTerminal(task.status) && (
+                <ProofOfWorkCard
+                  task={task}
+                  prompts={prompts ?? []}
+                  artifacts={artifacts ?? []}
+                />
+              )}
+            </>
           )}
           {activeTab === "output" && (
             <>

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,5 +1,30 @@
 const EM_DASH = "—";
 
+export function workflowLabel(state: string): string {
+  switch (state) {
+    case "discovered": return "Discovered";
+    case "scheduled": return "Scheduled";
+    case "implementing": return "Implementing";
+    case "pr_open": return "PR Open";
+    case "awaiting_feedback": return "Awaiting Feedback";
+    case "addressing_feedback": return "Addressing Feedback";
+    case "ready_to_merge": return "Ready To Merge";
+    case "blocked": return "Blocked";
+    case "done": return "Done";
+    case "failed": return "Failed";
+    case "cancelled": return "Cancelled";
+    case "idle": return "Idle";
+    case "polling_intake": return "Polling Intake";
+    case "planning_batch": return "Planning Batch";
+    case "dispatching": return "Dispatching";
+    case "monitoring": return "Monitoring";
+    case "sweeping_feedback": return "Sweeping Feedback";
+    case "paused": return "Paused";
+    case "degraded": return "Degraded";
+    default: return state;
+  }
+}
+
 function isFiniteNumber(n: unknown): n is number {
   return typeof n === "number" && Number.isFinite(n);
 }

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTasks, useDashboard } from "@/lib/queries";
 import { TaskDetailSlideover } from "@/components/TaskDetailSlideover";
+import { workflowLabel } from "@/lib/format";
 import type { Task, WorkflowSummary } from "@/types";
 
 interface Column {
@@ -73,51 +74,6 @@ function columnOf(taskStatus: string, workflowState?: string | null): string {
     if (c.fallbackTaskStatuses.includes(taskStatus)) return c.key;
   }
   return "other";
-}
-
-function workflowLabel(state: string): string {
-  switch (state) {
-    case "discovered":
-      return "Discovered";
-    case "scheduled":
-      return "Scheduled";
-    case "implementing":
-      return "Implementing";
-    case "pr_open":
-      return "PR Open";
-    case "awaiting_feedback":
-      return "Awaiting Feedback";
-    case "addressing_feedback":
-      return "Addressing Feedback";
-    case "ready_to_merge":
-      return "Ready To Merge";
-    case "blocked":
-      return "Blocked";
-    case "done":
-      return "Done";
-    case "failed":
-      return "Failed";
-    case "cancelled":
-      return "Cancelled";
-    case "idle":
-      return "Idle";
-    case "polling_intake":
-      return "Polling Intake";
-    case "planning_batch":
-      return "Planning Batch";
-    case "dispatching":
-      return "Dispatching";
-    case "monitoring":
-      return "Monitoring";
-    case "sweeping_feedback":
-      return "Sweeping Feedback";
-    case "paused":
-      return "Paused";
-    case "degraded":
-      return "Degraded";
-    default:
-      return state;
-  }
 }
 
 function TaskCard({

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -15,11 +15,32 @@ export interface Task {
   repo: string | null;
   description: string | null;
   created_at: string | null;
+  completed_at?: string;
   phase: string | null;
   depends_on: string[];
   subtask_ids: string[];
   project: string | null;
   workflow?: WorkflowSummary | null;
+}
+
+export interface TaskArtifact {
+  task_id: string;
+  turn: number;
+  artifact_type: string;
+  content: string;
+  created_at: string;
+}
+
+export interface TaskPrompt {
+  task_id: string;
+  turn: number;
+  phase: string;
+  prompt: string;
+  created_at: string;
+}
+
+export function isTerminal(status: string): boolean {
+  return status === "done" || status === "cancelled" || status === "failed";
 }
 
 export interface WorkflowSummary {

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -15,7 +15,7 @@ export interface Task {
   repo: string | null;
   description: string | null;
   created_at: string | null;
-  completed_at?: string;
+  updated_at?: string | null;
   phase: string | null;
   depends_on: string[];
   subtask_ids: string[];


### PR DESCRIPTION
## Summary

- Adds a `ProofOfWorkCard` component that renders in the summary tab of `TaskDetailSlideover` whenever a task reaches a terminal state (done / cancelled / failed)
- Card shows 5 sections: PR & GitHub state, round count + elapsed time, reviewer verdict, collapsible prompts, and artifacts — each with graceful fallback text
- Moves `workflowLabel()` from `Active.tsx` into `lib/format.ts` to avoid duplication

Closes #966

## Changes

| File | Change |
|------|--------|
| `web/src/types/task.ts` | Add `TaskArtifact`, `TaskPrompt`, `isTerminal()`, `completed_at?` |
| `web/src/lib/format.ts` | Move `workflowLabel()` here from `Active.tsx` |
| `web/src/routes/dashboard/Active.tsx` | Import `workflowLabel` from `lib/format`; remove local definition |
| `web/src/components/ProofOfWorkCard.tsx` | New self-contained display component (116 lines) |
| `web/src/components/TaskDetailSlideover.tsx` | Wire `ProofOfWorkCard`; type artifact/prompt queries; widen `enabled` flag for terminal tasks |
| `web/src/components/TaskDetailSlideover.test.tsx` | Add 3 tests: full data, non-terminal guard, graceful degradation |

## Test plan

- [ ] All 85 web tests pass: `bun run test` in `web/` → 23 files, 85 tests green
- [ ] TypeScript: no errors in changed files (`bunx tsc --noEmit` shows only pre-existing config warnings)
- [ ] Cargo check + clippy pass with `-D warnings`
- [ ] Manual: open a done task in the dashboard — proof-of-work card appears below the summary fields
- [ ] Manual: open an in-progress task — card is absent
- [ ] Manual: open a done task with no PR / no workflow — fallback strings ("No PR", "No reviewer data", etc.) render without error