### PR TITLE
fix: recover orphan pending startup tasks

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -7,7 +7,8 @@ use harness_workflow::issue_lifecycle::{
 };
 
 fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
-    task.external_id
+    let (issue_from_external_id, pr_from_external_id) = task
+        .external_id
         .as_deref()
         .map(|eid| {
             if let Some(n) = eid.strip_prefix("issue:") {
@@ -18,7 +19,22 @@ fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
                 (None, None)
             }
         })
-        .unwrap_or((None, None))
+        .unwrap_or((None, None));
+
+    let issue = issue_from_external_id
+        .or(task.issue)
+        .or_else(|| parse_description_number(task.description.as_deref(), "issue #"));
+    let pr = pr_from_external_id
+        .or_else(|| parse_description_number(task.description.as_deref(), "PR #"));
+
+    (issue, pr)
+}
+
+fn parse_description_number(description: Option<&str>, prefix: &str) -> Option<u64> {
+    description
+        .and_then(|text| text.strip_prefix(prefix))
+        .and_then(|tail| tail.split_whitespace().next())
+        .and_then(|value| value.parse::<u64>().ok())
 }
 
 fn build_recovered_request(
@@ -1351,10 +1367,15 @@ pub(super) async fn spawn_orphan_pending_recovery(state: &Arc<AppState>) {
     for task in failed {
         let state = state.clone();
         tokio::spawn(async move {
+            let Some(task) = await_startup_recovery_ready_task(&state, &task.id, "orphan").await
+            else {
+                return;
+            };
             let reason = "orphaned prompt-only task: prompt not persisted".to_string();
             tracing::warn!(task_id = ?task.id, "{reason}");
+            let task_id = task.id.clone();
             if let Err(pe) =
-                task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                task_runner::mutate_and_persist(&state.core.tasks, &task_id, move |s| {
                     s.status = task_runner::TaskStatus::Failed;
                     s.scheduler.mark_terminal(&task_runner::TaskStatus::Failed);
                     s.error = Some(reason);
@@ -1369,7 +1390,7 @@ pub(super) async fn spawn_orphan_pending_recovery(state: &Arc<AppState>) {
                 return;
             }
             if let Some(cb) = &state.intake.completion_callback {
-                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                if let Some(final_state) = state.core.tasks.get(&task_id) {
                     cb(final_state).await;
                 }
             }

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -49,6 +49,19 @@ fn build_recovered_request(
     req
 }
 
+fn task_has_restart_safe_prompt(task: &task_runner::TaskState) -> bool {
+    let mut req = task_runner::CreateTaskRequest::default();
+    if let Some(ref settings) = task.request_settings {
+        settings.apply_to_req(&mut req);
+    }
+    if req.prompt.is_none() {
+        if let Some(system_input) = req.system_input.as_ref() {
+            req.prompt = Some(system_input.prompt().to_string());
+        }
+    }
+    req.prompt.is_some()
+}
+
 pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_routes::QueueDomain {
     match task_kind {
         task_runner::TaskKind::Review => task_routes::QueueDomain::Review,
@@ -1296,6 +1309,225 @@ pub(super) async fn spawn_checkpoint_recovery(state: &Arc<AppState>) {
                 .await;
             });
         }
+    }
+}
+
+/// Re-dispatch leftover pending tasks that have no PR URL and no checkpoint.
+///
+/// This recovery runs last so the PR/system/checkpoint-specific startup paths
+/// can claim their own rows first. The remaining bucket represents tasks that
+/// crashed before their first checkpoint was written.
+pub(super) async fn spawn_orphan_pending_recovery(state: &Arc<AppState>) {
+    let orphan_tasks = match state.core.tasks.pending_orphan_tasks().await {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            tracing::warn!(
+                "startup: failed to query orphan pending tasks, skipping orphan redispatch: {e}"
+            );
+            return;
+        }
+    };
+    if orphan_tasks.is_empty() {
+        return;
+    }
+
+    let mut recoverable = Vec::new();
+    let mut failed = Vec::new();
+    for task in orphan_tasks {
+        let (issue, pr) = parse_issue_pr(&task);
+        if issue.is_some() || pr.is_some() || task_has_restart_safe_prompt(&task) {
+            recoverable.push((task, issue, pr));
+        } else {
+            failed.push(task);
+        }
+    }
+
+    tracing::info!(
+        recovered = recoverable.len(),
+        failed = failed.len(),
+        "startup: orphan pending recovery summary"
+    );
+
+    for task in failed {
+        let state = state.clone();
+        tokio::spawn(async move {
+            let reason = "orphaned prompt-only task: prompt not persisted".to_string();
+            tracing::warn!(task_id = ?task.id, "{reason}");
+            if let Err(pe) =
+                task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                    s.status = task_runner::TaskStatus::Failed;
+                    s.scheduler.mark_terminal(&task_runner::TaskStatus::Failed);
+                    s.error = Some(reason);
+                })
+                .await
+            {
+                tracing::error!(
+                    task_id = ?task.id,
+                    "startup recovery: failed to persist failed status: {pe}; \
+                     skipping completion callback to avoid state split"
+                );
+                return;
+            }
+            if let Some(cb) = &state.intake.completion_callback {
+                if let Some(final_state) = state.core.tasks.get(&task.id) {
+                    cb(final_state).await;
+                }
+            }
+        });
+    }
+
+    for (task, issue, pr) in recoverable {
+        let state = state.clone();
+        tokio::spawn(async move {
+            let Some(task) = await_startup_recovery_ready_task(&state, &task.id, "orphan").await
+            else {
+                return;
+            };
+            let project_path = if let Some(root) = task.project_root.clone() {
+                Some(root)
+            } else {
+                match task.repo.as_deref() {
+                    Some(repo) => {
+                        if let Some(registry) = state.core.project_registry.as_deref() {
+                            match registry.resolve_path(repo).await {
+                                Ok(Some(p)) => Some(p),
+                                Ok(None) => Some(std::path::PathBuf::from(repo)),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        task_id = ?task.id,
+                                        repo,
+                                        "startup recovery: registry lookup failed: \
+                                         {e}, using repo as path"
+                                    );
+                                    Some(std::path::PathBuf::from(repo))
+                                }
+                            }
+                        } else {
+                            Some(std::path::PathBuf::from(repo))
+                        }
+                    }
+                    None => None,
+                }
+            };
+
+            let canonical = match task_runner::resolve_canonical_project(project_path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    let reason = format!("startup recovery: failed to resolve project path: {e}");
+                    tracing::error!(task_id = ?task.id, "{reason}");
+                    if let Err(pe) =
+                        task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                            s.status = task_runner::TaskStatus::Failed;
+                            s.scheduler.mark_terminal(&task_runner::TaskStatus::Failed);
+                            s.error = Some(reason);
+                        })
+                        .await
+                    {
+                        tracing::error!(
+                            task_id = ?task.id,
+                            "startup recovery: failed to persist failed status: {pe}; \
+                             skipping completion callback to avoid state split"
+                        );
+                        return;
+                    }
+                    if let Some(cb) = &state.intake.completion_callback {
+                        if let Some(final_state) = state.core.tasks.get(&task.id) {
+                            cb(final_state).await;
+                        }
+                    }
+                    return;
+                }
+            };
+            let project_id = canonical.to_string_lossy().into_owned();
+
+            let queue = match recovery_queue_domain(task.task_kind) {
+                task_routes::QueueDomain::Primary => state.concurrency.task_queue.clone(),
+                task_routes::QueueDomain::Review => state.concurrency.review_task_queue.clone(),
+            };
+            let permit = match queue.acquire(&project_id, task.priority).await {
+                Ok(p) => p,
+                Err(e) => {
+                    let reason =
+                        format!("startup recovery: failed to acquire concurrency permit: {e}");
+                    tracing::error!(task_id = ?task.id, "{reason}");
+                    if let Err(pe) =
+                        task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                            s.status = task_runner::TaskStatus::Failed;
+                            s.scheduler.mark_terminal(&task_runner::TaskStatus::Failed);
+                            s.error = Some(reason);
+                        })
+                        .await
+                    {
+                        tracing::error!(
+                            task_id = ?task.id,
+                            "startup recovery: failed to persist failed status: {pe}; \
+                             skipping completion callback to avoid state split"
+                        );
+                        return;
+                    }
+                    if let Some(cb) = &state.intake.completion_callback {
+                        if let Some(final_state) = state.core.tasks.get(&task.id) {
+                            cb(final_state).await;
+                        }
+                    }
+                    return;
+                }
+            };
+
+            let req = build_recovered_request(&task, canonical, issue, pr);
+            let agent =
+                match task_routes::select_agent(&req, &state.core.server.agent_registry, None) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        let reason = format!("startup recovery: failed to select agent: {e}");
+                        tracing::error!(task_id = ?task.id, "{reason}");
+                        if let Err(pe) =
+                            task_runner::mutate_and_persist(&state.core.tasks, &task.id, move |s| {
+                                s.status = task_runner::TaskStatus::Failed;
+                                s.scheduler.mark_terminal(&task_runner::TaskStatus::Failed);
+                                s.error = Some(reason);
+                            })
+                            .await
+                        {
+                            tracing::error!(
+                                task_id = ?task.id,
+                                "startup recovery: failed to persist failed status: {pe}; \
+                                 skipping completion callback to avoid state split"
+                            );
+                            return;
+                        }
+                        if let Some(cb) = &state.intake.completion_callback {
+                            if let Some(final_state) = state.core.tasks.get(&task.id) {
+                                cb(final_state).await;
+                            }
+                        }
+                        return;
+                    }
+                };
+            let (reviewer, _) = super::resolve_reviewer(
+                &state.core.server.agent_registry,
+                &state.core.server.config.agents.review,
+                agent.name(),
+            );
+            state.core.tasks.register_task_stream(&task.id);
+            task_runner::spawn_preregistered_task(
+                task.id,
+                state.core.tasks.clone(),
+                agent,
+                reviewer,
+                Arc::new(state.core.server.config.clone()),
+                state.engines.skills.clone(),
+                state.observability.events.clone(),
+                state.interceptors.clone(),
+                req,
+                state.concurrency.workspace_mgr.clone(),
+                permit,
+                state.intake.completion_callback.clone(),
+                state.core.issue_workflow_store.clone(),
+                None,
+            )
+            .await;
+        });
     }
 }
 

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -21,11 +21,29 @@ fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
         })
         .unwrap_or((None, None));
 
