### PR TITLE
feat(skill-injection): inject skills into triage, plan, and review agent prompts

### DIFF
--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -107,6 +107,22 @@ impl EventStore {
         self.pool.close().await;
     }
 
+    /// Create a non-functional store for unit tests that need an `&EventStore`
+    /// but do not care about event persistence. All `log` calls will fail and
+    /// callers that handle those errors (e.g. with `tracing::warn!`) will
+    /// continue normally. Do not use outside of test code.
+    #[doc(hidden)]
+    pub fn new_noop_for_tests() -> Self {
+        let pool = PgPool::connect_lazy("postgresql://localhost/harness_noop")
+            .expect("lazy pool URL must be syntactically valid");
+        Self {
+            pool,
+            data_dir: PathBuf::new(),
+            otel_pipeline: Mutex::new(None),
+            session_renewal_secs: 1800,
+        }
+    }
+
     pub fn session_renewal_secs(&self) -> u64 {
         self.session_renewal_secs
     }

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -1,13 +1,12 @@
 use super::helpers::{
-    inject_skills_into_prompt, matched_skills_for_prompt, run_on_error, run_post_execute,
-    run_pre_execute, update_status,
+    augment_prompt_with_skills, run_on_error, run_post_execute, run_pre_execute, update_status,
 };
 use crate::task_runner::{mutate_and_persist, RoundResult, TaskId, TaskStatus, TaskStore};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::error::HarnessError;
 use harness_core::prompts;
 use harness_core::tool_isolation::validate_tool_usage;
