### PR TITLE
Fix GitHub intake issue URL deserialization

### DIFF
--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -186,8 +186,8 @@ struct GhIssue {
     number: u64,
     title: String,
     body: Option<String>,
-    #[serde(alias = "html_url")]
     url: String,
+    html_url: Option<String>,
     #[serde(default)]
     labels: Vec<GhLabel>,
     #[serde(alias = "createdAt")]
@@ -231,7 +231,7 @@ fn parse_gh_output(
             title: issue.title,
             description: issue.body,
             repo: Some(repo.to_string()),
-            url: Some(issue.url),
+            url: Some(issue.html_url.unwrap_or(issue.url)),
             priority: None,
             labels: issue.labels.into_iter().map(|l| l.name).collect(),
             created_at: issue.created_at,
@@ -268,7 +268,11 @@ impl IntakeSource for GitHubIssuesPoller {
         }
         let response = request.send().await?;
         if !response.status().is_success() {
-            anyhow::bail!("GitHub issue list failed with status {}", response.status());
+            anyhow::bail!(
+                "GitHub issue list failed for {} with status {}",
+                self.repo,
+                response.status()
+            );
         }
         let body = response.bytes().await?;
 
@@ -412,6 +416,29 @@ mod tests {
             Some("https://github.com/owner/repo/issues/42")
         );
         assert_eq!(issue.labels, vec!["harness", "bug"]);
+    }
+
+    #[test]
+    fn parse_gh_output_accepts_api_url_and_html_url() {
+        let json = br#"[
+            {
+                "number": 42,
+                "title": "Fix login bug",
+                "body": null,
+                "url": "https://api.github.com/repos/owner/repo/issues/42",
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "labels": []
+            }
+        ]"#;
+
+        let dispatched = DashMap::new();
+        let parsed = parse_gh_output(json, "owner/repo", &dispatched, None).unwrap();
+
+        assert_eq!(parsed.new_issues.len(), 1);
+        assert_eq!(
+            parsed.new_issues[0].url.as_deref(),
+            Some("https://github.com/owner/repo/issues/42")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #999.

- Parse GitHub REST issue `url` and `html_url` as separate fields instead of aliasing both into one serde field.
- Prefer `html_url` for the task-facing issue link, falling back to the API `url` if needed.
- Include the repo slug in GitHub issue-list non-2xx errors so 404s identify the failing repo.
- Add a regression test for payloads containing both `url` and `html_url`.

## Tests

- `cargo check`
- `cargo fmt --all`
- `cargo test -p harness-server intake::github_issues::tests::parse_gh_output_accepts_api_url_and_html_url`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Local full-suite note:

- `cargo test` currently fails in this environment because harness-server tests require a usable database configuration. With the inherited `DATABASE_URL`, failures are Supabase pooler auth/circuit-breaker errors. With `DATABASE_URL` unset, failures report `database URL is not configured`. The changed GitHub intake tests pass.