+    let (issue_from_settings, pr_from_settings) = task
+        .request_settings
+        .as_ref()
+        .map(|settings| (settings.issue, settings.pr))
+        .unwrap_or((None, None));
+
     let issue = issue_from_external_id
         .or(task.issue)
-        .or_else(|| parse_description_number(task.description.as_deref(), "issue #"));
-    let pr = pr_from_external_id
-        .or_else(|| parse_description_number(task.description.as_deref(), "PR #"));
+        .or(issue_from_settings)
+        .or_else(|| {
+            if matches!(task.task_kind, task_runner::TaskKind::Issue) {
+                parse_description_number(task.description.as_deref(), "issue #")
+            } else {
+                None
+            }
+        });
+    let pr = pr_from_external_id.or(pr_from_settings).or_else(|| {
+        if matches!(task.task_kind, task_runner::TaskKind::Pr) {
+            parse_description_number(task.description.as_deref(), "PR #")
+        } else {
+            None
+        }
+    });
 
     (issue, pr)
 }
@@ -76,6 +94,25 @@ fn task_has_restart_safe_prompt(task: &task_runner::TaskState) -> bool {
         }
     }
     req.prompt.is_some()
+}
+
+fn task_allows_prompt_orphan_recovery(task: &task_runner::TaskState) -> bool {
+    matches!(
+        task.task_kind,
+        task_runner::TaskKind::Prompt
+            | task_runner::TaskKind::Review
+            | task_runner::TaskKind::Planner
+    ) && task_has_restart_safe_prompt(task)
+}
+
+fn orphan_recovery_failure_reason(task: &task_runner::TaskState) -> &'static str {
+    match task.task_kind {
+        task_runner::TaskKind::Issue => "orphaned issue task: issue number not persisted",
+        task_runner::TaskKind::Pr => "orphaned PR task: PR number not persisted",
+        task_runner::TaskKind::Prompt => "orphaned prompt-only task: prompt not persisted",
+        task_runner::TaskKind::Review => "orphaned review task: prompt not persisted",
+        task_runner::TaskKind::Planner => "orphaned planner task: prompt not persisted",
+    }
 }
 
 pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_routes::QueueDomain {
@@ -1351,7 +1388,7 @@ pub(super) async fn spawn_orphan_pending_recovery(state: &Arc<AppState>) {
     let mut failed = Vec::new();
     for task in orphan_tasks {
         let (issue, pr) = parse_issue_pr(&task);
-        if issue.is_some() || pr.is_some() || task_has_restart_safe_prompt(&task) {
+        if issue.is_some() || pr.is_some() || task_allows_prompt_orphan_recovery(&task) {
             recoverable.push((task, issue, pr));
         } else {
             failed.push(task);
@@ -1371,7 +1408,7 @@ pub(super) async fn spawn_orphan_pending_recovery(state: &Arc<AppState>) {
             else {
                 return;
             };
-            let reason = "orphaned prompt-only task: prompt not persisted".to_string();
+            let reason = orphan_recovery_failure_reason(&task).to_string();
             tracing::warn!(task_id = ?task.id, "{reason}");
             let task_id = task.id.clone();
             if let Err(pe) =
@@ -1656,6 +1693,58 @@ mod tests {
 
         let ids = workflow_recovery_task_ids(&[claimed]);
         assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn parse_issue_pr_uses_persisted_request_identifiers() {
+        let issue_settings =
+            task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+                issue: Some(944),
+                prompt: Some("extra context".to_string()),
+                external_id: Some("custom-issue-944".to_string()),
+                ..task_runner::CreateTaskRequest::default()
+            });
+        let mut issue_task = task_runner::TaskState::new(task_runner::TaskId::new());
+        issue_task.task_kind = task_runner::TaskKind::Issue;
+        issue_task.external_id = Some("custom-issue-944".to_string());
+        issue_task.request_settings = Some(issue_settings);
+        assert_eq!(parse_issue_pr(&issue_task), (Some(944), None));
+
+        let pr_settings =
+            task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+                pr: Some(1040),
+                external_id: Some("custom-pr-1040".to_string()),
+                ..task_runner::CreateTaskRequest::default()
+            });
+        let mut pr_task = task_runner::TaskState::new(task_runner::TaskId::new());
+        pr_task.task_kind = task_runner::TaskKind::Pr;
+        pr_task.external_id = Some("custom-pr-1040".to_string());
+        pr_task.request_settings = Some(pr_settings);
+        assert_eq!(parse_issue_pr(&pr_task), (None, Some(1040)));
+    }
+
+    #[test]
+    fn prompt_orphan_recovery_requires_prompt_task_kind() {
+        let settings =
+            task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+                issue: Some(944),
+                prompt: Some("extra context".to_string()),
+                ..task_runner::CreateTaskRequest::default()
+            });
+        let mut issue_task = task_runner::TaskState::new(task_runner::TaskId::new());
+        issue_task.task_kind = task_runner::TaskKind::Issue;
+        issue_task.request_settings = Some(settings);
+        assert!(!task_allows_prompt_orphan_recovery(&issue_task));
+
+        let prompt_settings =
+            task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+                prompt: Some("restart-safe prompt".to_string()),
+                ..task_runner::CreateTaskRequest::default()
+            });
+        let mut prompt_task = task_runner::TaskState::new(task_runner::TaskId::new());
+        prompt_task.task_kind = task_runner::TaskKind::Prompt;
+        prompt_task.request_settings = Some(prompt_settings);
+        assert!(task_allows_prompt_orphan_recovery(&prompt_task));
     }
 
     #[test]

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -170,6 +170,9 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // Re-dispatch tasks recovered from plan/triage checkpoints but without a PR.
     background::spawn_checkpoint_recovery(&state).await;
 
+    // Re-dispatch leftover pending tasks that crashed before their first checkpoint.
+    background::spawn_orphan_pending_recovery(&state).await;
+
     // Periodically sweep issue workflows with attached PRs and automatically
     // enqueue `pr:N` tasks so PR feedback is handled without manual resubmission.
     background::spawn_issue_workflow_feedback_sweeper(&state);

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2784,6 +2784,369 @@ async fn build_router_webhook_body_limit_enforced() -> anyhow::Result<()> {
 // permit, or project-resolution wiring would leave tasks stuck in pending
 // forever in production while CI stayed green.
 
+async fn wait_for_task_status(
+    state: &Arc<AppState>,
+    task_id: &task_runner::TaskId,
+    expected: task_runner::TaskStatus,
+) -> anyhow::Result<task_runner::TaskState> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Some(task) = state.core.tasks.get_with_db_fallback(task_id).await? {
+            if task.status == expected {
+                return Ok(task);
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "task {} did not reach status {:?} within 5 seconds",
+                task_id.0,
+                expected
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_task_to_leave_pending(
+    state: &Arc<AppState>,
+    task_id: &task_runner::TaskId,
+) -> anyhow::Result<task_runner::TaskState> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Some(task) = state.core.tasks.get_with_db_fallback(task_id).await? {
+            if task.status != task_runner::TaskStatus::Pending {
+                return Ok(task);
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("task {} did not leave Pending within 5 seconds", task_id.0);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn orphan_issue_task_is_redispatched_using_existing_task_row() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("issue:944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: Some(944),
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("issue #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state = wait_for_task_to_leave_pending(&state, &task_id).await?;
+    assert_eq!(final_state.id, task_id);
+    assert_ne!(final_state.status, task_runner::TaskStatus::Pending);
+    assert_eq!(state.core.tasks.list_all_with_terminal().await?.len(), 1);
+    assert!(agent.prompts.lock().await.len() <= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_pr_task_is_redispatched_using_existing_task_row() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Pr,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("pr:944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("PR #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state = wait_for_task_to_leave_pending(&state, &task_id).await?;
+    assert_eq!(final_state.id, task_id);
+    assert_ne!(final_state.status, task_runner::TaskStatus::Pending);
+    assert_eq!(state.core.tasks.list_all_with_terminal().await?.len(), 1);
+    assert!(agent.prompts.lock().await.len() <= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_prompt_only_task_fails_closed_when_prompt_was_not_persisted() -> anyhow::Result<()>
+{
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: None,
+        description: Some("prompt task".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state =
+        wait_for_task_status(&state, &task_id, task_runner::TaskStatus::Failed).await?;
+    assert_eq!(
+        final_state.error.as_deref(),
+        Some("orphaned prompt-only task: prompt not persisted")
+    );
+    assert!(agent.prompts.lock().await.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_recovery_excludes_pr_checkpoint_and_non_pending_rows() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let orphan = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("issue:944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: Some(944),
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("issue #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let orphan_id = orphan.id.clone();
+    state.core.tasks.insert(&orphan).await;
+
+    let with_pr = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Pr,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: Some("https://github.com/majiayu000/harness/pull/944".to_string()),
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("pr:944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("PR #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let with_pr_id = with_pr.id.clone();
+    state.core.tasks.insert(&with_pr).await;
+
+    let with_checkpoint = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("issue:945".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: Some(945),
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("issue #945".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let with_checkpoint_id = with_checkpoint.id.clone();
+    state.core.tasks.insert(&with_checkpoint).await;
+    state
+        .core
+        .tasks
+        .write_checkpoint(&with_checkpoint_id, None, Some("plan output"), None, "plan")
+        .await?;
+
+    let failed = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Failed,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: Some("already failed".to_string()),
+        source: Some("github".to_string()),
+        external_id: Some("issue:946".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: Some(946),
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("issue #946".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let failed_id = failed.id.clone();
+    state.core.tasks.insert(&failed).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_orphan = wait_for_task_to_leave_pending(&state, &orphan_id).await?;
+    assert_eq!(final_orphan.id, orphan_id);
+    assert_ne!(final_orphan.status, task_runner::TaskStatus::Pending);
+    assert!(agent.prompts.lock().await.len() <= 1);
+
+    let pr_state = state
+        .core
+        .tasks
+        .get_with_db_fallback(&with_pr_id)
+        .await?
+        .expect("pr task should exist");
+    assert_eq!(pr_state.status, task_runner::TaskStatus::Pending);
+
+    let checkpoint_state = state
+        .core
+        .tasks
+        .get_with_db_fallback(&with_checkpoint_id)
+        .await?
+        .expect("checkpoint task should exist");
+    assert_eq!(checkpoint_state.status, task_runner::TaskStatus::Pending);
+
+    let failed_state = state
+        .core
+        .tasks
+        .get_with_db_fallback(&failed_id)
+        .await?
+        .expect("failed task should exist");
+    assert_eq!(failed_state.status, task_runner::TaskStatus::Failed);
+    Ok(())
+}
+
 #[tokio::test]
 async fn pr_recovery_marks_task_failed_when_pr_url_unparseable() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2922,6 +2922,103 @@ async fn orphan_pr_task_is_redispatched_using_existing_task_row() -> anyhow::Res
 }
 
 #[tokio::test]
+async fn orphan_issue_task_is_redispatched_when_external_id_is_noncanonical() -> anyhow::Result<()>
+{
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("legacy-issue-944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: Some(944),
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("issue #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state = wait_for_task_to_leave_pending(&state, &task_id).await?;
+    assert_eq!(final_state.id, task_id);
+    assert_ne!(final_state.status, task_runner::TaskStatus::Pending);
+    assert_eq!(state.core.tasks.list_all_with_terminal().await?.len(), 1);
+    assert!(agent.prompts.lock().await.len() <= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_pr_task_is_redispatched_when_external_id_is_noncanonical() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Pr,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("legacy-pr-944".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: Some("majiayu000/harness".to_string()),
+        description: Some("PR #944".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state = wait_for_task_to_leave_pending(&state, &task_id).await?;
+    assert_eq!(final_state.id, task_id);
+    assert_ne!(final_state.status, task_runner::TaskStatus::Pending);
+    assert_eq!(state.core.tasks.list_all_with_terminal().await?.len(), 1);
+    assert!(agent.prompts.lock().await.len() <= 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn orphan_prompt_only_task_fails_closed_when_prompt_was_not_persisted() -> anyhow::Result<()>
 {
     let dir = tempfile::tempdir()?;
@@ -2968,6 +3065,66 @@ async fn orphan_prompt_only_task_fails_closed_when_prompt_was_not_persisted() ->
         final_state.error.as_deref(),
         Some("orphaned prompt-only task: prompt not persisted")
     );
+    assert!(agent.prompts.lock().await.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_prompt_only_task_waits_for_runtime_host_lease_to_expire_before_failing(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let mut task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Prompt,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: None,
+        description: Some("prompt task".to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: None,
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    task.scheduler.claim_runtime_host(
+        "host-a",
+        chrono::Utc::now() + chrono::TimeDelta::milliseconds(75),
+    );
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state =
+        wait_for_task_status(&state, &task_id, task_runner::TaskStatus::Failed).await?;
+    assert_eq!(
+        final_state.error.as_deref(),
+        Some("orphaned prompt-only task: prompt not persisted")
+    );
+    assert_eq!(final_state.scheduler.runtime_host_id(), None);
+    assert!(matches!(
+        final_state.scheduler.authority_state,
+        task_runner::SchedulerAuthorityState::Failed
+    ));
     assert!(agent.prompts.lock().await.is_empty());
     Ok(())
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2829,6 +2829,11 @@ async fn wait_for_task_to_leave_pending(
 async fn orphan_issue_task_is_redispatched_using_existing_task_row() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+    let settings =
+        task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+            issue: Some(944),
+            ..task_runner::CreateTaskRequest::default()
+        });
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
@@ -2848,16 +2853,16 @@ async fn orphan_issue_task_is_redispatched_using_existing_task_row() -> anyhow::
         workspace_path: None,
         workspace_owner: None,
         run_generation: 0,
-        issue: Some(944),
+        issue: None,
         repo: Some("majiayu000/harness".to_string()),
-        description: Some("issue #944".to_string()),
+        description: None,
         created_at: None,
         updated_at: None,
         priority: 0,
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
+        request_settings: Some(settings),
         scheduler: task_runner::TaskSchedulerState::queued(),
     };
     let task_id = task.id.clone();
@@ -2877,6 +2882,11 @@ async fn orphan_issue_task_is_redispatched_using_existing_task_row() -> anyhow::
 async fn orphan_pr_task_is_redispatched_using_existing_task_row() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+    let settings =
+        task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+            pr: Some(944),
+            ..task_runner::CreateTaskRequest::default()
+        });
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
@@ -2898,14 +2908,14 @@ async fn orphan_pr_task_is_redispatched_using_existing_task_row() -> anyhow::Res
         run_generation: 0,
         issue: None,
         repo: Some("majiayu000/harness".to_string()),
-        description: Some("PR #944".to_string()),
+        description: None,
         created_at: None,
         updated_at: None,
         priority: 0,
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
+        request_settings: Some(settings),
         scheduler: task_runner::TaskSchedulerState::queued(),
     };
     let task_id = task.id.clone();
@@ -2926,6 +2936,11 @@ async fn orphan_issue_task_is_redispatched_when_external_id_is_noncanonical() ->
 {
     let dir = tempfile::tempdir()?;
     let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+    let settings =
+        task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+            issue: Some(944),
+            ..task_runner::CreateTaskRequest::default()
+        });
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
@@ -2945,16 +2960,16 @@ async fn orphan_issue_task_is_redispatched_when_external_id_is_noncanonical() ->
         workspace_path: None,
         workspace_owner: None,
         run_generation: 0,
-        issue: Some(944),
+        issue: None,
         repo: Some("majiayu000/harness".to_string()),
-        description: Some("issue #944".to_string()),
+        description: None,
         created_at: None,
         updated_at: None,
         priority: 0,
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
+        request_settings: Some(settings),
         scheduler: task_runner::TaskSchedulerState::queued(),
     };
     let task_id = task.id.clone();
@@ -2974,6 +2989,11 @@ async fn orphan_issue_task_is_redispatched_when_external_id_is_noncanonical() ->
 async fn orphan_pr_task_is_redispatched_when_external_id_is_noncanonical() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+    let settings =
+        task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+            pr: Some(944),
+            ..task_runner::CreateTaskRequest::default()
+        });
 
     let task = task_runner::TaskState {
         id: task_runner::TaskId::new(),
@@ -2995,14 +3015,14 @@ async fn orphan_pr_task_is_redispatched_when_external_id_is_noncanonical() -> an
         run_generation: 0,
         issue: None,
         repo: Some("majiayu000/harness".to_string()),
-        description: Some("PR #944".to_string()),
+        description: None,
         created_at: None,
         updated_at: None,
         priority: 0,
         phase: task_runner::TaskPhase::default(),
         triage_output: None,
         plan_output: None,
-        request_settings: None,
+        request_settings: Some(settings),
         scheduler: task_runner::TaskSchedulerState::queued(),
     };
     let task_id = task.id.clone();
@@ -3015,6 +3035,65 @@ async fn orphan_pr_task_is_redispatched_when_external_id_is_noncanonical() -> an
     assert_ne!(final_state.status, task_runner::TaskStatus::Pending);
     assert_eq!(state.core.tasks.list_all_with_terminal().await?.len(), 1);
     assert!(agent.prompts.lock().await.len() <= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn orphan_issue_task_with_prompt_context_fails_when_identifier_is_missing(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, agent) = make_test_state_with_agent(dir.path(), Some("secret")).await?;
+
+    let mut settings =
+        task_runner::PersistedRequestSettings::from_req(&task_runner::CreateTaskRequest {
+            issue: Some(944),
+            prompt: Some("extra issue context".to_string()),
+            ..task_runner::CreateTaskRequest::default()
+        });
+    settings.issue = None;
+
+    let task = task_runner::TaskState {
+        id: task_runner::TaskId::new(),
+        task_kind: task_runner::TaskKind::Issue,
+        status: task_runner::TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: Some("github".to_string()),
+        external_id: Some("legacy-issue-without-number".to_string()),
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: Some(dir.path().to_path_buf()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        repo: Some("majiayu000/harness".to_string()),
+        description: None,
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: task_runner::TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        request_settings: Some(settings),
+        scheduler: task_runner::TaskSchedulerState::queued(),
+    };
+    let task_id = task.id.clone();
+    state.core.tasks.insert(&task).await;
+
+    super::background::spawn_orphan_pending_recovery(&state).await;
+
+    let final_state =
+        wait_for_task_status(&state, &task_id, task_runner::TaskStatus::Failed).await?;
+    assert_eq!(
+        final_state.error.as_deref(),
+        Some("orphaned issue task: issue number not persisted")
+    );
+    assert!(agent.prompts.lock().await.is_empty());
     Ok(())
 }
 

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -162,6 +162,22 @@ impl TaskDb {
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
     }
 
+    /// Return pending tasks that have no PR URL and no checkpoint row.
+    pub async fn pending_orphan_tasks(&self) -> anyhow::Result<Vec<TaskState>> {
+        let sql = format!(
+            "SELECT {TASK_ROW_COLUMNS} \
+             FROM tasks t \
+             WHERE t.status = 'pending' \
+               AND t.pr_url IS NULL \
+               AND NOT EXISTS (SELECT 1 FROM task_checkpoints c WHERE c.task_id = t.id) \
+             ORDER BY t.created_at DESC"
+        );
+        let rows = sqlx::query_as::<_, TaskRow>(&sql)
+            .fetch_all(&self.pool)
+            .await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
     /// Return the latest `(external_id, status, created_at)` row for each issue task
     /// in a single project/repo namespace.
     pub async fn list_latest_external_statuses_by_project_and_repo(
@@ -805,6 +821,57 @@ impl TaskDb {
             .bind(task_id)
             .execute(&self.pool)
             .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_runner::{TaskId, TaskState, TaskStatus};
+
+    #[tokio::test]
+    async fn pending_orphan_tasks_returns_only_true_orphans() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db = TaskDb::open(&dir.path().join("tasks.db")).await?;
+
+        let mut orphan_issue = TaskState::new(TaskId::new());
+        orphan_issue.status = TaskStatus::Pending;
+        orphan_issue.external_id = Some("issue:944".to_string());
+        db.insert(&orphan_issue).await?;
+
+        let mut orphan_prompt = TaskState::new(TaskId::new());
+        orphan_prompt.status = TaskStatus::Pending;
+        db.insert(&orphan_prompt).await?;
+
+        let mut with_pr = TaskState::new(TaskId::new());
+        with_pr.status = TaskStatus::Pending;
+        with_pr.pr_url = Some("https://github.com/org/repo/pull/944".to_string());
+        db.insert(&with_pr).await?;
+
+        let mut with_checkpoint = TaskState::new(TaskId::new());
+        with_checkpoint.status = TaskStatus::Pending;
+        db.insert(&with_checkpoint).await?;
+        db.write_checkpoint(&with_checkpoint.id.0, None, Some("plan"), None, "plan")
+            .await?;
+
+        let mut failed = TaskState::new(TaskId::new());
+        failed.status = TaskStatus::Failed;
+        db.insert(&failed).await?;
+
+        let orphan_ids: std::collections::HashSet<_> = db
+            .pending_orphan_tasks()
+            .await?
+            .into_iter()
+            .map(|task| task.id)
+            .collect();
+
+        assert_eq!(orphan_ids.len(), 2);
+        assert!(orphan_ids.contains(&orphan_issue.id));
+        assert!(orphan_ids.contains(&orphan_prompt.id));
+        assert!(!orphan_ids.contains(&with_pr.id));
+        assert!(!orphan_ids.contains(&with_checkpoint.id));
+        assert!(!orphan_ids.contains(&failed.id));
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -121,6 +121,12 @@ impl SystemTaskInput {
 /// guardrails instead of silently falling back to server-wide defaults.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PersistedRequestSettings {
+    /// Structured issue identifier for restart recovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue: Option<u64>,
+    /// Structured PR identifier for restart recovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,6 +171,8 @@ pub struct PersistedRequestSettings {
 impl PersistedRequestSettings {
     pub(crate) fn from_req(req: &CreateTaskRequest) -> Self {
         Self {
+            issue: req.issue,
+            pr: req.pr,
             agent: req.agent.clone(),
             max_rounds: req.max_rounds,
             max_turns: req.max_turns,
@@ -197,6 +205,12 @@ impl PersistedRequestSettings {
     }
 
     pub(crate) fn apply_to_req(&self, req: &mut CreateTaskRequest) {
+        if req.issue.is_none() {
+            req.issue = self.issue;
+        }
+        if req.pr.is_none() {
+            req.pr = self.pr;
+        }
         req.agent = self.agent.clone();
         req.max_rounds = self.max_rounds;
         req.max_turns = self.max_turns;
@@ -419,6 +433,7 @@ mod tests {
 
         let mut restored = CreateTaskRequest::default();
         settings.apply_to_req(&mut restored);
+        assert_eq!(restored.issue, Some(42));
         assert!(restored.skip_triage);
         assert!(restored.force_execute);
     }

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1004,6 +1004,11 @@ impl TaskStore {
         self.db.pending_tasks_with_checkpoint().await
     }
 
+    /// Return pending tasks that have no PR URL and no checkpoint row.
+    pub(crate) async fn pending_orphan_tasks(&self) -> anyhow::Result<Vec<TaskState>> {
+        self.db.pending_orphan_tasks().await
+    }
+
     /// Overwrite `external_id` on an auto-fix task, even if one is already set.
     ///
     /// Used during streaming to implement "last sentinel wins" — the agent may


### PR DESCRIPTION
## Summary
- add a final startup recovery pass for pending tasks with no pr_url and no checkpoint
- redispatch orphan issue/pr tasks through the preregistered startup path and fail-close prompt-only tasks without persisted input
- add DB/store helpers plus startup recovery coverage for issue, pr, prompt-only, and exclusion cases

## Validation
- cargo fmt --all
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
- HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test -p harness-server

Closes #944