### PR TITLE
Convert generic Db store to Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "sqlite", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "chrono", "uuid"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
-use sqlx::{pool::PoolConnection, Sqlite};
-use std::borrow::Cow;
-use std::collections::HashSet;
+use sqlx::postgres::PgPool;
 use std::path::Path;
-use std::sync::OnceLock;
 
 // Postgres pool helpers and PgMigrator live in the sibling db_pg module.
 // Re-export them here so existing callers using `harness_core::db::*` continue
@@ -14,59 +10,13 @@ pub use crate::db_pg::{
     pg_open_pool_schematized, pg_schema_for_path, resolve_database_url, PgMigrator, PgStoreContext,
 };
 
-static SQLITE_TRANSACTIONAL_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();
-
-fn sqlite_transactional_prefixes() -> &'static [&'static str] {
-    SQLITE_TRANSACTIONAL_PREFIXES.get_or_init(|| {
-        vec![
-            "CREATE TABLE",
-            "CREATE INDEX",
-            "CREATE UNIQUE INDEX",
-            "CREATE VIEW",
-            "CREATE TRIGGER",
-            "ALTER TABLE",
-            "DROP TABLE",
-            "DROP INDEX",
-            "DROP VIEW",
-            "DROP TRIGGER",
-            "INSERT INTO",
-            "UPDATE ",
-            "DELETE FROM",
-            "REPLACE INTO",
-            "SELECT ",
-            "WITH ",
-        ]
-    })
-}
-
-fn normalized_sqlite_statement_prefix(statement: &str) -> String {
-    statement
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with("--"))
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_uppercase()
-}
-
-/// Create a SQLite connection pool for the given path.
+/// Create a Postgres connection pool for the logical store at `path`.
 ///
-/// All stores share this configuration: 8 max connections, 10 s acquire
-/// timeout, WAL journal mode, and 5 s busy timeout.
-pub async fn open_pool(path: &Path) -> anyhow::Result<SqlitePool> {
-    let url = format!("sqlite:{}?mode=rwc", path.display());
-    let pool = SqlitePoolOptions::new()
-        .max_connections(8)
-        .acquire_timeout(std::time::Duration::from_secs(10))
-        .connect(&url)
-        .await?;
-    sqlx::query("PRAGMA journal_mode=WAL")
-        .execute(&pool)
-        .await?;
-    sqlx::query("PRAGMA busy_timeout=5000")
-        .execute(&pool)
-        .await?;
-    Ok(pool)
+/// Historical stores accepted SQLite file paths as their identity boundary.
+/// The Postgres backend preserves that boundary by hashing each path to a
+/// stable schema name.
+pub async fn open_pool(path: &Path) -> anyhow::Result<PgPool> {
+    PgStoreContext::from_path(path, None)?.open_pool().await
 }
 
 /// Marker trait for entities that can be stored as JSON blobs.
@@ -79,23 +29,23 @@ pub trait DbEntity: Serialize + for<'de> Deserialize<'de> + Send + Unpin + 'stat
     fn create_table_sql() -> &'static str;
 }
 
-/// Generic SQLite store that persists entities as JSON blobs.
+/// Generic Postgres store that persists entities as JSON blobs.
 ///
 /// Schema:
 /// ```sql
 /// CREATE TABLE IF NOT EXISTS <table_name> (
 ///     id         TEXT PRIMARY KEY,
 ///     data       TEXT NOT NULL,
-///     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-///     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+///     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+///     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 /// )
 /// ```
 ///
 /// Use this when entities do not need queryable columns beyond `id`.
