### PR TITLE
Inject project context into task prompts

### DIFF
--- a/crates/harness-core/src/agents_md.rs
+++ b/crates/harness-core/src/agents_md.rs
@@ -2,45 +2,42 @@ use std::path::{Path, PathBuf};
 
 const MAX_COMBINED_BYTES: usize = 32 * 1024;
 
-/// Load and merge cascading AGENTS.md files.
+/// Load and merge cascading project instruction files.
 ///
 /// Discovery order (later entries override earlier):
-/// 1. `~/.harness/AGENTS.md` (global)
-/// 2. `<project_root>/AGENTS.md`
-/// 3. Subdirectory AGENTS.md files toward cwd (if different from project root)
+/// 1. `~/.harness/AGENTS.md` and `~/.harness/CLAUDE.md` (global)
+/// 2. `<project_root>/AGENTS.md` and `<project_root>/CLAUDE.md`
+/// 3. Subdirectory AGENTS.md / CLAUDE.md files in common code directories
 ///
 /// `AGENTS.override.md` at any level replaces all content accumulated so far.
 /// Combined output is capped at `MAX_COMBINED_BYTES` (32KB).
 pub fn load_agents_md(project_root: &Path) -> String {
     let mut parts: Vec<String> = Vec::new();
 
-    // 1. Global ~/.harness/AGENTS.md
+    // 1. Global ~/.harness/{AGENTS,CLAUDE}.md
     if let Ok(home) = std::env::var("HOME") {
-        let global = PathBuf::from(home).join(".harness").join("AGENTS.md");
-        if let Some(content) = read_md(&global) {
-            parts.push(content);
-        }
+        let global_dir = PathBuf::from(home).join(".harness");
+        push_instruction_files(&global_dir, &mut parts);
     }
 
-    // 2. Project root AGENTS.md / AGENTS.override.md
+    // 2. Project root AGENTS.md / CLAUDE.md / AGENTS.override.md
     let override_path = project_root.join("AGENTS.override.md");
-    let agents_path = project_root.join("AGENTS.md");
     if let Some(content) = read_md(&override_path) {
         parts.clear();
         parts.push(content);
-    } else if let Some(content) = read_md(&agents_path) {
-        parts.push(content);
+    } else {
+        push_instruction_files(project_root, &mut parts);
     }
 
     // 3. Subdirectories — scan common code directories
     for subdir in &["src", "crates", "lib", "pkg"] {
-        let sub_override = project_root.join(subdir).join("AGENTS.override.md");
-        let sub_agents = project_root.join(subdir).join("AGENTS.md");
+        let subdir = project_root.join(subdir);
+        let sub_override = subdir.join("AGENTS.override.md");
         if let Some(content) = read_md(&sub_override) {
             parts.clear();
             parts.push(content);
-        } else if let Some(content) = read_md(&sub_agents) {
-            parts.push(content);
+        } else {
+            push_instruction_files(&subdir, &mut parts);
         }
     }
 
@@ -52,18 +49,32 @@ pub fn load_agents_md(project_root: &Path) -> String {
     combined
 }
 
-/// Discover paths that would be checked for AGENTS.md files.
+/// Discover paths that would be checked for project instruction files.
 pub fn discovery_paths(project_root: &Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     if let Ok(home) = std::env::var("HOME") {
-        paths.push(PathBuf::from(home).join(".harness").join("AGENTS.md"));
+        let global_dir = PathBuf::from(home).join(".harness");
+        paths.push(global_dir.join("AGENTS.md"));
+        paths.push(global_dir.join("CLAUDE.md"));
     }
     paths.push(project_root.join("AGENTS.md"));
+    paths.push(project_root.join("CLAUDE.md"));
     paths.push(project_root.join("AGENTS.override.md"));
     for subdir in &["src", "crates", "lib", "pkg"] {
-        paths.push(project_root.join(subdir).join("AGENTS.md"));
+        let subdir = project_root.join(subdir);
+        paths.push(subdir.join("AGENTS.md"));
+        paths.push(subdir.join("CLAUDE.md"));
     }
     paths
+}
+
+fn push_instruction_files(dir: &Path, parts: &mut Vec<String>) {
+    for file_name in ["AGENTS.md", "CLAUDE.md"] {
+        let path = dir.join(file_name);
+        if let Some(content) = read_md(&path) {
+            parts.push(content);
+        }
+    }
 }
 
 fn read_md(path: &Path) -> Option<String> {
@@ -105,14 +116,26 @@ mod tests {
     }
 
     #[test]
-    fn subdirectory_agents_md_merged() {
+    fn claude_md_is_loaded_with_agents_md() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "agent instructions").unwrap();
+        fs::write(dir.path().join("CLAUDE.md"), "claude instructions").unwrap();
+        let result = load_agents_md(dir.path());
+        assert!(result.contains("agent instructions"));
+        assert!(result.contains("claude instructions"));
+    }
+
+    #[test]
+    fn subdirectory_instruction_files_are_merged() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("AGENTS.md"), "root").unwrap();
         fs::create_dir_all(dir.path().join("src")).unwrap();
         fs::write(dir.path().join("src/AGENTS.md"), "src specific").unwrap();
