### PR TITLE
refactor: add agent adapter execution strategy

### DIFF
--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -5,13 +5,39 @@ use harness_core::{
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Describes how an optional interactive adapter participates in turn execution.
+///
+/// `ControlOnly` adapters are registered only for side-channel operations such as
+/// interrupt, steer, or approval response. `ExecuteTurns` adapters are the
+/// canonical turn executor for the agent. This keeps agent-specific behavior at
+/// registration time instead of branching on agent names at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterExecutionStrategy {
+    ControlOnly,
+    ExecuteTurns,
+}
+
+impl AdapterExecutionStrategy {
+    pub fn executes_turns(self) -> bool {
+        matches!(self, Self::ExecuteTurns)
+    }
+}
+
+impl Default for AdapterExecutionStrategy {
+    fn default() -> Self {
+        Self::ControlOnly
+    }
+}
+
 /// Bundles an agent executor with an optional interactive adapter.
 ///
 /// A descriptor is created with `adapter: None` on plain `register()` calls.
-/// Call `register_adapter()` to attach an adapter after the agent is registered.
+/// Call `register_adapter()` or `register_adapter_with_strategy()` to attach an
+/// adapter after the agent is registered.
 pub struct AgentDescriptor {
     pub agent: Arc<dyn CodeAgent>,
     pub adapter: Option<Arc<dyn AgentAdapter>>,
+    pub adapter_strategy: AdapterExecutionStrategy,
 }
 
 pub struct AgentRegistry {
@@ -44,7 +70,9 @@ impl AgentRegistry {
         // Preserve any previously attached adapter so that hot-reload cannot
         // accidentally clear the adapter by re-registering the agent under the
         // same name (the old split-registry design had this property naturally).
-        let existing_adapter = self.entries.get(&name).and_then(|d| d.adapter.clone());
+        let existing = self.entries.get(&name);
+        let existing_adapter = existing.and_then(|d| d.adapter.clone());
+        let existing_strategy = existing.map(|d| d.adapter_strategy).unwrap_or_default();
         if !self.entries.contains_key(&name) {
             self.registration_order.push(name.clone());
         }
@@ -53,11 +81,12 @@ impl AgentRegistry {
             AgentDescriptor {
                 agent,
                 adapter: existing_adapter,
+                adapter_strategy: existing_strategy,
             },
         );
     }
 
-    /// Attach an adapter to an already-registered agent.
+    /// Attach a control-only adapter to an already-registered agent.
     ///
     /// Returns `Err(HarnessError::AgentNotFound)` if the agent name is unknown,
     /// so misconfiguration fails loudly instead of silently (U-23).
@@ -66,9 +95,24 @@ impl AgentRegistry {
         name: &str,
         adapter: Arc<dyn AgentAdapter>,
     ) -> harness_core::error::Result<()> {
+        self.register_adapter_with_strategy(name, adapter, AdapterExecutionStrategy::ControlOnly)
+    }
+
+    /// Attach an adapter with an explicit execution strategy.
+    ///
+    /// Use `ExecuteTurns` only when the adapter owns the full turn lifecycle for
+    /// the agent. Use `ControlOnly` when the adapter exists for side-channel
+    /// control while the legacy `CodeAgent` remains the turn executor.
+    pub fn register_adapter_with_strategy(
+        &mut self,
+        name: &str,
+        adapter: Arc<dyn AgentAdapter>,
+        strategy: AdapterExecutionStrategy,
+    ) -> harness_core::error::Result<()> {
         match self.entries.get_mut(name) {
             Some(descriptor) => {
                 descriptor.adapter = Some(adapter);
+                descriptor.adapter_strategy = strategy;
                 Ok(())
             }
             None => Err(HarnessError::AgentNotFound(format!(
@@ -85,6 +129,21 @@ impl AgentRegistry {
     /// Return the adapter registered for the given agent name, if any.
     pub fn get_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
         self.entries.get(name).and_then(|d| d.adapter.clone())
+    }
+
+    /// Return the adapter execution strategy for the given agent name.
+    pub fn adapter_strategy(&self, name: &str) -> Option<AdapterExecutionStrategy> {
+        self.entries.get(name).map(|d| d.adapter_strategy)
+    }
+
+    /// Return the adapter only when its strategy says it should execute turns.
+    pub fn turn_execution_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
+        let descriptor = self.entries.get(name)?;
+        if descriptor.adapter_strategy.executes_turns() {
+            descriptor.adapter.clone()
+        } else {
+            None
+        }
     }
 
     pub fn resolved_default_agent_name(&self) -> Option<&str> {
@@ -377,6 +436,47 @@ mod tests {
     }
 
     #[test]
+    fn register_adapter_defaults_to_control_only_strategy() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ControlOnly)
+        );
+        assert!(registry.turn_execution_adapter("mock").is_none());
+    }
+
+    #[test]
+    fn register_adapter_with_execute_strategy_enables_turn_execution() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter_with_strategy(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+                AdapterExecutionStrategy::ExecuteTurns,
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ExecuteTurns)
+        );
+        assert!(registry.turn_execution_adapter("mock").is_some());
+    }
+
+    #[test]
     fn register_creates_descriptor_with_no_adapter() {
         let mut registry = AgentRegistry::new("mock");
         registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
@@ -406,15 +506,16 @@ mod tests {
     }
 
     #[test]
-    fn re_register_preserves_existing_adapter() {
+    fn re_register_preserves_existing_adapter_and_strategy() {
         let mut registry = AgentRegistry::new("mock");
         registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
         registry
-            .register_adapter(
+            .register_adapter_with_strategy(
                 "mock",
                 Arc::new(StubAdapter {
                     adapter_name: "mock",
                 }),
+                AdapterExecutionStrategy::ExecuteTurns,
             )
             .unwrap();
 
@@ -432,6 +533,11 @@ mod tests {
             "adapter must survive re-registration of the same agent name"
         );
         assert_eq!(adapter.unwrap().name(), "mock");
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ExecuteTurns),
+            "adapter strategy must survive re-registration"
+        );
         // The agent itself must be updated.
         assert_eq!(registry.get("mock").unwrap().name(), "mock-v2");
     }

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -198,12 +198,13 @@ pub async fn run(
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
     agent_registry.register("claude", Arc::new(claude_agent));
     agent_registry
-        .register_adapter(
+        .register_adapter_with_strategy(
             "claude",
             Arc::new(harness_agents::claude_adapter::ClaudeAdapter::new(
                 serve_config.agents.claude.cli_path.clone(),
                 serve_config.agents.claude.default_model.clone(),
             )),
+            harness_agents::registry::AdapterExecutionStrategy::ControlOnly,
         )
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     agent_registry.register(
@@ -217,11 +218,12 @@ pub async fn run(
         ),
     );
     agent_registry
-        .register_adapter(
+        .register_adapter_with_strategy(
             "codex",
             Arc::new(harness_agents::codex_adapter::CodexAdapter::new(
                 serve_config.agents.codex.cli_path.clone(),
             )),
+            harness_agents::registry::AdapterExecutionStrategy::ExecuteTurns,
         )
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {

--- a/crates/harness-server/src/handlers/error.rs
+++ b/crates/harness-server/src/handlers/error.rs
@@ -1,0 +1,16 @@
+use harness_protocol::methods::{RpcResponse, INTERNAL_ERROR, INVALID_PARAMS, VALIDATION_ERROR};
+
+pub(crate) fn invalid_params(
+    id: Option<serde_json::Value>,
+    message: impl Into<String>,
+) -> RpcResponse {
+    RpcResponse::error(id, INVALID_PARAMS, message)
+}
+
+pub(crate) fn validation(id: Option<serde_json::Value>, message: impl Into<String>) -> RpcResponse {
+    RpcResponse::error(id, VALIDATION_ERROR, message)
+}
+
+pub(crate) fn internal(id: Option<serde_json::Value>, message: impl Into<String>) -> RpcResponse {
+    RpcResponse::error(id, INTERNAL_ERROR, message)
+}

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod classify;
 pub mod cross_review;
 pub mod dashboard;
+pub mod error;
 pub mod exec;
 pub mod gc;
 pub mod health;

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -1,5 +1,6 @@
-use crate::{http::AppState, validate_root};
-use harness_protocol::{methods::RpcResponse, methods::INTERNAL_ERROR};
+use crate::{handlers::error as rpc_error, http::AppState, validate_root};
+use harness_protocol::methods::RpcResponse;
+use harness_rules::engine::{WARN_EMPTY_SCAN_INPUT, WARN_NO_GUARDS_REGISTERED};
 use std::path::PathBuf;
 
 pub async fn rule_load(
@@ -14,7 +15,7 @@ pub async fn rule_load(
             let count = rules.rules().len();
             RpcResponse::success(id, serde_json::json!({ "rules_count": count }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => rpc_error::internal(id, e.to_string()),
     }
 }
 
@@ -36,7 +37,7 @@ pub async fn rule_check(
             for file in &f {
                 match crate::handlers::validate_file_in_root(file, &project_root) {
                     Ok(p) => validated.push(p),
-                    Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+                    Err(e) => return rpc_error::invalid_params(id, e),
                 }
             }
             Some(validated)
@@ -58,7 +59,14 @@ pub async fn rule_check(
                 error = %err,
                 "rule/check rejected before scan"
             );
-            return RpcResponse::error(id, INTERNAL_ERROR, err.to_string());
+            let message = err.to_string();
+            if message.contains(WARN_EMPTY_SCAN_INPUT) {
+                return rpc_error::invalid_params(id, message);
+            }
+            if message.contains(WARN_NO_GUARDS_REGISTERED) {
+                return rpc_error::validation(id, message);
+            }
+            return rpc_error::internal(id, message);
         }
         rules.snapshot()
     }; // read lock released here
@@ -86,7 +94,7 @@ pub async fn rule_check(
                 .await;
             match serde_json::to_value(&violations) {
                 Ok(v) => RpcResponse::success(id, v),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                Err(e) => rpc_error::internal(id, e.to_string()),
             }
         }
         Err(e) => {
@@ -96,7 +104,7 @@ pub async fn rule_check(
                 error = %e,
                 "rule/check scan failed"
             );
-            RpcResponse::error(id, INTERNAL_ERROR, e.to_string())
+            rpc_error::internal(id, e.to_string())
         }
     }
 }
@@ -105,7 +113,7 @@ pub async fn rule_check(
 mod tests {
     use super::rule_check;
     use harness_core::{types::EventFilters, types::GuardId, types::Language};
-    use harness_protocol::methods::INTERNAL_ERROR;
+    use harness_protocol::methods::{INVALID_PARAMS, VALIDATION_ERROR};
     use harness_rules::engine::{Guard, WARN_EMPTY_SCAN_INPUT, WARN_NO_GUARDS_REGISTERED};
     use std::path::PathBuf;
 
@@ -126,7 +134,7 @@ mod tests {
             .error
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("expected rule/check to fail without guards"))?;
-        assert_eq!(error.code, INTERNAL_ERROR);
+        assert_eq!(error.code, VALIDATION_ERROR);
         assert!(
             error.message.contains(WARN_NO_GUARDS_REGISTERED),
             "expected warning message in error: {}",
@@ -232,7 +240,7 @@ mod tests {
             .error
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("expected rule/check to fail for empty scan input"))?;
-        assert_eq!(error.code, INTERNAL_ERROR);
+        assert_eq!(error.code, INVALID_PARAMS);
         assert!(
             error.message.contains(WARN_EMPTY_SCAN_INPUT),
             "expected warning message in error: {}",

--- a/crates/harness-server/src/hook_enforcer.rs
+++ b/crates/harness-server/src/hook_enforcer.rs
@@ -40,8 +40,12 @@ use crate::circuit_breaker::CircuitBreaker;
 /// - `enabled` is `false` (controlled by `rules.hook_enforcement` in config)
 /// - `CI` environment variable is set
 /// - no guards are registered
-/// - no files were modified during the turn
+/// - no affected files are supplied by telemetry
 /// - the circuit breaker is open (consecutive-block limit reached)
+///
+/// Important: host-side git inspection is intentionally disabled by project
+/// policy. Until agent/file-write telemetry supplies `affected_files`, this is
+/// not a complete closed-loop rule-enforcement mechanism.
 pub struct HookEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
     events: Arc<EventStore>,

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -39,9 +39,11 @@ pub(crate) async fn build_services(
     let hook_enforcement = server.config.rules.hook_enforcement;
     let interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>> = vec![
         Arc::new(crate::contract_validator::ContractValidator::new()),
-        // RuleEnforcer disabled: false-positives on test fixtures in other repo
-        // worktrees (SEC-02 hardcoded secrets in test code) block periodic_review
-        // tasks. Re-enable after adding source-aware filtering or allowlists.
+        // RuleEnforcer intentionally disabled: false-positives on test fixtures
+        // in other repo worktrees (SEC-02 hardcoded secrets in test code)
+        // block periodic_review tasks. Until source-aware filtering or
+        // allowlists exist, rule checks are available through explicit scans and
+        // post-tool hooks only; they are not a full pre-turn enforcement gate.
         // Arc::new(crate::rule_enforcer::RuleEnforcer::new(
         //     engines.rules.clone(),
         // )),

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
-use harness_protocol::{methods::Method, methods::RpcRequest, methods::INTERNAL_ERROR};
+use harness_protocol::{methods::Method, methods::RpcRequest, methods::VALIDATION_ERROR};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -569,7 +569,7 @@ async fn rule_check_returns_warning_when_no_guards_loaded() -> anyhow::Result<()
         .error
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("expected warning error response"))?;
-    assert_eq!(error.code, INTERNAL_ERROR);
+    assert_eq!(error.code, VALIDATION_ERROR);
     assert!(
         error
             .message

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -74,9 +74,9 @@ pub(crate) async fn run_turn_lifecycle(
     let adapter_opt = server.agent_registry.get_adapter(&agent_name);
 
     // Register as live adapter (RAII guard for cleanup on turn exit).
-    // When an adapter is available, execution goes through adapter.start_turn()
-    // (see below), so the adapter's stdin is initialized before any
-    // steer/respond_approval call arrives.
+    // Adapters may be control-only (Claude: interrupt/steer/approval side
+    // channel only) or turn-executing (Codex: App Server JSON-RPC owns the
+    // full turn). The strategy is selected at agent registration time.
     let _adapter_guard = adapter_opt.as_ref().map(|adapter_arc| {
         server
             .thread_manager
@@ -90,15 +90,11 @@ pub(crate) async fn run_turn_lifecycle(
     let stall_timeout = Duration::from_secs(server.config.concurrency.stall_timeout_secs);
     let (stream_tx, mut stream_rx) = mpsc::channel(128);
 
-    // Only Codex uses the adapter for turn execution (initializes stdin so that
-    // subsequent steer/respond_approval calls can find a live process).
-    // Other adapters (e.g., ClaudeAdapter) exist for interrupt/steer only and must
-    // not override the configured CodeAgent execution path — ClaudeCodeAgent carries
-    // config-level settings (model, sandbox) that ClaudeAdapter does not replicate.
-    let execution_adapter = adapter_opt
-        .as_ref()
-        .filter(|a| a.name() == "codex")
-        .cloned();
+    // Use the adapter for turn execution only when its registered strategy says
+    // it owns the full lifecycle. This is the strategy pattern boundary between
+    // Codex's App Server adapter and Claude's control-only adapter; avoid
+    // branching on agent names here.
+    let execution_adapter = server.agent_registry.turn_execution_adapter(&agent_name);
     let mut execution: std::pin::Pin<
         Box<dyn std::future::Future<Output = harness_core::error::Result<()>> + Send>,
     > = if let Some(adapter_arc) = execution_adapter {

--- a/docs/design-cleanup-plan.md
+++ b/docs/design-cleanup-plan.md
@@ -1,0 +1,70 @@
+# Harness Design Cleanup Plan
+
+## Purpose
+
+Harness has accumulated several good abstractions that still coexist with older execution paths. The cleanup goal is not a rewrite; it is to make one path canonical per domain and delete or isolate the alternatives.
+
+## Current architectural pressure points
+
+### 1. Server crate owns too many concerns
+
+`harness-server` currently contains transport routing, task execution, persistence access, workspace lifecycle, intake, runtime host leasing, rule enforcement, review loops, dashboard APIs, and reconciliation. This makes it the highest-coupling crate in the workspace.
+
+Direction: keep HTTP/JSON-RPC transport in `harness-server`, but move domain orchestration behind service traits and smaller domain modules.
+
+### 2. Service layer is partially adopted
+
+`AppState` exposes both service traits and raw stores/engines. This lets handlers choose between the intended service boundary and direct concrete access.
+
+Direction: handlers should call services; services should own direct access to stores, engines, queues, and registries.
+
+### 3. Agent execution had name-based behavior
+
+The runtime previously distinguished Codex from Claude inside turn execution by checking the adapter name. This is brittle because agent semantics belong at registration time, not in execution control flow.
+
+Direction: use an adapter execution strategy:
+
+- `ControlOnly`: adapter is available for side-channel control, while `CodeAgent` executes turns.
+- `ExecuteTurns`: adapter owns the turn lifecycle.
+
+Claude is currently `ControlOnly`; Codex is currently `ExecuteTurns`.
+
+### 4. Rule enforcement is not a fully closed loop
+
+Rules, guards, interceptors, and events exist, but full runtime enforcement depends on affected-file telemetry. Host-side git inspection is intentionally disabled, and the full pre-turn `RuleEnforcer` is not active in the default interceptor stack.
+
+Direction: either make runtime enforcement complete with reliable file telemetry and source-aware filtering, or present rules as manual/on-demand scans. Avoid code comments or docs that imply enforcement is stronger than the active runtime path.
+
+### 5. Task state mixes multiple domains
+
+`TaskState` includes lifecycle, review metadata, intake links, dependency graph, workspace lease data, scheduler authority, and runtime-host lease state.
+
+Direction: keep the persisted record stable, but move mutation logic behind domain-specific transition APIs:
+
+- task lifecycle;
+- scheduler authority;
+- workspace lease;
+- review state;
+- intake/source link;
+- runtime host lease.
+
+### 6. Workspace lifecycle is a hotspot
+
+Workspace management combines git worktree operations, owner records, stale cleanup, key derivation, hooks, reconciliation, and tests. There is also an unfinished `workspace/` split in the source tree.
+
+Direction: finish the split or delete the unfinished split. The target layout should separate git utilities, owner records, lifecycle acquisition/release, reconciliation, key derivation, and hooks.
+
+### 7. Error mapping is inconsistent
+
+The protocol defines semantic JSON-RPC errors, but several handlers still map validation and client input failures to `INTERNAL_ERROR`.
+
+Direction: route handler failures through semantic helpers such as invalid params, validation, not found, storage, agent, and internal errors.
+
+## Refactoring rule
+
+For each cleanup, verify four links before merging:
+
+1. Declaration: the abstraction exists.
+2. Execution: startup/runtime code actually uses it.
+3. Validation: tests cover the entry point and observable effect.
+4. Removal: old duplicate paths are deleted or clearly marked as compatibility shims.


### PR DESCRIPTION
## Summary
- Add an adapter execution strategy to distinguish control-only adapters from turn-executing adapters.
- Register Claude as control-only and Codex as turn-executing, removing name-based turn lifecycle branching.
- Add semantic JSON-RPC error helpers and apply them to rule/check validation paths.
- Document the next design cleanup direction and clarify rule-enforcement comments.

## Validation
- `cargo fmt --all`
- `cargo check`
- `DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Note: a parallel `cargo test` run exposed existing state interference in two webhook route tests; the full suite passes serially with the local database URL above.
