### PR TITLE
feat(web): multi-step submit wizard (#965)

### DIFF
--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiJson, apiFetch } from "./api";
 import type { DashboardPayload, FullTask, OperatorSnapshotPayload, OverviewPayload, StreamItem, Task } from "@/types";
 
@@ -106,6 +106,14 @@ export function useTaskStream(
 
     return () => controller.abort();
   }, [id]);
+}
+
+export function useCancelTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiFetch(`/tasks/${id}/cancel`, { method: "POST" }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["tasks"] }),
+  });
 }
 
 export interface WorktreeCard {

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -154,6 +154,17 @@ describe("<Submit>", () => {
     expect(screen.getByRole("option", { name: "beta" })).toBeInTheDocument();
   });
 
+  it("blocks config advance while the project list is loading", () => {
+    mockUseOverview.mockReturnValue({ data: undefined, isLoading: true });
+    wrap(<Submit />);
+
+    goToConfig("Prompt");
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "do something" } });
+
+    expect(screen.getByText("Loading projects…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Next/ })).toBeDisabled();
+  });
+
   it("agent dropdown populates from the selected project's agents array", () => {
     wrap(<Submit />);
     goToConfig("Issue");
@@ -208,6 +219,33 @@ describe("<Submit>", () => {
 
     expect(await screen.findByText("Max turns must be a positive integer")).toBeInTheDocument();
     expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts zero turn timeout as no timeout and rejects invalid timeout values", async () => {
+    wrap(<Submit />);
+
+    goToConfig("Issue");
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "99" } });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+
+    const timeoutInput = screen.getAllByPlaceholderText(/leave blank for default/)[1];
+    fireEvent.change(timeoutInput, { target: { value: "-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    expect(
+      await screen.findByText("Turn timeout seconds must be a non-negative integer"),
+    ).toBeInTheDocument();
+    expect(mockApiFetch).not.toHaveBeenCalled();
+
+    fireEvent.change(timeoutInput, { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled());
+    const body = JSON.parse(mockApiFetch.mock.calls[0][1].body as string);
+    expect(body.turn_timeout_secs).toBe(0);
   });
 
   it("successful submit transitions to the success screen with the returned taskId", async () => {

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -105,8 +105,13 @@ describe("<Submit>", () => {
     fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "not-a-number" } });
     expect(nextBtn).toBeDisabled();
 
-    // valid issue number
+    // valid issue number still needs a project when projects are registered
     fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "42" } });
+    expect(nextBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
     expect(nextBtn).not.toBeDisabled();
   });
 
@@ -160,6 +165,9 @@ describe("<Submit>", () => {
 
     goToConfig("Prompt");
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "do something" } });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /Next/ }));
     fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
 

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -98,7 +98,7 @@ describe("<Submit>", () => {
     wrap(<Submit />);
     goToConfig("Issue");
 
-    const nextBtn = screen.getByRole("button", { name: /Next/ });
+    let nextBtn = screen.getByRole("button", { name: /Next/ });
     expect(nextBtn).toBeDisabled();
 
     // invalid input (not a number or URL)
@@ -112,6 +112,37 @@ describe("<Submit>", () => {
     fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
       target: { value: "alpha" },
     });
+    expect(nextBtn).not.toBeDisabled();
+  });
+
+  it("rejects non-positive issue and PR identifiers", () => {
+    wrap(<Submit />);
+    goToConfig("Issue");
+
+    let nextBtn = screen.getByRole("button", { name: /Next/ });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "0" } });
+    expect(nextBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), {
+      target: { value: "https://github.com/owner/repo/issues/0" },
+    });
+    expect(nextBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
+    goToConfig("Pull Request");
+    nextBtn = screen.getByRole("button", { name: /Next/ });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/456 or/), { target: { value: "-1" } });
+    expect(nextBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(/456 or/), { target: { value: "7" } });
     expect(nextBtn).not.toBeDisabled();
   });
 