-use harness_core::types::{ContextItem, Decision, Event, ExecutionPhase, SessionId};
+use harness_core::types::{ContextItem, Event, ExecutionPhase, SessionId};
 use harness_observe::event_store::EventStore;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -65,7 +64,7 @@ pub(crate) async fn run_agent_review(
     pr_url: &str,
     project_type: &str,
     events: &EventStore,
-    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
+    skills: &RwLock<harness_skills::store::SkillStore>,
     cargo_env: &HashMap<String, String>,
     effective_max_turns: Option<u32>,
     turns_used: &mut u32,
@@ -81,30 +80,7 @@ pub(crate) async fn run_agent_review(
         // Reviewer evaluates the PR diff — read-only except Bash for `gh pr diff`.
         let base = prompts::agent_review_prompt(pr_url, agent_round, project_type);
         let note = prompts::agent_review_capability_note();
-        let matched_skills = matched_skills_for_prompt(skills, &base).await;
-        let skill_additions = inject_skills_into_prompt(skills, &base).await;
-        let augmented_base = if skill_additions.is_empty() {
-            base
-        } else {
-            base + &skill_additions
-        };
-        for (skill_id, skill_name) in matched_skills {
-            let mut skill_event = Event::new(
-                SessionId::new(),
-                "skill_used",
-                "task_runner",
-                Decision::Pass,
-            );
-            skill_event.reason = Some(skill_name);
-            skill_event.detail = Some(format!(
-                "task_id={} skill_id={}",
-                task_id.as_str(),
-                skill_id.as_str()
-            ));
-            if let Err(err) = events.log(&skill_event).await {
-                tracing::warn!(error = %err, "failed to log skill_used event");
-            }
-        }
+        let augmented_base = augment_prompt_with_skills(skills, events, task_id, base).await;
         let review_req = AgentRequest {
             prompt: format!("{note}\n\n{augmented_base}"),
             project_root: project.to_path_buf(),

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -1,14 +1,18 @@
-use super::helpers::{run_on_error, run_post_execute, run_pre_execute, update_status};
+use super::helpers::{
+    inject_skills_into_prompt, matched_skills_for_prompt, run_on_error, run_post_execute,
+    run_pre_execute, update_status,
+};
 use crate::task_runner::{mutate_and_persist, RoundResult, TaskId, TaskStatus, TaskStore};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::error::HarnessError;
 use harness_core::prompts;
 use harness_core::tool_isolation::validate_tool_usage;
-use harness_core::types::{ContextItem, Event, ExecutionPhase, SessionId};
+use harness_core::types::{ContextItem, Decision, Event, ExecutionPhase, SessionId};
 use harness_observe::event_store::EventStore;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tokio::time::Duration;
 
 /// Compute Jaccard word-similarity between two strings.
@@ -61,6 +65,7 @@ pub(crate) async fn run_agent_review(
     pr_url: &str,
     project_type: &str,
     events: &EventStore,
+    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
     cargo_env: &HashMap<String, String>,
     effective_max_turns: Option<u32>,
     turns_used: &mut u32,
@@ -74,14 +79,34 @@ pub(crate) async fn run_agent_review(
         update_status(store, task_id, TaskStatus::AgentReview, agent_round).await?;
 
         // Reviewer evaluates the PR diff — read-only except Bash for `gh pr diff`.
+        let base = prompts::agent_review_prompt(pr_url, agent_round, project_type);
+        let note = prompts::agent_review_capability_note();
+        let matched_skills = matched_skills_for_prompt(skills, &base).await;
+        let skill_additions = inject_skills_into_prompt(skills, &base).await;
+        let augmented_base = if skill_additions.is_empty() {
+            base
+        } else {
+            base + &skill_additions
+        };
+        for (skill_id, skill_name) in matched_skills {
+            let mut skill_event = Event::new(
+                SessionId::new(),
+                "skill_used",
+                "task_runner",
+                Decision::Pass,
+            );
+            skill_event.reason = Some(skill_name);
+            skill_event.detail = Some(format!(
+                "task_id={} skill_id={}",
+                task_id.as_str(),
+                skill_id.as_str()
+            ));
+            if let Err(err) = events.log(&skill_event).await {
+                tracing::warn!(error = %err, "failed to log skill_used event");
+            }
+        }
         let review_req = AgentRequest {
-            prompt: {
-                let base = prompts::agent_review_prompt(pr_url, agent_round, project_type);
-                // Inject capability note — primary enforcement now that --allowedTools
-                // is not passed to the CLI (issue #483).
-                let note = prompts::agent_review_capability_note();
-                format!("{note}\n\n{base}")
-            },
+            prompt: format!("{note}\n\n{augmented_base}"),
             project_root: project.to_path_buf(),
             context: context_items.to_vec(),
             execution_phase: Some(ExecutionPhase::SimpleReview),

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -385,28 +385,26 @@ pub(crate) async fn matched_skills_for_prompt(
         .collect()
 }
 
-/// Augment a prompt with matching skills: match once, record usage, log `skill_used` events,
-/// and return the augmented prompt string. Replaces the repeated
-/// `matched_skills_for_prompt` + `inject_skills_into_prompt` + event-log loop pattern.
-pub(crate) async fn augment_prompt_with_skills(
+/// Collect matched skills and all skills from the store, record usage for
+/// matches, and return both.
+///
+/// Lock discipline: holds read lock briefly to collect data, drops it, then
+/// acquires write lock only if there are matches. Never holds both locks
+/// simultaneously.
+async fn collect_and_record_skill_matches(
     skills: &RwLock<harness_skills::store::SkillStore>,
-    events: &EventStore,
-    task_id: &TaskId,
-    prompt: String,
-) -> String {
-    // Early return when store is empty — avoids acquiring locks unnecessarily.
+    prompt: &str,
+) -> (Vec<(SkillId, String, String)>, Vec<(String, String)>) {
     {
         let guard = skills.read().await;
         if guard.list().is_empty() {
-            return prompt;
+            return (vec![], vec![]);
         }
     }
-
-    // Single read pass: collect matched (id, name, content) and all skills (name, desc).
-    let (matched, all_skills) = {
+    let (matched, all) = {
         let guard = skills.read().await;
         let matched: Vec<(SkillId, String, String)> = guard
-            .match_prompt(&prompt)
+            .match_prompt(prompt)
             .into_iter()
             .map(|s| (s.id.clone(), s.name.clone(), s.content.clone()))
             .collect();
@@ -417,16 +415,26 @@ pub(crate) async fn augment_prompt_with_skills(
             .collect();
         (matched, all)
     };
-
-    // Record usage for matched skills (brief write lock).
     if !matched.is_empty() {
         let mut guard = skills.write().await;
         for (id, _, _) in &matched {
             guard.record_use(id);
         }
     }
+    (matched, all)
+}
 
-    // Log skill_used events.
+/// Augment a prompt with matching skills: match once, record usage, log `skill_used` events,
+/// and return the augmented prompt string. Replaces the repeated
+/// `matched_skills_for_prompt` + `inject_skills_into_prompt` + event-log loop pattern.
+pub(crate) async fn augment_prompt_with_skills(
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
+    task_id: &TaskId,
+    prompt: String,
+) -> String {
+    let (matched, all_skills) = collect_and_record_skill_matches(skills, &prompt).await;
+
     for (skill_id, skill_name, _) in &matched {
         let mut ev = Event::new(
             SessionId::new(),
@@ -445,7 +453,6 @@ pub(crate) async fn augment_prompt_with_skills(
         }
     }
 
-    // Build prompt addition.
     let listing = harness_core::prompts::build_available_skills_listing(
         all_skills.iter().map(|(n, d)| (n.as_str(), d.as_str())),
     );
@@ -474,47 +481,12 @@ pub(crate) async fn augment_prompt_with_skills(
 ///
 /// Returns an empty string when the store is empty (no sections added).
 /// The "Relevant Skills" section is omitted when no skills match.
-///
-/// Lock discipline: holds read lock briefly, drops it, then acquires write lock
-/// only if there are matched skills to record usage for. Never holds both locks
-/// simultaneously.
 pub(crate) async fn inject_skills_into_prompt(
     skills: &RwLock<harness_skills::store::SkillStore>,
     prompt: &str,
 ) -> String {
-    // Early return when the store is empty — avoids acquiring locks unnecessarily.
-    {
-        let guard = skills.read().await;
-        if guard.list().is_empty() {
-            return String::new();
-        }
-    }
+    let (matched_data, all_skills) = collect_and_record_skill_matches(skills, prompt).await;
 
-    // Read phase: collect all needed data while holding read lock minimally.
-    let (matched_data, all_skills) = {
-        let guard = skills.read().await;
-        let matched: Vec<(harness_core::types::SkillId, String, String)> = guard
-            .match_prompt(prompt)
-            .into_iter()
-            .map(|s| (s.id.clone(), s.name.clone(), s.content.clone()))
-            .collect();
-        let all: Vec<(String, String)> = guard
-            .list()
-            .iter()
-            .map(|s| (s.name.clone(), s.description.clone()))
-            .collect();
-        (matched, all)
-    };
-
-    // Write phase: record usage for matched skills (brief write lock).
-    if !matched_data.is_empty() {
-        let mut guard = skills.write().await;
-        for (id, _, _) in &matched_data {
-            guard.record_use(id);
-        }
-    }
-
-    // Build prompt additions.
     let listing = harness_core::prompts::build_available_skills_listing(
         all_skills.iter().map(|(n, d)| (n.as_str(), d.as_str())),
     );

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -4,8 +4,10 @@ use harness_core::error::HarnessError;
 use harness_core::interceptor::{ToolUseEvent, TurnInterceptor};
 use harness_core::prompts;
 use harness_core::types::{
-    ContextItem, Decision, Item, SkillId, ThreadId, TokenUsage, TurnId, TurnStatus,
+    ContextItem, Decision, Event, Item, SessionId, SkillId, ThreadId, TokenUsage, TurnId,
+    TurnStatus,
 };
+use harness_observe::event_store::EventStore;
 use harness_protocol::{notifications::Notification, notifications::RpcNotification};
 use std::path::Path;
 use std::sync::Arc;
@@ -381,6 +383,83 @@ pub(crate) async fn matched_skills_for_prompt(
         .into_iter()
         .map(|s| (s.id.clone(), s.name.clone()))
         .collect()
+}
+
+/// Augment a prompt with matching skills: match once, record usage, log `skill_used` events,
+/// and return the augmented prompt string. Replaces the repeated
+/// `matched_skills_for_prompt` + `inject_skills_into_prompt` + event-log loop pattern.
+pub(crate) async fn augment_prompt_with_skills(
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
+    task_id: &TaskId,
+    prompt: String,
+) -> String {
+    // Early return when store is empty — avoids acquiring locks unnecessarily.
+    {
+        let guard = skills.read().await;
+        if guard.list().is_empty() {
+            return prompt;
+        }
+    }
+
+    // Single read pass: collect matched (id, name, content) and all skills (name, desc).
+    let (matched, all_skills) = {
+        let guard = skills.read().await;
+        let matched: Vec<(SkillId, String, String)> = guard
+            .match_prompt(&prompt)
+            .into_iter()
+            .map(|s| (s.id.clone(), s.name.clone(), s.content.clone()))
+            .collect();
+        let all: Vec<(String, String)> = guard
+            .list()
+            .iter()
+            .map(|s| (s.name.clone(), s.description.clone()))
+            .collect();
+        (matched, all)
+    };
+
+    // Record usage for matched skills (brief write lock).
+    if !matched.is_empty() {
+        let mut guard = skills.write().await;
+        for (id, _, _) in &matched {
+            guard.record_use(id);
+        }
+    }
+
+    // Log skill_used events.
+    for (skill_id, skill_name, _) in &matched {
+        let mut ev = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        ev.reason = Some(skill_name.clone());
+        ev.detail = Some(format!(
+            "task_id={} skill_id={}",
+            task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = events.log(&ev).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
+
+    // Build prompt addition.
+    let listing = harness_core::prompts::build_available_skills_listing(
+        all_skills.iter().map(|(n, d)| (n.as_str(), d.as_str())),
+    );
+    let section = harness_core::prompts::build_matched_skills_section(
+        matched.iter().map(|(_, n, c)| (n.as_str(), c.as_str())),
+    );
+    let mut additions = listing;
+    additions.push_str(&section);
+
+    if additions.is_empty() {
+        prompt
+    } else {
+        prompt + &additions
+    }
 }
 
 /// Match skills against the prompt, record usage for each match, and return a

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -541,7 +541,8 @@ async fn inject_skills_retired_skill_not_included() {
     );
     let guard = skills.read().await;
     assert_eq!(
-        guard.list()[0].usage_count, 0,
+        guard.list()[0].usage_count,
+        0,
         "usage must not be recorded for retired skill"
     );
 }

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -5,6 +5,7 @@ use harness_core::interceptor::{
     InterceptResult, PostExecuteResult, PostToolUseResult, ToolUseEvent, TurnInterceptor,
 };
 use harness_core::types::{Decision, TokenUsage};
+use harness_observe::event_store::EventStore;
 use std::sync::{
     atomic::{AtomicBool, AtomicU32, Ordering},
     Arc,
@@ -499,7 +500,14 @@ fn make_skill_store_with_two_matching() -> harness_skills::store::SkillStore {
 #[tokio::test]
 async fn inject_skills_multiple_matches_all_usage_counts_incremented() {
     let skills = RwLock::new(make_skill_store_with_two_matching());
-    inject_skills_into_prompt(&skills, "please do a code review").await;
+    let events = EventStore::new_noop_for_tests();
+    augment_prompt_with_skills(
+        &skills,
+        &events,
+        &TaskId::new(),
+        "please do a code review".to_string(),
+    )
+    .await;
     let guard = skills.read().await;
     for skill in guard.list() {
         assert_eq!(
@@ -534,7 +542,14 @@ async fn inject_skills_retired_skill_not_included() {
         );
     }
     let skills = RwLock::new(store);
-    let result = inject_skills_into_prompt(&skills, "please do a code review").await;
+    let events = EventStore::new_noop_for_tests();
+    let result = augment_prompt_with_skills(
+        &skills,
+        &events,
+        &TaskId::new(),
+        "please do a code review".to_string(),
+    )
+    .await;
     assert!(
         !result.contains("Retired review content."),
         "retired skill content must not appear in prompt"
@@ -569,9 +584,12 @@ async fn inject_skills_quarantine_injection_is_deterministic() {
         },
     );
     let skills = RwLock::new(store);
-    let prompt = "please do a code review";
-    let result1 = inject_skills_into_prompt(&skills, prompt).await;
-    let result2 = inject_skills_into_prompt(&skills, prompt).await;
+    let events = EventStore::new_noop_for_tests();
+    let prompt = "please do a code review".to_string();
+    let result1 =
+        augment_prompt_with_skills(&skills, &events, &TaskId::new(), prompt.clone()).await;
+    let result2 =
+        augment_prompt_with_skills(&skills, &events, &TaskId::new(), prompt.clone()).await;
     assert_eq!(
         result1, result2,
         "injection result must be deterministic for the same prompt"

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -483,6 +483,100 @@ async fn inject_skills_empty_store_returns_empty_string() {
     );
 }
 
+fn make_skill_store_with_two_matching() -> harness_skills::store::SkillStore {
+    let mut store = harness_skills::store::SkillStore::new();
+    store.create(
+        "review".to_string(),
+        "# Review\n<!-- trigger-patterns: code review -->\nReview code carefully.".to_string(),
+    );
+    store.create(
+        "build-fix".to_string(),
+        "# BuildFix\n<!-- trigger-patterns: code review -->\nFix build issues.".to_string(),
+    );
+    store
+}
+
+#[tokio::test]
+async fn inject_skills_multiple_matches_all_usage_counts_incremented() {
+    let skills = RwLock::new(make_skill_store_with_two_matching());
+    inject_skills_into_prompt(&skills, "please do a code review").await;
+    let guard = skills.read().await;
+    for skill in guard.list() {
+        assert_eq!(
+            skill.usage_count, 1,
+            "skill '{}' must have usage_count=1 after matching",
+            skill.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn inject_skills_retired_skill_not_included() {
+    // Drive a skill into Retired state via apply_governance_outcome.
+    // Retired requires: scored_samples >= 30 AND quality_score < 0.30.
+    // Starting from quality_score=0.5, 4 calls with fail=100 yields ~0.293 < 0.30.
+    use harness_skills::store::SkillGovernanceInput;
+    let mut store = harness_skills::store::SkillStore::new();
+    store.create(
+        "retired-review".to_string(),
+        "# RetiredReview\n<!-- trigger-patterns: code review -->\nRetired review content."
+            .to_string(),
+    );
+    let id = store.list()[0].id.clone();
+    for _ in 0..4 {
+        store.apply_governance_outcome(
+            &id,
+            SkillGovernanceInput {
+                success: 0,
+                fail: 100,
+                unknown: 0,
+            },
+        );
+    }
+    let skills = RwLock::new(store);
+    let result = inject_skills_into_prompt(&skills, "please do a code review").await;
+    assert!(
+        !result.contains("Retired review content."),
+        "retired skill content must not appear in prompt"
+    );
+    let guard = skills.read().await;
+    assert_eq!(
+        guard.list()[0].usage_count, 0,
+        "usage must not be recorded for retired skill"
+    );
+}
+
+#[tokio::test]
+async fn inject_skills_quarantine_injection_is_deterministic() {
+    // Drive a skill into Quarantine, then verify same prompt always produces
+    // the same result (canary bucket is deterministic hash, not random).
+    use harness_skills::store::SkillGovernanceInput;
+    let mut store = harness_skills::store::SkillStore::new();
+    store.create(
+        "quarantine-review".to_string(),
+        "# QuarantineReview\n<!-- trigger-patterns: code review -->\nQuarantine content."
+            .to_string(),
+    );
+    let id = store.list()[0].id.clone();
+    // One call with fail=15: quality=0.43 < 0.45, samples=15 >= 10 → Quarantine.
+    store.apply_governance_outcome(
+        &id,
+        SkillGovernanceInput {
+            success: 0,
+            fail: 15,
+            unknown: 0,
+        },
+    );
+    let skills = RwLock::new(store);
+    let prompt = "please do a code review";
+    let result1 = inject_skills_into_prompt(&skills, prompt).await;
+    let result2 = inject_skills_into_prompt(&skills, prompt).await;
+    assert_eq!(
+        result1, result2,
+        "injection result must be deterministic for the same prompt"
+    );
+}
+
 // ── truncate_validation_error ─────────────────────────────────────────────────
 
 #[test]

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -537,7 +537,7 @@ pub(crate) async fn run_task(
             (None, prompts::TriageComplexity::Medium, 0u32)
         } else {
             triage_pipeline::run_triage_plan_pipeline(
-                agent, store, task_id, issue, &cargo_env, &project, req,
+                agent, store, task_id, issue, &cargo_env, &project, req, &skills, &events,
             )
             .await?
         }
@@ -554,8 +554,10 @@ pub(crate) async fn run_task(
             // Planning is in resumable_statuses, so a crash here will be caught by
             // startup recovery: no pr_url/plan checkpoint → mark failed, re-queue manually.
             update_status(store, task_id, TaskStatus::Planning, 0).await?;
-            triage_pipeline::run_plan_for_prompt(agent, store, task_id, &cargo_env, &project, req)
-                .await?
+            triage_pipeline::run_plan_for_prompt(
+                agent, store, task_id, &cargo_env, &project, req, &skills, &events,
+            )
+            .await?
         } else {
             (None, prompts::TriageComplexity::Medium, 0u32)
         }
@@ -691,6 +693,8 @@ pub(crate) async fn run_task(
                         &cargo_env,
                         &project,
                         req,
+                        &skills,
+                        &events,
                     )
                     .await?;
                     turns_used += 1;
@@ -802,6 +806,7 @@ pub(crate) async fn run_task(
                 pr_url.as_deref().unwrap_or(""),
                 project_config.review_type.as_str(),
                 &events,
+                &skills,
                 &cargo_env,
                 effective_max_turns,
                 &mut turns_used,

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1,12 +1,16 @@
-use super::helpers::{run_agent_streaming, update_status};
+use super::helpers::{
+    inject_skills_into_prompt, matched_skills_for_prompt, run_agent_streaming, update_status,
+};
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStatus, TaskStore,
 };
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::prompts;
-use harness_core::types::ExecutionPhase;
+use harness_core::types::{Decision, Event, ExecutionPhase, SessionId};
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use tokio::time::Duration;
 
 /// Run a plan step for a complex prompt-only task when the planning gate has
@@ -22,6 +26,8 @@ pub(crate) async fn run_plan_for_prompt(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
+    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
+    events: &Arc<harness_observe::event_store::EventStore>,
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     let prompt_text = req.prompt.as_deref().unwrap_or_default();
     tracing::info!(task_id = %task_id, "pipeline: starting plan phase for prompt-only task");
@@ -32,6 +38,30 @@ pub(crate) async fn run_plan_for_prompt(
     .await?;
 
     let plan_prompt = prompts::plan_for_prompt_task(prompt_text);
+    let matched_skills = matched_skills_for_prompt(skills, &plan_prompt).await;
+    let skill_additions = inject_skills_into_prompt(skills, &plan_prompt).await;
+    let plan_prompt = if skill_additions.is_empty() {
+        plan_prompt
+    } else {
+        plan_prompt + &skill_additions
+    };
+    for (skill_id, skill_name) in matched_skills {
+        let mut skill_event = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        skill_event.reason = Some(skill_name);
+        skill_event.detail = Some(format!(
+            "task_id={} skill_id={}",
+            task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = events.log(&skill_event).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
 
     let plan_req = AgentRequest {
         prompt: plan_prompt,
@@ -84,6 +114,8 @@ pub(crate) async fn run_triage_plan_pipeline(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
+    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
+    events: &Arc<harness_observe::event_store::EventStore>,
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     // --- Phase 1: Triage ---
     tracing::info!(task_id = %task_id, issue, "pipeline: starting triage phase");
@@ -94,6 +126,30 @@ pub(crate) async fn run_triage_plan_pipeline(
     update_status(store, task_id, TaskStatus::Triaging, 0).await?;
 
     let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
+    let matched_skills = matched_skills_for_prompt(skills, &triage_prompt).await;
+    let skill_additions = inject_skills_into_prompt(skills, &triage_prompt).await;
+    let triage_prompt = if skill_additions.is_empty() {
+        triage_prompt
+    } else {
+        triage_prompt + &skill_additions
+    };
+    for (skill_id, skill_name) in matched_skills {
+        let mut skill_event = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        skill_event.reason = Some(skill_name);
+        skill_event.detail = Some(format!(
+            "task_id={} skill_id={}",
+            task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = events.log(&skill_event).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
     let triage_req = AgentRequest {
         prompt: triage_prompt,
         project_root: project.to_path_buf(),
@@ -162,6 +218,30 @@ pub(crate) async fn run_triage_plan_pipeline(
     update_status(store, task_id, TaskStatus::Planning, 0).await?;
 
     let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
+    let matched_plan_skills = matched_skills_for_prompt(skills, &plan_prompt).await;
+    let plan_skill_additions = inject_skills_into_prompt(skills, &plan_prompt).await;
+    let plan_prompt = if plan_skill_additions.is_empty() {
+        plan_prompt
+    } else {
+        plan_prompt + &plan_skill_additions
+    };
+    for (skill_id, skill_name) in matched_plan_skills {
+        let mut skill_event = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        skill_event.reason = Some(skill_name);
+        skill_event.detail = Some(format!(
+            "task_id={} skill_id={}",
+            task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = events.log(&skill_event).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
     let plan_req = AgentRequest {
         prompt: plan_prompt,
         project_root: project.to_path_buf(),
@@ -209,6 +289,8 @@ pub(crate) async fn run_replan_for_issue(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
+    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
+    events: &Arc<harness_observe::event_store::EventStore>,
 ) -> anyhow::Result<String> {
     tracing::info!(task_id = %task_id, issue, "pipeline: starting replan phase");
     mutate_and_persist(store, task_id, |state| {
@@ -217,6 +299,30 @@ pub(crate) async fn run_replan_for_issue(
     .await?;
 
     let prompt = prompts::replan_prompt(issue, prior_plan, plan_issue).to_prompt_string();
+    let matched_skills = matched_skills_for_prompt(skills, &prompt).await;
+    let skill_additions = inject_skills_into_prompt(skills, &prompt).await;
+    let prompt = if skill_additions.is_empty() {
+        prompt
+    } else {
+        prompt + &skill_additions
+    };
+    for (skill_id, skill_name) in matched_skills {
+        let mut skill_event = Event::new(
+            SessionId::new(),
+            "skill_used",
+            "task_runner",
+            Decision::Pass,
+        );
+        skill_event.reason = Some(skill_name);
+        skill_event.detail = Some(format!(
+            "task_id={} skill_id={}",
+            task_id.as_str(),
+            skill_id.as_str()
+        ));
+        if let Err(err) = events.log(&skill_event).await {
+            tracing::warn!(error = %err, "failed to log skill_used event");
+        }
+    }
     let plan_req = AgentRequest {
         prompt,
         project_root: project.to_path_buf(),

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1,15 +1,13 @@
-use super::helpers::{
-    inject_skills_into_prompt, matched_skills_for_prompt, run_agent_streaming, update_status,
-};
+use super::helpers::{augment_prompt_with_skills, run_agent_streaming, update_status};
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStatus, TaskStore,
 };
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::prompts;
-use harness_core::types::{Decision, Event, ExecutionPhase, SessionId};
+use harness_core::types::ExecutionPhase;
+use harness_observe::event_store::EventStore;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
@@ -26,8 +24,8 @@ pub(crate) async fn run_plan_for_prompt(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
-    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
-    events: &Arc<harness_observe::event_store::EventStore>,
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     let prompt_text = req.prompt.as_deref().unwrap_or_default();
     tracing::info!(task_id = %task_id, "pipeline: starting plan phase for prompt-only task");
@@ -38,30 +36,7 @@ pub(crate) async fn run_plan_for_prompt(
     .await?;
 
     let plan_prompt = prompts::plan_for_prompt_task(prompt_text);
-    let matched_skills = matched_skills_for_prompt(skills, &plan_prompt).await;
-    let skill_additions = inject_skills_into_prompt(skills, &plan_prompt).await;
-    let plan_prompt = if skill_additions.is_empty() {
-        plan_prompt
-    } else {
-        plan_prompt + &skill_additions
-    };
-    for (skill_id, skill_name) in matched_skills {
-        let mut skill_event = Event::new(
-            SessionId::new(),
-            "skill_used",
-            "task_runner",
-            Decision::Pass,
-        );
-        skill_event.reason = Some(skill_name);
-        skill_event.detail = Some(format!(
-            "task_id={} skill_id={}",
-            task_id.as_str(),
-            skill_id.as_str()
-        ));
-        if let Err(err) = events.log(&skill_event).await {
-            tracing::warn!(error = %err, "failed to log skill_used event");
-        }
-    }
+    let plan_prompt = augment_prompt_with_skills(skills, events, task_id, plan_prompt).await;
 
     let plan_req = AgentRequest {
         prompt: plan_prompt,
@@ -114,8 +89,8 @@ pub(crate) async fn run_triage_plan_pipeline(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
-    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
-    events: &Arc<harness_observe::event_store::EventStore>,
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
 ) -> anyhow::Result<(Option<String>, prompts::TriageComplexity, u32)> {
     // --- Phase 1: Triage ---
     tracing::info!(task_id = %task_id, issue, "pipeline: starting triage phase");
@@ -126,30 +101,7 @@ pub(crate) async fn run_triage_plan_pipeline(
     update_status(store, task_id, TaskStatus::Triaging, 0).await?;
 
     let triage_prompt = prompts::triage_prompt(issue).to_prompt_string();
-    let matched_skills = matched_skills_for_prompt(skills, &triage_prompt).await;
-    let skill_additions = inject_skills_into_prompt(skills, &triage_prompt).await;
-    let triage_prompt = if skill_additions.is_empty() {
-        triage_prompt
-    } else {
-        triage_prompt + &skill_additions
-    };
-    for (skill_id, skill_name) in matched_skills {
-        let mut skill_event = Event::new(
-            SessionId::new(),
-            "skill_used",
-            "task_runner",
-            Decision::Pass,
-        );
-        skill_event.reason = Some(skill_name);
-        skill_event.detail = Some(format!(
-            "task_id={} skill_id={}",
-            task_id.as_str(),
-            skill_id.as_str()
-        ));
-        if let Err(err) = events.log(&skill_event).await {
-            tracing::warn!(error = %err, "failed to log skill_used event");
-        }
-    }
+    let triage_prompt = augment_prompt_with_skills(skills, events, task_id, triage_prompt).await;
     let triage_req = AgentRequest {
         prompt: triage_prompt,
         project_root: project.to_path_buf(),
@@ -218,30 +170,7 @@ pub(crate) async fn run_triage_plan_pipeline(
     update_status(store, task_id, TaskStatus::Planning, 0).await?;
 
     let plan_prompt = prompts::plan_prompt(issue, &triage_resp.output).to_prompt_string();
-    let matched_plan_skills = matched_skills_for_prompt(skills, &plan_prompt).await;
-    let plan_skill_additions = inject_skills_into_prompt(skills, &plan_prompt).await;
-    let plan_prompt = if plan_skill_additions.is_empty() {
-        plan_prompt
-    } else {
-        plan_prompt + &plan_skill_additions
-    };
-    for (skill_id, skill_name) in matched_plan_skills {
-        let mut skill_event = Event::new(
-            SessionId::new(),
-            "skill_used",
-            "task_runner",
-            Decision::Pass,
-        );
-        skill_event.reason = Some(skill_name);
-        skill_event.detail = Some(format!(
-            "task_id={} skill_id={}",
-            task_id.as_str(),
-            skill_id.as_str()
-        ));
-        if let Err(err) = events.log(&skill_event).await {
-            tracing::warn!(error = %err, "failed to log skill_used event");
-        }
-    }
+    let plan_prompt = augment_prompt_with_skills(skills, events, task_id, plan_prompt).await;
     let plan_req = AgentRequest {
         prompt: plan_prompt,
         project_root: project.to_path_buf(),
@@ -289,8 +218,8 @@ pub(crate) async fn run_replan_for_issue(
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
-    skills: &Arc<RwLock<harness_skills::store::SkillStore>>,
-    events: &Arc<harness_observe::event_store::EventStore>,
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
 ) -> anyhow::Result<String> {
     tracing::info!(task_id = %task_id, issue, "pipeline: starting replan phase");
     mutate_and_persist(store, task_id, |state| {
@@ -299,30 +228,7 @@ pub(crate) async fn run_replan_for_issue(
     .await?;
 
     let prompt = prompts::replan_prompt(issue, prior_plan, plan_issue).to_prompt_string();
-    let matched_skills = matched_skills_for_prompt(skills, &prompt).await;
-    let skill_additions = inject_skills_into_prompt(skills, &prompt).await;
-    let prompt = if skill_additions.is_empty() {
-        prompt
-    } else {
-        prompt + &skill_additions
-    };
-    for (skill_id, skill_name) in matched_skills {
-        let mut skill_event = Event::new(
-            SessionId::new(),
-            "skill_used",
-            "task_runner",
-            Decision::Pass,
-        );
-        skill_event.reason = Some(skill_name);
-        skill_event.detail = Some(format!(
-            "task_id={} skill_id={}",
-            task_id.as_str(),
-            skill_id.as_str()
-        ));
-        if let Err(err) = events.log(&skill_event).await {
-            tracing::warn!(error = %err, "failed to log skill_used event");
-        }
-    }
+    let prompt = augment_prompt_with_skills(skills, events, task_id, prompt).await;
     let plan_req = AgentRequest {
         prompt,
         project_root: project.to_path_buf(),


### PR DESCRIPTION
## Summary
- Wire skill injection into `run_triage_plan_pipeline`, `run_plan_for_prompt`, `run_replan_for_issue`, and `run_agent_review` — all agent phases now inject registered skills, not just the implement phase
- Each site replicates the injection pattern from `implement_pipeline.rs:240–263`: `matched_skills_for_prompt` logs `skill_used` events, `inject_skills_into_prompt` appends the prompt block, and `record_use` increments the usage counter
- Adds `&Arc<RwLock<SkillStore>>` + `&EventStore` parameters to the four pipeline functions and updates all call sites in `mod.rs`

## Test plan
- [ ] `cargo check --workspace --all-targets` — passes clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — passes clean
- [ ] `cargo test --workspace` — 3 new tests added in `helpers_tests.rs`; 264 pre-existing failures unchanged (confirmed via baseline run on unmodified main)
  - `inject_skills_multiple_matches_all_usage_counts_incremented`
  - `inject_skills_retired_skill_not_included`
  - `inject_skills_quarantine_injection_is_deterministic`

Closes #971