+        fs::write(dir.path().join("src/CLAUDE.md"), "src claude specific").unwrap();
         let result = load_agents_md(dir.path());
         assert!(result.contains("root"));
         assert!(result.contains("src specific"));
+        assert!(result.contains("src claude specific"));
     }
 
     #[test]
@@ -129,6 +152,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = discovery_paths(dir.path());
         assert!(paths.iter().any(|p| p.ends_with("AGENTS.md")));
+        assert!(paths.iter().any(|p| p.ends_with("CLAUDE.md")));
         assert!(paths.iter().any(|p| p.ends_with("AGENTS.override.md")));
     }
 }

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -313,6 +313,25 @@ pub(crate) async fn collect_context_items(
     items
 }
 
+/// Inject project instruction files directly into the prompt text.
+///
+/// Harness currently invokes CLI agents in single-turn mode (`claude -p` /
+/// `codex ...`), and `AgentRequest.context` is retained for observability rather
+/// than automatically forwarded to the CLI. Embed AGENTS.md / CLAUDE.md content
+/// in the prompt so agents actually see project-specific rules.
+pub(crate) fn inject_project_context_into_prompt(project_root: &Path, prompt: String) -> String {
+    let project_context = harness_core::agents_md::load_agents_md(project_root);
+    if project_context.trim().is_empty() {
+        return prompt;
+    }
+
+    format!(
+        "{prompt}\n\n## Project Instructions\n\
+         The following trusted project instructions were loaded from AGENTS.md / CLAUDE.md files. \
+         Follow them for this task.\n\n{project_context}"
+    )
+}
+
 /// Return all skills whose trigger patterns match `prompt`, including their IDs
 /// and names for observability/event logging.
 pub(crate) async fn matched_skills_for_prompt(

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -505,6 +505,35 @@ fn inject_project_context_noops_without_instruction_files() {
     assert_eq!(result, "Base task");
 }
 
+#[tokio::test]
+async fn project_context_text_does_not_cause_skill_match_when_matching_original_prompt() {
+    let mut store = harness_skills::store::SkillStore::new();
+    store.create(
+        "review".to_string(),
+        "# Review\n<!-- trigger-patterns: code review -->\nReview code carefully.".to_string(),
+    );
+    let skills = RwLock::new(store);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("AGENTS.md"), "please do a code review").unwrap();
+
+    let original_prompt = "implement feature X".to_string();
+    let injected_prompt = inject_project_context_into_prompt(dir.path(), original_prompt.clone());
+
+    let matched_original = matched_skills_for_prompt(&skills, &original_prompt).await;
+    let matched_injected = matched_skills_for_prompt(&skills, &injected_prompt).await;
+
+    assert!(
+        matched_original.is_empty(),
+        "task prompt alone should not match the review skill"
+    );
+    assert_eq!(
+        matched_injected.len(),
+        1,
+        "project instruction content would falsely match without preserving the original task prompt"
+    );
+}
+
 fn make_skill_store_with_two_matching() -> harness_skills::store::SkillStore {
     let mut store = harness_skills::store::SkillStore::new();
     store.create(

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -484,6 +484,27 @@ async fn inject_skills_empty_store_returns_empty_string() {
     );
 }
 
+#[test]
+fn inject_project_context_appends_agents_and_claude_instructions() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("AGENTS.md"), "Always run cargo check").unwrap();
+    std::fs::write(dir.path().join("CLAUDE.md"), "Use English only").unwrap();
+
+    let result = inject_project_context_into_prompt(dir.path(), "Base task".to_string());
+
+    assert!(result.contains("Base task"));
+    assert!(result.contains("## Project Instructions"));
+    assert!(result.contains("Always run cargo check"));
+    assert!(result.contains("Use English only"));
+}
+
+#[test]
+fn inject_project_context_noops_without_instruction_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let result = inject_project_context_into_prompt(dir.path(), "Base task".to_string());
+    assert_eq!(result, "Base task");
+}
+
 fn make_skill_store_with_two_matching() -> harness_skills::store::SkillStore {
     let mut store = harness_skills::store::SkillStore::new();
     store.create(

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -1,7 +1,7 @@
 use super::helpers::{
-    collect_context_items, detect_modified_files, inject_skills_into_prompt,
-    matched_skills_for_prompt, run_agent_streaming, run_on_error, run_post_execute,
-    run_post_tool_use, run_pre_execute, update_status,
+    collect_context_items, detect_modified_files, inject_project_context_into_prompt,
+    inject_skills_into_prompt, matched_skills_for_prompt, run_agent_streaming, run_on_error,
+    run_post_execute, run_post_tool_use, run_pre_execute, update_status,
 };
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, TaskFailureKind, TaskId, TaskStatus, TaskStore,
@@ -232,6 +232,11 @@ pub(crate) async fn run_implement_phase(
     // Prepend the Golden Principles constitution when enabled.
     let first_prompt =
         prepend_constitution(first_prompt, server_config.server.constitution_enabled);
+
+    // Inject project instructions directly into the prompt text.
+    // AgentRequest.context is retained for observability, but CLI agents do not
+    // receive it automatically in single-turn mode.
+    let first_prompt = inject_project_context_into_prompt(project, first_prompt);
 
     // Inject skill content directly into the prompt text.
     // Since harness uses single-turn `claude -p`, context items are not visible

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -233,17 +233,22 @@ pub(crate) async fn run_implement_phase(
     let first_prompt =
         prepend_constitution(first_prompt, server_config.server.constitution_enabled);
 
-    // Inject project instructions directly into the prompt text.
-    // AgentRequest.context is retained for observability, but CLI agents do not
-    // receive it automatically in single-turn mode.
-    let first_prompt = inject_project_context_into_prompt(project, first_prompt);
-
     // Inject skill content directly into the prompt text.
     // Since harness uses single-turn `claude -p`, context items are not visible
     // to the agent — we must embed skill content in the prompt string itself.
     // Also records usage for any matched skills via record_use().
-    let matched_skills = matched_skills_for_prompt(skills, &first_prompt).await;
-    let skill_additions = inject_skills_into_prompt(skills, &first_prompt).await;
+    //
+    // Match against the task prompt before appending project instruction files.
+    // Otherwise AGENTS.md / CLAUDE.md trigger phrases can cause unrelated skills
+    // to be injected and logged as used.
+    let skill_match_prompt = first_prompt.clone();
+    let matched_skills = matched_skills_for_prompt(skills, &skill_match_prompt).await;
+    let skill_additions = inject_skills_into_prompt(skills, &skill_match_prompt).await;
+
+    // Inject project instructions directly into the prompt text.
+    // AgentRequest.context is retained for observability, but CLI agents do not
+    // receive it automatically in single-turn mode.
+    let first_prompt = inject_project_context_into_prompt(project, first_prompt);
     let first_prompt = if skill_additions.is_empty() {
         first_prompt
     } else {
@@ -267,7 +272,7 @@ pub(crate) async fn run_implement_phase(
         }
     }
 
-    let context_items = collect_context_items(skills, project, &first_prompt).await;
+    let context_items = collect_context_items(skills, project, &skill_match_prompt).await;
 
     let initial_allowed_tools: Option<Vec<String>> = None;
     let capability_prompt_note: Option<&'static str> = None;

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -193,12 +193,13 @@ async fn run_non_implementation_task(
         system_input.prompt().to_string(),
         server_config.server.constitution_enabled,
     );
+    let skill_match_prompt = prompt.clone();
+    let skill_additions = helpers::inject_skills_into_prompt(skills, &skill_match_prompt).await;
     prompt = helpers::inject_project_context_into_prompt(project, prompt);
-    let skill_additions = helpers::inject_skills_into_prompt(skills, &prompt).await;
     if !skill_additions.is_empty() {
         prompt.push_str(&skill_additions);
     }
-    let context_items = helpers::collect_context_items(skills, project, &prompt).await;
+    let context_items = helpers::collect_context_items(skills, project, &skill_match_prompt).await;
     let allowed_tools = Some(restricted_tools(CapabilityProfile::Standard)?);
     if let Some(note) = CapabilityProfile::Standard.prompt_note() {
         prompt = format!("{note}\n\n{prompt}");

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -193,6 +193,7 @@ async fn run_non_implementation_task(
         system_input.prompt().to_string(),
         server_config.server.constitution_enabled,
     );
+    prompt = helpers::inject_project_context_into_prompt(project, prompt);
     let skill_additions = helpers::inject_skills_into_prompt(skills, &prompt).await;
     if !skill_additions.is_empty() {
         prompt.push_str(&skill_additions);


### PR DESCRIPTION
## Summary

- Load CLAUDE.md alongside AGENTS.md for project instruction context.
- Embed project instructions directly into implementation and non-implementation task prompts because CLI agents do not receive AgentRequest.context automatically.
- Keep ContextItem collection for observability and add tests for instruction loading and prompt injection.

## Tests

- `CARGO_TARGET_DIR=target/cargo-check cargo check --package harness-core --package harness-server`
- `CARGO_TARGET_DIR=target/cargo-test cargo test --package harness-core agents_md`
- `CARGO_TARGET_DIR=target/cargo-test cargo test --package harness-server inject_project_context -- --nocapture`

Closes #1012
