### PR TITLE
feat(self-evolution): emit drafts_pending/adopted/skills_invoked telemetry

### DIFF
--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -188,6 +188,13 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     let feed = build_feed(&events, now);
     let alerts = build_alerts(&events, &runtime_hosts);
 
+    let evolution: Value = events
+        .iter()
+        .filter(|e| e.hook == "self_evolution_tick")
+        .max_by_key(|e| e.ts)
+        .and_then(|e| parse_evolution_from_reason(e.reason.as_deref()))
+        .unwrap_or(Value::Null);
+
     // Cluster heatmap: per-project 24-bucket intensity (normalised to the
     // project's peak hour). Runtime-dimension is collapsed because task rows
     // don't carry host attribution yet.
@@ -249,6 +256,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
         },
         "feed": feed,
         "alerts": alerts,
+        "evolution": evolution,
         "global": {
             "uptime_secs": uptime_secs,
             "running": running,
@@ -399,6 +407,29 @@ fn build_alerts(events: &[Event], hosts: &[crate::runtime_hosts::RuntimeHostInfo
     out
 }
 
+/// Parse `drafts_pending`, `drafts_adopted`, and `skills_invoked` from the
+/// space-separated `key=value` reason string of a `self_evolution_tick` event.
+///
+/// Returns `None` when any of the three required fields are absent — this
+/// gracefully degrades old events (pre-#972) to `null` on the dashboard.
+fn parse_evolution_from_reason(reason: Option<&str>) -> Option<Value> {
+    let reason = reason?;
+    let mut map = std::collections::HashMap::new();
+    for part in reason.split_whitespace() {
+        if let Some((k, v)) = part.split_once('=') {
+            map.insert(k, v);
+        }
+    }
+    let drafts_pending = map.get("drafts_pending")?.parse::<u64>().ok()?;
+    let drafts_auto_adopted = map.get("drafts_adopted")?.parse::<u64>().ok()?;
+    let skills_invoked_in_window = map.get("skills_invoked")?.parse::<u64>().ok()?;
+    Some(json!({
+        "drafts_pending": drafts_pending,
+        "drafts_auto_adopted": drafts_auto_adopted,
+        "skills_invoked_in_window": skills_invoked_in_window,
+    }))
+}
+
 /// Human-readable delta such as `14s`, `3m`, `2h`, `1d` — matches the feed
 /// column spacing in the design.
 fn relative_ago(now: DateTime<Utc>, then: DateTime<Utc>) -> String {
@@ -443,6 +474,23 @@ mod tests {
     #[test]
     fn rule_fail_rate_zero_when_no_events() {
         assert_eq!(compute_rule_fail_rate_pct(&[]), 0.0);
+    }
+
+    #[test]
+    fn parse_evolution_returns_none_for_old_reason_format() {
+        // Old events without the new fields must degrade to None, not panic.
+        let old_reason = "rules=0 skills=0 scored=0 quarantine=0 retired=0";
+        assert!(parse_evolution_from_reason(Some(old_reason)).is_none());
+        assert!(parse_evolution_from_reason(None).is_none());
+    }
+
+    #[test]
+    fn parse_evolution_extracts_three_fields() {
+        let reason = "rules=2 skills=1 scored=5 quarantine=0 retired=1 drafts_pending=3 drafts_adopted=2 skills_invoked=7";
+        let v = parse_evolution_from_reason(Some(reason)).expect("should parse");
+        assert_eq!(v["drafts_pending"], 3u64);
+        assert_eq!(v["drafts_auto_adopted"], 2u64);
+        assert_eq!(v["skills_invoked_in_window"], 7u64);
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/self_evolution.rs
+++ b/crates/harness-server/src/self_evolution.rs
@@ -1,7 +1,8 @@
 use crate::handlers::learn;
 use crate::http::AppState;
 use crate::skill_governor;
-use harness_core::types::{Decision, Event, SessionId};
+use chrono::{Duration as ChronoDuration, Utc};
+use harness_core::types::{Decision, DraftStatus, Event, EventFilters, SessionId};
 use harness_protocol::methods::RpcResponse;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,6 +15,9 @@ pub(crate) struct SelfEvolutionReport {
     pub(crate) skills_scored: usize,
     pub(crate) quarantined: usize,
     pub(crate) retired: usize,
+    pub(crate) drafts_pending: usize,
+    pub(crate) drafts_auto_adopted: usize,
+    pub(crate) skills_invoked_in_window: usize,
 }
 
 /// Start periodic self-evolution ticks.
@@ -66,6 +70,50 @@ pub(crate) async fn run_tick(state: &Arc<AppState>) -> anyhow::Result<SelfEvolut
         Err(err) => errors.push(format!("skill_governance failed: {err}")),
     }
 
+    // Telemetry: drafts pending at tick start.
+    match state.engines.gc_agent.drafts() {
+        Ok(drafts) => {
+            report.drafts_pending = drafts
+                .iter()
+                .filter(|d| d.status == DraftStatus::Pending)
+                .count();
+        }
+        Err(err) => errors.push(format!("draft_count failed: {err}")),
+    }
+
+    let since_window = Utc::now() - ChronoDuration::hours(24);
+
+    // Telemetry: gc_adopt events with Complete decision in the 24h window.
+    match state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("gc_adopt".to_string()),
+            decision: Some(Decision::Complete),
+            since: Some(since_window),
+            ..EventFilters::default()
+        })
+        .await
+    {
+        Ok(adopted_events) => report.drafts_auto_adopted = adopted_events.len(),
+        Err(err) => errors.push(format!("gc_adopt_count failed: {err}")),
+    }
+
+    // Telemetry: skill_used events in the 24h window.
+    match state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("skill_used".to_string()),
+            since: Some(since_window),
+            ..EventFilters::default()
+        })
+        .await
+    {
+        Ok(skill_events) => report.skills_invoked_in_window = skill_events.len(),
+        Err(err) => errors.push(format!("skill_invoked_count failed: {err}")),
+    }
+
     let decision = if errors.is_empty() {
         Decision::Complete
     } else {
@@ -78,12 +126,15 @@ pub(crate) async fn run_tick(state: &Arc<AppState>) -> anyhow::Result<SelfEvolut
         decision,
     );
     event.reason = Some(format!(
-        "rules={} skills={} scored={} quarantine={} retired={}",
+        "rules={} skills={} scored={} quarantine={} retired={} drafts_pending={} drafts_adopted={} skills_invoked={}",
         report.rules_learned,
         report.skills_learned,
         report.skills_scored,
         report.quarantined,
-        report.retired
+        report.retired,
+        report.drafts_pending,
+        report.drafts_auto_adopted,
+        report.skills_invoked_in_window,
     ));
     event.detail = Some(project_root.display().to_string());
     if !errors.is_empty() {
@@ -118,7 +169,38 @@ fn extract_count(response: &RpcResponse, key: &str) -> anyhow::Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::types::EventFilters;
+    use harness_core::types::{
+        Artifact, ArtifactType, Draft, DraftId, DraftStatus, EventFilters, ProjectId,
+        RemediationType, Signal, SignalType,
+    };
+
+    fn make_pending_draft() -> Draft {
+        Draft {
+            id: DraftId::new(),
+            status: DraftStatus::Pending,
+            signal: Signal::new(
+                SignalType::RepeatedWarn,
+                ProjectId::new(),
+                serde_json::json!({}),
+                RemediationType::Guard,
+            ),
+            artifacts: vec![Artifact {
+                artifact_type: ArtifactType::Guard,
+                target_path: std::path::PathBuf::from(".harness/drafts/test.md"),
+                content: "test".into(),
+            }],
+            rationale: "test".into(),
+            validation: "test".into(),
+            generated_at: chrono::Utc::now(),
+            agent_model: "test".into(),
+        }
+    }
+
+    fn make_test_event(hook: &str, decision: Decision) -> Event {
+        let mut e = Event::new(SessionId::new(), hook, "test", decision);
+        e.reason = Some(format!("test {hook}"));
+        e
+    }
 
     #[tokio::test]
     async fn run_tick_logs_summary_event_when_no_adopted_drafts() -> anyhow::Result<()> {
@@ -135,6 +217,9 @@ mod tests {
         assert_eq!(report.rules_learned, 0);
         assert_eq!(report.skills_learned, 0);
         assert_eq!(report.skills_scored, 0);
+        assert_eq!(report.drafts_pending, 0);
+        assert_eq!(report.drafts_auto_adopted, 0);
+        assert_eq!(report.skills_invoked_in_window, 0);
 
         let events = state
             .observability
@@ -150,10 +235,84 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("expected self_evolution_tick event"))?;
         assert_eq!(
             latest.reason.as_deref(),
-            Some("rules=0 skills=0 scored=0 quarantine=0 retired=0")
+            Some(
+                "rules=0 skills=0 scored=0 quarantine=0 retired=0 drafts_pending=0 drafts_adopted=0 skills_invoked=0"
+            )
         );
         let expected_detail = project_root.path().display().to_string();
         assert_eq!(latest.detail.as_deref(), Some(expected_detail.as_str()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_tick_counts_pending_drafts() -> anyhow::Result<()> {
+        let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let data_dir = crate::test_helpers::tempdir_in_home("harness-self-evo-pending-")?;
+        let project_root = crate::test_helpers::tempdir_in_home("harness-self-evo-pending-proj-")?;
+        let state = crate::test_helpers::make_test_state_with_project_root(
+            data_dir.path(),
+            project_root.path(),
+        )
+        .await?;
+
+        let draft = make_pending_draft();
+        state.engines.gc_agent.draft_store().save(&draft)?;
+
+        let report = run_tick(&state).await?;
+        assert_eq!(report.drafts_pending, 1, "expected 1 pending draft");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_tick_counts_adopted_in_window() -> anyhow::Result<()> {
+        let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let data_dir = crate::test_helpers::tempdir_in_home("harness-self-evo-adopted-")?;
+        let project_root = crate::test_helpers::tempdir_in_home("harness-self-evo-adopted-proj-")?;
+        let state = crate::test_helpers::make_test_state_with_project_root(
+            data_dir.path(),
+            project_root.path(),
+        )
+        .await?;
+
+        // Log one gc_adopt Complete event inside the 24h window.
+        let event_in = make_test_event("gc_adopt", Decision::Complete);
+        state.observability.events.log(&event_in).await?;
+
+        // Log one gc_adopt Complete event outside the 24h window — should not be counted.
+        let mut event_out = make_test_event("gc_adopt", Decision::Complete);
+        event_out.ts = chrono::Utc::now() - chrono::Duration::hours(25);
+        state.observability.events.log(&event_out).await?;
+
+        let report = run_tick(&state).await?;
+        assert_eq!(
+            report.drafts_auto_adopted, 1,
+            "only in-window gc_adopt events should be counted"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_tick_counts_skills_in_window() -> anyhow::Result<()> {
+        let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let data_dir = crate::test_helpers::tempdir_in_home("harness-self-evo-skills-")?;
+        let project_root = crate::test_helpers::tempdir_in_home("harness-self-evo-skills-proj-")?;
+        let state = crate::test_helpers::make_test_state_with_project_root(
+            data_dir.path(),
+            project_root.path(),
+        )
+        .await?;
+
+        // Log two skill_used events inside the 24h window.
+        let e1 = make_test_event("skill_used", Decision::Complete);
+        let e2 = make_test_event("skill_used", Decision::Complete);
+        state.observability.events.log(&e1).await?;
+        state.observability.events.log(&e2).await?;
+
+        let report = run_tick(&state).await?;
+        assert_eq!(
+            report.skills_invoked_in_window, 2,
+            "both skill_used events should be counted"
+        );
         Ok(())
     }
 }

--- a/web/src/components/EvolutionCard.test.tsx
+++ b/web/src/components/EvolutionCard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EvolutionCard } from "./EvolutionCard";
+
+describe("<EvolutionCard>", () => {
+  it("shows dashes for all values when evolution is null", () => {
+    render(<EvolutionCard evolution={null} />);
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBe(3);
+  });
+
+  it("renders the three counter values when evolution data is present", () => {
+    render(
+      <EvolutionCard
+        evolution={{ drafts_pending: 4, drafts_auto_adopted: 2, skills_invoked_in_window: 11 }}
+      />,
+    );
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("11")).toBeInTheDocument();
+  });
+
+  it("renders the card title", () => {
+    render(<EvolutionCard evolution={null} />);
+    expect(screen.getByText(/self-evolution/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/EvolutionCard.tsx
+++ b/web/src/components/EvolutionCard.tsx
@@ -1,0 +1,29 @@
+import type { OverviewEvolution } from "@/types/overview";
+import { Panel } from "./Panel";
+import { fmtInt } from "@/lib/format";
+
+interface Props {
+  evolution: OverviewEvolution | null;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between py-1.5 border-b border-line last:border-b-0">
+      <span className="text-ink-3">{label}</span>
+      <span className="text-ink font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function EvolutionCard({ evolution }: Props) {
+  const fmt = (n: number | undefined) => (n != null ? fmtInt(n) : "—");
+  return (
+    <Panel title="Self-evolution" sub="last tick telemetry">
+      <div className="px-5 py-3 font-mono text-[11px]">
+        <Row label="drafts pending" value={fmt(evolution?.drafts_pending)} />
+        <Row label="auto-adopted · 24h" value={fmt(evolution?.drafts_auto_adopted)} />
+        <Row label="skills invoked · 24h" value={fmt(evolution?.skills_invoked_in_window)} />
+      </div>
+    </Panel>
+  );
+}

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -65,6 +65,7 @@ function makeOverview(): OverviewPayload {
     },
     feed: [],
     alerts: [],
+    evolution: null,
     global: {
       uptime_secs: 1,
       running: 1,

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -10,6 +10,7 @@ import { Feed } from "@/components/Feed";
 import { AlertList } from "@/components/AlertList";
 import { StatusBadge } from "@/components/StatusBadge";
 import { PaletteFab } from "@/components/PaletteFab";
+import { EvolutionCard } from "@/components/EvolutionCard";
 import { useOperatorSnapshot, useOverview } from "@/lib/queries";
 import { OperatorPanel } from "./overview/OperatorPanel";
 import { fmtInt, fmtPct, fmtScore } from "@/lib/format";
@@ -152,6 +153,8 @@ export function Overview() {
               </Panel>
             </Panel>
           </div>
+
+          <EvolutionCard evolution={data?.evolution ?? null} />
 
           <OperatorPanel />
         </div>

--- a/web/src/types/overview.ts
+++ b/web/src/types/overview.ts
@@ -102,6 +102,12 @@ export interface OverviewGlobal {
   max_concurrent: number;
 }
 
+export interface OverviewEvolution {
+  drafts_pending: number;
+  drafts_auto_adopted: number;
+  skills_invoked_in_window: number;
+}
+
 export interface OverviewPayload {
   window: OverviewWindow;
   kpi: OverviewKpi;
@@ -112,5 +118,6 @@ export interface OverviewPayload {
   heatmap: OverviewHeatmap;
   feed: OverviewFeedEntry[];
   alerts: OverviewAlert[];
+  evolution: OverviewEvolution | null;
   global: OverviewGlobal;
 }


### PR DESCRIPTION
## Summary

- Extends `self_evolution_tick` event payload with three new `key=value` fields: `drafts_pending`, `drafts_adopted`, `skills_invoked` — so operators can tell a spinning-empty loop from a healthy one at a glance
- Adds a **Self-evolution** dashboard card on the Overview page that renders the three counters from the latest tick event (degrades gracefully to `—` for pre-PR events)
- Adds unit tests for the new counts in `self_evolution.rs`, pure-function tests for `parse_evolution_from_reason`, and component tests for `EvolutionCard`

Closes #972

## Test plan

- [ ] `cargo check --package harness-server` — passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` — passes (0 warnings)
- [ ] `handlers::overview` unit tests: 7 passed (includes 2 new parse tests)
- [ ] `bun run test --run` in `web/` — 85 passed (includes 3 new EvolutionCard tests + updated Overview mock)
- [ ] `self_evolution` tests require a live Postgres connection; pre-existing test was already gated by the same `ECIRCUITBREAKER` behaviour on main (confirmed by `git stash` + retest)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)