### PR TITLE
fix(codex): consume structured Codex events

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -1,18 +1,22 @@
 use crate::cloud_setup;
 use crate::streaming::{
-    captured_stderr_tail, enrich_stream_exit_error, filter_agent_stderr_with_capture,
-    log_captured_stderr, send_stream_item, stream_child_output,
+    capture_agent_stderr_diagnostics, captured_stderr_tail, enrich_stream_exit_error,
+    log_captured_stderr_diagnostics, send_stream_item,
 };
 use async_trait::async_trait;
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
 use harness_core::config::agents::SandboxMode;
 use harness_core::config::agents::{CodexAgentConfig, CodexCloudConfig};
-use harness_core::types::{Capability, TokenUsage};
+use harness_core::types::{Capability, Item, TokenUsage};
 use harness_sandbox::{wrap_command, SandboxSpec};
+use serde_json::Value;
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 pub struct CodexAgent {
@@ -68,6 +72,9 @@ impl CodexAgent {
         let mut args = vec![
             OsString::from("exec"),
             OsString::from("--skip-git-repo-check"),
+            OsString::from("--json"),
+            OsString::from("--color"),
+            OsString::from("never"),
             OsString::from("-m"),
             OsString::from(model),
             OsString::from("-c"),
@@ -88,6 +95,264 @@ impl CodexAgent {
         args.push(OsString::from(req.prompt.clone()));
         args
     }
+}
+
+#[derive(Debug)]
+enum ParsedCodexExecEvent {
+    MessageDelta { item_id: String, text: String },
+    ToolOutputDelta { item_id: String, text: String },
+    ItemStarted { item: Item },
+    ItemCompleted { item_id: String, item: Item },
+    TokenUsage { usage: TokenUsage },
+    Warning { message: String },
+    Error { message: String },
+    Ignore,
+}
+
+#[derive(Debug, Default)]
+struct ParsedCodexExecOutput {
+    output: String,
+    items: Vec<Item>,
+    token_usage: TokenUsage,
+    warnings: Vec<String>,
+    structured_error: Option<String>,
+}
+
+fn json_str_field<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(|field| field.as_str()))
+}
+
+pub(crate) fn parse_codex_item(item: &Value) -> Option<Item> {
+    match json_str_field(item, &["type"])? {
+        "agent_message" | "agentMessage" => Some(Item::AgentReasoning {
+            content: json_str_field(item, &["text"])?.to_string(),
+        }),
+        "command_execution" | "commandExecution" => Some(Item::ShellCommand {
+            command: json_str_field(item, &["command"])?.to_string(),
+            exit_code: item
+                .get("exit_code")
+                .or_else(|| item.get("exitCode"))
+                .and_then(|field| field.as_i64())
+                .and_then(|code| i32::try_from(code).ok()),
+            stdout: json_str_field(item, &["aggregated_output", "aggregatedOutput"])
+                .unwrap_or_default()
+                .to_string(),
+            stderr: String::new(),
+        }),
+        _ => None,
+    }
+}
+
+pub(crate) fn parse_codex_token_usage(usage: &Value) -> Option<TokenUsage> {
+    let input_tokens = usage
+        .get("input_tokens")
+        .or_else(|| usage.get("inputTokens"))
+        .and_then(|field| field.as_u64())?;
+    let output_tokens = usage
+        .get("output_tokens")
+        .or_else(|| usage.get("outputTokens"))
+        .and_then(|field| field.as_u64())?;
+    let total_tokens = usage
+        .get("total_tokens")
+        .or_else(|| usage.get("totalTokens"))
+        .and_then(|field| field.as_u64())
+        .unwrap_or(input_tokens.saturating_add(output_tokens));
+
+    Some(TokenUsage {
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        cost_usd: 0.0,
+    })
+}
+
+fn parse_codex_exec_event_line(line: &str) -> Option<ParsedCodexExecEvent> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    let event_type = json_str_field(&value, &["type"])?;
+
+    match event_type {
+        "thread.started" | "turn.started" => Some(ParsedCodexExecEvent::Ignore),
+        "warning" => Some(ParsedCodexExecEvent::Warning {
+            message: json_str_field(&value, &["message"])
+                .or_else(|| value.get("warning").and_then(Value::as_str))
+                .unwrap_or("unknown warning")
+                .to_string(),
+        }),
+        "error" => Some(ParsedCodexExecEvent::Error {
+            message: json_str_field(&value, &["message"])
+                .or_else(|| {
+                    value
+                        .get("error")
+                        .and_then(|error| json_str_field(error, &["message"]))
+                })
+                .unwrap_or("unknown error")
+                .to_string(),
+        }),
+        "turn.completed" => value
+            .get("usage")
+            .and_then(parse_codex_token_usage)
+            .map(|usage| ParsedCodexExecEvent::TokenUsage { usage })
+            .or(Some(ParsedCodexExecEvent::Ignore)),
+        "item.started" | "item.completed" => {
+            let item_value = value.get("item")?;
+            let item_id = json_str_field(item_value, &["id"])?.to_string();
+            let item = parse_codex_item(item_value)?;
+            if event_type == "item.started" {
+                let _ = item_id;
+                Some(ParsedCodexExecEvent::ItemStarted { item })
+            } else {
+                Some(ParsedCodexExecEvent::ItemCompleted { item_id, item })
+            }
+        }
+        "item.delta" | "item/agentMessage/delta" | "item.agent_message.delta" => {
+            Some(ParsedCodexExecEvent::MessageDelta {
+                item_id: json_str_field(&value, &["item_id", "itemId"])?.to_string(),
+                text: json_str_field(&value, &["delta", "text"])?.to_string(),
+            })
+        }
+        "item/commandExecution/outputDelta"
+        | "item.command_execution.output_delta"
+        | "item.command_output_delta" => Some(ParsedCodexExecEvent::ToolOutputDelta {
+            item_id: json_str_field(&value, &["item_id", "itemId"])?.to_string(),
+            text: json_str_field(&value, &["delta", "text"])?.to_string(),
+        }),
+        _ => Some(ParsedCodexExecEvent::Ignore),
+    }
+}
+
+fn apply_codex_exec_event(
+    parsed: &mut ParsedCodexExecOutput,
+    seen_message_deltas: &mut HashSet<String>,
+    event: ParsedCodexExecEvent,
+    emitted_items: &mut Vec<StreamItem>,
+) {
+    match event {
+        ParsedCodexExecEvent::MessageDelta { item_id, text } => {
+            seen_message_deltas.insert(item_id);
+            parsed.output.push_str(&text);
+            emitted_items.push(StreamItem::MessageDelta { text });
+        }
+        ParsedCodexExecEvent::ToolOutputDelta { item_id, text } => {
+            emitted_items.push(StreamItem::ToolOutputDelta { item_id, text });
+        }
+        ParsedCodexExecEvent::ItemStarted { item } => {
+            emitted_items.push(StreamItem::ItemStarted { item });
+        }
+        ParsedCodexExecEvent::ItemCompleted { item_id, item } => {
+            if let Item::AgentReasoning { content } = &item {
+                if !seen_message_deltas.contains(&item_id) {
+                    parsed.output.push_str(content);
+                    emitted_items.push(StreamItem::MessageDelta {
+                        text: content.clone(),
+                    });
+                }
+            } else {
+                parsed.items.push(item.clone());
+            }
+            emitted_items.push(StreamItem::ItemCompleted { item });
+        }
+        ParsedCodexExecEvent::TokenUsage { usage } => {
+            parsed.token_usage = usage.clone();
+            emitted_items.push(StreamItem::TokenUsage { usage });
+        }
+        ParsedCodexExecEvent::Warning { message } => {
+            parsed.warnings.push(message.clone());
+            emitted_items.push(StreamItem::Warning { message });
+        }
+        ParsedCodexExecEvent::Error { message } => {
+            parsed.structured_error = Some(message.clone());
+            emitted_items.push(StreamItem::Error { message });
+        }
+        ParsedCodexExecEvent::Ignore => {}
+    }
+}
+
+fn parse_codex_exec_output(stdout: &str) -> harness_core::error::Result<ParsedCodexExecOutput> {
+    let mut parsed = ParsedCodexExecOutput::default();
+    let mut seen_message_deltas = HashSet::new();
+
+    for line in stdout.lines() {
+        let event = parse_codex_exec_event_line(line).ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to parse codex json line: {line}"
+            ))
+        })?;
+        let mut ignored = Vec::new();
+        apply_codex_exec_event(&mut parsed, &mut seen_message_deltas, event, &mut ignored);
+    }
+
+    Ok(parsed)
+}
+
+async fn stream_codex_exec_output(
+    child: &mut tokio::process::Child,
+    tx: &tokio::sync::mpsc::Sender<StreamItem>,
+    idle_timeout: Option<Duration>,
+) -> harness_core::error::Result<ParsedCodexExecOutput> {
+    let stdout = child.stdout.take().ok_or_else(|| {
+        harness_core::error::HarnessError::AgentExecution("codex stdout unavailable".into())
+    })?;
+    let mut lines = BufReader::new(stdout).lines();
+    let mut parsed = ParsedCodexExecOutput::default();
+    let mut seen_message_deltas = HashSet::new();
+
+    loop {
+        let maybe_line = if let Some(duration) = idle_timeout {
+            tokio::time::timeout(duration, lines.next_line())
+                .await
+                .map_err(|_| {
+                    #[cfg(unix)]
+                    crate::kill_process_group(child);
+                    harness_core::error::HarnessError::AgentExecution(format!(
+                        "codex stream idle timeout after {}s: zombie connection terminated",
+                        duration.as_secs()
+                    ))
+                })?
+                .map_err(|error| {
+                    harness_core::error::HarnessError::AgentExecution(format!(
+                        "failed reading codex stdout: {error}"
+                    ))
+                })?
+        } else {
+            lines.next_line().await.map_err(|error| {
+                harness_core::error::HarnessError::AgentExecution(format!(
+                    "failed reading codex stdout: {error}"
+                ))
+            })?
+        };
+        let Some(line) = maybe_line else {
+            break;
+        };
+        let event = parse_codex_exec_event_line(&line).ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to parse codex json line: {line}"
+            ))
+        })?;
+        let mut emitted_items = Vec::new();
+        apply_codex_exec_event(
+            &mut parsed,
+            &mut seen_message_deltas,
+            event,
+            &mut emitted_items,
+        );
+        for item in emitted_items {
+            let item_label = match &item {
+                StreamItem::ItemStarted { .. } => "item_started",
+                StreamItem::MessageDelta { .. } => "message_delta",
+                StreamItem::ToolOutputDelta { .. } => "tool_output_delta",
+                StreamItem::ItemCompleted { .. } => "item_completed",
+                StreamItem::TokenUsage { .. } => "token_usage",
+                StreamItem::Warning { .. } => "warning",
+                StreamItem::Error { .. } => "error",
+                StreamItem::ApprovalRequest { .. } => "approval_request",
+                StreamItem::Done => "done",
+            };
+            send_stream_item(tx, item, "codex", item_label).await?;
+        }
+    }
+
+    Ok(parsed)
 }
 
 #[derive(Debug)]
@@ -286,7 +551,7 @@ impl CodeAgent for CodexAgent {
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        log_captured_stderr(&stderr, self.name());
+        log_captured_stderr_diagnostics(&stderr, self.name());
 
         if !output.status.success() {
             if harness_core::error::is_billing_failure_message(&stderr) {
@@ -307,11 +572,19 @@ impl CodeAgent for CodexAgent {
             )));
         }
 
+        let parsed = parse_codex_exec_output(&stdout)?;
+        if let Some(message) = parsed.structured_error {
+            return Err(harness_core::error::HarnessError::AgentExecution(message));
+        }
+        for warning in &parsed.warnings {
+            tracing::warn!(agent = self.name(), "{warning}");
+        }
+
         Ok(AgentResponse {
-            output: stdout,
+            output: parsed.output,
             stderr,
-            items: Vec::new(),
-            token_usage: TokenUsage::default(),
+            items: parsed.items,
+            token_usage: parsed.token_usage,
             model: "codex".to_string(),
             exit_code: output.status.code(),
         })
@@ -395,7 +668,7 @@ impl CodeAgent for CodexAgent {
             let agent = self.name().to_string();
             let captured = Arc::clone(&stderr_capture);
             stderr_task = Some(tokio::spawn(async move {
-                filter_agent_stderr_with_capture(stderr, &agent, Some(captured)).await;
+                capture_agent_stderr_diagnostics(stderr, &agent, Some(captured)).await;
             }));
         }
 
@@ -403,7 +676,7 @@ impl CodeAgent for CodexAgent {
             .stream_timeout_secs
             .filter(|&s| s > 0)
             .map(std::time::Duration::from_secs);
-        let stream_result = stream_child_output(&mut child, &tx, self.name(), idle_timeout).await;
+        let stream_result = stream_codex_exec_output(&mut child, &tx, idle_timeout).await;
         let stream_send_failed = matches!(
             &stream_result,
             Err(harness_core::error::HarnessError::AgentExecution(message))
@@ -420,7 +693,31 @@ impl CodeAgent for CodexAgent {
         if let Some(stderr_task) = stderr_task {
             let _ = stderr_task.await;
         }
-        if let Err(error) = stream_result {
+        let parsed = match stream_result {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                let stderr = captured_stderr_tail(&stderr_capture);
+                if !stderr.is_empty() {
+                    if harness_core::error::is_billing_failure_message(&stderr) {
+                        return Err(harness_core::error::HarnessError::BillingFailed(format!(
+                            "codex billing failure (streamed exit): {stderr}"
+                        )));
+                    }
+                    if harness_core::error::is_quota_failure_message(&stderr) {
+                        return Err(harness_core::error::HarnessError::QuotaExhausted(format!(
+                            "codex quota exhausted (streamed exit): {stderr}"
+                        )));
+                    }
+                }
+                return Err(enrich_stream_exit_error(error, &stderr));
+            }
+        };
+        let status = child.wait().await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed waiting for codex process: {error}"
+            ))
+        })?;
+        if !status.success() {
             let stderr = captured_stderr_tail(&stderr_capture);
             if !stderr.is_empty() {
                 if harness_core::error::is_billing_failure_message(&stderr) {
@@ -434,7 +731,15 @@ impl CodeAgent for CodexAgent {
                     )));
                 }
             }
-            return Err(enrich_stream_exit_error(error, &stderr));
+            return Err(enrich_stream_exit_error(
+                harness_core::error::HarnessError::AgentExecution(format!(
+                    "codex exited with {status}"
+                )),
+                &stderr,
+            ));
+        }
+        if let Some(message) = parsed.structured_error {
+            return Err(harness_core::error::HarnessError::AgentExecution(message));
         }
         send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;
         Ok(())
@@ -519,6 +824,132 @@ mod tests {
             fs::set_permissions(&path, perms).expect("set executable permissions");
         }
         (dir, path)
+    }
+
+    #[test]
+    fn base_args_enable_structured_json_stdout() {
+        let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
+        let request = AgentRequest {
+            prompt: "ping".to_string(),
+            project_root: PathBuf::from("/tmp/project"),
+            ..Default::default()
+        };
+
+        let args: Vec<String> = agent
+            .base_args(&request)
+            .iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+
+        assert!(args.iter().any(|arg| arg == "--json"));
+        assert!(args.windows(2).any(|window| window == ["--color", "never"]));
+    }
+
+    #[test]
+    fn parse_exec_agent_message_completion() {
+        let line = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}"#;
+        let event = parse_codex_exec_event_line(line).expect("event should parse");
+        match event {
+            ParsedCodexExecEvent::ItemCompleted { item_id, item } => {
+                assert_eq!(item_id, "item_0");
+                assert_eq!(
+                    item,
+                    Item::AgentReasoning {
+                        content: "hi".into()
+                    }
+                );
+            }
+            other => panic!("expected item completion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_exec_command_item_started() {
+        let line = r#"{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"pwd","aggregated_output":"","exit_code":null,"status":"in_progress"}}"#;
+        let event = parse_codex_exec_event_line(line).expect("event should parse");
+        match event {
+            ParsedCodexExecEvent::ItemStarted { item } => {
+                assert_eq!(
+                    item,
+                    Item::ShellCommand {
+                        command: "pwd".into(),
+                        exit_code: None,
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    }
+                );
+            }
+            other => panic!("expected item start, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_exec_command_output_delta() {
+        let line = r#"{"type":"item.command_execution.output_delta","item_id":"item_0","delta":"cargo check\n"}"#;
+        let event = parse_codex_exec_event_line(line).expect("event should parse");
+        match event {
+            ParsedCodexExecEvent::ToolOutputDelta { item_id, text } => {
+                assert_eq!(item_id, "item_0");
+                assert_eq!(text, "cargo check\n");
+            }
+            other => panic!("expected tool output delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_exec_warning_and_error() {
+        let warning = parse_codex_exec_event_line(r#"{"type":"warning","message":"careful"}"#)
+            .expect("warning should parse");
+        let error = parse_codex_exec_event_line(
+            r#"{"type":"error","error":{"message":"something failed"}}"#,
+        )
+        .expect("error should parse");
+
+        assert!(matches!(
+            warning,
+            ParsedCodexExecEvent::Warning { ref message } if message == "careful"
+        ));
+        assert!(matches!(
+            error,
+            ParsedCodexExecEvent::Error { ref message } if message == "something failed"
+        ));
+    }
+
+    #[test]
+    fn parse_exec_turn_completed_usage() {
+        let line = r#"{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":4,"output_tokens":3,"reasoning_output_tokens":2}}"#;
+        let event = parse_codex_exec_event_line(line).expect("event should parse");
+        match event {
+            ParsedCodexExecEvent::TokenUsage { usage } => {
+                assert_eq!(
+                    usage,
+                    TokenUsage {
+                        input_tokens: 10,
+                        output_tokens: 3,
+                        total_tokens: 13,
+                        cost_usd: 0.0,
+                    }
+                );
+            }
+            other => panic!("expected token usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_exec_output_deduplicates_completed_agent_message_after_delta() {
+        let stdout = concat!(
+            r#"{"type":"item.delta","item_id":"item_0","delta":"he"}"#,
+            "\n",
+            r#"{"type":"item.delta","item_id":"item_0","delta":"llo"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello"}}"#,
+            "\n",
+            r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}"#,
+        );
+
+        let parsed = parse_codex_exec_output(stdout).expect("stdout should parse");
+        assert_eq!(parsed.output, "hello");
+        assert_eq!(parsed.token_usage.total_tokens, 3);
     }
 
     enum StreamObservation {
@@ -624,9 +1055,11 @@ mod tests {
     async fn execute_stream_emits_delta_before_completion_and_done() {
         let (dir, script) = write_executable_script(
             r#"
-printf 'hello\n'
+printf '%s\n' '{"type":"item.delta","item_id":"item_0","delta":"hello "}'
 sleep 0.2
-printf 'world\n'
+printf '%s\n' '{"type":"item.delta","item_id":"item_0","delta":"world"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello world"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}'
 "#,
         );
         let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
@@ -751,9 +1184,9 @@ exit 1
     async fn execute_stream_cancel_path_converges_when_receiver_dropped_mid_stream() {
         let (dir, script) = write_executable_script(
             r#"
-printf 'first\n'
+printf '%s\n' '{"type":"item.delta","item_id":"item_0","delta":"first"}'
 sleep 0.1
-printf 'second\n'
+printf '%s\n' '{"type":"item.delta","item_id":"item_0","delta":"second"}'
 sleep 30
 "#,
         );

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -103,6 +103,14 @@ impl CodexAdapter {
         Ok(id)
     }
 
+    async fn send_notification(
+        state: &mut AdapterState,
+        method: &str,
+        params: Value,
+    ) -> harness_core::error::Result<()> {
+        Self::send_json_line(state, &notification_payload(method, params)).await
+    }
+
     async fn send_response(
         state: &mut AdapterState,
         id: Value,
@@ -216,6 +224,8 @@ impl CodexAdapter {
                 }
             }
         }
+
+        Self::send_notification(state, "initialized", Value::Null).await?;
 
         let thread_id_request = Self::send_request(
             state,
@@ -403,14 +413,25 @@ impl AgentAdapter for CodexAdapter {
         let mut state = self.state.lock().await;
         let request_id: Value =
             serde_json::from_str(&id).unwrap_or_else(|_| Value::String(id.clone()));
-        let result = match decision {
-            ApprovalDecision::Accept => Value::String("approved".to_string()),
-            ApprovalDecision::Reject { reason } => json!({
-                "decision": "denied",
-                "reason": reason,
-            }),
-        };
+        let result = approval_decision_result(decision);
         Self::send_response(&mut state, request_id, result).await
+    }
+}
+
+fn notification_payload(method: &str, params: Value) -> Value {
+    json!({
+        "method": method,
+        "params": params,
+    })
+}
+
+fn approval_decision_result(decision: ApprovalDecision) -> Value {
+    match decision {
+        ApprovalDecision::Accept => json!({ "decision": "accept" }),
+        ApprovalDecision::Reject { reason } => json!({
+            "decision": "decline",
+            "reason": reason,
+        }),
     }
 }
 
@@ -776,6 +797,34 @@ mod tests {
     fn parse_invalid_json_returns_none() {
         assert!(parse_codex_message("not json").is_none());
         assert!(parse_codex_message("").is_none());
+    }
+
+    #[test]
+    fn initialized_notification_payload_has_no_request_id() {
+        assert_eq!(
+            notification_payload("initialized", Value::Null),
+            json!({
+                "method": "initialized",
+                "params": null,
+            })
+        );
+    }
+
+    #[test]
+    fn approval_decision_result_uses_app_server_shape() {
+        assert_eq!(
+            approval_decision_result(ApprovalDecision::Accept),
+            json!({ "decision": "accept" })
+        );
+        assert_eq!(
+            approval_decision_result(ApprovalDecision::Reject {
+                reason: "nope".into()
+            }),
+            json!({
+                "decision": "decline",
+                "reason": "nope",
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -1,34 +1,28 @@
+use crate::codex::{parse_codex_item, parse_codex_token_usage};
+use crate::streaming::capture_agent_stderr_diagnostics;
 use async_trait::async_trait;
-use harness_core::{
-    agent::AgentAdapter, agent::AgentEvent, agent::ApprovalDecision, agent::TurnRequest,
-};
-use serde_json::json;
+use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
+use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::ChildStdout;
 use tokio::sync::{mpsc, Mutex};
-use tracing;
 
-/// Codex App Server adapter (L3-L4).
-///
-/// Spawns `codex` as a long-lived stdio subprocess speaking JSON-RPC 2.0.
-/// Bidirectional: sends requests via stdin, reads responses/notifications from stdout.
-/// Supports approval gates, interrupt, and steer.
+type StdoutLines = Lines<BufReader<ChildStdout>>;
+
 pub struct CodexAdapter {
     cli_path: PathBuf,
     state: Arc<Mutex<AdapterState>>,
 }
 
-/// Persistent stdout reader kept alive across turns.
-type StdoutLines = Lines<BufReader<ChildStdout>>;
-
 struct AdapterState {
     child: Option<tokio::process::Child>,
     stdin: Option<tokio::process::ChildStdin>,
-    /// Stdout reader persisted between turns so subsequent turns can read events.
     stdout_lines: Option<StdoutLines>,
     next_id: u64,
+    thread_id: Option<String>,
+    active_turn_id: Option<String>,
 }
 
 impl AdapterState {
@@ -38,6 +32,8 @@ impl AdapterState {
             stdin: None,
             stdout_lines: None,
             next_id: 1,
+            thread_id: None,
+            active_turn_id: None,
         }
     }
 
@@ -48,6 +44,15 @@ impl AdapterState {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedCodexMessage {
+    Event(AgentEvent),
+    ThreadStarted { thread_id: String },
+    TurnStarted { turn_id: String },
+    Response { id: Value, result: Value },
+    Ignore,
+}
+
 impl CodexAdapter {
     pub fn new(cli_path: PathBuf) -> Self {
         Self {
@@ -56,74 +61,204 @@ impl CodexAdapter {
         }
     }
 
-    /// Send a JSON-RPC request via stdin and return the request id.
+    async fn send_json_line(
+        state: &mut AdapterState,
+        payload: &Value,
+    ) -> harness_core::error::Result<()> {
+        let stdin = state.stdin.as_mut().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("codex stdin not available".into())
+        })?;
+
+        let mut line = serde_json::to_string(payload).map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to serialize codex payload: {error}"
+            ))
+        })?;
+        line.push('\n');
+
+        stdin.write_all(line.as_bytes()).await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to write to codex: {error}"
+            ))
+        })?;
+        stdin.flush().await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to flush codex stdin: {error}"
+            ))
+        })
+    }
+
     async fn send_request(
         state: &mut AdapterState,
         method: &str,
-        params: serde_json::Value,
+        params: Value,
     ) -> harness_core::error::Result<u64> {
         let id = state.next_request_id();
-        let request = json!({
-            "jsonrpc": "2.0",
+        let payload = json!({
             "id": id,
             "method": method,
             "params": params,
         });
-
-        let stdin = state.stdin.as_mut().ok_or_else(|| {
-            harness_core::error::HarnessError::AgentExecution("codex stdin not available".into())
-        })?;
-
-        let mut line = serde_json::to_string(&request).map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to serialize request: {e}"
-            ))
-        })?;
-        line.push('\n');
-
-        stdin.write_all(line.as_bytes()).await.map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to write to codex: {e}"
-            ))
-        })?;
-        stdin.flush().await.map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to flush codex stdin: {e}"
-            ))
-        })?;
-
+        Self::send_json_line(state, &payload).await?;
         Ok(id)
     }
 
-    /// Send a JSON-RPC notification (no id, no response expected).
-    async fn send_notification(
+    async fn send_response(
         state: &mut AdapterState,
-        method: &str,
+        id: Value,
+        result: Value,
     ) -> harness_core::error::Result<()> {
-        let notification = json!({
-            "jsonrpc": "2.0",
-            "method": method,
+        let payload = json!({
+            "id": id,
+            "result": result,
         });
+        Self::send_json_line(state, &payload).await
+    }
 
-        let stdin = state.stdin.as_mut().ok_or_else(|| {
-            harness_core::error::HarnessError::AgentExecution("codex stdin not available".into())
-        })?;
-
-        let mut line = serde_json::to_string(&notification).map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!("failed to serialize: {e}"))
-        })?;
-        line.push('\n');
-
-        stdin.write_all(line.as_bytes()).await.map_err(|e| {
+    async fn read_next_message(
+        lines: &mut StdoutLines,
+    ) -> harness_core::error::Result<Option<ParsedCodexMessage>> {
+        let Some(line) = lines.next_line().await.map_err(|error| {
             harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to write to codex: {e}"
+                "failed reading codex app-server stdout: {error}"
+            ))
+        })?
+        else {
+            return Ok(None);
+        };
+        if line.trim().is_empty() {
+            return Ok(Some(ParsedCodexMessage::Ignore));
+        }
+        Ok(parse_codex_message(&line))
+    }
+
+    async fn ensure_child(
+        &self,
+        req: &TurnRequest,
+        state: &mut AdapterState,
+    ) -> harness_core::error::Result<()> {
+        if state.child.is_some() {
+            return Ok(());
+        }
+
+        let mut cmd = tokio::process::Command::new(&self.cli_path);
+        cmd.arg("app-server")
+            .arg("--listen")
+            .arg("stdio://")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .current_dir(&req.project_root)
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
+        crate::strip_claude_env(&mut cmd);
+
+        let mut child = cmd.spawn().map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to spawn codex app-server: {error}"
             ))
         })?;
-        stdin.flush().await.map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to flush codex stdin: {e}"
-            ))
+
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(async move {
+                capture_agent_stderr_diagnostics(stderr, "codex", None).await;
+            });
+        }
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex app-server stdout unavailable".into(),
+            )
         })?;
+        state.stdin = child.stdin.take();
+        state.stdout_lines = Some(BufReader::new(stdout).lines());
+        state.child = Some(child);
+
+        let init_id = Self::send_request(
+            state,
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": "harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "capabilities": {
+                    "experimentalApi": true,
+                }
+            }),
+        )
+        .await?;
+
+        let mut lines = state.stdout_lines.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex stdout reader not available".into(),
+            )
+        })?;
+        loop {
+            match Self::read_next_message(&mut lines).await? {
+                Some(ParsedCodexMessage::Response { id, .. })
+                    if response_id_matches(&id, init_id) =>
+                {
+                    break;
+                }
+                Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
+                    tracing::warn!(agent = "codex", "{message}");
+                }
+                Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
+                    return Err(harness_core::error::HarnessError::AgentExecution(message));
+                }
+                Some(_) => {}
+                None => {
+                    return Err(harness_core::error::HarnessError::AgentExecution(
+                        "codex app-server exited during initialize".into(),
+                    ));
+                }
+            }
+        }
+
+        let thread_id_request = Self::send_request(
+            state,
+            "thread/start",
+            json!({
+                "cwd": req.project_root,
+                "model": req.model,
+                "ephemeral": true,
+            }),
+        )
+        .await?;
+
+        loop {
+            match Self::read_next_message(&mut lines).await? {
+                Some(ParsedCodexMessage::ThreadStarted { thread_id }) => {
+                    state.thread_id = Some(thread_id);
+                    break;
+                }
+                Some(ParsedCodexMessage::Response { id, result })
+                    if response_id_matches(&id, thread_id_request) =>
+                {
+                    if let Some(thread_id) = thread_id_from_result(&result) {
+                        state.thread_id = Some(thread_id);
+                        break;
+                    }
+                }
+                Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
+                    tracing::warn!(agent = "codex", "{message}");
+                }
+                Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
+                    return Err(harness_core::error::HarnessError::AgentExecution(message));
+                }
+                Some(_) => {}
+                None => {
+                    return Err(harness_core::error::HarnessError::AgentExecution(
+                        "codex app-server exited before thread/start completed".into(),
+                    ));
+                }
+            }
+        }
+
+        state.stdout_lines = Some(lines);
+
         Ok(())
     }
 }
@@ -140,113 +275,119 @@ impl AgentAdapter for CodexAdapter {
         tx: mpsc::Sender<AgentEvent>,
     ) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
+        self.ensure_child(&req, &mut state).await?;
 
-        // Spawn codex if not already running
-        if state.child.is_none() {
-            let mut cmd = tokio::process::Command::new(&self.cli_path);
-            cmd.stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .current_dir(&req.project_root)
-                .kill_on_drop(true);
-            #[cfg(unix)]
-            crate::set_process_group(&mut cmd);
-            crate::strip_claude_env(&mut cmd);
+        let thread_id = state.thread_id.clone().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex thread/start did not yield a thread id".into(),
+            )
+        })?;
 
-            let mut child = cmd.spawn().map_err(|e| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "failed to spawn codex: {e}"
-                ))
-            })?;
+        Self::send_request(
+            &mut state,
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "cwd": req.project_root,
+                "model": req.model,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": req.prompt,
+                    }
+                ],
+            }),
+        )
+        .await?;
 
-            state.stdin = child.stdin.take();
-            let stdout = child.stdout.take().ok_or_else(|| {
-                harness_core::error::HarnessError::AgentExecution("no stdout from codex".into())
-            })?;
-            state.child = Some(child);
-
-            // Initialize handshake
-            Self::send_request(&mut state, "initialize", json!({})).await?;
-
-            // Persist the stdout reader across turns so subsequent turns can read events.
-            let mut lines = BufReader::new(stdout).lines();
-
-            // Read init response
-            if let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!(line = %line, "codex initialize response");
-            }
-
-            // Send initialized notification
-            Self::send_notification(&mut state, "initialized").await?;
-
-            state.stdout_lines = Some(lines);
-        }
-
-        // Send turn/start for both first and subsequent turns.
-        Self::send_request(&mut state, "turn/start", json!({ "text": req.prompt })).await?;
-
-        // Take the persistent stdout reader out of state so we can read from it
-        // without holding the lock (which would block concurrent steer/interrupt calls).
         let mut lines = state.stdout_lines.take().ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(
                 "codex stdout reader not available".into(),
             )
         })?;
-
-        // Release state lock before blocking on stdout.
         drop(state);
 
-        if tx.send(AgentEvent::TurnStarted).await.is_err() {
-            // Put reader back so future turns can still use it.
-            self.state.lock().await.stdout_lines = Some(lines);
-            return Ok(());
+        while let Some(message) = Self::read_next_message(&mut lines).await? {
+            match message {
+                ParsedCodexMessage::TurnStarted { turn_id } => {
+                    let mut guard = self.state.lock().await;
+                    guard.active_turn_id = Some(turn_id);
+                    drop(guard);
+                    if tx.send(AgentEvent::TurnStarted).await.is_err() {
+                        break;
+                    }
+                }
+                ParsedCodexMessage::ThreadStarted { thread_id } => {
+                    self.state.lock().await.thread_id = Some(thread_id);
+                }
+                ParsedCodexMessage::Response { .. } | ParsedCodexMessage::Ignore => {}
+                ParsedCodexMessage::Event(event) => {
+                    let is_terminal = matches!(
+                        event,
+                        AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
+                    );
+                    if matches!(event, AgentEvent::TurnCompleted { .. }) {
+                        self.state.lock().await.active_turn_id = None;
+                    }
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                    if is_terminal {
+                        break;
+                    }
+                }
+            }
         }
 
-        // Read event stream until the turn completes or the channel closes.
-        while let Ok(Some(line)) = lines.next_line().await {
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            if let Some(event) = parse_codex_message(&line) {
-                let is_turn_completed = matches!(event, AgentEvent::TurnCompleted { .. });
-                let is_error = matches!(event, AgentEvent::Error { .. });
-
-                if tx.send(event).await.is_err() {
-                    break;
-                }
-
-                if is_turn_completed || is_error {
-                    break;
-                }
-            }
-        }
-
-        // Return the reader to state for the next turn.
         self.state.lock().await.stdout_lines = Some(lines);
-
         Ok(())
     }
 
     async fn interrupt(&self) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
-        if state.stdin.is_some() {
-            // Try graceful interrupt first
-            if let Err(e) = Self::send_request(&mut state, "turn/interrupt", json!({})).await {
-                tracing::warn!("failed to send turn/interrupt: {e}, killing process");
-                if let Some(ref mut child) = state.child {
-                    if let Err(e) = child.kill().await {
-                        tracing::warn!(pid = ?child.id(), "kill failed: {e}");
-                    }
-                }
-            }
-        }
+        let Some(thread_id) = state.thread_id.clone() else {
+            return Ok(());
+        };
+        let Some(turn_id) = state.active_turn_id.clone() else {
+            return Ok(());
+        };
+        Self::send_request(
+            &mut state,
+            "turn/interrupt",
+            json!({
+                "threadId": thread_id,
+                "turnId": turn_id,
+            }),
+        )
+        .await?;
         Ok(())
     }
 
     async fn steer(&self, text: String) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
-        Self::send_request(&mut state, "turn/steer", json!({ "text": text })).await?;
+        let thread_id = state.thread_id.clone().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("codex thread id unavailable".into())
+        })?;
+        let turn_id = state.active_turn_id.clone().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "codex active turn unavailable".into(),
+            )
+        })?;
+        Self::send_request(
+            &mut state,
+            "turn/steer",
+            json!({
+                "threadId": thread_id,
+                "expectedTurnId": turn_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": text,
+                    }
+                ],
+            }),
+        )
+        .await?;
         Ok(())
     }
 
@@ -256,214 +397,381 @@ impl AgentAdapter for CodexAdapter {
         decision: ApprovalDecision,
     ) -> harness_core::error::Result<()> {
         let mut state = self.state.lock().await;
-        let decision_value = match decision {
-            ApprovalDecision::Accept => json!({ "decision": "accept" }),
-            ApprovalDecision::Reject { reason } => {
-                json!({ "decision": "reject", "reason": reason })
-            }
+        let request_id: Value =
+            serde_json::from_str(&id).unwrap_or_else(|_| Value::String(id.clone()));
+        let result = match decision {
+            ApprovalDecision::Accept => Value::String("approved".to_string()),
+            ApprovalDecision::Reject { reason } => json!({
+                "decision": "denied",
+                "reason": reason,
+            }),
         };
-
-        let stdin = state.stdin.as_mut().ok_or_else(|| {
-            harness_core::error::HarnessError::AgentExecution("codex stdin not available".into())
-        })?;
-
-        // Approval response uses the original request id
-        let response = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "result": decision_value,
-        });
-
-        let mut line = serde_json::to_string(&response).map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!("failed to serialize: {e}"))
-        })?;
-        line.push('\n');
-
-        stdin.write_all(line.as_bytes()).await.map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to write to codex: {e}"
-            ))
-        })?;
-        stdin.flush().await.map_err(|e| {
-            harness_core::error::HarnessError::AgentExecution(format!(
-                "failed to flush codex stdin: {e}"
-            ))
-        })?;
-        Ok(())
+        Self::send_response(&mut state, request_id, result).await
     }
 }
 
-/// Parse a Codex App Server JSON-RPC message into an AgentEvent.
-///
-/// Handles both notifications (method field, no id) and responses (id, result/error).
-pub fn parse_codex_message(line: &str) -> Option<AgentEvent> {
-    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+fn response_id_matches(actual: &Value, expected: u64) -> bool {
+    actual.as_u64() == Some(expected) || actual.as_str() == Some(&expected.to_string())
+}
 
-    // Notification: has "method" field
-    if let Some(method) = v.get("method").and_then(|m| m.as_str()) {
-        let params = v.get("params").cloned().unwrap_or(serde_json::Value::Null);
-        return parse_notification(method, &params);
+fn request_id_string(id: &Value) -> String {
+    match id {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn thread_id_from_result(result: &Value) -> Option<String> {
+    result
+        .get("thread")
+        .and_then(|thread| thread.get("id"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            result
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+fn parse_app_server_agent_event(
+    method: &str,
+    params: &Value,
+    id: Option<&Value>,
+) -> ParsedCodexMessage {
+    match method {
+        "thread/started" => {
+            let thread_id = params
+                .get("thread")
+                .and_then(|thread| thread.get("id"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            ParsedCodexMessage::ThreadStarted { thread_id }
+        }
+        "turn/started" => {
+            let turn_id = params
+                .get("turn")
+                .and_then(|turn| turn.get("id"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            ParsedCodexMessage::TurnStarted { turn_id }
+        }
+        "item/agentMessage/delta" => ParsedCodexMessage::Event(AgentEvent::MessageDelta {
+            text: params
+                .get("delta")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        }),
+        "item/commandExecution/outputDelta" => {
+            ParsedCodexMessage::Event(AgentEvent::ToolOutputDelta {
+                item_id: params
+                    .get("itemId")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                text: params
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        "item/started" => params
+            .get("item")
+            .and_then(parse_codex_item)
+            .map(|item| ParsedCodexMessage::Event(AgentEvent::ItemStartedPayload { item }))
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "item/completed" => params
+            .get("item")
+            .and_then(parse_codex_item)
+            .map(|item| ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload { item }))
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "thread/tokenUsage/updated" => params
+            .get("tokenUsage")
+            .and_then(|usage| usage.get("last"))
+            .and_then(parse_codex_token_usage)
+            .map(|usage| ParsedCodexMessage::Event(AgentEvent::TokenUsage { usage }))
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "warning" => ParsedCodexMessage::Event(AgentEvent::Warning {
+            message: params
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown warning")
+                .to_string(),
+        }),
+        "error" => ParsedCodexMessage::Event(AgentEvent::Error {
+            message: params
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .or_else(|| params.get("message").and_then(Value::as_str))
+                .unwrap_or("unknown error")
+                .to_string(),
+        }),
+        "turn/completed" => ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
+            output: params
+                .get("turn")
+                .and_then(|turn| turn.get("items"))
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().rev().find_map(parse_codex_item))
+                .and_then(|item| match item {
+                    harness_core::types::Item::AgentReasoning { content } => Some(content),
+                    _ => None,
+                })
+                .unwrap_or_default(),
+        }),
+        "item/commandExecution/requestApproval"
+        | "item/fileChange/requestApproval"
+        | "item/permissions/requestApproval" => {
+            ParsedCodexMessage::Event(AgentEvent::ApprovalRequest {
+                id: id.map(request_id_string).unwrap_or_default(),
+                command: params
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .or_else(|| params.get("reason").and_then(Value::as_str))
+                    .unwrap_or(method)
+                    .to_string(),
+            })
+        }
+        _ => ParsedCodexMessage::Ignore,
+    }
+}
+
+pub fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {
+    let value: Value = serde_json::from_str(line).ok()?;
+
+    if let Some(method) = value.get("method").and_then(Value::as_str) {
+        let params = value.get("params").cloned().unwrap_or(Value::Null);
+        return Some(parse_app_server_agent_event(
+            method,
+            &params,
+            value.get("id"),
+        ));
     }
 
-    // Response: has "id" field
-    if v.get("id").is_some() {
-        if let Some(error) = v.get("error") {
+    if let Some(id) = value.get("id") {
+        if let Some(error) = value.get("error") {
             let message = error
                 .get("message")
-                .and_then(|m| m.as_str())
+                .and_then(Value::as_str)
                 .unwrap_or("unknown error")
                 .to_string();
-            return Some(AgentEvent::Error { message });
+            return Some(ParsedCodexMessage::Event(AgentEvent::Error { message }));
         }
-        // Successful response — typically handled by request correlation, skip here
-        return None;
+        if let Some(result) = value.get("result") {
+            return Some(ParsedCodexMessage::Response {
+                id: id.clone(),
+                result: result.clone(),
+            });
+        }
     }
 
-    None
-}
-
-fn parse_notification(method: &str, params: &serde_json::Value) -> Option<AgentEvent> {
-    match method {
-        "turn/started" | "turn_started" => Some(AgentEvent::TurnStarted),
-        "item/started" | "item_started" => {
-            let item_type = params
-                .get("type")
-                .and_then(|t| t.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            Some(AgentEvent::ItemStarted { item_type })
-        }
-        "message/delta" | "message_delta" => {
-            let text = params
-                .get("text")
-                .and_then(|t| t.as_str())
-                .unwrap_or("")
-                .to_string();
-            Some(AgentEvent::MessageDelta { text })
-        }
-        "item/completed" | "item_completed" => Some(AgentEvent::ItemCompleted),
-        "turn/completed" | "turn_completed" => {
-            let output = params
-                .get("output")
-                .and_then(|o| o.as_str())
-                .unwrap_or("")
-                .to_string();
-            Some(AgentEvent::TurnCompleted { output })
-        }
-        "approval/request" | "approval_request" => {
-            let id = params
-                .get("id")
-                .and_then(|i| i.as_str())
-                .unwrap_or("")
-                .to_string();
-            let command = params
-                .get("command")
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string();
-            Some(AgentEvent::ApprovalRequest { id, command })
-        }
-        _ => None,
-    }
+    Some(ParsedCodexMessage::Ignore)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::types::Item;
 
     #[test]
-    fn parse_turn_started_notification() {
-        let line = r#"{"jsonrpc":"2.0","method":"turn/started","params":{}}"#;
-        let event = parse_codex_message(line).unwrap();
-        assert!(matches!(event, AgentEvent::TurnStarted));
-    }
-
-    #[test]
-    fn parse_item_started_notification() {
-        let line = r#"{"jsonrpc":"2.0","method":"item/started","params":{"type":"tool_call"}}"#;
-        let event = parse_codex_message(line).unwrap();
-        match event {
-            AgentEvent::ItemStarted { item_type } => assert_eq!(item_type, "tool_call"),
-            other => panic!("expected ItemStarted, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_message_delta_notification() {
-        let line =
-            r#"{"jsonrpc":"2.0","method":"message/delta","params":{"text":"Let me check..."}}"#;
-        let event = parse_codex_message(line).unwrap();
-        match event {
-            AgentEvent::MessageDelta { text } => assert_eq!(text, "Let me check..."),
-            other => panic!("expected MessageDelta, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_item_completed_notification() {
-        let line = r#"{"jsonrpc":"2.0","method":"item/completed","params":{}}"#;
-        let event = parse_codex_message(line).unwrap();
-        assert!(matches!(event, AgentEvent::ItemCompleted));
-    }
-
-    #[test]
-    fn parse_turn_completed_notification() {
-        let line =
-            r#"{"jsonrpc":"2.0","method":"turn/completed","params":{"output":"Bug fixed."}}"#;
-        let event = parse_codex_message(line).unwrap();
-        match event {
-            AgentEvent::TurnCompleted { output } => assert_eq!(output, "Bug fixed."),
-            other => panic!("expected TurnCompleted, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_approval_request_notification() {
-        let line = r#"{"jsonrpc":"2.0","method":"approval/request","params":{"id":"req-42","command":"rm -rf /tmp/test"}}"#;
-        let event = parse_codex_message(line).unwrap();
-        match event {
-            AgentEvent::ApprovalRequest { id, command } => {
-                assert_eq!(id, "req-42");
-                assert_eq!(command, "rm -rf /tmp/test");
+    fn parse_no_jsonrpc_thread_started_notification() {
+        let line = r#"{"method":"thread/started","params":{"thread":{"id":"thread-1"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::ThreadStarted {
+                thread_id: "thread-1".into()
             }
-            other => panic!("expected ApprovalRequest, got {other:?}"),
-        }
+        );
     }
 
     #[test]
-    fn parse_error_response() {
-        let line =
-            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}"#;
-        let event = parse_codex_message(line).unwrap();
-        match event {
-            AgentEvent::Error { message } => assert_eq!(message, "invalid request"),
-            other => panic!("expected Error, got {other:?}"),
-        }
+    fn parse_no_jsonrpc_turn_started_notification() {
+        let line = r#"{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"inProgress"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::TurnStarted {
+                turn_id: "turn-1".into()
+            }
+        );
     }
 
     #[test]
-    fn parse_success_response_returns_none() {
-        let line = r#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}"#;
-        assert!(parse_codex_message(line).is_none());
+    fn parse_agent_message_delta_notification() {
+        let line = r#"{"method":"item/agentMessage/delta","params":{"itemId":"item-1","threadId":"thread-1","turnId":"turn-1","delta":"hello"}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::MessageDelta {
+                text: "hello".into()
+            })
+        );
     }
 
     #[test]
-    fn parse_unknown_notification_returns_none() {
-        let line = r#"{"jsonrpc":"2.0","method":"custom/unknown","params":{}}"#;
-        assert!(parse_codex_message(line).is_none());
+    fn parse_command_output_delta_notification() {
+        let line = r#"{"method":"item/commandExecution/outputDelta","params":{"itemId":"item-1","threadId":"thread-1","turnId":"turn-1","delta":"cargo check\n"}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::ToolOutputDelta {
+                item_id: "item-1".into(),
+                text: "cargo check\n".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_item_started_payload_notification() {
+        let line = r#"{"method":"item/started","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","type":"commandExecution","command":"pwd","commandActions":[],"cwd":"/tmp","status":"inProgress","aggregatedOutput":null,"exitCode":null}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::ItemStartedPayload {
+                item: Item::ShellCommand {
+                    command: "pwd".into(),
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_item_completed_payload_notification() {
+        let line = r#"{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-2","type":"agentMessage","text":"done"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload {
+                item: Item::AgentReasoning {
+                    content: "done".into()
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_warning_notification() {
+        let line = r#"{"method":"warning","params":{"message":"be careful"}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::Warning {
+                message: "be careful".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_error_notification() {
+        let line = r#"{"method":"error","params":{"threadId":"thread-1","turnId":"turn-1","willRetry":false,"error":{"message":"boom"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::Error {
+                message: "boom".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_token_usage_notification() {
+        let line = r#"{"method":"thread/tokenUsage/updated","params":{"threadId":"thread-1","turnId":"turn-1","tokenUsage":{"last":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":15},"total":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":15}}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::TokenUsage {
+                usage: harness_core::types::TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 3,
+                    total_tokens: 15,
+                    cost_usd: 0.0,
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_turn_completed_with_empty_output() {
+        let line = r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"completed"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
+                output: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_turn_completed_with_embedded_output() {
+        let line = r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed","items":[{"id":"item-9","type":"agentMessage","text":"final answer"}]}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
+                output: "final answer".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_approval_request_with_numeric_id() {
+        let line = r#"{"id":42,"method":"item/commandExecution/requestApproval","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","command":"rm -rf /tmp/test"}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::ApprovalRequest {
+                id: "42".into(),
+                command: "rm -rf /tmp/test".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_success_response_without_jsonrpc() {
+        let line = r#"{"id":1,"result":{"thread":{"id":"thread-1"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Response {
+                id: Value::from(1),
+                result: json!({"thread":{"id":"thread-1"}}),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_error_response_without_jsonrpc() {
+        let line = r#"{"id":1,"error":{"message":"invalid request"}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::Error {
+                message: "invalid request".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_unknown_notification_returns_ignore() {
+        let line = r#"{"method":"custom/unknown","params":{}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(message, ParsedCodexMessage::Ignore);
     }
 
     #[test]
     fn parse_invalid_json_returns_none() {
         assert!(parse_codex_message("not json").is_none());
         assert!(parse_codex_message("").is_none());
-    }
-
-    #[test]
-    fn parse_snake_case_notifications() {
-        let line = r#"{"jsonrpc":"2.0","method":"turn_completed","params":{"output":"done"}}"#;
-        let event = parse_codex_message(line).unwrap();
-        assert!(matches!(event, AgentEvent::TurnCompleted { .. }));
     }
 
     #[tokio::test]

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -261,6 +261,10 @@ impl CodexAdapter {
 
         Ok(())
     }
+
+    async fn clear_active_turn_id(&self) {
+        self.state.lock().await.active_turn_id = None;
+    }
 }
 
 #[async_trait]
@@ -326,8 +330,8 @@ impl AgentAdapter for CodexAdapter {
                         event,
                         AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
                     );
-                    if matches!(event, AgentEvent::TurnCompleted { .. }) {
-                        self.state.lock().await.active_turn_id = None;
+                    if is_terminal {
+                        self.clear_active_turn_id().await;
                     }
                     if tx.send(event).await.is_err() {
                         break;
@@ -778,5 +782,15 @@ mod tests {
     async fn interrupt_noop_when_no_child() {
         let adapter = CodexAdapter::new(PathBuf::from("codex"));
         adapter.interrupt().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clear_active_turn_id_drops_stale_turn_state() {
+        let adapter = CodexAdapter::new(PathBuf::from("codex"));
+        adapter.state.lock().await.active_turn_id = Some("turn-1".into());
+
+        adapter.clear_active_turn_id().await;
+
+        assert_eq!(adapter.state.lock().await.active_turn_id, None);
     }
 }

--- a/crates/harness-agents/src/streaming.rs
+++ b/crates/harness-agents/src/streaming.rs
@@ -17,6 +17,18 @@ const MAX_STDERR_LINE_LEN: usize = 1000;
 const MAX_CAPTURED_STDERR_CHARS: usize = 4000;
 const MAX_STREAM_FAILURE_OUTPUT_CHARS: usize = 500;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StderrHandling {
+    ClassifyWarnings,
+    DiagnosticsOnly,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StderrLineDisposition {
+    Debug,
+    Warning,
+}
+
 /// Truncate a string to at most `max_bytes`, snapping to a char boundary.
 fn truncate_to_char_boundary(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
@@ -221,6 +233,22 @@ fn append_stderr_capture(captured: &Arc<Mutex<String>>, line: &str) {
     }
 }
 
+fn stderr_line_disposition(line: &str, handling: StderrHandling) -> Option<StderrLineDisposition> {
+    let trimmed = truncate_to_char_boundary(line, MAX_STDERR_LINE_LEN);
+    if trimmed.is_empty() {
+        return None;
+    }
+    if handling == StderrHandling::DiagnosticsOnly || is_agent_internal(trimmed) {
+        return Some(StderrLineDisposition::Debug);
+    }
+    let lower = trimmed.to_lowercase();
+    if STDERR_ERROR_KEYWORDS.iter().any(|kw| lower.contains(kw)) {
+        Some(StderrLineDisposition::Warning)
+    } else {
+        Some(StderrLineDisposition::Debug)
+    }
+}
+
 pub(crate) fn captured_stderr_tail(captured: &Arc<Mutex<String>>) -> String {
     captured
         .lock()
@@ -242,10 +270,11 @@ pub(crate) fn enrich_stream_exit_error(error: HarnessError, stderr_tail: &str) -
     }
 }
 
-pub(crate) async fn filter_agent_stderr_with_capture(
+async fn drain_agent_stderr_with_capture(
     stderr: tokio::process::ChildStderr,
     agent_name: &str,
     captured: Option<Arc<Mutex<String>>>,
+    handling: StderrHandling,
 ) {
     let reader = BufReader::new(stderr);
     let mut lines = reader.lines();
@@ -258,17 +287,40 @@ pub(crate) async fn filter_agent_stderr_with_capture(
         if let Some(captured) = captured.as_ref() {
             append_stderr_capture(captured, trimmed);
         }
-        if is_agent_internal(trimmed) {
-            tracing::debug!(agent = agent_name, "{trimmed}");
-            continue;
-        }
-        let lower = trimmed.to_lowercase();
-        if STDERR_ERROR_KEYWORDS.iter().any(|kw| lower.contains(kw)) {
-            tracing::warn!(agent = agent_name, "{trimmed}");
-        } else {
-            tracing::debug!(agent = agent_name, "{trimmed}");
+        match stderr_line_disposition(trimmed, handling) {
+            Some(StderrLineDisposition::Warning) => tracing::warn!(agent = agent_name, "{trimmed}"),
+            Some(StderrLineDisposition::Debug) => tracing::debug!(agent = agent_name, "{trimmed}"),
+            None => {}
         }
     }
+}
+
+pub(crate) async fn filter_agent_stderr_with_capture(
+    stderr: tokio::process::ChildStderr,
+    agent_name: &str,
+    captured: Option<Arc<Mutex<String>>>,
+) {
+    drain_agent_stderr_with_capture(
+        stderr,
+        agent_name,
+        captured,
+        StderrHandling::ClassifyWarnings,
+    )
+    .await;
+}
+
+pub(crate) async fn capture_agent_stderr_diagnostics(
+    stderr: tokio::process::ChildStderr,
+    agent_name: &str,
+    captured: Option<Arc<Mutex<String>>>,
+) {
+    drain_agent_stderr_with_capture(
+        stderr,
+        agent_name,
+        captured,
+        StderrHandling::DiagnosticsOnly,
+    )
+    .await;
 }
 
 /// Read agent stderr line-by-line. Lines matching error keywords are logged
@@ -279,23 +331,23 @@ pub(crate) async fn filter_agent_stderr(stderr: tokio::process::ChildStderr, age
 }
 
 /// Log stderr captured from a non-streaming `output()` call.
-pub(crate) fn log_captured_stderr(stderr: &str, agent_name: &str) {
+fn log_captured_stderr_with_mode(stderr: &str, agent_name: &str, handling: StderrHandling) {
     for line in stderr.lines() {
         let trimmed = truncate_to_char_boundary(line, MAX_STDERR_LINE_LEN);
-        if trimmed.is_empty() {
-            continue;
-        }
-        if is_agent_internal(trimmed) {
-            tracing::debug!(agent = agent_name, "{trimmed}");
-            continue;
-        }
-        let lower = trimmed.to_lowercase();
-        if STDERR_ERROR_KEYWORDS.iter().any(|kw| lower.contains(kw)) {
-            tracing::warn!(agent = agent_name, "{trimmed}");
-        } else {
-            tracing::debug!(agent = agent_name, "{trimmed}");
+        match stderr_line_disposition(trimmed, handling) {
+            Some(StderrLineDisposition::Warning) => tracing::warn!(agent = agent_name, "{trimmed}"),
+            Some(StderrLineDisposition::Debug) => tracing::debug!(agent = agent_name, "{trimmed}"),
+            None => {}
         }
     }
+}
+
+pub(crate) fn log_captured_stderr(stderr: &str, agent_name: &str) {
+    log_captured_stderr_with_mode(stderr, agent_name, StderrHandling::ClassifyWarnings);
+}
+
+pub(crate) fn log_captured_stderr_diagnostics(stderr: &str, agent_name: &str) {
+    log_captured_stderr_with_mode(stderr, agent_name, StderrHandling::DiagnosticsOnly);
 }
 
 pub(crate) async fn send_stream_item(
@@ -660,6 +712,22 @@ mod tests {
         let long_line = "x".repeat(2000);
         // Should not panic
         log_captured_stderr(&long_line, "agent");
+    }
+
+    #[test]
+    fn diagnostics_only_stderr_does_not_promote_markdown_context_lines() {
+        let disposition = stderr_line_disposition(
+            "110:- Full cargo test --workspace ... -Dwarnings",
+            StderrHandling::DiagnosticsOnly,
+        );
+        assert_eq!(disposition, Some(StderrLineDisposition::Debug));
+    }
+
+    #[test]
+    fn warning_classifier_preserves_real_warning_lines() {
+        let disposition =
+            stderr_line_disposition("warning: unused import", StderrHandling::ClassifyWarnings);
+        assert_eq!(disposition, Some(StderrLineDisposition::Warning));
     }
 
     #[test]

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -94,13 +94,15 @@ pub struct AgentResponse {
     pub exit_code: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StreamItem {
     ItemStarted { item: Item },
     MessageDelta { text: String },
+    ToolOutputDelta { item_id: String, text: String },
     ItemCompleted { item: Item },
     TokenUsage { usage: TokenUsage },
+    Warning { message: String },
     Error { message: String },
     ApprovalRequest { id: String, command: String },
     Done,
@@ -134,7 +136,14 @@ pub enum AgentEvent {
     ItemStarted {
         item_type: String,
     },
+    ItemStartedPayload {
+        item: Item,
+    },
     MessageDelta {
+        text: String,
+    },
+    ToolOutputDelta {
+        item_id: String,
         text: String,
     },
     ToolCall {
@@ -146,6 +155,15 @@ pub enum AgentEvent {
         command: String,
     },
     ItemCompleted,
+    ItemCompletedPayload {
+        item: Item,
+    },
+    TokenUsage {
+        usage: TokenUsage,
+    },
+    Warning {
+        message: String,
+    },
     TurnCompleted {
         output: String,
     },
@@ -226,8 +244,20 @@ mod tests {
             AgentEvent::ItemStarted {
                 item_type: "message".into(),
             },
+            AgentEvent::ItemStartedPayload {
+                item: Item::ShellCommand {
+                    command: "pwd".into(),
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                },
+            },
             AgentEvent::MessageDelta {
                 text: "hello".into(),
+            },
+            AgentEvent::ToolOutputDelta {
+                item_id: "item-1".into(),
+                text: "output".into(),
             },
             AgentEvent::ToolCall {
                 name: "bash".into(),
@@ -238,6 +268,17 @@ mod tests {
                 command: "rm -rf /tmp/test".into(),
             },
             AgentEvent::ItemCompleted,
+            AgentEvent::ItemCompletedPayload {
+                item: Item::AgentReasoning {
+                    content: "done".into(),
+                },
+            },
+            AgentEvent::TokenUsage {
+                usage: TokenUsage::default(),
+            },
+            AgentEvent::Warning {
+                message: "careful".into(),
+            },
             AgentEvent::TurnCompleted {
                 output: "done".into(),
             },

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -167,7 +167,7 @@ pub enum TurnStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -252,7 +252,7 @@ impl Turn {
 
 // === Item ===
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Item {
     UserMessage {

--- a/crates/harness-protocol/src/notifications.rs
+++ b/crates/harness-protocol/src/notifications.rs
@@ -16,6 +16,12 @@ pub enum Notification {
     ItemCompleted { turn_id: TurnId, item: Item },
     #[serde(rename = "message/delta", alias = "message_delta")]
     MessageDelta { turn_id: TurnId, text: String },
+    #[serde(rename = "tool/output_delta")]
+    ToolOutputDelta {
+        turn_id: TurnId,
+        item_id: String,
+        text: String,
+    },
     #[serde(rename = "turn/completed")]
     TurnCompleted {
         turn_id: TurnId,
@@ -38,6 +44,8 @@ pub enum Notification {
         request_id: String,
         command: String,
     },
+    #[serde(rename = "warning")]
+    Warning { turn_id: TurnId, message: String },
 }
 
 /// Notification envelope (no id field per JSON-RPC 2.0 spec).

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -297,9 +297,11 @@ async fn make_test_state_with_project_root(
 }
 
 async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<Arc<AppState>> {
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.database_url = Some(crate::test_helpers::test_database_url()?);
     make_test_state_with(
         dir,
-        harness_core::config::HarnessConfig::default(),
+        config,
         harness_agents::registry::AgentRegistry::new("test"),
     )
     .await
@@ -597,6 +599,7 @@ async fn call_health(state: Arc<AppState>) -> anyhow::Result<HealthResponse> {
 
 #[tokio::test]
 async fn health_endpoint_returns_ok_and_task_count() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
     let health = call_health(state).await?;
@@ -610,6 +613,7 @@ async fn health_endpoint_returns_ok_and_task_count() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn health_degraded_when_subsystem_missing() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
     Arc::get_mut(&mut state).unwrap().degraded_subsystems = vec!["q_value_store"];
@@ -635,6 +639,7 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
     let state_mut = Arc::get_mut(&mut state).unwrap();
@@ -703,6 +708,7 @@ async fn health_degraded_both_conditions() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn health_reports_critical_store_failure_details() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let mut state = make_test_state(dir.path()).await?;
     Arc::get_mut(&mut state).unwrap().startup_statuses = vec![
@@ -1557,6 +1563,7 @@ async fn get_task_hides_internal_system_input_metadata() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn get_task_includes_round_telemetry_and_failure() -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
 

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -295,6 +295,17 @@ pub(crate) async fn process_stream_item(
                 },
             );
         }
+        StreamItem::ToolOutputDelta { item_id, text } => {
+            emit_runtime_notification(
+                notify_tx,
+                notification_tx,
+                Notification::ToolOutputDelta {
+                    turn_id: turn_id.clone(),
+                    item_id,
+                    text,
+                },
+            );
+        }
         StreamItem::ApprovalRequest { id, command } => {
             if let Err(err) = server.thread_manager.add_item(
                 thread_id,
@@ -316,6 +327,16 @@ pub(crate) async fn process_stream_item(
                     turn_id: turn_id.clone(),
                     request_id: id,
                     command,
+                },
+            );
+        }
+        StreamItem::Warning { message } => {
+            emit_runtime_notification(
+                notify_tx,
+                notification_tx,
+                Notification::Warning {
+                    turn_id: turn_id.clone(),
+                    message,
                 },
             );
         }

--- a/crates/harness-server/src/task_executor/helpers_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_tests.rs
@@ -953,3 +953,112 @@ async fn process_stream_item_approval_request_appends_item_and_emits_notificatio
         other => panic!("expected ApprovalRequest notification, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn process_stream_item_warning_emits_notification() {
+    use crate::server::HarnessServer;
+    use crate::thread_manager::ThreadManager;
+    use harness_agents::registry::AgentRegistry;
+    use harness_core::agent::StreamItem;
+    use harness_core::config::HarnessConfig;
+    use harness_core::types::AgentId;
+    use harness_protocol::notifications::RpcNotification;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+
+    let server = Arc::new(HarnessServer::new(
+        HarnessConfig::default(),
+        ThreadManager::new(),
+        AgentRegistry::new(""),
+    ));
+    let thread_id = server.thread_manager.start_thread(PathBuf::from("/tmp"));
+    let turn_id = server
+        .thread_manager
+        .start_turn(&thread_id, "task".to_string(), AgentId::new())
+        .unwrap();
+    let (notification_tx, mut notification_rx) = broadcast::channel::<RpcNotification>(16);
+
+    process_stream_item(
+        &server,
+        &None,
+        &None,
+        &notification_tx,
+        &thread_id,
+        &turn_id,
+        StreamItem::Warning {
+            message: "careful".to_string(),
+        },
+    )
+    .await;
+
+    let notif = notification_rx
+        .try_recv()
+        .expect("warning notification must be emitted");
+    match notif.notification {
+        harness_protocol::notifications::Notification::Warning {
+            turn_id: notif_turn_id,
+            message,
+        } => {
+            assert_eq!(notif_turn_id, turn_id);
+            assert_eq!(message, "careful");
+        }
+        other => panic!("expected Warning notification, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn process_stream_item_tool_output_delta_emits_notification() {
+    use crate::server::HarnessServer;
+    use crate::thread_manager::ThreadManager;
+    use harness_agents::registry::AgentRegistry;
+    use harness_core::agent::StreamItem;
+    use harness_core::config::HarnessConfig;
+    use harness_core::types::AgentId;
+    use harness_protocol::notifications::RpcNotification;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+
+    let server = Arc::new(HarnessServer::new(
+        HarnessConfig::default(),
+        ThreadManager::new(),
+        AgentRegistry::new(""),
+    ));
+    let thread_id = server.thread_manager.start_thread(PathBuf::from("/tmp"));
+    let turn_id = server
+        .thread_manager
+        .start_turn(&thread_id, "task".to_string(), AgentId::new())
+        .unwrap();
+    let (notification_tx, mut notification_rx) = broadcast::channel::<RpcNotification>(16);
+
+    process_stream_item(
+        &server,
+        &None,
+        &None,
+        &notification_tx,
+        &thread_id,
+        &turn_id,
+        StreamItem::ToolOutputDelta {
+            item_id: "item-1".to_string(),
+            text: "cargo check\n".to_string(),
+        },
+    )
+    .await;
+
+    let notif = notification_rx
+        .try_recv()
+        .expect("tool output notification must be emitted");
+    match notif.notification {
+        harness_protocol::notifications::Notification::ToolOutputDelta {
+            turn_id: notif_turn_id,
+            item_id,
+            text,
+        } => {
+            assert_eq!(notif_turn_id, turn_id);
+            assert_eq!(item_id, "item-1");
+            assert_eq!(text, "cargo check\n");
+        }
+        other => panic!("expected ToolOutputDelta notification, got {other:?}"),
+    }
+}

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -9,6 +9,43 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 
+fn bridge_agent_event(event: AgentEvent, output_buf: &mut String) -> Option<StreamItem> {
+    match event {
+        AgentEvent::ItemStartedPayload { item } => Some(StreamItem::ItemStarted { item }),
+        AgentEvent::MessageDelta { text } => {
+            output_buf.push_str(&text);
+            Some(StreamItem::MessageDelta { text })
+        }
+        AgentEvent::ToolOutputDelta { item_id, text } => {
+            Some(StreamItem::ToolOutputDelta { item_id, text })
+        }
+        AgentEvent::ApprovalRequest { id, command } => {
+            Some(StreamItem::ApprovalRequest { id, command })
+        }
+        AgentEvent::ItemCompletedPayload { item } => {
+            if let harness_core::types::Item::AgentReasoning { content } = &item {
+                output_buf.clear();
+                output_buf.push_str(content);
+            }
+            Some(StreamItem::ItemCompleted { item })
+        }
+        AgentEvent::TokenUsage { usage } => Some(StreamItem::TokenUsage { usage }),
+        AgentEvent::Warning { message } => Some(StreamItem::Warning { message }),
+        AgentEvent::Error { message } => Some(StreamItem::Error { message }),
+        AgentEvent::TurnCompleted { output } => {
+            let content = if output.is_empty() {
+                std::mem::take(output_buf)
+            } else {
+                output
+            };
+            Some(StreamItem::ItemCompleted {
+                item: harness_core::types::Item::AgentReasoning { content },
+            })
+        }
+        _ => None,
+    }
+}
+
 pub(crate) async fn run_turn_lifecycle(
     server: Arc<crate::server::HarnessServer>,
     thread_db: Option<crate::thread_db::ThreadDb>,
@@ -104,27 +141,7 @@ pub(crate) async fn run_turn_lifecycle(
         tokio::spawn(async move {
             let mut output_buf = String::new();
             while let Some(event) = event_rx.recv().await {
-                let maybe_item: Option<StreamItem> = match event {
-                    AgentEvent::MessageDelta { ref text } => {
-                        output_buf.push_str(text);
-                        Some(StreamItem::MessageDelta { text: text.clone() })
-                    }
-                    AgentEvent::ApprovalRequest { id, command } => {
-                        Some(StreamItem::ApprovalRequest { id, command })
-                    }
-                    AgentEvent::Error { message } => Some(StreamItem::Error { message }),
-                    AgentEvent::TurnCompleted { output } => {
-                        let content = if output.is_empty() {
-                            std::mem::take(&mut output_buf)
-                        } else {
-                            output
-                        };
-                        Some(StreamItem::ItemCompleted {
-                            item: harness_core::types::Item::AgentReasoning { content },
-                        })
-                    }
-                    _ => None,
-                };
+                let maybe_item = bridge_agent_event(event, &mut output_buf);
                 if let Some(item) = maybe_item {
                     if bridge_tx.send(item).await.is_err() {
                         return;
@@ -274,5 +291,80 @@ pub(crate) async fn run_turn_lifecycle(
             )
             .await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bridge_agent_event;
+    use harness_core::agent::{AgentEvent, StreamItem};
+    use harness_core::types::{Item, TokenUsage};
+
+    #[test]
+    fn bridge_preserves_warning_and_token_usage_events() {
+        let mut output_buf = String::new();
+
+        let warning = bridge_agent_event(
+            AgentEvent::Warning {
+                message: "careful".into(),
+            },
+            &mut output_buf,
+        );
+        let usage = bridge_agent_event(
+            AgentEvent::TokenUsage {
+                usage: TokenUsage {
+                    input_tokens: 1,
+                    output_tokens: 2,
+                    total_tokens: 3,
+                    cost_usd: 0.0,
+                },
+            },
+            &mut output_buf,
+        );
+
+        assert_eq!(
+            warning,
+            Some(StreamItem::Warning {
+                message: "careful".into()
+            })
+        );
+        assert_eq!(
+            usage,
+            Some(StreamItem::TokenUsage {
+                usage: TokenUsage {
+                    input_tokens: 1,
+                    output_tokens: 2,
+                    total_tokens: 3,
+                    cost_usd: 0.0,
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn bridge_uses_buffered_output_when_turn_completed_payload_is_empty() {
+        let mut output_buf = String::new();
+        let _ = bridge_agent_event(
+            AgentEvent::MessageDelta {
+                text: "hello".into(),
+            },
+            &mut output_buf,
+        );
+        let completed = bridge_agent_event(
+            AgentEvent::TurnCompleted {
+                output: String::new(),
+            },
+            &mut output_buf,
+        );
+
+        assert_eq!(
+            completed,
+            Some(StreamItem::ItemCompleted {
+                item: Item::AgentReasoning {
+                    content: "hello".into()
+                }
+            })
+        );
+        assert!(output_buf.is_empty());
     }
 }

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -9,7 +9,11 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 
-fn bridge_agent_event(event: AgentEvent, output_buf: &mut String) -> Option<StreamItem> {
+fn bridge_agent_event(
+    event: AgentEvent,
+    output_buf: &mut String,
+    emitted_agent_completion: &mut bool,
+) -> Option<StreamItem> {
     match event {
         AgentEvent::ItemStartedPayload { item } => Some(StreamItem::ItemStarted { item }),
         AgentEvent::MessageDelta { text } => {
@@ -26,6 +30,7 @@ fn bridge_agent_event(event: AgentEvent, output_buf: &mut String) -> Option<Stre
             if let harness_core::types::Item::AgentReasoning { content } = &item {
                 output_buf.clear();
                 output_buf.push_str(content);
+                *emitted_agent_completion = true;
             }
             Some(StreamItem::ItemCompleted { item })
         }
@@ -33,6 +38,10 @@ fn bridge_agent_event(event: AgentEvent, output_buf: &mut String) -> Option<Stre
         AgentEvent::Warning { message } => Some(StreamItem::Warning { message }),
         AgentEvent::Error { message } => Some(StreamItem::Error { message }),
         AgentEvent::TurnCompleted { output } => {
+            if *emitted_agent_completion {
+                output_buf.clear();
+                return None;
+            }
             let content = if output.is_empty() {
                 std::mem::take(output_buf)
             } else {
@@ -140,8 +149,10 @@ pub(crate) async fn run_turn_lifecycle(
         let bridge_tx = stream_tx;
         tokio::spawn(async move {
             let mut output_buf = String::new();
+            let mut emitted_agent_completion = false;
             while let Some(event) = event_rx.recv().await {
-                let maybe_item = bridge_agent_event(event, &mut output_buf);
+                let maybe_item =
+                    bridge_agent_event(event, &mut output_buf, &mut emitted_agent_completion);
                 if let Some(item) = maybe_item {
                     if bridge_tx.send(item).await.is_err() {
                         return;
@@ -303,12 +314,15 @@ mod tests {
     #[test]
     fn bridge_preserves_warning_and_token_usage_events() {
         let mut output_buf = String::new();
+        let mut warning_completion = false;
+        let mut usage_completion = false;
 
         let warning = bridge_agent_event(
             AgentEvent::Warning {
                 message: "careful".into(),
             },
             &mut output_buf,
+            &mut warning_completion,
         );
         let usage = bridge_agent_event(
             AgentEvent::TokenUsage {
@@ -320,6 +334,7 @@ mod tests {
                 },
             },
             &mut output_buf,
+            &mut usage_completion,
         );
 
         assert_eq!(
@@ -344,17 +359,20 @@ mod tests {
     #[test]
     fn bridge_uses_buffered_output_when_turn_completed_payload_is_empty() {
         let mut output_buf = String::new();
+        let mut emitted_agent_completion = false;
         let _ = bridge_agent_event(
             AgentEvent::MessageDelta {
                 text: "hello".into(),
             },
             &mut output_buf,
+            &mut emitted_agent_completion,
         );
         let completed = bridge_agent_event(
             AgentEvent::TurnCompleted {
                 output: String::new(),
             },
             &mut output_buf,
+            &mut emitted_agent_completion,
         );
 
         assert_eq!(
@@ -365,6 +383,40 @@ mod tests {
                 }
             })
         );
+        assert!(output_buf.is_empty());
+    }
+
+    #[test]
+    fn bridge_suppresses_duplicate_turn_completed_after_agent_message_completion() {
+        let mut output_buf = String::new();
+        let mut emitted_agent_completion = false;
+        let item_completed = bridge_agent_event(
+            AgentEvent::ItemCompletedPayload {
+                item: Item::AgentReasoning {
+                    content: "done".into(),
+                },
+            },
+            &mut output_buf,
+            &mut emitted_agent_completion,
+        );
+        let turn_completed = bridge_agent_event(
+            AgentEvent::TurnCompleted {
+                output: "done".into(),
+            },
+            &mut output_buf,
+            &mut emitted_agent_completion,
+        );
+
+        assert_eq!(
+            item_completed,
+            Some(StreamItem::ItemCompleted {
+                item: Item::AgentReasoning {
+                    content: "done".into()
+                }
+            })
+        );
+        assert!(emitted_agent_completion);
+        assert_eq!(turn_completed, None);
         assert!(output_buf.is_empty());
     }
 }

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -17,6 +17,7 @@ pub static HOME_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(())
 static DB_AVAILABLE: OnceCell<bool> = OnceCell::const_new();
 static DATABASE_URL_ENV_LOCK: Mutex<()> = Mutex::new(());
 static DB_STATE_LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+static TEST_DATABASE_URL: OnceLock<String> = OnceLock::new();
 
 fn db_state_lock() -> Arc<tokio::sync::Mutex<()>> {
     DB_STATE_LOCK
@@ -36,6 +37,11 @@ impl HomeGuard {
     /// The caller must hold `HOME_LOCK` for the lifetime of this guard.
     pub unsafe fn set(path: &std::path::Path) -> Self {
         let original = std::env::var("HOME").ok();
+        if TEST_DATABASE_URL.get().is_none() {
+            if let Ok(database_url) = resolve_database_url(None) {
+                let _ = TEST_DATABASE_URL.set(database_url);
+            }
+        }
         std::env::set_var("HOME", path);
         HomeGuard { original }
     }
@@ -100,7 +106,13 @@ pub async fn acquire_db_state_guard() -> tokio::sync::OwnedMutexGuard<()> {
 }
 
 pub fn test_database_url() -> anyhow::Result<String> {
-    resolve_database_url(None)
+    if let Some(database_url) = TEST_DATABASE_URL.get() {
+        return Ok(database_url.clone());
+    }
+
+    let database_url = resolve_database_url(None)?;
+    let _ = TEST_DATABASE_URL.set(database_url.clone());
+    Ok(database_url)
 }
 
 pub fn ensure_test_database_url_override() -> anyhow::Result<String> {


### PR DESCRIPTION
Closes #1034

## Summary
- switch Codex exec handling to structured JSONL parsing and keep stderr diagnostics-only
- repair the Codex app-server adapter handshake and preserve warning/tool/token events through the server bridge
- add parser, stderr, bridge, and test-stability coverage for the new structured event flow