### PR TITLE
Return queued task responses under saturation

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -58,15 +58,6 @@ pub(crate) async fn enqueue_task_background_in_domain(
         .await
 }
 
-fn create_task_status_response(state: &AppState, task_id: &task_runner::TaskId) -> &'static str {
-    match state.core.tasks.get(task_id) {
-        Some(task) if matches!(task.status, task_runner::TaskStatus::AwaitingDeps) => {
-            "awaiting_deps"
-        }
-        _ => "running",
-    }
-}
-
 /// A single task entry in the detailed batch format.
 #[derive(Debug, Deserialize)]
 pub struct BatchTaskItem {
@@ -298,18 +289,15 @@ pub(super) async fn create_task(
     State(state): State<Arc<AppState>>,
     Json(req): Json<task_runner::CreateTaskRequest>,
 ) -> Response {
-    match enqueue_task(&state, req).await {
-        Ok(task_id) => {
-            let status = create_task_status_response(state.as_ref(), &task_id);
-            (
-                StatusCode::ACCEPTED,
-                Json(json!({
-                    "task_id": task_id.0,
-                    "status": status
-                })),
-            )
-                .into_response()
-        }
+    match enqueue_task_background(state, req, None).await {
+        Ok(task_id) => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "task_id": task_id.0,
+                "status": "queued"
+            })),
+        )
+            .into_response(),
         Err(EnqueueTaskError::BadRequest(error)) => {
             (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
         }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -8,9 +8,10 @@ use harness_core::{
 };
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify, Semaphore};
 use tower::ServiceExt;
 
 struct CapturingAgent {
@@ -22,6 +23,66 @@ impl CapturingAgent {
         Arc::new(Self {
             prompts: Mutex::new(Vec::new()),
         })
+    }
+}
+
+struct BlockingAgent {
+    started: AtomicUsize,
+    started_notify: Notify,
+    release_permits: Semaphore,
+}
+
+impl BlockingAgent {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            started: AtomicUsize::new(0),
+            started_notify: Notify::new(),
+            release_permits: Semaphore::new(0),
+        })
+    }
+
+    async fn wait_for_started(&self, expected: usize) {
+        while self.started.load(Ordering::SeqCst) < expected {
+            self.started_notify.notified().await;
+        }
+    }
+
+    fn release_runs(&self, count: usize) {
+        self.release_permits.add_permits(count);
+    }
+
+    async fn wait_until_released(&self) {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.started_notify.notify_waiters();
+        let permit = self
+            .release_permits
+            .acquire()
+            .await
+            .expect("blocking agent release semaphore should stay open");
+        permit.forget();
+    }
+}
+
+fn empty_agent_response() -> AgentResponse {
+    AgentResponse {
+        output: String::new(),
+        stderr: String::new(),
+        items: vec![],
+        token_usage: TokenUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            cost_usd: 0.0,
+        },
+        model: "mock".into(),
+        exit_code: Some(0),
+    }
+}
+
+fn successful_agent_response() -> AgentResponse {
+    AgentResponse {
+        output: "done".to_string(),
+        ..empty_agent_response()
     }
 }
 
