### PR TITLE
Stabilize GitHub auth and workspace defaults

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -143,7 +143,12 @@ impl CodeAgent for CodexAgent {
         }
 
         let child = cmd.spawn().map_err(|err| {
-            harness_core::error::HarnessError::AgentExecution(format!("failed to run codex: {err}"))
+            harness_core::error::HarnessError::AgentExecution(format_spawn_error(
+                "codex",
+                &err,
+                &wrapped_command.program,
+                &req.project_root,
+            ))
         })?;
         let output = child.wait_with_output().await.map_err(|err| {
             harness_core::error::HarnessError::AgentExecution(format!(
@@ -238,8 +243,11 @@ impl CodeAgent for CodexAgent {
         }
 
         let mut child = cmd.spawn().map_err(|error| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to run codex: {error}"
+            harness_core::error::HarnessError::AgentExecution(format_spawn_error(
+                "codex",
+                &error,
+                &wrapped_command.program,
+                &req.project_root,
             ))
         })?;
 
@@ -267,6 +275,25 @@ fn codex_sandbox_mode(mode: SandboxMode) -> &'static str {
         SandboxMode::DangerFullAccess => "danger-full-access",
     }
 }
+
+fn format_spawn_error(
+    agent_name: &str,
+    err: &std::io::Error,
+    program: &Path,
+    cwd: &Path,
+) -> String {
+    let cwd_status = match std::fs::metadata(cwd) {
+        Ok(metadata) if metadata.is_dir() => "exists".to_string(),
+        Ok(_) => "exists but is not a directory".to_string(),
+        Err(metadata_err) => format!("unavailable: {metadata_err}"),
+    };
+    format!(
+        "failed to run {agent_name}: {err}; program={}; cwd={}; cwd_status={cwd_status}",
+        program.display(),
+        cwd.display()
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -861,6 +888,17 @@ printf 'third\n'
             codex_sandbox_mode(SandboxMode::DangerFullAccess),
             "danger-full-access"
         );
+    }
+
+    #[test]
+    fn spawn_error_reports_program_and_cwd() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing executable");
+        let message = format_spawn_error("codex", &err, Path::new("/missing/codex"), dir.path());
+
+        assert!(message.contains("program=/missing/codex"));
+        assert!(message.contains("cwd="));
+        assert!(message.contains("cwd_status=exists"));
     }
 
     #[test]

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -45,6 +45,11 @@ const AGENT_INTERNAL_PREFIXES: &[&str] = &[
     "reasoning summaries:",
     "session id:",
     "mcp startup:",
+    // Codex CLI telemetry failures are agent-internal and are not actionable
+    // server warnings.
+    "warn codex_analytics::client:",
+    "error codex_analytics::client:",
+    "codex_analytics::client:",
     // Codex reasoning/exec progress lines
     "codex ",
     "exec ",
@@ -619,6 +624,13 @@ mod tests {
         assert!(!looks_like_code_content("warning: unused import"));
         assert!(!looks_like_code_content(
             "agent execution failed: codex exited with status 1"
+        ));
+    }
+
+    #[test]
+    fn codex_analytics_stderr_is_agent_internal() {
+        assert!(is_agent_internal(
+            "WARN codex_analytics::client: events failed with status 403 Forbidden"
         ));
     }
 

--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -12,11 +12,12 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
     let db_path = default_db_path(&config.server.data_dir, "tasks");
     let store = harness_server::task_runner::TaskStore::open(&db_path).await?;
 
-    let report = harness_server::reconciliation::run_once(
+    let report = harness_server::reconciliation::run_once_with_token(
         &store,
         &project_root,
         config.reconciliation.max_gh_calls_per_minute,
         dry_run,
+        config.server.github_token.as_deref(),
     )
     .await;
 

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -69,7 +69,17 @@ impl HarnessConfig {
     /// precedence.
     pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
         self.server.apply_env_overrides()?;
+        self.apply_derived_defaults();
         Ok(())
+    }
+
+    /// Apply defaults that depend on other config fields.
+    ///
+    /// Serde field defaults cannot see sibling fields, so cross-field defaults
+    /// are resolved after loading, rebasing, and environment overrides.
+    pub fn apply_derived_defaults(&mut self) {
+        self.workspace
+            .use_data_dir_default_root(&self.server.data_dir);
     }
 
     /// Rebase all relative `PathBuf` fields against `base`.
@@ -720,6 +730,29 @@ mod tests {
         assert_eq!(config.before_remove_hook.as_deref(), Some("echo cleanup"));
         assert_eq!(config.hook_timeout_secs, 30);
         assert!(!config.auto_cleanup);
+    }
+
+    #[test]
+    fn derived_workspace_root_tracks_custom_data_dir_when_default() {
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = PathBuf::from("/tmp/harness-two");
+        config.apply_derived_defaults();
+        assert_eq!(
+            config.workspace.root,
+            PathBuf::from("/tmp/harness-two/workspaces")
+        );
+    }
+
+    #[test]
+    fn derived_workspace_root_preserves_explicit_workspace_root() {
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = PathBuf::from("/tmp/harness-two");
+        config.workspace.root = PathBuf::from("/tmp/shared-harness-workspaces");
+        config.apply_derived_defaults();
+        assert_eq!(
+            config.workspace.root,
+            PathBuf::from("/tmp/shared-harness-workspaces")
+        );
     }
 
     #[test]

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -756,6 +756,48 @@ mod tests {
     }
 
     #[test]
+    fn derived_workspace_root_preserves_explicit_legacy_workspace_root() {
+        let legacy_root = WorkspaceConfig::default().root;
+        let toml_str = format!(
+            r#"
+            root = "{}"
+        "#,
+            legacy_root.display()
+        );
+        let mut config = HarnessConfig {
+            server: ServerConfig {
+                data_dir: PathBuf::from("/tmp/harness-two"),
+                ..ServerConfig::default()
+            },
+            workspace: toml::from_str(&toml_str).unwrap(),
+            ..HarnessConfig::default()
+        };
+        config.apply_derived_defaults();
+        assert_eq!(config.workspace.root, legacy_root);
+    }
+
+    #[test]
+    fn derived_workspace_root_tracks_custom_data_dir_when_toml_root_is_absent() {
+        let toml_str = r#"
+            auto_cleanup = false
+        "#;
+        let mut config = HarnessConfig {
+            server: ServerConfig {
+                data_dir: PathBuf::from("/tmp/harness-two"),
+                ..ServerConfig::default()
+            },
+            workspace: toml::from_str(toml_str).unwrap(),
+            ..HarnessConfig::default()
+        };
+        config.apply_derived_defaults();
+        assert_eq!(
+            config.workspace.root,
+            PathBuf::from("/tmp/harness-two/workspaces")
+        );
+        assert!(!config.workspace.auto_cleanup);
+    }
+
+    #[test]
     fn harness_config_includes_workspace() {
         let config = HarnessConfig::default();
         assert!(config.workspace.auto_cleanup);

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,6 +1,6 @@
 use crate::types::Grade;
 use chrono::{DateTime, Duration, NaiveTime, TimeZone, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -10,11 +10,16 @@ use super::dirs::dirs_data_dir;
 ///
 /// WorkspaceManager provisions an isolated git worktree per task,
 /// preventing merge conflicts when multiple agents edit the same project.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct WorkspaceConfig {
     /// Root directory for all task worktrees. Runtime default: `[server.data_dir]/workspaces`.
     #[serde(default = "default_workspace_root")]
     pub root: PathBuf,
+    /// Tracks whether `root` came from config so derived defaults do not rewrite
+    /// an explicit legacy root value.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub root_configured: bool,
     /// Shell script run after worktree creation (cwd = workspace). Fatal on failure.
     #[serde(default)]
     pub after_create_hook: Option<String>,
@@ -45,11 +50,44 @@ impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             root: default_workspace_root(),
+            root_configured: false,
             after_create_hook: None,
             before_remove_hook: None,
             hook_timeout_secs: default_hook_timeout_secs(),
             auto_cleanup: default_auto_cleanup(),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WorkspaceConfigToml {
+            #[serde(default)]
+            root: Option<PathBuf>,
+            #[serde(default)]
+            after_create_hook: Option<String>,
+            #[serde(default)]
+            before_remove_hook: Option<String>,
+            #[serde(default = "default_hook_timeout_secs")]
+            hook_timeout_secs: u64,
+            #[serde(default = "default_auto_cleanup")]
+            auto_cleanup: bool,
+        }
+
+        let toml = WorkspaceConfigToml::deserialize(deserializer)?;
+        let root_configured = toml.root.is_some();
+        Ok(Self {
+            root: toml.root.unwrap_or_else(default_workspace_root),
+            root_configured,
+            after_create_hook: toml.after_create_hook,
+            before_remove_hook: toml.before_remove_hook,
+            hook_timeout_secs: toml.hook_timeout_secs,
+            auto_cleanup: toml.auto_cleanup,
+        })
     }
 }
 
@@ -59,7 +97,7 @@ impl WorkspaceConfig {
     }
 
     pub fn use_data_dir_default_root(&mut self, data_dir: &Path) {
-        if self.root == default_workspace_root() {
+        if !self.root_configured && self.root == default_workspace_root() {
             self.root = Self::root_for_data_dir(data_dir);
         }
     }

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -2,7 +2,7 @@ use crate::types::Grade;
 use chrono::{DateTime, Duration, NaiveTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::dirs::dirs_data_dir;
 
@@ -12,7 +12,7 @@ use super::dirs::dirs_data_dir;
 /// preventing merge conflicts when multiple agents edit the same project.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
-    /// Root directory for all task worktrees. Default: `~/.local/share/harness/workspaces`.
+    /// Root directory for all task worktrees. Runtime default: `[server.data_dir]/workspaces`.
     #[serde(default = "default_workspace_root")]
     pub root: PathBuf,
     /// Shell script run after worktree creation (cwd = workspace). Fatal on failure.
@@ -29,7 +29,7 @@ pub struct WorkspaceConfig {
     pub auto_cleanup: bool,
 }
 
-fn default_workspace_root() -> PathBuf {
+pub fn default_workspace_root() -> PathBuf {
     dirs_data_dir().join("harness").join("workspaces")
 }
 
@@ -49,6 +49,18 @@ impl Default for WorkspaceConfig {
             before_remove_hook: None,
             hook_timeout_secs: default_hook_timeout_secs(),
             auto_cleanup: default_auto_cleanup(),
+        }
+    }
+}
+
+impl WorkspaceConfig {
+    pub fn root_for_data_dir(data_dir: &Path) -> PathBuf {
+        data_dir.join("workspaces")
+    }
+
+    pub fn use_data_dir_default_root(&mut self, data_dir: &Path) {
+        if self.root == default_workspace_root() {
+            self.root = Self::root_for_data_dir(data_dir);
         }
     }
 }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -107,16 +107,22 @@ impl ServerConfig {
                 self.api_token = Some(v);
             }
         }
-        if let Some(v) = std::env::var("GITHUB_TOKEN")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .or_else(|| {
-                std::env::var("GH_TOKEN")
-                    .ok()
-                    .filter(|v| !v.trim().is_empty())
-            })
+        if self
+            .github_token
+            .as_deref()
+            .is_none_or(|v| v.trim().is_empty())
         {
-            self.github_token = Some(v);
+            if let Some(v) = std::env::var("GITHUB_TOKEN")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| {
+                    std::env::var("GH_TOKEN")
+                        .ok()
+                        .filter(|v| !v.trim().is_empty())
+                })
+            {
+                self.github_token = Some(v);
+            }
         }
         if let Ok(v) = std::env::var("GITHUB_WEBHOOK_SECRET") {
             if !v.is_empty() {
@@ -448,6 +454,24 @@ mod tests {
                 };
                 cfg.apply_env_overrides().unwrap();
                 assert_eq!(cfg.github_token, Some("gh-real".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn env_override_github_token_does_not_override_toml_token() {
+        temp_env::with_vars(
+            [
+                ("GITHUB_TOKEN", Some("github-env")),
+                ("GH_TOKEN", Some("gh-env")),
+            ],
+            || {
+                let mut cfg = ServerConfig {
+                    github_token: Some("configured-token".to_string()),
+                    ..ServerConfig::default()
+                };
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("configured-token".to_string()));
             },
         );
     }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -62,10 +62,11 @@ pub struct ServerConfig {
     /// Default: true.
     #[serde(default = "default_constitution_enabled")]
     pub constitution_enabled: bool,
-    /// GitHub personal access token for review bot auto-trigger.
+    /// GitHub personal access token for GitHub API clients.
     ///
-    /// Used to post comments on PRs (e.g. `@gemini-code-assist review`).
-    /// Falls back to `GITHUB_TOKEN` env var when not configured.
+    /// Used for issue intake, reconciliation, workspace GC, and review bot
+    /// auto-trigger. Falls back to `GITHUB_TOKEN` and then `GH_TOKEN` env vars
+    /// when not configured.
     #[serde(default)]
     pub github_token: Option<String>,
 }
@@ -83,7 +84,7 @@ impl ServerConfig {
     /// - `HARNESS_PROJECT_ROOT`    — `project_root`
     /// - `HARNESS_DATABASE_URL`    — `database_url`
     /// - `HARNESS_API_TOKEN`       — `api_token`
-    /// - `GITHUB_TOKEN`            — `github_token`
+    /// - `GITHUB_TOKEN` / `GH_TOKEN` — `github_token`
     /// - `GITHUB_WEBHOOK_SECRET`   — `github_webhook_secret`
     pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
         if let Ok(v) = std::env::var("HARNESS_DATA_DIR") {
@@ -106,10 +107,16 @@ impl ServerConfig {
                 self.api_token = Some(v);
             }
         }
-        if let Ok(v) = std::env::var("GITHUB_TOKEN") {
-            if !v.is_empty() {
-                self.github_token = Some(v);
-            }
+        if let Some(v) = std::env::var("GITHUB_TOKEN")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or_else(|| {
+                std::env::var("GH_TOKEN")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            })
+        {
+            self.github_token = Some(v);
         }
         if let Ok(v) = std::env::var("GITHUB_WEBHOOK_SECRET") {
             if !v.is_empty() {
@@ -353,11 +360,59 @@ mod tests {
 
     #[test]
     fn env_override_github_token_fallback() {
-        temp_env::with_vars([("GITHUB_TOKEN", Some("gh-test"))], || {
-            let mut cfg = ServerConfig::default();
-            cfg.apply_env_overrides().unwrap();
-            assert_eq!(cfg.github_token, Some("gh-test".to_string()));
-        });
+        temp_env::with_vars(
+            [
+                ("GITHUB_TOKEN", Some("gh-test")),
+                ("GH_TOKEN", None::<&str>),
+            ],
+            || {
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("gh-test".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn env_override_gh_token_fallback() {
+        temp_env::with_vars(
+            [
+                ("GITHUB_TOKEN", None::<&str>),
+                ("GH_TOKEN", Some("gh-test")),
+            ],
+            || {
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("gh-test".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn env_override_github_token_precedes_gh_token() {
+        temp_env::with_vars(
+            [
+                ("GITHUB_TOKEN", Some("github-test")),
+                ("GH_TOKEN", Some("gh-test")),
+            ],
+            || {
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("github-test".to_string()));
+            },
+        );
+    }
+
+    #[test]
+    fn env_override_empty_github_token_falls_back_to_gh_token() {
+        temp_env::with_vars(
+            [("GITHUB_TOKEN", Some("")), ("GH_TOKEN", Some("gh-test"))],
+            || {
+                let mut cfg = ServerConfig::default();
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("gh-test".to_string()));
+            },
+        );
     }
 
     #[test]
@@ -384,14 +439,17 @@ mod tests {
 
     #[test]
     fn env_override_empty_github_token_does_not_override_toml_token() {
-        temp_env::with_vars([("GITHUB_TOKEN", Some(""))], || {
-            let mut cfg = ServerConfig {
-                github_token: Some("gh-real".to_string()),
-                ..ServerConfig::default()
-            };
-            cfg.apply_env_overrides().unwrap();
-            assert_eq!(cfg.github_token, Some("gh-real".to_string()));
-        });
+        temp_env::with_vars(
+            [("GITHUB_TOKEN", Some("")), ("GH_TOKEN", None::<&str>)],
+            || {
+                let mut cfg = ServerConfig {
+                    github_token: Some("gh-real".to_string()),
+                    ..ServerConfig::default()
+                };
+                cfg.apply_env_overrides().unwrap();
+                assert_eq!(cfg.github_token, Some("gh-real".to_string()));
+            },
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/github_auth.rs
+++ b/crates/harness-server/src/github_auth.rs
@@ -1,0 +1,57 @@
+pub(crate) fn resolve_github_token(config_token: Option<&str>) -> Option<String> {
+    let github_token = std::env::var("GITHUB_TOKEN").ok();
+    let gh_token = std::env::var("GH_TOKEN").ok();
+    resolve_github_token_from_sources(config_token, github_token.as_deref(), gh_token.as_deref())
+}
+
+pub(crate) fn resolve_github_token_from_sources(
+    config_token: Option<&str>,
+    github_token: Option<&str>,
+    gh_token: Option<&str>,
+) -> Option<String> {
+    normalize_token(config_token)
+        .or_else(|| normalize_token(github_token))
+        .or_else(|| normalize_token(gh_token))
+}
+
+fn normalize_token(token: Option<&str>) -> Option<String> {
+    token
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_github_token_from_sources;
+
+    #[test]
+    fn configured_token_wins() {
+        assert_eq!(
+            resolve_github_token_from_sources(
+                Some(" config-token "),
+                Some("github-token"),
+                Some("gh-token"),
+            )
+            .as_deref(),
+            Some("config-token")
+        );
+    }
+
+    #[test]
+    fn github_token_precedes_gh_token() {
+        assert_eq!(
+            resolve_github_token_from_sources(None, Some("github-token"), Some("gh-token"))
+                .as_deref(),
+            Some("github-token")
+        );
+    }
+
+    #[test]
+    fn blank_values_fall_back() {
+        assert_eq!(
+            resolve_github_token_from_sources(Some(""), Some(" "), Some("gh-token")).as_deref(),
+            Some("gh-token")
+        );
+    }
+}

--- a/crates/harness-server/src/handlers/reconcile.rs
+++ b/crates/harness-server/src/handlers/reconcile.rs
@@ -24,11 +24,12 @@ pub async fn handle(
         .reconciliation
         .max_gh_calls_per_minute;
 
-    let report = crate::reconciliation::run_once(
+    let report = crate::reconciliation::run_once_with_token(
         &state.core.tasks,
         &state.core.project_root,
         max_calls,
         params.dry_run,
+        state.core.server.config.server.github_token.as_deref(),
     )
     .await;
 

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -99,9 +99,12 @@ pub(crate) async fn build_intake(
                 "intake: GitHub Issues poller registered"
             );
             let key = format!("github:{}", repo_cfg.repo);
-            let poller =
-                crate::intake::github_issues::GitHubIssuesPoller::new(&repo_cfg, Some(data_dir))
-                    .with_task_checker(storage.tasks.clone());
+            let poller = crate::intake::github_issues::GitHubIssuesPoller::new_with_token(
+                &repo_cfg,
+                Some(data_dir),
+                server.config.server.github_token.clone(),
+            )
+            .with_task_checker(storage.tasks.clone());
             match poller.reconcile_dispatched_with_store().await {
                 Ok(pruned) if pruned > 0 => tracing::info!(
                     repo = %repo_cfg.repo,

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -50,9 +50,12 @@ pub(crate) async fn build_services(
             engines.events.clone(),
             hook_enforcement,
         )),
-        Arc::new(crate::post_validator::PostExecutionValidator::new(
-            server.config.validation.clone(),
-        )),
+        Arc::new(
+            crate::post_validator::PostExecutionValidator::new_with_github_token(
+                server.config.validation.clone(),
+                server.config.server.github_token.clone(),
+            ),
+        ),
     ];
 
     // ── Service layer ─────────────────────────────────────────────────────────
@@ -134,9 +137,10 @@ pub(crate) async fn build_services(
     {
         let tasks_for_recovery = storage.tasks.clone();
         let cb_for_recovery = intake.completion_callback.clone();
+        let github_token = server.config.server.github_token.clone();
         tokio::spawn(async move {
             tasks_for_recovery
-                .validate_recovered_tasks(cb_for_recovery)
+                .validate_recovered_tasks_with_token(cb_for_recovery, github_token.as_deref())
                 .await;
         });
     }

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -322,9 +322,8 @@ pub(crate) fn build_completion_callback(
                         if let Some((owner, repo, pr_num)) =
                             harness_core::prompts::parse_github_pr_url(pr_url)
                         {
-                            let resolved_token = github_token
-                                .or_else(|| std::env::var("GITHUB_TOKEN").ok())
-                                .filter(|t| !t.is_empty());
+                            let resolved_token =
+                                crate::github_auth::resolve_github_token(github_token.as_deref());
                             match resolved_token {
                                 Some(token) => {
                                     if let Err(e) = post_review_bot_comment(
@@ -351,7 +350,7 @@ pub(crate) fn build_completion_callback(
                                 _ => {
                                     tracing::warn!(
                                         pr_url,
-                                        "review_bot_auto_trigger: GITHUB_TOKEN not set or empty; skipping"
+                                        "review_bot_auto_trigger: GitHub token not configured; skipping"
                                     );
                                 }
                             }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -150,11 +150,12 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
             .config
             .reconciliation
             .max_gh_calls_per_minute;
-        crate::reconciliation::run_once(
+        crate::reconciliation::run_once_with_token(
             &state.core.tasks,
             &state.core.project_root,
             max_calls,
             false,
+            state.core.server.config.server.github_token.as_deref(),
         )
         .await;
     }
@@ -207,6 +208,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         )),
         state.intake.feishu_intake.clone(),
         github_sources,
+        state.core.server.config.server.github_token.clone(),
     )
     .start(state.clone());
 

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -29,12 +29,21 @@ pub struct GitHubIssuesPoller {
     dispatched: DashMap<String, TaskId>,
     persist_path: Option<PathBuf>,
     task_checker: Option<Arc<dyn DispatchedTaskChecker>>,
+    github_token: Option<String>,
 }
 
 impl GitHubIssuesPoller {
     pub fn new(
         repo_config: &harness_core::config::intake::GitHubRepoConfig,
         data_dir: Option<&Path>,
+    ) -> Self {
+        Self::new_with_token(repo_config, data_dir, None)
+    }
+
+    pub fn new_with_token(
+        repo_config: &harness_core::config::intake::GitHubRepoConfig,
+        data_dir: Option<&Path>,
+        github_token: Option<String>,
     ) -> Self {
         let repo_slug = repo_config.repo.replace('/', "_");
         let persist_path = data_dir.map(|d| d.join(format!("github_dispatched_{repo_slug}.json")));
@@ -47,6 +56,7 @@ impl GitHubIssuesPoller {
             dispatched,
             persist_path,
             task_checker: None,
+            github_token,
         }
     }
 
@@ -261,10 +271,9 @@ impl IntakeSource for GitHubIssuesPoller {
         if !self.label.is_empty() {
             request = request.query(&[("labels", self.label.as_str())]);
         }
-        if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-            if !token.trim().is_empty() {
-                request = request.bearer_auth(token);
-            }
+        if let Some(token) = crate::github_auth::resolve_github_token(self.github_token.as_deref())
+        {
+            request = request.bearer_auth(token);
         }
         let response = request.send().await?;
         if !response.status().is_success() {
@@ -685,6 +694,27 @@ mod tests {
         };
         let poller = GitHubIssuesPoller::new(&repo_cfg, None);
         assert_eq!(poller.name(), "github");
+    }
+
+    #[test]
+    fn github_issues_poller_accepts_configured_token() {
+        let repo_cfg = harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: None,
+        };
+        let poller =
+            GitHubIssuesPoller::new_with_token(&repo_cfg, None, Some(" configured ".to_string()));
+
+        assert_eq!(
+            crate::github_auth::resolve_github_token_from_sources(
+                poller.github_token.as_deref(),
+                Some("env-github"),
+                Some("env-gh"),
+            )
+            .as_deref(),
+            Some("configured")
+        );
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -1124,6 +1124,7 @@ pub fn build_orchestrator(
     data_dir: Option<&std::path::Path>,
     feishu_intake: Option<Arc<feishu::FeishuIntake>>,
     github_sources: Vec<Arc<dyn IntakeSource>>,
+    github_token: Option<String>,
 ) -> IntakeOrchestrator {
     let mut sources: Vec<Arc<dyn IntakeSource>> = Vec::new();
     let mut poll_interval = Duration::from_secs(30);
@@ -1152,7 +1153,11 @@ pub fn build_orchestrator(
                         label = %repo_cfg.label,
                         "intake: GitHub Issues poller registered (fallback)"
                     );
-                    let poller = github_issues::GitHubIssuesPoller::new(&repo_cfg, data_dir);
+                    let poller = github_issues::GitHubIssuesPoller::new_with_token(
+                        &repo_cfg,
+                        data_dir,
+                        github_token.clone(),
+                    );
                     sources.push(Arc::new(poller));
                 }
             } else {
@@ -1657,7 +1662,7 @@ mod tests {
     #[test]
     fn build_orchestrator_with_no_config_returns_empty_orchestrator() {
         let config = harness_core::config::intake::IntakeConfig::default();
-        let orchestrator = build_orchestrator(&config, None, None, vec![]);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
         assert!(orchestrator.sources.is_empty());
     }
 
@@ -1669,7 +1674,7 @@ mod tests {
             repo: "owner/repo".to_string(),
             ..Default::default()
         });
-        let orchestrator = build_orchestrator(&config, None, None, vec![]);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
         assert!(orchestrator.sources.is_empty());
     }
 
@@ -1686,7 +1691,7 @@ mod tests {
             retry_backoff_max_secs: 90,
             ..Default::default()
         });
-        let orchestrator = build_orchestrator(&config, None, None, vec![]);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
         assert_eq!(orchestrator.sources.len(), 1);
         assert_eq!(orchestrator.sources[0].name(), "github");
         assert_eq!(orchestrator.poll_interval, Duration::from_secs(60));
@@ -1707,7 +1712,7 @@ mod tests {
             default_repo: None,
         });
 
-        let orchestrator = build_orchestrator(&config, None, None, vec![]);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
         assert!(orchestrator.sources.is_empty());
     }
 }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod contract_validator;
 pub mod dashboard;
 pub mod db;
 pub mod event_replay;
+pub(crate) mod github_auth;
 pub mod handlers;
 pub mod hook_enforcer;
 pub mod http;

--- a/crates/harness-server/src/post_validator.rs
+++ b/crates/harness-server/src/post_validator.rs
@@ -18,6 +18,7 @@ pub struct PostExecutionValidator {
     config: ValidationConfig,
     /// Deprecated test-only field retained for struct literal compatibility.
     gh_bin: String,
+    github_token: Option<String>,
 }
 
 /// Classify a command string into a human-readable error prefix.
@@ -91,9 +92,14 @@ pub(crate) fn validate_command_safety(cmd_str: &str) -> Result<(), String> {
 
 impl PostExecutionValidator {
     pub fn new(config: ValidationConfig) -> Self {
+        Self::new_with_github_token(config, None)
+    }
+
+    pub fn new_with_github_token(config: ValidationConfig, github_token: Option<String>) -> Self {
         Self {
             config,
             gh_bin: "gh".to_string(),
+            github_token,
         }
     }
 
@@ -103,6 +109,7 @@ impl PostExecutionValidator {
         pr_url: &str,
         _project: &Path,
         timeout_secs: u64,
+        github_token: Option<&str>,
     ) -> Result<(), String> {
         let (repo, pr_number) = parse_github_pr_url(pr_url)
             .ok_or_else(|| format!("Could not parse GitHub PR URL: {pr_url}"))?;
@@ -113,10 +120,8 @@ impl PostExecutionValidator {
             ))
             .header(reqwest::header::ACCEPT, "application/vnd.github+json")
             .header(reqwest::header::USER_AGENT, "harness-server");
-        if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-            if !token.trim().is_empty() {
-                request = request.bearer_auth(token);
-            }
+        if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+            request = request.bearer_auth(token);
         }
 
         let result = timeout(Duration::from_secs(timeout_secs), request.send()).await;
@@ -151,11 +156,13 @@ impl PostExecutionValidator {
         pr_url: &str,
         project: &Path,
         timeout_secs: u64,
+        github_token: Option<&str>,
     ) -> Result<(), String> {
         let max_attempts = 3;
         let mut last_err = String::new();
         for attempt in 1..=max_attempts {
-            match Self::verify_pr_exists(gh_bin, pr_url, project, timeout_secs).await {
+            match Self::verify_pr_exists(gh_bin, pr_url, project, timeout_secs, github_token).await
+            {
                 Ok(()) => return Ok(()),
                 Err(e) if !Self::is_transient_error(&e) => return Err(e),
                 Err(e) => {
@@ -286,7 +293,7 @@ impl TurnInterceptor for PostExecutionValidator {
         }
 
         // PR existence verification: if the agent output contains a PR_URL,
-        // verify via `gh pr view` that the PR actually exists on GitHub.
+        // verify via the GitHub REST API that the PR actually exists on GitHub.
         // This prevents silently succeeding when an agent claims to have created
         // a PR that does not exist. Runs only when all other validations pass
         // to avoid noisy failures from incomplete code.
@@ -295,8 +302,8 @@ impl TurnInterceptor for PostExecutionValidator {
                 // Guard: only verify URLs that look like a real GitHub PR
                 // (contain /pull/{number}).  Non-PR URLs are silently skipped.
                 if prompts::extract_pr_number(&pr_url).is_some() {
-                    // Use the full URL so `gh` resolves the exact repo the
-                    // agent targeted, not the repo of the current checkout.
+                    // Use the full URL so the API targets the exact repo the
+                    // agent used, not the repo of the current checkout.
                     // This prevents false passes (same PR number in local repo)
                     // and false failures (PR opened against a fork or different
                     // repo).
@@ -309,6 +316,7 @@ impl TurnInterceptor for PostExecutionValidator {
                         &pr_url,
                         project,
                         self.config.timeout_secs,
+                        self.github_token.as_deref(),
                     )
                     .await
                     {
@@ -760,6 +768,7 @@ mod tests {
             "https://example.com/not-a-pr",
             dir.path(),
             1,
+            None,
         )
         .await
         .unwrap_err();

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -154,16 +154,14 @@ fn github_api_base_url() -> String {
         .to_string()
 }
 
-async fn github_get_json<T: DeserializeOwned>(path: &str) -> Option<T> {
+async fn github_get_json<T: DeserializeOwned>(path: &str, github_token: Option<&str>) -> Option<T> {
     let client = reqwest::Client::new();
     let mut request = client
         .get(format!("{}{}", github_api_base_url(), path))
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        if !token.trim().is_empty() {
-            request = request.bearer_auth(token);
-        }
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
     }
     let response = match tokio::time::timeout(Duration::from_secs(10), request.send()).await {
         Ok(Ok(response)) if response.status().is_success() => response,
@@ -204,29 +202,40 @@ fn classify_issue_state(state: &GitHubIssueState) -> GitHubState {
 }
 
 /// Fetch GitHub PR state from a full URL (e.g. `https://github.com/.../pull/42`).
-async fn fetch_pr_state_by_url(pr_url: &str) -> GitHubState {
+async fn fetch_pr_state_by_url(pr_url: &str, github_token: Option<&str>) -> GitHubState {
     let Some((owner, repo, pr_number)) = harness_core::prompts::parse_github_pr_url(pr_url) else {
         tracing::debug!(pr_url, "GitHub PR state check skipped for unparseable URL");
         return GitHubState::Unknown;
     };
-    fetch_pr_state_by_slug(&format!("{owner}/{repo}"), pr_number).await
+    fetch_pr_state_by_slug_with_token(&format!("{owner}/{repo}"), pr_number, github_token).await
 }
 
-/// Fetch GitHub PR state by repository slug and number.
-pub(crate) async fn fetch_pr_state_by_slug(repo_slug: &str, pr_num: u64) -> GitHubState {
-    let Some(state) =
-        github_get_json::<GitHubPullState>(&format!("/repos/{repo_slug}/pulls/{pr_num}")).await
+pub(crate) async fn fetch_pr_state_by_slug_with_token(
+    repo_slug: &str,
+    pr_num: u64,
+    github_token: Option<&str>,
+) -> GitHubState {
+    let Some(state) = github_get_json::<GitHubPullState>(
+        &format!("/repos/{repo_slug}/pulls/{pr_num}"),
+        github_token,
+    )
+    .await
     else {
         return GitHubState::Unknown;
     };
     classify_pr_state(&state)
 }
 
-/// Fetch issue state by repository slug and number.
-pub(crate) async fn fetch_issue_state(repo_slug: &str, issue_num: u64) -> GitHubState {
-    let Some(state) =
-        github_get_json::<GitHubIssueState>(&format!("/repos/{repo_slug}/issues/{issue_num}"))
-            .await
+pub(crate) async fn fetch_issue_state_with_token(
+    repo_slug: &str,
+    issue_num: u64,
+    github_token: Option<&str>,
+) -> GitHubState {
+    let Some(state) = github_get_json::<GitHubIssueState>(
+        &format!("/repos/{repo_slug}/issues/{issue_num}"),
+        github_token,
+    )
+    .await
     else {
         return GitHubState::Unknown;
     };
@@ -240,12 +249,22 @@ pub async fn run_once(
     max_gh_calls_per_minute: u32,
     dry_run: bool,
 ) -> ReconciliationReport {
+    run_once_with_token(store, project, max_gh_calls_per_minute, dry_run, None).await
+}
+
+pub async fn run_once_with_token(
+    store: &Arc<TaskStore>,
+    project: &Path,
+    max_gh_calls_per_minute: u32,
+    dry_run: bool,
+    github_token: Option<&str>,
+) -> ReconciliationReport {
     let (candidates, skipped_terminal) = collect_candidates(store);
     let mut rate = RateLimiter::new(max_gh_calls_per_minute);
     let mut transitions = Vec::new();
 
     for candidate in &candidates {
-        let gh_state = resolve_github_state(candidate, project, &mut rate).await;
+        let gh_state = resolve_github_state(candidate, project, &mut rate, github_token).await;
 
         let new_status = transition_for_github_state(gh_state);
 
@@ -303,12 +322,13 @@ async fn resolve_github_state(
     candidate: &Candidate,
     project: &Path,
     rate: &mut RateLimiter,
+    github_token: Option<&str>,
 ) -> GitHubState {
     // PR URL takes precedence — most candidates in `implementing`/`reviewing`
     // will have one.
     if let Some(pr_url) = &candidate.pr_url {
         rate.acquire().await;
-        return fetch_pr_state_by_url(pr_url).await;
+        return fetch_pr_state_by_url(pr_url, github_token).await;
     }
     let repo_slug = match candidate.repo.as_deref() {
         Some(repo) if !repo.trim().is_empty() => Some(repo.to_string()),
@@ -323,11 +343,11 @@ async fn resolve_github_state(
     };
     if let Some(pr_num) = candidate.pr_num_from_ext {
         rate.acquire().await;
-        return fetch_pr_state_by_slug(&repo_slug, pr_num).await;
+        return fetch_pr_state_by_slug_with_token(&repo_slug, pr_num, github_token).await;
     }
     if let Some(issue_num) = candidate.issue_num {
         rate.acquire().await;
-        return fetch_issue_state(&repo_slug, issue_num).await;
+        return fetch_issue_state_with_token(&repo_slug, issue_num, github_token).await;
     }
     GitHubState::Unknown
 }
@@ -386,11 +406,12 @@ async fn reconciliation_loop(state: Arc<AppState>, config: ReconciliationConfig)
     sleep(Duration::from_secs(15)).await;
 
     loop {
-        let report = run_once(
+        let report = run_once_with_token(
             &state.core.tasks,
             &state.core.project_root,
             config.max_gh_calls_per_minute,
             false,
+            state.core.server.config.server.github_token.as_deref(),
         )
         .await;
 

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -60,7 +60,12 @@ impl Scheduler {
                         .reconciliation
                         .max_gh_calls_per_minute;
                     let summary = wmgr
-                        .reconcile_disk_workspaces(&wgc_state.core.project_root, "gh", max_rate)
+                        .reconcile_disk_workspaces(
+                            &wgc_state.core.project_root,
+                            "gh",
+                            max_rate,
+                            wgc_state.core.server.config.server.github_token.as_deref(),
+                        )
                         .await;
                     tracing::info!(
                         scanned = summary.scanned,

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -16,10 +16,11 @@ pub struct HarnessServer {
 
 impl HarnessServer {
     pub fn new(
-        config: HarnessConfig,
+        mut config: HarnessConfig,
         thread_manager: ThreadManager,
         agent_registry: AgentRegistry,
     ) -> Self {
+        config.apply_derived_defaults();
         Self {
             config,
             thread_manager,

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -137,7 +137,13 @@ pub(crate) async fn run_implement_phase(
     update_status(store, task_id, TaskStatus::Implementing, 1).await?;
 
     let first_prompt = if let Some(issue) = req.issue {
-        let base = match super::pr_detection::find_existing_pr_for_issue(project, issue).await {
+        let base = match super::pr_detection::find_existing_pr_for_issue_with_token(
+            project,
+            issue,
+            server_config.server.github_token.as_deref(),
+        )
+        .await
+        {
             Ok(Some((pr_num, branch, pr_url))) => {
                 tracing::info!(
                     "reusing existing PR #{pr_num} on branch `{branch}` for issue #{issue}"

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -37,7 +37,7 @@ fn restricted_tools(profile: CapabilityProfile) -> anyhow::Result<Vec<String>> {
 use pr_detection::{
     build_fix_ci_prompt, parse_harness_mention_command, HarnessMentionCommand, PromptBuilder,
 };
-use pr_detection::{detect_repo_slug, find_existing_pr_for_issue};
+use pr_detection::{detect_repo_slug, find_existing_pr_for_issue_with_token};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -519,11 +519,15 @@ pub(crate) async fn run_task(
         (Some(plan), prompts::TriageComplexity::Medium, 0u32)
     } else if let Some(issue) = req.issue {
         // Only triage fresh issues (no existing PR to continue).
-        let has_existing_pr = find_existing_pr_for_issue(&project, issue)
-            .await
-            .ok()
-            .flatten()
-            .is_some();
+        let has_existing_pr = find_existing_pr_for_issue_with_token(
+            &project,
+            issue,
+            server_config.server.github_token.as_deref(),
+        )
+        .await
+        .ok()
+        .flatten()
+        .is_some();
         if has_existing_pr {
             // Fresh issue task reusing an existing PR — treat as resumed for conflict gating.
             was_resumed_pr = true;
@@ -839,6 +843,7 @@ pub(crate) async fn run_task(
         task_start,
         repo_slug_for_review,
         jaccard_threshold,
+        server_config.server.github_token.as_deref(),
     )
     .await
 }

--- a/crates/harness-server/src/task_executor/pr_detection.rs
+++ b/crates/harness-server/src/task_executor/pr_detection.rs
@@ -218,9 +218,10 @@ pub(crate) fn build_pr_approved_prompt(
 /// closing relationship** to the issue are returned. The match is any of:
 /// - a closing keyword in title or body: `closes|closed|close|fixes|fixed|fix|resolves|resolved|resolve #N`
 /// - the `(#N)` suffix pattern that harness uses in its own PR titles
-pub(crate) async fn find_existing_pr_for_issue(
+pub(crate) async fn find_existing_pr_for_issue_with_token(
     project: &Path,
     issue: u64,
+    github_token: Option<&str>,
 ) -> anyhow::Result<Option<(u64, String, String)>> {
     let Some(repo_slug) = detect_repo_slug(project).await else {
         tracing::debug!(
@@ -237,10 +238,8 @@ pub(crate) async fn find_existing_pr_for_issue(
         .get(url)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        if !token.trim().is_empty() {
-            request = request.bearer_auth(token);
-        }
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
     }
     let response =
         match tokio::time::timeout(std::time::Duration::from_secs(10), request.send()).await {

--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -35,7 +35,11 @@ struct GitHubPullState {
 /// Returns [`PrExternalState::Unknown`] on any transient
 /// failure so callers do not abort a healthy review loop because of a flaky
 /// network call.
-async fn fetch_pr_external_state(pr_num: u64, project: &Path) -> PrExternalState {
+async fn fetch_pr_external_state(
+    pr_num: u64,
+    project: &Path,
+    github_token: Option<&str>,
+) -> PrExternalState {
     let Some(repo) = super::pr_detection::detect_repo_slug(project).await else {
         tracing::debug!(
             pr = pr_num,
@@ -50,10 +54,8 @@ async fn fetch_pr_external_state(pr_num: u64, project: &Path) -> PrExternalState
         ))
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        if !token.trim().is_empty() {
-            request = request.bearer_auth(token);
-        }
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
     }
     let response = match tokio::time::timeout(Duration::from_secs(10), request.send()).await {
         Ok(Ok(response)) if response.status().is_success() => response,
@@ -132,6 +134,7 @@ pub(crate) async fn run_review_loop(
     task_start: Instant,
     repo_slug: String,
     jaccard_threshold: f64,
+    github_token: Option<&str>,
 ) -> anyhow::Result<()> {
     let review_phase_start = Instant::now();
 
@@ -172,7 +175,7 @@ pub(crate) async fn run_review_loop(
         // against stale work — short-circuit to the appropriate terminal
         // status. Unknown/transient failures fall through and continue the
         // normal review flow.
-        match fetch_pr_external_state(pr_num, project).await {
+        match fetch_pr_external_state(pr_num, project, github_token).await {
             PrExternalState::Merged => {
                 tracing::info!(
                     task_id = %task_id,

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1091,13 +1091,23 @@ impl TaskStore {
     /// GitHub API failures are treated as transient network errors; the task is left
     /// Pending so it will be retried normally.
     pub async fn validate_recovered_tasks(&self, completion_callback: Option<CompletionCallback>) {
-        self.validate_recovered_tasks_with_github(completion_callback)
+        self.validate_recovered_tasks_with_github(completion_callback, None)
+            .await;
+    }
+
+    pub async fn validate_recovered_tasks_with_token(
+        &self,
+        completion_callback: Option<CompletionCallback>,
+        github_token: Option<&str>,
+    ) {
+        self.validate_recovered_tasks_with_github(completion_callback, github_token)
             .await;
     }
 
     async fn validate_recovered_tasks_with_github(
         &self,
         completion_callback: Option<CompletionCallback>,
+        github_token: Option<&str>,
     ) {
         let candidates = self.collect_recovered_pr_candidates();
 
@@ -1113,7 +1123,7 @@ impl TaskStore {
         // Probe PR states concurrently, but keep persistence and callbacks
         // serialized so terminal-state side effects preserve their current order.
         let mut results = futures::stream::iter(candidates)
-            .map(check_recovered_pr_state)
+            .map(|candidate| check_recovered_pr_state(candidate, github_token))
             .buffer_unordered(RECOVERED_PR_VALIDATION_CONCURRENCY);
 
         while let Some(result) = results.next().await {
@@ -1186,6 +1196,7 @@ fn recovered_pr_candidate(task: &TaskState) -> Option<RecoveredPrCandidate> {
 
 async fn check_recovered_pr_state(
     candidate: RecoveredPrCandidate,
+    github_token: Option<&str>,
 ) -> Option<RecoveredPrStatusUpdate> {
     let RecoveredPrCandidate { task_id, pr_url } = candidate;
     let Some((owner, repo, pr_number)) = super::spawn::parse_pr_url(&pr_url) else {
@@ -1203,10 +1214,8 @@ async fn check_recovered_pr_state(
         ))
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        if !token.trim().is_empty() {
-            request = request.bearer_auth(token);
-        }
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
     }
     let response = match tokio::time::timeout(RECOVERED_PR_VIEW_TIMEOUT, request.send()).await {
         Err(_elapsed) => {

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -776,6 +776,7 @@ impl WorkspaceManager {
         source_repo: &Path,
         _gh_bin: &str,
         max_rate: u32,
+        github_token: Option<&str>,
     ) -> DiskReconciliationSummary {
         let mut summary = DiskReconciliationSummary::default();
         let read_dir = match std::fs::read_dir(&self.config.root) {
@@ -829,10 +830,16 @@ impl WorkspaceManager {
 
             let gh_state = if let Some(n) = issue_num {
                 rate.acquire().await;
-                crate::reconciliation::fetch_issue_state(&repo_slug, n).await
+                crate::reconciliation::fetch_issue_state_with_token(&repo_slug, n, github_token)
+                    .await
             } else if let Some(n) = pr_num {
                 rate.acquire().await;
-                crate::reconciliation::fetch_pr_state_by_slug(&repo_slug, n).await
+                crate::reconciliation::fetch_pr_state_by_slug_with_token(
+                    &repo_slug,
+                    n,
+                    github_token,
+                )
+                .await
             } else {
                 crate::reconciliation::GitHubState::Unknown
             };
@@ -2470,7 +2477,9 @@ mod tests {
             .expect("create workspace");
         mgr.release_workspace(&task_id);
 
-        let summary = mgr.reconcile_disk_workspaces(source.path(), "gh", 20).await;
+        let summary = mgr
+            .reconcile_disk_workspaces(source.path(), "gh", 20, None)
+            .await;
 
         assert_eq!(summary.skipped_uuid, 1);
         assert_eq!(summary.removed, 0);
@@ -2514,7 +2523,9 @@ mod tests {
             github_state_server("/repos/myorg/my-repo/issues/42", r#"{"state":"closed"}"#).await;
         let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
 
-        let summary = mgr.reconcile_disk_workspaces(source.path(), "gh", 20).await;
+        let summary = mgr
+            .reconcile_disk_workspaces(source.path(), "gh", 20, None)
+            .await;
 
         assert_eq!(summary.removed, 1);
         assert!(!issue_dir.exists(), "closed issue workspace removed");
@@ -2552,7 +2563,9 @@ mod tests {
             github_state_server("/repos/myorg/my-repo/issues/7", r#"{"state":"open"}"#).await;
         let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
 
-        let summary = mgr.reconcile_disk_workspaces(source.path(), "gh", 20).await;
+        let summary = mgr
+            .reconcile_disk_workspaces(source.path(), "gh", 20, None)
+            .await;
 
         assert_eq!(summary.removed, 0);
         assert_eq!(summary.skipped_open, 1);


### PR DESCRIPTION
## Summary

Closes #1009.

- Resolve GitHub tokens through one helper and thread `server.github_token` into intake, reconciliation, workspace cleanup, recovered PR validation, post-validation, review loops, and existing-PR lookup paths.
- Support `GH_TOKEN` as a fallback while preserving an explicitly configured `server.github_token`.
- Derive the default workspace root from `server.data_dir` so parallel server configs do not share the same default worktree directory.
- Keep Codex analytics stderr out of operator WARN logs and include `program` / `cwd` diagnostics when Codex spawn fails.

## Tests

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test -p harness-agents`
- `cargo test -p harness-core derived_workspace_root`
- `cargo test -p harness-core env_override_gh_token`
- `cargo test -p harness-server github_auth`
- `cargo test -p harness-server github_issues_poller_accepts_configured_token`
- `cargo test -p harness-server parse_gh_output_accepts_api_url_and_html_url`
- `cargo test -p harness-server reconcile_disk_removes_closed_issue_workspace`

## Local full-suite note

`cargo test` was attempted. It reached `harness-server --lib` and failed with 658 passed / 267 failed because the local `DATABASE_URL` points at a Postgres instance that rejects the test connections and then opens a circuit breaker:

```text
(ECIRCUITBREAKER) too many authentication failures, new connections are temporarily blocked
```
