### PR TITLE
fix: report awaiting dependency task status from POST /tasks

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -58,6 +58,15 @@ pub(crate) async fn enqueue_task_background_in_domain(
         .await
 }
 
+fn create_task_status_response(state: &AppState, task_id: &task_runner::TaskId) -> &'static str {
+    match state.core.tasks.get(task_id) {
+        Some(task) if matches!(task.status, task_runner::TaskStatus::AwaitingDeps) => {
+            "awaiting_deps"
+        }
+        _ => "running",
+    }
+}
+
 /// A single task entry in the detailed batch format.
 #[derive(Debug, Deserialize)]
 pub struct BatchTaskItem {
@@ -290,14 +299,17 @@ pub(super) async fn create_task(
     Json(req): Json<task_runner::CreateTaskRequest>,
 ) -> Response {
     match enqueue_task(&state, req).await {
-        Ok(task_id) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "task_id": task_id.0,
-                "status": "running"
-            })),
-        )
-            .into_response(),
+        Ok(task_id) => {
+            let status = create_task_status_response(state.as_ref(), &task_id);
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "task_id": task_id.0,
+                    "status": status
+                })),
+            )
+                .into_response()
+        }
         Err(EnqueueTaskError::BadRequest(error)) => {
             (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
         }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -845,6 +845,50 @@ async fn create_task_with_prompt_returns_accepted() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn create_task_with_unresolved_dependencies_returns_awaiting_deps() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+
+    let dep = task_runner::TaskState::new(task_runner::TaskId::new());
+    let dep_id = dep.id.clone();
+    state.core.tasks.insert(&dep).await;
+
+    let app = task_app(state.clone());
+    let body = serde_json::json!({
+        "prompt": "fix the bug after deps",
+        "depends_on": [dep_id.0.clone()],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let resp = response_json(response).await?;
+    assert_eq!(resp["status"], "awaiting_deps");
+
+    let task_id = harness_core::types::TaskId(
+        resp["task_id"]
+            .as_str()
+            .expect("task_id should be string")
+            .to_string(),
+    );
+    let task = state
+        .core
+        .tasks
+        .get(&task_id)
+        .expect("task must be inserted into the task store");
+    assert!(matches!(task.status, task_runner::TaskStatus::AwaitingDeps));
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_empty_request_returns_bad_request() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;


### PR DESCRIPTION
Closes #892

## Summary
- return `awaiting_deps` from `POST /tasks` when the task is registered in the awaiting-dependencies state
- add an HTTP regression test covering unresolved dependency submission

## Validation
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace` (fails on clean `origin/main` with unrelated database auth circuit-breaker errors in existing `harness-server` tests)