### PR TITLE
fix(task): recover PR URL when sentinel is missing from agent output (#982)

### DIFF
--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -59,8 +59,7 @@ fn scan_bare_pr_url(output: &str) -> Option<String> {
                 .unwrap_or(candidate.len());
             // Trim trailing sentence punctuation that cannot be part of a PR URL.
             // Example: "see https://github.com/o/r/pull/5." — the period ends the sentence.
-            let url = candidate[..url_end]
-                .trim_end_matches(['.', ',', '!', '?', ')', ']']);
+            let url = candidate[..url_end].trim_end_matches(['.', ',', '!', '?', ')', ']']);
             if is_valid_github_pr_url(url) {
                 let normalized = url.split('#').next().unwrap_or(url).trim_end_matches('/');
                 last = Some(normalized.to_string());

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -60,7 +60,7 @@ fn scan_bare_pr_url(output: &str) -> Option<String> {
             // Trim trailing sentence punctuation that cannot be part of a PR URL.
             // Example: "see https://github.com/o/r/pull/5." — the period ends the sentence.
             let url = candidate[..url_end]
-                .trim_end_matches(|c: char| matches!(c, '.' | ',' | '!' | '?' | ')' | ']'));
+                .trim_end_matches(['.', ',', '!', '?', ')', ']']);
             if is_valid_github_pr_url(url) {
                 let normalized = url.split('#').next().unwrap_or(url).trim_end_matches('/');
                 last = Some(normalized.to_string());

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -13,6 +13,64 @@ pub fn extract_review_issues(output: &str) -> Vec<String> {
         .collect()
 }
 
+/// Strip ANSI CSI escape sequences (e.g. colour codes) from `s`.
+///
+/// Handles `ESC [ <params> <letter>` sequences. Bare ESC characters not
+/// followed by `[` are consumed silently. Uses a state machine so no regex
+/// dependency is required.
+fn strip_ansi_codes(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                              // Consume digits and semicolons until an ASCII letter ends the sequence.
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+            // else: bare ESC — skip it
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Scan `output` for the last valid bare GitHub PR URL.
+///
+/// Used as a fallback when no `PR_URL=` sentinel is found. Each candidate is
+/// validated with `is_valid_github_pr_url` to maintain the same injection
+/// protections. Returns the last valid URL found (consistent with the sentinel
+/// scan which also takes the last occurrence).
+fn scan_bare_pr_url(output: &str) -> Option<String> {
+    let needle = "https://github.com/";
+    let mut last: Option<String> = None;
+    for line in output.lines() {
+        let mut search_from = 0usize;
+        while let Some(rel) = line[search_from..].find(needle) {
+            let url_start = search_from + rel;
+            let candidate = &line[url_start..];
+            let url_end = candidate
+                .find(|c: char| c.is_whitespace() || matches!(c, '"' | '\'' | '<' | '>'))
+                .unwrap_or(candidate.len());
+            // Trim trailing sentence punctuation that cannot be part of a PR URL.
+            // Example: "see https://github.com/o/r/pull/5." — the period ends the sentence.
+            let url = candidate[..url_end]
+                .trim_end_matches(|c: char| matches!(c, '.' | ',' | '!' | '?' | ')' | ']'));
+            if is_valid_github_pr_url(url) {
+                let normalized = url.split('#').next().unwrap_or(url).trim_end_matches('/');
+                last = Some(normalized.to_string());
+            }
+            search_from = url_start + url_end.max(1);
+        }
+    }
+    last
+}
+
 /// Parse `PR_URL=<url>` from agent output (searches from last line).
 ///
 /// Only returns URLs matching the strict GitHub PR format
@@ -23,8 +81,16 @@ pub fn extract_review_issues(output: &str) -> Vec<String> {
 ///
 /// The fragment (if any) is stripped from the returned URL so it cannot
 /// escape shell quoting in downstream commands.
+///
+/// ANSI colour codes are stripped before scanning so that terminals that
+/// decorate the output do not break the literal `PR_URL=` match. If no
+/// `PR_URL=` sentinel is found, a second pass searches for any bare GitHub
+/// PR URL in the output and returns the last valid match.
 pub fn parse_pr_url(output: &str) -> Option<String> {
-    for line in output.lines().rev() {
+    let stripped = strip_ansi_codes(output);
+
+    // First pass: explicit PR_URL= sentinel (scan from end to get the last one).
+    for line in stripped.lines().rev() {
         let line = line.trim();
         if let Some(url) = line.strip_prefix("PR_URL=") {
             let url = url.trim();
@@ -38,7 +104,9 @@ pub fn parse_pr_url(output: &str) -> Option<String> {
             }
         }
     }
-    None
+
+    // Second pass: bare GitHub PR URL anywhere in the output.
+    scan_bare_pr_url(&stripped)
 }
 
 /// Returns `true` only for well-formed GitHub PR URLs.
@@ -351,6 +419,89 @@ which could mask silent failures.\nISSUES=1\nFIXED";
     #[test]
     fn test_parse_pr_url_not_found() {
         assert_eq!(parse_pr_url("no url here"), None);
+    }
+
+    // --- ANSI stripping tests (issue #982) ---
+
+    #[test]
+    fn test_parse_pr_url_ansi_reset_prefix() {
+        // T1: ANSI reset code on the same line as PR_URL=
+        let output = "Some output\n\x1b[0mPR_URL=https://github.com/owner/repo/pull/42";
+        assert_eq!(
+            parse_pr_url(output),
+            Some("https://github.com/owner/repo/pull/42".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_ansi_colors_wrapping_line() {
+        // T2: bold green colour codes wrapping the entire PR_URL= line
+        let output = "Some output\n\x1b[1;32mPR_URL=https://github.com/owner/repo/pull/99\x1b[0m";
+        assert_eq!(
+            parse_pr_url(output),
+            Some("https://github.com/owner/repo/pull/99".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_truncated_no_panic() {
+        // T3: truncated URL (no PR number) → None, no panic
+        assert_eq!(
+            parse_pr_url("PR_URL=https://github.com/foo/bar/pull/"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_multiple_returns_last() {
+        // T4: agent mentions an old PR then creates a new one — return the last valid URL
+        let output = "see old PR at PR_URL=https://github.com/owner/repo/pull/10\n\
+                      done\n\
+                      PR_URL=https://github.com/owner/repo/pull/42";
+        assert_eq!(
+            parse_pr_url(output),
+            Some("https://github.com/owner/repo/pull/42".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_bare_url_fallback() {
+        // T5: no PR_URL= prefix but a plain GitHub PR URL is present
+        let output = "Created PR: https://github.com/owner/repo/pull/77\nDone.";
+        assert_eq!(
+            parse_pr_url(output),
+            Some("https://github.com/owner/repo/pull/77".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_bare_url_fallback_returns_last() {
+        // T5 variant: multiple bare URLs → last valid PR URL is returned
+        let output = "Mentioned https://github.com/owner/repo/pull/1 earlier.\n\
+                      Final result https://github.com/owner/repo/pull/55.";
+        assert_eq!(
+            parse_pr_url(output),
+            Some("https://github.com/owner/repo/pull/55".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_bare_issue_url_ignored() {
+        // issue URLs must not match the bare URL fallback (not a /pull/ URL)
+        let output = "Created https://github.com/owner/repo/issues/10";
+        assert_eq!(parse_pr_url(output), None);
+    }
+
+    #[test]
+    fn test_parse_pr_url_stderr_combined_output() {
+        // T8: when stderr is appended to output with a separator, sentinel is found
+        let stdout = "Implementing changes...\n";
+        let stderr = "PR_URL=https://github.com/owner/repo/pull/88";
+        let combined = format!("{stdout}\n--- stderr ---\n{stderr}");
+        assert_eq!(
+            parse_pr_url(&combined),
+            Some("https://github.com/owner/repo/pull/88".to_string())
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -493,6 +493,15 @@ pub(crate) async fn run_implement_phase(
             tracing::warn!(stderr = %stderr, "agent stderr during implementation");
         }
 
+        // Append stderr to output so that sentinel parsers (parse_pr_url, etc.) see
+        // the full combined text. For streaming adapters stderr is always empty here;
+        // for non-streaming adapters (execute path) it carries real process output.
+        let output = if !stderr.is_empty() {
+            format!("{output}\n--- stderr ---\n{stderr}")
+        } else {
+            output
+        };
+
         // Fast-fail: if the agent observed a stale worktree managed by another harness
         // session, abort immediately. This prevents the task from pushing commits to the
         // wrong PR (issue #799).
@@ -540,74 +549,94 @@ pub(crate) async fn run_implement_phase(
             return Ok(ImplementOutcome::Done);
         }
 
-        let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
-            ImplementationOutcome::PlanIssue(plan_issue) => {
-                if let (Some(workflows), Some(issue_number)) =
-                    (issue_workflow_store.as_ref(), req.issue)
-                {
-                    let project_id = project_root.to_string_lossy().into_owned();
-                    if let Err(e) = workflows
-                        .record_plan_issue_detected(
-                            &project_id,
-                            req.repo.as_deref(),
-                            issue_number,
-                            &task_id.0,
-                            &plan_issue,
-                        )
-                        .await
+        let (mut pr_url, mut pr_num, created_issue_num) =
+            match parse_implementation_outcome(&output) {
+                ImplementationOutcome::PlanIssue(plan_issue) => {
+                    if let (Some(workflows), Some(issue_number)) =
+                        (issue_workflow_store.as_ref(), req.issue)
                     {
-                        tracing::warn!(
-                            issue = issue_number,
-                            task_id = %task_id.0,
-                            "issue workflow PLAN_ISSUE tracking failed: {e}"
-                        );
+                        let project_id = project_root.to_string_lossy().into_owned();
+                        if let Err(e) = workflows
+                            .record_plan_issue_detected(
+                                &project_id,
+                                req.repo.as_deref(),
+                                issue_number,
+                                &task_id.0,
+                                &plan_issue,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                issue = issue_number,
+                                task_id = %task_id.0,
+                                "issue workflow PLAN_ISSUE tracking failed: {e}"
+                            );
+                        }
                     }
+                    if let Some(issue_number) = req.issue {
+                        return Ok(ImplementOutcome::Replan {
+                            issue: issue_number,
+                            plan_issue,
+                            prior_plan: plan_output.clone(),
+                        });
+                    }
+                    tracing::error!(
+                        task_id = %task_id,
+                        plan_issue = %plan_issue,
+                        "implementation returned PLAN_ISSUE; marking task failed"
+                    );
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.turn = 2;
+                        s.error = Some(plan_issue.clone());
+                        s.rounds.push(RoundResult {
+                            turn: 1,
+                            action: "implement".into(),
+                            result: "plan_issue".into(),
+                            detail: if output.is_empty() {
+                                None
+                            } else {
+                                Some(output.clone())
+                            },
+                            first_token_latency_ms: impl_first_token_ms,
+                        });
+                    })
+                    .await?;
+                    tracing::info!(
+                        task_id = %task_id,
+                        status = "failed",
+                        turns = 2,
+                        pr_url = tracing::field::Empty,
+                        total_elapsed_secs = task_start.elapsed().as_secs(),
+                        "task_completed"
+                    );
+                    return Ok(ImplementOutcome::Done);
                 }
-                if let Some(issue_number) = req.issue {
-                    return Ok(ImplementOutcome::Replan {
-                        issue: issue_number,
-                        plan_issue,
-                        prior_plan: plan_output.clone(),
-                    });
-                }
-                tracing::error!(
-                    task_id = %task_id,
-                    plan_issue = %plan_issue,
-                    "implementation returned PLAN_ISSUE; marking task failed"
-                );
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.turn = 2;
-                    s.error = Some(plan_issue.clone());
-                    s.rounds.push(RoundResult {
-                        turn: 1,
-                        action: "implement".into(),
-                        result: "plan_issue".into(),
-                        detail: if output.is_empty() {
-                            None
-                        } else {
-                            Some(output.clone())
-                        },
-                        first_token_latency_ms: impl_first_token_ms,
-                    });
-                })
-                .await?;
+                ImplementationOutcome::ParsedPr {
+                    pr_url,
+                    pr_num,
+                    created_issue_num,
+                } => (pr_url, pr_num, created_issue_num),
+            };
+
+        // Fallback: if the agent produced no PR_URL= sentinel, try to recover via
+        // `gh pr list --search "head:<branch>"`. This handles the regression where
+        // ANSI codes or unexpected output channels caused sentinel parsing to miss
+        // an already-created PR (issue #982).
+        if pr_url.is_none() && task_needs_pr_url(req) {
+            if let Some((fallback_num, fallback_url)) =
+                super::pr_detection::fallback_find_pr_by_branch(project).await
+            {
                 tracing::info!(
                     task_id = %task_id,
-                    status = "failed",
-                    turns = 2,
-                    pr_url = tracing::field::Empty,
-                    total_elapsed_secs = task_start.elapsed().as_secs(),
-                    "task_completed"
+                    pr_number = fallback_num,
+                    pr_url = %fallback_url,
+                    "PR_URL sentinel missing from output; recovered via gh pr list"
                 );
-                return Ok(ImplementOutcome::Done);
+                pr_url = Some(fallback_url);
+                pr_num = Some(fallback_num);
             }
-            ImplementationOutcome::ParsedPr {
-                pr_url,
-                pr_num,
-                created_issue_num,
-            } => (pr_url, pr_num, created_issue_num),
-        };
+        }
 
         mutate_and_persist(store, task_id, |s| {
             s.pr_url = pr_url.clone();

--- a/crates/harness-server/src/task_executor/pr_detection.rs
+++ b/crates/harness-server/src/task_executor/pr_detection.rs
@@ -356,6 +356,84 @@ fn strip_trailing_repo_qualifier(s: &str) -> Option<&str> {
     Some(&s[..owner_start])
 }
 
+/// Attempt to recover a PR URL when the agent output lacked a `PR_URL=` sentinel.
+///
+/// Detects the current branch of `project_root` via `git rev-parse --abbrev-ref HEAD`,
+/// then queries `gh pr list --search "head:<branch>"` for open PRs on that branch.
+/// Returns `(pr_number, pr_url)` for the first result, or `None` when:
+///   - the branch cannot be detected (detached HEAD, git unavailable)
+///   - `gh pr list` fails (logged at warn)
+///   - the response JSON is empty or unparseable
+pub(crate) async fn fallback_find_pr_by_branch(project_root: &Path) -> Option<(u64, String)> {
+    let branch_out = Command::new("git")
+        .current_dir(project_root)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .await
+        .ok()?;
+    if !branch_out.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&branch_out.stdout)
+        .trim()
+        .to_string();
+    if branch.is_empty() || branch == "HEAD" {
+        tracing::warn!("fallback_find_pr_by_branch: detached HEAD, cannot search by branch");
+        return None;
+    }
+
+    let gh_out = Command::new("gh")
+        .current_dir(project_root)
+        .args([
+            "pr",
+            "list",
+            "--search",
+            &format!("head:{branch}"),
+            "--state",
+            "open",
+            "--json",
+            "number,url",
+            "--limit",
+            "5",
+        ])
+        .output()
+        .await
+        .ok()?;
+
+    if !gh_out.status.success() {
+        tracing::warn!(
+            branch = %branch,
+            stderr = %String::from_utf8_lossy(&gh_out.stderr).trim(),
+            "fallback_find_pr_by_branch: gh pr list failed"
+        );
+        return None;
+    }
+
+    #[derive(serde::Deserialize)]
+    struct PrItem {
+        number: u64,
+        url: String,
+    }
+    let items: Vec<PrItem> = match serde_json::from_slice(&gh_out.stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(branch = %branch, error = %e, "fallback_find_pr_by_branch: JSON parse failed");
+            return None;
+        }
+    };
+    let first = items.into_iter().next()?;
+    tracing::info!(
+        branch = %branch,
+        pr_number = first.number,
+        pr_url = %first.url,
+        "fallback_find_pr_by_branch: recovered PR via gh pr list"
+    );
+    Some((first.number, first.url))
+}
+
 /// Parse `"owner/repo"` from a git remote URL.
 ///
 /// Handles HTTPS (`https://github.com/owner/repo.git`),
@@ -681,6 +759,38 @@ mod tests {
     }
 
     // --- parse_harness_mention_command (pre-existing, light coverage) ---
+
+    // --- fallback_find_pr_by_branch JSON parsing tests (T6 / T7) ---
+
+    #[test]
+    fn fallback_json_valid_returns_first_item() {
+        // T6: JSON returned by `gh pr list` with one match should deserialise correctly.
+        #[derive(serde::Deserialize)]
+        struct PrItem {
+            number: u64,
+            url: String,
+        }
+        let json = r#"[{"number":42,"url":"https://github.com/owner/repo/pull/42"}]"#;
+        let items: Vec<PrItem> = serde_json::from_str(json).unwrap();
+        let first = items.into_iter().next().unwrap();
+        assert_eq!(first.number, 42);
+        assert_eq!(first.url, "https://github.com/owner/repo/pull/42");
+    }
+
+    #[test]
+    fn fallback_json_empty_array_returns_none() {
+        // T7: empty JSON array — no PR found on this branch.
+        #[derive(serde::Deserialize)]
+        struct PrItem {
+            #[allow(dead_code)]
+            number: u64,
+            #[allow(dead_code)]
+            url: String,
+        }
+        let json = r#"[]"#;
+        let items: Vec<PrItem> = serde_json::from_str(json).unwrap();
+        assert!(items.into_iter().next().is_none());
+    }
 
     #[test]
     fn parses_fix_ci_command() {


### PR DESCRIPTION
## Summary

- Fixes false-failed tasks where the agent created a PR but harness couldn't extract `PR_URL=` from output (issue #982)
- Three layered defences: ANSI stripping, bare-URL regex fallback, and `gh pr list` branch fallback
- 8 new unit tests covering all regression scenarios

Closes #982

## Root causes addressed

1. **ANSI colour codes** emitted by Claude CLI wrapped the `PR_URL=` line, breaking the literal prefix match
2. **No fallback** — if the sentinel scan failed for any reason, the task was immediately marked `Failed`
3. **Stderr not scanned** — for non-streaming adapters, `PR_URL=` on stderr was silently discarded

## Changes

| File | Change |
|---|---|
| `harness-core/src/prompts/parsing.rs` | `strip_ansi_codes()` applied before sentinel scan; `scan_bare_pr_url()` fallback; 8 new unit tests |
| `harness-server/src/task_executor/pr_detection.rs` | `fallback_find_pr_by_branch()`: detects current branch via git, queries `gh pr list --search "head:<branch>"` |
| `harness-server/src/task_executor/implement_pipeline.rs` | Appends stderr to output before parsing; inserts branch-fallback rescue block after `parse_implementation_outcome` |

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean  
- [x] `cargo test --package harness-core` — 339 passed, 0 failed
- [x] Pre-existing `harness-server` failures confirmed unchanged vs `main` (DB circuit breaker, not logic)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)