### PR TITLE
Remove hidden server-side PR URL recovery

### DIFF
--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -549,94 +549,74 @@ pub(crate) async fn run_implement_phase(
             return Ok(ImplementOutcome::Done);
         }
 
-        let (mut pr_url, mut pr_num, created_issue_num) =
-            match parse_implementation_outcome(&output) {
-                ImplementationOutcome::PlanIssue(plan_issue) => {
-                    if let (Some(workflows), Some(issue_number)) =
-                        (issue_workflow_store.as_ref(), req.issue)
+        let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
+            ImplementationOutcome::PlanIssue(plan_issue) => {
+                if let (Some(workflows), Some(issue_number)) =
+                    (issue_workflow_store.as_ref(), req.issue)
+                {
+                    let project_id = project_root.to_string_lossy().into_owned();
+                    if let Err(e) = workflows
+                        .record_plan_issue_detected(
+                            &project_id,
+                            req.repo.as_deref(),
+                            issue_number,
+                            &task_id.0,
+                            &plan_issue,
+                        )
+                        .await
                     {
-                        let project_id = project_root.to_string_lossy().into_owned();
-                        if let Err(e) = workflows
-                            .record_plan_issue_detected(
-                                &project_id,
-                                req.repo.as_deref(),
-                                issue_number,
-                                &task_id.0,
-                                &plan_issue,
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                issue = issue_number,
-                                task_id = %task_id.0,
-                                "issue workflow PLAN_ISSUE tracking failed: {e}"
-                            );
-                        }
+                        tracing::warn!(
+                            issue = issue_number,
+                            task_id = %task_id.0,
+                            "issue workflow PLAN_ISSUE tracking failed: {e}"
+                        );
                     }
-                    if let Some(issue_number) = req.issue {
-                        return Ok(ImplementOutcome::Replan {
-                            issue: issue_number,
-                            plan_issue,
-                            prior_plan: plan_output.clone(),
-                        });
-                    }
-                    tracing::error!(
-                        task_id = %task_id,
-                        plan_issue = %plan_issue,
-                        "implementation returned PLAN_ISSUE; marking task failed"
-                    );
-                    mutate_and_persist(store, task_id, |s| {
-                        s.status = TaskStatus::Failed;
-                        s.turn = 2;
-                        s.error = Some(plan_issue.clone());
-                        s.rounds.push(RoundResult {
-                            turn: 1,
-                            action: "implement".into(),
-                            result: "plan_issue".into(),
-                            detail: if output.is_empty() {
-                                None
-                            } else {
-                                Some(output.clone())
-                            },
-                            first_token_latency_ms: impl_first_token_ms,
-                        });
-                    })
-                    .await?;
-                    tracing::info!(
-                        task_id = %task_id,
-                        status = "failed",
-                        turns = 2,
-                        pr_url = tracing::field::Empty,
-                        total_elapsed_secs = task_start.elapsed().as_secs(),
-                        "task_completed"
-                    );
-                    return Ok(ImplementOutcome::Done);
                 }
-                ImplementationOutcome::ParsedPr {
-                    pr_url,
-                    pr_num,
-                    created_issue_num,
-                } => (pr_url, pr_num, created_issue_num),
-            };
-
-        // Fallback: if the agent produced no PR_URL= sentinel, try to recover from
-        // the current branch via GitHub REST. This handles the regression where
-        // ANSI codes or unexpected output channels caused sentinel parsing to miss
-        // an already-created PR (issue #982).
-        if pr_url.is_none() && task_needs_pr_url(req) {
-            if let Some((fallback_num, fallback_url)) =
-                super::pr_detection::fallback_find_pr_by_branch(project).await
-            {
+                if let Some(issue_number) = req.issue {
+                    return Ok(ImplementOutcome::Replan {
+                        issue: issue_number,
+                        plan_issue,
+                        prior_plan: plan_output.clone(),
+                    });
+                }
+                tracing::error!(
+                    task_id = %task_id,
+                    plan_issue = %plan_issue,
+                    "implementation returned PLAN_ISSUE; marking task failed"
+                );
+                mutate_and_persist(store, task_id, |s| {
+                    s.status = TaskStatus::Failed;
+                    s.turn = 2;
+                    s.error = Some(plan_issue.clone());
+                    s.rounds.push(RoundResult {
+                        turn: 1,
+                        action: "implement".into(),
+                        result: "plan_issue".into(),
+                        detail: if output.is_empty() {
+                            None
+                        } else {
+                            Some(output.clone())
+                        },
+                        first_token_latency_ms: impl_first_token_ms,
+                    });
+                })
+                .await?;
                 tracing::info!(
                     task_id = %task_id,
-                    pr_number = fallback_num,
-                    pr_url = %fallback_url,
-                    "PR_URL sentinel missing from output; recovered via GitHub REST"
+                    status = "failed",
+                    turns = 2,
+                    pr_url = tracing::field::Empty,
+                    total_elapsed_secs = task_start.elapsed().as_secs(),
+                    "task_completed"
                 );
-                pr_url = Some(fallback_url);
-                pr_num = Some(fallback_num);
+                return Ok(ImplementOutcome::Done);
             }
-        }
+            ImplementationOutcome::ParsedPr {
+                pr_url,
+                pr_num,
+                created_issue_num,
+            } => (pr_url, pr_num, created_issue_num),
+        };
 
         mutate_and_persist(store, task_id, |s| {
             s.pr_url = pr_url.clone();

--- a/crates/harness-server/src/task_executor/pr_detection.rs
+++ b/crates/harness-server/src/task_executor/pr_detection.rs
@@ -393,96 +393,6 @@ fn strip_trailing_repo_qualifier(s: &str) -> Option<&str> {
     Some(&s[..owner_start])
 }
 
-/// Attempt to recover a PR URL when the agent output lacked a `PR_URL=` sentinel.
-///
-/// Detects the current branch from Git metadata and then queries GitHub's REST
-/// API for open PRs whose head branch matches. Returns `(pr_number, pr_url)` for
-/// the first result, or `None` when branch, repo, or GitHub state is unavailable.
-pub(crate) async fn fallback_find_pr_by_branch(project_root: &Path) -> Option<(u64, String)> {
-    let Some(branch) = current_branch_from_git_metadata(project_root) else {
-        tracing::warn!("fallback_find_pr_by_branch: detached HEAD, cannot search by branch");
-        return None;
-    };
-
-    let Some(repo_slug) = detect_repo_slug(project_root).await else {
-        tracing::warn!(
-            branch = %branch,
-            project = %project_root.display(),
-            "fallback_find_pr_by_branch: repository slug unavailable"
-        );
-        return None;
-    };
-
-    let url = format!("https://api.github.com/repos/{repo_slug}/pulls?state=open&per_page=100");
-    let client = reqwest::Client::new();
-    let mut request = client
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
-        .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        if !token.trim().is_empty() {
-            request = request.bearer_auth(token);
-        }
-    }
-    let response =
-        match tokio::time::timeout(std::time::Duration::from_secs(10), request.send()).await {
-            Ok(Ok(response)) if response.status().is_success() => response,
-            Ok(Ok(response)) => {
-                tracing::warn!(
-                    branch = %branch,
-                    repo = %repo_slug,
-                    status = %response.status(),
-                    "fallback_find_pr_by_branch: GitHub state check returned non-success status"
-                );
-                return None;
-            }
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    branch = %branch,
-                    repo = %repo_slug,
-                    error = %e,
-                    "fallback_find_pr_by_branch: GitHub state check failed"
-                );
-                return None;
-            }
-            Err(_) => {
-                tracing::warn!(
-                    branch = %branch,
-                    repo = %repo_slug,
-                    "fallback_find_pr_by_branch: GitHub state check timed out"
-                );
-                return None;
-            }
-        };
-
-    let items: Vec<GhPrListItem> = match response
-        .json::<Vec<GitHubPullItem>>()
-        .await
-        .map(|items| items.into_iter().map(Into::into).collect())
-    {
-        Ok(items) => items,
-        Err(e) => {
-            tracing::warn!(
-                branch = %branch,
-                repo = %repo_slug,
-                error = %e,
-                "fallback_find_pr_by_branch: JSON parse failed"
-            );
-            return None;
-        }
-    };
-    let first = items
-        .into_iter()
-        .find(|item| item.head_ref_name == branch)?;
-    tracing::info!(
-        branch = %branch,
-        pr_number = first.number,
-        pr_url = %first.url,
-        "fallback_find_pr_by_branch: recovered PR via GitHub REST"
-    );
-    Some((first.number, first.url))
-}
-
 /// Parse `"owner/repo"` from a git remote URL.
 ///
 /// Handles HTTPS (`https://github.com/owner/repo.git`),
@@ -602,47 +512,6 @@ fn config_candidates_from_gitdir_file(dotgit: &Path) -> Vec<PathBuf> {
         candidates.push(common_git_dir.join("config"));
     }
     candidates
-}
-
-fn current_branch_from_git_metadata(project: &Path) -> Option<String> {
-    let git_dir = discover_git_dir(project)?;
-    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
-    let branch = head.trim().strip_prefix("ref: refs/heads/")?.trim();
-    if branch.is_empty() {
-        None
-    } else {
-        Some(branch.to_string())
-    }
-}
-
-fn discover_git_dir(project: &Path) -> Option<PathBuf> {
-    let mut current = if project.is_dir() {
-        Some(project)
-    } else {
-        project.parent()
-    };
-    while let Some(dir) = current {
-        let dotgit = dir.join(".git");
-        if dotgit.is_dir() {
-            return Some(dotgit);
-        }
-        if dotgit.is_file() {
-            return gitdir_from_file(&dotgit);
-        }
-        current = dir.parent();
-    }
-    None
-}
-
-fn gitdir_from_file(dotgit: &Path) -> Option<PathBuf> {
-    let contents = std::fs::read_to_string(dotgit).ok()?;
-    let raw_gitdir = contents.trim().strip_prefix("gitdir:")?;
-    let path = PathBuf::from(raw_gitdir.trim());
-    if path.is_absolute() {
-        Some(path)
-    } else {
-        dotgit.parent().map(|parent| parent.join(path))
-    }
 }
 
 fn parse_remote_urls_from_git_config(config: &str) -> Vec<(String, String)> {
@@ -949,31 +818,6 @@ mod tests {
     }
 
     // --- parse_harness_mention_command (pre-existing, light coverage) ---
-
-    // --- fallback_find_pr_by_branch JSON parsing tests (T6 / T7) ---
-
-    #[test]
-    fn fallback_json_valid_returns_first_item() {
-        // T6: GitHub REST JSON with one match should deserialize correctly.
-        let json = r#"[{"number":42,"html_url":"https://github.com/owner/repo/pull/42","title":"fix","body":null,"head":{"ref":"codex/fix"}}]"#;
-        let items: Vec<GhPrListItem> = serde_json::from_str::<Vec<GitHubPullItem>>(json)
-            .unwrap()
-            .into_iter()
-            .map(Into::into)
-            .collect();
-        let first = items.into_iter().next().unwrap();
-        assert_eq!(first.number, 42);
-        assert_eq!(first.url, "https://github.com/owner/repo/pull/42");
-        assert_eq!(first.head_ref_name, "codex/fix");
-    }
-
-    #[test]
-    fn fallback_json_empty_array_returns_none() {
-        // T7: empty JSON array — no PR found on this branch.
-        let json = r#"[]"#;
-        let items: Vec<serde_json::Value> = serde_json::from_str(json).unwrap();
-        assert!(items.into_iter().next().is_none());
-    }
 
     #[test]
     fn parses_fix_ci_command() {


### PR DESCRIPTION
## Summary
- remove the hidden GitHub REST fallback that recovered PR URLs after agent output parsing in the implement pipeline
- keep PR binding sourced only from agent-visible output and persisted task artifacts
- delete the now-unused branch-based recovery helper and its orphaned tests

## Signal report
- Root cause: when agent output lacked `PR_URL=...`, `run_implement_phase` queried GitHub state directly via `fallback_find_pr_by_branch` and synthesized the PR URL server-side.
- Impact: task completion could depend on hidden server-side GitHub I/O rather than the audited agent prompt/output contract, weakening observability for a correctness-critical decision.
- Fix: remove the server-side fallback so issue/PR tasks follow the existing explicit failure path when no PR URL is present in agent-visible output.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` *(fails in this workspace with broad unrelated `harness-server` test failures; isolated touched coverage passed, and the failing DB-backed tests report `ECIRCUITBREAKER` authentication errors)*
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test -p harness-server task_executor::implement_pipeline::tests::`
- `cargo test -p harness-server task_executor::pr_detection::tests::`