### PR TITLE
Prepare pr:N branches with a review rebase stage

### DIFF
--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -23,11 +23,12 @@ pub use issue::{
 pub use parsing::{
     extract_pr_number, extract_review_issues, is_lgtm, is_quota_exhausted, is_waiting,
     parse_complexity, parse_created_issue_number, parse_github_pr_url, parse_issue_count,
-    parse_plan_issue, parse_pr_url, parse_pushed_commit, parse_triage, repo_slug_from_pr_url,
-    TriageComplexity, TriageDecision,
+    parse_plan_issue, parse_pr_review_prep_outcome, parse_pr_url, parse_pushed_commit,
+    parse_triage, repo_slug_from_pr_url, PrReviewPrepOutcome, TriageComplexity, TriageDecision,
 };
 pub use pr::{
-    check_existing_pr, check_resumed_pr_conflicts, continue_existing_pr, rebase_conflicting_pr,
+    check_existing_pr, check_resumed_pr_conflicts, continue_existing_pr, prepare_pr_for_review,
+    rebase_conflicting_pr,
 };
 pub use review::{
     agent_review_fix_prompt, agent_review_intervention_prompt, agent_review_prompt, is_approved,

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -1,5 +1,12 @@
 use super::last_non_empty_line;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrReviewPrepOutcome {
+    RebasePushed,
+    RebaseSkipped,
+    RebaseConflict { paths: Vec<String> },
+}
+
 /// Extract `ISSUE:` prefixed lines from agent review output.
 pub fn extract_review_issues(output: &str) -> Vec<String> {
     output
@@ -106,6 +113,45 @@ pub fn parse_pr_url(output: &str) -> Option<String> {
 
     // Second pass: bare GitHub PR URL anywhere in the output.
     scan_bare_pr_url(&stripped)
+}
+
+/// Parse the strict rebase-preparation sentinel emitted by `pr:N` implement turns.
+///
+/// Accepted lines:
+/// - `REBASE_PUSHED`
+/// - `REBASE_SKIPPED`
+/// - `REBASE_CONFLICT paths=path1,path2`
+///
+/// Returns `None` when the sentinel is missing or malformed so the server can
+/// fail closed instead of assuming a review-prep outcome.
+pub fn parse_pr_review_prep_outcome(output: &str) -> Option<PrReviewPrepOutcome> {
+    let stripped = strip_ansi_codes(output);
+
+    for line in stripped.lines().rev() {
+        let line = line.trim();
+        match line {
+            "REBASE_PUSHED" => return Some(PrReviewPrepOutcome::RebasePushed),
+            "REBASE_SKIPPED" => return Some(PrReviewPrepOutcome::RebaseSkipped),
+            _ => {
+                if let Some(rest) = line.strip_prefix("REBASE_CONFLICT ") {
+                    let paths = rest.strip_prefix("paths=")?;
+                    let paths: Vec<String> = paths
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|path| !path.is_empty())
+                        .map(ToString::to_string)
+                        .collect();
+                    return (!paths.is_empty())
+                        .then_some(PrReviewPrepOutcome::RebaseConflict { paths });
+                }
+                if line.starts_with("REBASE_") {
+                    return None;
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// Returns `true` only for well-formed GitHub PR URLs.
@@ -742,6 +788,51 @@ PR_URL=https://github.com/owner/repo/pull/269";
         let output = "done\nPR_URL=https://github.com/o/r/pull/5  \n";
         let url = parse_pr_url(output).unwrap();
         assert_eq!(extract_pr_number(&url), Some(5));
+    }
+
+    #[test]
+    fn test_parse_pr_review_prep_outcome_pushed() {
+        assert_eq!(
+            parse_pr_review_prep_outcome(
+                "done\nREBASE_PUSHED\nPR_URL=https://github.com/o/r/pull/5"
+            ),
+            Some(PrReviewPrepOutcome::RebasePushed)
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_review_prep_outcome_skipped() {
+        assert_eq!(
+            parse_pr_review_prep_outcome(
+                "done\nREBASE_SKIPPED\nPR_URL=https://github.com/o/r/pull/5"
+            ),
+            Some(PrReviewPrepOutcome::RebaseSkipped)
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_review_prep_outcome_conflict_with_multiple_paths() {
+        assert_eq!(
+            parse_pr_review_prep_outcome(
+                "REBASE_CONFLICT paths=src/lib.rs, crates/harness-server/src/task_executor/mod.rs"
+            ),
+            Some(PrReviewPrepOutcome::RebaseConflict {
+                paths: vec![
+                    "src/lib.rs".to_string(),
+                    "crates/harness-server/src/task_executor/mod.rs".to_string(),
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_review_prep_outcome_missing_or_malformed_is_none() {
+        assert_eq!(
+            parse_pr_review_prep_outcome("PR_URL=https://github.com/o/r/pull/5"),
+            None
+        );
+        assert_eq!(parse_pr_review_prep_outcome("REBASE_CONFLICT"), None);
+        assert_eq!(parse_pr_review_prep_outcome("REBASE_CONFLICT paths="), None);
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -458,6 +458,7 @@ mod tests {
         assert!(p.contains("headRepository"));
         assert!(p.contains("PR_HEAD_SHA=$(git rev-parse FETCH_HEAD)"));
         assert!(p.contains("git worktree add /tmp/harness-pr-42 --detach \"$PR_HEAD_SHA\""));
+        assert!(p.contains("HEAD_REPO_URL=https://github.com/<head-owner>/<head-repo>.git"));
         assert!(p.contains("git merge-base HEAD origin/main"));
         assert!(p.contains("git rev-parse origin/main"));
     }

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -248,6 +248,54 @@ pub fn check_existing_pr(
     )
 }
 
+/// Build prompt: prepare an existing PR branch for downstream review.
+///
+/// This is the implement-phase prompt for `pr:N` tasks. It resolves the PR head
+/// branch from GitHub, fetches that branch even for fork PRs, rebases only when
+/// the PR is behind `origin/main`, and emits a strict machine-readable outcome
+/// for the server to parse before any review work starts.
+pub fn prepare_pr_for_review(pr: u64, repo: &str) -> String {
+    format!(
+        "Prepare PR #{pr} in `{repo}` for downstream review.\n\n\
+         IMPORTANT: Never run `git checkout` or `git stash` in the main repository working tree.\n\
+         All work must be done in an isolated `/tmp/harness-pr-{pr}` worktree.\n\n\
+         Steps:\n\
+         1. Resolve the PR head branch, head repository, and canonical PR URL from GitHub:\n\
+            - `gh pr view {pr} --repo {repo} --json headRefName,headRepositoryOwner,headRepository,url`\n\
+            - If `headRepository` is null, stop and report that the PR head repository is unavailable.\n\
+         2. Fetch the PR head branch from its actual head repository, capture that commit, then fetch latest main:\n\
+            - `HEAD_REPO_URL=https://github.com/<head-owner>/<head-repo>.git`\n\
+            - `git fetch \"$HEAD_REPO_URL\" \"<head-branch>\"`\n\
+            - `PR_HEAD_SHA=$(git rev-parse FETCH_HEAD)`\n\
+            - `git fetch origin main`\n\
+         3. Recreate the isolated worktree at `/tmp/harness-pr-{pr}` from the captured PR head commit:\n\
+            ```\n\
+            git worktree remove /tmp/harness-pr-{pr} 2>/dev/null || rm -rf /tmp/harness-pr-{pr} 2>/dev/null || true\n\
+            git worktree prune\n\
+            git worktree add /tmp/harness-pr-{pr} --detach \"$PR_HEAD_SHA\"\n\
+            cd /tmp/harness-pr-{pr}\n\
+            git switch -C \"<head-branch>\"\n\
+            ```\n\
+         4. Inside `/tmp/harness-pr-{pr}`, compare the PR branch against `origin/main`:\n\
+            - Compute `git merge-base HEAD origin/main`\n\
+            - Compute `git rev-parse origin/main`\n\
+            - If those SHAs are equal, the branch is already up to date. Do not rebase or push.\n\
+         5. If the branch is behind `origin/main`, run `git rebase origin/main` inside `/tmp/harness-pr-{pr}`.\n\
+         6. If the rebase is clean, push exactly once with lease safety:\n\
+            - `git push --force-with-lease \"$HEAD_REPO_URL\" HEAD:\"<head-branch>\"`\n\
+         7. If the rebase conflicts, do NOT resolve conflicts automatically. Capture the conflicting paths with:\n\
+            - `git diff --name-only --diff-filter=U`\n\
+            - Abort the rebase (`git rebase --abort || true`) and stop.\n\n\
+         Output contract:\n\
+         - Print exactly one sentinel on its own line:\n\
+           - `REBASE_PUSHED` if you rebased cleanly and pushed with `--force-with-lease`\n\
+           - `REBASE_SKIPPED` if the branch was already up to date with `origin/main`\n\
+           - `REBASE_CONFLICT paths=<comma-separated paths>` if the rebase conflicted\n\
+         - Always print `PR_URL=https://github.com/{repo}/pull/{pr}` on its own line.\n\
+         - Do not print `LGTM`, `FIXED`, or `WAITING` in this phase."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,5 +447,28 @@ mod tests {
         assert!(p.contains("gh pr view 42 --json baseRefName --jq .baseRefName"));
         assert!(p.contains("git fetch origin \"$BASE\""));
         assert!(p.contains("git rebase \"origin/$BASE\""));
+    }
+
+    #[test]
+    fn prepare_pr_for_review_uses_isolated_worktree_and_main_comparison() {
+        let p = prepare_pr_for_review(42, "owner/repo");
+        assert!(p.contains("/tmp/harness-pr-42"));
+        assert!(p.contains("git worktree add /tmp/harness-pr-42"));
+        assert!(p.contains("headRepositoryOwner"));
+        assert!(p.contains("headRepository"));
+        assert!(p.contains("PR_HEAD_SHA=$(git rev-parse FETCH_HEAD)"));
+        assert!(p.contains("git worktree add /tmp/harness-pr-42 --detach \"$PR_HEAD_SHA\""));
+        assert!(p.contains("git merge-base HEAD origin/main"));
+        assert!(p.contains("git rev-parse origin/main"));
+    }
+
+    #[test]
+    fn prepare_pr_for_review_requires_force_with_lease_and_sentinels() {
+        let p = prepare_pr_for_review(42, "owner/repo");
+        assert!(p.contains("git push --force-with-lease \"$HEAD_REPO_URL\" HEAD:\"<head-branch>\""));
+        assert!(p.contains("REBASE_PUSHED"));
+        assert!(p.contains("REBASE_SKIPPED"));
+        assert!(p.contains("REBASE_CONFLICT paths=<comma-separated paths>"));
+        assert!(p.contains("PR_URL=https://github.com/owner/repo/pull/42"));
     }
 }

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -43,7 +43,8 @@ pub struct TaskCheckpoint {
     pub plan_output: Option<String>,
     /// Non-null once a PR has been created (most critical for duplicate-PR prevention).
     pub pr_url: Option<String>,
-    /// Last completed phase: `triage_done` | `plan_done` | `pr_created`.
+    /// Last completed phase: `triage_done` | `plan_done` | `pr_created` |
+    /// `rebase_pushed` | `rebase_skipped`.
     pub last_phase: String,
     pub updated_at: String,
 }

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -903,7 +903,13 @@ pub(crate) async fn run_implement_phase(
                     created_issue_num,
                     pushed_commit,
                     review_prep,
-                }) => (pr_url, pr_num, created_issue_num, pushed_commit, review_prep),
+                }) => (
+                    pr_url,
+                    pr_num,
+                    created_issue_num,
+                    pushed_commit,
+                    review_prep,
+                ),
                 Err(parse_err) => {
                     tracing::error!(
                         task_id = %task_id,
@@ -1008,14 +1014,14 @@ pub(crate) async fn run_implement_phase(
                     reason: "missing_rebase_outcome".to_string(),
                 });
                 tracing::info!(
-                    task_id = %task_id,
-                    status = "failed",
-                    turns = 2,
-                    pr_url = tracing::field::Empty,
-                    total_elapsed_secs = task_start.elapsed().as_secs(),
-                    "task_completed"
-                    );
-                    return Ok(ImplementOutcome::Done);
+                task_id = %task_id,
+                status = "failed",
+                turns = 2,
+                pr_url = tracing::field::Empty,
+                total_elapsed_secs = task_start.elapsed().as_secs(),
+                "task_completed"
+                );
+                return Ok(ImplementOutcome::Done);
             };
             tracing::debug!(
                 pr = pr_number,
@@ -1024,66 +1030,64 @@ pub(crate) async fn run_implement_phase(
             );
         }
 
-        let pushed_commit = match resolve_pushed_commit_flag(
-            req.pr.is_some(),
-            pushed_commit,
-            review_prep.as_ref(),
-        ) {
-            Ok(pushed_commit) => pushed_commit,
-            Err(parse_err) => {
-                tracing::error!(
-                    task_id = %task_id,
-                    parse_error = %parse_err,
-                    "implementation omitted required PR-check structured output"
-                );
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.turn = 2;
-                    s.error = Some(parse_err.clone());
-                    s.rounds.push(RoundResult::new(
+        let pushed_commit =
+            match resolve_pushed_commit_flag(req.pr.is_some(), pushed_commit, review_prep.as_ref())
+            {
+                Ok(pushed_commit) => pushed_commit,
+                Err(parse_err) => {
+                    tracing::error!(
+                        task_id = %task_id,
+                        parse_error = %parse_err,
+                        "implementation omitted required PR-check structured output"
+                    );
+                    mutate_and_persist(store, task_id, |s| {
+                        s.status = TaskStatus::Failed;
+                        s.turn = 2;
+                        s.error = Some(parse_err.clone());
+                        s.rounds.push(RoundResult::new(
+                            1,
+                            "implement",
+                            "malformed_output",
+                            if output.is_empty() {
+                                None
+                            } else {
+                                Some(output.clone())
+                            },
+                            Some(impl_telemetry.clone()),
+                            None,
+                        ));
+                    })
+                    .await?;
+                    let event = build_task_event(
+                        task_id,
                         1,
                         "implement",
-                        "malformed_output",
+                        "task_implement",
+                        Decision::Block,
+                        Some(parse_err.clone()),
+                        None,
+                        Some(impl_telemetry.clone()),
+                        None,
                         if output.is_empty() {
                             None
                         } else {
                             Some(output.clone())
                         },
-                        Some(impl_telemetry.clone()),
-                        None,
-                    ));
-                })
-                .await?;
-                let event = build_task_event(
-                    task_id,
-                    1,
-                    "implement",
-                    "task_implement",
-                    Decision::Block,
-                    Some(parse_err.clone()),
-                    None,
-                    Some(impl_telemetry.clone()),
-                    None,
-                    if output.is_empty() {
-                        None
-                    } else {
-                        Some(output.clone())
-                    },
-                );
-                if let Err(error) = events.log(&event).await {
-                    tracing::warn!("failed to log task_implement event: {error}");
+                    );
+                    if let Err(error) = events.log(&event).await {
+                        tracing::warn!("failed to log task_implement event: {error}");
+                    }
+                    tracing::info!(
+                        task_id = %task_id,
+                        status = "failed",
+                        turns = 2,
+                        pr_url = tracing::field::Empty,
+                        total_elapsed_secs = task_start.elapsed().as_secs(),
+                        "task_completed"
+                    );
+                    return Ok(ImplementOutcome::Done);
                 }
-                tracing::info!(
-                    task_id = %task_id,
-                    status = "failed",
-                    turns = 2,
-                    pr_url = tracing::field::Empty,
-                    total_elapsed_secs = task_start.elapsed().as_secs(),
-                    "task_completed"
-                );
-                return Ok(ImplementOutcome::Done);
-            }
-        };
+            };
 
         mutate_and_persist(store, task_id, |s| {
             s.pr_url = pr_url.clone();

--- a/crates/harness-server/src/task_executor/implement_pipeline.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline.rs
@@ -40,6 +40,7 @@ pub(crate) enum ImplementationOutcome {
         pr_num: Option<u64>,
         created_issue_num: Option<u64>,
         pushed_commit: Option<bool>,
+        review_prep: Option<prompts::PrReviewPrepOutcome>,
     },
 }
 
@@ -51,22 +52,28 @@ pub(crate) fn parse_implementation_outcome(output: &str) -> Result<Implementatio
     let pr_num = pr_url.as_deref().and_then(prompts::extract_pr_number);
     let created_issue_num = prompts::parse_created_issue_number(output);
     let pushed_commit = prompts::parse_pushed_commit(output)?;
+    let review_prep = prompts::parse_pr_review_prep_outcome(output);
     Ok(ImplementationOutcome::ParsedPr {
         pr_url,
         pr_num,
         created_issue_num,
         pushed_commit,
+        review_prep,
     })
 }
 
 fn resolve_pushed_commit_flag(
     is_direct_pr_check: bool,
     pushed_commit: Option<bool>,
+    review_prep: Option<&prompts::PrReviewPrepOutcome>,
 ) -> Result<bool, String> {
-    match (is_direct_pr_check, pushed_commit) {
-        (_, Some(pushed_commit)) => Ok(pushed_commit),
-        (false, None) => Ok(false),
-        (true, None) => Err(
+    match (pushed_commit, review_prep) {
+        (Some(pushed_commit), _) => Ok(pushed_commit),
+        (None, Some(prompts::PrReviewPrepOutcome::RebasePushed)) => Ok(true),
+        (None, Some(prompts::PrReviewPrepOutcome::RebaseSkipped))
+        | (None, Some(prompts::PrReviewPrepOutcome::RebaseConflict { .. })) => Ok(false),
+        (None, None) if !is_direct_pr_check => Ok(false),
+        (None, None) => Err(
             "missing required PUSHED_COMMIT marker in PR-check output; refusing to skip freshness gate"
                 .to_string(),
         ),
@@ -124,6 +131,7 @@ pub(crate) enum ImplementOutcome {
         pr_url: Option<String>,
         pr_num: u64,
         implementation_pushed_commit: bool,
+        review_prep: Option<prompts::PrReviewPrepOutcome>,
         context_items: Vec<ContextItem>,
         #[allow(dead_code)]
         turn_timeout: Duration,
@@ -146,7 +154,7 @@ pub(crate) async fn run_implement_phase(
     req: &CreateTaskRequest,
     server_config: &harness_core::config::HarnessConfig,
     project_config: &harness_core::config::project::ProjectConfig,
-    review_config: &harness_core::config::agents::AgentReviewConfig,
+    _review_config: &harness_core::config::agents::AgentReviewConfig,
     interceptors: &Arc<Vec<Arc<dyn harness_core::interceptor::TurnInterceptor>>>,
     events: &Arc<harness_observe::event_store::EventStore>,
     skills: &Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
@@ -159,6 +167,7 @@ pub(crate) async fn run_implement_phase(
     project_root: &Path,
     plan_output: Option<String>,
     resumed_pr_url: Option<String>,
+    resumed_review_prep: Option<prompts::PrReviewPrepOutcome>,
     issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     turn_timeout: Duration,
     effective_max_turns: Option<u32>,
@@ -209,13 +218,7 @@ pub(crate) async fn run_implement_phase(
             base
         }
     } else if let Some(pr) = req.pr {
-        prompts::check_existing_pr(
-            pr,
-            &review_config.review_bot_command,
-            repo_slug,
-            &review_config.reviewer_name,
-            false,
-        )
+        prompts::prepare_pr_for_review(pr, repo_slug)
     } else {
         prompts::implement_from_prompt(req.prompt.as_deref().unwrap_or_default(), git)
     };
@@ -343,7 +346,12 @@ pub(crate) async fn run_implement_phase(
 
     // Duplicate-PR prevention guard: if checkpoint shows PR already created, skip the
     // implement agent entirely to avoid opening a second PR on resume.
-    let (pr_url, pr_num, pushed_commit): (Option<String>, u64, bool) = 'implement: {
+    let (pr_url, pr_num, pushed_commit, review_prep): (
+        Option<String>,
+        u64,
+        bool,
+        Option<prompts::PrReviewPrepOutcome>,
+    ) = 'implement: {
         if let Some(pr_str) = resumed_pr_url {
             tracing::info!(
                 task_id = %task_id,
@@ -376,7 +384,7 @@ pub(crate) async fn run_implement_phase(
                 ));
             })
             .await?;
-            break 'implement (Some(pr_str), n, false);
+            break 'implement (Some(pr_str), n, false, resumed_review_prep);
         }
 
         let impl_phase_start = Instant::now();
@@ -806,7 +814,7 @@ pub(crate) async fn run_implement_phase(
             return Ok(ImplementOutcome::Done);
         }
 
-        let (pr_url, pr_num, created_issue_num, pushed_commit) =
+        let (pr_url, pr_num, created_issue_num, pushed_commit, review_prep) =
             match parse_implementation_outcome(&output) {
                 Ok(ImplementationOutcome::PlanIssue(plan_issue)) => {
                     if let (Some(workflows), Some(issue_number)) =
@@ -894,7 +902,8 @@ pub(crate) async fn run_implement_phase(
                     pr_num,
                     created_issue_num,
                     pushed_commit,
-                }) => (pr_url, pr_num, created_issue_num, pushed_commit),
+                    review_prep,
+                }) => (pr_url, pr_num, created_issue_num, pushed_commit, review_prep),
                 Err(parse_err) => {
                     tracing::error!(
                         task_id = %task_id,
@@ -952,7 +961,74 @@ pub(crate) async fn run_implement_phase(
                 }
             };
 
-        let pushed_commit = match resolve_pushed_commit_flag(req.pr.is_some(), pushed_commit) {
+        if let Some(pr_number) = req.pr {
+            let Some(review_prep) = review_prep.as_ref() else {
+                let error =
+                    format!("PR #{pr_number} preparation produced no rebase outcome sentinel");
+                mutate_and_persist(store, task_id, |s| {
+                    s.status = TaskStatus::Failed;
+                    s.turn = 2;
+                    s.error = Some(error.clone());
+                    s.rounds.push(RoundResult::new(
+                        1,
+                        "implement",
+                        "missing_rebase_outcome",
+                        if output.is_empty() {
+                            None
+                        } else {
+                            Some(output.clone())
+                        },
+                        Some(impl_telemetry.clone()),
+                        None,
+                    ));
+                })
+                .await?;
+                let event = build_task_event(
+                    task_id,
+                    1,
+                    "implement",
+                    "task_implement",
+                    Decision::Block,
+                    Some(error.clone()),
+                    None,
+                    Some(impl_telemetry.clone()),
+                    None,
+                    if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.clone())
+                    },
+                );
+                if let Err(error) = events.log(&event).await {
+                    tracing::warn!("failed to log task_implement event: {error}");
+                }
+                store.log_event(crate::event_replay::TaskEvent::Failed {
+                    task_id: task_id.0.clone(),
+                    ts: crate::event_replay::now_ts(),
+                    reason: "missing_rebase_outcome".to_string(),
+                });
+                tracing::info!(
+                    task_id = %task_id,
+                    status = "failed",
+                    turns = 2,
+                    pr_url = tracing::field::Empty,
+                    total_elapsed_secs = task_start.elapsed().as_secs(),
+                    "task_completed"
+                    );
+                    return Ok(ImplementOutcome::Done);
+            };
+            tracing::debug!(
+                pr = pr_number,
+                ?review_prep,
+                "parsed pr review prep outcome"
+            );
+        }
+
+        let pushed_commit = match resolve_pushed_commit_flag(
+            req.pr.is_some(),
+            pushed_commit,
+            review_prep.as_ref(),
+        ) {
             Ok(pushed_commit) => pushed_commit,
             Err(parse_err) => {
                 tracing::error!(
@@ -1014,7 +1090,13 @@ pub(crate) async fn run_implement_phase(
             s.rounds.push(RoundResult::new(
                 1,
                 "implement",
-                if pr_num.is_some() {
+                if let Some(review_prep) = review_prep.as_ref() {
+                    match review_prep {
+                        prompts::PrReviewPrepOutcome::RebasePushed => "rebase_pushed",
+                        prompts::PrReviewPrepOutcome::RebaseSkipped => "rebase_skipped",
+                        prompts::PrReviewPrepOutcome::RebaseConflict { .. } => "rebase_conflict",
+                    }
+                } else if pr_num.is_some() {
                     "pr_created"
                 } else {
                     "no_pr"
@@ -1092,8 +1174,14 @@ pub(crate) async fn run_implement_phase(
         // Write PR checkpoint immediately after pr_url is persisted.
         // This is the most critical checkpoint — it prevents duplicate PR creation on resume.
         if let Some(pr_url_str) = pr_url.as_deref() {
+            let checkpoint_phase = match review_prep.as_ref() {
+                Some(prompts::PrReviewPrepOutcome::RebasePushed) => "rebase_pushed",
+                Some(prompts::PrReviewPrepOutcome::RebaseSkipped) => "rebase_skipped",
+                Some(prompts::PrReviewPrepOutcome::RebaseConflict { .. }) => "rebase_conflict",
+                None => "pr_created",
+            };
             if let Err(e) = store
-                .write_checkpoint(task_id, None, None, Some(pr_url_str), "pr_created")
+                .write_checkpoint(task_id, None, None, Some(pr_url_str), checkpoint_phase)
                 .await
             {
                 tracing::warn!(task_id = %task_id, "failed to write pr checkpoint: {e}");
@@ -1232,13 +1320,14 @@ pub(crate) async fn run_implement_phase(
             tracing::warn!("failed to log task_implement event: {error}");
         }
 
-        (pr_url, pr_num, pushed_commit)
+        (pr_url, pr_num, pushed_commit, review_prep)
     }; // end 'implement
 
     Ok(ImplementOutcome::Proceed {
         pr_url,
         pr_num,
         implementation_pushed_commit: pushed_commit,
+        review_prep,
         context_items,
         turn_timeout,
         initial_allowed_tools,
@@ -1292,6 +1381,59 @@ mod tests {
                 pr_num: Some(42),
                 created_issue_num: None,
                 pushed_commit: None,
+                review_prep: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_implementation_outcome_extracts_rebase_pushed() {
+        let output =
+            "Prepared.\nREBASE_PUSHED\nPR_URL=https://github.com/majiayu000/harness/pull/42";
+        let parsed = parse_implementation_outcome(output).expect("rebase prep should parse");
+        assert_eq!(
+            parsed,
+            ImplementationOutcome::ParsedPr {
+                pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
+                pr_num: Some(42),
+                created_issue_num: None,
+                pushed_commit: None,
+                review_prep: Some(prompts::PrReviewPrepOutcome::RebasePushed),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_implementation_outcome_extracts_rebase_skipped() {
+        let output =
+            "Prepared.\nREBASE_SKIPPED\nPR_URL=https://github.com/majiayu000/harness/pull/42";
+        let parsed = parse_implementation_outcome(output).expect("rebase prep should parse");
+        assert_eq!(
+            parsed,
+            ImplementationOutcome::ParsedPr {
+                pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
+                pr_num: Some(42),
+                created_issue_num: None,
+                pushed_commit: None,
+                review_prep: Some(prompts::PrReviewPrepOutcome::RebaseSkipped),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_implementation_outcome_extracts_rebase_conflict() {
+        let output = "Prepared.\nREBASE_CONFLICT paths=src/lib.rs,src/main.rs\nPR_URL=https://github.com/majiayu000/harness/pull/42";
+        let parsed = parse_implementation_outcome(output).expect("rebase prep should parse");
+        assert_eq!(
+            parsed,
+            ImplementationOutcome::ParsedPr {
+                pr_url: Some("https://github.com/majiayu000/harness/pull/42".to_string()),
+                pr_num: Some(42),
+                created_issue_num: None,
+                pushed_commit: None,
+                review_prep: Some(prompts::PrReviewPrepOutcome::RebaseConflict {
+                    paths: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+                }),
             }
         );
     }
@@ -1308,6 +1450,7 @@ mod tests {
                 pr_num: Some(42),
                 created_issue_num: None,
                 pushed_commit: Some(true),
+                review_prep: None,
             }
         );
     }
@@ -1324,14 +1467,34 @@ mod tests {
 
     #[test]
     fn resolve_pushed_commit_flag_requires_marker_for_direct_pr_checks() {
-        assert_eq!(resolve_pushed_commit_flag(true, Some(true)), Ok(true));
-        assert_eq!(resolve_pushed_commit_flag(false, None), Ok(false));
+        assert_eq!(resolve_pushed_commit_flag(true, Some(true), None), Ok(true));
+        assert_eq!(resolve_pushed_commit_flag(false, None, None), Ok(false));
         assert_eq!(
-            resolve_pushed_commit_flag(true, None),
+            resolve_pushed_commit_flag(true, None, None),
             Err(
                 "missing required PUSHED_COMMIT marker in PR-check output; refusing to skip freshness gate"
                     .to_string()
             )
+        );
+    }
+
+    #[test]
+    fn resolve_pushed_commit_flag_uses_rebase_prep_for_direct_pr_checks() {
+        assert_eq!(
+            resolve_pushed_commit_flag(
+                true,
+                None,
+                Some(&prompts::PrReviewPrepOutcome::RebasePushed)
+            ),
+            Ok(true)
+        );
+        assert_eq!(
+            resolve_pushed_commit_flag(
+                true,
+                None,
+                Some(&prompts::PrReviewPrepOutcome::RebaseSkipped)
+            ),
+            Ok(false)
         );
     }
 

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -17,6 +17,7 @@ use harness_core::tool_isolation::validate_tool_usage;
 use harness_core::{config::project::load_project_config, lang_detect, prompts};
 use std::collections::HashMap;
 
+use crate::task_runner::RoundResult;
 use chrono::Utc;
 use helpers::update_status;
 

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -17,7 +17,6 @@ use harness_core::tool_isolation::validate_tool_usage;
 use harness_core::{config::project::load_project_config, lang_detect, prompts};
 use std::collections::HashMap;
 
-use crate::task_runner::RoundResult;
 use chrono::Utc;
 use helpers::update_status;
 
@@ -136,7 +135,9 @@ fn review_prep_from_checkpoint_phase(last_phase: &str) -> Option<prompts::PrRevi
     match last_phase {
         "rebase_pushed" => Some(prompts::PrReviewPrepOutcome::RebasePushed),
         "rebase_skipped" => Some(prompts::PrReviewPrepOutcome::RebaseSkipped),
-        "rebase_conflict" => Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths: Vec::new() }),
+        "rebase_conflict" => {
+            Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths: Vec::new() })
+        }
         _ => None,
     }
 }
@@ -1036,13 +1037,15 @@ pub(crate) async fn run_task(
                 review_prep,
                 context_items,
                 ..
-            } => break (
-                pr_url,
-                pr_num,
-                implementation_pushed_commit,
-                review_prep,
-                context_items,
-            ),
+            } => {
+                break (
+                    pr_url,
+                    pr_num,
+                    implementation_pushed_commit,
+                    review_prep,
+                    context_items,
+                )
+            }
             implement_pipeline::ImplementOutcome::Replan {
                 issue,
                 plan_issue,

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod triage_pipeline;
 pub(crate) mod turn_lifecycle;
 
 use crate::task_runner::{
-    mutate_and_persist, CreateTaskRequest, TaskId, TaskKind, TaskStatus, TaskStore,
+    mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskKind, TaskStatus, TaskStore,
 };
 use anyhow::Context;
 use harness_core::agent::{AgentRequest, CodeAgent};
@@ -77,6 +77,99 @@ pub(crate) struct TaskContext {
 
 fn should_run_issue_triage(skip_triage: bool, has_existing_pr: bool) -> bool {
     !skip_triage && !has_existing_pr
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReviewEntryDecision {
+    Proceed { rebase_pushed: bool },
+    FailConflict { error: String, paths_csv: String },
+}
+
+fn review_entry_decision(
+    pr_num: u64,
+    review_prep: Option<&prompts::PrReviewPrepOutcome>,
+) -> ReviewEntryDecision {
+    match review_prep {
+        Some(prompts::PrReviewPrepOutcome::RebasePushed) => ReviewEntryDecision::Proceed {
+            rebase_pushed: true,
+        },
+        Some(prompts::PrReviewPrepOutcome::RebaseSkipped) | None => ReviewEntryDecision::Proceed {
+            rebase_pushed: false,
+        },
+        Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths }) => {
+            let paths_csv = if paths.is_empty() {
+                "unknown paths".to_string()
+            } else {
+                paths.join(", ")
+            };
+            ReviewEntryDecision::FailConflict {
+                error: format!(
+                    "PR #{pr_num} has rebase conflicts: {paths_csv}; manual resolution required"
+                ),
+                paths_csv,
+            }
+        }
+    }
+}
+
+fn review_prep_from_rounds(rounds: &[RoundResult]) -> Option<prompts::PrReviewPrepOutcome> {
+    rounds
+        .iter()
+        .rev()
+        .find(|round| round.action == "implement")
+        .and_then(|round| match round.result.as_str() {
+            "rebase_pushed" => Some(prompts::PrReviewPrepOutcome::RebasePushed),
+            "rebase_skipped" => Some(prompts::PrReviewPrepOutcome::RebaseSkipped),
+            "rebase_conflict" => round
+                .detail
+                .as_deref()
+                .and_then(prompts::parse_pr_review_prep_outcome)
+                .or_else(|| {
+                    Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths: Vec::new() })
+                }),
+            _ => None,
+        })
+}
+
+fn review_prep_from_checkpoint_phase(last_phase: &str) -> Option<prompts::PrReviewPrepOutcome> {
+    match last_phase {
+        "rebase_pushed" => Some(prompts::PrReviewPrepOutcome::RebasePushed),
+        "rebase_skipped" => Some(prompts::PrReviewPrepOutcome::RebaseSkipped),
+        "rebase_conflict" => Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths: Vec::new() }),
+        _ => None,
+    }
+}
+
+async fn fail_rebase_conflict(
+    store: &TaskStore,
+    task_id: &TaskId,
+    events: &Arc<harness_observe::event_store::EventStore>,
+    pr_num: u64,
+    error: String,
+    paths_csv: String,
+) -> anyhow::Result<()> {
+    mutate_and_persist(store, task_id, |s| {
+        s.status = TaskStatus::Failed;
+        s.error = Some(error.clone());
+    })
+    .await?;
+    store.log_event(crate::event_replay::TaskEvent::Failed {
+        task_id: task_id.0.clone(),
+        ts: crate::event_replay::now_ts(),
+        reason: error,
+    });
+    let mut event = harness_core::types::Event::new(
+        harness_core::types::SessionId::new(),
+        "pr_rebase_conflict",
+        "task_runner",
+        harness_core::types::Decision::Block,
+    );
+    event.reason = Some(paths_csv);
+    event.detail = Some(format!("task_id={} pr={pr_num}", task_id.as_str()));
+    if let Err(err) = events.log(&event).await {
+        tracing::warn!("failed to log pr_rebase_conflict event: {err}");
+    }
+    Ok(())
 }
 
 /// Run the project's test commands as a hard gate before accepting LGTM.
@@ -753,7 +846,8 @@ pub(crate) async fn run_task(
     // Check task store for an existing pr_url first — this survives checkpoint
     // read failures (e.g. transient SQLite contention) and lets us safely
     // resume review even when the checkpoint row is temporarily unreadable.
-    let task_pr_url: Option<String> = store.get(task_id).and_then(|t| t.pr_url);
+    let task_state = store.get(task_id);
+    let task_pr_url: Option<String> = task_state.as_ref().and_then(|t| t.pr_url.clone());
     let checkpoint = match store.load_checkpoint(task_id).await {
         Ok(cp) => cp,
         Err(e) => {
@@ -777,12 +871,20 @@ pub(crate) async fn run_task(
             }
         }
     };
+    let resumed_review_prep = task_state
+        .as_ref()
+        .and_then(|task| review_prep_from_rounds(&task.rounds))
+        .or_else(|| {
+            checkpoint
+                .as_ref()
+                .and_then(|c| review_prep_from_checkpoint_phase(&c.last_phase))
+        });
     let resumed_pr_url: Option<String> =
         task_pr_url.or_else(|| checkpoint.as_ref().and_then(|c| c.pr_url.clone()));
     // Capture before `resumed_pr_url` is moved into run_implement_phase.
     // Also covers fresh pr:N tasks from webhook (req.pr is set but no checkpoint pr_url yet).
     let mut was_resumed_pr = resumed_pr_url.is_some() || req.pr.is_some();
-    let resumed_plan: Option<String> = checkpoint.and_then(|c| c.plan_output);
+    let resumed_plan: Option<String> = checkpoint.as_ref().and_then(|c| c.plan_output.clone());
 
     // --- Pipeline: Triage → Plan → Implement ---
     // For issue-based tasks without an existing PR, run triage first.
@@ -895,7 +997,7 @@ pub(crate) async fn run_task(
 
     let mut current_plan_output = plan_output;
     let mut replan_attempted = false;
-    let (pr_url, pr_num, implementation_pushed_commit, context_items) = loop {
+    let (pr_url, pr_num, implementation_pushed_commit, review_prep, context_items) = loop {
         let outcome = implement_pipeline::run_implement_phase(
             store,
             task_id,
@@ -914,6 +1016,7 @@ pub(crate) async fn run_task(
             &project_root,
             current_plan_output.clone(),
             resumed_pr_url.clone(),
+            resumed_review_prep.clone(),
             issue_workflow_store.clone(),
             turn_timeout,
             effective_max_turns,
@@ -929,9 +1032,16 @@ pub(crate) async fn run_task(
                 pr_url,
                 pr_num,
                 implementation_pushed_commit,
+                review_prep,
                 context_items,
                 ..
-            } => break (pr_url, pr_num, implementation_pushed_commit, context_items),
+            } => break (
+                pr_url,
+                pr_num,
+                implementation_pushed_commit,
+                review_prep,
+                context_items,
+            ),
             implement_pipeline::ImplementOutcome::Replan {
                 issue,
                 plan_issue,
@@ -1019,7 +1129,23 @@ pub(crate) async fn run_task(
         return Ok(());
     }
 
-    let rebase_pushed = if was_resumed_pr {
+    let mut rebase_pushed = match review_entry_decision(pr_num, review_prep.as_ref()) {
+        ReviewEntryDecision::Proceed { rebase_pushed } => rebase_pushed,
+        ReviewEntryDecision::FailConflict { error, paths_csv } => {
+            fail_rebase_conflict(store, task_id, &events, pr_num, error, paths_csv).await?;
+            tracing::info!(
+                task_id = %task_id,
+                status = "failed",
+                turns = turns_used,
+                pr = pr_num,
+                total_elapsed_secs = task_start.elapsed().as_secs(),
+                "task_completed"
+            );
+            return Ok(());
+        }
+    };
+
+    if review_prep.is_none() && was_resumed_pr {
         match run_resumed_pr_conflict_gate(
             store,
             task_id,
@@ -1039,13 +1165,15 @@ pub(crate) async fn run_task(
         )
         .await?
         {
-            ConflictGateOutcome::Clean => false,
-            ConflictGateOutcome::RebasePushed => true,
+            ConflictGateOutcome::Clean => {
+                rebase_pushed = false;
+            }
+            ConflictGateOutcome::RebasePushed => {
+                rebase_pushed = true;
+            }
             ConflictGateOutcome::Failed => return Ok(()),
         }
-    } else {
-        false
-    };
+    }
 
     // Agent review loop (if enabled and reviewer available, and not skipped by triage complexity)
     let mut agent_pushed_commit = false;
@@ -1365,6 +1493,130 @@ mod tests {
             !implement_pipeline::task_needs_pr_url(&req),
             "prompt-only task must not require PR_URL (Done is correct)"
         );
+    }
+
+    #[test]
+    fn review_entry_decision_blocks_review_on_rebase_conflict() {
+        assert_eq!(
+            review_entry_decision(
+                42,
+                Some(&prompts::PrReviewPrepOutcome::RebaseConflict {
+                    paths: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+                })
+            ),
+            ReviewEntryDecision::FailConflict {
+                error: "PR #42 has rebase conflicts: src/lib.rs, src/main.rs; manual resolution required".to_string(),
+                paths_csv: "src/lib.rs, src/main.rs".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn review_entry_decision_propagates_rebase_pushed_flag() {
+        assert_eq!(
+            review_entry_decision(42, Some(&prompts::PrReviewPrepOutcome::RebasePushed)),
+            ReviewEntryDecision::Proceed {
+                rebase_pushed: true
+            }
+        );
+        assert_eq!(
+            review_entry_decision(42, Some(&prompts::PrReviewPrepOutcome::RebaseSkipped)),
+            ReviewEntryDecision::Proceed {
+                rebase_pushed: false
+            }
+        );
+    }
+
+    #[test]
+    fn review_prep_from_rounds_prefers_latest_implement_round() {
+        let rounds = vec![
+            RoundResult::new(1, "implement", "rebase_skipped", None, None, None),
+            RoundResult::new(2, "review", "needs_fix", None, None, None),
+            RoundResult::new(3, "implement", "rebase_pushed", None, None, None),
+        ];
+        assert_eq!(
+            review_prep_from_rounds(&rounds),
+            Some(prompts::PrReviewPrepOutcome::RebasePushed)
+        );
+    }
+
+    #[test]
+    fn review_prep_from_rounds_recovers_rebase_conflict_detail() {
+        let rounds = vec![RoundResult::new(
+            1,
+            "implement",
+            "rebase_conflict",
+            Some("REBASE_CONFLICT paths=src/lib.rs,src/main.rs".to_string()),
+            None,
+            None,
+        )];
+        assert_eq!(
+            review_prep_from_rounds(&rounds),
+            Some(prompts::PrReviewPrepOutcome::RebaseConflict {
+                paths: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn review_prep_from_checkpoint_phase_recovers_rebase_state() {
+        assert_eq!(
+            review_prep_from_checkpoint_phase("rebase_pushed"),
+            Some(prompts::PrReviewPrepOutcome::RebasePushed)
+        );
+        assert_eq!(
+            review_prep_from_checkpoint_phase("rebase_skipped"),
+            Some(prompts::PrReviewPrepOutcome::RebaseSkipped)
+        );
+        assert_eq!(
+            review_prep_from_checkpoint_phase("rebase_conflict"),
+            Some(prompts::PrReviewPrepOutcome::RebaseConflict { paths: Vec::new() })
+        );
+        assert_eq!(review_prep_from_checkpoint_phase("pr_created"), None);
+    }
+
+    #[tokio::test]
+    async fn fail_rebase_conflict_marks_task_failed_and_logs_event() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let events = Arc::new(harness_observe::event_store::EventStore::new(dir.path()).await?);
+        let task_id = TaskId::new();
+        let state = crate::task_runner::TaskState::new(task_id.clone());
+        store.insert(&state).await;
+
+        fail_rebase_conflict(
+            &store,
+            &task_id,
+            &events,
+            42,
+            "PR #42 has rebase conflicts: src/lib.rs, src/main.rs; manual resolution required"
+                .to_string(),
+            "src/lib.rs, src/main.rs".to_string(),
+        )
+        .await?;
+
+        let final_state = store
+            .get(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task must exist"))?;
+        assert!(matches!(final_state.status, TaskStatus::Failed));
+        assert_eq!(
+            final_state.error.as_deref(),
+            Some(
+                "PR #42 has rebase conflicts: src/lib.rs, src/main.rs; manual resolution required"
+            )
+        );
+
+        let logged = events
+            .query(&harness_core::types::EventFilters {
+                hook: Some("pr_rebase_conflict".to_string()),
+                ..harness_core::types::EventFilters::default()
+            })
+            .await?;
+        assert_eq!(logged.len(), 1);
+        assert_eq!(logged[0].reason.as_deref(), Some("src/lib.rs, src/main.rs"));
+        let expected_detail = format!("task_id={} pr=42", task_id.as_str());
+        assert_eq!(logged[0].detail.as_deref(), Some(expected_detail.as_str()));
+        Ok(())
     }
 
     // --- Gate A: pr:N task with non-empty output but no PR_URL gets Failed ---

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -1822,8 +1822,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/7\nPUSHED_COMMIT=false\nWAITING".into(),
-            "MANUAL_RESOLUTION_REQUIRED".into(),
+            "REBASE_CONFLICT paths=src/lib.rs\nPR_URL=https://github.com/owner/repo/pull/7".into(),
         ]);
 
         let req = CreateTaskRequest {
@@ -1863,8 +1862,8 @@ mod tests {
         let phases = agent.captured_phases().await;
         assert_eq!(
             phases.len(),
-            2,
-            "manual-resolution outcome must stop before the normal review loop"
+            1,
+            "rebase-conflict outcome must stop before the normal review loop"
         );
         let state = store.get(&task_id).expect("task should exist");
         assert!(
@@ -1896,8 +1895,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/8\nPUSHED_COMMIT=false\nWAITING".into(),
-            "CLEAN_PR".into(),
+            "REBASE_SKIPPED\nPR_URL=https://github.com/owner/repo/pull/8".into(),
             "LGTM".into(),
         ]);
 
@@ -1937,8 +1935,8 @@ mod tests {
 
         let phases = agent.captured_phases().await;
         assert!(
-            phases.len() >= 3,
-            "clean resumed PR must enter the review loop after the conflict gate"
+            phases.len() >= 2,
+            "clean pr:N prep must enter the review loop after rebase preparation"
         );
         Ok(())
     }
@@ -1961,8 +1959,7 @@ mod tests {
         );
 
         let agent = PhaseCapturingAgent::new(vec![
-            "PR_URL=https://github.com/owner/repo/pull/9\nPUSHED_COMMIT=false\nWAITING".into(),
-            "REBASE_PUSHED".into(),
+            "REBASE_PUSHED\nPR_URL=https://github.com/owner/repo/pull/9".into(),
             "LGTM".into(),
         ]);
 
@@ -2000,12 +1997,12 @@ mod tests {
         })
         .await?;
 
-        let prompts = wait_for_captured_prompts(agent.as_ref(), 3).await;
+        let prompts = wait_for_captured_prompts(agent.as_ref(), 2).await;
         assert!(
             prompts
-                .get(2)
+                .get(1)
                 .is_some_and(|prompt| prompt.contains("IMPORTANT — New review verification")),
-            "rebased resumed PRs must require a fresh reviewer pass before accepting LGTM"
+            "rebased pr:N tasks must require a fresh reviewer pass before accepting LGTM"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a review rebase preparation stage for PR branches
- preserve review-time rebase metadata before downstream automation continues

## Testing
- cargo check
- cargo test

Closes #946