### PR TITLE
Improve Postgres startup health reporting

### DIFF
--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -338,17 +338,75 @@ impl PgStoreContext {
         &self.schema
     }
 
+    pub async fn ensure_schema(&self, setup_pool: &PgPool) -> anyhow::Result<()> {
+        pg_create_schema_if_not_exists(setup_pool, &self.schema)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to ensure Postgres schema '{}' is ready: {error}",
+                    self.schema
+                )
+            })
+    }
+
+    pub async fn open_runtime_pool(&self) -> anyhow::Result<PgPool> {
+        pg_open_pool_schematized(&self.database_url, &self.schema)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to open Postgres runtime pool for schema '{}': {error}",
+                    self.schema
+                )
+            })
+    }
+
+    pub async fn open_pool_with_setup_pool(&self, setup_pool: &PgPool) -> anyhow::Result<PgPool> {
+        self.ensure_schema(setup_pool).await?;
+        self.open_runtime_pool().await
+    }
+
+    pub async fn open_migrated_pool_with_setup_pool(
+        &self,
+        setup_pool: &PgPool,
+        migrations: &[Migration],
+    ) -> anyhow::Result<PgPool> {
+        let pool = self.open_pool_with_setup_pool(setup_pool).await?;
+        PgMigrator::new(&pool, migrations)
+            .run()
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to run Postgres migrations for schema '{}': {error}",
+                    self.schema
+                )
+            })?;
+        Ok(pool)
+    }
+
     pub async fn open_pool(&self) -> anyhow::Result<PgPool> {
-        let setup = pg_open_pool(&self.database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &self.schema).await?;
+        let setup = pg_open_pool(&self.database_url).await.map_err(|error| {
+            anyhow::anyhow!(
+                "failed to open Postgres bootstrap pool for schema '{}': {error}",
+                self.schema
+            )
+        })?;
+        let pool = self.open_pool_with_setup_pool(&setup).await;
         setup.close().await;
-        pg_open_pool_schematized(&self.database_url, &self.schema).await
+        pool
     }
 
     pub async fn open_migrated_pool(&self, migrations: &[Migration]) -> anyhow::Result<PgPool> {
-        let pool = self.open_pool().await?;
-        PgMigrator::new(&pool, migrations).run().await?;
-        Ok(pool)
+        let setup = pg_open_pool(&self.database_url).await.map_err(|error| {
+            anyhow::anyhow!(
+                "failed to open Postgres bootstrap pool for schema '{}': {error}",
+                self.schema
+            )
+        })?;
+        let pool = self
+            .open_migrated_pool_with_setup_pool(&setup, migrations)
+            .await;
+        setup.close().await;
+        pool
     }
 }
 
@@ -538,9 +596,9 @@ impl<'a> PgMigrator<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        configure_pg_pool_from_server, pg_pool_settings, pg_schema_for_path, resolve_database_url,
-        validate_schema_name, PgStoreContext, DEFAULT_PG_ACQUIRE_TIMEOUT_SECS,
-        DEFAULT_PG_MAX_CONNECTIONS,
+        configure_pg_pool_from_server, pg_open_pool, pg_pool_settings, pg_schema_for_path,
+        resolve_database_url, validate_schema_name, PgStoreContext,
+        DEFAULT_PG_ACQUIRE_TIMEOUT_SECS, DEFAULT_PG_MAX_CONNECTIONS,
     };
     use crate::config::server::ServerConfig;
     use crate::test_support::process_env_lock;
@@ -694,6 +752,40 @@ mod tests {
             err.to_string().contains("ASCII letters"),
             "error should explain schema validation, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn pg_store_context_runtime_pool_errors_name_the_step() {
+        let context = PgStoreContext::new("not-a-valid-postgres-url", "h1b76aa87802f7705")
+            .expect("context should accept opaque URL strings");
+        let err = context
+            .open_runtime_pool()
+            .await
+            .expect_err("invalid URL should fail before connecting");
+        assert!(
+            err.to_string().contains("runtime pool"),
+            "error should identify the runtime-pool step: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_store_context_can_reuse_shared_setup_pool() {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return;
+        };
+        let setup_pool = match pg_open_pool(&database_url).await {
+            Ok(pool) => pool,
+            Err(_) => return,
+        };
+        let context =
+            PgStoreContext::from_path(Path::new("/tmp/harness/shared.db"), Some(&database_url))
+                .expect("context should resolve");
+        let pool = context
+            .open_pool_with_setup_pool(&setup_pool)
+            .await
+            .expect("shared setup pool should initialize the store");
+        pool.close().await;
+        setup_pool.close().await;
     }
 
     #[test]

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -1,9 +1,6 @@
 use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
@@ -72,24 +69,9 @@ impl EventStore {
     ) -> anyhow::Result<Self> {
         std::fs::create_dir_all(data_dir)?;
         let data_dir = data_dir.to_path_buf();
-
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let events_path = data_dir.join("events.db");
-        let path_utf8 = events_path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", events_path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
-
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, EVENT_MIGRATIONS).run().await?;
+        let context =
+            PgStoreContext::from_path(&data_dir.join("events.db"), configured_database_url)?;
+        let pool = context.open_migrated_pool(EVENT_MIGRATIONS).await?;
 
         let store = Self {
             pool,
@@ -98,6 +80,25 @@ impl EventStore {
             session_renewal_secs: 1800,
         };
 
+        store.migrate_from_jsonl().await;
+        Ok(store)
+    }
+
+    pub async fn new_with_context(
+        data_dir: &Path,
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(data_dir)?;
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, EVENT_MIGRATIONS)
+            .await?;
+        let store = Self {
+            pool,
+            data_dir: data_dir.to_path_buf(),
+            otel_pipeline: Mutex::new(None),
+            session_renewal_secs: 1800,
+        };
         store.migrate_from_jsonl().await;
         Ok(store)
     }
