### PR TITLE
Backfill partial workflow migrations

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -373,7 +373,7 @@ async fn migrate_issue_workflows_if_needed(
     target_store: &harness_workflow::issue_lifecycle::IssueWorkflowStore,
 ) -> anyhow::Result<()> {
     let legacy_schema = harness_workflow::issue_lifecycle::legacy_schema_for_path(legacy_path)?;
-    if legacy_schema == target_schema || target_store.row_count().await? > 0 {
+    if legacy_schema == target_schema {
         return Ok(());
     }
 
@@ -407,7 +407,7 @@ async fn migrate_project_workflows_if_needed(
     target_store: &harness_workflow::project_lifecycle::ProjectWorkflowStore,
 ) -> anyhow::Result<()> {
     let legacy_schema = harness_workflow::project_lifecycle::legacy_schema_for_path(legacy_path)?;
-    if legacy_schema == target_schema || target_store.row_count().await? > 0 {
+    if legacy_schema == target_schema {
         return Ok(());
     }
 
@@ -439,7 +439,10 @@ mod tests {
     use super::*;
     use crate::{server::HarnessServer, thread_manager::ThreadManager};
     use harness_agents::registry::AgentRegistry;
-    use harness_core::config::HarnessConfig;
+    use harness_core::{
+        config::HarnessConfig,
+        db::{pg_schema_for_path, resolve_database_url},
+    };
 
     async fn make_test_server_and_tasks(
         dir: &Path,
@@ -503,7 +506,7 @@ mod tests {
 
     async fn open_test_issue_store(
     ) -> anyhow::Result<Option<harness_workflow::issue_lifecycle::IssueWorkflowStore>> {
-        if harness_core::db::resolve_database_url(None).is_err() {
+        if resolve_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;
@@ -612,6 +615,143 @@ mod tests {
         assert_eq!(rewritten, 1);
         assert_eq!(failed, 0);
         assert_eq!(skipped, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_workflow_migration_backfills_partial_target() -> anyhow::Result<()> {
+        let configured_database_url = match resolve_database_url(None) {
+            Ok(url) => Some(url),
+            Err(_) => return Ok(()),
+        };
+        let dir = tempfile::tempdir()?;
+        let legacy_path = dir.path().join("issue_workflows.db");
+        let target_schema = pg_schema_for_path(&dir.path().join("issue_workflows_target.db"))?;
+
+        let legacy_store =
+            harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
+                &legacy_path,
+                configured_database_url.as_deref(),
+            )
+            .await?;
+        let target_store =
+            harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url_and_schema(
+                configured_database_url.as_deref(),
+                &target_schema,
+            )
+            .await?;
+
+        legacy_store
+            .record_issue_scheduled(
+                "/tmp/project",
+                Some("owner/repo"),
+                9101,
+                "task-9101",
+                &[],
+                false,
+            )
+            .await?;
+        legacy_store
+            .record_issue_scheduled(
+                "/tmp/project",
+                Some("owner/repo"),
+                9102,
+                "task-9102",
+                &[],
+                false,
+            )
+            .await?;
+        target_store
+            .record_issue_scheduled(
+                "/tmp/project",
+                Some("owner/repo"),
+                9101,
+                "task-9101",
+                &[],
+                false,
+            )
+            .await?;
+
+        migrate_issue_workflows_if_needed(
+            configured_database_url.as_deref(),
+            &legacy_path,
+            &target_schema,
+            &target_store,
+        )
+        .await?;
+
+        assert!(
+            target_store
+                .get_by_issue("/tmp/project", Some("owner/repo"), 9101)
+                .await?
+                .is_some(),
+            "existing target row should remain present"
+        );
+        assert!(
+            target_store
+                .get_by_issue("/tmp/project", Some("owner/repo"), 9102)
+                .await?
+                .is_some(),
+            "missing legacy row should be backfilled even when target is non-empty"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn project_workflow_migration_backfills_partial_target() -> anyhow::Result<()> {
+        let configured_database_url = match resolve_database_url(None) {
+            Ok(url) => Some(url),
+            Err(_) => return Ok(()),
+        };
+        let dir = tempfile::tempdir()?;
+        let legacy_path = dir.path().join("project_workflows.db");
+        let target_schema = pg_schema_for_path(&dir.path().join("project_workflows_target.db"))?;
+
+        let legacy_store =
+            harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url(
+                &legacy_path,
+                configured_database_url.as_deref(),
+            )
+            .await?;
+        let target_store =
+            harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url_and_schema(
+                configured_database_url.as_deref(),
+                &target_schema,
+            )
+            .await?;
+
+        legacy_store
+            .record_poll_started("/tmp/project", Some("owner/repo"))
+            .await?;
+        legacy_store
+            .record_poll_started("/tmp/project", Some("owner/repo-two"))
+            .await?;
+        target_store
+            .record_poll_started("/tmp/project", Some("owner/repo"))
+            .await?;
+
+        migrate_project_workflows_if_needed(
+            configured_database_url.as_deref(),
+            &legacy_path,
+            &target_schema,
+            &target_store,
+        )
+        .await?;
+
+        assert!(
+            target_store
+                .get_by_project("/tmp/project", Some("owner/repo"))
+                .await?
+                .is_some(),
+            "existing target row should remain present"
+        );
+        assert!(
+            target_store
+                .get_by_project("/tmp/project", Some("owner/repo-two"))
+                .await?
+                .is_some(),
+            "missing legacy row should be backfilled even when target is non-empty"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Continue workflow migration when the target schema is non-empty instead of skipping the whole copy.
- Preserve existing target rows while backfilling missing legacy issue and project workflow rows.
- Add regression coverage for partial target schemas in both issue and project workflow migrations.

## Verification
- cargo fmt --all
- cargo check
- HARNESS_DATABASE_URL=postgres://postgres:postgres@localhost:55431/harness_test cargo test --package harness-server --lib http::builders::registry::tests:: -- --test-threads=1
- HARNESS_DATABASE_URL=postgres://postgres:postgres@localhost:55431/harness_test cargo test --workspace
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

Stacked on #1001; retarget to main after #995 and #1001 land.