### PR TITLE
test(persistence): audit all 4 UUID workspace path surfaces (#968)

### DIFF
--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -530,3 +530,49 @@ async fn replay_terminal_failed_overrides_implementing() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// Surface 4 regression guard: every TaskEvent variant serialises to JSONL
+// containing only task_id, ts, and variant-specific scalar fields.
+// No workspace path must ever appear in the wire format.
+#[test]
+fn surface4_task_event_jsonl_has_no_workspace_paths() {
+    let events = [
+        TaskEvent::Created {
+            task_id: "t1".into(),
+            ts: 0,
+        },
+        TaskEvent::StatusChanged {
+            task_id: "t1".into(),
+            ts: 1,
+            status: "implementing".into(),
+            turn: 1,
+        },
+        TaskEvent::Failed {
+            task_id: "t1".into(),
+            ts: 2,
+            reason: "something went wrong".into(),
+        },
+        TaskEvent::Completed {
+            task_id: "t1".into(),
+            ts: 3,
+        },
+        TaskEvent::PrDetected {
+            task_id: "t1".into(),
+            ts: 4,
+            pr_url: "https://github.com/o/r/pull/1".into(),
+        },
+        TaskEvent::RoundCompleted {
+            task_id: "t1".into(),
+            ts: 5,
+            round: 1,
+            result: "passed".into(),
+        },
+    ];
+    for event in &events {
+        let json = serde_json::to_string(event).expect("TaskEvent must serialise");
+        assert!(
+            !json.contains("/workspaces/"),
+            "TaskEvent JSON must not contain a workspace path: {json}"
+        );
+    }
+}

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -721,4 +721,42 @@ mod tests {
         assert_eq!(pruned, 0);
         assert!(poller.dispatched.contains_key("1"));
     }
+
+    // Surface 3 regression guard: the dispatched JSON file stores only
+    // {issue_id → task_id} pairs.  No workspace path must ever be written.
+    #[test]
+    fn surface3_dispatched_json_has_no_path_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_cfg = harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: None,
+        };
+        let poller = GitHubIssuesPoller::new(&repo_cfg, Some(tmp.path()));
+        poller.dispatched.insert(
+            "42".to_string(),
+            harness_core::types::TaskId("task-abc123".to_string()),
+        );
+        poller.dispatched.insert(
+            "99".to_string(),
+            harness_core::types::TaskId("task-xyz456".to_string()),
+        );
+        poller.persist_dispatched();
+
+        let persist_path = tmp.path().join("github_dispatched_owner_repo.json");
+        let json = std::fs::read_to_string(&persist_path)
+            .expect("dispatched file should have been written");
+        assert!(
+            !json.contains("/workspaces/"),
+            "dispatched JSON must not contain workspace paths, got: {json}"
+        );
+        let map: HashMap<String, String> =
+            serde_json::from_str(&json).expect("dispatched JSON must parse");
+        assert_eq!(map.len(), 2, "both entries should be persisted");
+        assert!(
+            map.values()
+                .all(|v| !v.contains('/') || v.starts_with("skip-")),
+            "task IDs must not be filesystem paths"
+        );
+    }
 }

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -743,4 +743,28 @@ mod tests {
         assert_eq!(report.transitions.len(), 0);
         assert_eq!(report.candidates, 3);
     }
+
+    // Reconciliation payload guard: ReconciliationReport and
+    // ReconciliationTransition are serialised over HTTP.  They must never
+    // contain a UUID workspace path.
+    #[test]
+    fn reconciliation_payload_has_no_workspace_paths() {
+        let report = ReconciliationReport {
+            candidates: 3,
+            skipped_terminal: 1,
+            transitions: vec![ReconciliationTransition {
+                task_id: "task-abc123".to_string(),
+                from: "implementing".to_string(),
+                to: "done".to_string(),
+                reason: "PR merged".to_string(),
+                applied: true,
+            }],
+        };
+        let json =
+            serde_json::to_string(&report).expect("ReconciliationReport must serialise to JSON");
+        assert!(
+            !json.contains("/workspaces/"),
+            "ReconciliationReport JSON must not contain a workspace path, got: {json}"
+        );
+    }
 }

