### PR TITLE
Make runtime-host claims reject scheduler-owned pending tasks

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -386,6 +386,144 @@ async fn claim_endpoint_honors_project_filter() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn claim_endpoint_skips_scheduler_owned_pending_tasks() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some(state) = make_test_state(dir.path()).await? else {
+        return Ok(());
+    };
+
+    let mut scheduler_owned = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
+        status: crate::task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: None,
+        description: Some("scheduler-owned pending task".to_string()),
+        created_at: Some("2026-04-02T00:00:00Z".to_string()),
+        updated_at: None,
+        priority: 0,
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: crate::task_runner::TaskSchedulerState::queued(),
+    };
+    scheduler_owned.scheduler.claim_scheduler("local-scheduler");
+    let scheduler_owned_id = scheduler_owned.id.clone();
+
+    let claimable = crate::task_runner::TaskState {
+        id: crate::task_runner::TaskId::new(),
+        task_kind: crate::task_runner::TaskKind::Prompt,
+        status: crate::task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: None,
+        description: Some("claimable pending task".to_string()),
+        created_at: Some("2026-04-02T00:00:01Z".to_string()),
+        updated_at: None,
+        priority: 0,
+        phase: crate::task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: crate::task_runner::TaskSchedulerState::queued(),
+    };
+    let claimable_id = claimable.id.clone();
+
+    state.core.tasks.insert(&scheduler_owned).await;
+    state.core.tasks.insert(&claimable).await;
+
+    let app = runtime_hosts_app(state.clone());
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "host_id": "host-a" }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), axum::http::StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/tasks/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "lease_secs": 30 }).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_slice(
+        &http_body_util::BodyExt::collect(response.into_body())
+            .await?
+            .to_bytes(),
+    )?;
+    assert_eq!(json["claimed"], true);
+    assert_eq!(json["task_id"], claimable_id.to_string());
+
+    let blocked = state
+        .core
+        .tasks
+        .get(&scheduler_owned_id)
+        .expect("scheduler-owned task should remain cached");
+    assert!(matches!(
+        blocked
+            .scheduler
+            .owner
+            .as_ref()
+            .map(|owner| (&owner.kind, owner.id.as_str())),
+        Some((
+            crate::task_runner::SchedulerOwnerKind::Scheduler,
+            "local-scheduler"
+        ))
+    ));
+    assert_eq!(blocked.scheduler.runtime_host_id(), None);
+
+    let claimed = state
+        .core
+        .tasks
+        .get(&claimable_id)
+        .expect("claimable task should remain cached");
+    assert_eq!(claimed.scheduler.runtime_host_id(), Some("host-a"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn claim_endpoint_rejects_out_of_range_lease_secs() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let Some(state) = make_test_state(dir.path()).await? else {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
 
 use super::metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
-use super::state::{TaskState, TaskSummary};
+use super::state::{SchedulerOwnerKind, TaskState, TaskSummary};
 use super::types::{TaskId, TaskStatus};
 use super::CompletionCallback;
 
@@ -477,16 +477,22 @@ impl TaskStore {
             return Ok(None);
         }
         let original_scheduler = entry.scheduler.clone();
-        if entry.scheduler.owner.is_some() {
-            // Scheduler owner: never allow a runtime host to steal the task.
-            // RuntimeHost with live lease: the claim is still active.
-            if entry.scheduler.runtime_host_id().is_none()
-                || entry.scheduler.has_live_runtime_host_lease(now)
-            {
-                return Ok(None);
+        if let Some(owner) = entry.scheduler.owner.as_ref() {
+            match owner.kind {
+                SchedulerOwnerKind::Scheduler => {
+                    // Pending rows owned by the local scheduler are unreachable today,
+                    // but if one ever appears we must not let a runtime host steal it.
+                    return Ok(None);
+                }
+                SchedulerOwnerKind::RuntimeHost => {
+                    // RuntimeHost with live lease: the claim is still active.
+                    if entry.scheduler.has_live_runtime_host_lease(now) {
+                        return Ok(None);
+                    }
+                    // RuntimeHost with a stale lease: safe to clear and re-claim.
+                    entry.scheduler.clear_to_queued();
+                }
             }
-            // RuntimeHost with a stale lease: safe to clear and re-claim.
-            entry.scheduler.clear_to_queued();
         }
 
         entry.scheduler.claim_runtime_host(host_id, expires_at);
@@ -1860,6 +1866,148 @@ mod tests {
             .get(&non_pending_id)
             .expect("non-pending task should remain cached");
         assert_eq!(non_pending_task.scheduler.runtime_host_id(), Some("host-a"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_for_runtime_host_blocks_scheduler_owned_pending_tasks() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut task = pending_task("scheduler-owned");
+        task.scheduler.claim_scheduler("local-scheduler");
+        let task_id = task.id.clone();
+        store.insert(&task).await;
+
+        let claim = store
+            .claim_for_runtime_host(&task_id, "host-a", Some(30))
+            .await?;
+        assert!(claim.is_none());
+
+        let cached = store
+            .get(&task_id)
+            .expect("scheduler-owned task should remain cached");
+        assert!(matches!(
+            cached
+                .scheduler
+                .owner
+                .as_ref()
+                .map(|owner| (&owner.kind, owner.id.as_str())),
+            Some((
+                crate::task_runner::SchedulerOwnerKind::Scheduler,
+                "local-scheduler"
+            ))
+        ));
+        assert!(matches!(
+            cached.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Running
+        ));
+        assert_eq!(cached.scheduler.run_generation, 1);
+
+        let persisted = store
+            .db
+            .get(task_id.as_str())
+            .await?
+            .expect("scheduler-owned task should remain persisted");
+        assert!(matches!(
+            persisted
+                .scheduler
+                .owner
+                .as_ref()
+                .map(|owner| (&owner.kind, owner.id.as_str())),
+            Some((
+                crate::task_runner::SchedulerOwnerKind::Scheduler,
+                "local-scheduler"
+            ))
+        ));
+        assert!(matches!(
+            persisted.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Running
+        ));
+        assert_eq!(persisted.scheduler.run_generation, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_for_runtime_host_blocks_live_runtime_host_leases() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut task = pending_task("leased");
+        task.scheduler
+            .claim_runtime_host("host-a", Utc::now() + chrono::TimeDelta::seconds(60));
+        let task_id = task.id.clone();
+        store.insert(&task).await;
+
+        let claim = store
+            .claim_for_runtime_host(&task_id, "host-b", Some(30))
+            .await?;
+        assert!(claim.is_none());
+
+        let cached = store
+            .get(&task_id)
+            .expect("leased task should remain cached");
+        assert_eq!(cached.scheduler.runtime_host_id(), Some("host-a"));
+        assert!(matches!(
+            cached.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Leased
+        ));
+        assert_eq!(cached.scheduler.run_generation, 1);
+
+        let persisted = store
+            .db
+            .get(task_id.as_str())
+            .await?
+            .expect("leased task should remain persisted");
+        assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-a"));
+        assert!(matches!(
+            persisted.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Leased
+        ));
+        assert_eq!(persisted.scheduler.run_generation, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claim_for_runtime_host_reclaims_expired_runtime_host_leases() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let mut task = pending_task("expired-lease");
+        task.scheduler
+            .claim_runtime_host("host-a", Utc::now() - chrono::TimeDelta::seconds(60));
+        let task_id = task.id.clone();
+        store.insert(&task).await;
+
+        let claim = store
+            .claim_for_runtime_host(&task_id, "host-b", Some(30))
+            .await?;
+        let claim = claim.expect("expired lease should be reclaimed");
+        assert_eq!(claim.task_id, task_id);
+
+        let cached = store
+            .get(&task_id)
+            .expect("reclaimed task should remain cached");
+        assert_eq!(cached.scheduler.runtime_host_id(), Some("host-b"));
+        assert!(matches!(
+            cached.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Leased
+        ));
+        assert_eq!(cached.scheduler.run_generation, 2);
+        assert!(cached.scheduler.lease_expiry().is_some());
+
+        let persisted = store
+            .db
+            .get(task_id.as_str())
+            .await?
+            .expect("reclaimed task should remain persisted");
+        assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-b"));
+        assert!(matches!(
+            persisted.scheduler.authority_state,
+            crate::task_runner::SchedulerAuthorityState::Leased
+        ));
+        assert_eq!(persisted.scheduler.run_generation, 2);
+        assert!(persisted.scheduler.lease_expiry().is_some());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- make the scheduler-owned pending guard explicit in `claim_for_runtime_host`
- add store regressions for scheduler-owned pending tasks, live runtime-host leases, and expired lease reclamation
- add an API regression showing the claim endpoint skips scheduler-owned pending rows and claims the next eligible task

## Validation
- `cargo fmt --all`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1033-target cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1033-target cargo test -p harness-server claim_for_runtime_host_ -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1033-target-2 cargo test -p harness-server claim_endpoint_skips_scheduler_owned_pending_tasks -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1033-target cargo test --workspace -j 6`
- `RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR=/private/tmp/harness-review-1033-target cargo check --workspace --all-targets`

Closes #938
