### PR TITLE
Fail closed on resumed PR conflict gate

### DIFF
--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -26,7 +26,9 @@ pub use parsing::{
     parse_plan_issue, parse_pr_url, parse_triage, repo_slug_from_pr_url, TriageComplexity,
     TriageDecision,
 };
-pub use pr::{check_existing_pr, continue_existing_pr, rebase_conflicting_pr};
+pub use pr::{
+    check_existing_pr, check_resumed_pr_conflicts, continue_existing_pr, rebase_conflicting_pr,
+};
 pub use review::{
     agent_review_fix_prompt, agent_review_intervention_prompt, agent_review_prompt, is_approved,
     periodic_review_prompt, periodic_review_prompt_with_guard_scan, review_prompt,

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -23,8 +23,8 @@ pub use issue::{
 pub use parsing::{
     extract_pr_number, extract_review_issues, is_lgtm, is_quota_exhausted, is_waiting,
     parse_complexity, parse_created_issue_number, parse_github_pr_url, parse_issue_count,
-    parse_plan_issue, parse_pr_url, parse_triage, repo_slug_from_pr_url, TriageComplexity,
-    TriageDecision,
+    parse_plan_issue, parse_pr_url, parse_pushed_commit, parse_triage, repo_slug_from_pr_url,
+    TriageComplexity, TriageDecision,
 };
 pub use pr::{
     check_existing_pr, check_resumed_pr_conflicts, continue_existing_pr, rebase_conflicting_pr,

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -346,17 +346,38 @@ pub fn parse_plan_issue(output: &str) -> Option<String> {
     None
 }
 
-/// Parse `PUSHED_COMMIT=true|false` from agent output.
+/// Parse an optional `PUSHED_COMMIT=true|false` marker from agent output.
 ///
-/// Used by PR-check flows to propagate whether the agent pushed a commit
-/// during the initial pass, so later review freshness gates can require a
-/// re-review of the latest commit.
-pub fn parse_pushed_commit(output: &str) -> bool {
-    output.lines().rev().any(|line| {
-        line.trim()
-            .strip_prefix("PUSHED_COMMIT=")
-            .is_some_and(|value| value.trim().eq_ignore_ascii_case("true"))
-    })
+/// Returns:
+/// - `Ok(Some(true|false))` when the marker is present and valid
+/// - `Ok(None)` when the marker is absent
+/// - `Err(...)` when the marker is duplicated or malformed
+///
+/// PR-check flows require this marker so they can fail closed if an agent
+/// pushed new code without surfacing that fact to the freshness gate.
+pub fn parse_pushed_commit(output: &str) -> Result<Option<bool>, String> {
+    let mut parsed: Option<bool> = None;
+    for line in output.lines() {
+        let line = line.trim();
+        let Some(value) = line.strip_prefix("PUSHED_COMMIT=") else {
+            continue;
+        };
+        if parsed.is_some() {
+            return Err("duplicate PUSHED_COMMIT marker".to_string());
+        }
+        let value = value.trim();
+        let bool_value = match value.to_ascii_lowercase().as_str() {
+            "true" => true,
+            "false" => false,
+            _ => {
+                return Err(format!(
+                    "invalid PUSHED_COMMIT value `{value}`; expected true or false"
+                ));
+            }
+        };
+        parsed = Some(bool_value);
+    }
+    Ok(parsed)
 }
 
 #[cfg(test)]
@@ -382,14 +403,31 @@ mod tests {
 
     #[test]
     fn test_parse_pushed_commit() {
-        assert!(parse_pushed_commit(
-            "PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=true"
-        ));
-        assert!(parse_pushed_commit("PUSHED_COMMIT=TRUE\nFIXED"));
-        assert!(!parse_pushed_commit(
-            "PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=false\nLGTM"
-        ));
-        assert!(!parse_pushed_commit("LGTM"));
+        assert_eq!(
+            parse_pushed_commit("PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=true"),
+            Ok(Some(true))
+        );
+        assert_eq!(
+            parse_pushed_commit("PUSHED_COMMIT=TRUE\nFIXED"),
+            Ok(Some(true))
+        );
+        assert_eq!(
+            parse_pushed_commit("PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=false\nLGTM"),
+            Ok(Some(false))
+        );
+        assert_eq!(parse_pushed_commit("LGTM"), Ok(None));
+    }
+
+    #[test]
+    fn test_parse_pushed_commit_rejects_malformed_or_duplicate_markers() {
+        assert_eq!(
+            parse_pushed_commit("PUSHED_COMMIT=maybe\nFIXED"),
+            Err("invalid PUSHED_COMMIT value `maybe`; expected true or false".to_string())
+        );
+        assert_eq!(
+            parse_pushed_commit("PUSHED_COMMIT=true\nPUSHED_COMMIT=false\nFIXED"),
+            Err("duplicate PUSHED_COMMIT marker".to_string())
+        );
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -346,6 +346,19 @@ pub fn parse_plan_issue(output: &str) -> Option<String> {
     None
 }
 
+/// Parse `PUSHED_COMMIT=true|false` from agent output.
+///
+/// Used by PR-check flows to propagate whether the agent pushed a commit
+/// during the initial pass, so later review freshness gates can require a
+/// re-review of the latest commit.
+pub fn parse_pushed_commit(output: &str) -> bool {
+    output.lines().rev().any(|line| {
+        line.trim()
+            .strip_prefix("PUSHED_COMMIT=")
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case("true"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,6 +378,18 @@ mod tests {
         assert!(is_waiting("WAITING\n"));
         assert!(!is_waiting("LGTM"));
         assert!(!is_waiting("FIXED"));
+    }
+
+    #[test]
+    fn test_parse_pushed_commit() {
+        assert!(parse_pushed_commit(
+            "PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=true"
+        ));
+        assert!(parse_pushed_commit("PUSHED_COMMIT=TRUE\nFIXED"));
+        assert!(!parse_pushed_commit(
+            "PR_URL=https://github.com/o/r/pull/1\nPUSHED_COMMIT=false\nLGTM"
+        ));
+        assert!(!parse_pushed_commit("LGTM"));
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -34,11 +34,54 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
     )
 }
 
+/// Build prompt: resumed-PR conflict gate before the normal review loop.
+///
+/// The agent must inspect the PR's mergeability via `gh`, perform any repair in
+/// an isolated worktree, and finish by printing exactly one terminal token.
+pub fn check_resumed_pr_conflicts(pr_num: u64, repo: &str, project_root: &Path) -> String {
+    let validation_step = rebase_validation_step(pr_num, project_root)
+        .replace("REBASE_FAILED", "MANUAL_RESOLUTION_REQUIRED");
+    format!(
+        "Inspect PR #{pr_num} in `{repo}` before any review work.\n\n\
+         IMPORTANT:\n\
+         - You MUST inspect mergeability with GitHub CLI before deciding anything.\n\
+         - Never run `git checkout` or `git stash` in the main repository working tree.\n\
+         - Any repair or rebase MUST happen inside an isolated worktree.\n\
+         - The last non-empty line of your output MUST be exactly one of: \
+         `CLEAN_PR`, `REBASE_PUSHED`, or `MANUAL_RESOLUTION_REQUIRED`.\n\n\
+         Steps:\n\
+         1. Inspect PR mergeability and head branch:\n\
+            `gh pr view {pr_num} --json mergeable,headRefName,url`\n\
+         2. If `mergeable` is `MERGEABLE`, print `CLEAN_PR` on the last line and stop.\n\
+         3. If `mergeable` is `CONFLICTING`, repair it in an isolated worktree:\n\
+            ```\n\
+            BRANCH=$(gh pr view {pr_num} --json headRefName --jq .headRefName)\n\
+            git fetch origin \"$BRANCH\"\n\
+            git fetch origin main\n\
+            git worktree remove /tmp/harness-rebase-{pr_num} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr_num} 2>/dev/null || true\n\
+            git worktree prune\n\
+            git worktree add /tmp/harness-rebase-{pr_num} \"$BRANCH\"\n\
+            cd /tmp/harness-rebase-{pr_num}\n\
+            git rebase origin/main\n\
+            ```\n\
+         4. If rebase conflicts appear, resolve each file and continue the rebase. \
+            If you cannot finish cleanly, print `MANUAL_RESOLUTION_REQUIRED` on the last line.\n\
+         {validation_step}\
+         6. If the rebase succeeds, push the repaired branch:\n\
+            ```\n\
+            git push --force-with-lease origin \"$BRANCH\"\n\
+            ```\n\
+            Then print `REBASE_PUSHED` on the last line.\n\
+         7. If `mergeable` is `UNKNOWN`, `DIRTY`, or anything other than `MERGEABLE`/`CONFLICTING`, \
+            print `MANUAL_RESOLUTION_REQUIRED` on the last line."
+    )
+}
+
 /// Build prompt: rebase a conflicting PR onto the current main branch.
 ///
-/// Used when [`conflict_resolver::assess_pr_conflict`] classifies the PR as
-/// `Small` (≤3 files, <5 conflict regions). The agent performs the rebase
-/// inside an isolated worktree and force-pushes the result.
+/// Used when Harness wants the agent to repair a conflicting PR via rebase.
+/// The agent performs the rebase inside an isolated worktree and force-pushes
+/// the result.
 ///
 /// `project_root` is used to detect the project language so the validation
 /// step uses the correct build/test toolchain instead of hardcoding `cargo`.
@@ -169,11 +212,25 @@ pub fn check_existing_pr(
     };
     format!(
         "Check PR #{pr}:{freshness_check}\n\
-         1. Run `gh pr view {pr} --json statusCheckRollup` — parse the JSON. \
-         CI passes only if the `state` field in the `statusCheckRollup` object is `SUCCESS`\n\
-         2. `gh api repos/{repo}/pulls/{pr}/comments` — read inline review comments\n\
-         3. If CI passes and there are no unresolved review comments, print LGTM on the last line\n\
-         4. Otherwise fix each comment, commit, push, \
+         1. Run `gh pr view {pr} --json mergeable,headRefName,statusCheckRollup` — parse the JSON.\n\
+         2. If `mergeable` is `CONFLICTING`, do NOT treat the PR as healthy. \
+         Repair it only inside an isolated worktree:\n\
+            ```\n\
+            BRANCH=$(gh pr view {pr} --json headRefName --jq .headRefName)\n\
+            git fetch origin \"$BRANCH\"\n\
+            git fetch origin main\n\
+            git worktree remove /tmp/harness-rebase-{pr} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr} 2>/dev/null || true\n\
+            git worktree prune\n\
+            git worktree add /tmp/harness-rebase-{pr} \"$BRANCH\"\n\
+            cd /tmp/harness-rebase-{pr}\n\
+            git rebase origin/main\n\
+            git push --force-with-lease origin \"$BRANCH\"\n\
+            ```\n\
+            If you cannot complete that repair, explain that manual resolution required and print WAITING on the last line.\n\
+         3. CI passes only if the `state` field in the `statusCheckRollup` object is `SUCCESS`\n\
+         4. `gh api repos/{repo}/pulls/{pr}/comments` — read inline review comments\n\
+         5. If CI passes and there are no unresolved review comments, print LGTM on the last line\n\
+         6. Otherwise fix each comment, commit, push, \
          then run `gh pr comment {pr} --body {body}` to trigger re-review, \
          and print FIXED on the last line\n\n\
          Always print PR_URL=https://github.com/{repo}/pull/{pr} on a separate line of your output."
@@ -274,6 +331,14 @@ mod tests {
             p.contains("state") && p.contains("SUCCESS"),
             "must instruct agent to check state field for SUCCESS"
         );
+        assert!(
+            p.contains("--json mergeable,headRefName,statusCheckRollup"),
+            "must require mergeability inspection before health checks"
+        );
+        assert!(
+            p.contains("git worktree add /tmp/harness-rebase-10"),
+            "conflict repair must happen in an isolated worktree"
+        );
     }
 
     #[test]
@@ -284,5 +349,15 @@ mod tests {
             p.contains(r"'it'\''s a test'"),
             "single quote must be escaped"
         );
+    }
+
+    #[test]
+    fn resumed_pr_conflict_prompt_requires_exact_terminal_tokens() {
+        let p = check_resumed_pr_conflicts(17, "owner/repo", std::path::Path::new("."));
+        assert!(p.contains("gh pr view 17 --json mergeable,headRefName,url"));
+        assert!(p.contains("git worktree add /tmp/harness-rebase-17"));
+        assert!(p.contains("CLEAN_PR"));
+        assert!(p.contains("REBASE_PUSHED"));
+        assert!(p.contains("MANUAL_RESOLUTION_REQUIRED"));
     }
 }

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -73,7 +73,10 @@ pub fn check_resumed_pr_conflicts(pr_num: u64, repo: &str, project_root: &Path) 
             git push --force-with-lease origin \"$BRANCH\"\n\
             ```\n\
             Then print `REBASE_PUSHED` on the last line.\n\
-         7. If `mergeable` is `UNKNOWN`, `DIRTY`, or anything other than `MERGEABLE`/`CONFLICTING`, \
+         7. If `mergeable` is `UNKNOWN`, wait briefly and retry step 1 until GitHub finishes computing \
+            mergeability. If it never becomes `MERGEABLE` or `CONFLICTING` after several retries, \
+            print `MANUAL_RESOLUTION_REQUIRED` on the last line.\n\
+         8. If `mergeable` is `DIRTY` or anything other than `MERGEABLE`/`CONFLICTING`/`UNKNOWN`, \
             print `MANUAL_RESOLUTION_REQUIRED` on the last line."
     )
 }
@@ -375,6 +378,10 @@ mod tests {
         assert!(p.contains("gh pr view 17 --json mergeable,headRefName,baseRefName,url"));
         assert!(p.contains("git worktree add /tmp/harness-rebase-17"));
         assert!(p.contains("git rebase \"origin/$BASE\""));
+        assert!(
+            p.contains("If `mergeable` is `UNKNOWN`, wait briefly and retry step 1"),
+            "UNKNOWN mergeability must be treated as retryable instead of hard failure"
+        );
         assert!(p.contains("CLEAN_PR"));
         assert!(p.contains("REBASE_PUSHED"));
         assert!(p.contains("MANUAL_RESOLUTION_REQUIRED"));

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -233,7 +233,11 @@ pub fn check_existing_pr(
          6. Otherwise fix each comment, commit, push, \
          then run `gh pr comment {pr} --body {body}` to trigger re-review, \
          and print FIXED on the last line\n\n\
-         Always print PR_URL=https://github.com/{repo}/pull/{pr} on a separate line of your output."
+         Output format:\n\
+         - Always print `PR_URL=https://github.com/{repo}/pull/{pr}` on a separate line\n\
+         - Always print `PUSHED_COMMIT=true` if you created or pushed any commit during this check \
+         (including a rebase/force-push to repair conflicts); otherwise print `PUSHED_COMMIT=false`\n\
+         - Then print `LGTM`, `FIXED`, or `WAITING` on the very last line."
     )
 }
 
@@ -322,6 +326,8 @@ mod tests {
         assert!(p.contains("PR #10"));
         assert!(p.contains("LGTM"));
         assert!(p.contains("PR_URL=https://github.com/owner/repo/pull/10"));
+        assert!(p.contains("PUSHED_COMMIT=true"));
+        assert!(p.contains("PUSHED_COMMIT=false"));
         assert!(p.contains("repos/owner/repo/pulls/10/comments"));
         assert!(
             p.contains("statusCheckRollup"),

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -50,19 +50,20 @@ pub fn check_resumed_pr_conflicts(pr_num: u64, repo: &str, project_root: &Path) 
          - The last non-empty line of your output MUST be exactly one of: \
          `CLEAN_PR`, `REBASE_PUSHED`, or `MANUAL_RESOLUTION_REQUIRED`.\n\n\
          Steps:\n\
-         1. Inspect PR mergeability and head branch:\n\
-            `gh pr view {pr_num} --json mergeable,headRefName,url`\n\
+         1. Inspect PR mergeability, head branch, and base branch:\n\
+            `gh pr view {pr_num} --json mergeable,headRefName,baseRefName,url`\n\
          2. If `mergeable` is `MERGEABLE`, print `CLEAN_PR` on the last line and stop.\n\
          3. If `mergeable` is `CONFLICTING`, repair it in an isolated worktree:\n\
             ```\n\
             BRANCH=$(gh pr view {pr_num} --json headRefName --jq .headRefName)\n\
+            BASE=$(gh pr view {pr_num} --json baseRefName --jq .baseRefName)\n\
             git fetch origin \"$BRANCH\"\n\
-            git fetch origin main\n\
+            git fetch origin \"$BASE\"\n\
             git worktree remove /tmp/harness-rebase-{pr_num} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr_num} 2>/dev/null || true\n\
             git worktree prune\n\
             git worktree add /tmp/harness-rebase-{pr_num} \"$BRANCH\"\n\
             cd /tmp/harness-rebase-{pr_num}\n\
-            git rebase origin/main\n\
+            git rebase \"origin/$BASE\"\n\
             ```\n\
          4. If rebase conflicts appear, resolve each file and continue the rebase. \
             If you cannot finish cleanly, print `MANUAL_RESOLUTION_REQUIRED` on the last line.\n\
@@ -77,7 +78,7 @@ pub fn check_resumed_pr_conflicts(pr_num: u64, repo: &str, project_root: &Path) 
     )
 }
 
-/// Build prompt: rebase a conflicting PR onto the current main branch.
+/// Build prompt: rebase a conflicting PR onto its actual base branch.
 ///
 /// Used when Harness wants the agent to repair a conflicting PR via rebase.
 /// The agent performs the rebase inside an isolated worktree and force-pushes
@@ -114,10 +115,12 @@ pub fn rebase_conflicting_pr(pr_num: u64, branch: &str, repo: &str, project_root
             git worktree prune\n\
             git worktree add /tmp/harness-rebase-{pr_num} '{branch_arg}'\n\
             ```\n\
-         2. Rebase onto origin/main inside the worktree:\n\
+         2. Determine the PR base branch from GitHub and rebase onto it inside the worktree:\n\
             ```\n\
+            BASE=$(gh pr view {pr_num} --json baseRefName --jq .baseRefName)\n\
+            git fetch origin \"$BASE\"\n\
             cd /tmp/harness-rebase-{pr_num}\n\
-            git rebase origin/main\n\
+            git rebase \"origin/$BASE\"\n\
             ```\n\
          3. If rebase conflicts appear, resolve each file, then:\n\
             ```\n\
@@ -212,18 +215,19 @@ pub fn check_existing_pr(
     };
     format!(
         "Check PR #{pr}:{freshness_check}\n\
-         1. Run `gh pr view {pr} --json mergeable,headRefName,statusCheckRollup` — parse the JSON.\n\
+         1. Run `gh pr view {pr} --json mergeable,headRefName,baseRefName,statusCheckRollup` — parse the JSON.\n\
          2. If `mergeable` is `CONFLICTING`, do NOT treat the PR as healthy. \
          Repair it only inside an isolated worktree:\n\
             ```\n\
             BRANCH=$(gh pr view {pr} --json headRefName --jq .headRefName)\n\
+            BASE=$(gh pr view {pr} --json baseRefName --jq .baseRefName)\n\
             git fetch origin \"$BRANCH\"\n\
-            git fetch origin main\n\
+            git fetch origin \"$BASE\"\n\
             git worktree remove /tmp/harness-rebase-{pr} 2>/dev/null || rm -rf /tmp/harness-rebase-{pr} 2>/dev/null || true\n\
             git worktree prune\n\
             git worktree add /tmp/harness-rebase-{pr} \"$BRANCH\"\n\
             cd /tmp/harness-rebase-{pr}\n\
-            git rebase origin/main\n\
+            git rebase \"origin/$BASE\"\n\
             git push --force-with-lease origin \"$BRANCH\"\n\
             ```\n\
             If you cannot complete that repair, explain that manual resolution required and print WAITING on the last line.\n\
@@ -338,12 +342,20 @@ mod tests {
             "must instruct agent to check state field for SUCCESS"
         );
         assert!(
-            p.contains("--json mergeable,headRefName,statusCheckRollup"),
+            p.contains("--json mergeable,headRefName,baseRefName,statusCheckRollup"),
             "must require mergeability inspection before health checks"
         );
         assert!(
             p.contains("git worktree add /tmp/harness-rebase-10"),
             "conflict repair must happen in an isolated worktree"
+        );
+        assert!(
+            p.contains("BASE=$(gh pr view 10 --json baseRefName --jq .baseRefName)"),
+            "conflict repair must derive the base branch from PR metadata"
+        );
+        assert!(
+            p.contains("git rebase \"origin/$BASE\""),
+            "conflict repair must rebase onto the actual base branch"
         );
     }
 
@@ -360,10 +372,24 @@ mod tests {
     #[test]
     fn resumed_pr_conflict_prompt_requires_exact_terminal_tokens() {
         let p = check_resumed_pr_conflicts(17, "owner/repo", std::path::Path::new("."));
-        assert!(p.contains("gh pr view 17 --json mergeable,headRefName,url"));
+        assert!(p.contains("gh pr view 17 --json mergeable,headRefName,baseRefName,url"));
         assert!(p.contains("git worktree add /tmp/harness-rebase-17"));
+        assert!(p.contains("git rebase \"origin/$BASE\""));
         assert!(p.contains("CLEAN_PR"));
         assert!(p.contains("REBASE_PUSHED"));
         assert!(p.contains("MANUAL_RESOLUTION_REQUIRED"));
+    }
+
+    #[test]
+    fn rebase_prompt_uses_pr_base_branch() {
+        let p = rebase_conflicting_pr(
+            42,
+            "feat/my-branch",
+            "owner/repo",
+            std::path::Path::new("."),
+        );
+        assert!(p.contains("gh pr view 42 --json baseRefName --jq .baseRefName"));
+        assert!(p.contains("git fetch origin \"$BASE\""));
+        assert!(p.contains("git rebase \"origin/$BASE\""));
     }
 }

--- a/crates/harness-server/src/task_executor/conflict_resolver.rs
+++ b/crates/harness-server/src/task_executor/conflict_resolver.rs
@@ -1,34 +1,56 @@
-//! PR conflict-size assessment policy.
-//!
-//! Harness no longer queries `gh` or runs local git commands to inspect PRs.
-//! Repository mutation and GitHub state inspection belong in the agent prompt,
-//! so this module only preserves the conflict-size type used by the executor
-//! and reports that automatic host-side assessment is unavailable.
+//! Agent-reported resumed-PR conflict gate outcomes.
 
-use std::path::Path;
+const CLEAN_PR_TOKEN: &str = "CLEAN_PR";
+const REBASE_PUSHED_TOKEN: &str = "REBASE_PUSHED";
+const MANUAL_RESOLUTION_REQUIRED_TOKEN: &str = "MANUAL_RESOLUTION_REQUIRED";
 
-/// Classification of how large a PR's merge conflict is.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum PrConflictSize {
-    /// Host-side assessment is unavailable; the agent must inspect GitHub/git state.
-    Unknown(String),
+/// Exact conflict-gate outcomes accepted from the agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConflictCheckOutcome {
+    CleanPr,
+    RebasePushed,
+    ManualResolutionRequired,
 }
 
-/// Return an unknown conflict size so the executor continues without invoking
-/// host-side git/GitHub commands.
-pub(crate) async fn assess_pr_conflict(pr_num: u64, _project: &Path) -> PrConflictSize {
-    PrConflictSize::Unknown(format!(
-        "PR #{pr_num} conflict assessment is delegated to the agent prompt"
-    ))
+/// Parse the final conflict-gate terminal token from the agent output.
+///
+/// The gate is intentionally strict and fail-closed: only the exact last
+/// non-empty line is accepted as a valid outcome.
+pub(crate) fn parse_conflict_check_output(output: &str) -> Result<ConflictCheckOutcome, String> {
+    let Some(last_line) = output.lines().rev().find(|line| !line.trim().is_empty()) else {
+        return Err("missing terminal conflict gate token".to_string());
+    };
+    match last_line.trim() {
+        CLEAN_PR_TOKEN => Ok(ConflictCheckOutcome::CleanPr),
+        REBASE_PUSHED_TOKEN => Ok(ConflictCheckOutcome::RebasePushed),
+        MANUAL_RESOLUTION_REQUIRED_TOKEN => Ok(ConflictCheckOutcome::ManualResolutionRequired),
+        other => Err(format!("unexpected conflict gate terminal token `{other}`")),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn conflict_assessment_is_delegated() {
-        let result = assess_pr_conflict(42, std::path::Path::new(".")).await;
-        assert!(matches!(result, PrConflictSize::Unknown(_)));
+    #[test]
+    fn parses_clean_pr_token() {
+        let result = parse_conflict_check_output("inspected mergeability\nCLEAN_PR");
+        assert_eq!(result, Ok(ConflictCheckOutcome::CleanPr));
+    }
+
+    #[test]
+    fn parses_rebase_pushed_token() {
+        let result = parse_conflict_check_output("rebased and pushed\nREBASE_PUSHED");
+        assert_eq!(result, Ok(ConflictCheckOutcome::RebasePushed));
+    }
+
+    #[test]
+    fn rejects_malformed_last_line() {
+        let result =
+            parse_conflict_check_output("MANUAL_RESOLUTION_REQUIRED\nextra trailing output");
+        assert_eq!(
+            result,
+            Err("unexpected conflict gate terminal token `extra trailing output`".to_string())
+        );
     }
 }

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -39,6 +39,7 @@ pub(crate) enum ImplementationOutcome {
         pr_url: Option<String>,
         pr_num: Option<u64>,
         created_issue_num: Option<u64>,
+        pushed_commit: bool,
     },
 }
 
@@ -49,10 +50,12 @@ pub(crate) fn parse_implementation_outcome(output: &str) -> ImplementationOutcom
     let pr_url = prompts::parse_pr_url(output);
     let pr_num = pr_url.as_deref().and_then(prompts::extract_pr_number);
     let created_issue_num = prompts::parse_created_issue_number(output);
+    let pushed_commit = prompts::parse_pushed_commit(output);
     ImplementationOutcome::ParsedPr {
         pr_url,
         pr_num,
         created_issue_num,
+        pushed_commit,
     }
 }
 
@@ -106,6 +109,7 @@ pub(crate) enum ImplementOutcome {
     Proceed {
         pr_url: Option<String>,
         pr_num: u64,
+        implementation_pushed_commit: bool,
         context_items: Vec<ContextItem>,
         #[allow(dead_code)]
         turn_timeout: Duration,
@@ -325,7 +329,7 @@ pub(crate) async fn run_implement_phase(
 
     // Duplicate-PR prevention guard: if checkpoint shows PR already created, skip the
     // implement agent entirely to avoid opening a second PR on resume.
-    let (pr_url, pr_num): (Option<String>, u64) = 'implement: {
+    let (pr_url, pr_num, pushed_commit): (Option<String>, u64, bool) = 'implement: {
         if let Some(pr_str) = resumed_pr_url {
             tracing::info!(
                 task_id = %task_id,
@@ -358,7 +362,7 @@ pub(crate) async fn run_implement_phase(
                 ));
             })
             .await?;
-            break 'implement (Some(pr_str), n);
+            break 'implement (Some(pr_str), n, false);
         }
 
         let impl_phase_start = Instant::now();
@@ -788,94 +792,96 @@ pub(crate) async fn run_implement_phase(
             return Ok(ImplementOutcome::Done);
         }
 
-        let (pr_url, pr_num, created_issue_num) = match parse_implementation_outcome(&output) {
-            ImplementationOutcome::PlanIssue(plan_issue) => {
-                if let (Some(workflows), Some(issue_number)) =
-                    (issue_workflow_store.as_ref(), req.issue)
-                {
-                    let project_id = project_root.to_string_lossy().into_owned();
-                    if let Err(e) = workflows
-                        .record_plan_issue_detected(
-                            &project_id,
-                            req.repo.as_deref(),
-                            issue_number,
-                            &task_id.0,
-                            &plan_issue,
-                        )
-                        .await
+        let (pr_url, pr_num, created_issue_num, pushed_commit) =
+            match parse_implementation_outcome(&output) {
+                ImplementationOutcome::PlanIssue(plan_issue) => {
+                    if let (Some(workflows), Some(issue_number)) =
+                        (issue_workflow_store.as_ref(), req.issue)
                     {
-                        tracing::warn!(
-                            issue = issue_number,
-                            task_id = %task_id.0,
-                            "issue workflow PLAN_ISSUE tracking failed: {e}"
-                        );
+                        let project_id = project_root.to_string_lossy().into_owned();
+                        if let Err(e) = workflows
+                            .record_plan_issue_detected(
+                                &project_id,
+                                req.repo.as_deref(),
+                                issue_number,
+                                &task_id.0,
+                                &plan_issue,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                issue = issue_number,
+                                task_id = %task_id.0,
+                                "issue workflow PLAN_ISSUE tracking failed: {e}"
+                            );
+                        }
                     }
-                }
-                if let Some(issue_number) = req.issue {
-                    return Ok(ImplementOutcome::Replan {
-                        issue: issue_number,
-                        plan_issue,
-                        prior_plan: plan_output.clone(),
-                    });
-                }
-                tracing::error!(
-                    task_id = %task_id,
-                    plan_issue = %plan_issue,
-                    "implementation returned PLAN_ISSUE; marking task failed"
-                );
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.turn = 2;
-                    s.error = Some(plan_issue.clone());
-                    s.rounds.push(RoundResult::new(
+                    if let Some(issue_number) = req.issue {
+                        return Ok(ImplementOutcome::Replan {
+                            issue: issue_number,
+                            plan_issue,
+                            prior_plan: plan_output.clone(),
+                        });
+                    }
+                    tracing::error!(
+                        task_id = %task_id,
+                        plan_issue = %plan_issue,
+                        "implementation returned PLAN_ISSUE; marking task failed"
+                    );
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.turn = 2;
+                        s.error = Some(plan_issue.clone());
+                        s.rounds.push(RoundResult::new(
+                            1,
+                            "implement",
+                            "plan_issue",
+                            if output.is_empty() {
+                                None
+                            } else {
+                                Some(output.clone())
+                            },
+                            Some(impl_telemetry.clone()),
+                            None,
+                        ));
+                    })
+                    .await?;
+                    let event = build_task_event(
+                        task_id,
                         1,
                         "implement",
-                        "plan_issue",
+                        "task_implement",
+                        Decision::Block,
+                        Some(plan_issue.clone()),
+                        None,
+                        Some(impl_telemetry.clone()),
+                        None,
                         if output.is_empty() {
                             None
                         } else {
                             Some(output.clone())
                         },
-                        Some(impl_telemetry.clone()),
-                        None,
-                    ));
-                })
-                .await?;
-                let event = build_task_event(
-                    task_id,
-                    1,
-                    "implement",
-                    "task_implement",
-                    Decision::Block,
-                    Some(plan_issue.clone()),
-                    None,
-                    Some(impl_telemetry.clone()),
-                    None,
-                    if output.is_empty() {
-                        None
-                    } else {
-                        Some(output.clone())
-                    },
-                );
-                if let Err(error) = events.log(&event).await {
-                    tracing::warn!("failed to log task_implement event: {error}");
+                    );
+                    if let Err(error) = events.log(&event).await {
+                        tracing::warn!("failed to log task_implement event: {error}");
+                    }
+                    tracing::info!(
+                        task_id = %task_id,
+                        status = "failed",
+                        turns = 2,
+                        pr_url = tracing::field::Empty,
+                        total_elapsed_secs = task_start.elapsed().as_secs(),
+                        "task_completed"
+                    );
+                    return Ok(ImplementOutcome::Done);
                 }
-                tracing::info!(
-                    task_id = %task_id,
-                    status = "failed",
-                    turns = 2,
-                    pr_url = tracing::field::Empty,
-                    total_elapsed_secs = task_start.elapsed().as_secs(),
-                    "task_completed"
-                );
-                return Ok(ImplementOutcome::Done);
-            }
-            ImplementationOutcome::ParsedPr {
-                pr_url,
-                pr_num,
-                created_issue_num,
-            } => (pr_url, pr_num, created_issue_num),
-        };
+                ImplementationOutcome::ParsedPr {
+                    pr_url,
+                    pr_num,
+                    created_issue_num,
+                    pushed_commit,
+                } => (pr_url, pr_num, created_issue_num, pushed_commit),
+            };
 
         mutate_and_persist(store, task_id, |s| {
             s.pr_url = pr_url.clone();
@@ -1100,12 +1106,13 @@ pub(crate) async fn run_implement_phase(
             tracing::warn!("failed to log task_implement event: {error}");
         }
 
-        (pr_url, pr_num)
+        (pr_url, pr_num, pushed_commit)
     }; // end 'implement
 
     Ok(ImplementOutcome::Proceed {
         pr_url,
         pr_num,
+        implementation_pushed_commit: pushed_commit,
         context_items,
         turn_timeout,
         initial_allowed_tools,
@@ -1158,6 +1165,23 @@ mod tests {
                 pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
                 pr_num: Some(42),
                 created_issue_num: None,
+                pushed_commit: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_implementation_outcome_extracts_pushed_commit_flag() {
+        let output =
+            "PR_URL=https://github.com/majiayu000/harness/pull/42\nPUSHED_COMMIT=true\nFIXED";
+        let parsed = parse_implementation_outcome(output);
+        assert_eq!(
+            parsed,
+            ImplementationOutcome::ParsedPr {
+                pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
+                pr_num: Some(42),
+                created_issue_num: None,
+                pushed_commit: true,
             }
         );
     }

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -39,23 +39,37 @@ pub(crate) enum ImplementationOutcome {
         pr_url: Option<String>,
         pr_num: Option<u64>,
         created_issue_num: Option<u64>,
-        pushed_commit: bool,
+        pushed_commit: Option<bool>,
     },
 }
 
-pub(crate) fn parse_implementation_outcome(output: &str) -> ImplementationOutcome {
+pub(crate) fn parse_implementation_outcome(output: &str) -> Result<ImplementationOutcome, String> {
     if let Some(desc) = prompts::parse_plan_issue(output) {
-        return ImplementationOutcome::PlanIssue(desc);
+        return Ok(ImplementationOutcome::PlanIssue(desc));
     }
     let pr_url = prompts::parse_pr_url(output);
     let pr_num = pr_url.as_deref().and_then(prompts::extract_pr_number);
     let created_issue_num = prompts::parse_created_issue_number(output);
-    let pushed_commit = prompts::parse_pushed_commit(output);
-    ImplementationOutcome::ParsedPr {
+    let pushed_commit = prompts::parse_pushed_commit(output)?;
+    Ok(ImplementationOutcome::ParsedPr {
         pr_url,
         pr_num,
         created_issue_num,
         pushed_commit,
+    })
+}
+
+fn resolve_pushed_commit_flag(
+    is_direct_pr_check: bool,
+    pushed_commit: Option<bool>,
+) -> Result<bool, String> {
+    match (is_direct_pr_check, pushed_commit) {
+        (_, Some(pushed_commit)) => Ok(pushed_commit),
+        (false, None) => Ok(false),
+        (true, None) => Err(
+            "missing required PUSHED_COMMIT marker in PR-check output; refusing to skip freshness gate"
+                .to_string(),
+        ),
     }
 }
 
@@ -671,7 +685,7 @@ pub(crate) async fn run_implement_phase(
             // If the agent already pushed to a PR before we detected the collision,
             // capture the URL so there is a tracked handle for cleanup.
             let collision_pr_url = match parse_implementation_outcome(&output) {
-                ImplementationOutcome::ParsedPr { pr_url, .. } => pr_url,
+                Ok(ImplementationOutcome::ParsedPr { pr_url, .. }) => pr_url,
                 _ => None,
             };
             tracing::error!(
@@ -794,7 +808,7 @@ pub(crate) async fn run_implement_phase(
 
         let (pr_url, pr_num, created_issue_num, pushed_commit) =
             match parse_implementation_outcome(&output) {
-                ImplementationOutcome::PlanIssue(plan_issue) => {
+                Ok(ImplementationOutcome::PlanIssue(plan_issue)) => {
                     if let (Some(workflows), Some(issue_number)) =
                         (issue_workflow_store.as_ref(), req.issue)
                     {
@@ -875,13 +889,125 @@ pub(crate) async fn run_implement_phase(
                     );
                     return Ok(ImplementOutcome::Done);
                 }
-                ImplementationOutcome::ParsedPr {
+                Ok(ImplementationOutcome::ParsedPr {
                     pr_url,
                     pr_num,
                     created_issue_num,
                     pushed_commit,
-                } => (pr_url, pr_num, created_issue_num, pushed_commit),
+                }) => (pr_url, pr_num, created_issue_num, pushed_commit),
+                Err(parse_err) => {
+                    tracing::error!(
+                        task_id = %task_id,
+                        parse_error = %parse_err,
+                        "implementation returned malformed structured output"
+                    );
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.turn = 2;
+                        s.error = Some(format!(
+                            "implementation returned malformed structured output: {parse_err}"
+                        ));
+                        s.rounds.push(RoundResult::new(
+                            1,
+                            "implement",
+                            "malformed_output",
+                            if output.is_empty() {
+                                None
+                            } else {
+                                Some(output.clone())
+                            },
+                            Some(impl_telemetry.clone()),
+                            None,
+                        ));
+                    })
+                    .await?;
+                    let event = build_task_event(
+                        task_id,
+                        1,
+                        "implement",
+                        "task_implement",
+                        Decision::Block,
+                        Some(format!("malformed structured output: {parse_err}")),
+                        None,
+                        Some(impl_telemetry.clone()),
+                        None,
+                        if output.is_empty() {
+                            None
+                        } else {
+                            Some(output.clone())
+                        },
+                    );
+                    if let Err(error) = events.log(&event).await {
+                        tracing::warn!("failed to log task_implement event: {error}");
+                    }
+                    tracing::info!(
+                        task_id = %task_id,
+                        status = "failed",
+                        turns = 2,
+                        pr_url = tracing::field::Empty,
+                        total_elapsed_secs = task_start.elapsed().as_secs(),
+                        "task_completed"
+                    );
+                    return Ok(ImplementOutcome::Done);
+                }
             };
+
+        let pushed_commit = match resolve_pushed_commit_flag(req.pr.is_some(), pushed_commit) {
+            Ok(pushed_commit) => pushed_commit,
+            Err(parse_err) => {
+                tracing::error!(
+                    task_id = %task_id,
+                    parse_error = %parse_err,
+                    "implementation omitted required PR-check structured output"
+                );
+                mutate_and_persist(store, task_id, |s| {
+                    s.status = TaskStatus::Failed;
+                    s.turn = 2;
+                    s.error = Some(parse_err.clone());
+                    s.rounds.push(RoundResult::new(
+                        1,
+                        "implement",
+                        "malformed_output",
+                        if output.is_empty() {
+                            None
+                        } else {
+                            Some(output.clone())
+                        },
+                        Some(impl_telemetry.clone()),
+                        None,
+                    ));
+                })
+                .await?;
+                let event = build_task_event(
+                    task_id,
+                    1,
+                    "implement",
+                    "task_implement",
+                    Decision::Block,
+                    Some(parse_err.clone()),
+                    None,
+                    Some(impl_telemetry.clone()),
+                    None,
+                    if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.clone())
+                    },
+                );
+                if let Err(error) = events.log(&event).await {
+                    tracing::warn!("failed to log task_implement event: {error}");
+                }
+                tracing::info!(
+                    task_id = %task_id,
+                    status = "failed",
+                    turns = 2,
+                    pr_url = tracing::field::Empty,
+                    total_elapsed_secs = task_start.elapsed().as_secs(),
+                    "task_completed"
+                );
+                return Ok(ImplementOutcome::Done);
+            }
+        };
 
         mutate_and_persist(store, task_id, |s| {
             s.pr_url = pr_url.clone();
@@ -1148,7 +1274,7 @@ mod tests {
     #[test]
     fn parse_implementation_outcome_prefers_plan_issue() {
         let output = "PLAN_ISSUE=Plan missed rollback path\nPR_URL=https://github.com/o/r/pull/123";
-        let parsed = parse_implementation_outcome(output);
+        let parsed = parse_implementation_outcome(output).expect("plan issue should parse");
         assert_eq!(
             parsed,
             ImplementationOutcome::PlanIssue("Plan missed rollback path".to_string())
@@ -1158,14 +1284,14 @@ mod tests {
     #[test]
     fn parse_implementation_outcome_extracts_pr_when_no_plan_issue() {
         let output = "Done.\nPR_URL=https://github.com/majiayu000/harness/pull/42";
-        let parsed = parse_implementation_outcome(output);
+        let parsed = parse_implementation_outcome(output).expect("pr output should parse");
         assert_eq!(
             parsed,
             ImplementationOutcome::ParsedPr {
                 pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
                 pr_num: Some(42),
                 created_issue_num: None,
-                pushed_commit: false,
+                pushed_commit: None,
             }
         );
     }
@@ -1174,15 +1300,38 @@ mod tests {
     fn parse_implementation_outcome_extracts_pushed_commit_flag() {
         let output =
             "PR_URL=https://github.com/majiayu000/harness/pull/42\nPUSHED_COMMIT=true\nFIXED";
-        let parsed = parse_implementation_outcome(output);
+        let parsed = parse_implementation_outcome(output).expect("pushed flag should parse");
         assert_eq!(
             parsed,
             ImplementationOutcome::ParsedPr {
                 pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
                 pr_num: Some(42),
                 created_issue_num: None,
-                pushed_commit: true,
+                pushed_commit: Some(true),
             }
+        );
+    }
+
+    #[test]
+    fn parse_implementation_outcome_rejects_malformed_pushed_commit_flag() {
+        let output =
+            "PR_URL=https://github.com/majiayu000/harness/pull/42\nPUSHED_COMMIT=maybe\nFIXED";
+        assert_eq!(
+            parse_implementation_outcome(output),
+            Err("invalid PUSHED_COMMIT value `maybe`; expected true or false".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_pushed_commit_flag_requires_marker_for_direct_pr_checks() {
+        assert_eq!(resolve_pushed_commit_flag(true, Some(true)), Ok(true));
+        assert_eq!(resolve_pushed_commit_flag(false, None), Ok(false));
+        assert_eq!(
+            resolve_pushed_commit_flag(true, None),
+            Err(
+                "missing required PUSHED_COMMIT marker in PR-check output; refusing to skip freshness gate"
+                    .to_string()
+            )
         );
     }
 

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -895,7 +895,7 @@ pub(crate) async fn run_task(
 
     let mut current_plan_output = plan_output;
     let mut replan_attempted = false;
-    let (pr_url, pr_num, context_items) = loop {
+    let (pr_url, pr_num, implementation_pushed_commit, context_items) = loop {
         let outcome = implement_pipeline::run_implement_phase(
             store,
             task_id,
@@ -928,9 +928,10 @@ pub(crate) async fn run_task(
             implement_pipeline::ImplementOutcome::Proceed {
                 pr_url,
                 pr_num,
+                implementation_pushed_commit,
                 context_items,
                 ..
-            } => break (pr_url, pr_num, context_items),
+            } => break (pr_url, pr_num, implementation_pushed_commit, context_items),
             implement_pipeline::ImplementOutcome::Replan {
                 issue,
                 plan_issue,
@@ -1079,6 +1080,7 @@ pub(crate) async fn run_task(
             tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
         }
     }
+    agent_pushed_commit |= implementation_pushed_commit;
 
     // Skip external review bot wait when auto-trigger is disabled — there is
     // no bot to wait for, so the loop would always exhaust all rounds and fail.

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -399,6 +399,266 @@ async fn run_non_implementation_task(
     Ok(())
 }
 
+enum ConflictGateOutcome {
+    Clean,
+    RebasePushed,
+    Failed,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_resumed_pr_conflict_gate(
+    store: &TaskStore,
+    task_id: &TaskId,
+    agent: &dyn CodeAgent,
+    req: &CreateTaskRequest,
+    project: &std::path::Path,
+    pr_num: u64,
+    repo_slug: &str,
+    context_items: &[harness_core::types::ContextItem],
+    interceptors: &Arc<Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
+    events: &Arc<harness_observe::event_store::EventStore>,
+    cargo_env: &HashMap<String, String>,
+    turn_timeout: Duration,
+    effective_max_turns: Option<u32>,
+    turns_used: &mut u32,
+    turns_used_acc: &mut u32,
+) -> anyhow::Result<ConflictGateOutcome> {
+    use crate::task_executor::conflict_resolver::{
+        parse_conflict_check_output, ConflictCheckOutcome,
+    };
+
+    let gate_turn = turns_used.saturating_add(1);
+    let persist_failure =
+        |result: &'static str,
+         reason: String,
+         detail: Option<String>,
+         telemetry: Option<harness_core::types::TurnTelemetry>,
+         failure: Option<harness_core::types::TurnFailure>| async move {
+            mutate_and_persist(store, task_id, |s| {
+                s.status = TaskStatus::Failed;
+                s.turn = gate_turn;
+                s.error = Some(reason.clone());
+                s.rounds.push(crate::task_runner::RoundResult::new(
+                    gate_turn,
+                    "conflict_gate",
+                    result,
+                    detail.clone(),
+                    telemetry.clone(),
+                    failure.clone(),
+                ));
+            })
+            .await?;
+            let event = helpers::build_task_event(
+                task_id,
+                gate_turn,
+                "conflict_gate",
+                "pr_conflict_gate",
+                harness_core::types::Decision::Block,
+                Some(reason),
+                Some(format!("pr={pr_num}")),
+                telemetry,
+                failure,
+                detail,
+            );
+            if let Err(error) = events.log(&event).await {
+                tracing::warn!("failed to log pr_conflict_gate event: {error}");
+            }
+            Ok::<ConflictGateOutcome, anyhow::Error>(ConflictGateOutcome::Failed)
+        };
+
+    if let Some(max) = effective_max_turns {
+        if *turns_used >= max {
+            return persist_failure(
+                "turn_budget_exhausted",
+                format!(
+                    "pr:{pr_num} conflict gate could not run before review; manual resolution required: turn budget exhausted after {} of {} allowed turns",
+                    turns_used, max
+                ),
+                None,
+                None,
+                None,
+            )
+            .await;
+        }
+    }
+
+    let prompt_built_at = Utc::now();
+    let gate_prompt = prompts::check_resumed_pr_conflicts(pr_num, repo_slug, project);
+    let gate_req = AgentRequest {
+        prompt: gate_prompt,
+        project_root: project.to_path_buf(),
+        context: context_items.to_vec(),
+        max_budget_usd: req.max_budget_usd,
+        execution_phase: Some(harness_core::types::ExecutionPhase::Execution),
+        env_vars: cargo_env.clone(),
+        ..Default::default()
+    };
+    let gate_req = helpers::run_pre_execute(interceptors, gate_req).await?;
+    let gate_started_at = Utc::now();
+    let gate_resp = tokio::time::timeout(
+        turn_timeout,
+        helpers::run_agent_streaming(
+            agent,
+            gate_req.clone(),
+            task_id,
+            store,
+            gate_turn,
+            prompt_built_at,
+            gate_started_at,
+        ),
+    )
+    .await;
+    *turns_used += 1;
+    *turns_used_acc = *turns_used;
+
+    let (response, telemetry) = match gate_resp {
+        Ok(Ok(success)) => {
+            let response = success.response;
+            if let Some(validation_err) =
+                helpers::run_post_execute(interceptors, &gate_req, &response).await
+            {
+                helpers::run_on_error(interceptors, &gate_req, &validation_err).await;
+                return persist_failure(
+                    "validation_failed",
+                    format!(
+                        "pr:{pr_num} conflict gate failed closed; manual resolution required: post-execution validation failed: {validation_err}"
+                    ),
+                    if response.output.is_empty() {
+                        None
+                    } else {
+                        Some(response.output)
+                    },
+                    Some(success.telemetry),
+                    None,
+                )
+                .await;
+            }
+            (response, success.telemetry)
+        }
+        Ok(Err(failure)) => {
+            helpers::run_on_error(interceptors, &gate_req, &failure.error.to_string()).await;
+            return persist_failure(
+                "failed",
+                format!(
+                    "pr:{pr_num} conflict gate failed closed; manual resolution required: {}",
+                    failure.error
+                ),
+                None,
+                Some(failure.telemetry),
+                Some(failure.failure),
+            )
+            .await;
+        }
+        Err(_) => {
+            let msg = format!(
+                "pr:{pr_num} conflict gate timed out; manual resolution required after {}s",
+                turn_timeout.as_secs()
+            );
+            helpers::run_on_error(interceptors, &gate_req, &msg).await;
+            let telemetry =
+                helpers::telemetry_for_timeout(prompt_built_at, gate_started_at, Utc::now(), None);
+            let failure = harness_core::types::TurnFailure {
+                kind: harness_core::types::TurnFailureKind::Timeout,
+                provider: Some(agent.name().to_string()),
+                upstream_status: None,
+                message: Some(msg.clone()),
+                body_excerpt: None,
+            };
+            return persist_failure("timeout", msg, None, Some(telemetry), Some(failure)).await;
+        }
+    };
+
+    let detail = if response.output.is_empty() {
+        None
+    } else {
+        Some(response.output.clone())
+    };
+    match parse_conflict_check_output(&response.output) {
+        Ok(ConflictCheckOutcome::CleanPr) => {
+            mutate_and_persist(store, task_id, |s| {
+                s.rounds.push(crate::task_runner::RoundResult::new(
+                    gate_turn,
+                    "conflict_gate",
+                    "clean",
+                    detail.clone(),
+                    Some(telemetry.clone()),
+                    None,
+                ));
+            })
+            .await?;
+            let event = helpers::build_task_event(
+                task_id,
+                gate_turn,
+                "conflict_gate",
+                "pr_conflict_gate",
+                harness_core::types::Decision::Complete,
+                Some("resumed PR conflict gate passed cleanly".to_string()),
+                Some(format!("pr={pr_num}")),
+                Some(telemetry),
+                None,
+                detail,
+            );
+            if let Err(error) = events.log(&event).await {
+                tracing::warn!("failed to log pr_conflict_gate event: {error}");
+            }
+            Ok(ConflictGateOutcome::Clean)
+        }
+        Ok(ConflictCheckOutcome::RebasePushed) => {
+            mutate_and_persist(store, task_id, |s| {
+                s.rounds.push(crate::task_runner::RoundResult::new(
+                    gate_turn,
+                    "conflict_gate",
+                    "rebase_pushed",
+                    detail.clone(),
+                    Some(telemetry.clone()),
+                    None,
+                ));
+            })
+            .await?;
+            let event = helpers::build_task_event(
+                task_id,
+                gate_turn,
+                "conflict_gate",
+                "pr_conflict_gate",
+                harness_core::types::Decision::Complete,
+                Some("resumed PR conflict gate rebased and pushed".to_string()),
+                Some(format!("pr={pr_num}")),
+                Some(telemetry),
+                None,
+                detail,
+            );
+            if let Err(error) = events.log(&event).await {
+                tracing::warn!("failed to log pr_conflict_gate event: {error}");
+            }
+            Ok(ConflictGateOutcome::RebasePushed)
+        }
+        Ok(ConflictCheckOutcome::ManualResolutionRequired) => {
+            persist_failure(
+                "manual_resolution_required",
+                format!(
+                    "pr:{pr_num} is conflicting and rebase was not pushed; manual resolution required"
+                ),
+                detail,
+                Some(telemetry),
+                None,
+            )
+            .await
+        }
+        Err(parse_err) => {
+            persist_failure(
+                "malformed_output",
+                format!(
+                    "pr:{pr_num} conflict gate failed closed; manual resolution required: malformed output ({parse_err})"
+                ),
+                detail,
+                Some(telemetry),
+                None,
+            )
+            .await
+        }
+    }
+}
+
 pub(crate) async fn run_task(
     store: &TaskStore,
     task_id: &TaskId,
@@ -758,15 +1018,33 @@ pub(crate) async fn run_task(
         return Ok(());
     }
 
-    // Conflict resolution gate: host-side GitHub/git inspection is disabled by
-    // project policy. On resume paths, ask the agent/reviewer loop to inspect
-    // and resolve any conflicts instead of probing from the server process.
-    if was_resumed_pr {
-        use conflict_resolver::{assess_pr_conflict, PrConflictSize};
-        let PrConflictSize::Unknown(reason) = assess_pr_conflict(pr_num, &project).await;
-        tracing::debug!(pr = pr_num, reason, "conflict assessment delegated");
-    }
-    let rebase_pushed = false;
+    let rebase_pushed = if was_resumed_pr {
+        match run_resumed_pr_conflict_gate(
+            store,
+            task_id,
+            agent,
+            req,
+            &project,
+            pr_num,
+            &repo_slug,
+            &context_items,
+            &interceptors,
+            &events,
+            &cargo_env,
+            turn_timeout,
+            effective_max_turns,
+            &mut turns_used,
+            turns_used_acc,
+        )
+        .await?
+        {
+            ConflictGateOutcome::Clean => false,
+            ConflictGateOutcome::RebasePushed => true,
+            ConflictGateOutcome::Failed => return Ok(()),
+        }
+    } else {
+        false
+    };
 
     // Agent review loop (if enabled and reviewer available, and not skipped by triage complexity)
     let mut agent_pushed_commit = false;

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -1569,6 +1569,7 @@ mod tests {
     /// returns pre-configured responses in order.
     struct PhaseCapturingAgent {
         phases: tokio::sync::Mutex<Vec<Option<ExecutionPhase>>>,
+        prompts: tokio::sync::Mutex<Vec<String>>,
         responses: tokio::sync::Mutex<Vec<String>>,
     }
 
@@ -1576,12 +1577,17 @@ mod tests {
         fn new(responses: Vec<String>) -> Arc<Self> {
             Arc::new(Self {
                 phases: tokio::sync::Mutex::new(Vec::new()),
+                prompts: tokio::sync::Mutex::new(Vec::new()),
                 responses: tokio::sync::Mutex::new(responses),
             })
         }
 
         async fn captured_phases(&self) -> Vec<Option<ExecutionPhase>> {
             self.phases.lock().await.clone()
+        }
+
+        async fn captured_prompts(&self) -> Vec<String> {
+            self.prompts.lock().await.clone()
         }
 
         async fn next_response(&self) -> String {
@@ -1608,6 +1614,20 @@ mod tests {
         }
     }
 
+    async fn wait_for_captured_prompts(
+        agent: &PhaseCapturingAgent,
+        min_count: usize,
+    ) -> Vec<String> {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let prompts = agent.captured_prompts().await;
+            if prompts.len() >= min_count || Instant::now() >= deadline {
+                return prompts;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
+
     #[async_trait]
     impl harness_core::agent::CodeAgent for PhaseCapturingAgent {
         fn name(&self) -> &str {
@@ -1620,6 +1640,7 @@ mod tests {
 
         async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
             self.phases.lock().await.push(req.execution_phase);
+            self.prompts.lock().await.push(req.prompt.clone());
             let output = self.next_response().await;
             Ok(AgentResponse {
                 output,
@@ -1637,6 +1658,7 @@ mod tests {
             tx: tokio::sync::mpsc::Sender<StreamItem>,
         ) -> harness_core::error::Result<()> {
             self.phases.lock().await.push(req.execution_phase);
+            self.prompts.lock().await.push(req.prompt.clone());
             let output = self.next_response().await;
             if !output.is_empty() {
                 if let Err(e) = tx.send(StreamItem::MessageDelta { text: output }).await {
@@ -1778,6 +1800,212 @@ mod tests {
             phases[1],
             Some(ExecutionPhase::Execution),
             "review loop turn must use Execution phase (agent needs write access to fix bot comments)"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resumed_pr_manual_conflict_fails_before_review_loop() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let store =
+            TaskStore::open_with_database_url(&dir.path().join("tasks.db"), Some(&database_url))
+                .await?;
+        let skills = Arc::new(RwLock::new(harness_skills::store::SkillStore::new()));
+        let events = Arc::new(
+            harness_observe::event_store::EventStore::new_with_database_url(
+                dir.path(),
+                Some(&database_url),
+            )
+            .await?,
+        );
+
+        let agent = PhaseCapturingAgent::new(vec![
+            "PR_URL=https://github.com/owner/repo/pull/7\nWAITING".into(),
+            "MANUAL_RESOLUTION_REQUIRED".into(),
+        ]);
+
+        let req = CreateTaskRequest {
+            pr: Some(7),
+            project: Some(dir.path().to_path_buf()),
+            wait_secs: 0,
+            max_rounds: Some(1),
+            turn_timeout_secs: 30,
+            ..Default::default()
+        };
+
+        let queue = crate::task_queue::TaskQueue::unbounded();
+        let permit = queue.acquire("test", 0).await?;
+        let task_id = spawn_task(
+            store.clone(),
+            agent.clone(),
+            None,
+            Default::default(),
+            skills,
+            events,
+            vec![],
+            req,
+            None,
+            permit,
+            None,
+            None,
+        )
+        .await;
+
+        wait_until(Duration::from_secs(15), || {
+            store
+                .get(&task_id)
+                .is_some_and(|state| matches!(state.status, TaskStatus::Failed))
+        })
+        .await?;
+
+        let phases = agent.captured_phases().await;
+        assert_eq!(
+            phases.len(),
+            2,
+            "manual-resolution outcome must stop before the normal review loop"
+        );
+        let state = store.get(&task_id).expect("task should exist");
+        assert!(
+            state
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("manual resolution required"),
+            "failure must preserve manual-resolution wording for intake safeguards"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resumed_pr_clean_conflict_gate_enters_review_loop() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let store =
+            TaskStore::open_with_database_url(&dir.path().join("tasks.db"), Some(&database_url))
+                .await?;
+        let skills = Arc::new(RwLock::new(harness_skills::store::SkillStore::new()));
+        let events = Arc::new(
+            harness_observe::event_store::EventStore::new_with_database_url(
+                dir.path(),
+                Some(&database_url),
+            )
+            .await?,
+        );
+
+        let agent = PhaseCapturingAgent::new(vec![
+            "PR_URL=https://github.com/owner/repo/pull/8\nWAITING".into(),
+            "CLEAN_PR".into(),
+            "LGTM".into(),
+        ]);
+
+        let req = CreateTaskRequest {
+            pr: Some(8),
+            project: Some(dir.path().to_path_buf()),
+            wait_secs: 0,
+            max_rounds: Some(1),
+            turn_timeout_secs: 30,
+            ..Default::default()
+        };
+
+        let queue = crate::task_queue::TaskQueue::unbounded();
+        let permit = queue.acquire("test", 0).await?;
+        let task_id = spawn_task(
+            store.clone(),
+            agent.clone(),
+            None,
+            Default::default(),
+            skills,
+            events,
+            vec![],
+            req,
+            None,
+            permit,
+            None,
+            None,
+        )
+        .await;
+
+        wait_until(Duration::from_secs(15), || {
+            store
+                .get(&task_id)
+                .is_some_and(|state| matches!(state.status, TaskStatus::Done))
+        })
+        .await?;
+
+        let phases = agent.captured_phases().await;
+        assert!(
+            phases.len() >= 3,
+            "clean resumed PR must enter the review loop after the conflict gate"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resumed_pr_rebase_push_requires_fresh_review_prompt() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let store =
+            TaskStore::open_with_database_url(&dir.path().join("tasks.db"), Some(&database_url))
+                .await?;
+        let skills = Arc::new(RwLock::new(harness_skills::store::SkillStore::new()));
+        let events = Arc::new(
+            harness_observe::event_store::EventStore::new_with_database_url(
+                dir.path(),
+                Some(&database_url),
+            )
+            .await?,
+        );
+
+        let agent = PhaseCapturingAgent::new(vec![
+            "PR_URL=https://github.com/owner/repo/pull/9\nWAITING".into(),
+            "REBASE_PUSHED".into(),
+            "LGTM".into(),
+        ]);
+
+        let req = CreateTaskRequest {
+            pr: Some(9),
+            project: Some(dir.path().to_path_buf()),
+            wait_secs: 0,
+            max_rounds: Some(1),
+            turn_timeout_secs: 30,
+            ..Default::default()
+        };
+
+        let queue = crate::task_queue::TaskQueue::unbounded();
+        let permit = queue.acquire("test", 0).await?;
+        let task_id = spawn_task(
+            store.clone(),
+            agent.clone(),
+            None,
+            Default::default(),
+            skills,
+            events,
+            vec![],
+            req,
+            None,
+            permit,
+            None,
+            None,
+        )
+        .await;
+
+        wait_until(Duration::from_secs(15), || {
+            store
+                .get(&task_id)
+                .is_some_and(|state| matches!(state.status, TaskStatus::Done))
+        })
+        .await?;
+
+        let prompts = wait_for_captured_prompts(agent.as_ref(), 3).await;
+        assert!(
+            prompts
+                .get(2)
+                .is_some_and(|prompt| prompt.contains("IMPORTANT — New review verification")),
+            "rebased resumed PRs must require a fresh reviewer pass before accepting LGTM"
         );
         Ok(())
     }

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -1822,7 +1822,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/7\nWAITING".into(),
+            "PR_URL=https://github.com/owner/repo/pull/7\nPUSHED_COMMIT=false\nWAITING".into(),
             "MANUAL_RESOLUTION_REQUIRED".into(),
         ]);
 
@@ -1896,7 +1896,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/8\nWAITING".into(),
+            "PR_URL=https://github.com/owner/repo/pull/8\nPUSHED_COMMIT=false\nWAITING".into(),
             "CLEAN_PR".into(),
             "LGTM".into(),
         ]);
@@ -1961,7 +1961,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/9\nWAITING".into(),
+            "PR_URL=https://github.com/owner/repo/pull/9\nPUSHED_COMMIT=false\nWAITING".into(),
             "REBASE_PUSHED".into(),
             "LGTM".into(),
         ]);


### PR DESCRIPTION
## Summary
- add a dedicated resumed-PR conflict gate that only allows clean or rebased outputs to reach review
- parse exact conflict-gate terminal tokens and fail closed on manual resolution, malformed output, timeouts, or agent failures
- harden PR prompts and add executor regressions for clean, manual, and rebased resumed PR paths

## Validation
- cargo fmt --all
- CARGO_TARGET_DIR=target/cargo-check cargo check --workspace --all-targets -j 6
- CARGO_TARGET_DIR=target/cargo-clippy cargo clippy --workspace --all-targets -j 6 -- -D warnings
- CARGO_TARGET_DIR=target/cargo-check-warnings RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets -j 6
- CARGO_TARGET_DIR=target/cargo-test-core cargo test -p harness-core prompts::pr::tests::
- CARGO_TARGET_DIR=target/cargo-test-server cargo test -p harness-server conflict_resolver::tests::
- CARGO_TARGET_DIR=target/cargo-test-server2 cargo test -p harness-server resumed_pr_
- CARGO_TARGET_DIR=target/cargo-test cargo test --workspace -j 6 (fails in unrelated pre-existing areas outside issue #990 scope, including multiple http/builders/skills tests)

Closes #990