@@ -220,13 +221,40 @@ impl EventStore {
         otel_config: &OtelConfig,
     ) -> anyhow::Result<Self> {
         let mut store = Self::new_with_database_url(data_dir, configured_database_url).await?;
-        store.session_renewal_secs = session_renewal_secs;
+        store
+            .apply_policies_and_otel(session_renewal_secs, log_retention_days, otel_config)
+            .await?;
+        Ok(store)
+    }
+
+    pub async fn with_policies_and_otel_with_context(
+        data_dir: &Path,
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        session_renewal_secs: u64,
+        log_retention_days: u32,
+        otel_config: &OtelConfig,
+    ) -> anyhow::Result<Self> {
+        let mut store = Self::new_with_context(data_dir, context, setup_pool).await?;
+        store
+            .apply_policies_and_otel(session_renewal_secs, log_retention_days, otel_config)
+            .await?;
+        Ok(store)
+    }
+
+    async fn apply_policies_and_otel(
+        &mut self,
+        session_renewal_secs: u64,
+        log_retention_days: u32,
+        otel_config: &OtelConfig,
+    ) -> anyhow::Result<()> {
+        self.session_renewal_secs = session_renewal_secs;
         tracing::debug!(
             session_renewal_secs,
             log_retention_days,
             "event store: applying retention policies"
         );
-        if let Err(e) = store.purge_old_events(log_retention_days).await {
+        if let Err(e) = self.purge_old_events(log_retention_days).await {
             tracing::warn!("event store: failed to purge old events: {e}");
         }
         let pipeline = match crate::otel_export::OtelPipeline::from_config(otel_config).await {
@@ -238,11 +266,8 @@ impl EventStore {
                 None
             }
         };
-        *store
-            .otel_pipeline
-            .lock()
-            .unwrap_or_else(|e| e.into_inner()) = pipeline;
-        Ok(store)
+        *self.otel_pipeline.lock().unwrap_or_else(|e| e.into_inner()) = pipeline;
+        Ok(())
     }
 
     /// Import events from an existing `events.jsonl` file (backward compat).

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -140,8 +140,8 @@ pub(crate) async fn build_engines(
     };
 
     let retention = server.config.observe.log_retention_days;
-    if retention > 0 && events.is_some() {
-        let purge_events = Arc::clone(events.as_ref().expect("checked is_some above"));
+    if let (true, Some(events)) = (retention > 0, events.as_ref()) {
+        let purge_events = Arc::clone(events);
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(24 * 3600)).await;

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
+use crate::http::state::StoreStartupResult;
 use crate::server::HarnessServer;
 
 /// Outputs of the engine initialization phase.
 pub(crate) struct EnginesBundle {
     pub rules: Arc<RwLock<harness_rules::engine::RuleEngine>>,
-    pub events: Arc<harness_observe::event_store::EventStore>,
+    pub events: Option<Arc<harness_observe::event_store::EventStore>>,
     pub gc_agent: Arc<harness_gc::gc_agent::GcAgent>,
     pub skills: Arc<RwLock<harness_skills::store::SkillStore>>,
+    pub startup_results: Vec<StoreStartupResult>,
 }
 
 /// Initialize rule engine, event store, GC agent, and skill store.
@@ -86,20 +88,60 @@ pub(crate) async fn build_engines(
         .context("failed to load configured rules.requirements_path")?;
 
     // ── Event store ──────────────────────────────────────────────────────────
-    let events = Arc::new(
-        harness_observe::event_store::EventStore::with_policies_and_otel_with_database_url(
-            data_dir,
-            server.config.server.database_url.as_deref(),
-            server.config.observe.session_renewal_secs,
-            server.config.observe.log_retention_days,
-            &server.config.otel,
-        )
-        .await?,
-    );
+    let (events, event_result) = match super::forced_startup_error("event_store") {
+        Some(error) => (
+            None,
+            StoreStartupResult::critical("event_store").failed(error),
+        ),
+        None => {
+            let database_url = harness_core::db::resolve_database_url(
+                server.config.server.database_url.as_deref(),
+            );
+            match database_url {
+                Ok(database_url) => match harness_core::db::pg_open_pool(&database_url).await {
+                    Ok(setup_pool) => {
+                        let event_context = harness_core::db::PgStoreContext::new(
+                            database_url,
+                            harness_core::db::pg_schema_for_path(&data_dir.join("events.db"))?,
+                        )?;
+                        let store = harness_observe::event_store::EventStore::with_policies_and_otel_with_context(
+                            data_dir,
+                            &event_context,
+                            &setup_pool,
+                            server.config.observe.session_renewal_secs,
+                            server.config.observe.log_retention_days,
+                            &server.config.otel,
+                        )
+                        .await;
+                        setup_pool.close().await;
+                        match store {
+                            Ok(store) => (
+                                Some(Arc::new(store)),
+                                StoreStartupResult::critical("event_store"),
+                            ),
+                            Err(error) => (
+                                None,
+                                StoreStartupResult::critical("event_store")
+                                    .failed(error.to_string()),
+                            ),
+                        }
+                    }
+                    Err(error) => (
+                        None,
+                        StoreStartupResult::critical("event_store").failed(error.to_string()),
+                    ),
+                },
+                Err(error) => (
+                    None,
+                    StoreStartupResult::critical("event_store").failed(error.to_string()),
+                ),
+            }
+        }
+    };
 
     let retention = server.config.observe.log_retention_days;
-    if retention > 0 {
-        let purge_events = Arc::clone(&events);
+    if retention > 0 && events.is_some() {
+        let purge_events = Arc::clone(events.as_ref().expect("checked is_some above"));
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(24 * 3600)).await;
@@ -114,31 +156,33 @@ pub(crate) async fn build_engines(
     // On first boot after upgrading from file-checkpoint to KV-watermark, seed
     // the KV watermark from gc-checkpoint.json so the first incremental scan
     // doesn't regress to a full O(total-events) scan.
-    let project_key = project_root.to_string_lossy().into_owned();
-    match events.get_scan_watermark(&project_key, "gc").await {
-        Ok(None) => {
-            // No KV watermark yet — try the legacy file checkpoint.
-            let checkpoint_path = harness_gc::checkpoint::default_checkpoint_path(project_root);
-            if let Some(cp) = harness_gc::checkpoint::GcCheckpoint::load(&checkpoint_path) {
-                match events
-                    .set_scan_watermark(&project_key, "gc", cp.last_scan_at)
-                    .await
-                {
-                    Ok(()) => {
-                        tracing::info!(
-                            ts = %cp.last_scan_at,
-                            "gc: migrated legacy checkpoint to KV watermark"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!("gc: failed to seed KV watermark from checkpoint: {e}");
+    if let Some(events) = events.as_ref() {
+        let project_key = project_root.to_string_lossy().into_owned();
+        match events.get_scan_watermark(&project_key, "gc").await {
+            Ok(None) => {
+                // No KV watermark yet — try the legacy file checkpoint.
+                let checkpoint_path = harness_gc::checkpoint::default_checkpoint_path(project_root);
+                if let Some(cp) = harness_gc::checkpoint::GcCheckpoint::load(&checkpoint_path) {
+                    match events
+                        .set_scan_watermark(&project_key, "gc", cp.last_scan_at)
+                        .await
+                    {
+                        Ok(()) => {
+                            tracing::info!(
+                                ts = %cp.last_scan_at,
+                                "gc: migrated legacy checkpoint to KV watermark"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("gc: failed to seed KV watermark from checkpoint: {e}");
+                        }
                     }
                 }
             }
-        }
-        Ok(Some(_)) => {} // already seeded — nothing to do
-        Err(e) => {
-            tracing::warn!("gc: failed to read KV watermark during migration check: {e}");
+            Ok(Some(_)) => {} // already seeded — nothing to do
+            Err(e) => {
+                tracing::warn!("gc: failed to read KV watermark during migration check: {e}");
+            }
         }
     }
 
@@ -178,6 +222,7 @@ pub(crate) async fn build_engines(
         events,
         gc_agent,
         skills: Arc::new(RwLock::new(skill_store)),
+        startup_results: vec![event_result],
     })
 }
 
@@ -234,5 +279,24 @@ mod tests {
             !rules.guards().is_empty(),
             "expected builtins even without discovery path"
         );
+    }
+
+    #[tokio::test]
+    async fn event_store_failure_is_recorded_as_critical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let server = make_test_server(dir.path());
+        let bundle = super::super::with_forced_startup_failures(
+            &[("event_store", "failed to open Postgres bootstrap pool")],
+            build_engines(&server, dir.path(), dir.path()),
+        )
+        .await
+        .expect("build_engines should still return a bundle");
+        assert!(
+            bundle.events.is_none(),
+            "critical event store should be absent"
+        );
+        assert_eq!(bundle.startup_results.len(), 1);
+        assert!(bundle.startup_results[0].is_critical());
+        assert!(!bundle.startup_results[0].ready);
     }
 }

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -29,6 +29,17 @@ pub(crate) async fn build_intake(
     project_root: &Path,
     data_dir: &Path,
 ) -> anyhow::Result<IntakeBundle> {
+    let tasks = storage
+        .tasks
+        .as_ref()
+        .expect("build_intake requires a ready task store")
+        .clone();
+    let events = engines
+        .events
+        .as_ref()
+        .expect("build_intake requires a ready event store")
+        .clone();
+
     // ── Task queues ───────────────────────────────────────────────────────────
     let memory_pressure =
         server
@@ -104,7 +115,7 @@ pub(crate) async fn build_intake(
                 Some(data_dir),
                 server.config.server.github_token.clone(),
             )
-            .with_task_checker(storage.tasks.clone());
+            .with_task_checker(tasks.clone());
             match poller.reconcile_dispatched_with_store().await {
                 Ok(pruned) if pruned > 0 => tracing::info!(
                     repo = %repo_cfg.repo,
@@ -153,7 +164,7 @@ pub(crate) async fn build_intake(
             }
         });
         Arc::new(crate::quality_trigger::QualityTrigger::new(
-            engines.events.clone(),
+            events.clone(),
             engines.gc_agent.clone(),
             server.agent_registry.clone(),
             project_root.to_path_buf(),
@@ -276,7 +287,10 @@ async fn runtime_review_concurrency_config(
             1usize,
         );
     }
-    match registry.project_registry.list().await {
+    let Some(project_registry) = registry.project_registry.as_ref() else {
+        return config;
+    };
+    match project_registry.list().await {
         Ok(projects) => {
             for project in projects.into_iter().filter(|project| project.active) {
                 config
@@ -326,10 +340,14 @@ mod tests {
         let engines = crate::http::builders::engines::build_engines(&server, dir, dir)
             .await
             .expect("engines");
-        let registry =
-            crate::http::builders::registry::build_registry(&server, dir, dir, &storage.tasks)
-                .await
-                .expect("registry");
+        let registry = crate::http::builders::registry::build_registry(
+            &server,
+            dir,
+            dir,
+            storage.tasks.as_ref().expect("tasks store"),
+        )
+        .await
+        .expect("registry");
         (server, storage, engines, registry)
     }
 
@@ -446,6 +464,8 @@ mod tests {
         std::fs::create_dir_all(&runtime_project_root).expect("create runtime project");
         registry
             .project_registry
+            .as_ref()
+            .expect("project registry")
             .register(crate::project_registry::Project {
                 id: "runtime-project".to_string(),
                 root: runtime_project_root.clone(),

--- a/crates/harness-server/src/http/builders/mod.rs
+++ b/crates/harness-server/src/http/builders/mod.rs
@@ -27,10 +27,10 @@ where
 pub(crate) fn forced_startup_error(name: &'static str) -> Option<String> {
     #[cfg(test)]
     {
-        return FORCED_STARTUP_FAILURES
+        FORCED_STARTUP_FAILURES
             .try_with(|failures| failures.get(name).cloned())
             .ok()
-            .flatten();
+            .flatten()
     }
 
     #[cfg(not(test))]

--- a/crates/harness-server/src/http/builders/mod.rs
+++ b/crates/harness-server/src/http/builders/mod.rs
@@ -3,3 +3,39 @@ pub(crate) mod intake;
 pub(crate) mod registry;
 pub(crate) mod services;
 pub(crate) mod storage;
+
+#[cfg(test)]
+tokio::task_local! {
+    static FORCED_STARTUP_FAILURES: std::collections::HashMap<&'static str, String>;
+}
+
+#[cfg(test)]
+pub(crate) async fn with_forced_startup_failures<F, T>(
+    failures: &[(&'static str, &str)],
+    future: F,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let mut forced = std::collections::HashMap::new();
+    for (name, error) in failures {
+        forced.insert(*name, (*error).to_string());
+    }
+    FORCED_STARTUP_FAILURES.scope(forced, future).await
+}
+
+pub(crate) fn forced_startup_error(name: &'static str) -> Option<String> {
+    #[cfg(test)]
+    {
+        return FORCED_STARTUP_FAILURES
+            .try_with(|failures| failures.get(name).cloned())
+            .ok()
+            .flatten();
+    }
+
+    #[cfg(not(test))]
+    {
+        let _ = name;
+        None
+    }
+}

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -19,6 +19,18 @@ pub(crate) struct RegistryBundle {
     pub startup_results: Vec<StoreStartupResult>,
 }
 
+fn failed_registry_startup_results(error: &str) -> Vec<StoreStartupResult> {
+    vec![
+        StoreStartupResult::critical("thread_db").failed(error),
+        StoreStartupResult::critical("plan_db").failed(error),
+        StoreStartupResult::optional("issue_workflow_store").failed(error),
+        StoreStartupResult::optional("project_workflow_store").failed(error),
+        StoreStartupResult::critical("project_registry").failed(error),
+        StoreStartupResult::optional("workspace_manager").failed(error),
+        StoreStartupResult::optional("runtime_state_store").failed(error),
+    ]
+}
+
 /// Initialize thread DB, plan DB, plan cache, project registry, workspace
 /// manager, and runtime state store.
 ///
@@ -30,14 +42,6 @@ pub(crate) async fn build_registry(
     project_root: &Path,
     tasks: &Arc<crate::task_runner::TaskStore>,
 ) -> anyhow::Result<RegistryBundle> {
-    fn startup_failure(name: &'static str, critical: bool, error: &str) -> StoreStartupResult {
-        if critical {
-            StoreStartupResult::critical(name).failed(error)
-        } else {
-            StoreStartupResult::optional(name).failed(error)
-        }
-    }
-
     let configured_database_url = server.config.server.database_url.as_deref();
     let workflow_config =
         harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_default();
@@ -58,14 +62,7 @@ pub(crate) async fn build_registry(
                 project_registry: None,
                 runtime_state_store: None,
                 workspace_mgr: None,
-                startup_results: vec![
-                    startup_failure("thread_db", true, &error),
-                    startup_failure("plan_db", true, &error),
-                    startup_failure("issue_workflow_store", false, &error),
-                    startup_failure("project_workflow_store", false, &error),
-                    startup_failure("project_registry", true, &error),
-                    startup_failure("runtime_state_store", false, &error),
-                ],
+                startup_results: failed_registry_startup_results(&error),
             });
         }
     };
@@ -82,14 +79,7 @@ pub(crate) async fn build_registry(
                 project_registry: None,
                 runtime_state_store: None,
                 workspace_mgr: None,
-                startup_results: vec![
-                    startup_failure("thread_db", true, &error),
-                    startup_failure("plan_db", true, &error),
-                    startup_failure("issue_workflow_store", false, &error),
-                    startup_failure("project_workflow_store", false, &error),
-                    startup_failure("project_registry", true, &error),
-                    startup_failure("runtime_state_store", false, &error),
-                ],
+                startup_results: failed_registry_startup_results(&error),
             });
         }
     };
@@ -108,10 +98,7 @@ pub(crate) async fn build_registry(
         None => match crate::thread_db::ThreadDb::open_with_context(&thread_context, &setup_pool)
             .await
         {
-            Ok(thread_db) => {
-                startup_results.push(StoreStartupResult::critical("thread_db"));
-                Some(thread_db)
-            }
+            Ok(thread_db) => Some(thread_db),
             Err(error) => {
                 startup_results
                     .push(StoreStartupResult::critical("thread_db").failed(error.to_string()));
@@ -122,11 +109,21 @@ pub(crate) async fn build_registry(
 
     // Load persisted threads into the in-memory ThreadManager cache.
     if let Some(thread_db) = thread_db.as_ref() {
-        for thread in thread_db.list().await? {
-            server
-                .thread_manager
-                .threads_cache()
-                .insert(thread.id.as_str().to_string(), thread);
+        match thread_db.list().await {
+            Ok(threads) => {
+                for thread in threads {
+                    server
+                        .thread_manager
+                        .threads_cache()
+                        .insert(thread.id.as_str().to_string(), thread);
+                }
+                startup_results.push(StoreStartupResult::critical("thread_db"));
+            }
+            Err(error) => {
+                startup_results
+                    .push(StoreStartupResult::critical("thread_db").failed(error.to_string()));
+                tracing::warn!("thread cache: failed to load threads on startup: {error}");
+            }
         }
     }
 
@@ -489,7 +486,11 @@ pub(crate) async fn build_registry(
                     )
                     .await
                     {
-                        Ok(store) => Some(Arc::new(store)),
+                        Ok(store) => {
+                            startup_results
+                                .push(StoreStartupResult::optional("runtime_state_store"));
+                            Some(Arc::new(store))
+                        }
                         Err(e) => {
                             startup_results.push(
                                 StoreStartupResult::optional("runtime_state_store")
@@ -517,14 +518,6 @@ pub(crate) async fn build_registry(
             },
         }
     };
-
-    if runtime_state_store.is_some()
-        && !startup_results
-            .iter()
-            .any(|result| result.name == "runtime_state_store")
-    {
-        startup_results.push(StoreStartupResult::optional("runtime_state_store"));
-    }
 
     setup_pool.close().await;
 
@@ -814,6 +807,18 @@ mod tests {
             assert!(!status.is_critical());
             assert!(!status.ready);
         }
+    }
+
+    #[test]
+    fn bootstrap_failure_records_workspace_manager_status() {
+        let statuses = failed_registry_startup_results("database unavailable");
+        let workspace_status = statuses
+            .iter()
+            .find(|status| status.name == "workspace_manager")
+            .expect("workspace_manager status");
+
+        assert!(!workspace_status.ready);
+        assert!(!workspace_status.is_critical());
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -31,6 +31,23 @@ fn failed_registry_startup_results(error: &str) -> Vec<StoreStartupResult> {
     ]
 }
 
+fn failed_registry_bundle(
+    plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    error: &str,
+) -> RegistryBundle {
+    RegistryBundle {
+        thread_db: None,
+        plan_db: None,
+        plan_cache,
+        issue_workflow_store: None,
+        project_workflow_store: None,
+        project_registry: None,
+        runtime_state_store: None,
+        workspace_mgr: None,
+        startup_results: failed_registry_startup_results(error),
+    }
+}
+
 /// Initialize thread DB, plan DB, plan cache, project registry, workspace
 /// manager, and runtime state store.
 ///
@@ -53,34 +70,14 @@ pub(crate) async fn build_registry(
         Ok(database_url) => database_url,
         Err(error) => {
             let error = error.to_string();
-            return Ok(RegistryBundle {
-                thread_db: None,
-                plan_db: None,
-                plan_cache,
-                issue_workflow_store: None,
-                project_workflow_store: None,
-                project_registry: None,
-                runtime_state_store: None,
-                workspace_mgr: None,
-                startup_results: failed_registry_startup_results(&error),
-            });
+            return Ok(failed_registry_bundle(plan_cache, &error));
         }
     };
     let setup_pool = match harness_core::db::pg_open_pool(&database_url).await {
         Ok(pool) => pool,
         Err(error) => {
             let error = error.to_string();
-            return Ok(RegistryBundle {
-                thread_db: None,
-                plan_db: None,
-                plan_cache,
-                issue_workflow_store: None,
-                project_workflow_store: None,
-                project_registry: None,
-                runtime_state_store: None,
-                workspace_mgr: None,
-                startup_results: failed_registry_startup_results(&error),
-            });
+            return Ok(failed_registry_bundle(plan_cache, &error));
         }
     };
 

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -185,51 +185,70 @@ pub(crate) async fn build_registry(
         harness_core::config::dirs::default_db_path(data_dir, "issue_workflows");
     let issue_workflow_store = {
         let schema = format!("{workflow_ns}_issue");
-        let context = harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
         match super::forced_startup_error("issue_workflow_store") {
             Some(error) => {
                 startup_results
                     .push(StoreStartupResult::optional("issue_workflow_store").failed(error));
                 None
             }
-            None => match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_context(
-                &context,
-                &setup_pool,
-            )
-            .await
-            {
-                Ok(store) => {
-                    startup_results.push(StoreStartupResult::optional("issue_workflow_store"));
-                    if let Err(e) = migrate_issue_workflows_if_needed(
-                        configured_database_url,
-                        &issue_workflows_db_path,
-                        &schema,
-                        &store,
+            None => match harness_core::db::PgStoreContext::new(
+                database_url.clone(),
+                schema.clone(),
+            ) {
+                Ok(context) => {
+                    match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_context(
+                        &context,
+                        &setup_pool,
                     )
                     .await
                     {
-                        tracing::warn!(
-                            schema = %schema,
-                            "issue workflow migration check failed: {e}"
-                        );
+                        Ok(store) => {
+                            startup_results
+                                .push(StoreStartupResult::optional("issue_workflow_store"));
+                            if let Err(e) = migrate_issue_workflows_if_needed(
+                                configured_database_url,
+                                &issue_workflows_db_path,
+                                &schema,
+                                &store,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    schema = %schema,
+                                    "issue workflow migration check failed: {e}"
+                                );
+                            }
+                            let (rewritten, failed, skipped) =
+                                repair_corrupt_project_ids(&store, project_root).await;
+                            tracing::info!(
+                                rewritten,
+                                failed,
+                                skipped,
+                                "startup repair of corrupt issue workflow project_ids complete"
+                            );
+                            Some(Arc::new(store))
+                        }
+                        Err(e) => {
+                            startup_results.push(
+                                StoreStartupResult::optional("issue_workflow_store")
+                                    .failed(e.to_string()),
+                            );
+                            tracing::warn!(
+                                schema = %schema,
+                                "issue workflow store init failed, issue lifecycle state will not persist: {e}"
+                            );
+                            None
+                        }
                     }
-                    let (rewritten, failed, skipped) =
-                        repair_corrupt_project_ids(&store, project_root).await;
-                    tracing::info!(
-                        rewritten,
-                        failed,
-                        skipped,
-                        "startup repair of corrupt issue workflow project_ids complete"
-                    );
-                    Some(Arc::new(store))
                 }
-                Err(e) => {
+                Err(error) => {
                     startup_results.push(
-                        StoreStartupResult::optional("issue_workflow_store").failed(e.to_string()),
+                        StoreStartupResult::optional("issue_workflow_store")
+                            .failed(error.to_string()),
                     );
                     tracing::warn!(
                         schema = %schema,
-                        "issue workflow store init failed, issue lifecycle state will not persist: {e}"
+                        "issue workflow store context init failed, issue lifecycle state will not persist: {error}"
                     );
                     None
                 }
@@ -242,51 +261,66 @@ pub(crate) async fn build_registry(
         harness_core::config::dirs::default_db_path(data_dir, "project_workflows");
     let project_workflow_store = {
         let schema = format!("{workflow_ns}_project");
-        let context = harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
         match super::forced_startup_error("project_workflow_store") {
             Some(error) => {
                 startup_results
                     .push(StoreStartupResult::optional("project_workflow_store").failed(error));
                 None
             }
-            None => {
-                match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_context(
-                    &context,
-                    &setup_pool,
-                )
-                .await
-                {
-                    Ok(store) => {
-                        startup_results
-                            .push(StoreStartupResult::optional("project_workflow_store"));
-                        if let Err(e) = migrate_project_workflows_if_needed(
-                            configured_database_url,
-                            &project_workflows_db_path,
-                            &schema,
-                            &store,
-                        )
-                        .await
-                        {
+            None => match harness_core::db::PgStoreContext::new(
+                database_url.clone(),
+                schema.clone(),
+            ) {
+                Ok(context) => {
+                    match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_context(
+                        &context,
+                        &setup_pool,
+                    )
+                    .await
+                    {
+                        Ok(store) => {
+                            startup_results
+                                .push(StoreStartupResult::optional("project_workflow_store"));
+                            if let Err(e) = migrate_project_workflows_if_needed(
+                                configured_database_url,
+                                &project_workflows_db_path,
+                                &schema,
+                                &store,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    schema = %schema,
+                                    "project workflow migration check failed: {e}"
+                                );
+                            }
+                            Some(Arc::new(store))
+                        }
+                        Err(e) => {
+                            startup_results.push(
+                                StoreStartupResult::optional("project_workflow_store")
+                                    .failed(e.to_string()),
+                            );
                             tracing::warn!(
                                 schema = %schema,
-                                "project workflow migration check failed: {e}"
+                                "project workflow store init failed, project lifecycle state will not persist: {e}"
                             );
+                            None
                         }
-                        Some(Arc::new(store))
-                    }
-                    Err(e) => {
-                        startup_results.push(
-                            StoreStartupResult::optional("project_workflow_store")
-                                .failed(e.to_string()),
-                        );
-                        tracing::warn!(
-                            schema = %schema,
-                            "project workflow store init failed, project lifecycle state will not persist: {e}"
-                        );
-                        None
                     }
                 }
-            }
+                Err(error) => {
+                    startup_results.push(
+                        StoreStartupResult::optional("project_workflow_store")
+                            .failed(error.to_string()),
+                    );
+                    tracing::warn!(
+                        schema = %schema,
+                        "project workflow store context init failed, project lifecycle state will not persist: {error}"
+                    );
+                    None
+                }
+            },
         }
     };
 
@@ -439,30 +473,44 @@ pub(crate) async fn build_registry(
     let runtime_state_store = {
         let runtime_state_db_path =
             harness_core::config::dirs::default_db_path(data_dir, "runtime_state");
-        let context = harness_core::db::PgStoreContext::new(
-            database_url.clone(),
-            harness_core::db::pg_schema_for_path(&runtime_state_db_path)?,
-        )?;
         match super::forced_startup_error("runtime_state_store") {
             Some(error) => {
                 startup_results
                     .push(StoreStartupResult::optional("runtime_state_store").failed(error));
                 None
             }
-            None => match crate::runtime_state_store::RuntimeStateStore::open_with_context(
-                &context,
-                &setup_pool,
-            )
-            .await
-            {
-                Ok(store) => Some(Arc::new(store)),
-                Err(e) => {
+            None => match harness_core::db::pg_schema_for_path(&runtime_state_db_path).and_then(
+                |schema| harness_core::db::PgStoreContext::new(database_url.clone(), schema),
+            ) {
+                Ok(context) => {
+                    match crate::runtime_state_store::RuntimeStateStore::open_with_context(
+                        &context,
+                        &setup_pool,
+                    )
+                    .await
+                    {
+                        Ok(store) => Some(Arc::new(store)),
+                        Err(e) => {
+                            startup_results.push(
+                                StoreStartupResult::optional("runtime_state_store")
+                                    .failed(e.to_string()),
+                            );
+                            tracing::warn!(
+                                path = %runtime_state_db_path.display(),
+                                "runtime state store init failed, runtime host state will not persist: {e}"
+                            );
+                            None
+                        }
+                    }
+                }
+                Err(error) => {
                     startup_results.push(
-                        StoreStartupResult::optional("runtime_state_store").failed(e.to_string()),
+                        StoreStartupResult::optional("runtime_state_store")
+                            .failed(error.to_string()),
                     );
                     tracing::warn!(
                         path = %runtime_state_db_path.display(),
-                        "runtime state store init failed, runtime host state will not persist: {e}"
+                        "runtime state store context init failed, runtime host state will not persist: {error}"
                     );
                     None
                 }
@@ -734,6 +782,38 @@ mod tests {
             .expect("runtime_state_store startup result");
         assert!(!status.is_critical());
         assert!(!status.ready);
+    }
+
+    #[tokio::test]
+    async fn invalid_workflow_schema_namespace_disables_optional_workflow_stores() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            "---\nstorage:\n  schema_namespace: invalid-name\n---\n",
+        )
+        .expect("write workflow config");
+        let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+
+        let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
+            .await
+            .expect("optional workflow-store context failures should not abort startup");
+
+        assert!(
+            bundle.project_registry.is_some(),
+            "critical stores should stay ready: {:?}",
+            bundle.startup_results
+        );
+        assert!(bundle.issue_workflow_store.is_none());
+        assert!(bundle.project_workflow_store.is_none());
+        for name in ["issue_workflow_store", "project_workflow_store"] {
+            let status = bundle
+                .startup_results
+                .iter()
+                .find(|status| status.name == name)
+                .unwrap_or_else(|| panic!("{name} startup result should be recorded"));
+            assert!(!status.is_critical());
+            assert!(!status.ready);
+        }
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -2,19 +2,21 @@ use dashmap::DashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::http::state::StoreStartupResult;
 use crate::server::HarnessServer;
 
 /// Outputs of the registry initialization phase.
 pub(crate) struct RegistryBundle {
-    pub thread_db: crate::thread_db::ThreadDb,
-    pub plan_db: crate::plan_db::PlanDb,
+    pub thread_db: Option<crate::thread_db::ThreadDb>,
+    pub plan_db: Option<crate::plan_db::PlanDb>,
     pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
     pub issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     pub project_workflow_store:
         Option<Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>>,
-    pub project_registry: Arc<crate::project_registry::ProjectRegistry>,
+    pub project_registry: Option<Arc<crate::project_registry::ProjectRegistry>>,
     pub runtime_state_store: Option<Arc<crate::runtime_state_store::RuntimeStateStore>>,
     pub workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
+    pub startup_results: Vec<StoreStartupResult>,
 }
 
 /// Initialize thread DB, plan DB, plan cache, project registry, workspace
@@ -28,56 +30,154 @@ pub(crate) async fn build_registry(
     project_root: &Path,
     tasks: &Arc<crate::task_runner::TaskStore>,
 ) -> anyhow::Result<RegistryBundle> {
+    fn startup_failure(name: &'static str, critical: bool, error: &str) -> StoreStartupResult {
+        if critical {
+            StoreStartupResult::critical(name).failed(error)
+        } else {
+            StoreStartupResult::optional(name).failed(error)
+        }
+    }
+
     let configured_database_url = server.config.server.database_url.as_deref();
     let workflow_config =
         harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_default();
     let workflow_ns = workflow_config.storage.schema_namespace;
+    let mut startup_results = Vec::new();
+    let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());
+
+    let database_url = match harness_core::db::resolve_database_url(configured_database_url) {
+        Ok(database_url) => database_url,
+        Err(error) => {
+            let error = error.to_string();
+            return Ok(RegistryBundle {
+                thread_db: None,
+                plan_db: None,
+                plan_cache,
+                issue_workflow_store: None,
+                project_workflow_store: None,
+                project_registry: None,
+                runtime_state_store: None,
+                workspace_mgr: None,
+                startup_results: vec![
+                    startup_failure("thread_db", true, &error),
+                    startup_failure("plan_db", true, &error),
+                    startup_failure("issue_workflow_store", false, &error),
+                    startup_failure("project_workflow_store", false, &error),
+                    startup_failure("project_registry", true, &error),
+                    startup_failure("runtime_state_store", false, &error),
+                ],
+            });
+        }
+    };
+    let setup_pool = match harness_core::db::pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(error) => {
+            let error = error.to_string();
+            return Ok(RegistryBundle {
+                thread_db: None,
+                plan_db: None,
+                plan_cache,
+                issue_workflow_store: None,
+                project_workflow_store: None,
+                project_registry: None,
+                runtime_state_store: None,
+                workspace_mgr: None,
+                startup_results: vec![
+                    startup_failure("thread_db", true, &error),
+                    startup_failure("plan_db", true, &error),
+                    startup_failure("issue_workflow_store", false, &error),
+                    startup_failure("project_workflow_store", false, &error),
+                    startup_failure("project_registry", true, &error),
+                    startup_failure("runtime_state_store", false, &error),
+                ],
+            });
+        }
+    };
+
     // ── Thread DB ─────────────────────────────────────────────────────────────
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
-    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
-        &thread_db_path,
-        configured_database_url,
-    )
-    .await?;
+    let thread_context = harness_core::db::PgStoreContext::new(
+        database_url.clone(),
+        harness_core::db::pg_schema_for_path(&thread_db_path)?,
+    )?;
+    let thread_db = match super::forced_startup_error("thread_db") {
+        Some(error) => {
+            startup_results.push(StoreStartupResult::critical("thread_db").failed(error));
+            None
+        }
+        None => match crate::thread_db::ThreadDb::open_with_context(&thread_context, &setup_pool)
+            .await
+        {
+            Ok(thread_db) => {
+                startup_results.push(StoreStartupResult::critical("thread_db"));
+                Some(thread_db)
+            }
+            Err(error) => {
+                startup_results
+                    .push(StoreStartupResult::critical("thread_db").failed(error.to_string()));
+                None
+            }
+        },
+    };
 
     // Load persisted threads into the in-memory ThreadManager cache.
-    for thread in thread_db.list().await? {
-        server
-            .thread_manager
-            .threads_cache()
-            .insert(thread.id.as_str().to_string(), thread);
+    if let Some(thread_db) = thread_db.as_ref() {
+        for thread in thread_db.list().await? {
+            server
+                .thread_manager
+                .threads_cache()
+                .insert(thread.id.as_str().to_string(), thread);
+        }
     }
 
     // ── Plan DB + cache ───────────────────────────────────────────────────────
-    let plan_db = crate::plan_db::PlanDb::open_with_database_url(
-        &harness_core::config::dirs::default_db_path(data_dir, "plans"),
-        configured_database_url,
-    )
-    .await?;
+    let plans_db_path = harness_core::config::dirs::default_db_path(data_dir, "plans");
+    let plan_context = harness_core::db::PgStoreContext::new(
+        database_url.clone(),
+        harness_core::db::pg_schema_for_path(&plans_db_path)?,
+    )?;
+    let plan_db = match super::forced_startup_error("plan_db") {
+        Some(error) => {
+            startup_results.push(StoreStartupResult::critical("plan_db").failed(error));
+            None
+        }
+        None => match crate::plan_db::PlanDb::open_with_context(&plan_context, &setup_pool).await {
+            Ok(plan_db) => {
+                startup_results.push(StoreStartupResult::critical("plan_db"));
+                Some(plan_db)
+            }
+            Err(error) => {
+                startup_results
+                    .push(StoreStartupResult::critical("plan_db").failed(error.to_string()));
+                None
+            }
+        },
+    };
 
     let plans_md_dir = data_dir.join("plans");
-    match plan_db.migrate_from_markdown_dir(&plans_md_dir).await {
-        Ok(0) => {}
-        Ok(n) => tracing::debug!(
-            count = n,
-            "plan migration: imported {} plan(s) from markdown",
-            n
-        ),
-        Err(e) => tracing::warn!("plan migration: failed: {e}"),
-    }
-
-    let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());
-    match plan_db.list().await {
-        Ok(plans) => {
-            let count = plans.len();
-            for plan in plans {
-                plan_cache.insert(plan.id.as_str().to_string(), plan);
-            }
-            if count > 0 {
-                tracing::debug!(count, "plan cache: loaded {} plan(s) from db", count);
-            }
+    if let Some(plan_db) = plan_db.as_ref() {
+        match plan_db.migrate_from_markdown_dir(&plans_md_dir).await {
+            Ok(0) => {}
+            Ok(n) => tracing::debug!(
+                count = n,
+                "plan migration: imported {} plan(s) from markdown",
+                n
+            ),
+            Err(e) => tracing::warn!("plan migration: failed: {e}"),
         }
-        Err(e) => tracing::warn!("plan cache: failed to load plans on startup: {e}"),
+
+        match plan_db.list().await {
+            Ok(plans) => {
+                let count = plans.len();
+                for plan in plans {
+                    plan_cache.insert(plan.id.as_str().to_string(), plan);
+                }
+                if count > 0 {
+                    tracing::debug!(count, "plan cache: loaded {} plan(s) from db", count);
+                }
+            }
+            Err(e) => tracing::warn!("plan cache: failed to load plans on startup: {e}"),
+        }
     }
 
     // ── Issue workflow store ──────────────────────────────────────────────────
@@ -85,43 +185,55 @@ pub(crate) async fn build_registry(
         harness_core::config::dirs::default_db_path(data_dir, "issue_workflows");
     let issue_workflow_store = {
         let schema = format!("{workflow_ns}_issue");
-        match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url_and_schema(
-            configured_database_url,
-            &schema,
-        )
-        .await
-        {
-            Ok(store) => {
-                if let Err(e) = migrate_issue_workflows_if_needed(
-                    configured_database_url,
-                    &issue_workflows_db_path,
-                    &schema,
-                    &store,
-                )
-                .await
-                {
-                    tracing::warn!(
-                        schema = %schema,
-                        "issue workflow migration check failed: {e}"
-                    );
-                }
-                let (rewritten, failed, skipped) =
-                    repair_corrupt_project_ids(&store, project_root).await;
-                tracing::info!(
-                    rewritten,
-                    failed,
-                    skipped,
-                    "startup repair of corrupt issue workflow project_ids complete"
-                );
-                Some(Arc::new(store))
-            }
-            Err(e) => {
-                tracing::warn!(
-                    schema = %schema,
-                    "issue workflow store init failed, issue lifecycle state will not persist: {e}"
-                );
+        let context = harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
+        match super::forced_startup_error("issue_workflow_store") {
+            Some(error) => {
+                startup_results
+                    .push(StoreStartupResult::optional("issue_workflow_store").failed(error));
                 None
             }
+            None => match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_context(
+                &context,
+                &setup_pool,
+            )
+            .await
+            {
+                Ok(store) => {
+                    startup_results.push(StoreStartupResult::optional("issue_workflow_store"));
+                    if let Err(e) = migrate_issue_workflows_if_needed(
+                        configured_database_url,
+                        &issue_workflows_db_path,
+                        &schema,
+                        &store,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            schema = %schema,
+                            "issue workflow migration check failed: {e}"
+                        );
+                    }
+                    let (rewritten, failed, skipped) =
+                        repair_corrupt_project_ids(&store, project_root).await;
+                    tracing::info!(
+                        rewritten,
+                        failed,
+                        skipped,
+                        "startup repair of corrupt issue workflow project_ids complete"
+                    );
+                    Some(Arc::new(store))
+                }
+                Err(e) => {
+                    startup_results.push(
+                        StoreStartupResult::optional("issue_workflow_store").failed(e.to_string()),
+                    );
+                    tracing::warn!(
+                        schema = %schema,
+                        "issue workflow store init failed, issue lifecycle state will not persist: {e}"
+                    );
+                    None
+                }
+            },
         }
     };
 
@@ -130,44 +242,83 @@ pub(crate) async fn build_registry(
         harness_core::config::dirs::default_db_path(data_dir, "project_workflows");
     let project_workflow_store = {
         let schema = format!("{workflow_ns}_project");
-        match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_database_url_and_schema(
-            configured_database_url,
-            &schema,
-        )
-        .await
-        {
-            Ok(store) => {
-                if let Err(e) = migrate_project_workflows_if_needed(
-                    configured_database_url,
-                    &project_workflows_db_path,
-                    &schema,
-                    &store,
+        let context = harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
+        match super::forced_startup_error("project_workflow_store") {
+            Some(error) => {
+                startup_results
+                    .push(StoreStartupResult::optional("project_workflow_store").failed(error));
+                None
+            }
+            None => {
+                match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_context(
+                    &context,
+                    &setup_pool,
                 )
                 .await
                 {
-                    tracing::warn!(
-                        schema = %schema,
-                        "project workflow migration check failed: {e}"
-                    );
+                    Ok(store) => {
+                        startup_results
+                            .push(StoreStartupResult::optional("project_workflow_store"));
+                        if let Err(e) = migrate_project_workflows_if_needed(
+                            configured_database_url,
+                            &project_workflows_db_path,
+                            &schema,
+                            &store,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                schema = %schema,
+                                "project workflow migration check failed: {e}"
+                            );
+                        }
+                        Some(Arc::new(store))
+                    }
+                    Err(e) => {
+                        startup_results.push(
+                            StoreStartupResult::optional("project_workflow_store")
+                                .failed(e.to_string()),
+                        );
+                        tracing::warn!(
+                            schema = %schema,
+                            "project workflow store init failed, project lifecycle state will not persist: {e}"
+                        );
+                        None
+                    }
                 }
-                Some(Arc::new(store))
-            }
-            Err(e) => {
-                tracing::warn!(
-                    schema = %schema,
-                    "project workflow store init failed, project lifecycle state will not persist: {e}"
-                );
-                None
             }
         }
     };
 
     // ── Project registry ──────────────────────────────────────────────────────
-    let project_registry = crate::project_registry::ProjectRegistry::open_with_database_url(
-        &harness_core::config::dirs::default_db_path(data_dir, "projects"),
-        configured_database_url,
-    )
-    .await?;
+    let projects_db_path = harness_core::config::dirs::default_db_path(data_dir, "projects");
+    let project_context = harness_core::db::PgStoreContext::new(
+        database_url.clone(),
+        harness_core::db::pg_schema_for_path(&projects_db_path)?,
+    )?;
+    let project_registry = match super::forced_startup_error("project_registry") {
+        Some(error) => {
+            startup_results.push(StoreStartupResult::critical("project_registry").failed(error));
+            None
+        }
+        None => match crate::project_registry::ProjectRegistry::open_with_context(
+            &project_context,
+            &setup_pool,
+        )
+        .await
+        {
+            Ok(project_registry) => {
+                startup_results.push(StoreStartupResult::critical("project_registry"));
+                Some(project_registry)
+            }
+            Err(error) => {
+                startup_results.push(
+                    StoreStartupResult::critical("project_registry").failed(error.to_string()),
+                );
+                None
+            }
+        },
+    };
 
     // Auto-register the default project from --project-root on startup.
     let canonical_project_root = project_root.canonicalize().ok();
@@ -211,27 +362,29 @@ pub(crate) async fn build_registry(
         active: true,
         created_at: chrono::Utc::now().to_rfc3339(),
     };
-    if let Err(e) = project_registry.register(default_project).await {
-        tracing::warn!("failed to auto-register default project: {e}");
-    }
-    for project in &server.startup_projects {
-        let startup_root = project
-            .root
-            .canonicalize()
-            .unwrap_or_else(|_| project.root.clone());
-        let proj = crate::project_registry::Project {
-            id: harness_core::types::ProjectId::from_path(&startup_root)
-                .as_str()
-                .to_owned(),
-            root: startup_root,
-            name: Some(project.name.clone()),
-            max_concurrent: project.max_concurrent,
-            default_agent: project.default_agent.clone(),
-            active: true,
-            created_at: chrono::Utc::now().to_rfc3339(),
-        };
-        if let Err(e) = project_registry.register(proj).await {
-            tracing::warn!(project = %project.name, "failed to register startup project: {e}");
+    if let Some(project_registry) = project_registry.as_ref() {
+        if let Err(e) = project_registry.register(default_project).await {
+            tracing::warn!("failed to auto-register default project: {e}");
+        }
+        for project in &server.startup_projects {
+            let startup_root = project
+                .root
+                .canonicalize()
+                .unwrap_or_else(|_| project.root.clone());
+            let proj = crate::project_registry::Project {
+                id: harness_core::types::ProjectId::from_path(&startup_root)
+                    .as_str()
+                    .to_owned(),
+                root: startup_root,
+                name: Some(project.name.clone()),
+                max_concurrent: project.max_concurrent,
+                default_agent: project.default_agent.clone(),
+                active: true,
+                created_at: chrono::Utc::now().to_rfc3339(),
+            };
+            if let Err(e) = project_registry.register(proj).await {
+                tracing::warn!(project = %project.name, "failed to register startup project: {e}");
+            }
         }
     }
 
@@ -239,6 +392,7 @@ pub(crate) async fn build_registry(
     let workspace_mgr =
         match crate::workspace::WorkspaceManager::new(server.config.workspace.clone()) {
             Ok(mgr) => {
+                startup_results.push(StoreStartupResult::optional("workspace_manager"));
                 tracing::debug!(
                     root = %server.config.workspace.root.display(),
                     "workspace manager initialized"
@@ -246,6 +400,8 @@ pub(crate) async fn build_registry(
                 Some(Arc::new(mgr))
             }
             Err(e) => {
+                startup_results
+                    .push(StoreStartupResult::optional("workspace_manager").failed(e.to_string()));
                 tracing::warn!(
                 "failed to initialize workspace manager: {e}; running without workspace isolation"
             );
@@ -283,22 +439,46 @@ pub(crate) async fn build_registry(
     let runtime_state_store = {
         let runtime_state_db_path =
             harness_core::config::dirs::default_db_path(data_dir, "runtime_state");
-        match crate::runtime_state_store::RuntimeStateStore::open_with_database_url(
-            &runtime_state_db_path,
-            configured_database_url,
-        )
-        .await
-        {
-            Ok(store) => Some(Arc::new(store)),
-            Err(e) => {
-                tracing::warn!(
-                    path = %runtime_state_db_path.display(),
-                    "runtime state store init failed, runtime host state will not persist: {e}"
-                );
+        let context = harness_core::db::PgStoreContext::new(
+            database_url.clone(),
+            harness_core::db::pg_schema_for_path(&runtime_state_db_path)?,
+        )?;
+        match super::forced_startup_error("runtime_state_store") {
+            Some(error) => {
+                startup_results
+                    .push(StoreStartupResult::optional("runtime_state_store").failed(error));
                 None
             }
+            None => match crate::runtime_state_store::RuntimeStateStore::open_with_context(
+                &context,
+                &setup_pool,
+            )
+            .await
+            {
+                Ok(store) => Some(Arc::new(store)),
+                Err(e) => {
+                    startup_results.push(
+                        StoreStartupResult::optional("runtime_state_store").failed(e.to_string()),
+                    );
+                    tracing::warn!(
+                        path = %runtime_state_db_path.display(),
+                        "runtime state store init failed, runtime host state will not persist: {e}"
+                    );
+                    None
+                }
+            },
         }
     };
+
+    if runtime_state_store.is_some()
+        && !startup_results
+            .iter()
+            .any(|result| result.name == "runtime_state_store")
+    {
+        startup_results.push(StoreStartupResult::optional("runtime_state_store"));
+    }
+
+    setup_pool.close().await;
 
     Ok(RegistryBundle {
         thread_db,
@@ -309,6 +489,7 @@ pub(crate) async fn build_registry(
         project_registry,
         runtime_state_store,
         workspace_mgr,
+        startup_results,
     })
 }
 
@@ -482,7 +663,13 @@ mod tests {
             .await
             .expect("build_registry should succeed");
         // The default project is always auto-registered; registry should have exactly 1 entry.
-        let projects = bundle.project_registry.list().await.expect("list projects");
+        let project_registry = bundle.project_registry.as_ref().unwrap_or_else(|| {
+            panic!(
+                "project registry should be ready: {:?}",
+                bundle.startup_results
+            )
+        });
+        let projects = project_registry.list().await.expect("list projects");
         assert_eq!(projects.len(), 1, "expected only the default project");
         // ID is the canonical path of the project root, not the literal "default".
         let canonical = dir
@@ -516,6 +703,60 @@ mod tests {
             bundle.plan_cache.contains_key(&plan_id),
             "plan should be hydrated into cache"
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_state_failure_is_recorded_as_optional() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+        let bundle = super::super::with_forced_startup_failures(
+            &[(
+                "runtime_state_store",
+                "pool timed out while waiting for an open connection",
+            )],
+            build_registry(&server, dir.path(), dir.path(), &tasks),
+        )
+        .await
+        .expect("build_registry should succeed");
+        assert!(
+            bundle.project_registry.is_some(),
+            "critical stores should stay ready: {:?}",
+            bundle.startup_results
+        );
+        assert!(
+            bundle.runtime_state_store.is_none(),
+            "optional runtime state store should be disabled"
+        );
+        let status = bundle
+            .startup_results
+            .iter()
+            .find(|status| status.name == "runtime_state_store")
+            .expect("runtime_state_store startup result");
+        assert!(!status.is_critical());
+        assert!(!status.ready);
+    }
+
+    #[tokio::test]
+    async fn project_registry_failure_is_recorded_as_critical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+        let bundle = super::super::with_forced_startup_failures(
+            &[("project_registry", "failed to open Postgres bootstrap pool")],
+            build_registry(&server, dir.path(), dir.path(), &tasks),
+        )
+        .await
+        .expect("build_registry should succeed");
+        assert!(
+            bundle.project_registry.is_none(),
+            "critical project registry should be absent"
+        );
+        let status = bundle
+            .startup_results
+            .iter()
+            .find(|status| status.name == "project_registry")
+            .expect("project_registry startup result");
+        assert!(status.is_critical());
+        assert!(!status.ready);
     }
 
     async fn open_test_issue_store(

--- a/crates/harness-server/src/http/builders/services.rs
+++ b/crates/harness-server/src/http/builders/services.rs
@@ -35,21 +35,35 @@ pub(crate) async fn build_services(
     intake: &IntakeBundle,
     project_root: &Path,
 ) -> anyhow::Result<ServicesBundle> {
+    let tasks = storage
+        .tasks
+        .as_ref()
+        .expect("build_services requires a ready task store")
+        .clone();
+    let events = engines
+        .events
+        .as_ref()
+        .expect("build_services requires a ready event store")
+        .clone();
+    let project_registry = registry
+        .project_registry
+        .as_ref()
+        .expect("build_services requires a ready project registry")
+        .clone();
+
     // ── Interceptor stack ─────────────────────────────────────────────────────
     let hook_enforcement = server.config.rules.hook_enforcement;
     let interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>> = vec![
         Arc::new(crate::contract_validator::ContractValidator::new()),
-        // RuleEnforcer intentionally disabled: false-positives on test fixtures
-        // in other repo worktrees (SEC-02 hardcoded secrets in test code)
-        // block periodic_review tasks. Until source-aware filtering or
-        // allowlists exist, rule checks are available through explicit scans and
-        // post-tool hooks only; they are not a full pre-turn enforcement gate.
+        // RuleEnforcer disabled: false-positives on test fixtures in other repo
+        // worktrees (SEC-02 hardcoded secrets in test code) block periodic_review
+        // tasks. Re-enable after adding source-aware filtering or allowlists.
         // Arc::new(crate::rule_enforcer::RuleEnforcer::new(
         //     engines.rules.clone(),
         // )),
         Arc::new(crate::hook_enforcer::HookEnforcer::new(
             engines.rules.clone(),
-            engines.events.clone(),
+            events.clone(),
             hook_enforcement,
         )),
         Arc::new(
@@ -62,23 +76,23 @@ pub(crate) async fn build_services(
 
     // ── Service layer ─────────────────────────────────────────────────────────
     let project_svc = crate::services::project::DefaultProjectService::new(
-        registry.project_registry.clone(),
+        project_registry.clone(),
         project_root.to_path_buf(),
     );
-    let task_svc = crate::services::task::DefaultTaskService::new(storage.tasks.clone());
+    let task_svc = crate::services::task::DefaultTaskService::new(tasks.clone());
     let execution_svc = crate::services::execution::DefaultExecutionService::new(
-        storage.tasks.clone(),
+        tasks.clone(),
         server.agent_registry.clone(),
         Arc::new(server.config.clone()),
         engines.skills.clone(),
-        engines.events.clone(),
+        events.clone(),
         interceptors.clone(),
         registry.workspace_mgr.clone(),
         intake.task_queue.clone(),
         intake.review_task_queue.clone(),
         intake.completion_callback.clone(),
         registry.issue_workflow_store.clone(),
-        Some(registry.project_registry.clone()),
+        Some(project_registry.clone()),
         server.config.server.allowed_project_roots.clone(),
     );
 
@@ -137,7 +151,7 @@ pub(crate) async fn build_services(
     // The completion callback is passed so that tasks marked Failed (closed PR)
     // trigger intake cleanup (e.g. removing the issue from the dispatched map).
     {
-        let tasks_for_recovery = storage.tasks.clone();
+        let tasks_for_recovery = tasks.clone();
         let cb_for_recovery = intake.completion_callback.clone();
         let github_token = server.config.server.github_token.clone();
         tokio::spawn(async move {
@@ -185,10 +199,14 @@ mod tests {
         let engines = crate::http::builders::engines::build_engines(&server, dir, dir)
             .await
             .expect("engines");
-        let registry =
-            crate::http::builders::registry::build_registry(&server, dir, dir, &storage.tasks)
-                .await
-                .expect("registry");
+        let registry = crate::http::builders::registry::build_registry(
+            &server,
+            dir,
+            dir,
+            storage.tasks.as_ref().expect("tasks store"),
+        )
+        .await
+        .expect("registry");
         let intake = crate::http::builders::intake::build_intake(
             &server, &storage, &engines, &registry, dir, dir,
         )

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -12,6 +12,13 @@ pub(crate) struct StorageBundle {
     pub startup_results: Vec<StoreStartupResult>,
 }
 
+fn failed_storage_startup_results(error: &str) -> Vec<StoreStartupResult> {
+    vec![
+        StoreStartupResult::critical("tasks").failed(error),
+        StoreStartupResult::optional("q_value_store").failed(error),
+    ]
+}
+
 /// Initialize persistent storage: validate `data_dir`, open the task DB and
 /// optionally the Q-value DB.
 ///
@@ -26,14 +33,6 @@ pub(crate) async fn build_storage_with_database_url(
     data_dir: &Path,
     configured_database_url: Option<&str>,
 ) -> anyhow::Result<StorageBundle> {
-    fn startup_failure(name: &'static str, critical: bool, error: &str) -> StoreStartupResult {
-        if critical {
-            StoreStartupResult::critical(name).failed(error)
-        } else {
-            StoreStartupResult::optional(name).failed(error)
-        }
-    }
-
     std::fs::create_dir_all(data_dir)?;
 
     #[cfg(unix)]
@@ -66,10 +65,7 @@ pub(crate) async fn build_storage_with_database_url(
             return Ok(StorageBundle {
                 tasks: None,
                 q_values: None,
-                startup_results: vec![
-                    startup_failure("tasks", true, &error),
-                    startup_failure("q_value_store", false, &error),
-                ],
+                startup_results: failed_storage_startup_results(&error),
             });
         }
     };
@@ -80,10 +76,7 @@ pub(crate) async fn build_storage_with_database_url(
             return Ok(StorageBundle {
                 tasks: None,
                 q_values: None,
-                startup_results: vec![
-                    startup_failure("tasks", true, &error),
-                    startup_failure("q_value_store", false, &error),
-                ],
+                startup_results: failed_storage_startup_results(&error),
             });
         }
     };
@@ -184,6 +177,18 @@ mod tests {
         assert!(bundle.startup_results[0].ready);
         assert!(!bundle.startup_results[1].ready);
         assert!(!bundle.startup_results[1].is_critical());
+    }
+
+    #[test]
+    fn bootstrap_failure_records_all_storage_statuses() {
+        let statuses = failed_storage_startup_results("database unavailable");
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].name, "tasks");
+        assert!(statuses[0].is_critical());
+        assert!(!statuses[0].ready);
+        assert_eq!(statuses[1].name, "q_value_store");
+        assert!(!statuses[1].is_critical());
+        assert!(!statuses[1].ready);
     }
 
     #[cfg(unix)]

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -2,12 +2,14 @@ use anyhow::Context as _;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::http::state::StoreStartupResult;
 use crate::{q_value_store::QValueStore, task_runner::TaskStore};
 
 /// Outputs of the storage initialization phase.
 pub(crate) struct StorageBundle {
-    pub tasks: Arc<TaskStore>,
+    pub tasks: Option<Arc<TaskStore>>,
     pub q_values: Option<Arc<QValueStore>>,
+    pub startup_results: Vec<StoreStartupResult>,
 }
 
 /// Initialize persistent storage: validate `data_dir`, open the task DB and
@@ -24,6 +26,14 @@ pub(crate) async fn build_storage_with_database_url(
     data_dir: &Path,
     configured_database_url: Option<&str>,
 ) -> anyhow::Result<StorageBundle> {
+    fn startup_failure(name: &'static str, critical: bool, error: &str) -> StoreStartupResult {
+        if critical {
+            StoreStartupResult::critical(name).failed(error)
+        } else {
+            StoreStartupResult::optional(name).failed(error)
+        }
+    }
+
     std::fs::create_dir_all(data_dir)?;
 
     #[cfg(unix)]
@@ -46,24 +56,88 @@ pub(crate) async fn build_storage_with_database_url(
 
     let db_path = harness_core::config::dirs::default_db_path(data_dir, "tasks");
     tracing::debug!("task db: {}", db_path.display());
-    let tasks = TaskStore::open_with_database_url(&db_path, configured_database_url).await?;
-
     let q_values_db_path = harness_core::config::dirs::default_db_path(data_dir, "q_values");
     tracing::debug!("q_value db: {}", q_values_db_path.display());
-    let q_values =
-        match QValueStore::open_with_database_url(&q_values_db_path, configured_database_url).await
-        {
-            Ok(store) => Some(Arc::new(store)),
-            Err(e) => {
-                tracing::warn!(
-                    path = %q_values_db_path.display(),
-                    "q_value store init failed, rule utility tracking will be disabled: {e}"
-                );
-                None
-            }
-        };
 
-    Ok(StorageBundle { tasks, q_values })
+    let database_url = match harness_core::db::resolve_database_url(configured_database_url) {
+        Ok(database_url) => database_url,
+        Err(error) => {
+            let error = error.to_string();
+            return Ok(StorageBundle {
+                tasks: None,
+                q_values: None,
+                startup_results: vec![
+                    startup_failure("tasks", true, &error),
+                    startup_failure("q_value_store", false, &error),
+                ],
+            });
+        }
+    };
+    let setup_pool = match harness_core::db::pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(error) => {
+            let error = error.to_string();
+            return Ok(StorageBundle {
+                tasks: None,
+                q_values: None,
+                startup_results: vec![
+                    startup_failure("tasks", true, &error),
+                    startup_failure("q_value_store", false, &error),
+                ],
+            });
+        }
+    };
+
+    let task_context = harness_core::db::PgStoreContext::new(
+        database_url.clone(),
+        harness_core::db::pg_schema_for_path(&db_path)?,
+    )?;
+    let (tasks, task_result) = match super::forced_startup_error("tasks") {
+        Some(error) => (None, StoreStartupResult::critical("tasks").failed(error)),
+        None => match TaskStore::open_with_context(&db_path, &task_context, &setup_pool).await {
+            Ok(store) => (Some(store), StoreStartupResult::critical("tasks")),
+            Err(error) => (
+                None,
+                StoreStartupResult::critical("tasks").failed(error.to_string()),
+            ),
+        },
+    };
+
+    let q_value_context = harness_core::db::PgStoreContext::new(
+        database_url,
+        harness_core::db::pg_schema_for_path(&q_values_db_path)?,
+    )?;
+    let (q_values, q_value_result) = match super::forced_startup_error("q_value_store") {
+        Some(error) => (
+            None,
+            StoreStartupResult::optional("q_value_store").failed(error),
+        ),
+        None => match QValueStore::open_with_context(&q_value_context, &setup_pool).await {
+            Ok(store) => (
+                Some(Arc::new(store)),
+                StoreStartupResult::optional("q_value_store"),
+            ),
+            Err(error) => (
+                None,
+                StoreStartupResult::optional("q_value_store").failed(error.to_string()),
+            ),
+        },
+    };
+
+    if let Some(error) = q_value_result.error.as_deref() {
+        tracing::warn!(
+            path = %q_values_db_path.display(),
+            "q_value store init failed, rule utility tracking will be disabled: {error}"
+        );
+    }
+
+    setup_pool.close().await;
+
+    Ok(StorageBundle {
+        tasks,
+        q_values,
+        startup_results: vec![task_result, q_value_result],
+    })
 }
 
 #[cfg(test)]
@@ -76,12 +150,34 @@ mod tests {
         let bundle = build_storage(dir.path())
             .await
             .expect("build_storage should succeed");
-        // Both stores are accessible; q_values may be Some or None depending on
-        // whether the SQLite backend initialises without error — on CI it should succeed.
-        let _tasks = bundle.tasks;
-        // q_values is best-effort; we don't assert Some here because a CI
-        // environment with a read-only /tmp might fail the SQLite open.
+        assert!(bundle.tasks.is_some(), "tasks store should be ready");
         drop(bundle.q_values);
+    }
+
+    #[tokio::test]
+    async fn q_value_failure_is_recorded_as_optional() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = super::super::with_forced_startup_failures(
+            &[(
+                "q_value_store",
+                "pool timed out while waiting for an open connection",
+            )],
+            build_storage(dir.path()),
+        )
+        .await
+        .expect("build_storage should succeed");
+        assert!(
+            bundle.tasks.is_some(),
+            "critical task store should still open"
+        );
+        assert!(
+            bundle.q_values.is_none(),
+            "optional q_value store should stay disabled"
+        );
+        assert_eq!(bundle.startup_results.len(), 2);
+        assert!(bundle.startup_results[0].ready);
+        assert!(!bundle.startup_results[1].ready);
+        assert!(!bundle.startup_results[1].is_critical());
     }
 
     #[cfg(unix)]

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -19,6 +19,14 @@ fn failed_storage_startup_results(error: &str) -> Vec<StoreStartupResult> {
     ]
 }
 
+fn failed_storage_bundle(error: &str) -> StorageBundle {
+    StorageBundle {
+        tasks: None,
+        q_values: None,
+        startup_results: failed_storage_startup_results(error),
+    }
+}
+
 /// Initialize persistent storage: validate `data_dir`, open the task DB and
 /// optionally the Q-value DB.
 ///
@@ -62,22 +70,14 @@ pub(crate) async fn build_storage_with_database_url(
         Ok(database_url) => database_url,
         Err(error) => {
             let error = error.to_string();
-            return Ok(StorageBundle {
-                tasks: None,
-                q_values: None,
-                startup_results: failed_storage_startup_results(&error),
-            });
+            return Ok(failed_storage_bundle(&error));
         }
     };
     let setup_pool = match harness_core::db::pg_open_pool(&database_url).await {
         Ok(pool) => pool,
         Err(error) => {
             let error = error.to_string();
-            return Ok(StorageBundle {
-                tasks: None,
-                q_values: None,
-                startup_results: failed_storage_startup_results(&error),
-            });
+            return Ok(failed_storage_bundle(&error));
         }
     };
 

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -103,20 +103,26 @@ pub(crate) async fn build_storage_with_database_url(
         },
     };
 
-    let q_value_context = harness_core::db::PgStoreContext::new(
-        database_url,
-        harness_core::db::pg_schema_for_path(&q_values_db_path)?,
-    )?;
     let (q_values, q_value_result) = match super::forced_startup_error("q_value_store") {
         Some(error) => (
             None,
             StoreStartupResult::optional("q_value_store").failed(error),
         ),
-        None => match QValueStore::open_with_context(&q_value_context, &setup_pool).await {
-            Ok(store) => (
-                Some(Arc::new(store)),
-                StoreStartupResult::optional("q_value_store"),
-            ),
+        None => match harness_core::db::pg_schema_for_path(&q_values_db_path)
+            .and_then(|schema| harness_core::db::PgStoreContext::new(database_url, schema))
+        {
+            Ok(q_value_context) => {
+                match QValueStore::open_with_context(&q_value_context, &setup_pool).await {
+                    Ok(store) => (
+                        Some(Arc::new(store)),
+                        StoreStartupResult::optional("q_value_store"),
+                    ),
+                    Err(error) => (
+                        None,
+                        StoreStartupResult::optional("q_value_store").failed(error.to_string()),
+                    ),
+                }
+            }
             Err(error) => (
                 None,
                 StoreStartupResult::optional("q_value_store").failed(error.to_string()),

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -101,10 +101,18 @@ async fn build_review_store(
         }
     };
 
-    let context = harness_core::db::PgStoreContext::new(
-        database_url,
-        harness_core::db::pg_schema_for_path(&review_db_path)?,
-    )?;
+    let context = match harness_core::db::pg_schema_for_path(&review_db_path)
+        .and_then(|schema| harness_core::db::PgStoreContext::new(database_url, schema))
+    {
+        Ok(context) => context,
+        Err(error) => {
+            setup_pool.close().await;
+            return Ok((
+                None,
+                StoreStartupResult::optional("review_store").failed(error.to_string()),
+            ));
+        }
+    };
     let review_store =
         crate::review_store::ReviewStore::open_with_context(&context, &setup_pool).await;
     setup_pool.close().await;

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -7,7 +7,7 @@ use super::{
     builders, rate_limit,
     state::{
         AppState, ConcurrencyServices, CoreServices, EngineServices, IntakeServices,
-        NotificationServices, ObservabilityServices,
+        NotificationServices, ObservabilityServices, StoreStartupResult,
     },
 };
 
@@ -49,6 +49,78 @@ fn parse_external_id_number(prefix: &str, external_id: Option<&str>) -> Option<u
     value.strip_prefix(prefix)?.parse::<u64>().ok()
 }
 
+fn startup_failure_error(startup_statuses: &[StoreStartupResult]) -> Option<anyhow::Error> {
+    let failures: Vec<String> = startup_statuses
+        .iter()
+        .filter(|status| status.is_critical() && !status.ready)
+        .map(|status| {
+            let error = status.error.as_deref().unwrap_or("unknown startup failure");
+            format!("{}: {error}", status.name)
+        })
+        .collect();
+    (!failures.is_empty()).then(|| {
+        anyhow::anyhow!(
+            "critical startup stores failed to initialize: {}",
+            failures.join("; ")
+        )
+    })
+}
+
+async fn build_review_store(
+    data_dir: &std::path::Path,
+    configured_database_url: Option<&str>,
+) -> anyhow::Result<(
+    Option<Arc<crate::review_store::ReviewStore>>,
+    StoreStartupResult,
+)> {
+    let review_db_path = harness_core::config::dirs::default_db_path(data_dir, "reviews");
+    let forced = builders::forced_startup_error("review_store");
+    if let Some(error) = forced {
+        return Ok((
+            None,
+            StoreStartupResult::optional("review_store").failed(error),
+        ));
+    }
+
+    let database_url = match harness_core::db::resolve_database_url(configured_database_url) {
+        Ok(database_url) => database_url,
+        Err(error) => {
+            return Ok((
+                None,
+                StoreStartupResult::optional("review_store").failed(error.to_string()),
+            ));
+        }
+    };
+    let setup_pool = match harness_core::db::pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(error) => {
+            return Ok((
+                None,
+                StoreStartupResult::optional("review_store").failed(error.to_string()),
+            ));
+        }
+    };
+
+    let context = harness_core::db::PgStoreContext::new(
+        database_url,
+        harness_core::db::pg_schema_for_path(&review_db_path)?,
+    )?;
+    let review_store =
+        crate::review_store::ReviewStore::open_with_context(&context, &setup_pool).await;
+    setup_pool.close().await;
+
+    match review_store {
+        Ok(store) => Ok((
+            Some(Arc::new(store)),
+            StoreStartupResult::optional("review_store"),
+        )),
+        Err(error) => Ok((
+            None,
+            StoreStartupResult::optional("review_store").failed(error.to_string()),
+        )),
+    }
+}
+
 /// Build an AppState with all stores. Used by both HTTP and stdio transports.
 ///
 /// Initialization is split into five ordered phases — each phase's outputs
@@ -87,22 +159,40 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         Some(_) => {}
     }
 
+    let mut startup_statuses = Vec::new();
+
     // Phase 1: storage — dir validation (symlink check, chmod), task DB, q_value DB.
     let storage = builders::storage::build_storage_with_database_url(
         &dir,
         server.config.server.database_url.as_deref(),
     )
     .await?;
+    startup_statuses.extend(storage.startup_results.clone());
+    if let Some(error) = startup_failure_error(&startup_statuses) {
+        return Err(error);
+    }
+    let tasks = storage
+        .tasks
+        .as_ref()
+        .expect("critical task store should be present after startup validation")
+        .clone();
 
     // Phase 2: engines — rule engine, event store (+purge task), GC agent, skill store.
     // Depends on: storage (none directly, but must precede registry which uses storage.tasks).
     let engines = builders::engines::build_engines(&server, &dir, &project_root).await?;
+    startup_statuses.extend(engines.startup_results.clone());
+    if let Some(error) = startup_failure_error(&startup_statuses) {
+        return Err(error);
+    }
 
     // Phase 3: registry — thread DB, plan DB + cache, project registry, workspace manager,
     // runtime state store.
     // Depends on: storage.tasks (orphan-worktree cleanup reads terminal task IDs).
-    let registry =
-        builders::registry::build_registry(&server, &dir, &project_root, &storage.tasks).await?;
+    let registry = builders::registry::build_registry(&server, &dir, &project_root, &tasks).await?;
+    startup_statuses.extend(registry.startup_results.clone());
+    if let Some(error) = startup_failure_error(&startup_statuses) {
+        return Err(error);
+    }
 
     // Phase 4: intake — task queue, Feishu/GitHub pollers, quality trigger, completion callback
     // (including Q-value wrapper).
@@ -150,35 +240,18 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         Arc::new(AtomicBool::new(in_window))
     };
 
-    let review_store = {
-        let review_db_path = harness_core::config::dirs::default_db_path(&dir, "reviews");
-        match crate::review_store::ReviewStore::open_with_database_url(
-            &review_db_path,
-            server.config.server.database_url.as_deref(),
-        )
-        .await
-        {
-            Ok(store) => Some(Arc::new(store)),
-            Err(e) => {
-                tracing::warn!("review store init failed, reviews will not be persisted: {e}");
-                None
-            }
-        }
-    };
+    let (review_store, review_status) =
+        build_review_store(&dir, server.config.server.database_url.as_deref()).await?;
+    startup_statuses.push(review_status);
 
     // NOTE: add a matching entry here whenever a new optional store is added.
-    let mut degraded_subsystems: Vec<&'static str> = Vec::new();
-    if storage.q_values.is_none() {
-        degraded_subsystems.push("q_value_store");
-    }
-    if registry.runtime_state_store.is_none() || services.snapshot_load_failed {
+    let mut degraded_subsystems: Vec<&'static str> = startup_statuses
+        .iter()
+        .filter(|status| !status.ready)
+        .map(|status| status.name)
+        .collect();
+    if services.snapshot_load_failed && !degraded_subsystems.contains(&"runtime_state_store") {
         degraded_subsystems.push("runtime_state_store");
-    }
-    if registry.workspace_mgr.is_none() {
-        degraded_subsystems.push("workspace_manager");
-    }
-    if review_store.is_none() {
-        degraded_subsystems.push("review_store");
     }
 
     Ok(AppState {
@@ -186,13 +259,25 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             server,
             project_root,
             home_dir,
-            tasks: storage.tasks,
-            thread_db: Some(registry.thread_db),
-            plan_db: Some(registry.plan_db),
+            tasks,
+            thread_db: Some(
+                registry
+                    .thread_db
+                    .expect("critical thread DB should be present after startup validation"),
+            ),
+            plan_db: Some(
+                registry
+                    .plan_db
+                    .expect("critical plan DB should be present after startup validation"),
+            ),
             plan_cache: registry.plan_cache,
             issue_workflow_store: registry.issue_workflow_store,
             project_workflow_store: registry.project_workflow_store,
-            project_registry: Some(registry.project_registry),
+            project_registry: Some(
+                registry
+                    .project_registry
+                    .expect("critical project registry should be present after startup validation"),
+            ),
             runtime_state_store: registry.runtime_state_store,
             q_values: storage.q_values,
             maintenance_active,
@@ -203,7 +288,9 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             gc_agent: engines.gc_agent,
         },
         observability: ObservabilityServices {
-            events: engines.events,
+            events: engines
+                .events
+                .expect("critical event store should be present after startup validation"),
             signal_rate_limiter: Arc::new(rate_limit::SignalRateLimiter::new(signal_rate_limit)),
             password_reset_rate_limiter: Arc::new(rate_limit::PasswordResetRateLimiter::new(
                 password_reset_rate_limit,
@@ -231,6 +318,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             ws_shutdown_tx: broadcast::channel(1).0,
         },
         interceptors: services.interceptors,
+        startup_statuses,
         degraded_subsystems,
         intake: IntakeServices {
             feishu_intake: intake.feishu_intake,
@@ -528,4 +616,73 @@ async fn post_review_bot_comment(
         anyhow::bail!("GitHub API returned {status}: {text}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{server::HarnessServer, thread_manager::ThreadManager};
+    use harness_agents::registry::AgentRegistry;
+    use harness_core::{config::HarnessConfig, db::resolve_database_url};
+
+    fn make_test_server(root: &std::path::Path) -> Arc<HarnessServer> {
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = root.to_path_buf();
+        config.server.project_root = root.to_path_buf();
+        Arc::new(HarnessServer::new(
+            config,
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        ))
+    }
+
+    #[tokio::test]
+    async fn build_app_state_aborts_on_pool_timeout_for_critical_task_store() {
+        if resolve_database_url(None).is_err() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let server = make_test_server(dir.path());
+        let result = builders::with_forced_startup_failures(
+            &[(
+                "tasks",
+                "pool timed out while waiting for an open connection",
+            )],
+            build_app_state(server),
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("critical task store failure must abort startup"),
+            Err(err) => err,
+        };
+        assert!(crate::test_helpers::is_pool_timeout(&err));
+        assert!(err.to_string().contains("tasks"));
+    }
+
+    #[tokio::test]
+    async fn build_app_state_records_optional_q_value_failure() {
+        if resolve_database_url(None).is_err() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let server = make_test_server(dir.path());
+        let state = builders::with_forced_startup_failures(
+            &[(
+                "q_value_store",
+                "pool timed out while waiting for an open connection",
+            )],
+            build_app_state(server),
+        )
+        .await
+        .expect("optional q_value failure should not abort startup");
+        assert!(state.core.q_values.is_none());
+        assert!(state.degraded_subsystems.contains(&"q_value_store"));
+        let status = state
+            .startup_statuses
+            .iter()
+            .find(|status| status.name == "q_value_store")
+            .expect("q_value startup status");
+        assert!(!status.is_critical());
+        assert!(!status.ready);
+    }
 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -13,6 +13,25 @@ use std::sync::Arc;
 use super::{state::AppState, task_routes};
 use crate::{router, task_runner};
 
+fn startup_error_code(error: Option<&str>) -> Option<&'static str> {
+    let error = error?;
+    let lower = error.to_ascii_lowercase();
+    if lower.contains("migration") {
+        Some("migration_failed")
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        Some("timeout")
+    } else if lower.contains("connection")
+        || lower.contains("connect")
+        || lower.contains("database")
+        || lower.contains("postgres")
+        || lower.contains("pool")
+    {
+        Some("database_unavailable")
+    } else {
+        Some("startup_failed")
+    }
+}
+
 pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let count = state.core.tasks.count();
     let dirty = state.is_runtime_state_dirty();
@@ -25,7 +44,7 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
                 "name": status.name,
                 "critical": status.is_critical(),
                 "ready": status.ready,
-                "error": status.error,
+                "error": startup_error_code(status.error.as_deref()),
             })
         })
         .collect();

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -17,6 +17,18 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
     let count = state.core.tasks.count();
     let dirty = state.is_runtime_state_dirty();
     let degraded = &state.degraded_subsystems;
+    let startup_statuses: Vec<serde_json::Value> = state
+        .startup_statuses
+        .iter()
+        .map(|status| {
+            json!({
+                "name": status.name,
+                "critical": status.is_critical(),
+                "ready": status.ready,
+                "error": status.error,
+            })
+        })
+        .collect();
     let status = if degraded.is_empty() && !dirty {
         "ok"
     } else {
@@ -28,6 +40,9 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
         "persistence": {
             "degraded_subsystems": degraded,
             "runtime_state_dirty": dirty,
+            "startup": {
+                "stores": startup_statuses,
+            }
         }
     }))
 }

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -7,6 +7,50 @@ use tokio::sync::{broadcast, Mutex};
 
 use super::rate_limit;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupTier {
+    Critical,
+    Optional,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreStartupResult {
+    pub name: &'static str,
+    pub tier: StartupTier,
+    pub ready: bool,
+    pub error: Option<String>,
+}
+
+impl StoreStartupResult {
+    pub fn critical(name: &'static str) -> Self {
+        Self {
+            name,
+            tier: StartupTier::Critical,
+            ready: true,
+            error: None,
+        }
+    }
+
+    pub fn optional(name: &'static str) -> Self {
+        Self {
+            name,
+            tier: StartupTier::Optional,
+            ready: true,
+            error: None,
+        }
+    }
+
+    pub fn failed(mut self, error: impl Into<String>) -> Self {
+        self.ready = false;
+        self.error = Some(error.into());
+        self
+    }
+
+    pub fn is_critical(&self) -> bool {
+        matches!(self.tier, StartupTier::Critical)
+    }
+}
+
 /// Core services: thread/task management and persistence.
 pub struct CoreServices {
     pub server: Arc<crate::server::HarnessServer>,
@@ -107,6 +151,8 @@ pub struct AppState {
     pub notifications: NotificationServices,
     pub intake: IntakeServices,
     pub interceptors: Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>,
+    /// Structured startup outcomes for stores and optional subsystems.
+    pub startup_statuses: Vec<StoreStartupResult>,
     /// Subsystem names that degraded to `None` at startup (optional stores only).
     /// Set once during `build_app_state`; read-only thereafter.
     pub degraded_subsystems: Vec<&'static str>,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -187,6 +187,7 @@ async fn make_test_state_with_project_root(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        startup_statuses: vec![],
         degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -427,6 +427,20 @@ struct HealthResponse {
 struct PersistenceBlock {
     degraded_subsystems: Vec<String>,
     runtime_state_dirty: bool,
+    startup: StartupBlock,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct StartupBlock {
+    stores: Vec<StoreHealth>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct StoreHealth {
+    name: String,
+    critical: bool,
+    ready: bool,
+    error: Option<String>,
 }
 
 async fn call_health(state: Arc<AppState>) -> anyhow::Result<HealthResponse> {
@@ -451,6 +465,7 @@ async fn health_endpoint_returns_ok_and_task_count() -> anyhow::Result<()> {
     assert_eq!(health.tasks, 0);
     assert!(health.persistence.degraded_subsystems.is_empty());
     assert!(!health.persistence.runtime_state_dirty);
+    assert!(health.persistence.startup.stores.is_empty());
     Ok(())
 }
 
@@ -476,6 +491,33 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
     assert_eq!(health.status, "degraded");
     assert!(health.persistence.degraded_subsystems.is_empty());
     assert!(health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    let state_mut = Arc::get_mut(&mut state).unwrap();
+    state_mut.degraded_subsystems = vec!["review_store"];
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("review_store")
+                .failed("failed to connect to postgres://user:secret@db.internal/harness"),
+        ];
+
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert_eq!(health.persistence.startup.stores.len(), 1);
+    let store = &health.persistence.startup.stores[0];
+    assert_eq!(store.name, "review_store");
+    assert!(!store.critical);
+    assert!(!store.ready);
+    assert_eq!(store.error.as_deref(), Some("database_unavailable"));
+    assert!(
+        !format!("{health:?}").contains("secret"),
+        "health response must not expose raw startup error text"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -1,7 +1,4 @@
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::PathBuf;
@@ -63,22 +60,18 @@ impl ProjectRegistry {
         path: &std::path::Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Arc<Self>> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(PROJECT_MIGRATIONS).await?;
+        Ok(Arc::new(Self { pool }))
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, PROJECT_MIGRATIONS).run().await?;
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Arc<Self>> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, PROJECT_MIGRATIONS)
+            .await?;
         Ok(Arc::new(Self { pool }))
     }
 
@@ -194,6 +187,7 @@ pub fn validate_project_root(root: &std::path::Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::resolve_database_url;
 
     async fn open_test_registry(name: &str) -> anyhow::Result<Option<Arc<ProjectRegistry>>> {
         if resolve_database_url(None).is_err() {

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -22,10 +22,7 @@
 //! - `closed`        → 0.0 (PR rejected/abandoned)
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
@@ -87,22 +84,18 @@ impl QValueStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(Q_VALUE_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, Q_VALUE_MIGRATIONS).run().await?;
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, Q_VALUE_MIGRATIONS)
+            .await?;
         Ok(Self { pool })
     }
 
@@ -235,6 +228,7 @@ impl QValueStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::resolve_database_url;
     use tempfile::tempdir;
 
     async fn open_test_store() -> anyhow::Result<Option<(QValueStore, tempfile::TempDir)>> {

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -1,7 +1,4 @@
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -110,22 +107,18 @@ impl ReviewStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(REVIEW_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, REVIEW_MIGRATIONS).run().await?;
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, REVIEW_MIGRATIONS)
+            .await?;
         Ok(Self { pool })
     }
 

--- a/crates/harness-server/src/review_store/store_tests.rs
+++ b/crates/harness-server/src/review_store/store_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use chrono::Utc;
+use harness_core::db::resolve_database_url;
 
 async fn open_test_store() -> anyhow::Result<Option<ReviewStore>> {
     if resolve_database_url(None).is_err() {

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -120,6 +120,7 @@ async fn make_test_state_with_config_and_registry(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        startup_statuses: vec![],
         degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,
@@ -1455,6 +1456,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        startup_statuses: vec![],
         degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -1,10 +1,7 @@
 use crate::runtime_hosts_state::PersistedRuntimeHost;
 use crate::runtime_project_cache_state::PersistedHostProjectCache;
 use chrono::{DateTime, Utc};
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -73,23 +70,17 @@ impl RuntimeStateStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(RUNTIME_STATE_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, RUNTIME_STATE_MIGRATIONS)
-            .run()
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, RUNTIME_STATE_MIGRATIONS)
             .await?;
         Ok(Self { pool })
     }
@@ -159,6 +150,7 @@ impl RuntimeStateStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::resolve_database_url;
 
     async fn open_test_store() -> anyhow::Result<Option<RuntimeStateStore>> {
         if resolve_database_url(None).is_err() {

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -176,24 +176,16 @@ mod tests {
     }
 
     async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
-        let database_url = crate::test_helpers::test_database_url()?;
         let server = Arc::new(HarnessServer::new(
             HarnessConfig::default(),
             ThreadManager::new(),
             AgentRegistry::new("test"),
         ));
-        let tasks = crate::task_runner::TaskStore::open_with_database_url(
+        let tasks = crate::task_runner::TaskStore::open(
             &harness_core::config::dirs::default_db_path(dir, "tasks"),
-            Some(&database_url),
         )
         .await?;
-        let events = Arc::new(
-            harness_observe::event_store::EventStore::new_with_database_url(
-                dir,
-                Some(&database_url),
-            )
-            .await?,
-        );
+        let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
         let signal_detector = harness_gc::signal_detector::SignalDetector::new(
             server.config.gc.signal_thresholds.clone().into(),
             harness_core::types::ProjectId::new(),
@@ -205,14 +197,12 @@ mod tests {
             draft_store,
             dir.to_path_buf(),
         ));
-        let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
+        let thread_db = crate::thread_db::ThreadDb::open(
             &harness_core::config::dirs::default_db_path(dir, "threads"),
-            Some(&database_url),
         )
         .await?;
-        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open_with_database_url(
+        let _project_svc_tmp = crate::project_registry::ProjectRegistry::open(
             &harness_core::config::dirs::default_db_path(dir, "projects"),
-            Some(&database_url),
         )
         .await?;
         let project_svc = crate::services::project::DefaultProjectService::new(
@@ -292,6 +282,7 @@ mod tests {
                 ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
             },
             interceptors: vec![],
+            startup_statuses: vec![],
             degraded_subsystems: vec![],
             intake: crate::http::IntakeServices {
                 feishu_intake: None,

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -5,10 +5,7 @@ mod types;
 
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
 
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    PgMigrator,
-};
+use harness_core::db::{PgMigrator, PgStoreContext};
 use migrations::TASK_MIGRATIONS;
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -32,22 +29,19 @@ impl TaskDb {
         db_path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = db_path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", db_path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(db_path, configured_database_url)?;
+        let pool = context.open_migrated_pool(TASK_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        Self::from_pg_pool(pool).await
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, TASK_MIGRATIONS)
+            .await?;
+        Ok(Self { pool })
     }
 
     pub async fn from_pg_pool(pool: PgPool) -> anyhow::Result<Self> {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -3,6 +3,7 @@ use chrono::Utc;
 use dashmap::DashMap;
 use futures::StreamExt;
 use harness_core::agent::StreamItem;
+use harness_core::db::PgStoreContext;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -59,7 +60,19 @@ impl TaskStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Arc<Self>> {
         let db = TaskDb::open_with_database_url(db_path, configured_database_url).await?;
+        Self::from_task_db(db, db_path).await
+    }
 
+    pub async fn open_with_context(
+        db_path: &std::path::Path,
+        context: &PgStoreContext,
+        setup_pool: &sqlx::postgres::PgPool,
+    ) -> anyhow::Result<Arc<Self>> {
+        let db = TaskDb::open_with_context(context, setup_pool).await?;
+        Self::from_task_db(db, db_path).await
+    }
+
+    async fn from_task_db(db: TaskDb, db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
         // 1. Event replay: runs BEFORE recover_in_progress so event-sourced
         //    data (pr_url, terminal status) wins over checkpoint data.
         let event_log_path = db_path

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -100,26 +100,7 @@ pub async fn acquire_db_state_guard() -> tokio::sync::OwnedMutexGuard<()> {
 }
 
 pub fn test_database_url() -> anyhow::Result<String> {
-    if let Ok(url) = resolve_database_url(None) {
-        return Ok(url);
-    }
-
-    let config_path =
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../config/default.toml");
-    let content = std::fs::read_to_string(&config_path)?;
-
-    content
-        .lines()
-        .find_map(|line| {
-            let trimmed = line.trim();
-            let (_, value) = trimmed.split_once('=')?;
-            if !trimmed.starts_with("database_url") {
-                return None;
-            }
-            let url = value.trim().trim_matches('"').trim().to_string();
-            (!url.is_empty()).then_some(url)
-        })
-        .ok_or_else(|| anyhow::anyhow!("config/default.toml is missing server.database_url"))
+    resolve_database_url(None)
 }
 
 pub fn is_pool_timeout(err: &anyhow::Error) -> bool {
@@ -194,17 +175,12 @@ async fn make_state_inner(
         ThreadManager::new(),
         agent_registry,
     ));
-    let database_url = test_database_url()?;
     let password_reset_rate_limit = server.config.server.password_reset_rate_limit_per_hour;
-    let tasks = crate::task_runner::TaskStore::open_with_database_url(
-        &harness_core::config::dirs::default_db_path(dir, "tasks"),
-        Some(&database_url),
-    )
+    let tasks = crate::task_runner::TaskStore::open(&harness_core::config::dirs::default_db_path(
+        dir, "tasks",
+    ))
     .await?;
-    let events = Arc::new(
-        harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
-            .await?,
-    );
+    let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
     let signal_detector = harness_gc::signal_detector::SignalDetector::new(
         server.config.gc.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
@@ -216,10 +192,9 @@ async fn make_state_inner(
         draft_store,
         project_root.to_path_buf(),
     ));
-    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
-        &harness_core::config::dirs::default_db_path(dir, "threads"),
-        Some(&database_url),
-    )
+    let thread_db = crate::thread_db::ThreadDb::open(&harness_core::config::dirs::default_db_path(
+        dir, "threads",
+    ))
     .await?;
     let (notification_tx, _) = tokio::sync::broadcast::channel(64);
     let task_queue = Arc::new(crate::task_queue::TaskQueue::new(&Default::default()));
@@ -227,9 +202,8 @@ async fn make_state_inner(
     // Service layer — use concrete defaults backed by the same infrastructure.
     let project_svc = crate::services::project::DefaultProjectService::new(
         // Tests that don't need a registry still get a lightweight one.
-        crate::project_registry::ProjectRegistry::open_with_database_url(
+        crate::project_registry::ProjectRegistry::open(
             &harness_core::config::dirs::default_db_path(dir, "projects"),
-            Some(&database_url),
         )
         .await?,
         project_root.to_path_buf(),
@@ -305,6 +279,7 @@ async fn make_state_inner(
             ws_shutdown_tx: tokio::sync::broadcast::channel(1).0,
         },
         interceptors: vec![],
+        startup_statuses: vec![],
         degraded_subsystems: vec![],
         intake: crate::http::IntakeServices {
             feishu_intake: None,

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,8 +1,5 @@
 use anyhow::Context;
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -35,22 +32,18 @@ impl ThreadDb {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(THREAD_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, THREAD_MIGRATIONS).run().await?;
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, THREAD_MIGRATIONS)
+            .await?;
         Ok(Self { pool })
     }
 
@@ -148,6 +141,7 @@ impl ThreadRow {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::resolve_database_url;
     use std::path::PathBuf;
 
     async fn open_test_db() -> anyhow::Result<Option<ThreadDb>> {

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -376,6 +376,7 @@ mod tests {
                 ws_shutdown_tx,
             },
             interceptors: vec![],
+            startup_statuses: vec![],
             degraded_subsystems: vec![],
             intake: crate::http::IntakeServices {
                 feishu_intake: None,

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -1,8 +1,5 @@
 use chrono::{DateTime, Utc};
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use sqlx::postgres::PgPool;
 use sqlx::Postgres;
 use std::path::Path;
@@ -57,16 +54,10 @@ impl IssueWorkflowStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let schema = legacy_schema_for_path(path)?;
-
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
-            .run()
+        let context =
+            PgStoreContext::from_schema(&legacy_schema_for_path(path)?, configured_database_url)?;
+        let pool = context
+            .open_migrated_pool(ISSUE_WORKFLOW_MIGRATIONS)
             .await?;
         Ok(Self { pool })
     }
@@ -75,14 +66,19 @@ impl IssueWorkflowStore {
         configured_database_url: Option<&str>,
         schema: &str,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, schema).await?;
-        setup.close().await;
+        let context = PgStoreContext::from_schema(schema, configured_database_url)?;
+        let pool = context
+            .open_migrated_pool(ISSUE_WORKFLOW_MIGRATIONS)
+            .await?;
+        Ok(Self { pool })
+    }
 
-        let pool = pg_open_pool_schematized(&database_url, schema).await?;
-        PgMigrator::new(&pool, ISSUE_WORKFLOW_MIGRATIONS)
-            .run()
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, ISSUE_WORKFLOW_MIGRATIONS)
             .await?;
         Ok(Self { pool })
     }

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -1,7 +1,4 @@
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use harness_core::{types::ExecPlanId, types::ExecPlanStatus};
 use harness_exec::plan::ExecPlan;
 use sqlx::postgres::PgPool;
@@ -50,22 +47,21 @@ impl PlanDb {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        use sha2::{Digest, Sha256};
-        let path_utf8 = path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
-        let digest = Sha256::digest(path_utf8.as_bytes());
-        let mut schema_bytes = [0u8; 8];
-        schema_bytes.copy_from_slice(&digest[..8]);
-        let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(PLAN_MIGRATIONS).await?;
+        Ok(Self {
+            pool,
+            update_lock: tokio::sync::Mutex::new(()),
+        })
+    }
 
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, PLAN_MIGRATIONS).run().await?;
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, PLAN_MIGRATIONS)
+            .await?;
         Ok(Self {
             pool,
             update_lock: tokio::sync::Mutex::new(()),
@@ -215,6 +211,9 @@ impl PlanDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::{
+        pg_open_pool, pg_open_pool_schematized, resolve_database_url, PgMigrator,
+    };
     use harness_core::types::ExecPlanStatus;
     use std::sync::OnceLock;
     use tokio::sync::{Semaphore, SemaphorePermit};

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -1,8 +1,5 @@
 use chrono::{DateTime, Utc};
-use harness_core::db::{
-    pg_create_schema_if_not_exists, pg_open_pool, pg_open_pool_schematized, resolve_database_url,
-    Migration, PgMigrator,
-};
+use harness_core::db::{Migration, PgStoreContext};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgPool;
@@ -201,16 +198,10 @@ impl ProjectWorkflowStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let schema = legacy_schema_for_path(path)?;
-
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, &schema).await?;
-        setup.close().await;
-
-        let pool = pg_open_pool_schematized(&database_url, &schema).await?;
-        PgMigrator::new(&pool, PROJECT_WORKFLOW_MIGRATIONS)
-            .run()
+        let context =
+            PgStoreContext::from_schema(&legacy_schema_for_path(path)?, configured_database_url)?;
+        let pool = context
+            .open_migrated_pool(PROJECT_WORKFLOW_MIGRATIONS)
             .await?;
         Ok(Self { pool })
     }
@@ -219,14 +210,19 @@ impl ProjectWorkflowStore {
         configured_database_url: Option<&str>,
         schema: &str,
     ) -> anyhow::Result<Self> {
-        let database_url = resolve_database_url(configured_database_url)?;
-        let setup = pg_open_pool(&database_url).await?;
-        pg_create_schema_if_not_exists(&setup, schema).await?;
-        setup.close().await;
+        let context = PgStoreContext::from_schema(schema, configured_database_url)?;
+        let pool = context
+            .open_migrated_pool(PROJECT_WORKFLOW_MIGRATIONS)
+            .await?;
+        Ok(Self { pool })
+    }
 
-        let pool = pg_open_pool_schematized(&database_url, schema).await?;
-        PgMigrator::new(&pool, PROJECT_WORKFLOW_MIGRATIONS)
-            .run()
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, PROJECT_WORKFLOW_MIGRATIONS)
             .await?;
         Ok(Self { pool })
     }
@@ -533,6 +529,7 @@ impl ProjectWorkflowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::db::resolve_database_url;
 
     async fn open_test_store() -> anyhow::Result<Option<ProjectWorkflowStore>> {
         if resolve_database_url(None).is_err() {


### PR DESCRIPTION
## Summary
- Reuse shared Postgres setup pools while opening startup stores.
- Record critical and optional store startup statuses instead of dropping failures silently.
- Expose degraded startup state through health/app state without aborting optional stores.
- Redact startup failure details in the public `/health` response; health now exposes coarse error codes only.
- Keep optional store context/schema failures non-fatal for q-value, workflow, runtime-state, and review stores.
- Complete startup health reporting for bootstrap failures, workspace manager failures, thread cache hydration, and runtime state success.
- Deduplicate failed startup bundle construction so bootstrap failure status stays consistent.
- Isolate forced startup failure tests with task-local scopes.

Closes #874

## Tests
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check --message-format short`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server startup -- --test-threads=1`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server bootstrap_failure -- --test-threads=1`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server invalid_workflow_schema_namespace_disables_optional_workflow_stores -- --test-threads=1`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server runtime_state_failure_is_recorded_as_optional -- --test-threads=1`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server health_startup_errors_are_redacted -- --test-threads=1`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
