### PR TITLE
feat(web): show full task prompt history

### DIFF
--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -79,17 +79,17 @@ export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
         ) : prompts.length === 0 ? (
           <span className="text-ink-3">No prompts recorded</span>
         ) : (
-          <div className="flex flex-col gap-1">
-            {prompts.map((p, i) => (
-              <details key={i} className="border border-line">
-                <summary className="px-2 py-1 cursor-pointer text-ink-2 hover:bg-bg-1">
-                  {p.phase} (turn {p.turn})
-                </summary>
-                <pre className="p-2 text-ink whitespace-pre-wrap break-words text-[10px]">
-                  {p.prompt.length > 500 ? p.prompt.slice(0, 500) + "…" : p.prompt}
-                </pre>
-              </details>
-            ))}
+          <div className="flex flex-col gap-2">
+            <span className="text-ink">
+              {prompts.length} prompt{prompts.length === 1 ? "" : "s"} recorded
+            </span>
+            <div className="flex flex-col gap-1">
+              {prompts.map((p, i) => (
+                <div key={i} className="border border-line px-2 py-1 text-ink-2">
+                  {p.phase} (turn {p.turn}) · {p.created_at}
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </section>

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -175,6 +175,8 @@ describe("TaskDetailSlideover", () => {
     expect(card).toHaveTextContent("Approved");
     expect(await screen.findByText("patch")).toBeInTheDocument();
     expect(await screen.findByText(/implement/)).toBeInTheDocument();
+    expect(card).toHaveTextContent("1 prompt recorded");
+    expect(card).not.toHaveTextContent("Write the fix");
   });
 
   it("does not render proof-of-work card for non-terminal task", () => {
@@ -195,6 +197,108 @@ describe("TaskDetailSlideover", () => {
       expect(card).toHaveTextContent("No prompts recorded");
       expect(card).toHaveTextContent("No artifacts");
     });
+  });
+
+  it("fetches and renders prompt history in chronological order for the prompts tab", async () => {
+    const task = makeFullTask({ status: "implementing" });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/prompts")) {
+        return Promise.resolve([
+          {
+            task_id: task.id,
+            turn: 2,
+            phase: "retry",
+            prompt: "Second prompt body",
+            created_at: "2024-01-01T00:20:00Z",
+          },
+          {
+            task_id: task.id,
+            turn: 1,
+            phase: "plan",
+            prompt: "First prompt body",
+            created_at: "2024-01-01T00:10:00Z",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("prompts"));
+
+    expect(await screen.findByText("First prompt body")).toBeInTheDocument();
+    expect(screen.getByText("Second prompt body")).toBeInTheDocument();
+
+    const promptBodies = await screen.findAllByTestId(/prompt-body-/);
+    expect(promptBodies[0]).toHaveTextContent("First prompt body");
+    expect(promptBodies[1]).toHaveTextContent("Second prompt body");
+    expect(screen.getByText("plan")).toBeInTheDocument();
+    expect(screen.getByText("retry")).toBeInTheDocument();
+    expect(screen.getByText("2024-01-01T00:10:00Z")).toBeInTheDocument();
+    expect(screen.getByText("2024-01-01T00:20:00Z")).toBeInTheDocument();
+  });
+
+  it("renders long multiline prompts in full without truncation", async () => {
+    const task = makeFullTask({ status: "implementing" });
+    const longPrompt = ["Line 1", "Line 2", "Line 3", "x".repeat(700)].join("\n");
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/prompts")) {
+        return Promise.resolve([
+          {
+            task_id: task.id,
+            turn: 1,
+            phase: "implement",
+            prompt: longPrompt,
+            created_at: "2024-01-01T00:10:00Z",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("prompts"));
+
+    const promptBody = await screen.findByTestId("prompt-body-0");
+    expect(promptBody.textContent).toBe(longPrompt);
+    expect(promptBody).toHaveTextContent("Line 1");
+    expect(promptBody).toHaveTextContent("Line 2");
+    expect(promptBody).toHaveTextContent("Line 3");
+    expect(promptBody.textContent?.endsWith("…")).toBe(false);
+  });
+
+  it("renders a clear empty state when no prompts are recorded", async () => {
+    const task = makeFullTask({ status: "implementing" });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/prompts")) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("prompts"));
+
+    expect(await screen.findByText("No prompts recorded.")).toBeInTheDocument();
+  });
+
+  it("renders a clear error state when prompts fail to load", async () => {
+    const task = makeFullTask({ status: "implementing" });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/prompts")) {
+        return Promise.reject(new Error("boom"));
+      }
+      return Promise.resolve([]);
+    });
+
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("prompts"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Failed to load prompts.");
   });
 
   it("switches tabs without remounting (Summary → Output → Summary)", () => {

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -150,7 +150,7 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
             </>
           )}
           {activeTab === "prompts" && (
-            <RawJsonContent data={prompts} label="prompts" isError={isPromptsError} />
+            <PromptHistoryContent data={prompts} isError={isPromptsError} />
           )}
           {activeTab === "artifacts" && (
             <RawJsonContent data={artifacts} label="artifacts" isError={isArtifactsError} />
@@ -214,5 +214,61 @@ function RawJsonContent({ data, label, isError }: { data: unknown; label: string
     <pre className="font-mono text-[11px] text-ink whitespace-pre-wrap break-words">
       {JSON.stringify(data, null, 2)}
     </pre>
+  );
+}
+
+function PromptHistoryContent({
+  data,
+  isError,
+}: {
+  data: TaskPrompt[] | undefined;
+  isError?: boolean;
+}) {
+  if (isError) {
+    return (
+      <div className="font-mono text-[11px] text-rust" role="alert">
+        Failed to load prompts.
+      </div>
+    );
+  }
+
+  if (data === undefined) {
+    return <div className="font-mono text-[11px] text-ink-3">Loading prompts…</div>;
+  }
+
+  if (data.length === 0) {
+    return <div className="font-mono text-[11px] text-ink-3">No prompts recorded.</div>;
+  }
+
+  const prompts = [...data].sort((a, b) => {
+    const createdAtDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    if (createdAtDiff !== 0) return createdAtDiff;
+    if (a.turn !== b.turn) return a.turn - b.turn;
+    return a.phase.localeCompare(b.phase);
+  });
+
+  return (
+    <div className="flex flex-col gap-3">
+      {prompts.map((prompt, index) => (
+        <section
+          key={`${prompt.task_id}-${prompt.turn}-${prompt.phase}-${prompt.created_at}-${index}`}
+          className="border border-line bg-bg-1"
+        >
+          <header className="border-b border-line px-3 py-2 font-mono text-[10px] text-ink-3">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span className="text-ink">{prompt.phase}</span>
+              <span>turn {prompt.turn}</span>
+              <span>{prompt.created_at}</span>
+            </div>
+          </header>
+          <pre
+            data-testid={`prompt-body-${index}`}
+            className="max-h-72 overflow-auto p-3 font-mono text-[11px] text-ink whitespace-pre-wrap break-words"
+          >
+            {prompt.prompt}
+          </pre>
+        </section>
+      ))}
+    </div>
   );
 }

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -241,8 +241,7 @@ function PromptHistoryContent({
   }
 
   const prompts = [...data].sort((a, b) => {
-    const createdAtDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-    if (createdAtDiff !== 0) return createdAtDiff;
+    if (a.created_at !== b.created_at) return a.created_at < b.created_at ? -1 : 1;
     if (a.turn !== b.turn) return a.turn - b.turn;
     return a.phase.localeCompare(b.phase);
   });

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -175,11 +175,19 @@ describe("<Active>", () => {
     expect(screen.getByText("impl-task")).toBeInTheDocument();
   });
 
-  it("clicking a TaskCard opens the slide-over with that task's id", () => {
+  it("clicking a standard task card opens the slide-over with that task's id", () => {
     mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
     wrap(<Active />);
     fireEvent.click(screen.getByText("t1"));
     expect(screen.getByTestId("task-slideover")).toHaveAttribute("data-task-id", "t1");
+  });
+
+  it("clicking a prompt task card opens the shared slide-over", () => {
+    const promptTask = makeTask("prompt-task", "proj", "planning", "prompt");
+    mockUseTasks.mockReturnValue({ data: [promptTask], isLoading: false, isError: false });
+    wrap(<Active />);
+    fireEvent.click(screen.getByText("prompt-task"));
+    expect(screen.getByTestId("task-slideover")).toHaveAttribute("data-task-id", "prompt-task");
   });
 
   it("calling onClose from the slide-over hides it", () => {


### PR DESCRIPTION
Closes #904

## Summary
- rebuild the PR onto current `origin/main` as a clean web-only change
- replace the prompts tab raw JSON dump with an ordered full-text prompt history view
- keep the proof-of-work summary metadata-only and add prompt-history coverage for the shared task slideover
- address Gemini review by sorting ISO prompt timestamps lexicographically instead of parsing dates in the comparator

## Validation
- `cargo fmt --all -- --check`
- `cargo check --message-format short`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness DATABASE_URL=postgres://harness:harness@localhost:5432/harness RUST_TEST_THREADS=1 cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cd web && bun run typecheck`
- `cd web && bun run test src/components/TaskDetailSlideover.test.tsx src/routes/dashboard/Active.test.tsx`