--- a/crates/harness-workflow/src/checkpoint.rs
+++ b/crates/harness-workflow/src/checkpoint.rs
@@ -265,4 +265,16 @@ mod tests {
         // exists in CI the test still passes; what matters is no panic.
         let _ = loaded;
     }
+
+    // Surface 2 regression guard: TaskCheckpoint serializes only task metadata
+    // fields (phase, turn, pr_url, branch).  No workspace path must ever appear.
+    #[test]
+    fn surface2_serialized_checkpoint_has_no_workspace_path() {
+        let cp = make_checkpoint("task-s2-audit");
+        let json = serde_json::to_string(&cp).expect("TaskCheckpoint must serialize to JSON");
+        assert!(
+            !json.contains("/workspaces/"),
+            "TaskCheckpoint JSON must not contain a workspace path, got: {json}"
+        );
+    }
 }

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -1289,4 +1289,39 @@ mod tests {
         );
         Ok(())
     }
+
+    // Surface 1 regression guard: after repair_project_id the stored project_id
+    // must never contain a UUID workspace path segment.
+    #[tokio::test]
+    async fn surface1_repaired_project_id_has_no_workspaces_path() -> anyhow::Result<()> {
+        let Some(store) = open_test_store().await? else {
+            return Ok(());
+        };
+        let uuid_path = "/data/workspaces/6b10f4d1-8381-4ceb-be46-9bcd13c08eb1/some-project-s1";
+        store
+            .record_issue_scheduled(uuid_path, Some("owner/repo"), 9101, "task-s1a", &[], false)
+            .await?;
+
+        let workflow = store
+            .get_by_issue(uuid_path, Some("owner/repo"), 9101)
+            .await?
+            .expect("row should exist before repair");
+        let row_id = workflow.id.clone();
+
+        let canonical = "/home/user/projects/some-project-s1";
+        store.repair_project_id(&row_id, canonical).await?;
+
+        let repaired = store
+            .get_by_issue(canonical, Some("owner/repo"), 9101)
+            .await?
+            .expect("repaired row should exist");
+
+        assert!(
+            !repaired.project_id.contains("/workspaces/"),
+            "repaired project_id must not contain a workspace path, got: {}",
+            repaired.project_id
+        );
+        assert_eq!(repaired.project_id, canonical);
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Add regression guard for Surface 1 (`issue_workflows.project_id`): asserts `repair_project_id()` leaves no `/workspaces/` segment in the stored project_id after repair
- Add regression guard for Surface 2 (`TaskCheckpoint`): asserts JSON serialisation contains only scalar metadata fields, never a workspace path
- Add regression guard for Surface 3 (`github_dispatched_*.json`): asserts `persist_dispatched()` writes a pure `{issue_id → task_id}` map with no filesystem paths
- Add regression guard for Surface 4 (`task-events.jsonl`): asserts every `TaskEvent` variant serialises without any `/workspaces/` path segment
- Add reconciliation payload guard: asserts `ReconciliationReport` JSON is path-free

Closes #968

## Test plan

- [ ] `cargo test -p harness-workflow checkpoint::tests::surface2_serialized_checkpoint_has_no_workspace_path` passes
- [ ] `cargo test -p harness-workflow issue_lifecycle::tests::surface1_repaired_project_id_has_no_workspaces_path` passes (skips gracefully without DATABASE_URL)
- [ ] `cargo test -p harness-server event_replay::tests::surface4_task_event_jsonl_has_no_workspace_paths` passes
- [ ] `cargo test -p harness-server intake::github_issues::tests::surface3_dispatched_json_has_no_path_fields` passes
- [ ] `cargo test -p harness-server reconciliation::tests::reconciliation_payload_has_no_workspace_paths` passes
- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean