### PR TITLE
fix(workflow): separate feedback claims from active PR tasks

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -29,8 +29,9 @@ Current externally configurable rules:
   - Enables or disables automatic background PR feedback sweeping.
 
 - `pr_feedback.claim_stale_after_secs`
-  - Maximum age for a claimed feedback workflow before the sweeper reclaims it
-    after an interrupted enqueue path.
+  - Maximum age for a `feedback_claimed` placeholder before the sweeper reclaims it
+    after an interrupted enqueue path. This does not reclaim live
+    `addressing_feedback` tasks with a real `active_task_id`.
 
 - `storage.schema_namespace`
   - Stable namespace used for workflow persistence in Postgres so multiple instances do not split by local `data_dir` path.

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::task_runner;
-use harness_workflow::issue_lifecycle::{workflow_id, IssueLifecycleState, IssueWorkflowInstance};
+use harness_workflow::issue_lifecycle::{
+    is_feedback_claim_placeholder, workflow_id, IssueLifecycleState, IssueWorkflowInstance,
+};
 
 fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
     task.external_id
@@ -497,6 +499,24 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
 
                 match task_routes::enqueue_task_background(state.clone(), req, None).await {
                     Ok(task_id) => {
+                        if let Err(e) = issue_workflows
+                            .bind_feedback_task_if_claimed(
+                                &workflow.project_id,
+                                workflow.repo.as_deref(),
+                                pr_number,
+                                &task_id.0,
+                            )
+                            .await
+                        {
+                            incomplete_projects.insert(project_key.clone());
+                            tracing::warn!(
+                                project_id = %workflow.project_id,
+                                pr = pr_number,
+                                task_id = %task_id.0,
+                                "workflow feedback sweep: failed to bind real task id: {e}"
+                            );
+                            continue;
+                        }
                         tracing::info!(
                             project_id = %workflow.project_id,
                             pr = pr_number,
@@ -824,6 +844,7 @@ fn workflow_recovery_task_ids(
             workflow
                 .active_task_id
                 .as_deref()
+                .filter(|task_id| !is_feedback_claim_placeholder(task_id))
                 .map(|task_id| harness_core::types::TaskId(task_id.to_string()))
         })
         .collect()
@@ -1368,6 +1389,20 @@ mod tests {
         let ids = workflow_recovery_task_ids(&[addressing, waiting, no_task]);
         assert_eq!(ids.len(), 1);
         assert!(ids.contains(&harness_core::types::TaskId("task-1".to_string())));
+    }
+
+    #[test]
+    fn workflow_recovery_task_ids_ignores_claim_placeholder_ids() {
+        let mut claimed = IssueWorkflowInstance::new(
+            "/tmp/project".to_string(),
+            Some("owner/repo".to_string()),
+            4,
+        );
+        claimed.state = IssueLifecycleState::AddressingFeedback;
+        claimed.active_task_id = Some("claim:workflow-4".to_string());
+
+        let ids = workflow_recovery_task_ids(&[claimed]);
+        assert!(ids.is_empty());
     }
 
     #[test]

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -279,6 +279,7 @@ mod startup_tests {
         let project_root = sandbox.path().join("project");
         std::fs::create_dir_all(&project_root)?;
         let data_dir = sandbox.path().join("data");
+        let database_url = crate::test_helpers::ensure_test_database_url_override()?;
 
         // Redirect HOME to an empty sandbox directory so that
         // $HOME/.harness/skills/ cannot shadow the persisted skill under
@@ -292,10 +293,12 @@ mod startup_tests {
         let startup = |project_root: &std::path::Path, data_dir: &std::path::Path| {
             let project_root = project_root.to_path_buf();
             let data_dir = data_dir.to_path_buf();
+            let database_url = database_url.clone();
             async move {
                 let mut config = HarnessConfig::default();
                 config.server.project_root = project_root;
                 config.server.data_dir = data_dir;
+                config.server.database_url = Some(database_url);
                 let server = Arc::new(HarnessServer::new(
                     config,
                     ThreadManager::new(),

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -318,6 +318,37 @@ fn workflow_reuse_strategy_reuses_only_active_pr_task_when_active_task_missing()
 }
 
 #[test]
+fn workflow_reuse_strategy_claimed_feedback_falls_back_to_pr() {
+    let mut workflow = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        42,
+    );
+    workflow.state = IssueLifecycleState::FeedbackClaimed;
+    workflow.pr_number = Some(100);
+    match workflow_reuse_strategy(&workflow) {
+        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:100"),
+        _ => panic!("expected pr-external-id reuse strategy"),
+    }
+}
+
+#[test]
+fn workflow_reuse_strategy_ignores_claim_placeholder_task_ids() {
+    let mut workflow = IssueWorkflowInstance::new(
+        "/tmp/project".to_string(),
+        Some("owner/repo".to_string()),
+        42,
+    );
+    workflow.state = IssueLifecycleState::AddressingFeedback;
+    workflow.active_task_id = Some("claim:workflow-42".to_string());
+    workflow.pr_number = Some(101);
+    match workflow_reuse_strategy(&workflow) {
+        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:101"),
+        _ => panic!("expected pr-external-id reuse strategy"),
+    }
+}
+
+#[test]
 fn workflow_reuse_strategy_rejects_failed_and_cancelled_workflows() {
     let mut failed = IssueWorkflowInstance::new(
         "/tmp/project".to_string(),

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -327,8 +327,8 @@ fn workflow_reuse_strategy_claimed_feedback_falls_back_to_pr() {
     workflow.state = IssueLifecycleState::FeedbackClaimed;
     workflow.pr_number = Some(100);
     match workflow_reuse_strategy(&workflow) {
-        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:100"),
-        _ => panic!("expected pr-external-id reuse strategy"),
+        WorkflowReuseStrategy::ActivePrExternalId(ext_id) => assert_eq!(ext_id, "pr:100"),
+        _ => panic!("expected active-pr-external-id reuse strategy"),
     }
 }
 
@@ -343,8 +343,8 @@ fn workflow_reuse_strategy_ignores_claim_placeholder_task_ids() {
     workflow.active_task_id = Some("claim:workflow-42".to_string());
     workflow.pr_number = Some(101);
     match workflow_reuse_strategy(&workflow) {
-        WorkflowReuseStrategy::PrExternalId(ext_id) => assert_eq!(ext_id, "pr:101"),
-        _ => panic!("expected pr-external-id reuse strategy"),
+        WorkflowReuseStrategy::ActivePrExternalId(ext_id) => assert_eq!(ext_id, "pr:101"),
+        _ => panic!("expected active-pr-external-id reuse strategy"),
     }
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -153,10 +153,12 @@ async fn make_test_state_with(
 async fn make_test_state_with_project_root(
     dir: &std::path::Path,
     project_root: &std::path::Path,
-    config: harness_core::config::HarnessConfig,
+    mut config: harness_core::config::HarnessConfig,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
     let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+    config.server.database_url = Some(database_url.clone());
     let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
         (cfg.enabled && crate::intake::feishu::has_verification_token(cfg))
             .then(|| Arc::new(crate::intake::feishu::FeishuIntake::new(cfg.clone())))
@@ -167,10 +169,15 @@ async fn make_test_state_with_project_root(
         thread_manager,
         agent_registry,
     ));
-    let tasks =
-        task_runner::TaskStore::open(&harness_core::config::dirs::default_db_path(dir, "tasks"))
-            .await?;
-    let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+    let tasks = task_runner::TaskStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "tasks"),
+        Some(&database_url),
+    )
+    .await?;
+    let events = Arc::new(
+        harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
+            .await?,
+    );
     let signal_detector = harness_gc::signal_detector::SignalDetector::new(
         server.config.gc.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
@@ -182,12 +189,14 @@ async fn make_test_state_with_project_root(
         draft_store,
         project_root.to_path_buf(),
     ));
-    let thread_db = crate::thread_db::ThreadDb::open(&harness_core::config::dirs::default_db_path(
-        dir, "threads",
-    ))
+    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "threads"),
+        Some(&database_url),
+    )
     .await?;
-    let _project_svc_tmp = crate::project_registry::ProjectRegistry::open(
+    let _project_svc_tmp = crate::project_registry::ProjectRegistry::open_with_database_url(
         &harness_core::config::dirs::default_db_path(dir, "projects"),
+        Some(&database_url),
     )
     .await?;
     let project_svc = crate::services::project::DefaultProjectService::new(
@@ -653,6 +662,7 @@ async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn health_degraded_multiple_subsystems() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
     Arc::get_mut(&mut state).unwrap().startup_statuses = vec![
@@ -676,6 +686,7 @@ async fn health_degraded_multiple_subsystems() -> anyhow::Result<()> {
 #[tokio::test]
 async fn health_degraded_both_conditions() -> anyhow::Result<()> {
     use std::sync::atomic::Ordering;
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
     Arc::get_mut(&mut state).unwrap().degraded_subsystems = vec!["workspace_manager"];
@@ -1065,6 +1076,7 @@ async fn create_task_empty_request_returns_bad_request() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn get_task_returns_not_found_for_missing_id() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
     let app = task_app(state);

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -139,9 +139,19 @@ struct PreparedEnqueue {
     reviewer: Option<Arc<dyn CodeAgent>>,
 }
 
+const WORKFLOW_FEEDBACK_SOURCE: &str = "workflow_feedback";
+
 enum PreparedEnqueueResult {
     Existing(TaskId),
     Ready(Box<PreparedEnqueue>),
+}
+
+fn is_workflow_feedback_request(req: &CreateTaskRequest) -> bool {
+    req.pr.is_some() && req.source.as_deref() == Some(WORKFLOW_FEEDBACK_SOURCE)
+}
+
+fn allows_terminal_pr_duplicate_reuse(req: &CreateTaskRequest) -> bool {
+    !is_workflow_feedback_request(req)
 }
 
 pub(crate) enum WorkflowReuseStrategy {
@@ -448,6 +458,9 @@ impl DefaultExecutionService {
         project_id: &str,
         req: &CreateTaskRequest,
     ) -> Option<TaskId> {
+        if !allows_terminal_pr_duplicate_reuse(req) {
+            return None;
+        }
         let ext_id = req.external_id.as_deref()?;
         let (existing_id, pr_url) = self
             .tasks
@@ -896,6 +909,24 @@ mod tests {
             ..Default::default()
         };
         assert!(DefaultExecutionService::validate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn workflow_feedback_pr_request_bypasses_terminal_pr_duplicate_reuse() {
+        let feedback_req = CreateTaskRequest {
+            pr: Some(123),
+            source: Some(WORKFLOW_FEEDBACK_SOURCE.to_string()),
+            ..Default::default()
+        };
+        assert!(is_workflow_feedback_request(&feedback_req));
+        assert!(!allows_terminal_pr_duplicate_reuse(&feedback_req));
+
+        let regular_pr_req = CreateTaskRequest {
+            pr: Some(123),
+            ..Default::default()
+        };
+        assert!(!is_workflow_feedback_request(&regular_pr_req));
+        assert!(allows_terminal_pr_duplicate_reuse(&regular_pr_req));
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -13,7 +13,9 @@ use async_trait::async_trait;
 use harness_agents::registry::AgentRegistry;
 use harness_core::{agent::CodeAgent, config::HarnessConfig, interceptor::TurnInterceptor};
 use harness_skills::store::SkillStore;
-use harness_workflow::issue_lifecycle::{IssueLifecycleState, IssueWorkflowInstance};
+use harness_workflow::issue_lifecycle::{
+    is_feedback_claim_placeholder, IssueLifecycleState, IssueWorkflowInstance,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
@@ -160,7 +162,9 @@ pub(crate) fn workflow_reuse_strategy(workflow: &IssueWorkflowInstance) -> Workf
         return WorkflowReuseStrategy::None;
     }
     if let Some(task_id) = workflow.active_task_id.as_ref() {
-        return WorkflowReuseStrategy::ActiveTask(harness_core::types::TaskId(task_id.clone()));
+        if !is_feedback_claim_placeholder(task_id) {
+            return WorkflowReuseStrategy::ActiveTask(harness_core::types::TaskId(task_id.clone()));
+        }
     }
     if let Some(pr_number) = workflow.pr_number {
         return WorkflowReuseStrategy::ActivePrExternalId(format!("pr:{pr_number}"));

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -102,6 +102,21 @@ pub fn test_database_url() -> anyhow::Result<String> {
     resolve_database_url(None)
 }
 
+pub fn ensure_test_database_url_override() -> anyhow::Result<String> {
+    if let Ok(url) = std::env::var("HARNESS_DATABASE_URL") {
+        let url = url.trim();
+        if !url.is_empty() {
+            return Ok(url.to_string());
+        }
+    }
+
+    let url = test_database_url()?;
+    unsafe {
+        std::env::set_var("HARNESS_DATABASE_URL", &url);
+    }
+    Ok(url)
+}
+
 pub fn is_pool_timeout(err: &anyhow::Error) -> bool {
     err.to_string()
         .contains("pool timed out while waiting for an open connection")
@@ -159,21 +174,27 @@ async fn make_state_inner(
     dir: &std::path::Path,
     project_root: &std::path::Path,
     agent_registry: AgentRegistry,
-    config: HarnessConfig,
+    mut config: HarnessConfig,
 ) -> anyhow::Result<AppState> {
     #[cfg(test)]
     let db_state_guard = Some(acquire_db_state_guard().await);
+    let database_url = ensure_test_database_url_override()?;
+    config.server.database_url = Some(database_url.clone());
     let server = Arc::new(HarnessServer::new(
         config,
         ThreadManager::new(),
         agent_registry,
     ));
     let password_reset_rate_limit = server.config.server.password_reset_rate_limit_per_hour;
-    let tasks = crate::task_runner::TaskStore::open(&harness_core::config::dirs::default_db_path(
-        dir, "tasks",
-    ))
+    let tasks = crate::task_runner::TaskStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "tasks"),
+        Some(&database_url),
+    )
     .await?;
-    let events = Arc::new(harness_observe::event_store::EventStore::new(dir).await?);
+    let events = Arc::new(
+        harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
+            .await?,
+    );
     let signal_detector = harness_gc::signal_detector::SignalDetector::new(
         server.config.gc.signal_thresholds.clone().into(),
         harness_core::types::ProjectId::new(),
@@ -185,9 +206,10 @@ async fn make_state_inner(
         draft_store,
         project_root.to_path_buf(),
     ));
-    let thread_db = crate::thread_db::ThreadDb::open(&harness_core::config::dirs::default_db_path(
-        dir, "threads",
-    ))
+    let thread_db = crate::thread_db::ThreadDb::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir, "threads"),
+        Some(&database_url),
+    )
     .await?;
     let (notification_tx, _) = tokio::sync::broadcast::channel(64);
     let task_queue = Arc::new(crate::task_queue::TaskQueue::new(&Default::default()));
@@ -195,8 +217,9 @@ async fn make_state_inner(
     // Service layer — use concrete defaults backed by the same infrastructure.
     let project_svc = crate::services::project::DefaultProjectService::new(
         // Tests that don't need a registry still get a lightweight one.
-        crate::project_registry::ProjectRegistry::open(
+        crate::project_registry::ProjectRegistry::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "projects"),
+            Some(&database_url),
         )
         .await?,
         project_root.to_path_buf(),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64},
-    Arc, OnceLock,
+    Arc, Mutex, OnceLock,
 };
 use std::time::Duration;
 
@@ -15,6 +15,7 @@ use tokio::sync::OnceCell;
 /// spurious "project root must be within HOME" failures.
 pub static HOME_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 static DB_AVAILABLE: OnceCell<bool> = OnceCell::const_new();
+static DATABASE_URL_ENV_LOCK: Mutex<()> = Mutex::new(());
 static DB_STATE_LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
 
 fn db_state_lock() -> Arc<tokio::sync::Mutex<()>> {
@@ -103,6 +104,9 @@ pub fn test_database_url() -> anyhow::Result<String> {
 }
 
 pub fn ensure_test_database_url_override() -> anyhow::Result<String> {
+    let _guard = DATABASE_URL_ENV_LOCK
+        .lock()
+        .expect("database URL env lock poisoned");
     if let Ok(url) = std::env::var("HARNESS_DATABASE_URL") {
         let url = url.trim();
         if !url.is_empty() {

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 pub use crate::issue_workflow_store::IssueWorkflowStore;
 
 const ISSUE_WORKFLOW_SCHEMA_VERSION: u32 = 1;
+pub const FEEDBACK_CLAIM_TASK_PREFIX: &str = "claim:";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -17,6 +18,7 @@ pub enum IssueLifecycleState {
     Implementing,
     PrOpen,
     AwaitingFeedback,
+    FeedbackClaimed,
     AddressingFeedback,
     ReadyToMerge,
     Blocked,
@@ -162,11 +164,21 @@ impl IssueWorkflowInstance {
                 self.pr_number = event.pr_number;
                 self.pr_url = event.pr_url.clone();
             }
-            IssueLifecycleEventKind::FeedbackTaskScheduled
-            | IssueLifecycleEventKind::FeedbackFound => {
+            IssueLifecycleEventKind::FeedbackFound => {
+                self.state = IssueLifecycleState::FeedbackClaimed;
+                self.active_task_id = None;
+                self.feedback_claimed_at = Some(event.at);
+                if event.pr_number.is_some() {
+                    self.pr_number = event.pr_number;
+                }
+                if event.pr_url.is_some() {
+                    self.pr_url = event.pr_url.clone();
+                }
+            }
+            IssueLifecycleEventKind::FeedbackTaskScheduled => {
                 self.state = IssueLifecycleState::AddressingFeedback;
                 self.active_task_id = event.task_id.clone();
-                self.feedback_claimed_at = Some(Utc::now());
+                self.feedback_claimed_at = None;
                 if event.pr_number.is_some() {
                     self.pr_number = event.pr_number;
                 }
@@ -212,6 +224,10 @@ impl IssueWorkflowInstance {
         self.last_event = Some(event);
         self.updated_at = Utc::now();
     }
+}
+
+pub fn is_feedback_claim_placeholder(task_id: &str) -> bool {
+    task_id.starts_with(FEEDBACK_CLAIM_TASK_PREFIX)
 }
 
 fn repo_key(repo: Option<&str>) -> &str {

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -5,8 +5,8 @@ use sqlx::Postgres;
 use std::path::Path;
 
 use crate::issue_lifecycle::{
-    legacy_schema_for_path, workflow_id, IssueLifecycleEvent, IssueLifecycleEventKind,
-    IssueLifecycleState, IssueWorkflowInstance,
+    is_feedback_claim_placeholder, legacy_schema_for_path, workflow_id, IssueLifecycleEvent,
+    IssueLifecycleEventKind, IssueLifecycleState, IssueWorkflowInstance,
 };
 
 static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
@@ -297,6 +297,43 @@ impl IssueWorkflowStore {
         .await
     }
 
+    pub async fn bind_feedback_task_if_claimed(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        pr_number: u64,
+        task_id: &str,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        let mut tx = self.pool.begin().await?;
+        let Some((wf_id, mut workflow)) = self
+            .load_for_update_by_pr(&mut tx, project_id, repo, pr_number)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let needs_binding = workflow.state == IssueLifecycleState::FeedbackClaimed
+            || workflow
+                .active_task_id
+                .as_deref()
+                .is_some_and(is_feedback_claim_placeholder);
+        if !needs_binding {
+            tx.commit().await?;
+            return Ok(Some(workflow));
+        }
+
+        let mut event = IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
+            .with_task_id(task_id.to_string());
+        if let Some(pr_url) = workflow.pr_url.clone() {
+            event = event.with_pr(pr_number, pr_url);
+        }
+        workflow.apply_event(event);
+        self.upsert_in_tx(&mut tx, &workflow).await?;
+        debug_assert_eq!(workflow.id, wf_id);
+        tx.commit().await?;
+        Ok(Some(workflow))
+    }
+
     pub async fn record_terminal_for_issue(
         &self,
         project_id: &str,
@@ -389,7 +426,7 @@ impl IssueWorkflowStore {
                AND (
                     data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
                     OR (
-                        data::jsonb->>'state' = 'addressing_feedback'
+                        data::jsonb->>'state' = 'feedback_claimed'
                         AND updated_at <= $2
                     )
                )
@@ -414,12 +451,10 @@ impl IssueWorkflowStore {
                     continue;
                 }
             };
-            let claim_id = format!("claim:{}", workflow.id);
             if let Some(pr_number) = workflow.pr_number {
                 let pr_url = workflow.pr_url.clone().unwrap_or_default();
                 workflow.apply_event(
-                    IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackTaskScheduled)
-                        .with_task_id(claim_id)
+                    IssueLifecycleEvent::new(IssueLifecycleEventKind::FeedbackFound)
                         .with_pr(pr_number, pr_url),
                 );
                 self.upsert_in_tx(&mut tx, &workflow).await?;

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use crate::issue_lifecycle::{
     is_feedback_claim_placeholder, legacy_schema_for_path, workflow_id, IssueLifecycleEvent,
     IssueLifecycleEventKind, IssueLifecycleState, IssueWorkflowInstance,
+    FEEDBACK_CLAIM_TASK_PREFIX,
 };
 
 static ISSUE_WORKFLOW_MIGRATIONS: &[Migration] = &[
@@ -420,13 +421,19 @@ impl IssueWorkflowStore {
         stale_before: DateTime<Utc>,
     ) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
         let mut tx = self.pool.begin().await?;
+        let claim_placeholder_like = format!("{FEEDBACK_CLAIM_TASK_PREFIX}%");
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT id, data FROM issue_workflows
              WHERE data::jsonb->>'pr_number' IS NOT NULL
                AND (
-                    data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
-                    OR (
+                     data::jsonb->>'state' IN ('pr_open', 'awaiting_feedback')
+                     OR (
                         data::jsonb->>'state' = 'feedback_claimed'
+                        AND updated_at <= $2
+                    )
+                    OR (
+                        data::jsonb->>'state' = 'addressing_feedback'
+                        AND data::jsonb->>'active_task_id' LIKE $3
                         AND updated_at <= $2
                     )
                )
@@ -436,6 +443,7 @@ impl IssueWorkflowStore {
         )
         .bind(limit)
         .bind(stale_before)
+        .bind(claim_placeholder_like)
         .fetch_all(&mut *tx)
         .await?;
 

--- a/crates/harness-workflow/src/issue_workflow_store_tests.rs
+++ b/crates/harness-workflow/src/issue_workflow_store_tests.rs
@@ -141,11 +141,12 @@ async fn issue_workflow_store_records_cancelled_pr_tasks_as_cancelled() -> anyho
 }
 
 #[tokio::test]
-async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()> {
+async fn claim_feedback_candidates_does_not_reclaim_live_addressing_feedback_tasks(
+) -> anyhow::Result<()> {
     let Some(store) = open_test_store().await? else {
         return Ok(());
     };
-    let project_id = "/tmp/project-stale-claim";
+    let project_id = "/tmp/project-live-feedback";
     store
         .record_issue_scheduled(project_id, Some("owner/repo"), 9, "task-1", &[], false)
         .await?;
@@ -163,12 +164,10 @@ async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()>
         .record_feedback_task_scheduled(project_id, Some("owner/repo"), 77, "task-2")
         .await?;
 
-    let mut workflow = store
+    let workflow = store
         .get_by_pr(project_id, Some("owner/repo"), 77)
         .await?
         .expect("workflow");
-    workflow.feedback_claimed_at = Some(Utc::now() - chrono::Duration::minutes(10));
-    store.upsert(&workflow).await?;
     sqlx::query(
         "UPDATE issue_workflows
          SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
@@ -181,9 +180,139 @@ async fn claim_feedback_candidates_reclaims_stale_claims() -> anyhow::Result<()>
     let claimed = store
         .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
         .await?;
+    assert!(claimed.is_empty());
+
+    let persisted = store
+        .get_by_pr(project_id, Some("owner/repo"), 77)
+        .await?
+        .expect("workflow");
+    assert_eq!(persisted.state, IssueLifecycleState::AddressingFeedback);
+    assert_eq!(persisted.active_task_id.as_deref(), Some("task-2"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_feedback_candidates_reclaims_stale_claim_placeholders() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-stale-claim";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 10, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            10,
+            "task-1",
+            78,
+            "https://github.com/owner/repo/pull/78",
+        )
+        .await?;
+
+    let claimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].pr_number, Some(77));
-    assert_eq!(claimed[0].state, IssueLifecycleState::AddressingFeedback);
+    assert_eq!(claimed[0].pr_number, Some(78));
+    assert_eq!(claimed[0].state, IssueLifecycleState::FeedbackClaimed);
+    assert!(claimed[0].active_task_id.is_none());
+
+    sqlx::query(
+        "UPDATE issue_workflows
+         SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
+         WHERE id = $1",
+    )
+    .bind(&claimed[0].id)
+    .execute(&store.pool)
+    .await?;
+
+    let reclaimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].pr_number, Some(78));
+    assert_eq!(reclaimed[0].state, IssueLifecycleState::FeedbackClaimed);
+    assert!(reclaimed[0].active_task_id.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn bind_feedback_task_if_claimed_promotes_placeholder_to_active_feedback(
+) -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-bind-feedback";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 11, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            11,
+            "task-1",
+            79,
+            "https://github.com/owner/repo/pull/79",
+        )
+        .await?;
+    let claimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].state, IssueLifecycleState::FeedbackClaimed);
+
+    let workflow = store
+        .bind_feedback_task_if_claimed(project_id, Some("owner/repo"), 79, "task-2")
+        .await?
+        .expect("workflow");
+    assert_eq!(workflow.state, IssueLifecycleState::AddressingFeedback);
+    assert_eq!(workflow.active_task_id.as_deref(), Some("task-2"));
+    assert!(workflow.feedback_claimed_at.is_none());
+
+    let persisted = store
+        .get_by_pr(project_id, Some("owner/repo"), 79)
+        .await?
+        .expect("workflow");
+    assert_eq!(persisted.state, IssueLifecycleState::AddressingFeedback);
+    assert_eq!(persisted.active_task_id.as_deref(), Some("task-2"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn release_feedback_claim_returns_placeholder_to_awaiting_feedback() -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-release-feedback";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 12, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            12,
+            "task-1",
+            80,
+            "https://github.com/owner/repo/pull/80",
+        )
+        .await?;
+    let claimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].state, IssueLifecycleState::FeedbackClaimed);
+
+    let workflow = store
+        .release_feedback_claim(project_id, Some("owner/repo"), 80, "enqueue failed")
+        .await?
+        .expect("workflow");
+    assert_eq!(workflow.state, IssueLifecycleState::AwaitingFeedback);
+    assert!(workflow.active_task_id.is_none());
+    assert!(workflow.feedback_claimed_at.is_none());
     Ok(())
 }
 

--- a/crates/harness-workflow/src/issue_workflow_store_tests.rs
+++ b/crates/harness-workflow/src/issue_workflow_store_tests.rs
@@ -239,6 +239,64 @@ async fn claim_feedback_candidates_reclaims_stale_claim_placeholders() -> anyhow
 }
 
 #[tokio::test]
+async fn claim_feedback_candidates_reclaims_legacy_addressing_feedback_placeholders(
+) -> anyhow::Result<()> {
+    let Some(store) = open_test_store().await? else {
+        return Ok(());
+    };
+    let project_id = "/tmp/project-legacy-claim";
+    store
+        .record_issue_scheduled(project_id, Some("owner/repo"), 12, "task-1", &[], false)
+        .await?;
+    store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            12,
+            "task-1",
+            80,
+            "https://github.com/owner/repo/pull/80",
+        )
+        .await?;
+    store
+        .record_feedback_task_scheduled(
+            project_id,
+            Some("owner/repo"),
+            80,
+            "claim:legacy-workflow-80",
+        )
+        .await?;
+
+    let workflow = store
+        .get_by_pr(project_id, Some("owner/repo"), 80)
+        .await?
+        .expect("workflow");
+    assert_eq!(workflow.state, IssueLifecycleState::AddressingFeedback);
+    assert_eq!(
+        workflow.active_task_id.as_deref(),
+        Some("claim:legacy-workflow-80")
+    );
+    sqlx::query(
+        "UPDATE issue_workflows
+         SET updated_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes'
+         WHERE id = $1",
+    )
+    .bind(&workflow.id)
+    .execute(&store.pool)
+    .await?;
+
+    let reclaimed = store
+        .claim_feedback_candidates(16, Utc::now() - chrono::Duration::minutes(5))
+        .await?;
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].pr_number, Some(80));
+    assert_eq!(reclaimed[0].state, IssueLifecycleState::FeedbackClaimed);
+    assert!(reclaimed[0].active_task_id.is_none());
+    assert!(reclaimed[0].feedback_claimed_at.is_some());
+    Ok(())
+}
+
+#[tokio::test]
 async fn bind_feedback_task_if_claimed_promotes_placeholder_to_active_feedback(
 ) -> anyhow::Result<()> {
     let Some(store) = open_test_store().await? else {

--- a/docs/issue-lifecycle-workflow-spec.md
+++ b/docs/issue-lifecycle-workflow-spec.md
@@ -187,6 +187,7 @@ scheduled
 implementing
 pr_open
 awaiting_feedback
+feedback_claimed
 addressing_feedback
 ready_to_merge
 blocked
@@ -211,6 +212,10 @@ cancelled
 
 - `awaiting_feedback`
   - The PR exists and the workflow is waiting for new actionable feedback or mergeability.
+
+- `feedback_claimed`
+  - Actionable PR feedback was claimed by the sweeper, but enqueue has not yet
+    persisted a real PR task id.
 
 - `addressing_feedback`
   - Actionable PR feedback has been detected and a fix round is active.
@@ -252,6 +257,7 @@ cancelled
 
 - `feedback_sweep_completed`
 - `feedback_found`
+- `feedback_task_scheduled`
 - `no_feedback_found`
 - `changes_requested`
 - `approved`
@@ -320,7 +326,7 @@ Instead it triggers a policy decision:
 
 ```text
 pr_open --feedback_sweep_completed--> awaiting_feedback
-awaiting_feedback --feedback_found--> addressing_feedback
+awaiting_feedback --feedback_found--> feedback_claimed
 awaiting_feedback --mergeable--> ready_to_merge
 awaiting_feedback --conflicting--> blocked
 awaiting_feedback --ci_failed--> awaiting_feedback
@@ -330,6 +336,8 @@ awaiting_feedback --no_feedback_found--> awaiting_feedback
 ### Feedback loop
 
 ```text
+feedback_claimed --feedback_task_scheduled--> addressing_feedback
+feedback_claimed --no_feedback_found--> awaiting_feedback
 addressing_feedback --implement_started--> addressing_feedback
 addressing_feedback --pr_detected--> pr_open
 addressing_feedback --implement_failed--> failed
@@ -437,7 +445,8 @@ This must be a first-class activity, not an incidental webhook side effect.
 
 - structured actionable feedback list
 - workflow events:
-  - `feedback_found`
+  - `feedback_found` (claim placeholder persisted)
+  - `feedback_task_scheduled`
   - `no_feedback_found`
   - `approved`
   - `changes_requested`


### PR DESCRIPTION
Closes #927

Separates feedback claim placeholders from active PR tasks so cleanup only affects completed issue tasks and preserves pending PR work.