### PR TITLE
fix(review_loop): harden Gemini quota graduation

### DIFF
--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -235,23 +235,18 @@ pub fn is_waiting(output: &str) -> bool {
 
 /// Check if reviewer output indicates quota exhaustion (e.g., Gemini 24h rate limit).
 ///
-/// Requires ≥ 2 co-occurring quota-signal terms, or a single high-specificity phrase,
-/// to prevent false positives from reviews that incidentally mention "quota" in code.
+/// Matches only explicit Gemini quota-warning signatures to avoid false positives
+/// from normal review comments that discuss quota or rate-limit handling in code.
 pub fn is_quota_exhausted(output: &str) -> bool {
     let lower = output.to_lowercase();
-    // High-specificity phrase: shortcut without requiring two co-occurring indicators.
-    if lower.contains("start processing again") {
-        return true;
-    }
-    let indicators = [
-        "quota",
-        "rate limit",
-        "24 hour",
-        "processing again",
-        "will be processed",
-        "not available",
+    const GEMINI_QUOTA_SIGNATURES: [&str; 3] = [
+        "you have reached your daily quota limit",
+        "i will start processing again in 24 hours once the quota resets",
+        "i will start processing again in 24 hours",
     ];
-    indicators.iter().filter(|&&s| lower.contains(s)).count() >= 2
+    GEMINI_QUOTA_SIGNATURES
+        .iter()
+        .any(|signature| lower.contains(signature))
 }
 
 /// Extract `ISSUES=N` from agent output (any line). Returns `None` if absent.
@@ -381,9 +376,9 @@ mod tests {
     }
 
     #[test]
-    fn test_is_quota_exhausted_two_co_occurring_indicators() {
+    fn test_is_quota_exhausted_daily_limit_phrase() {
         assert!(is_quota_exhausted(
-            "rate limit exceeded, quota exhausted for today"
+            "You have reached your daily quota limit for Gemini Code Assist."
         ));
     }
 
@@ -398,6 +393,15 @@ mod tests {
 The implementation looks clean. I noticed a potential edge case in the error \
 handler: when the input is empty the function returns Ok(()) without logging, \
 which could mask silent failures.\nISSUES=1\nFIXED";
+        assert!(!is_quota_exhausted(review));
+    }
+
+    #[test]
+    fn test_is_quota_exhausted_false_for_review_discussing_quota_code() {
+        let review = "\
+Please tighten the is_quota_exhausted matcher. A review comment that mentions \
+rate limits and quota handling in the parser should not graduate the PR.\n\
+ISSUES=1\nFIXED";
         assert!(!is_quota_exhausted(review));
     }
 

--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -102,6 +102,43 @@ fn issue_count_not_decreasing(counts: &[Option<u32>]) -> bool {
     matches!(tail, [Some(a), Some(b), Some(c)] if c >= a && c >= b)
 }
 
+const QUOTA_EXHAUSTED_THRESHOLD: u32 = 3;
+const MAX_QUOTA_HEURISTIC_GRADUATIONS: u32 = 2;
+const QUOTA_HEURISTIC_ATTEMPT_RESULT: &str = "quota_heuristic_attempt";
+const NEEDS_MANUAL_REVIEW_RESULT: &str = "needs_manual_review";
+
+fn update_quota_exhausted_rounds(current: u32, waiting: bool, quota_exhausted: bool) -> u32 {
+    if quota_exhausted {
+        current.saturating_add(1)
+    } else if waiting {
+        current
+    } else {
+        0
+    }
+}
+
+fn quota_exhausted_streak(rounds: &[RoundResult]) -> u32 {
+    let mut streak = 0;
+    for round in rounds.iter().rev() {
+        if round.action != "review" {
+            continue;
+        }
+        if round.result == "quota_exhausted" {
+            streak += 1;
+        } else {
+            break;
+        }
+    }
+    streak
+}
+
+fn quota_heuristic_attempt_count(rounds: &[RoundResult]) -> u32 {
+    rounds
+        .iter()
+        .filter(|round| round.action == "review" && round.result == QUOTA_HEURISTIC_ATTEMPT_RESULT)
+        .count() as u32
+}
+
 /// Execute the external review bot wait loop.
 ///
 /// Polls the PR for review bot feedback, handles LGTM/FIXED/WAITING responses,
@@ -159,8 +196,13 @@ pub(crate) async fn run_review_loop(
     // Tracks the most recent non-waiting review output for Jaccard loop detection.
     let mut prev_review_output: Option<String> = None;
 
-    const QUOTA_EXHAUSTED_THRESHOLD: u32 = 3;
-    let mut quota_exhausted_rounds: u32 = 0;
+    let existing_rounds = store
+        .get_with_db_fallback(task_id)
+        .await?
+        .map(|state| state.rounds)
+        .unwrap_or_default();
+    let mut quota_exhausted_rounds = quota_exhausted_streak(&existing_rounds);
+    let mut quota_heuristic_attempts = quota_heuristic_attempt_count(&existing_rounds);
 
     // Review loop.
     // Use an explicit counter so WAITING responses don't consume a round — `continue`
@@ -350,6 +392,8 @@ pub(crate) async fn run_review_loop(
         let raw_lgtm = prompts::is_lgtm(&output);
         let waiting = prompts::is_waiting(&output);
         let quota_exhausted = !raw_lgtm && !waiting && prompts::is_quota_exhausted(&output);
+        quota_exhausted_rounds =
+            update_quota_exhausted_rounds(quota_exhausted_rounds, waiting, quota_exhausted);
         // If post-execute validation failed this round, block LGTM acceptance even
         // if the reviewer approved — the local validator caught an issue that must be
         // fixed before the PR can be marked done.
@@ -449,7 +493,6 @@ pub(crate) async fn run_review_loop(
         // Don't consume a round — sleep and retry. After K consecutive quota rounds,
         // run the test gate as a heuristic graduation check.
         if quota_exhausted {
-            quota_exhausted_rounds += 1;
             tracing::info!(
                 round,
                 quota_exhausted_rounds,
@@ -467,9 +510,53 @@ pub(crate) async fn run_review_loop(
             .await?;
 
             if quota_exhausted_rounds >= QUOTA_EXHAUSTED_THRESHOLD && !lgtm_test_gate_rejected {
+                quota_heuristic_attempts += 1;
+                let attempt_num = quota_heuristic_attempts;
+                mutate_and_persist(store, task_id, |s| {
+                    s.rounds.push(RoundResult {
+                        turn: round,
+                        action: "review".into(),
+                        result: QUOTA_HEURISTIC_ATTEMPT_RESULT.into(),
+                        detail: Some(format!(
+                            "attempt={attempt_num}/{MAX_QUOTA_HEURISTIC_GRADUATIONS}; quota_rounds={quota_exhausted_rounds}"
+                        )),
+                        first_token_latency_ms: None,
+                    });
+                })
+                .await?;
+
+                if attempt_num > MAX_QUOTA_HEURISTIC_GRADUATIONS {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        attempt_num,
+                        max_attempts = MAX_QUOTA_HEURISTIC_GRADUATIONS,
+                        "quota-heuristic graduation cap exceeded; manual review required"
+                    );
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.turn = round.saturating_add(1);
+                        s.error = Some(format!(
+                            "needs_manual_review: reviewer quota remained exhausted after {} quota-heuristic attempts",
+                            MAX_QUOTA_HEURISTIC_GRADUATIONS
+                        ));
+                        s.rounds.push(RoundResult {
+                            turn: round,
+                            action: "review".into(),
+                            result: NEEDS_MANUAL_REVIEW_RESULT.into(),
+                            detail: Some(format!(
+                                "quota_heuristic_attempts={attempt_num}; quota_rounds={quota_exhausted_rounds}"
+                            )),
+                            first_token_latency_ms: None,
+                        });
+                    })
+                    .await?;
+                    return Ok(());
+                }
+
                 tracing::info!(
                     task_id = %task_id,
                     quota_exhausted_rounds,
+                    attempt_num,
                     "quota-heuristic graduation: running test gate after {} quota-exhausted rounds",
                     quota_exhausted_rounds
                 );
@@ -618,9 +705,6 @@ pub(crate) async fn run_review_loop(
         // Also treat a test gate rejection as a "fixed" round — the agent needs
         // to push a fix and get a fresh review before LGTM can be accepted.
         prev_fixed = fixed || pending_test_failure.is_some();
-        if fixed {
-            quota_exhausted_rounds = 0;
-        }
         tracing::info!("PR #{pr_num} fixed at round {round}; waiting for bot re-review");
         if round < max_rounds {
             waiting_count += 1;
@@ -682,4 +766,55 @@ pub(crate) async fn run_review_loop(
         "task_completed"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn review_round(result: &str) -> RoundResult {
+        RoundResult {
+            turn: 1,
+            action: "review".into(),
+            result: result.into(),
+            detail: None,
+            first_token_latency_ms: None,
+        }
+    }
+
+    #[test]
+    fn quota_counter_resets_on_real_review_response() {
+        assert_eq!(update_quota_exhausted_rounds(2, false, false), 0);
+    }
+
+    #[test]
+    fn quota_counter_keeps_waiting_streak_intact() {
+        assert_eq!(update_quota_exhausted_rounds(2, true, false), 2);
+    }
+
+    #[test]
+    fn quota_counter_increments_on_quota_round() {
+        assert_eq!(update_quota_exhausted_rounds(2, false, true), 3);
+    }
+
+    #[test]
+    fn quota_exhausted_streak_uses_trailing_review_rounds() {
+        let rounds = vec![
+            review_round("fixed"),
+            review_round("quota_exhausted"),
+            review_round("quota_exhausted"),
+        ];
+        assert_eq!(quota_exhausted_streak(&rounds), 2);
+    }
+
+    #[test]
+    fn quota_heuristic_attempt_count_uses_persisted_rounds() {
+        let rounds = vec![
+            review_round("quota_exhausted"),
+            review_round(QUOTA_HEURISTIC_ATTEMPT_RESULT),
+            review_round("fixed"),
+            review_round(QUOTA_HEURISTIC_ATTEMPT_RESULT),
+        ];
+        assert_eq!(quota_heuristic_attempt_count(&rounds), 2);
+    }
 }


### PR DESCRIPTION
## Summary
- narrow Gemini quota detection to explicit quota-warning signatures
- reset the consecutive quota counter on every non-quota review response, including LGTM
- persist quota-heuristic attempts and fail closed with a manual-review marker after the cap is exceeded

## Validation
- cargo fmt --all
- cargo check
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test -p harness-core test_is_quota_exhausted_
- cargo test -p harness-server quota_
- cargo test --workspace (fails in this repo snapshot because many harness-server tests require local DB/file setup, including HARNESS_DATABASE_URL, and are not green on the baseline checkout)

Closes #846