### PR TITLE
test(web): cover intentional /tasks task list route

### DIFF
--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { useWorktrees, useTaskDetail, useTaskStream } from "./queries";
+import { useTasks, useWorktrees, useTaskDetail, useTaskStream } from "./queries";
 import { TOKEN_KEY } from "./api";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -95,6 +95,29 @@ describe("stream URL construction", () => {
 
   it("omits token param when no session token", () => {
     expect(buildStreamUrl("abc-123")).not.toContain("token=");
+  });
+});
+
+// ── useTasks ─────────────────────────────────────────────────────────────────
+
+describe("useTasks", () => {
+  it("fetches the task list from /tasks without an /api prefix", async () => {
+    const task = { id: "t1", status: "implementing", turn: 1, project: null };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([task]), { status: 200 }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTasks(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/tasks",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "application/json" }),
+      }),
+    );
+    expect(result.current.data).toMatchObject([{ id: "t1", status: "implementing" }]);
   });
 });
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -28,6 +28,8 @@ export function useOperatorSnapshot() {
 export function useTasks() {
   return useQuery<Task[], Error>({
     queryKey: ["tasks"],
+    // Task list/detail/stream routes are exposed at `/tasks`; only aggregate
+    // dashboard endpoints are mounted under `/api/*`.
     queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
   });
 }


### PR DESCRIPTION
## Summary
- verified `useTasks` already matches `GET /tasks` in `crates/harness-server/src/http/http_router.rs`
- added an inline comment documenting why task routes stay outside `/api/*`
- added a regression test asserting the hook fetches `/tasks`

## Validation
- `bun run test -- src/lib/queries.test.ts`
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace` currently enters unrelated long-hanging Rust tests from clean `origin/main`; no touched frontend test/regression failed before that hang

Closes #844