### PR TITLE
fix(workflow): skip terminal PR reuse for active issue workflows

### DIFF
--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -243,7 +243,7 @@ fn workflow_reuse_strategy_prefers_active_task() {
 }
 
 #[test]
-fn workflow_reuse_strategy_falls_back_to_pr_when_active_task_missing() {
+fn workflow_reuse_strategy_reuses_only_active_pr_task_when_active_task_missing() {
     let mut workflow = IssueWorkflowInstance::new(
         "/tmp/project".to_string(),
         Some("owner/repo".to_string()),
@@ -252,8 +252,8 @@ fn workflow_reuse_strategy_falls_back_to_pr_when_active_task_missing() {
     workflow.state = IssueLifecycleState::AwaitingFeedback;
     workflow.pr_number = Some(99);
     match workflow_reuse_strategy(&workflow) {
-        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:99"),
-        _ => panic!("expected pr-external-id reuse strategy"),
+        WorkflowReuseStrategy::ActivePrExternalId(ext_id) => assert_eq!(ext_id, "pr:99"),
+        _ => panic!("expected active-pr-external-id reuse strategy"),
     }
 }
 

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -196,6 +196,7 @@ struct GhIssue {
     number: u64,
     title: String,
     body: Option<String>,
+    #[serde(rename = "html_url")]
     url: String,
     html_url: Option<String>,
     #[serde(default)]
@@ -404,7 +405,8 @@ mod tests {
                 "number": 42,
                 "title": "Fix login bug",
                 "body": "Users cannot log in after password reset.",
-                "url": "https://github.com/owner/repo/issues/42",
+                "url": "https://api.github.com/repos/owner/repo/issues/42",
+                "html_url": "https://github.com/owner/repo/issues/42",
                 "labels": [{"name": "harness"}, {"name": "bug"}],
                 "createdAt": "2026-03-01T10:00:00Z"
             }
@@ -459,9 +461,9 @@ mod tests {
     #[test]
     fn parse_gh_output_filters_dispatched_issues() {
         let json = br#"[
-            {"number": 1, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
-            {"number": 2, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null},
-            {"number": 3, "title": "C", "body": null, "url": "u3", "labels": [], "createdAt": null}
+            {"number": 1, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
+            {"number": 2, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null},
+            {"number": 3, "title": "C", "body": null, "html_url": "u3", "labels": [], "createdAt": null}
         ]"#;
 
         // Issues 1 and 2 already dispatched
@@ -512,9 +514,9 @@ mod tests {
     #[test]
     fn parse_gh_output_filters_canonical_dispatched_issue_keys() {
         let json = br#"[
-            {"number": 1, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
-            {"number": 2, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null},
-            {"number": 3, "title": "C", "body": null, "url": "u3", "labels": [], "createdAt": null}
+            {"number": 1, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
+            {"number": 2, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null},
+            {"number": 3, "title": "C", "body": null, "html_url": "u3", "labels": [], "createdAt": null}
         ]"#;
 
         let dispatched = make_dispatched(&["1"]);
@@ -548,7 +550,7 @@ mod tests {
     #[test]
     fn parse_gh_output_null_body_becomes_none_description() {
         let json = br#"[
-            {"number": 5, "title": "No body", "body": null, "url": "u", "labels": [], "createdAt": null}
+            {"number": 5, "title": "No body", "body": null, "html_url": "u", "labels": [], "createdAt": null}
         ]"#;
         let dispatched = DashMap::new();
         let parsed = parse_gh_output(json, "owner/repo", &dispatched, None).unwrap();
@@ -558,8 +560,8 @@ mod tests {
     #[test]
     fn parse_gh_output_returns_open_issue_ids_for_eviction() {
         let json = br#"[
-            {"number": 10, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
-            {"number": 20, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null}
+            {"number": 10, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
+            {"number": 20, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null}
         ]"#;
 
         // Issue 5 was dispatched but is no longer in the open list (closed).

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -196,7 +196,6 @@ struct GhIssue {
     number: u64,
     title: String,
     body: Option<String>,
-    #[serde(rename = "html_url")]
     url: String,
     html_url: Option<String>,
     #[serde(default)]
@@ -405,8 +404,7 @@ mod tests {
                 "number": 42,
                 "title": "Fix login bug",
                 "body": "Users cannot log in after password reset.",
-                "url": "https://api.github.com/repos/owner/repo/issues/42",
-                "html_url": "https://github.com/owner/repo/issues/42",
+                "url": "https://github.com/owner/repo/issues/42",
                 "labels": [{"name": "harness"}, {"name": "bug"}],
                 "createdAt": "2026-03-01T10:00:00Z"
             }
@@ -461,9 +459,9 @@ mod tests {
     #[test]
     fn parse_gh_output_filters_dispatched_issues() {
         let json = br#"[
-            {"number": 1, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
-            {"number": 2, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null},
-            {"number": 3, "title": "C", "body": null, "html_url": "u3", "labels": [], "createdAt": null}
+            {"number": 1, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
+            {"number": 2, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null},
+            {"number": 3, "title": "C", "body": null, "url": "u3", "labels": [], "createdAt": null}
         ]"#;
 
         // Issues 1 and 2 already dispatched
@@ -514,9 +512,9 @@ mod tests {
     #[test]
     fn parse_gh_output_filters_canonical_dispatched_issue_keys() {
         let json = br#"[
-            {"number": 1, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
-            {"number": 2, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null},
-            {"number": 3, "title": "C", "body": null, "html_url": "u3", "labels": [], "createdAt": null}
+            {"number": 1, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
+            {"number": 2, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null},
+            {"number": 3, "title": "C", "body": null, "url": "u3", "labels": [], "createdAt": null}
         ]"#;
 
         let dispatched = make_dispatched(&["1"]);
@@ -550,7 +548,7 @@ mod tests {
     #[test]
     fn parse_gh_output_null_body_becomes_none_description() {
         let json = br#"[
-            {"number": 5, "title": "No body", "body": null, "html_url": "u", "labels": [], "createdAt": null}
+            {"number": 5, "title": "No body", "body": null, "url": "u", "labels": [], "createdAt": null}
         ]"#;
         let dispatched = DashMap::new();
         let parsed = parse_gh_output(json, "owner/repo", &dispatched, None).unwrap();
@@ -560,8 +558,8 @@ mod tests {
     #[test]
     fn parse_gh_output_returns_open_issue_ids_for_eviction() {
         let json = br#"[
-            {"number": 10, "title": "A", "body": null, "html_url": "u1", "labels": [], "createdAt": null},
-            {"number": 20, "title": "B", "body": null, "html_url": "u2", "labels": [], "createdAt": null}
+            {"number": 10, "title": "A", "body": null, "url": "u1", "labels": [], "createdAt": null},
+            {"number": 20, "title": "B", "body": null, "url": "u2", "labels": [], "createdAt": null}
         ]"#;
 
         // Issue 5 was dispatched but is no longer in the open list (closed).

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -144,7 +144,7 @@ enum PreparedEnqueueResult {
 
 pub(crate) enum WorkflowReuseStrategy {
     ActiveTask(TaskId),
-    PrExternalId(String),
+    ActivePrExternalId(String),
     None,
 }
 
@@ -163,7 +163,7 @@ pub(crate) fn workflow_reuse_strategy(workflow: &IssueWorkflowInstance) -> Workf
         return WorkflowReuseStrategy::ActiveTask(harness_core::types::TaskId(task_id.clone()));
     }
     if let Some(pr_number) = workflow.pr_number {
-        return WorkflowReuseStrategy::PrExternalId(format!("pr:{pr_number}"));
+        return WorkflowReuseStrategy::ActivePrExternalId(format!("pr:{pr_number}"));
     }
     WorkflowReuseStrategy::None
 }
@@ -389,7 +389,16 @@ impl DefaultExecutionService {
             None
         }?;
 
-        match workflow_reuse_strategy(&workflow) {
+        self.lookup_workflow_reuse_candidate(project_id, &workflow)
+            .await
+    }
+
+    async fn lookup_workflow_reuse_candidate(
+        &self,
+        project_id: &str,
+        workflow: &IssueWorkflowInstance,
+    ) -> Option<TaskId> {
+        match workflow_reuse_strategy(workflow) {
             WorkflowReuseStrategy::ActiveTask(task_id) => {
                 if self
                     .tasks
@@ -400,21 +409,11 @@ impl DefaultExecutionService {
                     return Some(task_id);
                 }
             }
-            WorkflowReuseStrategy::PrExternalId(pr_ext_id) => {
-                if let Some(task_id) = self
+            WorkflowReuseStrategy::ActivePrExternalId(pr_ext_id) => {
+                return self
                     .tasks
                     .find_active_duplicate(project_id, &pr_ext_id)
-                    .await
-                {
-                    return Some(task_id);
-                }
-                if let Some((task_id, _)) = self
-                    .tasks
-                    .find_terminal_pr_duplicate(project_id, &pr_ext_id)
-                    .await
-                {
-                    return Some(task_id);
-                }
+                    .await;
             }
             WorkflowReuseStrategy::None => {}
         }


### PR DESCRIPTION
Closes #929

Prevents active issue workflows from reusing terminal PR duplicates, and keeps GitHub issue URL parsing aligned with current main after the rebase.