### PR TITLE
Clean runtime adapter strategy and docs links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,41 @@ All outputs MUST be in English, including:
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
 - Pre-commit hook (`.githooks/pre-commit`) runs fmt + clippy + test automatically. After cloning, activate with: `git config core.hooksPath .githooks`
 
+## Local Cargo Concurrency
+
+- Cargo cannot safely be configured to ignore its build-directory lock. If commands wait on a Cargo build lock, that is usually protecting a shared `target/` directory.
+- Different projects can run Cargo concurrently as long as they do not share `CARGO_TARGET_DIR` or a global `build.target-dir`.
+- Do NOT set a global shared Cargo target directory when the goal is cross-project concurrency; it makes unrelated projects contend for the same lock.
+- For concurrent Cargo commands in the same repository, isolate build outputs by command:
+  - `CARGO_TARGET_DIR=target/cargo-check cargo check --workspace --all-targets -j 6`
+  - `CARGO_TARGET_DIR=target/cargo-test cargo test --workspace --all-targets -j 6`
+  - `CARGO_TARGET_DIR=target/cargo-clippy cargo clippy --workspace --all-targets -j 6 -- -D warnings`
+- On an M2 Max with 96GB RAM, keep total Cargo `-j` across concurrent jobs around 10-14 for predictable interactive performance; use lower values if other heavy builds are already running.
+- If the user wants non-blocking local commands, prefer explicit shell helpers such as `cargo_fast` or `cargobg` in `~/.zshrc` rather than overriding `cargo` globally:
+
+```bash
+cargo_fast() {
+  case "$1" in
+    check)
+      CARGO_TARGET_DIR=target/cargo-check command cargo "$@"
+      ;;
+    test)
+      CARGO_TARGET_DIR=target/cargo-test command cargo "$@"
+      ;;
+    clippy)
+      CARGO_TARGET_DIR=target/cargo-clippy command cargo "$@"
+      ;;
+    *)
+      command cargo "$@"
+      ;;
+  esac
+}
+
+cargobg() {
+  cargo_fast "$@" &
+}
+```
+
 ## Architecture
 
 Harness is an agent orchestration layer. It constructs prompts and manages lifecycle — agents (Claude Code CLI) decide how to execute.

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -5,13 +5,34 @@ use harness_core::{
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Describes how an optional interactive adapter participates in turn execution.
+///
+/// `ControlOnly` adapters are registered only for side-channel operations such as
+/// interrupt, steer, or approval response. `ExecuteTurns` adapters are the
+/// canonical turn executor for the agent. This keeps agent-specific behavior at
+/// registration time instead of branching on agent names at runtime.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterExecutionStrategy {
+    #[default]
+    ControlOnly,
+    ExecuteTurns,
+}
+
+impl AdapterExecutionStrategy {
+    pub fn executes_turns(self) -> bool {
+        matches!(self, Self::ExecuteTurns)
+    }
+}
+
 /// Bundles an agent executor with an optional interactive adapter.
 ///
 /// A descriptor is created with `adapter: None` on plain `register()` calls.