@@ -158,6 +189,25 @@ describe("<Submit>", () => {
     const call = mockApiFetch.mock.calls[0];
     const body = JSON.parse(call[1].body as string);
     expect(body).toMatchObject({ issue: 99, project: "alpha" });
+  });
+
+  it("rejects invalid max turns before submitting", async () => {
+    wrap(<Submit />);
+
+    goToConfig("Issue");
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "99" } });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+
+    fireEvent.change(screen.getAllByPlaceholderText(/leave blank for default/)[0], {
+      target: { value: "1.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    expect(await screen.findByText("Max turns must be a positive integer")).toBeInTheDocument();
+    expect(mockApiFetch).not.toHaveBeenCalled();
   });
 
   it("successful submit transitions to the success screen with the returned taskId", async () => {

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { Submit } from "./Submit";
+import { SubmitSuccess } from "./SubmitSuccess";
+import { useOverview, useTaskStream, useCancelTask } from "@/lib/queries";
+import { apiFetch } from "@/lib/api";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/queries", () => ({
+  useOverview: vi.fn(),
+  useTaskStream: vi.fn(),
+  useCancelTask: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+  TOKEN_KEY: "harness_token",
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
+const mockUseTaskStream = useTaskStream as ReturnType<typeof vi.fn>;
+const mockUseCancelTask = useCancelTask as ReturnType<typeof vi.fn>;
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: React.ReactElement) {
+  return render(<QueryClientProvider client={makeQC()}>{ui}</QueryClientProvider>);
+}
+
+const PROJECTS = [
+  { id: "alpha", root: "/alpha", agents: ["claude", "codex"], running: 0, queued: 0, done: 0, failed: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
+  { id: "beta", root: "/beta", agents: ["gemini"], running: 0, queued: 0, done: 0, failed: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
+];
+
+beforeEach(() => {
+  mockUseOverview.mockReturnValue({ data: { projects: PROJECTS } });
+  mockUseTaskStream.mockImplementation(() => {});
+  mockUseCancelTask.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  mockApiFetch.mockResolvedValue(
+    new Response(JSON.stringify({ task_id: "task-xyz", status: "running" }), { status: 200 }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Navigate the wizard to the config step with the given mode
+function goToConfig(mode: "Issue" | "Pull Request" | "Prompt") {
+  fireEvent.click(screen.getByRole("button", { name: mode }));
+  fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+}
+
+// ── <Submit> tests ─────────────────────────────────────────────────────────────
+
+describe("<Submit>", () => {
+  it("step 1: renders three mode options with none pre-selected", () => {
+    wrap(<Submit />);
+    expect(screen.getByRole("button", { name: "Issue" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pull Request" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Prompt" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Next/ })).toBeDisabled();
+  });
+
+  it("selecting issue shows only the issue field; selecting pr shows only the pr field", () => {
+    wrap(<Submit />);
+
+    // issue mode → config
+    goToConfig("Issue");
+    expect(screen.getByPlaceholderText(/123 or/)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/456 or/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /Prompt/ })).not.toBeInTheDocument();
+
+    // back to mode, switch to pr
+    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
+    goToConfig("Pull Request");
+    expect(screen.getByPlaceholderText(/456 or/)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/123 or/)).not.toBeInTheDocument();
+  });
+
+  it("Next is disabled in config step until required field is non-empty", () => {
+    wrap(<Submit />);
+    goToConfig("Issue");
+
+    const nextBtn = screen.getByRole("button", { name: /Next/ });
+    expect(nextBtn).toBeDisabled();
+
+    // invalid input (not a number or URL)
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "not-a-number" } });
+    expect(nextBtn).toBeDisabled();
+
+    // valid issue number
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "42" } });
+    expect(nextBtn).not.toBeDisabled();
+  });
+
+  it("project dropdown lists registered project names from useOverview", () => {
+    wrap(<Submit />);
+    goToConfig("Issue");
+
+    expect(screen.getByRole("option", { name: "alpha" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "beta" })).toBeInTheDocument();
+  });
+
+  it("agent dropdown populates from the selected project's agents array", () => {
+    wrap(<Submit />);
+    goToConfig("Issue");
+
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+    expect(screen.getByRole("option", { name: "claude" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "codex" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "beta" },
+    });
+    expect(screen.getByRole("option", { name: "gemini" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "claude" })).not.toBeInTheDocument();
+  });
+
+  it("submitting an issue task calls POST /tasks with correct payload", async () => {
+    wrap(<Submit />);
+
+    goToConfig("Issue");
+    fireEvent.change(screen.getByPlaceholderText(/123 or/), { target: { value: "99" } });
+    fireEvent.change(screen.getByRole("combobox", { name: /Project/ }), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+
+    // options step
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledWith("/tasks", expect.objectContaining({ method: "POST" })));
+
+    const call = mockApiFetch.mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    expect(body).toMatchObject({ issue: 99, project: "alpha" });
+  });
+
+  it("successful submit transitions to the success screen with the returned taskId", async () => {
+    wrap(<Submit />);
+
+    goToConfig("Prompt");
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "do something" } });
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText("task-xyz")).toBeInTheDocument(),
+    );
+  });
+
+  it("no projects: shows empty state message and form can still advance to submit", async () => {
+    mockUseOverview.mockReturnValue({ data: { projects: [] } });
+    wrap(<Submit />);
+
+    goToConfig("Prompt");
+    expect(screen.getByText("No projects registered")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Submit Task/ }));
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled());
+    const body = JSON.parse(mockApiFetch.mock.calls[0][1].body as string);
+    expect(body.project).toBeUndefined();
+    expect(body.prompt).toBe("hello");
+  });
+});
+
+// ── <SubmitSuccess> tests ──────────────────────────────────────────────────────
+
+describe("<SubmitSuccess>", () => {
+  it("cancel button calls useCancelTask.mutate with taskId and triggers onReset", () => {
+    const onReset = vi.fn();
+    const mockMutate = vi.fn().mockImplementation((_id: string, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    mockUseCancelTask.mockReturnValue({ mutate: mockMutate, isPending: false });
+
+    wrap(<SubmitSuccess taskId="task-abc" onReset={onReset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockMutate).toHaveBeenCalledWith("task-abc", expect.objectContaining({ onSuccess: expect.any(Function) }));
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it("stream error in success screen displays an error message (not silent)", async () => {
+    let capturedOnError: ((msg: string) => void) | undefined;
+    mockUseTaskStream.mockImplementation(
+      (_id: string, _onChunk: unknown, onError?: (msg: string) => void) => {
+        capturedOnError = onError;
+      },
+    );
+
+    wrap(<SubmitSuccess taskId="task-err" onReset={vi.fn()} />);
+
+    await act(async () => {
+      capturedOnError?.("connection refused");
+    });
+
+    expect(screen.getByTestId("stream-error")).toHaveTextContent("connection refused");
+  });
+});

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -22,11 +22,20 @@ interface Props {
   projectFilter?: string | null;
 }
 
-function parseNumber(input: string): number | null {
+function parseIssueNumber(input: string): number | null {
   const trimmed = input.trim();
   const direct = parseInt(trimmed, 10);
   if (!isNaN(direct) && String(direct) === trimmed) return direct;
-  const match = trimmed.match(/\/(?:issues|pull)\/(\d+)/);
+  const match = trimmed.match(/\/issues\/(\d+)/);
+  if (match) return parseInt(match[1], 10);
+  return null;
+}
+
+function parsePrNumber(input: string): number | null {
+  const trimmed = input.trim();
+  const direct = parseInt(trimmed, 10);
+  if (!isNaN(direct) && String(direct) === trimmed) return direct;
+  const match = trimmed.match(/\/pull\/(\d+)/);
   if (match) return parseInt(match[1], 10);
   return null;
 }
@@ -95,8 +104,8 @@ function StepConfig({ state, projects, onChange, onNext, onBack }: StepConfigPro
   const agents = projects.find((p) => p.id === state.project)?.agents ?? [];
 
   const isValid =
-    (state.mode === "issue" && parseNumber(state.issueInput) !== null) ||
-    (state.mode === "pr" && parseNumber(state.prInput) !== null) ||
+    (state.mode === "issue" && parseIssueNumber(state.issueInput) !== null) ||
+    (state.mode === "pr" && parsePrNumber(state.prInput) !== null) ||
     (state.mode === "prompt" && state.promptInput.trim().length > 0);
 
   return (
@@ -337,7 +346,7 @@ export function Submit({ projectFilter }: Props) {
 
     let modePayload: Record<string, unknown>;
     if (wizardState.mode === "issue") {
-      const num = parseNumber(wizardState.issueInput);
+      const num = parseIssueNumber(wizardState.issueInput);
       if (num === null) {
         setSubmitError("Invalid issue number");
         setBusy(false);
@@ -345,7 +354,7 @@ export function Submit({ projectFilter }: Props) {
       }
       modePayload = { issue: num };
     } else if (wizardState.mode === "pr") {
-      const num = parseNumber(wizardState.prInput);
+      const num = parsePrNumber(wizardState.prInput);
       if (num === null) {
         setSubmitError("Invalid PR number");
         setBusy(false);

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -1,84 +1,435 @@
 import { useState, useEffect } from "react";
+import { useOverview } from "@/lib/queries";
 import { apiFetch } from "@/lib/api";
+import type { CreateTaskResponse } from "@/types";
+import { SubmitSuccess } from "./SubmitSuccess";
+
+type InputMode = "issue" | "pr" | "prompt";
+type WizardStep = "mode" | "config" | "options" | "success";
+
+interface WizardState {
+  mode: InputMode | null;
+  issueInput: string;
+  prInput: string;
+  promptInput: string;
+  project: string;
+  agent: string;
+  maxTurns: string;
+  turnTimeoutSecs: string;
+}
 
 interface Props {
   projectFilter?: string | null;
 }
 
+function parseNumber(input: string): number | null {
+  const trimmed = input.trim();
+  const direct = parseInt(trimmed, 10);
+  if (!isNaN(direct) && String(direct) === trimmed) return direct;
+  const match = trimmed.match(/\/(?:issues|pull)\/(\d+)/);
+  if (match) return parseInt(match[1], 10);
+  return null;
+}
+
+// ── Step: Mode ────────────────────────────────────────────────────────────────
+
+interface StepModeProps {
+  mode: InputMode | null;
+  onChange: (mode: InputMode) => void;
+  onNext: () => void;
+}
+
+function StepMode({ mode, onChange, onNext }: StepModeProps) {
+  const MODES: { id: InputMode; label: string; tooltip: string }[] = [
+    { id: "issue", label: "Issue", tooltip: "Run agent on a GitHub issue number" },
+    { id: "pr", label: "Pull Request", tooltip: "Run agent on a GitHub pull request number" },
+    { id: "prompt", label: "Prompt", tooltip: "Run agent on a free-form text prompt" },
+  ];
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-2">
+          Input mode
+        </label>
+        <div className="flex gap-2">
+          {MODES.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              title={m.tooltip}
+              onClick={() => onChange(m.id)}
+              className={`flex-1 py-3 px-4 border font-mono text-[12px] rounded-[3px] text-left ${
+                mode === m.id
+                  ? "border-rust text-rust bg-rust/5"
+                  : "border-line-2 text-ink-2 hover:border-line hover:text-ink hover:bg-bg-2"
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={!mode}
+        onClick={onNext}
+        className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
+      >
+        Next →
+      </button>
+    </div>
+  );
+}
+
+// ── Step: Config ──────────────────────────────────────────────────────────────
+
+interface StepConfigProps {
+  state: WizardState;
+  projects: { id: string; agents: string[] }[];
+  onChange: (patch: Partial<WizardState>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+function StepConfig({ state, projects, onChange, onNext, onBack }: StepConfigProps) {
+  const agents = projects.find((p) => p.id === state.project)?.agents ?? [];
+
+  const isValid =
+    (state.mode === "issue" && parseNumber(state.issueInput) !== null) ||
+    (state.mode === "pr" && parseNumber(state.prInput) !== null) ||
+    (state.mode === "prompt" && state.promptInput.trim().length > 0);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="wizard-project"
+          className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1"
+        >
+          Project
+        </label>
+        {projects.length === 0 ? (
+          <p className="font-mono text-[11px] text-ink-3 py-1">No projects registered</p>
+        ) : (
+          <select
+            id="wizard-project"
+            value={state.project}
+            onChange={(e) => onChange({ project: e.target.value, agent: "" })}
+            className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+          >
+            <option value="">— select project —</option>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.id}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      <div>
+        <label
+          htmlFor="wizard-agent"
+          className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1"
+        >
+          Agent
+        </label>
+        <select
+          id="wizard-agent"
+          value={state.agent}
+          onChange={(e) => onChange({ agent: e.target.value })}
+          disabled={agents.length === 0}
+          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px] disabled:opacity-60"
+        >
+          <option value="">— auto-select —</option>
+          {agents.map((a) => (
+            <option key={a} value={a}>
+              {a}
+            </option>
+          ))}
+        </select>
+      </div>
+      {state.mode === "issue" && (
+        <div>
+          <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+            Issue number or URL
+          </label>
+          <input
+            value={state.issueInput}
+            onChange={(e) => onChange({ issueInput: e.target.value })}
+            placeholder="123 or https://github.com/owner/repo/issues/123"
+            className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+          />
+        </div>
+      )}
+      {state.mode === "pr" && (
+        <div>
+          <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+            PR number or URL
+          </label>
+          <input
+            value={state.prInput}
+            onChange={(e) => onChange({ prInput: e.target.value })}
+            placeholder="456 or https://github.com/owner/repo/pull/456"
+            className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+          />
+        </div>
+      )}
+      {state.mode === "prompt" && (
+        <div>
+          <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+            Prompt
+          </label>
+          <textarea
+            value={state.promptInput}
+            onChange={(e) => onChange({ promptInput: e.target.value })}
+            rows={4}
+            className="w-full bg-bg border border-line-2 px-2.5 py-2 text-ink font-mono text-[12px] rounded-[3px]"
+          />
+        </div>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-3 py-1.5 bg-bg-2 text-ink-2 font-mono text-[12px] border border-line-2 rounded-[3px]"
+        >
+          ← Back
+        </button>
+        <button
+          type="button"
+          disabled={!isValid}
+          onClick={onNext}
+          className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Step: Options ─────────────────────────────────────────────────────────────
+
+interface StepOptionsProps {
+  state: WizardState;
+  onChange: (patch: Partial<WizardState>) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+  busy: boolean;
+  error: string | null;
+}
+
+function StepOptions({ state, onChange, onSubmit, onBack, busy, error }: StepOptionsProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+          Max turns (optional)
+        </label>
+        <input
+          type="number"
+          min="1"
+          value={state.maxTurns}
+          onChange={(e) => onChange({ maxTurns: e.target.value })}
+          placeholder="leave blank for default"
+          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+        />
+      </div>
+      <div>
+        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">
+          Turn timeout seconds (optional)
+        </label>
+        <input
+          type="number"
+          min="1"
+          value={state.turnTimeoutSecs}
+          onChange={(e) => onChange({ turnTimeoutSecs: e.target.value })}
+          placeholder="leave blank for default"
+          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+        />
+      </div>
+      {error && (
+        <div className="px-3 py-2 border border-danger/40 text-danger font-mono text-[12px] rounded-[3px] bg-danger/5">
+          {error}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-3 py-1.5 bg-bg-2 text-ink-2 font-mono text-[12px] border border-line-2 rounded-[3px]"
+        >
+          ← Back
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onSubmit}
+          className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
+        >
+          {busy ? "Submitting…" : "Submit Task"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main wizard ───────────────────────────────────────────────────────────────
+
+const STEP_LABELS: Record<Exclude<WizardStep, "success">, string> = {
+  mode: "1. Mode",
+  config: "2. Config",
+  options: "3. Options",
+};
+
 export function Submit({ projectFilter }: Props) {
-  const [title, setTitle] = useState("");
-  const [desc, setDesc] = useState("");
-  const [project, setProject] = useState(projectFilter ?? "");
-  const [msg, setMsg] = useState<string | null>(null);
+  const [step, setStep] = useState<WizardStep>("mode");
+  const [wizardState, setWizardState] = useState<WizardState>({
+    mode: null,
+    issueInput: "",
+    prInput: "",
+    promptInput: "",
+    project: projectFilter ?? "",
+    agent: "",
+    maxTurns: "",
+    turnTimeoutSecs: "",
+  });
+  const [createdTaskId, setCreatedTaskId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const { data: overview } = useOverview();
+  const projects = overview?.projects ?? [];
 
   useEffect(() => {
-    setProject(projectFilter ?? "");
+    setWizardState((prev) => ({ ...prev, project: projectFilter ?? "" }));
   }, [projectFilter]);
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!title.trim() || !desc.trim()) return;
+  function patchState(patch: Partial<WizardState>) {
+    setWizardState((prev) => ({ ...prev, ...patch }));
+  }
+
+  function handleModeChange(mode: InputMode) {
+    patchState({
+      mode,
+      issueInput: mode === "issue" ? wizardState.issueInput : "",
+      prInput: mode === "pr" ? wizardState.prInput : "",
+      promptInput: mode === "prompt" ? wizardState.promptInput : "",
+    });
+  }
+
+  async function handleSubmit() {
+    if (!wizardState.mode) return;
     setBusy(true);
-    setMsg(null);
+    setSubmitError(null);
+
+    const common: Record<string, unknown> = {};
+    if (wizardState.project) common.project = wizardState.project;
+    if (wizardState.agent) common.agent = wizardState.agent;
+    if (wizardState.maxTurns) {
+      const n = parseInt(wizardState.maxTurns, 10);
+      if (!isNaN(n)) common.max_turns = n;
+    }
+    if (wizardState.turnTimeoutSecs) {
+      const n = parseInt(wizardState.turnTimeoutSecs, 10);
+      if (!isNaN(n)) common.turn_timeout_secs = n;
+    }
+
+    let modePayload: Record<string, unknown>;
+    if (wizardState.mode === "issue") {
+      const num = parseNumber(wizardState.issueInput);
+      if (num === null) {
+        setSubmitError("Invalid issue number");
+        setBusy(false);
+        return;
+      }
+      modePayload = { issue: num };
+    } else if (wizardState.mode === "pr") {
+      const num = parseNumber(wizardState.prInput);
+      if (num === null) {
+        setSubmitError("Invalid PR number");
+        setBusy(false);
+        return;
+      }
+      modePayload = { pr: num };
+    } else {
+      modePayload = { prompt: wizardState.promptInput.trim() };
+    }
+
     try {
-      const prompt = title.trim() + (desc.trim() ? `\n\n${desc.trim()}` : "");
-      const body = JSON.stringify({ prompt, project: project.trim() || undefined });
       const resp = await apiFetch("/tasks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body,
+        body: JSON.stringify({ ...modePayload, ...common }),
       });
-      const json = await resp.json();
-      setMsg(`created task ${json.id ?? "?"}`);
-      setTitle("");
-      setDesc("");
-      setProject(projectFilter ?? "");
+      const json = (await resp.json()) as CreateTaskResponse;
+      setCreatedTaskId(json.task_id);
+      setStep("success");
     } catch (e) {
-      setMsg((e as Error).message);
+      setSubmitError((e as Error).message);
     } finally {
       setBusy(false);
     }
   }
 
+  function handleReset() {
+    setCreatedTaskId(null);
+    setStep("mode");
+    setWizardState({
+      mode: null,
+      issueInput: "",
+      prInput: "",
+      promptInput: "",
+      project: projectFilter ?? "",
+      agent: "",
+      maxTurns: "",
+      turnTimeoutSecs: "",
+    });
+    setSubmitError(null);
+  }
+
   return (
-    <form onSubmit={submit} className="max-w-[640px] border border-line bg-bg-1 p-5 space-y-4">
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Project</label>
-        <input
-          value={project}
-          onChange={(e) => setProject(e.target.value)}
-          placeholder="project id (optional)"
-          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
-        />
+    <div className="max-w-[640px] space-y-5">
+      {step !== "success" && (
+        <div className="flex gap-4 font-mono text-[10.5px]">
+          {(["mode", "config", "options"] as Exclude<WizardStep, "success">[]).map((s) => (
+            <span key={s} className={step === s ? "text-rust font-medium" : "text-ink-3"}>
+              {STEP_LABELS[s]}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="border border-line bg-bg-1 p-5">
+        {step === "mode" && (
+          <StepMode
+            mode={wizardState.mode}
+            onChange={handleModeChange}
+            onNext={() => setStep("config")}
+          />
+        )}
+        {step === "config" && (
+          <StepConfig
+            state={wizardState}
+            projects={projects}
+            onChange={patchState}
+            onNext={() => setStep("options")}
+            onBack={() => setStep("mode")}
+          />
+        )}
+        {step === "options" && (
+          <StepOptions
+            state={wizardState}
+            onChange={patchState}
+            onSubmit={handleSubmit}
+            onBack={() => setStep("config")}
+            busy={busy}
+            error={submitError}
+          />
+        )}
+        {step === "success" && createdTaskId && (
+          <SubmitSuccess taskId={createdTaskId} onReset={handleReset} />
+        )}
       </div>
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Title</label>
-        <input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          required
-          className="w-full h-[30px] bg-bg border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-      </div>
-      <div>
-        <label className="block font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3 mb-1">Description</label>
-        <textarea
-          value={desc}
-          onChange={(e) => setDesc(e.target.value)}
-          required
-          rows={4}
-          className="w-full bg-bg border border-line-2 px-2.5 py-2 text-ink font-mono text-[12px] rounded-[3px]"
-        />
-      </div>
-      <button
-        disabled={busy}
-        type="submit"
-        className="px-3 py-1.5 bg-rust text-white font-mono text-[12px] border-0 disabled:opacity-60"
-      >
-        {busy ? "Submitting…" : "Submit Task"}
-      </button>
-      {msg && <div className="font-mono text-[11px] text-ink-2">{msg}</div>}
-    </form>
+    </div>
   );
 }

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -103,10 +103,12 @@ interface StepConfigProps {
 function StepConfig({ state, projects, onChange, onNext, onBack }: StepConfigProps) {
   const agents = projects.find((p) => p.id === state.project)?.agents ?? [];
 
+  const projectSelected = projects.length === 0 || state.project !== "";
   const isValid =
-    (state.mode === "issue" && parseIssueNumber(state.issueInput) !== null) ||
-    (state.mode === "pr" && parsePrNumber(state.prInput) !== null) ||
-    (state.mode === "prompt" && state.promptInput.trim().length > 0);
+    projectSelected &&
+    ((state.mode === "issue" && parseIssueNumber(state.issueInput) !== null) ||
+      (state.mode === "pr" && parsePrNumber(state.prInput) !== null) ||
+      (state.mode === "prompt" && state.promptInput.trim().length > 0));
 
   return (
     <div className="space-y-4">

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -22,21 +22,28 @@ interface Props {
   projectFilter?: string | null;
 }
 
+function parsePositiveInteger(input: string): number | null {
+  const trimmed = input.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
 function parseIssueNumber(input: string): number | null {
   const trimmed = input.trim();
-  const direct = parseInt(trimmed, 10);
-  if (!isNaN(direct) && String(direct) === trimmed) return direct;
+  const direct = parsePositiveInteger(trimmed);
+  if (direct !== null) return direct;
   const match = trimmed.match(/\/issues\/(\d+)/);
-  if (match) return parseInt(match[1], 10);
+  if (match) return parsePositiveInteger(match[1]);
   return null;
 }
 
 function parsePrNumber(input: string): number | null {
   const trimmed = input.trim();
-  const direct = parseInt(trimmed, 10);
-  if (!isNaN(direct) && String(direct) === trimmed) return direct;
+  const direct = parsePositiveInteger(trimmed);
+  if (direct !== null) return direct;
   const match = trimmed.match(/\/pull\/(\d+)/);
-  if (match) return parseInt(match[1], 10);
+  if (match) return parsePositiveInteger(match[1]);
   return null;
 }
 
@@ -337,13 +344,23 @@ export function Submit({ projectFilter }: Props) {
     const common: Record<string, unknown> = {};
     if (wizardState.project) common.project = wizardState.project;
     if (wizardState.agent) common.agent = wizardState.agent;
-    if (wizardState.maxTurns) {
-      const n = parseInt(wizardState.maxTurns, 10);
-      if (!isNaN(n)) common.max_turns = n;
+    if (wizardState.maxTurns.trim() !== "") {
+      const n = parsePositiveInteger(wizardState.maxTurns);
+      if (n === null) {
+        setSubmitError("Max turns must be a positive integer");
+        setBusy(false);
+        return;
+      }
+      common.max_turns = n;
     }
-    if (wizardState.turnTimeoutSecs) {
-      const n = parseInt(wizardState.turnTimeoutSecs, 10);
-      if (!isNaN(n)) common.turn_timeout_secs = n;
+    if (wizardState.turnTimeoutSecs.trim() !== "") {
+      const n = parsePositiveInteger(wizardState.turnTimeoutSecs);
+      if (n === null) {
+        setSubmitError("Turn timeout seconds must be a positive integer");
+        setBusy(false);
+        return;
+      }
+      common.turn_timeout_secs = n;
     }
 
     let modePayload: Record<string, unknown>;

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -29,6 +29,13 @@ function parsePositiveInteger(input: string): number | null {
   return Number.isSafeInteger(value) ? value : null;
 }
 
+function parseNonNegativeInteger(input: string): number | null {
+  const trimmed = input.trim();
+  if (!/^(0|[1-9]\d*)$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
 function parseIssueNumber(input: string): number | null {
   const trimmed = input.trim();
   const direct = parsePositiveInteger(trimmed);
@@ -102,15 +109,23 @@ function StepMode({ mode, onChange, onNext }: StepModeProps) {
 interface StepConfigProps {
   state: WizardState;
   projects: { id: string; agents: string[] }[];
+  projectsLoading: boolean;
   onChange: (patch: Partial<WizardState>) => void;
   onNext: () => void;
   onBack: () => void;
 }
 
-function StepConfig({ state, projects, onChange, onNext, onBack }: StepConfigProps) {
+function StepConfig({
+  state,
+  projects,
+  projectsLoading,
+  onChange,
+  onNext,
+  onBack,
+}: StepConfigProps) {
   const agents = projects.find((p) => p.id === state.project)?.agents ?? [];
 
-  const projectSelected = projects.length === 0 || state.project !== "";
+  const projectSelected = !projectsLoading && (projects.length === 0 || state.project !== "");
   const isValid =
     projectSelected &&
     ((state.mode === "issue" && parseIssueNumber(state.issueInput) !== null) ||
@@ -126,7 +141,9 @@ function StepConfig({ state, projects, onChange, onNext, onBack }: StepConfigPro
         >
           Project
         </label>
-        {projects.length === 0 ? (
+        {projectsLoading ? (
+          <p className="font-mono text-[11px] text-ink-3 py-1">Loading projects…</p>
+        ) : projects.length === 0 ? (
           <p className="font-mono text-[11px] text-ink-3 py-1">No projects registered</p>
         ) : (
           <select
@@ -259,7 +276,7 @@ function StepOptions({ state, onChange, onSubmit, onBack, busy, error }: StepOpt
         </label>
         <input
           type="number"
-          min="1"
+          min="0"
           value={state.turnTimeoutSecs}
           onChange={(e) => onChange({ turnTimeoutSecs: e.target.value })}
           placeholder="leave blank for default"
@@ -316,7 +333,7 @@ export function Submit({ projectFilter }: Props) {
   const [busy, setBusy] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const { data: overview } = useOverview();
+  const { data: overview, isLoading: projectsLoading = false } = useOverview();
   const projects = overview?.projects ?? [];
 
   useEffect(() => {
@@ -354,9 +371,9 @@ export function Submit({ projectFilter }: Props) {
       common.max_turns = n;
     }
     if (wizardState.turnTimeoutSecs.trim() !== "") {
-      const n = parsePositiveInteger(wizardState.turnTimeoutSecs);
+      const n = parseNonNegativeInteger(wizardState.turnTimeoutSecs);
       if (n === null) {
-        setSubmitError("Turn timeout seconds must be a positive integer");
+        setSubmitError("Turn timeout seconds must be a non-negative integer");
         setBusy(false);
         return;
       }
@@ -439,6 +456,7 @@ export function Submit({ projectFilter }: Props) {
           <StepConfig
             state={wizardState}
             projects={projects}
+            projectsLoading={projectsLoading}
             onChange={patchState}
             onNext={() => setStep("options")}
             onBack={() => setStep("mode")}

--- a/web/src/routes/dashboard/SubmitSuccess.tsx
+++ b/web/src/routes/dashboard/SubmitSuccess.tsx
@@ -8,13 +8,13 @@ interface Props {
 }
 
 export function SubmitSuccess({ taskId, onReset }: Props) {
-  const [output, setOutput] = useState<string[]>([]);
+  const [output, setOutput] = useState<string>("");
   const [streamError, setStreamError] = useState<string | null>(null);
   const cancel = useCancelTask();
 
   useTaskStream(
     taskId,
-    (text) => setOutput((prev) => [...prev, text]),
+    (text) => setOutput((prev) => prev + text),
     (err) => setStreamError(err),
   );
 
@@ -72,9 +72,9 @@ export function SubmitSuccess({ taskId, onReset }: Props) {
           Stream error: {streamError}
         </div>
       )}
-      {output.length > 0 && (
+      {output && (
         <pre className="font-mono text-[11px] text-ink bg-bg border border-line p-4 overflow-auto max-h-[400px] rounded-[3px] whitespace-pre-wrap">
-          {output.join("")}
+          {output}
         </pre>
       )}
     </div>

--- a/web/src/routes/dashboard/SubmitSuccess.tsx
+++ b/web/src/routes/dashboard/SubmitSuccess.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { useTaskStream, useCancelTask } from "@/lib/queries";
+import { TOKEN_KEY } from "@/lib/api";
+
+interface Props {
+  taskId: string;
+  onReset: () => void;
+}
+
+export function SubmitSuccess({ taskId, onReset }: Props) {
+  const [output, setOutput] = useState<string[]>([]);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const cancel = useCancelTask();
+
+  useTaskStream(
+    taskId,
+    (text) => setOutput((prev) => [...prev, text]),
+    (err) => setStreamError(err),
+  );
+
+  function openStream() {
+    const tok = (globalThis.sessionStorage?.getItem?.(TOKEN_KEY) ?? "").trim();
+    const base = `/tasks/${taskId}/stream`;
+    const url = tok ? `${base}?token=${encodeURIComponent(tok)}` : base;
+    window.open(url, "_blank", "noreferrer");
+  }
+
+  function handleCancel() {
+    cancel.mutate(taskId, { onSuccess: onReset });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[10.5px] tracking-[0.1em] uppercase text-ink-3">Task</span>
+        <code className="font-mono text-[12px] text-ink px-1.5 py-0.5 bg-bg-2 border border-line-2 rounded-[3px]">
+          {taskId}
+        </code>
+        <span className="font-mono text-[10.5px] px-1.5 py-[1px] border border-ok/40 text-ok rounded-[10px]">
+          running
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={openStream}
+          className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-2 rounded-[3px] hover:bg-bg-2 hover:text-ink"
+        >
+          Watch live
+        </button>
+        <button
+          type="button"
+          disabled={cancel.isPending}
+          onClick={handleCancel}
+          className="font-mono text-[11.5px] px-3 py-1 border border-danger/40 text-danger rounded-[3px] hover:bg-danger/5 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {cancel.isPending ? "Cancelling…" : "Cancel"}
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          className="ml-auto font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-3 rounded-[3px] hover:bg-bg-2"
+        >
+          Submit another
+        </button>
+      </div>
+      {streamError && (
+        <div
+          data-testid="stream-error"
+          className="px-3 py-2 border border-danger/40 text-danger font-mono text-[12px] rounded-[3px] bg-danger/5"
+        >
+          Stream error: {streamError}
+        </div>
+      )}
+      {output.length > 0 && (
+        <pre className="font-mono text-[11px] text-ink bg-bg border border-line p-4 overflow-auto max-h-[400px] rounded-[3px] whitespace-pre-wrap">
+          {output.join("")}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -71,3 +71,13 @@ export type StreamItem =
   | { type: "Done" }
   | { type: "Error"; message: string }
   | { type: "TokenUsage"; usage: { input_tokens: number; output_tokens: number } };
+
+export type CreateTaskPayload =
+  | { issue: number; project?: string; agent?: string; max_turns?: number; turn_timeout_secs?: number }
+  | { pr: number; project?: string; agent?: string; max_turns?: number; turn_timeout_secs?: number }
+  | { prompt: string; project?: string; agent?: string; max_turns?: number; turn_timeout_secs?: number };
+
+export interface CreateTaskResponse {
+  task_id: string;
+  status: string;
+}


### PR DESCRIPTION
## Summary
- Rebuilt the #965 submit wizard branch on current main as web-only changes.
- Adds the multi-step mode/config/preview submit flow for issue, PR, and prompt tasks.
- Keeps the URL parsing and stream-output performance fixes.
- Requires project data to finish loading before config advance, then requires project selection when projects are registered.
- Validates issue/PR IDs and optional numeric fields before submission; `turn_timeout_secs=0` is accepted as "no timeout" to match server semantics.

## Validation
- `cargo check --message-format short`
- `cd web && bun run test -- Submit.test.tsx`
- `cd web && bun run typecheck`
- `cargo fmt --all -- --check`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- GitHub Actions on `cc3fed923cf26d6e5e23fa785f657a530a0a8e07`: all current checks passed, including Gemini Re-review.

Closes #965