-/// For entities requiring SQL-level filtering (e.g. `WHERE status = ?`),
-/// keep a specialised store and call [`open_pool`] for pool creation.
+/// For entities requiring SQL-level filtering, keep a specialised store and
+/// call [`open_pool`] for pool creation.
 pub struct Db<T: DbEntity> {
-    pub(crate) pool: SqlitePool,
+    pub(crate) pool: PgPool,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -121,9 +71,9 @@ impl<T: DbEntity> Db<T> {
     pub async fn upsert(&self, entity: &T) -> anyhow::Result<()> {
         let data = serde_json::to_string(entity)?;
         let sql = format!(
-            "INSERT INTO {table} (id, data) VALUES (?, ?)
-             ON CONFLICT(id) DO UPDATE SET data = excluded.data,
-                 updated_at = datetime('now')",
+            "INSERT INTO {table} (id, data) VALUES ($1, $2)
+             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+                 updated_at = CURRENT_TIMESTAMP",
             table = T::table_name()
         );
         sqlx::query(&sql)
@@ -135,7 +85,7 @@ impl<T: DbEntity> Db<T> {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<T>> {
-        let sql = format!("SELECT data FROM {} WHERE id = ?", T::table_name());
+        let sql = format!("SELECT data FROM {} WHERE id = $1", T::table_name());
         let row: Option<(String,)> = sqlx::query_as(&sql)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -158,23 +108,19 @@ impl<T: DbEntity> Db<T> {
     }
 
     pub async fn delete(&self, id: &str) -> anyhow::Result<bool> {
-        let sql = format!("DELETE FROM {} WHERE id = ?", T::table_name());
+        let sql = format!("DELETE FROM {} WHERE id = $1", T::table_name());
         let result = sqlx::query(&sql).bind(id).execute(&self.pool).await?;
         Ok(result.rows_affected() > 0)
     }
 
-    /// Expose the underlying pool for stores that need custom queries
-    /// beyond the generic CRUD operations (e.g. `json_extract` filters).
-    pub fn pool(&self) -> &SqlitePool {
+    /// Expose the underlying pool for stores that need custom queries beyond
+    /// the generic CRUD operations.
+    pub fn pool(&self) -> &PgPool {
         &self.pool
     }
 }
 
-/// Trait for types that can be serialized to/from a SQLite status column.
-///
-/// Implementing this trait once per status type is sufficient — the blanket
-/// `AsRef<str>` and `FromStr` impls are provided by callers that delegate to
-/// these methods, eliminating duplicated match arms across DB modules.
+/// Trait for types that can be serialized to/from a database status column.
 pub trait DbSerializable: Sized {
     /// Return the canonical database string for this value.
     fn to_db_str(&self) -> &'static str;
@@ -192,338 +138,8 @@ pub struct Migration {
     pub sql: &'static str,
 }
 
-/// Runs versioned SQL migrations against a pool.
-///
-/// Maintains a `schema_migrations` table to track which versions have been
-/// applied. Safe to call on every startup — already-applied versions are
-/// skipped.
-///
-/// For `ALTER TABLE ADD COLUMN` statements on pre-existing databases,
-/// "duplicate column name" errors are silently ignored so that migrating
-/// databases that predate the migration system is idempotent.
-pub struct Migrator<'a> {
-    pool: &'a SqlitePool,
-    migrations: &'a [Migration],
-}
-
-struct MigrationStatement<'a> {
-    index: usize,
-    sql: Cow<'a, str>,
-}
-
-fn migration_statements(sql: &str) -> Vec<MigrationStatement<'_>> {
-    let mut statements = Vec::new();
-    let mut current = String::new();
-    let mut chars = sql.chars().peekable();
-    let mut index = 0;
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut in_line_comment = false;
-    let mut in_block_comment = false;
-    let mut trigger_begin_depth = 0usize;
-    let mut trigger_case_depth = 0usize;
-    let mut statement_tokens = Vec::new();
-    let mut current_statement_is_trigger = false;
-
-    while let Some(ch) = chars.next() {
-        let next = chars.peek().copied();
-
-        if in_line_comment {
-            current.push(ch);
-            if ch == '\n' {
-                in_line_comment = false;
-            }
-            continue;
-        }
-
-        if in_block_comment {
-            current.push(ch);
-            if ch == '*' && next == Some('/') {
-                current.push(chars.next().expect("peeked slash must exist"));
-                in_block_comment = false;
-            }
-            continue;
-        }
-
-        if in_single_quote {
-            current.push(ch);
-            if ch == '\'' {
-                if next == Some('\'') {
-                    current.push(chars.next().expect("peeked quote must exist"));
-                } else {
-                    in_single_quote = false;
-                }
-            }
-            continue;
-        }
-
-        if in_double_quote {
-            current.push(ch);
-            if ch == '"' {
-                if next == Some('"') {
-                    current.push(chars.next().expect("peeked quote must exist"));
-                } else {
-                    in_double_quote = false;
-                }
-            }
-            continue;
-        }
-
-        if ch == '-' && next == Some('-') {
-            current.push(ch);
-            current.push(chars.next().expect("peeked dash must exist"));
-            in_line_comment = true;
-            continue;
-        }
-
-        if ch == '/' && next == Some('*') {
-            current.push(ch);
-            current.push(chars.next().expect("peeked star must exist"));
-            in_block_comment = true;
-            continue;
-        }
-
-        if ch == '\'' {
-            current.push(ch);
-            in_single_quote = true;
-            continue;
-        }
-
-        if ch == '"' {
-            current.push(ch);
-            in_double_quote = true;
-            continue;
-        }
-
-        current.push(ch);
-
-        if ch.is_ascii_alphabetic() || ch == '_' {
-            let mut token = String::from(ch);
-            while let Some(peek) = chars.peek().copied() {
-                if peek.is_ascii_alphanumeric() || peek == '_' {
-                    token.push(chars.next().expect("peeked token char must exist"));
-                    current.push(*token.as_bytes().last().unwrap() as char);
-                } else {
-                    break;
-                }
-            }
-
-            let token = token.to_ascii_uppercase();
-            if statement_tokens.len() < 3 {
-                statement_tokens.push(token.clone());
-                current_statement_is_trigger |= match statement_tokens.as_slice() {
-                    [first, second] => first == "CREATE" && second == "TRIGGER",
-                    [first, second, third] => {
-                        first == "CREATE"
-                            && (second == "TEMP" || second == "TEMPORARY")
-                            && third == "TRIGGER"
-                    }
-                    _ => false,
-                };
-            }
-
-            match token.as_str() {
-                "BEGIN" if current_statement_is_trigger => trigger_begin_depth += 1,
-                "CASE" if current_statement_is_trigger && trigger_begin_depth > 0 => {
-                    trigger_case_depth += 1;
-                }
-                "END"
-                    if current_statement_is_trigger
-                        && trigger_begin_depth > 0
-                        && trigger_case_depth > 0 =>
-                {
-                    trigger_case_depth -= 1;
-                }
-                "END" if current_statement_is_trigger && trigger_begin_depth > 0 => {
-                    trigger_begin_depth -= 1;
-                }
-                _ => {}
-            }
-            if trigger_begin_depth == 0 {
-                trigger_case_depth = 0;
-            }
-            continue;
-        }
-
-        if ch == ';' && trigger_begin_depth == 0 {
-            let statement = current[..current.len() - 1].trim();
-            if !statement.is_empty() {
-                index += 1;
-                statements.push(MigrationStatement {
-                    index,
-                    sql: Cow::Owned(statement.to_string()),
-                });
-            }
-            current.clear();
-            statement_tokens.clear();
-            current_statement_is_trigger = false;
-        }
-    }
-
-    let trailing = current.trim();
-    if !trailing.is_empty() {
-        index += 1;
-        statements.push(MigrationStatement {
-            index,
-            sql: Cow::Owned(trailing.to_string()),
-        });
-    }
-
-    statements
-}
-
-async fn apply_statements_on_connection(
-    conn: &mut PoolConnection<Sqlite>,
-    migration: &Migration,
-    statements: &[MigrationStatement<'_>],
-) -> anyhow::Result<()> {
-    for statement in statements {
-        if let Err(error) = sqlx::query(statement.sql.as_ref())
-            .execute(conn.as_mut())
-            .await
-        {
-            if duplicate_add_column_error(statement.sql.as_ref(), &error) {
-                continue;
-            }
-            return Err(format_migration_error(migration, statement, &error, false));
-        }
-    }
-
-    sqlx::query("INSERT INTO schema_migrations (version, description) VALUES (?, ?)")
-        .bind(migration.version as i64)
-        .bind(migration.description)
-        .execute(conn.as_mut())
-        .await?;
-    Ok(())
-}
-
-async fn apply_outside_transaction(
-    pool: &SqlitePool,
-    migration: &Migration,
-    statements: &[MigrationStatement<'_>],
-) -> anyhow::Result<()> {
-    let mut conn = pool.acquire().await?;
-    let result = apply_statements_on_connection(&mut conn, migration, statements).await;
-    if result.is_err() {
-        // Close rather than return to pool: connection-scoped state set by a
-        // partially-executed migration (e.g. PRAGMA changes) must not leak to
-        // future pool borrowers.
-        let _ = conn.close().await;
-    }
-    result
-}
-
-fn duplicate_add_column_error(statement: &str, error: &sqlx::Error) -> bool {
-    statement.to_ascii_uppercase().contains("ADD COLUMN")
-        && error
-            .to_string()
-            .to_ascii_lowercase()
-            .contains("duplicate column name")
-}
-
-fn sqlite_statement_is_transaction_safe(statement: &str) -> bool {
-    let normalized = normalized_sqlite_statement_prefix(statement);
-    sqlite_transactional_prefixes()
-        .iter()
-        .any(|prefix| normalized.starts_with(prefix))
-}
-
-fn format_migration_error(
-    migration: &Migration,
-    statement: &MigrationStatement<'_>,
-    error: &sqlx::Error,
-    in_transaction: bool,
-) -> anyhow::Error {
-    let mode = if in_transaction {
-        ""
-    } else {
-        " outside transaction"
-    };
-    anyhow::anyhow!(
-        "migration v{} '{}' failed at statement {}{}: {} [sql: {}]",
-        migration.version,
-        migration.description,
-        statement.index,
-        mode,
-        error,
-        statement.sql
-    )
-}
-
-fn pending_migrations<'a>(
-    migrations: &'a [Migration],
-    applied: &HashSet<u32>,
-) -> Vec<&'a Migration> {
-    let mut pending: Vec<&Migration> = migrations
-        .iter()
-        .filter(|migration| !applied.contains(&migration.version))
-        .collect();
-    pending.sort_by_key(|migration| migration.version);
-    pending
-}
-
-async fn apply_migration(pool: &SqlitePool, migration: &Migration) -> anyhow::Result<()> {
-    let statements = migration_statements(migration.sql);
-    let use_transaction = statements
-        .iter()
-        .all(|statement| sqlite_statement_is_transaction_safe(statement.sql.as_ref()));
-
-    if use_transaction {
-        let mut tx = pool.begin().await?;
-        for statement in &statements {
-            if let Err(error) = sqlx::query(statement.sql.as_ref()).execute(&mut *tx).await {
-                if duplicate_add_column_error(statement.sql.as_ref(), &error) {
-                    continue;
-                }
-                return Err(format_migration_error(migration, statement, &error, true));
-            }
-        }
-        sqlx::query("INSERT INTO schema_migrations (version, description) VALUES (?, ?)")
-            .bind(migration.version as i64)
-            .bind(migration.description)
-            .execute(&mut *tx)
-            .await?;
-        tx.commit().await?;
-        return Ok(());
-    }
-
-    apply_outside_transaction(pool, migration, &statements).await
-}
-
-fn applied_versions_set(rows: Vec<(i64,)>) -> HashSet<u32> {
-    rows.into_iter().map(|(version,)| version as u32).collect()
-}
-
-impl<'a> Migrator<'a> {
-    pub fn new(pool: &'a SqlitePool, migrations: &'a [Migration]) -> Self {
-        Self { pool, migrations }
-    }
-
-    pub async fn run(&self) -> anyhow::Result<()> {
-        // Create the migrations tracking table if it doesn't exist yet.
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS schema_migrations (
-                version     INTEGER PRIMARY KEY,
-                description TEXT NOT NULL,
-                applied_at  TEXT NOT NULL DEFAULT (datetime('now'))
-            )",
-        )
-        .execute(self.pool)
-        .await?;
-
-        // Fetch already-applied version numbers.
-        let rows: Vec<(i64,)> =
-            sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version ASC")
-                .fetch_all(self.pool)
-                .await?;
-        let applied = applied_versions_set(rows);
-
-        for migration in pending_migrations(self.migrations, &applied) {
-            apply_migration(self.pool, migration).await?;
-        }
-        Ok(())
-    }
-}
+/// Backwards-compatible alias for the Postgres migrator.
+pub type Migrator<'a> = PgMigrator<'a>;
 
 #[cfg(test)]
 #[path = "db_tests.rs"]

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -265,6 +265,42 @@ fn load_database_config_from_path(path: &Path) -> anyhow::Result<LoadedDatabaseC
     })
 }
 
