### PR TITLE
feat(workspace): deterministic per-issue/PR workspace keys on write path

### DIFF
--- a/crates/harness-server/src/parallel_dispatch.rs
+++ b/crates/harness-server/src/parallel_dispatch.rs
@@ -322,8 +322,9 @@ async fn run_sequential_subtasks(
 
     // One shared workspace for all sequential steps — step N sees step N-1 outputs.
     let seq_id = harness_core::types::TaskId(format!("{}-seq", task_id.0));
+    // Sub-tasks use synthetic IDs and intentionally keep UUID-based workspace keys.
     let workspace = match workspace_mgr
-        .create_workspace(&seq_id, source_repo, remote, base_branch, 1)
+        .create_workspace(&seq_id, source_repo, remote, base_branch, 1, None, None)
         .await
     {
         Ok(lease) => lease.workspace_path,
@@ -455,8 +456,9 @@ async fn run_concurrent_subtasks(
 
     for (i, spec) in subtasks.into_iter().enumerate() {
         let sub_id = harness_core::types::TaskId(format!("{}-p{i}", task_id.0));
+        // Sub-tasks use synthetic IDs and intentionally keep UUID-based workspace keys.
         match workspace_mgr
-            .create_workspace(&sub_id, source_repo, remote, base_branch, 1)
+            .create_workspace(&sub_id, source_repo, remote, base_branch, 1, None, None)
             .await
         {
             Ok(lease) => {

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -363,11 +363,14 @@ async fn wait_for_terminal_task(
     state: &AppState,
     task_id: &str,
 ) -> anyhow::Result<crate::task_runner::TaskState> {
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{sleep, Duration, Instant};
 
     let tid = harness_core::types::TaskId(task_id.to_string());
-    for _ in 0..120 {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last_status = None;
+    loop {
         if let Some(task) = state.core.tasks.get(&tid) {
+            last_status = Some(format!("{:?}", task.status));
             if matches!(
                 task.status,
                 crate::task_runner::TaskStatus::Done | crate::task_runner::TaskStatus::Failed
@@ -375,9 +378,12 @@ async fn wait_for_terminal_task(
                 return Ok(task);
             }
         }
+        if Instant::now() >= deadline {
+            break;
+        }
         sleep(Duration::from_millis(25)).await;
     }
-    anyhow::bail!("task did not reach terminal state in time");
+    anyhow::bail!("task did not reach terminal state in time; last_status={last_status:?}");
 }
 
 async fn run_gc_adopt_and_wait_for_failure_turn(max_rounds: u32) -> anyhow::Result<u32> {

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -656,6 +656,8 @@ where
                     &project_config.git.remote,
                     &project_config.git.base_branch,
                     run_generation,
+                    req.external_id.as_deref(),
+                    req.repo.as_deref(),
                 )
                 .await
             {

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -814,6 +814,8 @@ where
                 if let Err(e) = wmgr.remove_workspace(&id).await {
                     tracing::warn!("workspace cleanup failed for {id:?}: {e}");
                 }
+            } else {
+                wmgr.release_workspace(&id);
             }
         }
 

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -214,7 +214,7 @@ impl WorkspaceManager {
         external_id: Option<&str>,
         repo: Option<&str>,
     ) -> Result<WorkspaceLease, WorkspaceLifecycleError> {
-        let workspace_key = derive_workspace_key(task_id, external_id, repo);
+        let workspace_key = derive_workspace_key(task_id, external_id, repo, Some(source_repo));
         // Validate inputs to prevent unexpected git behavior.
         if !is_valid_branch_name(base_branch) {
             return Err(WorkspaceLifecycleError::CreateFailed {
@@ -850,13 +850,24 @@ fn sanitize_task_id(id: &str) -> String {
 /// Derive the filesystem key for a workspace.
 ///
 /// For tasks with `external_id` matching `issue:N` or `pr:N` and a non-empty `repo`,
-/// returns `<sanitized_repo>__<sanitized_external_id>` (e.g. `myorg_my-repo__issue_42`),
-/// creating a deterministic flat path that survives task-id changes across retries.
-/// Falls back to the UUID-derived key when either argument is absent or doesn't match.
-fn derive_workspace_key(task_id: &TaskId, external_id: Option<&str>, repo: Option<&str>) -> String {
+/// returns `<sanitized_project>__<sanitized_repo>__<sanitized_external_id>`
+/// (e.g. `my-project__myorg_my-repo__issue_42`), scoped to the project root so that
+/// two different projects targeting the same GitHub repo/issue do not collide.
+/// Falls back to the UUID-derived key when `external_id`/`repo` are absent or don't match.
+fn derive_workspace_key(
+    task_id: &TaskId,
+    external_id: Option<&str>,
+    repo: Option<&str>,
+    source_repo: Option<&std::path::Path>,
+) -> String {
     if let (Some(eid), Some(r)) = (external_id, repo) {
         if !r.is_empty() && is_issue_or_pr_id(eid) {
-            return format!("{}__{}", sanitize_task_id(r), sanitize_task_id(eid));
+            let project_prefix = source_repo
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .map(|n| format!("{}__", sanitize_task_id(n)))
+                .unwrap_or_default();
+            return format!("{}{}__{}", project_prefix, sanitize_task_id(r), sanitize_task_id(eid));
         }
     }
     sanitize_task_id(&task_id.0)
@@ -1219,34 +1230,60 @@ mod tests {
 
     #[test]
     fn derive_workspace_key_issue() {
-        let key = derive_workspace_key(&test_task_id(), Some("issue:42"), Some("myorg/my-repo"));
-        assert_eq!(key, "myorg_my-repo__issue_42");
+        let key = derive_workspace_key(
+            &test_task_id(),
+            Some("issue:42"),
+            Some("myorg/my-repo"),
+            Some(std::path::Path::new("/projects/my-project")),
+        );
+        assert_eq!(key, "my-project__myorg_my-repo__issue_42");
     }
 
     #[test]
     fn derive_workspace_key_pr() {
-        let key = derive_workspace_key(&test_task_id(), Some("pr:7"), Some("myorg/my-repo"));
-        assert_eq!(key, "myorg_my-repo__pr_7");
+        let key = derive_workspace_key(
+            &test_task_id(),
+            Some("pr:7"),
+            Some("myorg/my-repo"),
+            Some(std::path::Path::new("/projects/my-project")),
+        );
+        assert_eq!(key, "my-project__myorg_my-repo__pr_7");
     }
 
     #[test]
     fn derive_workspace_key_prompt_falls_back_to_uuid() {
         let id = test_task_id();
-        let key = derive_workspace_key(&id, None, None);
+        let key = derive_workspace_key(&id, None, None, None);
         assert_eq!(key, sanitize_task_id(&id.0));
     }
 
     #[test]
     fn derive_workspace_key_missing_repo_falls_back() {
         let id = test_task_id();
-        let key = derive_workspace_key(&id, Some("issue:42"), None);
+        let key = derive_workspace_key(&id, Some("issue:42"), None, None);
         assert_eq!(key, sanitize_task_id(&id.0));
     }
 
     #[test]
     fn derive_workspace_key_special_chars_in_repo() {
-        let key = derive_workspace_key(&test_task_id(), Some("issue:99"), Some("my.org/repo name"));
-        assert_eq!(key, "my_org_repo_name__issue_99");
+        let key = derive_workspace_key(
+            &test_task_id(),
+            Some("issue:99"),
+            Some("my.org/repo name"),
+            Some(std::path::Path::new("/projects/my-project")),
+        );
+        assert_eq!(key, "my-project__my_org_repo_name__issue_99");
+    }
+
+    #[test]
+    fn derive_workspace_key_no_source_repo_omits_prefix() {
+        let key = derive_workspace_key(
+            &test_task_id(),
+            Some("issue:42"),
+            Some("myorg/my-repo"),
+            None,
+        );
+        assert_eq!(key, "myorg_my-repo__issue_42");
     }
 
     #[test]

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -2181,7 +2181,7 @@ mod tests {
         let mgr_a = WorkspaceManager::new(config.clone()).expect("mgr_a");
         let uuid_id = harness_core::types::TaskId("uuid-task-migration-123".to_string());
         let uuid_lease = mgr_a
-            .create_workspace(&uuid_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&uuid_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create uuid workspace");
 
@@ -2194,6 +2194,7 @@ mod tests {
                 task_id: "issue:42".to_string(),
                 run_generation: 1,
                 owner_session: "test-session".to_string(),
+                workspace_key: None,
             })
             .expect("serialize"),
         )
@@ -2241,7 +2242,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("orphan-uuid-task".to_string());
 
         let lease = mgr_a
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create workspace");
 
@@ -2275,7 +2276,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("some-uuid-task".to_string());
 
         let lease = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create workspace");
         mgr.active.remove(&task_id);
@@ -2313,6 +2314,7 @@ mod tests {
                 task_id: "issue:42".to_string(),
                 run_generation: 1,
                 owner_session: "s".to_string(),
+                workspace_key: None,
             })
             .expect("serialize"),
         )
@@ -2357,6 +2359,7 @@ mod tests {
                 task_id: "issue:7".to_string(),
                 run_generation: 1,
                 owner_session: "s".to_string(),
+                workspace_key: None,
             })
             .expect("serialize"),
         )

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -867,7 +867,12 @@ fn derive_workspace_key(
                 .and_then(|n| n.to_str())
                 .map(|n| format!("{}__", sanitize_task_id(n)))
                 .unwrap_or_default();
-            return format!("{}{}__{}", project_prefix, sanitize_task_id(r), sanitize_task_id(eid));
+            return format!(
+                "{}{}__{}",
+                project_prefix,
+                sanitize_task_id(r),
+                sanitize_task_id(eid)
+            );
         }
     }
     sanitize_task_id(&task_id.0)

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -898,12 +898,15 @@ fn sanitize_task_id(id: &str) -> String {
 
 /// Sanitize a GitHub repository slug for use as a filesystem path component.
 ///
-/// Preserves dots (valid in repo names) so that `my.org/repo` and `my_org/repo`
-/// produce distinct keys (`my.org_repo` vs `my_org_repo`).
+/// Preserves underscores, dots, and hyphens (all valid in repo names) so that
+/// `my.org/repo` and `my_org/repo` produce distinct keys (`my.org_repo` vs
+/// `my_org_repo`). The `/` org-repo separator maps to `_`. GitHub organisation
+/// names cannot contain underscores (only `[a-zA-Z0-9-]`), so the `owner_repo`
+/// output is unambiguous for valid GitHub slugs.
 fn sanitize_repo_slug(s: &str) -> String {
     s.chars()
         .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '.' {
+            if c.is_alphanumeric() || c == '-' || c == '.' || c == '_' {
                 c
             } else {
                 '_'

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -509,11 +509,13 @@ impl WorkspaceManager {
         source_repo: &Path,
         workspace_path: Option<&Path>,
     ) -> anyhow::Result<()> {
-        self.active.remove(task_id);
-        let fallback_path = self.config.root.join(sanitize_task_id(&task_id.0));
+        // Resolve target before removing from active so deterministic-key workspaces
+        // (whose directory name differs from sanitize_task_id(task_id)) are found.
         let target = workspace_path
             .map(Path::to_path_buf)
-            .unwrap_or(fallback_path);
+            .or_else(|| self.active.get(task_id).map(|e| e.workspace_path.clone()))
+            .unwrap_or_else(|| self.config.root.join(sanitize_task_id(&task_id.0)));
+        self.active.remove(task_id);
         cleanup_workspace_path(source_repo, &target).await
     }
 
@@ -759,6 +761,8 @@ impl WorkspaceManager {
     ///
     /// Errors from individual removals are logged and do not abort the sweep.
     pub async fn cleanup_orphan_worktrees(&self, source_repo: &Path, terminal_task_ids: &[TaskId]) {
+        let terminal_set: std::collections::HashSet<&str> =
+            terminal_task_ids.iter().map(|id| id.0.as_str()).collect();
         let terminal_dirs: std::collections::HashSet<String> = terminal_task_ids
             .iter()
             .map(|id| sanitize_task_id(&id.0))
@@ -790,6 +794,9 @@ impl WorkspaceManager {
             // A broad `starts_with("{td}-")` would also match unrelated workspaces
             // like `task-42-hotfix`, incorrectly deleting them when `task-42` is
             // terminal.  Restricting to the two known suffixes prevents false positives.
+            //
+            // Deterministic workspace keys (e.g. `{hash}__{repo}__{issue}`) don't match
+            // the UUID-derived directory name pattern, so also check the owner record.
             let is_terminal = terminal_dirs.iter().any(|td| {
                 dir_name == *td
                     || dir_name == format!("{td}-seq")
@@ -798,7 +805,9 @@ impl WorkspaceManager {
                         .is_some_and(|rest| {
                             !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
                         })
-            });
+            }) || read_owner_record(&path)
+                .map(|record| terminal_set.contains(record.task_id.as_str()))
+                .unwrap_or(false);
             if !is_terminal {
                 continue;
             }
@@ -847,12 +856,42 @@ fn sanitize_task_id(id: &str) -> String {
         .collect()
 }
 
+/// Sanitize a GitHub repository slug for use as a filesystem path component.
+///
+/// Preserves dots (valid in repo names) so that `my.org/repo` and `my_org/repo`
+/// produce distinct keys (`my.org_repo` vs `my_org_repo`).
+fn sanitize_repo_slug(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Return an 8-character lowercase hex string from a 32-bit FNV-1a hash of `s`.
+///
+/// This is a deterministic, stable hash with no external dependencies, used to
+/// produce a unique project scope component in deterministic workspace keys.
+fn fnv1a_8(s: &str) -> String {
+    let mut hash: u32 = 0x811c9dc5;
+    for b in s.bytes() {
+        hash ^= u32::from(b);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    format!("{hash:08x}")
+}
+
 /// Derive the filesystem key for a workspace.
 ///
 /// For tasks with `external_id` matching `issue:N` or `pr:N` and a non-empty `repo`,
-/// returns `<sanitized_project>__<sanitized_repo>__<sanitized_external_id>`
-/// (e.g. `my-project__myorg_my-repo__issue_42`), scoped to the project root so that
-/// two different projects targeting the same GitHub repo/issue do not collide.
+/// returns `<path_hash>__<sanitized_repo>__<sanitized_external_id>`
+/// (e.g. `a3f2b1c4__myorg_my-repo__issue_42`), scoped by a hash of the project's
+/// absolute path so that two different projects targeting the same GitHub repo/issue
+/// do not collide even when their directory names are identical.
 /// Falls back to the UUID-derived key when `external_id`/`repo` are absent or don't match.
 fn derive_workspace_key(
     task_id: &TaskId,
@@ -863,14 +902,15 @@ fn derive_workspace_key(
     if let (Some(eid), Some(r)) = (external_id, repo) {
         if !r.is_empty() && is_issue_or_pr_id(eid) {
             let project_prefix = source_repo
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
-                .map(|n| format!("{}__", sanitize_task_id(n)))
+                .map(|p| {
+                    let canonical = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+                    format!("{}__", fnv1a_8(&canonical.to_string_lossy()))
+                })
                 .unwrap_or_default();
             return format!(
                 "{}{}__{}",
                 project_prefix,
-                sanitize_task_id(r),
+                sanitize_repo_slug(r),
                 sanitize_task_id(eid)
             );
         }
@@ -1235,24 +1275,28 @@ mod tests {
 
     #[test]
     fn derive_workspace_key_issue() {
+        let path = std::path::Path::new("/projects/my-project");
+        // canonicalize fails in test env; fnv1a_8 hashes the given path string
+        let prefix = fnv1a_8("/projects/my-project");
         let key = derive_workspace_key(
             &test_task_id(),
             Some("issue:42"),
             Some("myorg/my-repo"),
-            Some(std::path::Path::new("/projects/my-project")),
+            Some(path),
         );
-        assert_eq!(key, "my-project__myorg_my-repo__issue_42");
+        assert_eq!(key, format!("{prefix}__myorg_my-repo__issue_42"));
     }
 
     #[test]
     fn derive_workspace_key_pr() {
+        let prefix = fnv1a_8("/projects/my-project");
         let key = derive_workspace_key(
             &test_task_id(),
             Some("pr:7"),
             Some("myorg/my-repo"),
             Some(std::path::Path::new("/projects/my-project")),
         );
-        assert_eq!(key, "my-project__myorg_my-repo__pr_7");
+        assert_eq!(key, format!("{prefix}__myorg_my-repo__pr_7"));
     }
 
     #[test]
@@ -1271,13 +1315,16 @@ mod tests {
 
     #[test]
     fn derive_workspace_key_special_chars_in_repo() {
+        // sanitize_repo_slug preserves dots: "my.org/repo name" -> "my.org_repo_name"
+        // (distinct from "my_org/repo_name" -> "my_org_repo_name")
+        let prefix = fnv1a_8("/projects/my-project");
         let key = derive_workspace_key(
             &test_task_id(),
             Some("issue:99"),
             Some("my.org/repo name"),
             Some(std::path::Path::new("/projects/my-project")),
         );
-        assert_eq!(key, "my-project__my_org_repo_name__issue_99");
+        assert_eq!(key, format!("{prefix}__my.org_repo_name__issue_99"));
     }
 
     #[test]
@@ -1289,6 +1336,39 @@ mod tests {
             None,
         );
         assert_eq!(key, "myorg_my-repo__issue_42");
+    }
+
+    #[test]
+    fn sanitize_repo_slug_preserves_dots() {
+        assert_eq!(sanitize_repo_slug("my.org/my-repo"), "my.org_my-repo");
+        assert_eq!(sanitize_repo_slug("my_org/my-repo"), "my_org_my-repo");
+        // dots and underscores produce distinct keys
+        assert_ne!(
+            sanitize_repo_slug("my.org/repo"),
+            sanitize_repo_slug("my_org/repo")
+        );
+    }
+
+    #[test]
+    fn derive_workspace_key_different_projects_same_dirname_differ() {
+        // Two projects with the same dir name but different parent paths must
+        // produce different workspace keys (hash of full path, not just file_name).
+        let key_a = derive_workspace_key(
+            &test_task_id(),
+            Some("issue:1"),
+            Some("org/repo"),
+            Some(std::path::Path::new("/home/user/app")),
+        );
+        let key_b = derive_workspace_key(
+            &test_task_id(),
+            Some("issue:1"),
+            Some("org/repo"),
+            Some(std::path::Path::new("/opt/app")),
+        );
+        assert_ne!(
+            key_a, key_b,
+            "projects at different paths must produce different keys"
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -850,13 +850,13 @@ fn sanitize_task_id(id: &str) -> String {
 /// Derive the filesystem key for a workspace.
 ///
 /// For tasks with `external_id` matching `issue:N` or `pr:N` and a non-empty `repo`,
-/// returns `<sanitized_repo>/<sanitized_external_id>` (e.g. `myorg_my-repo/issue_42`),
-/// creating a deterministic two-level path that survives task-id changes across retries.
+/// returns `<sanitized_repo>__<sanitized_external_id>` (e.g. `myorg_my-repo__issue_42`),
+/// creating a deterministic flat path that survives task-id changes across retries.
 /// Falls back to the UUID-derived key when either argument is absent or doesn't match.
 fn derive_workspace_key(task_id: &TaskId, external_id: Option<&str>, repo: Option<&str>) -> String {
     if let (Some(eid), Some(r)) = (external_id, repo) {
         if !r.is_empty() && is_issue_or_pr_id(eid) {
-            return format!("{}/{}", sanitize_task_id(r), sanitize_task_id(eid));
+            return format!("{}__{}", sanitize_task_id(r), sanitize_task_id(eid));
         }
     }
     sanitize_task_id(&task_id.0)
@@ -1220,13 +1220,13 @@ mod tests {
     #[test]
     fn derive_workspace_key_issue() {
         let key = derive_workspace_key(&test_task_id(), Some("issue:42"), Some("myorg/my-repo"));
-        assert_eq!(key, "myorg_my-repo/issue_42");
+        assert_eq!(key, "myorg_my-repo__issue_42");
     }
 
     #[test]
     fn derive_workspace_key_pr() {
         let key = derive_workspace_key(&test_task_id(), Some("pr:7"), Some("myorg/my-repo"));
-        assert_eq!(key, "myorg_my-repo/pr_7");
+        assert_eq!(key, "myorg_my-repo__pr_7");
     }
 
     #[test]
@@ -1246,7 +1246,7 @@ mod tests {
     #[test]
     fn derive_workspace_key_special_chars_in_repo() {
         let key = derive_workspace_key(&test_task_id(), Some("issue:99"), Some("my.org/repo name"));
-        assert_eq!(key, "my_org_repo_name/issue_99");
+        assert_eq!(key, "my_org_repo_name__issue_99");
     }
 
     #[test]

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -52,6 +52,8 @@ struct WorkspaceOwnerRecord {
     task_id: String,
     run_generation: u32,
     owner_session: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -234,6 +236,22 @@ impl WorkspaceManager {
         let workspace_path = self.config.root.join(&workspace_key);
         let owner_session = self.owner_session.clone();
 
+        if let Some(existing) = self
+            .active
+            .iter()
+            .find(|entry| entry.key() != task_id && entry.workspace_path == workspace_path)
+        {
+            return Err(WorkspaceLifecycleError::LiveForeignOwner {
+                workspace_path: existing.workspace_path.clone(),
+                workspace_owner: Some(existing.owner_session.clone()),
+                message: format!(
+                    "WorktreeCollision: workspace path {:?} already owned by active task {}; manual resolution required",
+                    existing.workspace_path,
+                    existing.key().0
+                ),
+            });
+        }
+
         // Atomic check-and-insert: prevents TOCTOU where two concurrent calls for the
         // same task_id would both attempt git worktree add on the same path.
         // Insert a placeholder immediately so any concurrent caller returns early.
@@ -277,8 +295,7 @@ impl WorkspaceManager {
         if workspace_path.exists() {
             let owner_record = read_owner_record(&workspace_path);
             if owner_record.as_ref().is_some_and(|record| {
-                record.task_id == task_id.0
-                    && record.run_generation == run_generation
+                owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
                     && record.owner_session != owner_session
             }) {
                 self.active.remove(task_id);
@@ -293,10 +310,23 @@ impl WorkspaceManager {
             }
 
             if owner_record.as_ref().is_some_and(|record| {
-                record.task_id == task_id.0
-                    && record.run_generation == run_generation
+                owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
                     && record.owner_session == owner_session
             }) {
+                let owner_record = WorkspaceOwnerRecord {
+                    task_id: task_id.0.clone(),
+                    run_generation,
+                    owner_session: owner_session.clone(),
+                    workspace_key: Some(workspace_key.clone()),
+                };
+                if let Err(err) = write_owner_record(&workspace_path, &owner_record) {
+                    self.active.remove(task_id);
+                    return Err(WorkspaceLifecycleError::CreateFailed {
+                        workspace_path: workspace_path.clone(),
+                        workspace_owner: Some(owner_session.clone()),
+                        message: format!("failed to update workspace owner record: {err}"),
+                    });
+                }
                 tracing::info!(
                     task_id = %task_id.0,
                     path = ?workspace_path,
@@ -416,6 +446,7 @@ impl WorkspaceManager {
             task_id: task_id.0.clone(),
             run_generation,
             owner_session: owner_session.clone(),
+            workspace_key: Some(workspace_key),
         };
         if let Err(err) = write_owner_record(&workspace_path, &owner_record) {
             self.active.remove(task_id);
@@ -501,6 +532,15 @@ impl WorkspaceManager {
             );
         }
         Ok(())
+    }
+
+    /// Release the in-memory lease without deleting the workspace on disk.
+    ///
+    /// Used when `auto_cleanup=false` so a later task with the same deterministic
+    /// issue/PR workspace key can reuse the directory while concurrent tasks are
+    /// still protected by the active-path collision check.
+    pub fn release_workspace(&self, task_id: &TaskId) {
+        self.active.remove(task_id);
     }
 
     pub async fn cleanup_workspace_for_retry(
@@ -980,6 +1020,20 @@ fn read_owner_record(workspace_path: &Path) -> Option<WorkspaceOwnerRecord> {
     serde_json::from_slice(&bytes).ok()
 }
 
+fn owner_record_matches_workspace(
+    record: &WorkspaceOwnerRecord,
+    task_id: &TaskId,
+    workspace_key: &str,
+    run_generation: u32,
+) -> bool {
+    let identity_matches = record
+        .workspace_key
+        .as_deref()
+        .map(|key| key == workspace_key)
+        .unwrap_or(record.task_id == task_id.0);
+    identity_matches && record.run_generation == run_generation
+}
+
 fn write_owner_record(
     workspace_path: &Path,
     owner_record: &WorkspaceOwnerRecord,
@@ -1443,6 +1497,64 @@ mod tests {
         );
 
         mgr.remove_workspace(&task_id).await.expect("remove");
+    }
+
+    #[tokio::test]
+    async fn deterministic_issue_workspace_reuses_existing_directory_for_new_task() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            auto_cleanup: false,
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let first_task = harness_core::types::TaskId("task-first".to_string());
+        let second_task = harness_core::types::TaskId("task-second".to_string());
+
+        let first = mgr
+            .create_workspace(
+                &first_task,
+                source.path(),
+                "origin",
+                &branch,
+                1,
+                Some("issue:42"),
+                Some("owner/repo"),
+            )
+            .await
+            .expect("create first workspace");
+        let marker = first.workspace_path.join("handoff.txt");
+        std::fs::write(&marker, "keep this file").expect("write marker");
+        mgr.release_workspace(&first_task);
+
+        let second = mgr
+            .create_workspace(
+                &second_task,
+                source.path(),
+                "origin",
+                &branch,
+                1,
+                Some("issue:42"),
+                Some("owner/repo"),
+            )
+            .await
+            .expect("reuse deterministic workspace");
+
+        assert_eq!(first.workspace_path, second.workspace_path);
+        assert_eq!(second.decision, WorkspaceAcquireDecision::ReusedRecovered);
+        assert!(
+            second.workspace_path.join("handoff.txt").exists(),
+            "reused workspace must preserve prior task output"
+        );
+        let owner = read_owner_record(&second.workspace_path).expect("owner record");
+        assert_eq!(owner.task_id, second_task.0);
+        assert!(owner.workspace_key.is_some());
+
+        mgr.remove_workspace(&second_task).await.expect("remove");
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -211,25 +211,27 @@ impl WorkspaceManager {
         remote: &str,
         base_branch: &str,
         run_generation: u32,
+        external_id: Option<&str>,
+        repo: Option<&str>,
     ) -> Result<WorkspaceLease, WorkspaceLifecycleError> {
+        let workspace_key = derive_workspace_key(task_id, external_id, repo);
         // Validate inputs to prevent unexpected git behavior.
         if !is_valid_branch_name(base_branch) {
             return Err(WorkspaceLifecycleError::CreateFailed {
-                workspace_path: self.config.root.join(sanitize_task_id(&task_id.0)),
+                workspace_path: self.config.root.join(&workspace_key),
                 workspace_owner: None,
                 message: format!("invalid base_branch: {base_branch:?}"),
             });
         }
         if !is_valid_branch_name(remote) {
             return Err(WorkspaceLifecycleError::CreateFailed {
-                workspace_path: self.config.root.join(sanitize_task_id(&task_id.0)),
+                workspace_path: self.config.root.join(&workspace_key),
                 workspace_owner: None,
                 message: format!("invalid remote: {remote:?}"),
             });
         }
 
-        let sanitized = sanitize_task_id(&task_id.0);
-        let workspace_path = self.config.root.join(&sanitized);
+        let workspace_path = self.config.root.join(&workspace_key);
         let owner_session = self.owner_session.clone();
 
         // Atomic check-and-insert: prevents TOCTOU where two concurrent calls for the
@@ -845,6 +847,32 @@ fn sanitize_task_id(id: &str) -> String {
         .collect()
 }
 
+/// Derive the filesystem key for a workspace.
+///
+/// For tasks with `external_id` matching `issue:N` or `pr:N` and a non-empty `repo`,
+/// returns `<sanitized_repo>/<sanitized_external_id>` (e.g. `myorg_my-repo/issue_42`),
+/// creating a deterministic two-level path that survives task-id changes across retries.
+/// Falls back to the UUID-derived key when either argument is absent or doesn't match.
+fn derive_workspace_key(task_id: &TaskId, external_id: Option<&str>, repo: Option<&str>) -> String {
+    if let (Some(eid), Some(r)) = (external_id, repo) {
+        if !r.is_empty() && is_issue_or_pr_id(eid) {
+            return format!("{}/{}", sanitize_task_id(r), sanitize_task_id(eid));
+        }
+    }
+    sanitize_task_id(&task_id.0)
+}
+
+fn is_issue_or_pr_id(s: &str) -> bool {
+    let digits = if let Some(rest) = s.strip_prefix("issue:") {
+        rest
+    } else if let Some(rest) = s.strip_prefix("pr:") {
+        rest
+    } else {
+        return false;
+    };
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
 /// Returns true when the git worktree at `path` is currently on `branch`.
 /// Used to distinguish crash-recovery (same task's worktree) from a true collision.
 async fn run_hook(script: &str, cwd: &Path) -> anyhow::Result<()> {
@@ -1185,6 +1213,42 @@ mod tests {
         assert_eq!(sanitize_task_id("abc.123"), "abc_123");
     }
 
+    fn test_task_id() -> TaskId {
+        harness_core::types::TaskId("550e8400-e29b-41d4-a716-446655440000".to_string())
+    }
+
+    #[test]
+    fn derive_workspace_key_issue() {
+        let key = derive_workspace_key(&test_task_id(), Some("issue:42"), Some("myorg/my-repo"));
+        assert_eq!(key, "myorg_my-repo/issue_42");
+    }
+
+    #[test]
+    fn derive_workspace_key_pr() {
+        let key = derive_workspace_key(&test_task_id(), Some("pr:7"), Some("myorg/my-repo"));
+        assert_eq!(key, "myorg_my-repo/pr_7");
+    }
+
+    #[test]
+    fn derive_workspace_key_prompt_falls_back_to_uuid() {
+        let id = test_task_id();
+        let key = derive_workspace_key(&id, None, None);
+        assert_eq!(key, sanitize_task_id(&id.0));
+    }
+
+    #[test]
+    fn derive_workspace_key_missing_repo_falls_back() {
+        let id = test_task_id();
+        let key = derive_workspace_key(&id, Some("issue:42"), None);
+        assert_eq!(key, sanitize_task_id(&id.0));
+    }
+
+    #[test]
+    fn derive_workspace_key_special_chars_in_repo() {
+        let key = derive_workspace_key(&test_task_id(), Some("issue:99"), Some("my.org/repo name"));
+        assert_eq!(key, "my_org_repo_name/issue_99");
+    }
+
     #[test]
     fn workspace_manager_new_creates_root_dir() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1213,7 +1277,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("test-task-001".to_string());
 
         let ws_path = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create");
         assert!(ws_path.workspace_path.is_dir());
@@ -1238,7 +1302,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("test-task-owner-record".to_string());
 
         let lease = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create");
 
@@ -1289,11 +1353,11 @@ mod tests {
         let task_id = harness_core::types::TaskId("test-task-002".to_string());
 
         let path1 = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create first");
         let path2 = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create second");
         assert_eq!(path1.workspace_path, path2.workspace_path);
@@ -1318,7 +1382,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("test-task-git-index-file".to_string());
 
         let ws_path = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create");
         assert!(ws_path.workspace_path.is_dir());
@@ -1344,7 +1408,7 @@ mod tests {
         let mgr = WorkspaceManager::new(config).expect("new");
         let task_id = harness_core::types::TaskId("test-task-003".to_string());
 
-        mgr.create_workspace(&task_id, source.path(), "origin", &branch, 1)
+        mgr.create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create");
         assert!(
@@ -1371,7 +1435,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("test-task-004".to_string());
 
         let result = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await;
         assert!(result.is_err(), "should fail when hook exits 1");
         assert!(
@@ -1404,7 +1468,7 @@ mod tests {
         std::fs::create_dir_all(&stale_path).expect("create stale dir");
 
         let result = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await;
         assert!(
             result.is_ok(),
@@ -1436,12 +1500,12 @@ mod tests {
         let task_id = harness_core::types::TaskId("foreign-owner-task".to_string());
 
         mgr_a
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create first owner");
 
         let err = mgr_b
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect_err("second owner should be blocked");
         assert!(
@@ -1466,7 +1530,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("startup-reconcile-task".to_string());
 
         let lease = mgr_a
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create workspace");
         assert!(lease.workspace_path.exists());
@@ -1526,7 +1590,15 @@ mod tests {
         let task_id = harness_core::types::TaskId("startup-owning-repo-task".to_string());
 
         let lease = mgr_a
-            .create_workspace(&task_id, source_a.path(), "origin", &branch_a, 1)
+            .create_workspace(
+                &task_id,
+                source_a.path(),
+                "origin",
+                &branch_a,
+                1,
+                None,
+                None,
+            )
             .await
             .expect("create workspace");
         assert!(lease.workspace_path.exists());
@@ -1601,7 +1673,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("missing-registered-task".to_string());
 
         let lease = mgr
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create workspace");
         std::fs::remove_dir_all(&lease.workspace_path).expect("remove checkout dir");
@@ -1637,7 +1709,7 @@ mod tests {
         let task_id = harness_core::types::TaskId("startup-missing-registered-task".to_string());
 
         let lease = mgr_a
-            .create_workspace(&task_id, source.path(), "origin", &branch, 1)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
             .await
             .expect("create workspace");
         std::fs::remove_dir_all(&lease.workspace_path).expect("remove checkout dir");
@@ -1683,7 +1755,7 @@ mod tests {
         );
 
         let recreated = mgr_b
-            .create_workspace(&task_id, source.path(), "origin", &branch, 2)
+            .create_workspace(&task_id, source.path(), "origin", &branch, 2, None, None)
             .await
             .expect("recreate workspace after startup reconcile");
         assert!(
@@ -1773,7 +1845,7 @@ mod tests {
         let mgr = WorkspaceManager::new(config).expect("new");
         let task_id = harness_core::types::TaskId("test-task-relative-path".to_string());
 
-        mgr.create_workspace(&task_id, &source, "origin", &branch, 1)
+        mgr.create_workspace(&task_id, &source, "origin", &branch, 1, None, None)
             .await
             .expect("create");
         let relative_workspace_path =
@@ -1805,7 +1877,7 @@ mod tests {
             .collect();
 
         for id in &ids {
-            mgr.create_workspace(id, source.path(), "origin", &branch, 1)
+            mgr.create_workspace(id, source.path(), "origin", &branch, 1, None, None)
                 .await
                 .expect("create");
         }


### PR DESCRIPTION
## Summary

- Adds `derive_workspace_key()` helper: for tasks with `external_id` matching `issue:N` or `pr:N` plus a non-empty `repo`, derives path as `<sanitized-repo>/<sanitized-external-id>` (e.g. `myorg_my-repo/issue_42`)
- Extends `create_workspace` signature with `external_id: Option<&str>` and `repo: Option<&str>`; spawn.rs passes task values, parallel_dispatch.rs passes `None, None` for synthetic sub-task IDs
- Prompt-only tasks and parallel sub-tasks retain the existing UUID-based key unchanged

Closes #967

## Test plan

- [ ] `cargo test --package harness-server --lib workspace` — 28 tests pass (5 new: `derive_workspace_key_issue`, `derive_workspace_key_pr`, `derive_workspace_key_prompt_falls_back_to_uuid`, `derive_workspace_key_missing_repo_falls_back`, `derive_workspace_key_special_chars_in_repo`)
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — applied