@@ -37,19 +98,7 @@ impl CodeAgent for CapturingAgent {
 
     async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
         self.prompts.lock().await.push(req.prompt);
-        Ok(AgentResponse {
-            output: String::new(),
-            stderr: String::new(),
-            items: vec![],
-            token_usage: TokenUsage {
-                input_tokens: 0,
-                output_tokens: 0,
-                total_tokens: 0,
-                cost_usd: 0.0,
-            },
-            model: "mock".into(),
-            exit_code: Some(0),
-        })
+        Ok(empty_agent_response())
     }
 
     async fn execute_stream(
@@ -57,6 +106,37 @@ impl CodeAgent for CapturingAgent {
         _req: AgentRequest,
         _tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CodeAgent for BlockingAgent {
+    fn name(&self) -> &str {
+        "blocking-agent"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        self.wait_until_released().await;
+        Ok(successful_agent_response())
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        self.wait_until_released().await;
+        let _ = tx
+            .send(StreamItem::MessageDelta {
+                text: "done".to_string(),
+            })
+            .await;
+        let _ = tx.send(StreamItem::Done).await;
         Ok(())
     }
 }
@@ -114,6 +194,12 @@ async fn make_test_state_with_project_root(
         project_root.to_path_buf(),
     );
     let task_svc = crate::services::task::DefaultTaskService::new(tasks.clone());
+    let task_queue = Arc::new(crate::task_queue::TaskQueue::new(
+        &server.config.concurrency,
+    ));
+    let mut review_queue_config = server.config.concurrency.clone();
+    review_queue_config.max_concurrent_tasks = server.config.review.max_concurrent_tasks.max(1);
+    let review_task_queue = Arc::new(crate::task_queue::TaskQueue::new(&review_queue_config));
     let execution_svc = crate::services::execution::DefaultExecutionService::new(
         tasks.clone(),
         server.agent_registry.clone(),
@@ -122,8 +208,8 @@ async fn make_test_state_with_project_root(
         events.clone(),
         vec![],
         None,
-        Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
-        Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
+        task_queue.clone(),
+        review_task_queue.clone(),
         None,
         None,
         None,
@@ -165,8 +251,8 @@ async fn make_test_state_with_project_root(
             review_store: None,
         },
         concurrency: crate::http::ConcurrencyServices {
-            task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
-            review_task_queue: Arc::new(crate::task_queue::TaskQueue::new(&Default::default())),
+            task_queue,
+            review_task_queue,
             workspace_mgr: None,
         },
         #[cfg(test)]
@@ -279,6 +365,19 @@ async fn build_test_state_with_agent(
     Ok((state, capturing))
 }
 
+async fn make_test_state_with_blocking_agent_and_config(
+    dir: &std::path::Path,
+    project_root: &std::path::Path,
+    config: harness_core::config::HarnessConfig,
+) -> anyhow::Result<(Arc<AppState>, Arc<BlockingAgent>)> {
+    let blocking = BlockingAgent::new();
+    let mut registry = harness_agents::registry::AgentRegistry::new("test");
+    registry.register("test", blocking.clone());
+
+    let state = make_test_state_with_project_root(dir, project_root, config, registry).await?;
+    Ok((state, blocking))
+}
+
 fn init_fake_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(root.join(".git"))?;
     Ok(())
@@ -288,6 +387,7 @@ fn task_app(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health_check))
         .route("/tasks", post(task_routes::create_task))
+        .route("/tasks/batch", post(task_routes::create_tasks_batch))
         .route("/tasks/{id}", get(get_task))
         .with_state(state)
 }
@@ -390,19 +490,48 @@ async fn response_json(response: axum::response::Response) -> anyhow::Result<ser
     Ok(serde_json::from_slice(&body)?)
 }
 
+async fn wait_for_task_statuses(
+    state: &Arc<AppState>,
+    task_ids: &[String],
+    expected: task_runner::TaskStatus,
+) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let mut all_match = true;
+        for task_id in task_ids {
+            let task = state
+                .core
+                .tasks
+                .get_with_db_fallback(&harness_core::types::TaskId(task_id.clone()))
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("task {task_id} not found"))?;
+            if task.status != expected {
+                all_match = false;
+                break;
+            }
+        }
+        if all_match {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("tasks did not all reach status {expected:?} before timeout");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 async fn wait_for_task_project_root(
     state: &Arc<AppState>,
     task_id: &str,
 ) -> anyhow::Result<std::path::PathBuf> {
     let task_id = harness_core::types::TaskId(task_id.to_string());
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
-    while tokio::time::Instant::now() < deadline {
+    for _ in 0..200 {
         if let Some(task) = state.core.tasks.get_with_db_fallback(&task_id).await? {
             if let Some(project_root) = task.project_root {
                 return Ok(project_root);
             }
         }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
     anyhow::bail!("task {task_id} did not resolve a project root")
@@ -525,6 +654,12 @@ async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
 async fn health_degraded_multiple_subsystems() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
+    Arc::get_mut(&mut state).unwrap().startup_statuses = vec![
+        crate::http::state::StoreStartupResult::optional("q_value_store")
+            .failed("pool timed out while waiting for an open connection"),
+        crate::http::state::StoreStartupResult::optional("runtime_state_store")
+            .failed("runtime state snapshot restore failed"),
+    ];
     Arc::get_mut(&mut state).unwrap().degraded_subsystems =
         vec!["q_value_store", "runtime_state_store"];
     let health = call_health(state).await?;
@@ -533,6 +668,7 @@ async fn health_degraded_multiple_subsystems() -> anyhow::Result<()> {
         health.persistence.degraded_subsystems,
         ["q_value_store", "runtime_state_store"]
     );
+    assert_eq!(health.persistence.startup.stores.len(), 2);
     Ok(())
 }
 
@@ -550,6 +686,24 @@ async fn health_degraded_both_conditions() -> anyhow::Result<()> {
         ["workspace_manager"]
     );
     assert!(health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_reports_critical_store_failure_details() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    Arc::get_mut(&mut state).unwrap().startup_statuses = vec![
+        crate::http::state::StoreStartupResult::critical("event_store")
+            .failed("failed to open Postgres bootstrap pool"),
+    ];
+    Arc::get_mut(&mut state).unwrap().degraded_subsystems = vec!["event_store"];
+    let health = call_health(state).await?;
+    assert_eq!(health.status, "degraded");
+    assert_eq!(health.persistence.startup.stores.len(), 1);
+    assert_eq!(health.persistence.startup.stores[0].name, "event_store");
+    assert!(health.persistence.startup.stores[0].critical);
+    assert!(!health.persistence.startup.stores[0].ready);
     Ok(())
 }
 
@@ -880,56 +1034,10 @@ async fn create_task_with_prompt_returns_accepted() -> anyhow::Result<()> {
         .await?;
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-    use http_body_util::BodyExt;
-    let resp_body = response.into_body().collect().await?.to_bytes();
-    let resp: serde_json::Value = serde_json::from_slice(&resp_body)?;
-    assert!(resp["task_id"].is_string());
-    assert_eq!(state.core.tasks.count(), before_count + 1);
-    Ok(())
-}
-
-#[tokio::test]
-async fn create_task_with_unresolved_dependencies_returns_awaiting_deps() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let state = make_test_state(dir.path()).await?;
-
-    let dep = task_runner::TaskState::new(task_runner::TaskId::new());
-    let dep_id = dep.id.clone();
-    state.core.tasks.insert(&dep).await;
-
-    let app = task_app(state.clone());
-    let body = serde_json::json!({
-        "prompt": "fix the bug after deps",
-        "depends_on": [dep_id.0.clone()],
-    });
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/tasks")
-                .header("content-type", "application/json")
-                .body(Body::from(body.to_string()))?,
-        )
-        .await?;
-
-    assert_eq!(response.status(), StatusCode::ACCEPTED);
-
     let resp = response_json(response).await?;
-    assert_eq!(resp["status"], "awaiting_deps");
-
-    let task_id = harness_core::types::TaskId(
-        resp["task_id"]
-            .as_str()
-            .expect("task_id should be string")
-            .to_string(),
-    );
-    let task = state
-        .core
-        .tasks
-        .get(&task_id)
-        .expect("task must be inserted into the task store");
-    assert!(matches!(task.status, task_runner::TaskStatus::AwaitingDeps));
+    assert!(resp["task_id"].is_string());
+    assert_eq!(resp["status"], "queued");
+    assert_eq!(state.core.tasks.count(), before_count + 1);
     Ok(())
 }
 
@@ -989,14 +1097,14 @@ async fn create_then_get_task_returns_state() -> anyhow::Result<()> {
         .await?;
     assert_eq!(create_resp.status(), StatusCode::ACCEPTED);
 
-    use http_body_util::BodyExt;
-    let create_body = create_resp.into_body().collect().await?.to_bytes();
-    let create_json: serde_json::Value = serde_json::from_slice(&create_body)?;
+    let create_json = response_json(create_resp).await?;
     let task_id = create_json["task_id"]
         .as_str()
         .expect("task_id should be string");
+    assert_eq!(create_json["status"], "queued");
 
-    // GET the task — agent executes instantly (mock), so status should be observable
+    // GET the task — the route accepts immediately, while execution becomes
+    // observable through the task record.
     let get_resp = task_app(state)
         .oneshot(
             Request::builder()
@@ -1006,11 +1114,384 @@ async fn create_then_get_task_returns_state() -> anyhow::Result<()> {
         .await?;
     assert_eq!(get_resp.status(), StatusCode::OK);
 
+    use http_body_util::BodyExt;
     let get_body = get_resp.into_body().collect().await?.to_bytes();
     let task_json: serde_json::Value = serde_json::from_slice(&get_body)?;
     assert_eq!(task_json["id"], task_id);
     assert!(task_json["scheduler"]["authority_state"].is_string());
     assert!(task_json["scheduler"]["run_generation"].is_number());
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_task_returns_quickly_when_capacity_saturated() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("queued-task-saturation-")?;
+    let project_dir = dir.path().join("repo");
+    std::fs::create_dir_all(&project_dir)?;
+    init_fake_git_repo(&project_dir)?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.concurrency.max_concurrent_tasks = 1;
+    config.concurrency.max_queue_size = 32;
+    let project = project_dir.display().to_string();
+
+    let (state, blocking_agent) =
+        make_test_state_with_blocking_agent_and_config(dir.path(), &project_dir, config).await?;
+
+    let first_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "prompt": "hold the only execution slot"
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(first_response.status(), StatusCode::ACCEPTED);
+    let first_json = response_json(first_response).await?;
+    let first_task_id = first_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+
+    blocking_agent.wait_for_started(1).await;
+
+    let started_at = tokio::time::Instant::now();
+    let saturated_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "prompt": "queued behind the blocking task"
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    let elapsed = started_at.elapsed();
+
+    assert_eq!(saturated_response.status(), StatusCode::ACCEPTED);
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "saturated POST /tasks should return quickly, took {elapsed:?}"
+    );
+    let queued_json = response_json(saturated_response).await?;
+    assert_eq!(queued_json["status"], "queued");
+
+    let queued_task_id = queued_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+    wait_for_task_statuses(
+        &state,
+        std::slice::from_ref(&queued_task_id),
+        task_runner::TaskStatus::Pending,
+    )
+    .await?;
+
+    blocking_agent.release_runs(2);
+    wait_for_task_statuses(
+        &state,
+        &[first_task_id, queued_task_id],
+        task_runner::TaskStatus::Done,
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_task_repeated_submits_stay_pending_and_distinct_when_saturated(
+) -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("queued-task-repeated-")?;
+    let project_dir = dir.path().join("repo");
+    std::fs::create_dir_all(&project_dir)?;
+    init_fake_git_repo(&project_dir)?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.concurrency.max_concurrent_tasks = 1;
+    config.concurrency.max_queue_size = 32;
+    let project = project_dir.display().to_string();
+
+    let (state, blocking_agent) =
+        make_test_state_with_blocking_agent_and_config(dir.path(), &project_dir, config).await?;
+
+    let blocker_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "prompt": "occupy execution"
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(blocker_response.status(), StatusCode::ACCEPTED);
+    let blocker_json = response_json(blocker_response).await?;
+    let blocker_task_id = blocker_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+
+    blocking_agent.wait_for_started(1).await;
+
+    let mut queued_task_ids = Vec::new();
+    for index in 0..10 {
+        let started_at = tokio::time::Instant::now();
+        let response = task_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "project": project.clone(),
+                            "prompt": format!("queued task {index}")
+                        })
+                        .to_string(),
+                    ))?,
+            )
+            .await?;
+        let elapsed = started_at.elapsed();
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "queued submit {index} should return quickly, took {elapsed:?}"
+        );
+
+        let json = response_json(response).await?;
+        assert_eq!(json["status"], "queued");
+        queued_task_ids.push(
+            json["task_id"]
+                .as_str()
+                .expect("task_id should be present")
+                .to_string(),
+        );
+    }
+
+    let unique_ids: std::collections::HashSet<_> = queued_task_ids.iter().cloned().collect();
+    assert_eq!(unique_ids.len(), queued_task_ids.len());
+
+    wait_for_task_statuses(&state, &queued_task_ids, task_runner::TaskStatus::Pending).await?;
+
+    for task_id in &queued_task_ids {
+        let get_resp = task_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/tasks/{task_id}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        let task_json = response_json(get_resp).await?;
+        assert_eq!(task_json["id"], task_id.as_str());
+        assert_eq!(task_json["status"], "pending");
+    }
+
+    blocking_agent.release_runs(1 + queued_task_ids.len());
+    let mut all_task_ids = vec![blocker_task_id];
+    all_task_ids.extend(queued_task_ids);
+    wait_for_task_statuses(&state, &all_task_ids, task_runner::TaskStatus::Done).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_task_deduplicates_external_id_while_queued_under_saturation() -> anyhow::Result<()>
+{
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("queued-task-dedup-")?;
+    let project_dir = dir.path().join("repo");
+    std::fs::create_dir_all(&project_dir)?;
+    init_fake_git_repo(&project_dir)?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.concurrency.max_concurrent_tasks = 1;
+    config.concurrency.max_queue_size = 32;
+    let project = project_dir.display().to_string();
+
+    let (state, blocking_agent) =
+        make_test_state_with_blocking_agent_and_config(dir.path(), &project_dir, config).await?;
+
+    let blocker_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "prompt": "occupy execution"
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(blocker_response.status(), StatusCode::ACCEPTED);
+    let blocker_json = response_json(blocker_response).await?;
+    let blocker_task_id = blocker_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+
+    blocking_agent.wait_for_started(1).await;
+
+    let issue_body = serde_json::json!({
+        "project": project.clone(),
+        "external_id": "issue:42",
+        "prompt": "fix issue 42"
+    })
+    .to_string();
+    let first_issue_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(issue_body.clone()))?,
+        )
+        .await?;
+    assert_eq!(first_issue_response.status(), StatusCode::ACCEPTED);
+    let first_issue_json = response_json(first_issue_response).await?;
+    let first_issue_task_id = first_issue_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+
+    wait_for_task_statuses(
+        &state,
+        std::slice::from_ref(&first_issue_task_id),
+        task_runner::TaskStatus::Pending,
+    )
+    .await?;
+
+    let duplicate_issue_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(issue_body))?,
+        )
+        .await?;
+    assert_eq!(duplicate_issue_response.status(), StatusCode::ACCEPTED);
+    let duplicate_issue_json = response_json(duplicate_issue_response).await?;
+    assert_eq!(duplicate_issue_json["status"], "queued");
+    assert_eq!(
+        duplicate_issue_json["task_id"].as_str(),
+        Some(first_issue_task_id.as_str())
+    );
+
+    blocking_agent.release_runs(2);
+    wait_for_task_statuses(
+        &state,
+        &[blocker_task_id, first_issue_task_id],
+        task_runner::TaskStatus::Done,
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_tasks_batch_remains_queued_under_saturation() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("queued-task-batch-")?;
+    let project_dir = dir.path().join("repo");
+    std::fs::create_dir_all(&project_dir)?;
+    init_fake_git_repo(&project_dir)?;
+
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.concurrency.max_concurrent_tasks = 1;
+    config.concurrency.max_queue_size = 32;
+    let project = project_dir.display().to_string();
+
+    let (state, blocking_agent) =
+        make_test_state_with_blocking_agent_and_config(dir.path(), &project_dir, config).await?;
+
+    let blocker_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "prompt": "occupy execution"
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(blocker_response.status(), StatusCode::ACCEPTED);
+    let blocker_json = response_json(blocker_response).await?;
+    let blocker_task_id = blocker_json["task_id"]
+        .as_str()
+        .expect("task_id should be present")
+        .to_string();
+
+    blocking_agent.wait_for_started(1).await;
+
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project.clone(),
+                        "tasks": [
+                            { "description": "batch task 1" },
+                            { "description": "batch task 2" }
+                        ]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+
+    let queued_task_ids: Vec<String> = entries
+        .iter()
+        .map(|entry| {
+            assert_eq!(entry["status"], "queued");
+            entry["task_id"]
+                .as_str()
+                .expect("task_id should be present")
+                .to_string()
+        })
+        .collect();
+    wait_for_task_statuses(&state, &queued_task_ids, task_runner::TaskStatus::Pending).await?;
+
+    blocking_agent.release_runs(1 + queued_task_ids.len());
+    let mut all_task_ids = vec![blocker_task_id];
+    all_task_ids.extend(queued_task_ids);
+    wait_for_task_statuses(&state, &all_task_ids, task_runner::TaskStatus::Done).await?;
     Ok(())
 }
 