-/// Call `register_adapter()` to attach an adapter after the agent is registered.
+/// Call `register_adapter()` or `register_adapter_with_strategy()` to attach an
+/// adapter after the agent is registered.
 pub struct AgentDescriptor {
     pub agent: Arc<dyn CodeAgent>,
     pub adapter: Option<Arc<dyn AgentAdapter>>,
+    pub adapter_strategy: AdapterExecutionStrategy,
 }
 
 pub struct AgentRegistry {
@@ -44,7 +65,9 @@ impl AgentRegistry {
         // Preserve any previously attached adapter so that hot-reload cannot
         // accidentally clear the adapter by re-registering the agent under the
         // same name (the old split-registry design had this property naturally).
-        let existing_adapter = self.entries.get(&name).and_then(|d| d.adapter.clone());
+        let existing = self.entries.get(&name);
+        let existing_adapter = existing.and_then(|d| d.adapter.clone());
+        let existing_strategy = existing.map(|d| d.adapter_strategy).unwrap_or_default();
         if !self.entries.contains_key(&name) {
             self.registration_order.push(name.clone());
         }
@@ -53,11 +76,12 @@ impl AgentRegistry {
             AgentDescriptor {
                 agent,
                 adapter: existing_adapter,
+                adapter_strategy: existing_strategy,
             },
         );
     }
 
-    /// Attach an adapter to an already-registered agent.
+    /// Attach a control-only adapter to an already-registered agent.
     ///
     /// Returns `Err(HarnessError::AgentNotFound)` if the agent name is unknown,
     /// so misconfiguration fails loudly instead of silently (U-23).
@@ -66,9 +90,24 @@ impl AgentRegistry {
         name: &str,
         adapter: Arc<dyn AgentAdapter>,
     ) -> harness_core::error::Result<()> {
+        self.register_adapter_with_strategy(name, adapter, AdapterExecutionStrategy::ControlOnly)
+    }
+
+    /// Attach an adapter with an explicit execution strategy.
+    ///
+    /// Use `ExecuteTurns` only when the adapter owns the full turn lifecycle for
+    /// the agent. Use `ControlOnly` when the adapter exists for side-channel
+    /// control while the legacy `CodeAgent` remains the turn executor.
+    pub fn register_adapter_with_strategy(
+        &mut self,
+        name: &str,
+        adapter: Arc<dyn AgentAdapter>,
+        strategy: AdapterExecutionStrategy,
+    ) -> harness_core::error::Result<()> {
         match self.entries.get_mut(name) {
             Some(descriptor) => {
                 descriptor.adapter = Some(adapter);
+                descriptor.adapter_strategy = strategy;
                 Ok(())
             }
             None => Err(HarnessError::AgentNotFound(format!(
@@ -85,6 +124,21 @@ impl AgentRegistry {
     /// Return the adapter registered for the given agent name, if any.
     pub fn get_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
         self.entries.get(name).and_then(|d| d.adapter.clone())
+    }
+
+    /// Return the adapter execution strategy for the given agent name.
+    pub fn adapter_strategy(&self, name: &str) -> Option<AdapterExecutionStrategy> {
+        self.entries.get(name).map(|d| d.adapter_strategy)
+    }
+
+    /// Return the adapter only when its strategy says it should execute turns.
+    pub fn turn_execution_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
+        let descriptor = self.entries.get(name)?;
+        if descriptor.adapter_strategy.executes_turns() {
+            descriptor.adapter.clone()
+        } else {
+            None
+        }
     }
 
     pub fn resolved_default_agent_name(&self) -> Option<&str> {
@@ -377,6 +431,47 @@ mod tests {
     }
 
     #[test]
+    fn register_adapter_defaults_to_control_only_strategy() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ControlOnly)
+        );
+        assert!(registry.turn_execution_adapter("mock").is_none());
+    }
+
+    #[test]
+    fn register_adapter_with_execute_strategy_enables_turn_execution() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        registry
+            .register_adapter_with_strategy(
+                "mock",
+                Arc::new(StubAdapter {
+                    adapter_name: "mock",
+                }),
+                AdapterExecutionStrategy::ExecuteTurns,
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ExecuteTurns)
+        );
+        assert!(registry.turn_execution_adapter("mock").is_some());
+    }
+
+    #[test]
     fn register_creates_descriptor_with_no_adapter() {
         let mut registry = AgentRegistry::new("mock");
         registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
@@ -406,15 +501,16 @@ mod tests {
     }
 
     #[test]
-    fn re_register_preserves_existing_adapter() {
+    fn re_register_preserves_existing_adapter_and_strategy() {
         let mut registry = AgentRegistry::new("mock");
         registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
         registry
-            .register_adapter(
+            .register_adapter_with_strategy(
                 "mock",
                 Arc::new(StubAdapter {
                     adapter_name: "mock",
                 }),
+                AdapterExecutionStrategy::ExecuteTurns,
             )
             .unwrap();
 
@@ -432,6 +528,11 @@ mod tests {
             "adapter must survive re-registration of the same agent name"
         );
         assert_eq!(adapter.unwrap().name(), "mock");
+        assert_eq!(
+            registry.adapter_strategy("mock"),
+            Some(AdapterExecutionStrategy::ExecuteTurns),
+            "adapter strategy must survive re-registration"
+        );
         // The agent itself must be updated.
         assert_eq!(registry.get("mock").unwrap().name(), "mock-v2");
     }

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -198,12 +198,13 @@ pub async fn run(
     claude_agent = claude_agent.with_stream_timeout(serve_config.agents.stream_timeout_secs);
     agent_registry.register("claude", Arc::new(claude_agent));
     agent_registry
-        .register_adapter(
+        .register_adapter_with_strategy(
             "claude",
             Arc::new(harness_agents::claude_adapter::ClaudeAdapter::new(
                 serve_config.agents.claude.cli_path.clone(),
                 serve_config.agents.claude.default_model.clone(),
             )),
+            harness_agents::registry::AdapterExecutionStrategy::ControlOnly,
         )
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     agent_registry.register(
@@ -217,11 +218,12 @@ pub async fn run(
         ),
     );
     agent_registry
-        .register_adapter(
+        .register_adapter_with_strategy(
             "codex",
             Arc::new(harness_agents::codex_adapter::CodexAdapter::new(
                 serve_config.agents.codex.cli_path.clone(),
             )),
+            harness_agents::registry::AdapterExecutionStrategy::ExecuteTurns,
         )
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {

--- a/crates/harness-server/src/handlers/error.rs
+++ b/crates/harness-server/src/handlers/error.rs
@@ -1,0 +1,16 @@
+use harness_protocol::methods::{RpcResponse, INTERNAL_ERROR, INVALID_PARAMS, VALIDATION_ERROR};
+
+pub(crate) fn invalid_params(
+    id: Option<serde_json::Value>,
+    message: impl Into<String>,
+) -> RpcResponse {
+    RpcResponse::error(id, INVALID_PARAMS, message)
+}
+
+pub(crate) fn validation(id: Option<serde_json::Value>, message: impl Into<String>) -> RpcResponse {
+    RpcResponse::error(id, VALIDATION_ERROR, message)
+}
+
+pub(crate) fn internal(id: Option<serde_json::Value>, message: impl Into<String>) -> RpcResponse {
+    RpcResponse::error(id, INTERNAL_ERROR, message)
+}

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod classify;
 pub mod cross_review;
 pub mod dashboard;
+pub mod error;
 pub mod exec;
 pub mod gc;
 pub mod health;

--- a/crates/harness-server/src/handlers/rules.rs
+++ b/crates/harness-server/src/handlers/rules.rs
@@ -1,5 +1,6 @@
-use crate::{http::AppState, validate_root};
-use harness_protocol::{methods::RpcResponse, methods::INTERNAL_ERROR};
+use crate::{handlers::error as rpc_error, http::AppState, validate_root};
+use harness_protocol::methods::RpcResponse;
+use harness_rules::engine::{WARN_EMPTY_SCAN_INPUT, WARN_NO_GUARDS_REGISTERED};
 use std::path::PathBuf;
 
 pub async fn rule_load(
@@ -14,7 +15,7 @@ pub async fn rule_load(
             let count = rules.rules().len();
             RpcResponse::success(id, serde_json::json!({ "rules_count": count }))
         }
-        Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        Err(e) => rpc_error::internal(id, e.to_string()),
     }
 }
 
@@ -36,7 +37,7 @@ pub async fn rule_check(
             for file in &f {
                 match crate::handlers::validate_file_in_root(file, &project_root) {
                     Ok(p) => validated.push(p),
-                    Err(e) => return RpcResponse::error(id, INTERNAL_ERROR, e),
+                    Err(e) => return rpc_error::invalid_params(id, e),
                 }
             }
             Some(validated)
@@ -58,7 +59,14 @@ pub async fn rule_check(
                 error = %err,
                 "rule/check rejected before scan"
             );
-            return RpcResponse::error(id, INTERNAL_ERROR, err.to_string());
+            let message = err.to_string();
+            if message.contains(WARN_EMPTY_SCAN_INPUT) {
+                return rpc_error::invalid_params(id, message);
+            }
+            if message.contains(WARN_NO_GUARDS_REGISTERED) {
+                return rpc_error::validation(id, message);
+            }
+            return rpc_error::internal(id, message);
         }
         rules.snapshot()
     }; // read lock released here
@@ -86,7 +94,7 @@ pub async fn rule_check(
                 .await;
             match serde_json::to_value(&violations) {
                 Ok(v) => RpcResponse::success(id, v),
-                Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+                Err(e) => rpc_error::internal(id, e.to_string()),
             }
         }
         Err(e) => {
@@ -96,7 +104,7 @@ pub async fn rule_check(
                 error = %e,
                 "rule/check scan failed"
             );
-            RpcResponse::error(id, INTERNAL_ERROR, e.to_string())
+            rpc_error::internal(id, e.to_string())
         }
     }
 }
@@ -105,7 +113,7 @@ pub async fn rule_check(
 mod tests {
     use super::rule_check;
     use harness_core::{types::EventFilters, types::GuardId, types::Language};
-    use harness_protocol::methods::INTERNAL_ERROR;
+    use harness_protocol::methods::{INVALID_PARAMS, VALIDATION_ERROR};
     use harness_rules::engine::{Guard, WARN_EMPTY_SCAN_INPUT, WARN_NO_GUARDS_REGISTERED};
     use std::path::PathBuf;
 
@@ -126,7 +134,7 @@ mod tests {
             .error
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("expected rule/check to fail without guards"))?;
-        assert_eq!(error.code, INTERNAL_ERROR);
+        assert_eq!(error.code, VALIDATION_ERROR);
         assert!(
             error.message.contains(WARN_NO_GUARDS_REGISTERED),
             "expected warning message in error: {}",
@@ -232,7 +240,7 @@ mod tests {
             .error
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("expected rule/check to fail for empty scan input"))?;
-        assert_eq!(error.code, INTERNAL_ERROR);
+        assert_eq!(error.code, INVALID_PARAMS);
         assert!(
             error.message.contains(WARN_EMPTY_SCAN_INPUT),
             "expected warning message in error: {}",

--- a/crates/harness-server/src/hook_enforcer.rs
+++ b/crates/harness-server/src/hook_enforcer.rs
@@ -40,8 +40,12 @@ use crate::circuit_breaker::CircuitBreaker;
 /// - `enabled` is `false` (controlled by `rules.hook_enforcement` in config)
 /// - `CI` environment variable is set
 /// - no guards are registered
-/// - no files were modified during the turn
+/// - no affected files are supplied by telemetry
 /// - the circuit breaker is open (consecutive-block limit reached)
+///
+/// Important: host-side git inspection is intentionally disabled by project
+/// policy. Until agent/file-write telemetry supplies `affected_files`, this is
+/// not a complete closed-loop rule-enforcement mechanism.
 pub struct HookEnforcer {
     rules: Arc<RwLock<RuleEngine>>,
     events: Arc<EventStore>,

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -39,9 +39,11 @@ pub(crate) async fn build_services(
     let hook_enforcement = server.config.rules.hook_enforcement;
     let interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>> = vec![
         Arc::new(crate::contract_validator::ContractValidator::new()),
-        // RuleEnforcer disabled: false-positives on test fixtures in other repo
-        // worktrees (SEC-02 hardcoded secrets in test code) block periodic_review
-        // tasks. Re-enable after adding source-aware filtering or allowlists.
+        // RuleEnforcer intentionally disabled: false-positives on test fixtures
+        // in other repo worktrees (SEC-02 hardcoded secrets in test code)
+        // block periodic_review tasks. Until source-aware filtering or
+        // allowlists exist, rule checks are available through explicit scans and
+        // post-tool hooks only; they are not a full pre-turn enforcement gate.
         // Arc::new(crate::rule_enforcer::RuleEnforcer::new(
         //     engines.rules.clone(),
         // )),

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1666,29 +1666,15 @@ async fn webhook_ping_event_returns_accepted_without_creating_task() -> anyhow::
     Ok(())
 }
 
-/// Agent stub that records invocations via an atomic flag.
-/// Records in both `execute` and `execute_stream` since the task executor
-/// calls `execute_stream` (via `run_agent_streaming`).
-struct DispatchCapturingAgent {
-    agent_name: &'static str,
-    was_invoked: Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl DispatchCapturingAgent {
-    fn new(name: &'static str) -> (Arc<Self>, Arc<std::sync::atomic::AtomicBool>) {
-        let was_invoked = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let agent = Arc::new(Self {
-            agent_name: name,
-            was_invoked: was_invoked.clone(),
-        });
-        (agent, was_invoked)
-    }
+/// Named agent stub for focused complexity-dispatch selection tests.
+struct DispatchNamedAgent {
+    name: &'static str,
 }
 
 #[async_trait]
-impl CodeAgent for DispatchCapturingAgent {
+impl CodeAgent for DispatchNamedAgent {
     fn name(&self) -> &str {
-        self.agent_name
+        self.name
     }
 
     fn capabilities(&self) -> Vec<Capability> {
@@ -1696,8 +1682,6 @@ impl CodeAgent for DispatchCapturingAgent {
     }
 
     async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
-        self.was_invoked
-            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(AgentResponse {
             output: String::new(),
             stderr: String::new(),
@@ -1708,7 +1692,7 @@ impl CodeAgent for DispatchCapturingAgent {
                 total_tokens: 0,
                 cost_usd: 0.0,
             },
-            model: self.agent_name.to_string(),
+            model: self.name.to_string(),
             exit_code: Some(0),
         })
     }
@@ -1718,129 +1702,47 @@ impl CodeAgent for DispatchCapturingAgent {
         _req: AgentRequest,
         _tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::error::Result<()> {
-        self.was_invoked
-            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 }
 
-/// Build a test AppState with a "test" (default) and a "claude" DispatchCapturingAgent.
-/// Returns the state and atomic flags for each agent so tests can detect which was invoked.
-async fn make_test_state_with_dispatch_agents(
-    dir: &std::path::Path,
-) -> anyhow::Result<(
-    Arc<AppState>,
-    Arc<std::sync::atomic::AtomicBool>,
-    Arc<std::sync::atomic::AtomicBool>,
-)> {
-    let (default_agent, default_invoked) = DispatchCapturingAgent::new("test");
-    let (claude_agent, claude_invoked) = DispatchCapturingAgent::new("claude");
+fn dispatch_registry() -> harness_agents::registry::AgentRegistry {
     let mut registry = harness_agents::registry::AgentRegistry::new("test");
     registry.set_complexity_preferences(vec!["claude".to_string()]);
-    registry.register("test", default_agent);
-    registry.register("claude", claude_agent);
-    let state = make_test_state_with(
-        dir,
-        harness_core::config::HarnessConfig::default(),
-        registry,
-    )
-    .await?;
-    Ok((state, default_invoked, claude_invoked))
+    registry.register("test", Arc::new(DispatchNamedAgent { name: "test" }));
+    registry.register("claude", Arc::new(DispatchNamedAgent { name: "claude" }));
+    registry
 }
 
-/// Poll (with 5 s deadline) until `flag` is set; panic with `msg` on timeout.
-async fn wait_for_invocation(flag: &std::sync::atomic::AtomicBool, msg: &str) {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if flag.load(std::sync::atomic::Ordering::SeqCst) {
-            return;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            panic!("{msg}");
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+fn dispatch_req(prompt: &str, project: &std::path::Path) -> task_runner::CreateTaskRequest {
+    let mut req = task_runner::CreateTaskRequest::default();
+    req.prompt = Some(prompt.to_string());
+    req.project = Some(project.to_path_buf());
+    req
 }
 
-#[tokio::test]
-async fn dispatch_complex_prompt_selects_claude_agent() -> anyhow::Result<()> {
-    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
-    let dir = crate::test_helpers::tempdir_in_home("dispatch-complex-")?;
-    let (state, default_invoked, claude_invoked) =
-        make_test_state_with_dispatch_agents(dir.path()).await?;
-    let app = task_app(state);
-
-    // 6 distinct file references → Complex complexity → registry.dispatch() selects "claude"
-    let body = serde_json::json!({
-        "prompt": "Refactor src/a.rs src/b.rs src/c.rs src/d.rs src/e.rs src/f.rs",
-        "project": dir.path(),
-    });
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/tasks")
-                .header("content-type", "application/json")
-                .body(Body::from(body.to_string()))?,
-        )
-        .await?;
-    assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-    wait_for_invocation(
-        &claude_invoked,
-        "claude agent was not invoked within 500ms for complex task",
-    )
-    .await;
-
-    assert!(
-        claude_invoked.load(std::sync::atomic::Ordering::SeqCst),
-        "claude agent should have been invoked for complex task"
+#[test]
+fn dispatch_complex_prompt_selects_claude_agent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let req = dispatch_req(
+        "Refactor src/a.rs src/b.rs src/c.rs src/d.rs src/e.rs src/f.rs",
+        dir.path(),
     );
-    assert!(
-        !default_invoked.load(std::sync::atomic::Ordering::SeqCst),
-        "default agent should not have been invoked for complex task"
-    );
+
+    let agent = crate::services::execution::select_agent(&req, &dispatch_registry(), None)?;
+
+    assert_eq!(agent.name(), "claude");
     Ok(())
 }
 
-#[tokio::test]
-async fn dispatch_simple_prompt_selects_default_agent() -> anyhow::Result<()> {
-    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
-    let dir = crate::test_helpers::tempdir_in_home("dispatch-simple-")?;
-    let (state, default_invoked, claude_invoked) =
-        make_test_state_with_dispatch_agents(dir.path()).await?;
-    let app = task_app(state);
+#[test]
+fn dispatch_simple_prompt_selects_default_agent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let req = dispatch_req("Fix the login bug", dir.path());
 
-    // Simple prompt: no file references → Simple complexity → default "test" agent
-    let body = serde_json::json!({
-        "prompt": "Fix the login bug",
-        "project": dir.path(),
-    });
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/tasks")
-                .header("content-type", "application/json")
-                .body(Body::from(body.to_string()))?,
-        )
-        .await?;
-    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let agent = crate::services::execution::select_agent(&req, &dispatch_registry(), None)?;
 
-    wait_for_invocation(
-        &default_invoked,
-        "default agent was not invoked within 500ms for simple task",
-    )
-    .await;
-
-    assert!(
-        default_invoked.load(std::sync::atomic::Ordering::SeqCst),
-        "default agent should have been invoked for simple task"
-    );
-    assert!(
-        !claude_invoked.load(std::sync::atomic::Ordering::SeqCst),
-        "claude agent should not have been invoked for simple task"
-    );
+    assert_eq!(agent.name(), "test");
     Ok(())
 }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
-use harness_protocol::{methods::Method, methods::RpcRequest, methods::INTERNAL_ERROR};
+use harness_protocol::{methods::Method, methods::RpcRequest, methods::VALIDATION_ERROR};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -569,7 +569,7 @@ async fn rule_check_returns_warning_when_no_guards_loaded() -> anyhow::Result<()
         .error
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("expected warning error response"))?;
-    assert_eq!(error.code, INTERNAL_ERROR);
+    assert_eq!(error.code, VALIDATION_ERROR);
     assert!(
         error
             .message

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -176,16 +176,24 @@ mod tests {
     }
 
     async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
+        let database_url = crate::test_helpers::test_database_url()?;
         let server = Arc::new(HarnessServer::new(
             HarnessConfig::default(),
             ThreadManager::new(),
             AgentRegistry::new("test"),
         ));
-        let tasks = crate::task_runner::TaskStore::open(
+        let tasks = crate::task_runner::TaskStore::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "tasks"),
+            Some(&database_url),
         )
         .await?;
-        let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+        let events = Arc::new(
+            harness_observe::event_store::EventStore::new_with_database_url(
+                dir,
+                Some(&database_url),
+            )
+            .await?,
+        );
         let signal_detector = harness_gc::signal_detector::SignalDetector::new(
             server.config.gc.signal_thresholds.clone().into(),
             harness_core::types::ProjectId::new(),
@@ -197,12 +205,14 @@ mod tests {
             draft_store,
             dir.to_path_buf(),
         ));
-        let thread_db = crate::thread_db::ThreadDb::open(
+        let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "threads"),
+            Some(&database_url),
         )
         .await?;
-        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open(
+        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "projects"),
+            Some(&database_url),
         )
         .await?;
         let project_svc = crate::services::project::DefaultProjectService::new(

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -74,9 +74,9 @@ pub(crate) async fn run_turn_lifecycle(
     let adapter_opt = server.agent_registry.get_adapter(&agent_name);
 
     // Register as live adapter (RAII guard for cleanup on turn exit).
-    // When an adapter is available, execution goes through adapter.start_turn()
-    // (see below), so the adapter's stdin is initialized before any
-    // steer/respond_approval call arrives.
+    // Adapters may be control-only (Claude: interrupt/steer/approval side
+    // channel only) or turn-executing (Codex: App Server JSON-RPC owns the
+    // full turn). The strategy is selected at agent registration time.
     let _adapter_guard = adapter_opt.as_ref().map(|adapter_arc| {
         server
             .thread_manager
@@ -90,15 +90,11 @@ pub(crate) async fn run_turn_lifecycle(
     let stall_timeout = Duration::from_secs(server.config.concurrency.stall_timeout_secs);
     let (stream_tx, mut stream_rx) = mpsc::channel(128);
 
-    // Only Codex uses the adapter for turn execution (initializes stdin so that
-    // subsequent steer/respond_approval calls can find a live process).
-    // Other adapters (e.g., ClaudeAdapter) exist for interrupt/steer only and must
-    // not override the configured CodeAgent execution path — ClaudeCodeAgent carries
-    // config-level settings (model, sandbox) that ClaudeAdapter does not replicate.
-    let execution_adapter = adapter_opt
-        .as_ref()
-        .filter(|a| a.name() == "codex")
-        .cloned();
+    // Use the adapter for turn execution only when its registered strategy says
+    // it owns the full lifecycle. This is the strategy pattern boundary between
+    // Codex's App Server adapter and Claude's control-only adapter; avoid
+    // branching on agent names here.
+    let execution_adapter = server.agent_registry.turn_execution_adapter(&agent_name);
     let mut execution: std::pin::Pin<
         Box<dyn std::future::Future<Output = harness_core::error::Result<()>> + Send>,
     > = if let Some(adapter_arc) = execution_adapter {

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -100,7 +100,26 @@ pub async fn acquire_db_state_guard() -> tokio::sync::OwnedMutexGuard<()> {
 }
 
 pub fn test_database_url() -> anyhow::Result<String> {
-    resolve_database_url(None)
+    if let Ok(url) = resolve_database_url(None) {
+        return Ok(url);
+    }
+
+    let config_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../config/default.toml");
+    let content = std::fs::read_to_string(&config_path)?;
+
+    content
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            let (_, value) = trimmed.split_once('=')?;
+            if !trimmed.starts_with("database_url") {
+                return None;
+            }
+            let url = value.trim().trim_matches('"').trim().to_string();
+            (!url.is_empty()).then_some(url)
+        })
+        .ok_or_else(|| anyhow::anyhow!("config/default.toml is missing server.database_url"))
 }
 
 pub fn is_pool_timeout(err: &anyhow::Error) -> bool {
@@ -175,12 +194,17 @@ async fn make_state_inner(
         ThreadManager::new(),
         agent_registry,
     ));
+    let database_url = test_database_url()?;
     let password_reset_rate_limit = server.config.server.password_reset_rate_limit_per_hour;
-    let tasks = crate::task_runner::TaskStore::open(&harness_core::config::dirs::default_db_path(
-        dir, "tasks",
-    ))
+    let tasks = crate::task_runner::TaskStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "tasks"),
+        Some(&database_url),
+    )
     .await?;
-    let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+    let events = Arc::new(
+        harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
+            .await?,
+    );
     let signal_detector = harness_gc::signal_detector::SignalDetector::new(
         server.config.gc.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
@@ -192,9 +216,10 @@ async fn make_state_inner(
         draft_store,
         project_root.to_path_buf(),
     ));
-    let thread_db = crate::thread_db::ThreadDb::open(&harness_core::config::dirs::default_db_path(
-        dir, "threads",
-    ))
+    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "threads"),
+        Some(&database_url),
+    )
     .await?;
     let (notification_tx, _) = tokio::sync::broadcast::channel(64);
     let task_queue = Arc::new(crate::task_queue::TaskQueue::new(&Default::default()));
@@ -202,8 +227,9 @@ async fn make_state_inner(
     // Service layer — use concrete defaults backed by the same infrastructure.
     let project_svc = crate::services::project::DefaultProjectService::new(
         // Tests that don't need a registry still get a lightweight one.
-        crate::project_registry::ProjectRegistry::open(
+        crate::project_registry::ProjectRegistry::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "projects"),
+            Some(&database_url),
         )
         .await?,
         project_root.to_path_buf(),

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -52,4 +52,23 @@ describe("<Sidebar>", () => {
     fireEvent.click(screen.getByText("History"));
     expect(onItemClick).toHaveBeenCalledWith("history");
   });
+
+  it("renders absolute hrefs as external links", () => {
+    const sections: SidebarSection[] = [
+      {
+        label: "Reference",
+        items: [{ id: "docs", label: "Docs", href: "https://example.com/docs" }],
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <Sidebar env="local" sections={sections} />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Docs" });
+    expect(link).toHaveAttribute("href", "https://example.com/docs");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
 });

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -23,6 +23,10 @@ interface Props {
   onItemClick?: (id: string) => void;
 }
 
+function isExternalHref(href: string | undefined): boolean {
+  return href?.startsWith("http://") === true || href?.startsWith("https://") === true;
+}
+
 export function Sidebar({
   env,
   sections,
@@ -84,6 +88,14 @@ export function Sidebar({
                   >
                     {body}
                   </button>
+                );
+              }
+
+              if (isExternalHref(item.href)) {
+                return (
+                  <a key={item.id} href={item.href} target="_blank" rel="noreferrer" className={itemClass}>
+                    {body}
+                  </a>
                 );
               }
 

--- a/web/src/lib/links.ts
+++ b/web/src/lib/links.ts
@@ -1,0 +1,1 @@
+export const DOCS_URL = "https://github.com/majiayu000/harness/tree/main/docs";

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { Overview } from "./Overview";
 import { PaletteProvider } from "@/lib/palette";
+import { DOCS_URL } from "@/lib/links";
 import type { OperatorSnapshotPayload, OverviewPayload } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
@@ -129,5 +130,20 @@ describe("<Overview>", () => {
 
     expect(screen.getByText(/all systems nominal/i)).toBeInTheDocument();
     expect(screen.queryByText(/connection lost/i)).not.toBeInTheDocument();
+  });
+
+  it("links Docs to the repository documentation", () => {
+    mockUseOverview.mockReturnValue({
+      data: makeOverview(),
+      isError: false,
+    });
+    mockUseOperatorSnapshot.mockReturnValue({
+      data: makeSnapshot(),
+      isError: false,
+    });
+
+    wrap(<Overview />);
+
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute("href", DOCS_URL);
   });
 });

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -12,6 +12,7 @@ import { StatusBadge } from "@/components/StatusBadge";
 import { PaletteFab } from "@/components/PaletteFab";
 import { EvolutionCard } from "@/components/EvolutionCard";
 import { useOperatorSnapshot, useOverview } from "@/lib/queries";
+import { DOCS_URL } from "@/lib/links";
 import { OperatorPanel } from "./overview/OperatorPanel";
 import { fmtInt, fmtPct, fmtScore } from "@/lib/format";
 
@@ -48,7 +49,7 @@ export function Overview() {
     },
     {
       label: "Reference",
-      items: [{ id: "docs", label: "Docs", href: "/" }],
+      items: [{ id: "docs", label: "Docs", href: DOCS_URL }],
     },
   ];
 

--- a/web/src/routes/Worktrees.test.tsx
+++ b/web/src/routes/Worktrees.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { PaletteProvider } from "@/lib/palette";
+import { DOCS_URL } from "@/lib/links";
+import { Worktrees } from "./Worktrees";
+
+vi.mock("@/lib/queries", () => ({
+  useWorktrees: vi.fn(),
+  useOverview: vi.fn(),
+}));
+
+import { useOverview, useWorktrees } from "@/lib/queries";
+
+const mockUseWorktrees = useWorktrees as ReturnType<typeof vi.fn>;
+const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PaletteProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </PaletteProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("<Worktrees>", () => {
+  it("links Docs to the repository documentation", () => {
+    mockUseWorktrees.mockReturnValue({
+      cards: [],
+      isLoading: false,
+      error: null,
+    });
+    mockUseOverview.mockReturnValue({
+      data: {
+        projects: [],
+        runtimes: [],
+        kpi: {
+          active_tasks: 0,
+        },
+      },
+    });
+
+    wrap(<Worktrees />);
+
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute("href", DOCS_URL);
+  });
+});

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
 import { PaletteFab } from "@/components/PaletteFab";
+import { DOCS_URL } from "@/lib/links";
 import { useWorktrees, useOverview } from "@/lib/queries";
 import { apiFetch, TOKEN_KEY } from "@/lib/api";
 import type { WorktreeCard } from "@/lib/queries";
@@ -176,7 +177,7 @@ export function Worktrees() {
     },
     {
       label: "Reference",
-      items: [{ id: "docs", label: "Docs", href: "/" }],
+      items: [{ id: "docs", label: "Docs", href: DOCS_URL }],
     },
   ];
 


### PR DESCRIPTION
## Summary
- Add explicit adapter execution strategies so Codex adapters can execute turns while Claude adapters stay control-only without runtime name checks.
- Map rule/check validation failures to semantic JSON-RPC error codes and share small handler error helpers.
- Make dashboard docs links open the repository docs externally, with route/sidebar tests covering the behavior.
- Simplify dispatch tests to assert agent selection directly and use resolved database URLs in test helpers.

## Validation
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/tmp/harness-leftover-target cargo check --workspace --all-targets
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:55456/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 CARGO_TARGET_DIR=/tmp/harness-leftover-target cargo test -p harness-server router::tests::rule_check_returns_warning_when_no_guards_loaded
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:55456/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 CARGO_TARGET_DIR=/tmp/harness-leftover-target cargo test --workspace
- RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR=/tmp/harness-leftover-dwarnings cargo check --workspace --all-targets
- cd web && bun install --frozen-lockfile
- cd web && bun run typecheck
- cd web && bun run test