### PR TITLE
Normalize Postgres schema path aliases

### DIFF
--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -267,11 +267,11 @@ fn load_database_config_from_path(path: &Path) -> anyhow::Result<LoadedDatabaseC
 }
 
 fn schema_hash_path(path: &Path) -> anyhow::Result<PathBuf> {
-    if path.is_absolute() {
-        return Ok(path.to_path_buf());
-    }
-
-    let absolute = std::env::current_dir()?.join(path);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
     if let Some(parent) = absolute.parent() {
         if let Ok(canonical_parent) = parent.canonicalize() {
             if let Some(file_name) = absolute.file_name() {
@@ -780,6 +780,24 @@ mod tests {
             pg_schema_for_path(Path::new("../app/tasks.db"))
                 .expect("parent alias schema should resolve"),
             canonical_schema
+        );
+    }
+
+    #[test]
+    fn pg_schema_for_path_normalizes_absolute_aliases() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let app_dir = dir.path().join("app");
+        std::fs::create_dir(&app_dir).expect("create app dir");
+
+        let canonical_path = app_dir
+            .canonicalize()
+            .expect("canonical app dir")
+            .join("tasks.db");
+        let absolute_alias = app_dir.join("..").join("app").join("tasks.db");
+
+        assert_eq!(
+            pg_schema_for_path(&absolute_alias).expect("absolute alias schema should resolve"),
+            pg_schema_for_path(&canonical_path).expect("canonical path schema should resolve")
         );
     }
 

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -5,7 +5,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use harness_core::db::{pg_open_pool, resolve_database_url};
+use harness_core::db::{pg_open_pool, pg_schema_for_path, resolve_database_url};
 use tokio::sync::OnceCell;
 
 /// Serialises every test that reads or mutates the process-global `HOME` env
@@ -54,7 +54,6 @@ impl Drop for HomeGuard {
 use crate::{http::AppState, server::HarnessServer, thread_manager::ThreadManager};
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
-use sha2::{Digest, Sha256};
 
 /// Create a temp directory under a writable base path without mutating
 /// global state (`HOME` env var).  Tries `$HOME` first; falls back to
@@ -121,13 +120,7 @@ pub async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> 
 pub async fn drop_tasks_table(dir: &std::path::Path) -> anyhow::Result<()> {
     let db_path = harness_core::config::dirs::default_db_path(dir, "tasks");
     let database_url = harness_core::db::resolve_database_url(None)?;
-    let path_utf8 = db_path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", db_path))?;
-    let digest = Sha256::digest(path_utf8.as_bytes());
-    let mut schema_bytes = [0u8; 8];
-    schema_bytes.copy_from_slice(&digest[..8]);
-    let schema = format!("h{:016x}", u64::from_le_bytes(schema_bytes));
+    let schema = pg_schema_for_path(&db_path)?;
     let pool = harness_core::db::pg_open_pool_schematized(&database_url, &schema).await?;
     sqlx::query("DROP TABLE tasks CASCADE")
         .execute(&pool)


### PR DESCRIPTION
## Summary
- Normalize absolute path aliases before deriving Postgres per-file schemas
- Add coverage for absolute path aliases such as `dir/../dir/tasks.db`
- Reuse the production schema derivation in test helpers that intentionally drop the tasks table

Follow-up to #1030.

## Verification
- `cargo fmt --all -- --check`
- `env -u DATABASE_URL CARGO_TARGET_DIR=target/cargo-check cargo check --workspace --all-targets`
- `env -u DATABASE_URL RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR=target/cargo-ci-check cargo check --workspace --all-targets`
- `env -u DATABASE_URL HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness CARGO_TARGET_DIR=target/cargo-test cargo test --workspace`
- `env -u DATABASE_URL RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR=target/cargo-clippy cargo clippy --workspace --all-targets`