+fn schema_hash_path(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+
+    let absolute = std::env::current_dir()?.join(path);
+    if let Some(parent) = absolute.parent() {
+        if let Ok(canonical_parent) = parent.canonicalize() {
+            if let Some(file_name) = absolute.file_name() {
+                return Ok(canonical_parent.join(file_name));
+            }
+            return Ok(canonical_parent);
+        }
+    }
+
+    Ok(normalize_path_lexically(&absolute))
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
 /// Derive the legacy per-store Postgres schema name from a store identity path.
 ///
 /// Historical SQLite-backed stores accepted a database file path. The Postgres
@@ -274,9 +310,10 @@ fn load_database_config_from_path(path: &Path) -> anyhow::Result<LoadedDatabaseC
 pub fn pg_schema_for_path(path: &Path) -> anyhow::Result<String> {
     use sha2::{Digest, Sha256};
 
-    let path_utf8 = path
+    let hash_path = schema_hash_path(path)?;
+    let path_utf8 = hash_path
         .to_str()
-        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", path))?;
+        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", hash_path))?;
     let digest = Sha256::digest(path_utf8.as_bytes());
     let mut schema_bytes = [0u8; 8];
     schema_bytes.copy_from_slice(&digest[..8]);
@@ -570,17 +607,33 @@ impl<'a> PgMigrator<'a> {
             if stmt.is_empty() {
                 continue;
             }
-            if let Err(e) = sqlx::query(stmt).execute(&mut *tx).await {
-                if pg_duplicate_column_error(stmt, &e) {
+            sqlx::query("SAVEPOINT harness_migration_stmt")
+                .execute(&mut *tx)
+                .await?;
+            match sqlx::query(stmt).execute(&mut *tx).await {
+                Ok(_) => {
+                    sqlx::query("RELEASE SAVEPOINT harness_migration_stmt")
+                        .execute(&mut *tx)
+                        .await?;
+                }
+                Err(e) if pg_duplicate_column_error(stmt, &e) => {
+                    sqlx::query("ROLLBACK TO SAVEPOINT harness_migration_stmt")
+                        .execute(&mut *tx)
+                        .await?;
+                    sqlx::query("RELEASE SAVEPOINT harness_migration_stmt")
+                        .execute(&mut *tx)
+                        .await?;
                     continue;
                 }
-                return Err(anyhow::anyhow!(
-                    "migration v{} '{}' failed: {} [sql: {}]",
-                    migration.version,
-                    migration.description,
-                    e,
-                    stmt
-                ));
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "migration v{} '{}' failed: {} [sql: {}]",
+                        migration.version,
+                        migration.description,
+                        e,
+                        stmt
+                    ));
+                }
             }
         }
         sqlx::query("INSERT INTO schema_migrations (version, description) VALUES ($1, $2)")
@@ -709,6 +762,32 @@ mod tests {
             .expect("path schema should resolve");
 
         assert_eq!(schema, "h1b76aa87802f7705");
+    }
+
+    #[test]
+    fn pg_schema_for_path_normalizes_relative_aliases() {
+        let _lock = process_env_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let app_dir = dir.path().join("app");
+        std::fs::create_dir(&app_dir).expect("create app dir");
+        let _cwd = CurrentDirGuard::enter(&app_dir);
+
+        let canonical_path = app_dir
+            .canonicalize()
+            .expect("canonical app dir")
+            .join("tasks.db");
+        let canonical_schema =
+            pg_schema_for_path(&canonical_path).expect("canonical path schema should resolve");
+
+        assert_eq!(
+            pg_schema_for_path(Path::new("./tasks.db")).expect("dot path schema should resolve"),
+            canonical_schema
+        );
+        assert_eq!(
+            pg_schema_for_path(Path::new("../app/tasks.db"))
+                .expect("parent alias schema should resolve"),
+            canonical_schema
+        );
     }
 
     #[test]

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -1,4 +1,5 @@
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::Acquire as _;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
@@ -607,25 +608,17 @@ impl<'a> PgMigrator<'a> {
             if stmt.is_empty() {
                 continue;
             }
-            sqlx::query("SAVEPOINT harness_migration_stmt")
-                .execute(&mut *tx)
-                .await?;
-            match sqlx::query(stmt).execute(&mut *tx).await {
+            let mut statement_tx = (&mut tx).begin().await?;
+            match sqlx::query(stmt).execute(&mut *statement_tx).await {
                 Ok(_) => {
-                    sqlx::query("RELEASE SAVEPOINT harness_migration_stmt")
-                        .execute(&mut *tx)
-                        .await?;
+                    statement_tx.commit().await?;
                 }
                 Err(e) if pg_duplicate_column_error(stmt, &e) => {
-                    sqlx::query("ROLLBACK TO SAVEPOINT harness_migration_stmt")
-                        .execute(&mut *tx)
-                        .await?;
-                    sqlx::query("RELEASE SAVEPOINT harness_migration_stmt")
-                        .execute(&mut *tx)
-                        .await?;
+                    statement_tx.rollback().await?;
                     continue;
                 }
                 Err(e) => {
+                    let _ = statement_tx.rollback().await;
                     return Err(anyhow::anyhow!(
                         "migration v{} '{}' failed: {} [sql: {}]",
                         migration.version,

--- a/crates/harness-core/src/db_tests.rs
+++ b/crates/harness-core/src/db_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPool;
+use std::future::Future;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct Note {
@@ -29,110 +31,64 @@ impl DbEntity for Note {
         "CREATE TABLE IF NOT EXISTS notes (
             id         TEXT PRIMARY KEY,
             data       TEXT NOT NULL,
-            created_at TEXT NOT NULL DEFAULT (datetime('now')),
-            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"
     }
 }
 
-#[tokio::test]
-async fn upsert_and_get_roundtrip() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    let note = Note::new("n1", "hello");
-    db.upsert(&note).await?;
-
-    let loaded = db
-        .get("n1")
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("note should exist"))?;
-    assert_eq!(loaded, note);
-    Ok(())
+fn run_db_test<F, Fut>(test: F) -> anyhow::Result<()>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let _lock = crate::test_support::process_env_lock();
+    runtime.block_on(test())
 }
 
-#[tokio::test]
-async fn get_returns_none_for_missing() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    assert!(db.get("missing").await?.is_none());
-    Ok(())
+macro_rules! db_test {
+    ($name:ident, $body:block) => {
+        #[test]
+        fn $name() -> anyhow::Result<()> {
+            run_db_test(|| async $body)
+        }
+    };
 }
 
-#[tokio::test]
-async fn upsert_overwrites_existing() -> anyhow::Result<()> {
+fn db_path(name: &str) -> anyhow::Result<std::path::PathBuf> {
     let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    db.upsert(&Note::new("n1", "original")).await?;
-    db.upsert(&Note::new("n1", "updated")).await?;
-
-    let loaded = db
-        .get("n1")
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("note should exist after upsert"))?;
-    assert_eq!(loaded.body, "updated");
-
-    let all = db.list().await?;
-    assert_eq!(all.len(), 1, "upsert should not duplicate rows");
-    Ok(())
+    Ok(dir.path().join(name))
 }
 
-#[tokio::test]
-async fn list_returns_all_entities() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    db.upsert(&Note::new("n1", "a")).await?;
-    db.upsert(&Note::new("n2", "b")).await?;
-    db.upsert(&Note::new("n3", "c")).await?;
-
-    let all = db.list().await?;
-    assert_eq!(all.len(), 3);
-    Ok(())
+async fn applied_versions(pool: &PgPool) -> anyhow::Result<Vec<i64>> {
+    Ok(
+        sqlx::query_as::<_, (i64,)>("SELECT version FROM schema_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .map(|(version,)| version)
+            .collect(),
+    )
 }
 
-#[tokio::test]
-async fn delete_returns_true_when_found() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    db.upsert(&Note::new("n1", "bye")).await?;
-    assert!(db.delete("n1").await?);
-    assert!(db.get("n1").await?.is_none());
-    Ok(())
+async fn table_columns(pool: &PgPool, table: &str) -> anyhow::Result<Vec<String>> {
+    Ok(sqlx::query_as::<_, (String,)>(
+        "SELECT column_name
+         FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = $1
+         ORDER BY ordinal_position",
+    )
+    .bind(table)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|(name,)| name)
+    .collect())
 }
-
-#[tokio::test]
-async fn delete_returns_false_when_missing() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db = Db::<Note>::open(&dir.path().join("notes.db")).await?;
-
-    assert!(!db.delete("nonexistent").await?);
-    Ok(())
-}
-
-#[tokio::test]
-async fn survives_reopen() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let db_path = dir.path().join("notes.db");
-
-    {
-        let db = Db::<Note>::open(&db_path).await?;
-        db.upsert(&Note::new("persistent", "content")).await?;
-    }
-
-    let db = Db::<Note>::open(&db_path).await?;
-    let loaded = db
-        .get("persistent")
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("note should survive reopen"))?;
-    assert_eq!(loaded.body, "content");
-    Ok(())
-}
-
-// --- Migrator tests ---
 
 static SIMPLE_MIGRATIONS: &[Migration] = &[
     Migration {
@@ -147,338 +103,187 @@ static SIMPLE_MIGRATIONS: &[Migration] = &[
     },
 ];
 
-async fn applied_versions(pool: &SqlitePool) -> anyhow::Result<Vec<i64>> {
-    Ok(
-        sqlx::query_as::<_, (i64,)>("SELECT version FROM schema_migrations ORDER BY version")
-            .fetch_all(pool)
-            .await?
-            .into_iter()
-            .map(|(version,)| version)
-            .collect(),
-    )
-}
+db_test!(upsert_and_get_roundtrip, {
+    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
 
-async fn table_columns(pool: &SqlitePool, table: &str) -> anyhow::Result<Vec<String>> {
-    let pragma = format!("PRAGMA table_info({table})");
-    Ok(
-        sqlx::query_as::<_, (i64, String, String, i64, Option<String>, i64)>(&pragma)
-            .fetch_all(pool)
-            .await?
-            .into_iter()
-            .map(|(_, name, _, _, _, _)| name)
-            .collect(),
-    )
-}
+    let note = Note::new("n1", "hello");
+    db.upsert(&note).await?;
 
-#[tokio::test]
-async fn migrator_applies_pending_migrations() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-
-    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-
-    // Both versions should be recorded.
-    let rows: Vec<(i64,)> =
-        sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version")
-            .fetch_all(&pool)
-            .await?;
-    assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].0, 1);
-    assert_eq!(rows[1].0, 2);
+    let loaded = db
+        .get("n1")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected note"))?;
+    assert_eq!(loaded, note);
     Ok(())
-}
+});
 
-#[tokio::test]
-async fn migrator_is_idempotent_on_rerun() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
+db_test!(get_returns_none_for_missing, {
+    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
 
-    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-    // Running again must not fail or duplicate rows.
-    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-
-    let rows: Vec<(i64,)> =
-        sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version")
-            .fetch_all(&pool)
-            .await?;
-    assert_eq!(rows.len(), 2);
+    assert!(db.get("missing").await?.is_none());
     Ok(())
-}
+});
 
-#[tokio::test]
-async fn migrator_tolerates_duplicate_column_on_alter_table() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
+db_test!(upsert_overwrites_existing_and_list_does_not_duplicate, {
+    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
 
-    // Run only version 1 first (creates the table).
-    Migrator::new(&pool, &SIMPLE_MIGRATIONS[..1]).run().await?;
+    db.upsert(&Note::new("n1", "original")).await?;
+    db.upsert(&Note::new("n1", "updated")).await?;
 
-    // Manually add the column that migration v2 would add.
-    sqlx::query("ALTER TABLE items ADD COLUMN tag TEXT")
+    let loaded = db
+        .get("n1")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected note"))?;
+    assert_eq!(loaded.body, "updated");
+
+    let list = db.list().await?;
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].body, "updated");
+    Ok(())
+});
+
+db_test!(list_returns_all_entities, {
+    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+
+    db.upsert(&Note::new("n1", "a")).await?;
+    db.upsert(&Note::new("n2", "b")).await?;
+
+    let mut ids: Vec<String> = db.list().await?.into_iter().map(|n| n.id).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["n1", "n2"]);
+    Ok(())
+});
+
+db_test!(delete_roundtrip, {
+    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+
+    db.upsert(&Note::new("n1", "bye")).await?;
+    assert!(db.delete("n1").await?);
+    assert!(db.get("n1").await?.is_none());
+    assert!(!db.delete("n1").await?);
+    Ok(())
+});
+
+db_test!(survives_reopen_for_same_path, {
+    let db_path = db_path("notes.db")?;
+
+    {
+        let db = Db::<Note>::open(&db_path).await?;
+        db.upsert(&Note::new("n1", "persisted")).await?;
+    }
+
+    {
+        let db = Db::<Note>::open(&db_path).await?;
+        let loaded = db
+            .get("n1")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("expected persisted note"))?;
+        assert_eq!(loaded.body, "persisted");
+    }
+    Ok(())
+});
+
+db_test!(different_paths_are_schema_isolated, {
+    let db_a = Db::<Note>::open(&db_path("notes-a.db")?).await?;
+    let db_b = Db::<Note>::open(&db_path("notes-b.db")?).await?;
+
+    db_a.upsert(&Note::new("shared-id", "alpha")).await?;
+    db_b.upsert(&Note::new("shared-id", "beta")).await?;
+
+    let loaded_a = db_a
+        .get("shared-id")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("row should exist in first schema"))?;
+    let loaded_b = db_b
+        .get("shared-id")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("row should exist in second schema"))?;
+
+    assert_eq!(loaded_a.body, "alpha");
+    assert_eq!(loaded_b.body, "beta");
+    assert_eq!(db_a.list().await?.len(), 1);
+    assert_eq!(db_b.list().await?.len(), 1);
+    Ok(())
+});
+
+db_test!(db_open_uses_deterministic_schema_name, {
+    let path = db_path("notes.db")?;
+    let expected_schema = pg_schema_for_path(&path)?;
+    let db = Db::<Note>::open(&path).await?;
+
+    let (actual_schema,): (String,) = sqlx::query_as("SELECT current_schema()")
+        .fetch_one(db.pool())
+        .await?;
+    assert_eq!(actual_schema, expected_schema);
+    Ok(())
+});
+
+db_test!(migrator_applies_pending_migrations, {
+    let pool = open_pool(&db_path("mig.db")?).await?;
+
+    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
+
+    assert_eq!(applied_versions(&pool).await?, vec![1, 2]);
+    assert_eq!(
+        table_columns(&pool, "items").await?,
+        vec!["id", "value", "tag"]
+    );
+    Ok(())
+});
+
+db_test!(migrator_is_idempotent_on_rerun, {
+    let pool = open_pool(&db_path("mig.db")?).await?;
+
+    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
+    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
+
+    assert_eq!(applied_versions(&pool).await?, vec![1, 2]);
+    Ok(())
+});
+
+db_test!(migrator_tolerates_duplicate_column_on_alter_table, {
+    let pool = open_pool(&db_path("mig.db")?).await?;
+    sqlx::query("CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT NOT NULL, tag TEXT)")
         .execute(&pool)
         .await?;
 
-    // Running v2 now must not fail even though the column already exists.
-    Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
-    assert_eq!(applied_versions(&pool).await?, vec![1, 2]);
-    Ok(())
-}
-
-#[tokio::test]
-async fn failing_multi_statement_migration_is_not_recorded() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-    let migrations = [
-        Migration {
-            version: 1,
-            description: "create items table",
-            sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-        },
-        Migration {
-            version: 2,
-            description: "broken migration",
-            sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
-        },
-    ];
-
-    let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-
-    assert!(
-        err.to_string()
-            .contains("migration v2 'broken migration' failed"),
-        "unexpected error: {err:#}"
-    );
-    assert_eq!(applied_versions(&pool).await?, vec![1]);
-    Ok(())
-}
-
-#[tokio::test]
-async fn failing_multi_statement_migration_does_not_partially_persist() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-    let migrations = [
-        Migration {
-            version: 1,
-            description: "create items table",
-            sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-        },
-        Migration {
-            version: 2,
-            description: "broken migration",
-            sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
-        },
-    ];
-
-    let _ = Migrator::new(&pool, &migrations).run().await;
-
-    assert_eq!(applied_versions(&pool).await?, vec![1]);
-    assert_eq!(table_columns(&pool, "items").await?, vec!["id"]);
-    Ok(())
-}
-
-#[tokio::test]
-async fn migration_error_reports_failed_statement_index() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-    let migrations = [
-        Migration {
-            version: 1,
-            description: "create items table",
-            sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-        },
-        Migration {
-            version: 2,
-            description: "broken migration",
-            sql: "ALTER TABLE items ADD COLUMN tag TEXT; SELECT nope FROM missing_table",
-        },
-    ];
-
-    let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("migration v2 'broken migration' failed at statement 2"),
-        "unexpected error: {message}"
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn pragma_foreign_keys_migration_runs_outside_transaction() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-    let migrations = [
-        Migration {
-            version: 1,
-            description: "create items table",
-            sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-        },
-        Migration {
-            version: 2,
-            description: "pragma migration",
-            sql: "PRAGMA foreign_keys = OFF; SELECT nope FROM missing_table",
-        },
-    ];
-
-    let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("outside transaction"),
-        "unexpected error: {message}"
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn multiline_create_table_migration_stays_transactional() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
     let migrations = [Migration {
         version: 1,
-        description: "broken multiline create table",
-        sql: "CREATE\nTABLE items (id TEXT PRIMARY KEY); SELECT nope FROM missing_table",
-    }];
-
-    let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        !message.contains("outside transaction"),
-        "unexpected error: {message}"
-    );
-    assert_eq!(applied_versions(&pool).await?, Vec::<i64>::new());
-    assert_eq!(table_columns(&pool, "items").await?, Vec::<String>::new());
-    Ok(())
-}
-
-#[tokio::test]
-async fn pragma_defer_foreign_keys_migration_runs_outside_transaction() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let pool = open_pool(&dir.path().join("mig.db")).await?;
-    let migrations = [
-        Migration {
-            version: 1,
-            description: "create items table",
-            sql: "CREATE TABLE items (id TEXT PRIMARY KEY)",
-        },
-        Migration {
-            version: 2,
-            description: "pragma defer migration",
-            sql: "PRAGMA defer_foreign_keys = ON; SELECT nope FROM missing_table",
-        },
-    ];
-
-    let err = Migrator::new(&pool, &migrations).run().await.unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("outside transaction"),
-        "unexpected error: {message}"
-    );
-    Ok(())
-}
-
-#[test]
-fn migration_statements_keep_trigger_body_intact() {
-    let statements = migration_statements(
-        "CREATE TABLE items (id INTEGER PRIMARY KEY);\n\
-         CREATE TRIGGER items_touch AFTER INSERT ON items BEGIN\n\
-         UPDATE items SET id = NEW.id;\n\
-         INSERT INTO items_log DEFAULT VALUES;\n\
-         END;",
-    );
-
-    assert_eq!(statements.len(), 2);
-    assert_eq!(
-        statements[0].sql,
-        "CREATE TABLE items (id INTEGER PRIMARY KEY)"
-    );
-    assert!(
-        statements[1]
-            .sql
-            .starts_with("CREATE TRIGGER items_touch AFTER INSERT ON items BEGIN"),
-        "unexpected trigger statement: {}",
-        statements[1].sql
-    );
-    assert!(
-        statements[1].sql.ends_with("END"),
-        "unexpected trigger statement: {}",
-        statements[1].sql
-    );
-}
-
-#[test]
-fn migration_statements_split_explicit_transaction_control() {
-    let statements = migration_statements(
-        "BEGIN;\n\
-         CREATE TABLE items (id INTEGER PRIMARY KEY);\n\
-         INSERT INTO items VALUES (1);\n\
-         COMMIT;",
-    );
-
-    assert_eq!(statements.len(), 4);
-    assert_eq!(statements[0].sql, "BEGIN");
-    assert_eq!(
-        statements[1].sql,
-        "CREATE TABLE items (id INTEGER PRIMARY KEY)"
-    );
-    assert_eq!(statements[2].sql, "INSERT INTO items VALUES (1)");
-    assert_eq!(statements[3].sql, "COMMIT");
-}
-
-#[test]
-fn migration_statements_keep_case_end_inside_trigger_body() {
-    let statements = migration_statements(
-        "CREATE TRIGGER items_touch AFTER INSERT ON items BEGIN\n\
-         UPDATE items\n\
-         SET id = CASE WHEN NEW.id IS NULL THEN OLD.id ELSE NEW.id END;\n\
-         INSERT INTO items_log DEFAULT VALUES;\n\
-         END;",
-    );
-
-    assert_eq!(statements.len(), 1);
-    assert!(
-        statements[0]
-            .sql
-            .contains("CASE WHEN NEW.id IS NULL THEN OLD.id ELSE NEW.id END;"),
-        "unexpected trigger statement: {}",
-        statements[0].sql
-    );
-    assert!(
-        statements[0]
-            .sql
-            .contains("INSERT INTO items_log DEFAULT VALUES;"),
-        "unexpected trigger statement: {}",
-        statements[0].sql
-    );
-    assert!(
-        statements[0].sql.ends_with("END"),
-        "unexpected trigger statement: {}",
-        statements[0].sql
-    );
-}
-
-#[tokio::test]
-async fn pragma_style_migration_keeps_connection_local_state_on_one_connection(
-) -> anyhow::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let url = format!("sqlite:{}?mode=rwc", dir.path().join("mig.db").display());
-    let pool = SqlitePoolOptions::new()
-        .min_connections(2)
-        .max_connections(2)
-        .acquire_timeout(std::time::Duration::from_secs(10))
-        .connect(&url)
-        .await?;
-    let migrations = [Migration {
-        version: 1,
-        description: "temp table migration",
-        sql: "CREATE TEMP TABLE migration_temp (id INTEGER); \
-              INSERT INTO migration_temp VALUES (1); \
-              SELECT * FROM migration_temp",
+        description: "add existing tag column",
+        sql: "ALTER TABLE items ADD COLUMN tag TEXT",
     }];
 
     Migrator::new(&pool, &migrations).run().await?;
+
     assert_eq!(applied_versions(&pool).await?, vec![1]);
+    assert_eq!(
+        table_columns(&pool, "items").await?,
+        vec!["id", "value", "tag"]
+    );
     Ok(())
-}
+});
+
+db_test!(failing_migration_is_not_recorded, {
+    let pool = open_pool(&db_path("mig.db")?).await?;
+    let migrations = [Migration {
+        version: 1,
+        description: "bad migration",
+        sql: "CREATE TABLE bad_items (id TEXT PRIMARY KEY); SELECT * FROM missing_table",
+    }];
+
+    let err = Migrator::new(&pool, &migrations)
+        .run()
+        .await
+        .expect_err("migration should fail");
+    assert!(
+        err.to_string().contains("bad migration"),
+        "unexpected error: {err}"
+    );
+
+    let (exists,): (Option<String>,) = sqlx::query_as("SELECT to_regclass('bad_items')::TEXT")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(exists, None);
+    assert_eq!(applied_versions(&pool).await?, Vec::<i64>::new());
+    Ok(())
+});

--- a/crates/harness-exec/src/plan.rs
+++ b/crates/harness-exec/src/plan.rs
@@ -151,8 +151,8 @@ impl ExecPlan {
 const EXEC_PLAN_CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS exec_plans (
     id         TEXT PRIMARY KEY,
     data       TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 )";
 
 impl DbEntity for ExecPlan {


### PR DESCRIPTION
## Summary
- convert the generic harness-core Db<T> blob store from SQLite to Postgres-backed schemas
- remove the SQLite migrator implementation in favor of the existing PgMigrator alias
- update generic store tests and ExecPlan DDL to Postgres timestamp/default syntax
- remove the workspace sqlx sqlite feature

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS=\"-Dwarnings\" CARGO_TARGET_DIR=target/cargo-ci-check cargo check --workspace --all-targets
- RUSTFLAGS=\"-Dwarnings\" CARGO_TARGET_DIR=target/cargo-clippy cargo clippy --workspace --all-targets
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness CARGO_TARGET_DIR=target/cargo-test cargo test --workspace

Closes #749