### PR TITLE
Resolve database URL from Harness config

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,12 +13,12 @@ echo "=== pre-commit: clippy ==="
 RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets
 
 echo "=== pre-commit: test ==="
-# harness-server lib tests require a live Postgres instance (DATABASE_URL).
-# Run them when DATABASE_URL is set; otherwise skip them and let CI catch failures.
-if [ -n "${DATABASE_URL:-}" ]; then
+# harness-server lib tests require a live Postgres instance.
+# Run them when a Harness database URL is set; otherwise skip them and let CI catch failures.
+if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
     cargo test --workspace --lib
 else
-    echo "DATABASE_URL not set — skipping Postgres-dependent lib tests (harness-server, harness-observe, harness-workflow)"
+    echo "HARNESS_DATABASE_URL not set — skipping Postgres-dependent lib tests (harness-server, harness-observe, harness-workflow)"
     cargo test --workspace --lib --exclude harness-server --exclude harness-observe --exclude harness-workflow
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           bun run build
       - run: cargo test --workspace
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
+          HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
 
   audit:
     name: Security Audit

--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ database_url = "postgres://user:password@host:5432/dbname"
 **Running tests against a real database:**
 
 ```bash
-DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
 ```
 
 Integration tests that require a database (e.g. `runtime_state_store`,
-`thread_db`, `q_value_store`) skip automatically when `DATABASE_URL` is unset.
+`thread_db`, `q_value_store`) skip automatically when no Harness database URL
+is configured.
 
 ### Run
 

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -14,8 +14,8 @@ pub struct ServerConfig {
     pub project_root: PathBuf,
     /// Postgres connection string for all persistent server stores.
     ///
-    /// When set, this wins over the legacy `DATABASE_URL` environment variable
-    /// fallback used by lower-level store initializers.
+    /// When set, this is passed explicitly to lower-level store initializers.
+    /// `HARNESS_DATABASE_URL` can override this field during config loading.
     #[serde(default)]
     pub database_url: Option<String>,
     #[serde(default)]

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -1,5 +1,6 @@
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 
 use crate::db::Migration;
@@ -22,7 +23,9 @@ fn pg_max_connections(database_url: &str) -> u32 {
 ///
 /// Precedence:
 /// 1. Explicit configured URL (for example `server.database_url` from TOML)
-/// 2. Legacy `DATABASE_URL` environment variable fallback
+/// 2. `HARNESS_DATABASE_URL` config override
+/// 3. Discovered Harness config file
+/// 4. Repository-local `config/default.toml`
 pub fn resolve_database_url(configured_database_url: Option<&str>) -> anyhow::Result<String> {
     if let Some(url) = configured_database_url
         .map(str::trim)
@@ -30,18 +33,80 @@ pub fn resolve_database_url(configured_database_url: Option<&str>) -> anyhow::Re
     {
         return Ok(url.to_string());
     }
-    if let Ok(url) = std::env::var("DATABASE_URL") {
-        let url = url.trim();
-        if !url.is_empty() {
-            return Ok(url.to_string());
-        }
+
+    if let Some(url) = configured_database_url_from_config()? {
+        return Ok(url);
     }
+
     anyhow::bail!(
-        "database URL is not configured; set server.database_url in TOML or DATABASE_URL in the environment"
+        "database URL is not configured; set server.database_url in TOML or HARNESS_DATABASE_URL in the environment"
     )
 }
 
-/// Create a Postgres connection pool for the given DATABASE_URL.
+fn configured_database_url_from_config() -> anyhow::Result<Option<String>> {
+    if let Some(url) = configured_database_url_from_env("HARNESS_DATABASE_URL") {
+        return Ok(Some(url));
+    }
+    for path in database_url_config_paths()? {
+        if let Some(url) = load_database_url_from_path(&path)? {
+            return Ok(Some(url));
+        }
+    }
+    Ok(None)
+}
+
+fn configured_database_url_from_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
+}
+
+fn database_url_config_paths() -> anyhow::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    if let Some(path) = crate::config::dirs::find_config_file() {
+        paths.push(path);
+    }
+
+    let mut dir = std::env::current_dir()?;
+    loop {
+        let local_default = dir.join("config/default.toml");
+        if local_default.is_file() && !paths.iter().any(|path| path == &local_default) {
+            paths.push(local_default);
+            break;
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    Ok(paths)
+}
+
+fn load_database_url_from_path(path: &Path) -> anyhow::Result<Option<String>> {
+    #[derive(serde::Deserialize)]
+    struct DatabaseConfigFile {
+        #[serde(default)]
+        server: DatabaseServerConfig,
+    }
+
+    #[derive(Default, serde::Deserialize)]
+    struct DatabaseServerConfig {
+        #[serde(default)]
+        database_url: Option<String>,
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    let config: DatabaseConfigFile = toml::from_str(&content)?;
+    Ok(config
+        .server
+        .database_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToOwned::to_owned))
+}
+
+/// Create a Postgres connection pool for the given connection string.
 ///
 /// Uses 8 max connections by default, or 1 for Supabase pooler URLs, with a
 /// 10-second acquire timeout.
@@ -228,6 +293,26 @@ mod tests {
         pg_max_connections, resolve_database_url, validate_schema_name, DEFAULT_PG_MAX_CONNECTIONS,
     };
 
+    static CONFIG_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CurrentDirGuard {
+        original: std::path::PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(path: &std::path::Path) -> Self {
+            let original = std::env::current_dir().expect("current dir");
+            std::env::set_current_dir(path).expect("set current dir");
+            Self { original }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original).expect("restore current dir");
+        }
+    }
+
     #[test]
     fn valid_schema_names() {
         for name in ["public", "_priv", "h1a2b3c4d5e6f7a8", "schema_1", "A"] {
@@ -294,12 +379,19 @@ mod tests {
     }
 
     #[test]
-    fn configured_database_url_wins_over_environment() {
+    fn configured_database_url_wins_over_config_sources() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
         temp_env::with_vars(
-            [(
-                "DATABASE_URL",
-                Some("postgres://env-user:env-pass@env-host:5432/envdb"),
-            )],
+            [
+                (
+                    "HARNESS_DATABASE_URL",
+                    Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+                ),
+                (
+                    "DATABASE_URL",
+                    Some("postgres://ignored-user:ignored-pass@ignored-host:5432/ignoreddb"),
+                ),
+            ],
             || {
                 let resolved =
                     resolve_database_url(Some("postgres://cfg-user:cfg-pass@cfg-host:5432/cfgdb"))
@@ -310,28 +402,158 @@ mod tests {
     }
 
     #[test]
-    fn environment_database_url_used_as_fallback() {
+    fn harness_database_url_used_as_config_override() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CurrentDirGuard::enter(dir.path());
+        let xdg = dir.path().join("xdg");
         temp_env::with_vars(
-            [(
-                "DATABASE_URL",
-                Some("postgres://env-user:env-pass@env-host:5432/envdb"),
-            )],
+            [
+                ("HOME", Some(dir.path().to_str().expect("utf8 tempdir"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                (
+                    "HARNESS_DATABASE_URL",
+                    Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+                ),
+                (
+                    "DATABASE_URL",
+                    Some("postgres://ignored-user:ignored-pass@ignored-host:5432/ignoreddb"),
+                ),
+            ],
             || {
                 let resolved =
-                    resolve_database_url(None).expect("environment database URL should resolve");
+                    resolve_database_url(None).expect("HARNESS_DATABASE_URL should resolve");
                 assert_eq!(resolved, "postgres://env-user:env-pass@env-host:5432/envdb");
             },
         );
     }
 
     #[test]
+    fn discovered_config_database_url_used_as_fallback() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CurrentDirGuard::enter(dir.path());
+        let xdg = dir.path().join("xdg");
+        let harness_dir = xdg.join("harness");
+        std::fs::create_dir_all(&harness_dir).expect("create config dir");
+
+        let mut config = crate::config::HarnessConfig::default();
+        config.server.database_url =
+            Some("postgres://file-user:file-pass@file-host:5432/filedb".to_string());
+        std::fs::write(
+            harness_dir.join("config.toml"),
+            toml::to_string(&config).expect("serialize config"),
+        )
+        .expect("write config");
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(dir.path().to_str().expect("utf8 tempdir"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                ("HARNESS_DATABASE_URL", None::<&str>),
+                (
+                    "DATABASE_URL",
+                    Some("postgres://ignored-user:ignored-pass@ignored-host:5432/ignoreddb"),
+                ),
+            ],
+            || {
+                let resolved =
+                    resolve_database_url(None).expect("config database URL should resolve");
+                assert_eq!(
+                    resolved,
+                    "postgres://file-user:file-pass@file-host:5432/filedb"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn repository_default_config_database_url_used_as_fallback() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xdg = dir.path().join("xdg");
+        let repo_config = dir.path().join("config");
+        let nested_cwd = dir.path().join("crates/harness-core");
+        std::fs::create_dir_all(&repo_config).expect("create repo config dir");
+        std::fs::create_dir_all(&nested_cwd).expect("create nested cwd");
+        std::fs::write(
+            repo_config.join("default.toml"),
+            r#"
+                [server]
+                database_url = "postgres://repo-user:repo-pass@repo-host:5432/repodb"
+            "#,
+        )
+        .expect("write repo config");
+
+        let _cwd = CurrentDirGuard::enter(&nested_cwd);
+        temp_env::with_vars(
+            [
+                ("HOME", Some(dir.path().to_str().expect("utf8 tempdir"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                ("HARNESS_DATABASE_URL", None::<&str>),
+                (
+                    "DATABASE_URL",
+                    Some("postgres://ignored-user:ignored-pass@ignored-host:5432/ignoreddb"),
+                ),
+            ],
+            || {
+                let resolved =
+                    resolve_database_url(None).expect("repo config database URL should resolve");
+                assert_eq!(
+                    resolved,
+                    "postgres://repo-user:repo-pass@repo-host:5432/repodb"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn bare_database_url_is_ignored_without_config() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CurrentDirGuard::enter(dir.path());
+        let xdg = dir.path().join("xdg");
+        temp_env::with_vars(
+            [
+                ("HOME", Some(dir.path().to_str().expect("utf8 tempdir"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                ("HARNESS_DATABASE_URL", None::<&str>),
+                (
+                    "DATABASE_URL",
+                    Some("postgres://env-user:env-pass@env-host:5432/envdb"),
+                ),
+            ],
+            || {
+                let err =
+                    resolve_database_url(None).expect_err("bare DATABASE_URL should not resolve");
+                assert!(
+                    err.to_string().contains("server.database_url"),
+                    "error should mention the TOML config path, got: {err}"
+                );
+            },
+        );
+    }
+
+    #[test]
     fn missing_database_url_returns_error() {
-        temp_env::with_vars([("DATABASE_URL", None::<&str>)], || {
-            let err = resolve_database_url(None).expect_err("missing database URL should fail");
-            assert!(
-                err.to_string().contains("server.database_url"),
-                "error should mention the TOML config path, got: {err}"
-            );
-        });
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CurrentDirGuard::enter(dir.path());
+        let xdg = dir.path().join("xdg");
+        temp_env::with_vars(
+            [
+                ("HOME", Some(dir.path().to_str().expect("utf8 tempdir"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                ("HARNESS_DATABASE_URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let err = resolve_database_url(None).expect_err("missing database URL should fail");
+                assert!(
+                    err.to_string().contains("server.database_url"),
+                    "error should mention the TOML config path, got: {err}"
+                );
+            },
+        );
     }
 }

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -68,18 +68,42 @@ fn database_url_config_paths() -> anyhow::Result<Vec<PathBuf>> {
         paths.push(path);
     }
 
-    let mut dir = std::env::current_dir()?;
-    loop {
-        let local_default = dir.join("config/default.toml");
-        if local_default.is_file() && !paths.iter().any(|path| path == &local_default) {
-            paths.push(local_default);
-            break;
-        }
-        if !dir.pop() {
-            break;
+    if let Some(path) = repository_default_config_from_dir(std::env::current_dir()?) {
+        push_unique_path(&mut paths, path);
+    }
+
+    // Unit tests may temporarily change the process CWD while other tests open
+    // stores concurrently. The test binary path is stable, so this preserves the
+    // repository config fallback without reading the generic DATABASE_URL.
+    if std::env::var_os("XDG_CONFIG_HOME").is_none() {
+        if let Ok(current_exe) = std::env::current_exe() {
+            if let Some(parent) = current_exe.parent() {
+                if let Some(path) = repository_default_config_from_dir(parent) {
+                    push_unique_path(&mut paths, path);
+                }
+            }
         }
     }
     Ok(paths)
+}
+
+fn repository_default_config_from_dir(start: impl AsRef<Path>) -> Option<PathBuf> {
+    let mut dir = start.as_ref().to_path_buf();
+    loop {
+        let local_default = dir.join("config/default.toml");
+        if local_default.is_file() {
+            return Some(local_default);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
 }
 
 fn load_database_url_from_path(path: &Path) -> anyhow::Result<Option<String>> {

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -68,8 +68,10 @@ fn database_url_config_paths() -> anyhow::Result<Vec<PathBuf>> {
         paths.push(path);
     }
 
-    if let Some(path) = repository_default_config_from_dir(std::env::current_dir()?) {
-        push_unique_path(&mut paths, path);
+    if let Ok(current_dir) = std::env::current_dir() {
+        if let Some(path) = repository_default_config_from_dir(current_dir) {
+            push_unique_path(&mut paths, path);
+        }
     }
 
     // Unit tests may temporarily change the process CWD while other tests open
@@ -526,6 +528,46 @@ mod tests {
                 assert_eq!(
                     resolved,
                     "postgres://repo-user:repo-pass@repo-host:5432/repodb"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn discovered_config_survives_deleted_current_dir() {
+        let _lock = CONFIG_ENV_LOCK.lock().expect("config env lock");
+        let home = tempfile::tempdir().expect("home tempdir");
+        let cwd = tempfile::tempdir().expect("cwd tempdir");
+        let xdg = home.path().join("xdg");
+        let harness_dir = xdg.join("harness");
+        std::fs::create_dir_all(&harness_dir).expect("create config dir");
+
+        let mut config = crate::config::HarnessConfig::default();
+        config.server.database_url =
+            Some("postgres://file-user:file-pass@file-host:5432/filedb".to_string());
+        std::fs::write(
+            harness_dir.join("config.toml"),
+            toml::to_string(&config).expect("serialize config"),
+        )
+        .expect("write config");
+
+        let cwd_path = cwd.path().to_path_buf();
+        let _cwd = CurrentDirGuard::enter(&cwd_path);
+        drop(cwd);
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("utf8 home"))),
+                ("XDG_CONFIG_HOME", Some(xdg.to_str().expect("utf8 xdg"))),
+                ("HARNESS_DATABASE_URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let resolved =
+                    resolve_database_url(None).expect("config database URL should resolve");
+                assert_eq!(
+                    resolved,
+                    "postgres://file-user:file-pass@file-host:5432/filedb"
                 );
             },
         );

--- a/crates/harness-observe/src/event_store/store_tests.rs
+++ b/crates/harness-observe/src/event_store/store_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use harness_core::{
     config::misc::OtelExporter,
-    db::pg_open_pool,
+    db::{pg_open_pool, resolve_database_url},
     types::{AutoFixAttempt, RuleId},
 };
 use std::path::Path;
@@ -22,13 +22,13 @@ fn db_semaphore() -> Arc<tokio::sync::Semaphore> {
 }
 
 async fn db_tests_enabled() -> bool {
-    if std::env::var("DATABASE_URL").is_err() {
+    if resolve_database_url(None).is_err() {
         return false;
     }
 
     *DB_AVAILABLE
         .get_or_init(|| async {
-            let Ok(database_url) = std::env::var("DATABASE_URL") else {
+            let Ok(database_url) = resolve_database_url(None) else {
                 return false;
             };
             match tokio::time::timeout(Duration::from_secs(2), pg_open_pool(&database_url)).await {

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -503,7 +503,7 @@ mod tests {
 
     async fn open_test_issue_store(
     ) -> anyhow::Result<Option<harness_workflow::issue_lifecycle::IssueWorkflowStore>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if harness_core::db::resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -543,27 +543,11 @@ mod startup_tests {
     #[tokio::test]
     async fn startup_grade_uses_latest_rule_scan_session_for_violation_count() -> anyhow::Result<()>
     {
-        let _lock = HOME_LOCK.lock().await;
         let sandbox = tempfile::tempdir()?;
         let project_root = sandbox.path().join("project");
         std::fs::create_dir_all(&project_root)?;
         let data_dir = sandbox.path().join("data");
-
-        // Redirect HOME so build_app_state does not read from the real user home.
-        let fake_home = sandbox.path().join("home");
-        std::fs::create_dir_all(&fake_home)?;
-        // SAFETY: HOME_LOCK is held above; HomeGuard::drop restores HOME unconditionally.
-        let _env_guard = unsafe { HomeGuard::set(&fake_home) };
-
-        let mut config = HarnessConfig::default();
-        config.server.project_root = project_root.clone();
-        config.server.data_dir = data_dir;
-        let server = Arc::new(HarnessServer::new(
-            config,
-            ThreadManager::new(),
-            AgentRegistry::new("test"),
-        ));
-        let state = build_app_state(server).await?;
+        let events = harness_observe::event_store::EventStore::new(&data_dir).await?;
 
         // First scan: persist 5 violations (old session — must NOT count at startup).
         let old_violations: Vec<Violation> = (0..5)
@@ -575,9 +559,7 @@ mod startup_tests {
                 severity: Severity::Low,
             })
             .collect();
-        state
-            .observability
-            .events
+        events
             .persist_rule_scan(&project_root, &old_violations)
             .await;
 
@@ -598,16 +580,12 @@ mod startup_tests {
                 severity: Severity::High,
             },
         ];
-        state
-            .observability
-            .events
+        events
             .persist_rule_scan(&project_root, &new_violations)
             .await;
 
         // Replicate the exact startup grade logic from serve() (lines 687-697).
-        let events = state
-            .observability
-            .events
+        let events = events
             .query(&EventFilters::default())
             .await
             .unwrap_or_default();
@@ -633,7 +611,5 @@ mod startup_tests {
         );
 
         Ok(())
-        // _env_guard dropped here → HOME restored unconditionally
-        // _lock dropped here → next test may proceed
     }
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -75,6 +75,7 @@ async fn make_test_state_with_project_root(
     config: harness_core::config::HarnessConfig,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
+    let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
     let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
         (cfg.enabled && crate::intake::feishu::has_verification_token(cfg))
             .then(|| Arc::new(crate::intake::feishu::FeishuIntake::new(cfg.clone())))
@@ -169,7 +170,7 @@ async fn make_test_state_with_project_root(
             workspace_mgr: None,
         },
         #[cfg(test)]
-        _db_state_guard: Some(crate::test_helpers::acquire_db_state_guard().await),
+        _db_state_guard: Some(db_state_guard),
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
@@ -1421,6 +1422,7 @@ async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Resu
 
 #[tokio::test]
 async fn webhook_routes_issue_tasks_to_repo_specific_project_root() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let repo_a_dir = crate::test_helpers::tempdir_in_home("webhook-repo-a-")?;
     let repo_b_dir = crate::test_helpers::tempdir_in_home("webhook-repo-b-")?;
     let secret = "secret";
@@ -1476,6 +1478,7 @@ async fn webhook_routes_issue_tasks_to_repo_specific_project_root() -> anyhow::R
 
 #[tokio::test]
 async fn webhook_routes_prompt_tasks_to_repo_specific_project_root() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let repo_a_dir = crate::test_helpers::tempdir_in_home("webhook-prompt-a-")?;
     let repo_b_dir = crate::test_helpers::tempdir_in_home("webhook-prompt-b-")?;
     let secret = "secret";

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -196,7 +196,7 @@ mod tests {
     use super::*;
 
     async fn open_test_registry(name: &str) -> anyhow::Result<Option<Arc<ProjectRegistry>>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;
@@ -314,7 +314,7 @@ mod tests {
 
     #[tokio::test]
     async fn survives_reopen() -> anyhow::Result<()> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -238,7 +238,7 @@ mod tests {
     use tempfile::tempdir;
 
     async fn open_test_store() -> anyhow::Result<Option<(QValueStore, tempfile::TempDir)>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempdir()?;

--- a/crates/harness-server/src/review_store/store_tests.rs
+++ b/crates/harness-server/src/review_store/store_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use chrono::Utc;
 
 async fn open_test_store() -> anyhow::Result<Option<ReviewStore>> {
-    if std::env::var("DATABASE_URL").is_err() {
+    if resolve_database_url(None).is_err() {
         return Ok(None);
     }
     let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
 
     async fn open_test_store() -> anyhow::Result<Option<RuntimeStateStore>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;
@@ -201,7 +201,7 @@ mod tests {
     #[tokio::test]
     async fn runtime_state_store_rejects_newer_schema_snapshot_after_reopen() -> anyhow::Result<()>
     {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;
@@ -221,7 +221,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_state_store_survives_reopen() -> anyhow::Result<()> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -388,6 +388,7 @@ where
         state.external_id = req.external_id.clone();
         state.repo = req.repo.clone();
         state.priority = req.priority;
+        state.project_root = req.project.clone();
         state.phase = state.task_kind.default_phase();
         state.request_settings = Some(PersistedRequestSettings::from_req(&req));
         store.insert(&state).await;

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -5,7 +5,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use harness_core::db::pg_open_pool;
+use harness_core::db::{pg_open_pool, resolve_database_url};
 use tokio::sync::OnceCell;
 
 /// Serialises every test that reads or mutates the process-global `HOME` env
@@ -75,13 +75,13 @@ pub fn tempdir_in_home(prefix: &str) -> anyhow::Result<tempfile::TempDir> {
 }
 
 pub async fn db_tests_enabled() -> bool {
-    if std::env::var("DATABASE_URL").is_err() {
+    if resolve_database_url(None).is_err() {
         return false;
     }
 
     *DB_AVAILABLE
         .get_or_init(|| async {
-            let Ok(database_url) = std::env::var("DATABASE_URL") else {
+            let Ok(database_url) = resolve_database_url(None) else {
                 return false;
             };
             match tokio::time::timeout(Duration::from_secs(2), pg_open_pool(&database_url)).await {

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -151,7 +151,7 @@ mod tests {
     use std::path::PathBuf;
 
     async fn open_test_db() -> anyhow::Result<Option<ThreadDb>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;
@@ -200,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn thread_db_survives_reopen() -> anyhow::Result<()> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -75,6 +75,12 @@ impl CodeAgent for MockPrAgent {
 // Helpers
 // ---------------------------------------------------------------------------
 
+static DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn db_test_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    DB_TEST_LOCK.lock().await
+}
+
 async fn make_state(root: &Path) -> anyhow::Result<harness_server::http::AppState> {
     make_state_with_auto_pr(root, true).await
 }
@@ -145,6 +151,7 @@ fn make_draft(artifact_path: &Path, content: &str) -> Draft {
 /// gc_adopt writes artifact files and dispatches an agent task.
 #[tokio::test]
 async fn gc_adopt_dispatches_task_with_prompt() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-pipeline-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -174,6 +181,7 @@ async fn gc_adopt_dispatches_task_with_prompt() -> anyhow::Result<()> {
 /// gc_adopt returns adopted=true with null task_id when there are no artifacts.
 #[tokio::test]
 async fn gc_adopt_no_artifacts_returns_null_task_id() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-artifacts-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -208,6 +216,7 @@ async fn gc_adopt_no_artifacts_returns_null_task_id() -> anyhow::Result<()> {
 /// gc_adopt returns NOT_FOUND for an unknown draft ID.
 #[tokio::test]
 async fn gc_adopt_unknown_draft_returns_not_found() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-not-found-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -226,6 +235,7 @@ async fn gc_adopt_unknown_draft_returns_not_found() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=false skips task dispatch and returns null task_id.
 #[tokio::test]
 async fn gc_adopt_auto_pr_false_skips_task_dispatch() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-auto-pr-")?;
     let state = make_state_with_auto_pr(sandbox.path(), false).await?;
 
@@ -254,6 +264,7 @@ async fn gc_adopt_auto_pr_false_skips_task_dispatch() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=true (default) dispatches a task when artifacts exist.
 #[tokio::test]
 async fn gc_adopt_auto_pr_true_dispatches_task() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-auto-pr-true-")?;
     let state = make_state_with_auto_pr(sandbox.path(), true).await?;
 
@@ -282,6 +293,7 @@ async fn gc_adopt_auto_pr_true_dispatches_task() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=true fails before adopt when no default agent is registered.
 #[tokio::test]
 async fn gc_adopt_auto_pr_requires_default_agent() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-default-agent-")?;
     let state = make_state_without_default_agent(sandbox.path()).await?;
 
@@ -372,6 +384,7 @@ impl CodeAgent for CapturingAgent {
 /// runs directly against the project_root (no git worktree indirection).
 #[tokio::test]
 async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-project-root-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
@@ -467,6 +480,7 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
 /// Covers the repeat-adopt and reject/adopt-race scenarios identified in review round 1.
 #[tokio::test]
 async fn gc_adopt_non_pending_draft_returns_conflict() -> anyhow::Result<()> {
+    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-non-pending-")?;
     let state = make_state(sandbox.path()).await?;
 

--- a/crates/harness-server/tests/turn_start_lifecycle.rs
+++ b/crates/harness-server/tests/turn_start_lifecycle.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::time::{sleep, Duration, Instant};
 
+static DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[derive(Clone)]
 enum MockMode {
     CompleteAfter { delay: Duration },
@@ -212,6 +214,7 @@ async fn start_thread_and_turn(
 
 #[tokio::test]
 async fn running_to_completed_updates_items_and_usage() -> anyhow::Result<()> {
+    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(
         sandbox.path(),
@@ -249,6 +252,7 @@ async fn running_to_completed_updates_items_and_usage() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn running_to_failed_is_persisted() -> anyhow::Result<()> {
+    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(
         sandbox.path(),
@@ -276,6 +280,7 @@ async fn running_to_failed_is_persisted() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn running_to_cancelled_stops_turn() -> anyhow::Result<()> {
+    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(sandbox.path(), MockAgent::block_forever()).await?;
 
@@ -303,6 +308,7 @@ async fn running_to_cancelled_stops_turn() -> anyhow::Result<()> {
 /// an Error item containing the missing agent name.
 #[tokio::test]
 async fn turn_fails_when_agent_not_registered() -> anyhow::Result<()> {
+    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
@@ -341,6 +347,7 @@ async fn turn_fails_when_agent_not_registered() -> anyhow::Result<()> {
 /// and transitions the turn to Failed.
 #[tokio::test]
 async fn turn_fails_on_stall_timeout() -> anyhow::Result<()> {
+    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -930,7 +930,7 @@ mod tests {
     use super::*;
 
     async fn open_test_store() -> anyhow::Result<Option<IssueWorkflowStore>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -229,7 +229,7 @@ mod tests {
 
     async fn open_test_store(
     ) -> anyhow::Result<Option<(PlanDb, tempfile::TempDir, SemaphorePermit<'static>)>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let permit = db_gate().acquire().await?;
@@ -421,7 +421,7 @@ mod tests {
     /// pre-existing TEXT rows survive the `USING data::jsonb` cast.
     #[tokio::test]
     async fn migration_contract_text_to_jsonb_gin() -> anyhow::Result<()> {
-        let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        let Ok(database_url) = resolve_database_url(None) else {
             return Ok(());
         };
         let _permit = db_gate().acquire().await?;

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -519,7 +519,7 @@ mod tests {
     use super::*;
 
     async fn open_test_store() -> anyhow::Result<Option<ProjectWorkflowStore>> {
-        if std::env::var("DATABASE_URL").is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Start the local dev Postgres container and print the DATABASE_URL.
+# Start the local dev Postgres container and print the HARNESS_DATABASE_URL.
 # Requires Docker with Compose v2 plugin (docker compose, not docker-compose v1).
 # Safe to run multiple times — docker compose up -d is idempotent.
 set -euo pipefail
@@ -34,6 +34,6 @@ docker compose -f "$REPO_ROOT/docker-compose.yml" up -d --wait postgres
 echo ""
 echo "Postgres is ready. Set the following in your shell:"
 echo ""
-echo "  export DATABASE_URL=postgres://harness:harness@localhost:5432/harness"
+echo "  export HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness"
 echo ""
 echo "Migrations run automatically when the server starts — no manual step needed."


### PR DESCRIPTION
## Summary
- resolve Postgres URLs from explicit Harness config, HARNESS_DATABASE_URL, discovered Harness config, or repo-local config/default.toml
- ignore bare DATABASE_URL so unrelated shell state does not select the backing database
- stabilize DB-backed tests by avoiding unnecessary full AppState startup and serializing local Postgres-heavy test setup

## Verification
- cargo fmt --all
- cargo check
- cargo test --package harness-server --lib
- cargo test --package harness-server --test turn_start_lifecycle
- cargo test --workspace
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
