### PR TITLE
Improve Codex runtime diagnostics and intake parsing

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -88,6 +88,117 @@ impl CodexAgent {
     }
 }
 
+#[derive(Debug)]
+struct ProgramSpawnDiagnostics {
+    resolved_path: Option<PathBuf>,
+    exists: bool,
+    executable: Option<bool>,
+}
+
+fn resolve_program_for_spawn(program: &Path, current_dir: &Path) -> Option<PathBuf> {
+    if program.components().count() == 1 {
+        let path = std::env::var_os("PATH")?;
+        std::env::split_paths(&path)
+            .map(|dir| dir.join(program))
+            .find(|candidate| candidate.is_file())
+    } else if program.is_absolute() && program.exists() {
+        Some(program.to_path_buf())
+    } else {
+        let candidate = current_dir.join(program);
+        candidate.exists().then_some(candidate)
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> Option<bool> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> Option<bool> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(metadata.is_file())
+}
+
+fn program_spawn_diagnostics(program: &Path, current_dir: &Path) -> ProgramSpawnDiagnostics {
+    let resolved_path = resolve_program_for_spawn(program, current_dir);
+    let executable = resolved_path.as_deref().and_then(is_executable);
+    ProgramSpawnDiagnostics {
+        exists: resolved_path.is_some(),
+        resolved_path,
+        executable,
+    }
+}
+
+fn log_codex_spawn_attempt(
+    program: &Path,
+    arg_count: usize,
+    req: &AgentRequest,
+    engine: harness_sandbox::SandboxEngine,
+    mode: &'static str,
+) {
+    let program_diag = program_spawn_diagnostics(program, &req.project_root);
+    let current_dir_exists = req.project_root.exists();
+    let current_dir_is_dir = req.project_root.is_dir();
+    tracing::debug!(
+        agent = "codex",
+        mode,
+        program = %program.display(),
+        program_resolved = program_diag
+            .resolved_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .as_deref()
+            .unwrap_or("<unresolved>"),
+        program_exists = program_diag.exists,
+        program_executable = ?program_diag.executable,
+        current_dir = %req.project_root.display(),
+        current_dir_exists,
+        current_dir_is_dir,
+        phase = ?req.execution_phase,
+        sandbox_engine = ?engine,
+        arg_count,
+        prompt_len = req.prompt.len(),
+        env_var_count = req.env_vars.len(),
+        "codex spawn prepared"
+    );
+}
+
+fn codex_spawn_failure_message(
+    error: &std::io::Error,
+    program: &Path,
+    req: &AgentRequest,
+    engine: harness_sandbox::SandboxEngine,
+    mode: &'static str,
+) -> String {
+    let program_diag = program_spawn_diagnostics(program, &req.project_root);
+    let current_dir_exists = req.project_root.exists();
+    let current_dir_is_dir = req.project_root.is_dir();
+    let resolved_program = program_diag
+        .resolved_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unresolved>".to_string());
+
+    format!(
+        "failed to run codex: {error}; mode={mode}; phase={:?}; program={}; \
+         program_resolved={resolved_program}; program_exists={}; program_executable={:?}; \
+         current_dir={}; current_dir_exists={current_dir_exists}; \
+         current_dir_is_dir={current_dir_is_dir}; sandbox_engine={engine:?}; \
+         prompt_len={}; env_var_count={}",
+        req.execution_phase,
+        program.display(),
+        program_diag.exists,
+        program_diag.executable,
+        req.project_root.display(),
+        req.prompt.len(),
+        req.env_vars.len(),
+    )
+}
+
 #[async_trait]
 impl CodeAgent for CodexAgent {
     fn name(&self) -> &str {
@@ -142,8 +253,28 @@ impl CodeAgent for CodexAgent {
             }
         }
 
+        log_codex_spawn_attempt(
+            &wrapped_command.program,
+            wrapped_command.args.len(),
+            &req,
+            wrapped_command.engine,
+            "execute",
+        );
         let child = cmd.spawn().map_err(|err| {
-            harness_core::error::HarnessError::AgentExecution(format!("failed to run codex: {err}"))
+            let message = codex_spawn_failure_message(
+                &err,
+                &wrapped_command.program,
+                &req,
+                wrapped_command.engine,
+                "execute",
+            );
+            tracing::error!(
+                agent = "codex",
+                mode = "execute",
+                error_kind = ?err.kind(),
+                "{message}"
+            );
+            harness_core::error::HarnessError::AgentExecution(message)
         })?;
         let output = child.wait_with_output().await.map_err(|err| {
             harness_core::error::HarnessError::AgentExecution(format!(
@@ -237,10 +368,28 @@ impl CodeAgent for CodexAgent {
             }
         }
 
+        log_codex_spawn_attempt(
+            &wrapped_command.program,
+            wrapped_command.args.len(),
+            &req,
+            wrapped_command.engine,
+            "execute_stream",
+        );
         let mut child = cmd.spawn().map_err(|error| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to run codex: {error}"
-            ))
+            let message = codex_spawn_failure_message(
+                &error,
+                &wrapped_command.program,
+                &req,
+                wrapped_command.engine,
+                "execute_stream",
+            );
+            tracing::error!(
+                agent = "codex",
+                mode = "execute_stream",
+                error_kind = ?error.kind(),
+                "{message}"
+            );
+            harness_core::error::HarnessError::AgentExecution(message)
         })?;
 
         if let Some(stderr) = child.stderr.take() {
@@ -861,6 +1010,20 @@ printf 'third\n'
             codex_sandbox_mode(SandboxMode::DangerFullAccess),
             "danger-full-access"
         );
+    }
+
+    #[test]
+    fn spawn_diagnostics_resolve_relative_program_from_spawn_current_dir() {
+        let project = tempdir().expect("create project dir");
+        let bin_dir = project.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create bin dir");
+        let program_path = bin_dir.join("codex");
+        fs::write(&program_path, "#!/bin/sh\n").expect("write program");
+
+        let resolved = resolve_program_for_spawn(Path::new("bin/codex"), project.path())
+            .expect("relative program should resolve from spawn current dir");
+
+        assert_eq!(resolved, program_path);
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -331,7 +331,7 @@ pub(crate) async fn run_implement_phase(
             project_root: project.to_path_buf(),
             context: context_items.clone(),
             max_budget_usd: req.max_budget_usd,
-            execution_phase: Some(ExecutionPhase::Planning),
+            execution_phase: Some(ExecutionPhase::Execution),
             allowed_tools: initial_allowed_tools.clone(),
             env_vars: cargo_env.clone(),
             ..Default::default()

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -1485,7 +1485,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn planning_phase_is_set_on_initial_implementation_turn() -> anyhow::Result<()> {
+    async fn execution_phase_is_set_on_initial_implementation_turn() -> anyhow::Result<()> {
         let _lock = crate::test_helpers::HOME_LOCK.lock().await;
         let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;
         let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
@@ -1530,8 +1530,8 @@ mod tests {
         );
         assert_eq!(
             phases[0],
-            Some(ExecutionPhase::Planning),
-            "initial implementation turn must use Planning phase"
+            Some(ExecutionPhase::Execution),
+            "initial implementation turn must use Execution phase"
         );
         Ok(())
     }
@@ -1587,8 +1587,8 @@ mod tests {
         );
         assert_eq!(
             phases[0],
-            Some(ExecutionPhase::Planning),
-            "implementation turn must use Planning phase"
+            Some(ExecutionPhase::Execution),
+            "implementation turn must use Execution phase"
         );
         assert_eq!(
             phases[1],


### PR DESCRIPTION
## Summary
- Add detailed Codex spawn diagnostics so runtime failures show the executable, cwd, phase, sandbox, prompt size, and environment count.
- Mark implementation turns with the execution phase during recovered task execution.
- Fix GitHub issue intake parsing by reading `html_url` directly instead of aliasing it with the API `url` field.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `cargo build --release`
- `cargo test --package harness-server intake::github_issues`
- `cargo test --package harness-server phase_is_set`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test` with local Postgres: 919 passed, 3 parallel-run failures; each failed test passed when rerun with `--exact`.