@@ -1754,15 +2235,29 @@ async fn webhook_ping_event_returns_accepted_without_creating_task() -> anyhow::
     Ok(())
 }
 
-/// Named agent stub for focused complexity-dispatch selection tests.
-struct DispatchNamedAgent {
-    name: &'static str,
+/// Agent stub that records invocations via an atomic flag.
+/// Records in both `execute` and `execute_stream` since the task executor
+/// calls `execute_stream` (via `run_agent_streaming`).
+struct DispatchCapturingAgent {
+    agent_name: &'static str,
+    was_invoked: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl DispatchCapturingAgent {
+    fn new(name: &'static str) -> (Arc<Self>, Arc<std::sync::atomic::AtomicBool>) {
+        let was_invoked = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let agent = Arc::new(Self {
+            agent_name: name,
+            was_invoked: was_invoked.clone(),
+        });
+        (agent, was_invoked)
+    }
 }
 
 #[async_trait]
-impl CodeAgent for DispatchNamedAgent {
+impl CodeAgent for DispatchCapturingAgent {
     fn name(&self) -> &str {
-        self.name
+        self.agent_name
     }
 
     fn capabilities(&self) -> Vec<Capability> {
@@ -1770,6 +2265,8 @@ impl CodeAgent for DispatchNamedAgent {
     }
 
     async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        self.was_invoked
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(AgentResponse {
             output: String::new(),
             stderr: String::new(),
@@ -1780,7 +2277,7 @@ impl CodeAgent for DispatchNamedAgent {
                 total_tokens: 0,
                 cost_usd: 0.0,
             },
-            model: self.name.to_string(),
+            model: self.agent_name.to_string(),
             exit_code: Some(0),
         })
     }
@@ -1790,47 +2287,129 @@ impl CodeAgent for DispatchNamedAgent {
         _req: AgentRequest,
         _tx: tokio::sync::mpsc::Sender<StreamItem>,
     ) -> harness_core::error::Result<()> {
+        self.was_invoked
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 }
 
-fn dispatch_registry() -> harness_agents::registry::AgentRegistry {
+/// Build a test AppState with a "test" (default) and a "claude" DispatchCapturingAgent.
+/// Returns the state and atomic flags for each agent so tests can detect which was invoked.
+async fn make_test_state_with_dispatch_agents(
+    dir: &std::path::Path,
+) -> anyhow::Result<(
+    Arc<AppState>,
+    Arc<std::sync::atomic::AtomicBool>,
+    Arc<std::sync::atomic::AtomicBool>,
+)> {
+    let (default_agent, default_invoked) = DispatchCapturingAgent::new("test");
+    let (claude_agent, claude_invoked) = DispatchCapturingAgent::new("claude");
     let mut registry = harness_agents::registry::AgentRegistry::new("test");
     registry.set_complexity_preferences(vec!["claude".to_string()]);
-    registry.register("test", Arc::new(DispatchNamedAgent { name: "test" }));
-    registry.register("claude", Arc::new(DispatchNamedAgent { name: "claude" }));
-    registry
+    registry.register("test", default_agent);
+    registry.register("claude", claude_agent);
+    let state = make_test_state_with(
+        dir,
+        harness_core::config::HarnessConfig::default(),
+        registry,
+    )
+    .await?;
+    Ok((state, default_invoked, claude_invoked))
 }
 
-fn dispatch_req(prompt: &str, project: &std::path::Path) -> task_runner::CreateTaskRequest {
-    let mut req = task_runner::CreateTaskRequest::default();
-    req.prompt = Some(prompt.to_string());
-    req.project = Some(project.to_path_buf());
-    req
+/// Poll (with 5 s deadline) until `flag` is set; panic with `msg` on timeout.
+async fn wait_for_invocation(flag: &std::sync::atomic::AtomicBool, msg: &str) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if flag.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("{msg}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
 }
 
-#[test]
-fn dispatch_complex_prompt_selects_claude_agent() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let req = dispatch_req(
-        "Refactor src/a.rs src/b.rs src/c.rs src/d.rs src/e.rs src/f.rs",
-        dir.path(),
+#[tokio::test]
+async fn dispatch_complex_prompt_selects_claude_agent() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("dispatch-complex-")?;
+    let (state, default_invoked, claude_invoked) =
+        make_test_state_with_dispatch_agents(dir.path()).await?;
+    let app = task_app(state);
+
+    // 6 distinct file references → Complex complexity → registry.dispatch() selects "claude"
+    let body = serde_json::json!({
+        "prompt": "Refactor src/a.rs src/b.rs src/c.rs src/d.rs src/e.rs src/f.rs",
+        "project": dir.path(),
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    wait_for_invocation(
+        &claude_invoked,
+        "claude agent was not invoked within 500ms for complex task",
+    )
+    .await;
+
+    assert!(
+        claude_invoked.load(std::sync::atomic::Ordering::SeqCst),
+        "claude agent should have been invoked for complex task"
     );
-
-    let agent = crate::services::execution::select_agent(&req, &dispatch_registry(), None)?;
-
-    assert_eq!(agent.name(), "claude");
+    assert!(
+        !default_invoked.load(std::sync::atomic::Ordering::SeqCst),
+        "default agent should not have been invoked for complex task"
+    );
     Ok(())
 }
 
-#[test]
-fn dispatch_simple_prompt_selects_default_agent() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let req = dispatch_req("Fix the login bug", dir.path());
+#[tokio::test]
+async fn dispatch_simple_prompt_selects_default_agent() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = crate::test_helpers::tempdir_in_home("dispatch-simple-")?;
+    let (state, default_invoked, claude_invoked) =
+        make_test_state_with_dispatch_agents(dir.path()).await?;
+    let app = task_app(state);
 
-    let agent = crate::services::execution::select_agent(&req, &dispatch_registry(), None)?;
+    // Simple prompt: no file references → Simple complexity → default "test" agent
+    let body = serde_json::json!({
+        "prompt": "Fix the login bug",
+        "project": dir.path(),
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
 
-    assert_eq!(agent.name(), "test");
+    wait_for_invocation(
+        &default_invoked,
+        "default agent was not invoked within 500ms for simple task",
+    )
+    .await;
+
+    assert!(
+        default_invoked.load(std::sync::atomic::Ordering::SeqCst),
+        "default agent should have been invoked for simple task"
+    );
+    assert!(
+        !claude_invoked.load(std::sync::atomic::Ordering::SeqCst),
+        "claude agent should not have been invoked for simple task"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -130,6 +130,18 @@ pub struct DefaultExecutionService {
     allowed_project_roots: Vec<PathBuf>,
 }
 
+struct PreparedEnqueue {
+    req: CreateTaskRequest,
+    project_id: String,
+    agent: Arc<dyn CodeAgent>,
+    reviewer: Option<Arc<dyn CodeAgent>>,
+}
+
+enum PreparedEnqueueResult {
+    Existing(TaskId),
+    Ready(Box<PreparedEnqueue>),
+}
+
 pub(crate) enum WorkflowReuseStrategy {
     ActiveTask(TaskId),
     PrExternalId(String),
@@ -502,19 +514,11 @@ impl DefaultExecutionService {
             }
         }
     }
-}
 
-#[async_trait]
-impl ExecutionService for DefaultExecutionService {
-    async fn enqueue(&self, req: CreateTaskRequest) -> Result<TaskId, EnqueueTaskError> {
-        self.enqueue_in_domain(req, QueueDomain::Primary).await
-    }
-
-    async fn enqueue_in_domain(
+    async fn prepare_enqueue(
         &self,
         mut req: CreateTaskRequest,
-        queue_domain: QueueDomain,
-    ) -> Result<TaskId, EnqueueTaskError> {
+    ) -> Result<PreparedEnqueueResult, EnqueueTaskError> {
         let now = chrono::Utc::now();
         if self.server_config.maintenance_window.in_quiet_window(now) {
             let retry_after_secs = self
@@ -539,14 +543,15 @@ impl ExecutionService for DefaultExecutionService {
 
         task_runner::fill_missing_repo_from_project(&mut req).await;
         Self::populate_external_id(&mut req);
+
         if let Some(existing_id) = self.check_workflow_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
+            return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
         if let Some(existing_id) = self.check_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
+            return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
         if let Some(existing_id) = self.check_pr_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
+            return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
 
         if self.dependencies_blocked(&req).await {
@@ -556,20 +561,9 @@ impl ExecutionService for DefaultExecutionService {
                 .map_err(|e| EnqueueTaskError::BadRequest(e.to_string()))?;
             self.track_issue_workflow(&project_id, &workflow_req, &task_id)
                 .await;
-            return Ok(task_id);
+            return Ok(PreparedEnqueueResult::Existing(task_id));
         }
         req.depends_on.clear();
-
-        let queue = self.queue_for(queue_domain);
-        let permit = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            queue.acquire(&project_id, req.priority),
-        )
-        .await
-        .map_err(|_| {
-            EnqueueTaskError::Internal(queue_timeout_message(&queue, &project_id, queue_domain))
-        })?
-        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
 
         let agent = select_agent(
             &req,
@@ -582,16 +576,56 @@ impl ExecutionService for DefaultExecutionService {
             agent.name(),
         );
 
-        let workflow_req = req.clone();
-        let task_id = task_runner::spawn_task(
-            self.tasks.clone(),
+        Ok(PreparedEnqueueResult::Ready(Box::new(PreparedEnqueue {
+            req,
+            project_id,
             agent,
             reviewer,
+        })))
+    }
+}
+
+#[async_trait]
+impl ExecutionService for DefaultExecutionService {
+    async fn enqueue(&self, req: CreateTaskRequest) -> Result<TaskId, EnqueueTaskError> {
+        self.enqueue_in_domain(req, QueueDomain::Primary).await
+    }
+
+    async fn enqueue_in_domain(
+        &self,
+        req: CreateTaskRequest,
+        queue_domain: QueueDomain,
+    ) -> Result<TaskId, EnqueueTaskError> {
+        let prepared = match self.prepare_enqueue(req).await? {
+            PreparedEnqueueResult::Existing(task_id) => return Ok(task_id),
+            PreparedEnqueueResult::Ready(prepared) => *prepared,
+        };
+
+        let queue = self.queue_for(queue_domain);
+        let permit = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            queue.acquire(&prepared.project_id, prepared.req.priority),
+        )
+        .await
+        .map_err(|_| {
+            EnqueueTaskError::Internal(queue_timeout_message(
+                &queue,
+                &prepared.project_id,
+                queue_domain,
+            ))
+        })?
+        .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
+
+        let workflow_req = prepared.req.clone();
+        let task_id = task_runner::spawn_task(
+            self.tasks.clone(),
+            prepared.agent,
+            prepared.reviewer,
             self.server_config.clone(),
             self.skills.clone(),
             self.events.clone(),
             self.interceptors.clone(),
-            req,
+            prepared.req,
             self.workspace_mgr.clone(),
             permit,
             self.completion_callback.clone(),
@@ -599,7 +633,7 @@ impl ExecutionService for DefaultExecutionService {
         )
         .await;
 
-        self.track_issue_workflow(&project_id, &workflow_req, &task_id)
+        self.track_issue_workflow(&prepared.project_id, &workflow_req, &task_id)
             .await;
 
         Ok(task_id)
@@ -612,75 +646,24 @@ impl ExecutionService for DefaultExecutionService {
 
     async fn enqueue_background_with_options(
         &self,
-        mut req: CreateTaskRequest,
+        req: CreateTaskRequest,
         options: EnqueueBackgroundOptions,
     ) -> Result<TaskId, EnqueueTaskError> {
-        let now = chrono::Utc::now();
-        if self.server_config.maintenance_window.in_quiet_window(now) {
-            let retry_after_secs = self
-                .server_config
-                .maintenance_window
-                .secs_until_window_end(now);
-            return Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs });
-        }
-
-        Self::validate_request(&req)?;
-
-        let (resolved_project, registry_default_agent) = self.resolve_project(req.project).await?;
-        req.project = resolved_project;
-
-        let canonical = task_runner::resolve_canonical_project(req.project.clone())
-            .await
-            .map_err(|e| EnqueueTaskError::Internal(e.to_string()))?;
-        self.check_allowed_roots(&canonical)?;
-
-        let project_id = canonical.to_string_lossy().into_owned();
-        req.project = Some(canonical);
-        task_runner::fill_missing_repo_from_project(&mut req).await;
-
-        let agent = select_agent(
-            &req,
-            &self.agent_registry,
-            registry_default_agent.as_deref(),
-        )?;
-        let (reviewer, _) = resolve_reviewer(
-            &self.agent_registry,
-            &self.server_config.agents.review,
-            agent.name(),
-        );
-
-        Self::populate_external_id(&mut req);
-        if let Some(existing_id) = self.check_workflow_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
-        }
-        if let Some(existing_id) = self.check_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
-        }
-        if let Some(existing_id) = self.check_pr_duplicate(&project_id, &req).await {
-            return Ok(existing_id);
-        }
-
-        if self.dependencies_blocked(&req).await {
-            let workflow_req = req.clone();
-            let task_id = task_runner::spawn_task_awaiting_deps(self.tasks.clone(), req)
-                .await
-                .map_err(|e| EnqueueTaskError::BadRequest(e.to_string()))?;
-            self.track_issue_workflow(&project_id, &workflow_req, &task_id)
-                .await;
-            return Ok(task_id);
-        }
-        req.depends_on.clear();
+        let prepared = match self.prepare_enqueue(req).await? {
+            PreparedEnqueueResult::Existing(task_id) => return Ok(task_id),
+            PreparedEnqueueResult::Ready(prepared) => *prepared,
+        };
 
         let server_config = self.server_config.clone();
 
         tracing::info!(
-            project = %req.project.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "None".to_string()),
+            project = %prepared.req.project.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "None".to_string()),
             domain = options.queue_domain.label(),
             "execution service: resolved project for background task"
         );
 
         // Register the task immediately so the caller gets an ID without blocking.
-        let task_id = task_runner::register_pending_task(self.tasks.clone(), &req).await;
+        let task_id = task_runner::register_pending_task(self.tasks.clone(), &prepared.req).await;
 
         // Spawn a background tokio task that waits for a concurrency slot then executes.
         let tasks = self.tasks.clone();
@@ -694,7 +677,12 @@ impl ExecutionService for DefaultExecutionService {
         let completion_callback = self.completion_callback.clone();
         let issue_workflow_store = self.issue_workflow_store.clone();
         let task_id2 = task_id.clone();
-        self.track_issue_workflow(&project_id, &req, &task_id).await;
+        let project_id = prepared.project_id;
+        self.track_issue_workflow(&project_id, &prepared.req, &task_id)
+            .await;
+        let req = prepared.req;
+        let agent = prepared.agent;
+        let reviewer = prepared.reviewer;
         tokio::spawn(async move {
             let group_permit = if let Some(sem) = group_sem {
                 sem.acquire_owned().await.ok()

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -359,6 +359,8 @@ pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskReques
     state.depends_on = req.depends_on.clone();
     state.priority = req.priority;
     state.issue = req.issue;
+    // Keep queued tasks visible to duplicate detection while they wait for a permit.
+    state.project_root = req.project.clone();
     state.phase = state.task_kind.default_phase();
     state.description = summarize_request_description(req);
     state.request_settings = Some(PersistedRequestSettings::from_req(req));
@@ -1542,6 +1544,7 @@ mod tests {
             source: Some("github".to_string()),
             external_id: Some("20".to_string()),
             repo: Some("acme/harness".to_string()),
+            project: Some(dir.path().to_path_buf()),
             ..Default::default()
         };
 
@@ -1553,6 +1556,7 @@ mod tests {
         assert_eq!(state.source.as_deref(), Some("github"));
         assert_eq!(state.external_id.as_deref(), Some("20"));
         assert_eq!(state.repo.as_deref(), Some("acme/harness"));
+        assert_eq!(state.project_root.as_deref(), Some(dir.path()));
         assert_eq!(state.description.as_deref(), Some("issue #20"));
         Ok(())
     }

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -145,8 +145,11 @@ curl -X POST http://127.0.0.1:9800/tasks \
 Response:
 
 ```json
-{ "status": "running", "task_id": "a1b2c3d4-..." }
+{ "status": "queued", "task_id": "a1b2c3d4-..." }
 ```
+
+The task is accepted immediately and registered as pending work. Use
+`GET /tasks/{task_id}` to observe when execution actually starts.
 
 ### By GitHub Issue
 
@@ -192,7 +195,7 @@ Response:
 
 ```json
 [
-  { "task_id": "...", "status": "running" },
+  { "task_id": "...", "status": "queued" },
   { "task_id": "...", "status": "queued" },
   { "task_id": "...", "status": "queued" },
   { "task_id": "...", "status": "queued" }


### PR DESCRIPTION
## Summary
- return accepted queued responses from POST /tasks and /tasks/batch without waiting for task permits
- move permit acquisition into background execution for HTTP task submission
- keep queue admission failures visible by marking preregistered tasks failed
- keep preregistered queued tasks visible to active duplicate detection by preserving project roots
- cover saturated single, batch, repeated, and duplicate-external-id submissions

Closes #841

## Tests
- cargo fmt --all
- cargo fmt --all -- --check
- cargo check
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 cargo test -p harness-server --lib create_task_deduplicates_external_id_while_queued_under_saturation -- --nocapture
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 cargo test -p harness-server --lib task_runner::spawn::tests::register_pending_task_keeps_repo_metadata_visible -- --exact --nocapture
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 cargo test -p harness-server --lib saturat -- --nocapture
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 cargo test -p harness-server --lib http::tests::health_degraded_when_subsystem_missing -- --exact --nocapture
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=30 cargo test -p harness-server --lib
- RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets
- RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets