### PR TITLE
test(core): isolate shared Postgres pool test

### DIFF
--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -768,24 +768,31 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn pg_store_context_can_reuse_shared_setup_pool() {
+    #[test]
+    fn pg_store_context_can_reuse_shared_setup_pool() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let _lock = process_env_lock();
         let Ok(database_url) = resolve_database_url(None) else {
             return;
         };
-        let setup_pool = match pg_open_pool(&database_url).await {
-            Ok(pool) => pool,
-            Err(_) => return,
-        };
-        let context =
-            PgStoreContext::from_path(Path::new("/tmp/harness/shared.db"), Some(&database_url))
-                .expect("context should resolve");
-        let pool = context
-            .open_pool_with_setup_pool(&setup_pool)
-            .await
-            .expect("shared setup pool should initialize the store");
-        pool.close().await;
-        setup_pool.close().await;
+        runtime.block_on(async {
+            let setup_pool = match pg_open_pool(&database_url).await {
+                Ok(pool) => pool,
+                Err(_) => return,
+            };
+            let context =
+                PgStoreContext::from_path(Path::new("/tmp/harness/shared.db"), Some(&database_url))
+                    .expect("context should resolve");
+            let pool = context
+                .open_pool_with_setup_pool(&setup_pool)
+                .await
+                .expect("shared setup pool should initialize the store");
+            pool.close().await;
+            setup_pool.close().await;
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- serialize `pg_store_context_can_reuse_shared_setup_pool` with the existing process env/current-dir test lock
- run the async Postgres pool work inside a local Tokio runtime so Clippy does not see a sync mutex guard across `.await`
- prevents the full test suite from racing with DB config tests that temporarily delete the process current directory

## Tests
- cargo fmt --all -- --check
- cargo check --message-format short
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-core db_pg::tests::pg_store_context_can_reuse_shared_setup_pool -- --test-threads=1
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings