### PR TITLE
Promote actionable triage skips into planned work

### DIFF
--- a/crates/harness-core/src/config/project.rs
+++ b/crates/harness-core/src/config/project.rs
@@ -77,6 +77,15 @@ pub struct ProjectGcConfig {
     pub max_drafts_per_run: Option<usize>,
 }
 
+/// Per-project triage configuration overrides.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProjectTriageConfig {
+    /// When `true`, preserve legacy "review label may skip" behavior for
+    /// non-actionable issues. Actionable issues are still promoted.
+    #[serde(default)]
+    pub skip_on_review_label: Option<bool>,
+}
+
 /// Git configuration for a project.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
@@ -138,6 +147,9 @@ pub struct ProjectConfig {
     /// Per-project GC overrides. `None` inherits from server defaults.
     #[serde(default)]
     pub gc: Option<ProjectGcConfig>,
+    /// Per-project triage overrides. `None` inherits from defaults.
+    #[serde(default)]
+    pub triage: Option<ProjectTriageConfig>,
     /// Project type used to select review focus criteria. Default: mixed.
     #[serde(default)]
     pub review_type: ReviewType,
@@ -172,6 +184,13 @@ mod tests {
         assert_eq!(config.git.base_branch, "main");
         assert_eq!(config.git.remote, "origin");
         assert_eq!(config.review_type, ReviewType::Mixed);
+        assert_eq!(
+            config
+                .triage
+                .as_ref()
+                .and_then(|triage| triage.skip_on_review_label),
+            None
+        );
         Ok(())
     }
 
@@ -204,6 +223,9 @@ base_branch = "develop"
 remote = "upstream"
 branch_prefix = "featx/"
 
+[triage]
+skip_on_review_label = true
+
 review_type = "rust"
 "#,
         )?;
@@ -212,6 +234,13 @@ review_type = "rust"
         assert_eq!(config.git.base_branch, "develop");
         assert_eq!(config.git.remote, "upstream");
         assert_eq!(config.git.branch_prefix, "featx/");
+        assert_eq!(
+            config
+                .triage
+                .as_ref()
+                .and_then(|triage| triage.skip_on_review_label),
+            Some(true)
+        );
         Ok(())
     }
 }

--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -43,11 +43,14 @@ pub fn triage_prompt(issue: u64) -> PromptParts {
              - SKIP — ONLY if the issue is a literal duplicate of another issue, or fundamentally impossible\n\n\
              **IMPORTANT RULES:**\n\
              - Default to PROCEED or PROCEED_WITH_PLAN. Most issues should be attempted.\n\
+             - Treat a `review` label as advisory context, never as a skip signal by itself.\n\
+             - If the issue has concrete file:line references plus a recommended fix, acceptance criteria, or explicit steps/code, choose PROCEED_WITH_PLAN rather than SKIP.\n\
              - Do NOT skip issues just because they are large, complex, or ambitious.\n\
              - Do NOT use NEEDS_CLARIFICATION — if the issue is unclear, PROCEED_WITH_PLAN and let the planner figure it out.\n\
              - Large refactors (4+ files) → PROCEED_WITH_PLAN, never SKIP.\n\n\
-             **OUTPUT FORMAT (mandatory, must be the last 2 lines):**\n\
+             **OUTPUT FORMAT (mandatory, must be the last 3 lines):**\n\
              COMPLEXITY=<low|medium|high>\n\
+             TRIAGE_REASON=<short_snake_case_reason>\n\
              TRIAGE=<PROCEED|PROCEED_WITH_PLAN|SKIP>"
         ),
         context: String::new(),
@@ -346,6 +349,7 @@ mod tests {
         assert!(s.contains("PROCEED_WITH_PLAN"));
         assert!(s.contains("SKIP"));
         assert!(s.contains("TRIAGE="));
+        assert!(s.contains("TRIAGE_REASON="));
     }
 
     #[test]
@@ -368,6 +372,10 @@ mod tests {
         assert!(
             p.contains("TRIAGE="),
             "triage prompt must instruct TRIAGE= output"
+        );
+        assert!(
+            p.contains("TRIAGE_REASON="),
+            "triage prompt must instruct TRIAGE_REASON= output"
         );
     }
 }

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -24,7 +24,8 @@ pub use parsing::{
     extract_pr_number, extract_review_issues, is_lgtm, is_quota_exhausted, is_waiting,
     parse_complexity, parse_created_issue_number, parse_github_pr_url, parse_issue_count,
     parse_plan_issue, parse_pr_review_prep_outcome, parse_pr_url, parse_pushed_commit,
-    parse_triage, repo_slug_from_pr_url, PrReviewPrepOutcome, TriageComplexity, TriageDecision,
+    parse_triage, parse_triage_reason, repo_slug_from_pr_url, PrReviewPrepOutcome,
+    TriageComplexity, TriageDecision,
 };
 pub use pr::{
     check_existing_pr, check_resumed_pr_conflicts, continue_existing_pr, prepare_pr_for_review,

--- a/crates/harness-core/src/prompts/parsing.rs
+++ b/crates/harness-core/src/prompts/parsing.rs
@@ -324,20 +324,26 @@ pub enum TriageComplexity {
 
 /// Parse `COMPLEXITY=<low|medium|high>` from triage agent output.
 ///
-/// The protocol requires `COMPLEXITY=` to appear on the second-to-last line
-/// (just before `TRIAGE=` on the last line). Only the second-to-last non-empty
-/// line is examined to prevent untrusted issue content (e.g. a line containing
-/// `COMPLEXITY=low` in the issue body) from influencing classification.
+/// The protocol requires `COMPLEXITY=` to appear immediately before the final
+/// `TRIAGE_REASON=`/`TRIAGE=` footer. Only the footer block is examined to
+/// prevent untrusted issue content (e.g. a line containing `COMPLEXITY=low`
+/// in the issue body) from influencing classification.
 ///
 /// Returns `TriageComplexity::Medium` if the tag is absent or unrecognised
 /// (backward-compatible fallback).
 pub fn parse_complexity(output: &str) -> TriageComplexity {
     let non_empty: Vec<&str> = output.lines().filter(|l| !l.trim().is_empty()).collect();
-    // second-to-last line (index len-2); need at least 2 non-empty lines
     if non_empty.len() < 2 {
         return TriageComplexity::Medium;
     }
-    let candidate = non_empty[non_empty.len() - 2].trim();
+    let mut index = non_empty.len() - 2;
+    if non_empty[index].trim().starts_with("TRIAGE_REASON=") {
+        if index == 0 {
+            return TriageComplexity::Medium;
+        }
+        index -= 1;
+    }
+    let candidate = non_empty[index].trim();
     if let Some(value) = candidate.strip_prefix("COMPLEXITY=") {
         return match value.trim().to_ascii_lowercase().as_str() {
             "low" => TriageComplexity::Low,
@@ -375,6 +381,26 @@ pub fn parse_triage(output: &str) -> Option<TriageDecision> {
         "SKIP" => Some(TriageDecision::Skip),
         _ => None,
     }
+}
+
+/// Parse an optional `TRIAGE_REASON=<value>` footer from triage agent output.
+///
+/// Only the second-to-last non-empty line is examined so injected issue body
+/// content cannot influence the parsed reason.
+pub fn parse_triage_reason(output: &str) -> Option<String> {
+    let non_empty: Vec<&str> = output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    if non_empty.len() < 2 {
+        return None;
+    }
+    non_empty[non_empty.len() - 2]
+        .trim()
+        .strip_prefix("TRIAGE_REASON=")
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// Check if the agent flagged an issue with the implementation plan.
@@ -934,6 +960,23 @@ PR_URL=https://github.com/owner/repo/pull/269";
     }
 
     #[test]
+    fn test_parse_triage_reason_present() {
+        let output = "Assessment\nCOMPLEXITY=high\nTRIAGE_REASON=actionable_issue_markers\nTRIAGE=PROCEED_WITH_PLAN";
+        assert_eq!(
+            parse_triage_reason(output),
+            Some("actionable_issue_markers".to_string())
+        );
+        assert_eq!(parse_complexity(output), TriageComplexity::High);
+    }
+
+    #[test]
+    fn test_parse_triage_reason_absent_is_safe() {
+        let output = "Assessment\nCOMPLEXITY=medium\nTRIAGE=PROCEED";
+        assert_eq!(parse_triage_reason(output), None);
+        assert_eq!(parse_complexity(output), TriageComplexity::Medium);
+    }
+
+    #[test]
     fn test_parse_plan_issue() {
         assert_eq!(
             parse_plan_issue("Working on it...\nPLAN_ISSUE=The plan missed error handling"),
@@ -984,7 +1027,8 @@ PR_URL=https://github.com/owner/repo/pull/269";
 
     #[test]
     fn test_parse_complexity_with_triage_combo() {
-        let output = "This is a simple typo fix.\nCOMPLEXITY=high\nTRIAGE=PROCEED";
+        let output =
+            "This is a simple typo fix.\nCOMPLEXITY=high\nTRIAGE_REASON=simple_fix\nTRIAGE=PROCEED";
         assert_eq!(parse_complexity(output), TriageComplexity::High);
         assert_eq!(parse_triage(output), Some(TriageDecision::Proceed));
     }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -277,6 +277,7 @@ mod startup_tests {
     async fn persisted_skills_survive_restart() -> anyhow::Result<()> {
         // Hold the shared HOME_LOCK so no sibling test races on HOME.
         let _lock = HOME_LOCK.lock().await;
+        let _ = crate::test_helpers::test_database_url()?;
 
         let sandbox = tempfile::tempdir()?;
         let project_root = sandbox.path().join("project");

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -156,6 +156,7 @@ async fn make_test_state_with_project_root(
     mut config: harness_core::config::HarnessConfig,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
+    let _ = crate::test_helpers::test_database_url()?;
     let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
     let database_url = crate::test_helpers::ensure_test_database_url_override()?;
     config.server.database_url = Some(database_url.clone());

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -922,7 +922,18 @@ pub(crate) async fn run_task(
             (None, prompts::TriageComplexity::Medium, 0u32)
         } else {
             match triage_pipeline::run_triage_plan_pipeline(
-                agent, store, task_id, issue, &cargo_env, &project, req, &skills, &events,
+                agent,
+                store,
+                task_id,
+                issue,
+                &repo_slug,
+                server_config.server.github_token.as_deref(),
+                project_config.triage.as_ref(),
+                &cargo_env,
+                &project,
+                req,
+                &skills,
+                &events,
             )
             .await?
             {

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -8,12 +8,340 @@ use crate::task_runner::{
 };
 use chrono::Utc;
 use harness_core::agent::{AgentRequest, CodeAgent};
+use harness_core::config::project::ProjectTriageConfig;
 use harness_core::prompts;
 use harness_core::types::{Decision, ExecutionPhase, TurnFailure, TurnFailureKind, TurnTelemetry};
 use harness_observe::event_store::EventStore;
+use reqwest::header::{ACCEPT, USER_AGENT};
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
+use std::time::Duration;
 use tokio::sync::RwLock;
+
+const GITHUB_ISSUE_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+const UNKNOWN_REPO_SLUG: &str = "{owner}/{repo}";
+
+type IssueFetchFuture<'a> =
+    Pin<Box<dyn Future<Output = anyhow::Result<TypedIssueSnapshot>> + Send + 'a>>;
+type IssueFetchFn = for<'a> fn(&'a str, u64, Option<&'a str>) -> IssueFetchFuture<'a>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct TypedIssueSnapshot {
+    body: String,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubIssueSnapshotResponse {
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    labels: Vec<GitHubIssueLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubIssueLabel {
+    name: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ActionabilitySignals {
+    file_line_reference: bool,
+    recommended_section: bool,
+    acceptance_criteria: bool,
+    code_block_or_step_list: bool,
+}
+
+impl ActionabilitySignals {
+    fn count(self) -> usize {
+        [
+            self.file_line_reference,
+            self.recommended_section,
+            self.acceptance_criteria,
+            self.code_block_or_step_list,
+        ]
+        .into_iter()
+        .filter(|present| *present)
+        .count()
+    }
+
+    fn is_actionable(self) -> bool {
+        self.file_line_reference
+            && self.code_block_or_step_list
+            && (self.recommended_section || self.acceptance_criteria)
+            && self.count() >= 3
+    }
+
+    fn names(self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        if self.file_line_reference {
+            names.push("file_line");
+        }
+        if self.recommended_section {
+            names.push("recommended_section");
+        }
+        if self.acceptance_criteria {
+            names.push("acceptance_criteria");
+        }
+        if self.code_block_or_step_list {
+            names.push("code_or_steps");
+        }
+        names
+    }
+
+    fn promotion_reason(self) -> String {
+        format!("actionable_issue_markers:{}", self.names().join(","))
+    }
+
+    fn non_actionable_reason(self) -> String {
+        let names = self.names();
+        if names.is_empty() {
+            "non_actionable_issue_markers:none".to_string()
+        } else {
+            format!("non_actionable_issue_markers:{}", names.join(","))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedTriageDecision {
+    decision: prompts::TriageDecision,
+    reason: String,
+}
+
+fn github_api_base_url() -> String {
+    std::env::var("HARNESS_GITHUB_API_BASE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "https://api.github.com".to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn issue_has_review_label(labels: &[String]) -> bool {
+    labels
+        .iter()
+        .any(|label| label.trim().eq_ignore_ascii_case("review"))
+}
+
+fn effective_skip_on_review_label(config: Option<&ProjectTriageConfig>) -> bool {
+    config
+        .and_then(|triage| triage.skip_on_review_label)
+        .unwrap_or(false)
+}
+
+fn trim_token(candidate: &str) -> &str {
+    candidate.trim_matches(|ch: char| {
+        matches!(
+            ch,
+            '`' | '"' | '\'' | ',' | '.' | ';' | ':' | '(' | ')' | '[' | ']' | '{' | '}'
+        )
+    })
+}
+
+fn contains_file_line_reference(body: &str) -> bool {
+    body.split_whitespace().any(|token| {
+        let candidate = trim_token(token);
+        let Some((path, line)) = candidate.rsplit_once(':') else {
+            return false;
+        };
+        !path.is_empty()
+            && !line.is_empty()
+            && line.chars().all(|ch| ch.is_ascii_digit())
+            && (path.contains('/') || path.contains('\\') || path.contains('.'))
+            && path.chars().any(|ch| ch.is_ascii_alphabetic())
+    })
+}
+
+fn has_section(body: &str, marker: &str) -> bool {
+    body.lines()
+        .map(|line| line.trim().to_ascii_lowercase())
+        .any(|line| line.starts_with(marker) || line == marker)
+}
+
+fn is_numbered_step(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let digit_count = trimmed.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    if digit_count == 0 {
+        return false;
+    }
+    matches!(trimmed.chars().nth(digit_count), Some('.') | Some(')'))
+        && trimmed[digit_count + 1..].starts_with(' ')
+}
+
+fn has_step_list(body: &str) -> bool {
+    body.lines()
+        .filter(|line| is_numbered_step(line))
+        .take(2)
+        .count()
+        >= 2
+}
+
+fn detect_actionability_signals(body: &str) -> ActionabilitySignals {
+    let lower = body.to_ascii_lowercase();
+    ActionabilitySignals {
+        file_line_reference: contains_file_line_reference(body),
+        recommended_section: has_section(&lower, "## recommended fix")
+            || has_section(&lower, "## recommended action")
+            || has_section(&lower, "recommended fix:")
+            || has_section(&lower, "recommended action:"),
+        acceptance_criteria: has_section(&lower, "## acceptance criteria")
+            || has_section(&lower, "acceptance criteria:"),
+        code_block_or_step_list: body.contains("```") || has_step_list(body),
+    }
+}
+
+fn default_triage_reason(decision: &prompts::TriageDecision) -> &'static str {
+    match decision {
+        prompts::TriageDecision::Proceed => "agent_proceed",
+        prompts::TriageDecision::ProceedWithPlan => "agent_proceed_with_plan",
+        prompts::TriageDecision::NeedsClarification => "agent_needs_clarification",
+        prompts::TriageDecision::Skip => "agent_skip",
+    }
+}
+
+fn resolve_triage_decision(
+    agent_decision: prompts::TriageDecision,
+    agent_reason: Option<&str>,
+    issue_snapshot: Option<&TypedIssueSnapshot>,
+    triage_config: Option<&ProjectTriageConfig>,
+) -> ResolvedTriageDecision {
+    let fallback_reason = agent_reason
+        .filter(|reason| !reason.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| default_triage_reason(&agent_decision).to_string());
+
+    if agent_decision != prompts::TriageDecision::Skip {
+        return ResolvedTriageDecision {
+            decision: agent_decision,
+            reason: fallback_reason,
+        };
+    }
+
+    let Some(issue_snapshot) = issue_snapshot else {
+        return ResolvedTriageDecision {
+            decision: prompts::TriageDecision::Skip,
+            reason: fallback_reason,
+        };
+    };
+
+    let signals = detect_actionability_signals(&issue_snapshot.body);
+    if signals.is_actionable() {
+        return ResolvedTriageDecision {
+            decision: prompts::TriageDecision::ProceedWithPlan,
+            reason: signals.promotion_reason(),
+        };
+    }
+
+    if issue_has_review_label(&issue_snapshot.labels)
+        && effective_skip_on_review_label(triage_config)
+    {
+        return ResolvedTriageDecision {
+            decision: prompts::TriageDecision::Skip,
+            reason: "review_label_skip_allowed_non_actionable".to_string(),
+        };
+    }
+
+    ResolvedTriageDecision {
+        decision: prompts::TriageDecision::Skip,
+        reason: agent_reason
+            .filter(|reason| !reason.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| signals.non_actionable_reason()),
+    }
+}
+
+fn final_triage_event_result(decision: &prompts::TriageDecision) -> &'static str {
+    match decision {
+        prompts::TriageDecision::Skip => "skip",
+        prompts::TriageDecision::Proceed
+        | prompts::TriageDecision::ProceedWithPlan
+        | prompts::TriageDecision::NeedsClarification => "promote",
+    }
+}
+
+fn final_triage_event_decision(decision: &prompts::TriageDecision) -> Decision {
+    match decision {
+        prompts::TriageDecision::Skip => Decision::Block,
+        prompts::TriageDecision::Proceed
+        | prompts::TriageDecision::ProceedWithPlan
+        | prompts::TriageDecision::NeedsClarification => Decision::Complete,
+    }
+}
+
+async fn emit_final_triage_decision_event(
+    events: &EventStore,
+    task_id: &TaskId,
+    turn: u32,
+    decision: &ResolvedTriageDecision,
+) {
+    let event = build_task_event(
+        task_id,
+        turn,
+        "triage",
+        "triage_decision",
+        final_triage_event_decision(&decision.decision),
+        Some(decision.reason.clone()),
+        Some(format!(
+            "result={}",
+            final_triage_event_result(&decision.decision)
+        )),
+        None,
+        None,
+        None,
+    );
+    if let Err(error) = events.log(&event).await {
+        tracing::warn!(task_id = %task_id, "failed to log triage_decision event: {error}");
+    }
+}
+
+async fn fetch_typed_issue_snapshot(
+    repo_slug: &str,
+    issue: u64,
+    github_token: Option<&str>,
+) -> anyhow::Result<TypedIssueSnapshot> {
+    if repo_slug.trim().is_empty() || repo_slug == UNKNOWN_REPO_SLUG {
+        anyhow::bail!("repository slug unavailable for issue triage lookup");
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(GITHUB_ISSUE_LOOKUP_TIMEOUT)
+        .build()?;
+    let url = format!("{}/repos/{repo_slug}/issues/{issue}", github_api_base_url());
+    let mut request = client
+        .get(url)
+        .header(ACCEPT, "application/vnd.github+json")
+        .header(USER_AGENT, "harness-server");
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("GitHub issue lookup failed with status {status}: {body}");
+    }
+    let snapshot: GitHubIssueSnapshotResponse = response.json().await?;
+    Ok(TypedIssueSnapshot {
+        body: snapshot.body.unwrap_or_default(),
+        labels: snapshot
+            .labels
+            .into_iter()
+            .map(|label| label.name)
+            .collect(),
+    })
+}
+
+fn fetch_typed_issue_snapshot_boxed<'a>(
+    repo_slug: &'a str,
+    issue: u64,
+    github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(fetch_typed_issue_snapshot(repo_slug, issue, github_token))
+}
 
 async fn record_phase_observability(
     store: &TaskStore,
@@ -258,11 +586,48 @@ pub(crate) async fn run_triage_plan_pipeline(
     store: &TaskStore,
     task_id: &TaskId,
     issue: u64,
+    repo_slug: &str,
+    github_token: Option<&str>,
+    triage_config: Option<&ProjectTriageConfig>,
     cargo_env: &HashMap<String, String>,
     project: &Path,
     req: &CreateTaskRequest,
     skills: &RwLock<harness_skills::store::SkillStore>,
     events: &EventStore,
+) -> anyhow::Result<TriagePlanPipelineOutcome> {
+    run_triage_plan_pipeline_with_issue_fetcher(
+        agent,
+        store,
+        task_id,
+        issue,
+        repo_slug,
+        github_token,
+        triage_config,
+        cargo_env,
+        project,
+        req,
+        skills,
+        events,
+        fetch_typed_issue_snapshot_boxed,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_triage_plan_pipeline_with_issue_fetcher(
+    agent: &dyn CodeAgent,
+    store: &TaskStore,
+    task_id: &TaskId,
+    issue: u64,
+    repo_slug: &str,
+    github_token: Option<&str>,
+    triage_config: Option<&ProjectTriageConfig>,
+    cargo_env: &HashMap<String, String>,
+    project: &Path,
+    req: &CreateTaskRequest,
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
+    issue_fetcher: IssueFetchFn,
 ) -> anyhow::Result<TriagePlanPipelineOutcome> {
     // --- Phase 1: Triage ---
     tracing::info!(task_id = %task_id, issue, "pipeline: starting triage phase");
@@ -415,16 +780,48 @@ pub(crate) async fn run_triage_plan_pipeline(
             anyhow::bail!("triage output unparseable — agent did not produce TRIAGE=<decision>")
         }
     };
+    let triage_reason = prompts::parse_triage_reason(&triage_resp.output);
     let complexity = prompts::parse_complexity(&triage_resp.output);
-    tracing::info!(task_id = %task_id, ?decision, ?complexity, "triage decision");
+    let fetched_issue = if decision == prompts::TriageDecision::Skip {
+        match issue_fetcher(repo_slug, issue, github_token).await {
+            Ok(issue_snapshot) => Some(issue_snapshot),
+            Err(error) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    issue,
+                    repo = repo_slug,
+                    "triage issue fetch failed, falling back to agent decision: {error}"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let resolved_decision = resolve_triage_decision(
+        decision.clone(),
+        triage_reason.as_deref(),
+        fetched_issue.as_ref(),
+        triage_config,
+    );
+    emit_final_triage_decision_event(events, task_id, 0, &resolved_decision).await;
+    tracing::info!(
+        task_id = %task_id,
+        raw_decision = ?decision,
+        final_decision = ?resolved_decision.decision,
+        ?complexity,
+        triage_reason = %resolved_decision.reason,
+        "triage decision resolved"
+    );
 
-    match decision {
+    match resolved_decision.decision {
         prompts::TriageDecision::Skip => {
             mutate_and_persist(store, task_id, |state| {
                 state.status = TaskStatus::Done;
                 state.phase = TaskPhase::Terminal;
                 state.error = Some(format!(
-                    "Triage skipped issue #{issue}: not worth implementing"
+                    "Triage skipped issue #{issue}: {}",
+                    resolved_decision.reason
                 ));
             })
             .await?;
@@ -718,6 +1115,9 @@ mod tests {
             &store,
             &task_id,
             123,
+            UNKNOWN_REPO_SLUG,
+            None,
+            None,
             &HashMap::new(),
             dir.path(),
             &req,

--- a/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
@@ -3,10 +3,23 @@ use async_trait::async_trait;
 use harness_core::agent::{AgentResponse, StreamItem};
 use harness_core::error::HarnessError;
 use harness_core::types::{Capability, EventFilters, TokenUsage};
+use std::sync::Arc;
 
 struct PromptPlanningAgent;
 
 struct FailingPromptPlanningAgent;
+
+struct TriageStaticStreamAgent {
+    output: String,
+}
+
+impl TriageStaticStreamAgent {
+    fn new(output: &str) -> Self {
+        Self {
+            output: output.to_string(),
+        }
+    }
+}
 
 #[async_trait]
 impl CodeAgent for PromptPlanningAgent {
@@ -72,6 +85,44 @@ impl CodeAgent for FailingPromptPlanningAgent {
         Err(HarnessError::AgentExecution(
             "planner exited with exit status: 1: stdout_tail=[secret prompt]".to_string(),
         ))
+    }
+}
+
+#[async_trait]
+impl CodeAgent for TriageStaticStreamAgent {
+    fn name(&self) -> &str {
+        "triage-static-stream-agent"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        Ok(AgentResponse {
+            output: self.output.clone(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        tx.send(StreamItem::MessageDelta {
+            text: self.output.clone(),
+        })
+        .await
+        .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+        tx.send(StreamItem::Done)
+            .await
+            .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -247,4 +298,337 @@ fn redact_prompt_plan_error_message_preserves_only_safe_fields() {
     );
     assert!(!message.contains("secret prompt"));
     assert!(!message.contains("still secret"));
+}
+
+fn actionable_issue_body() -> String {
+    r#"
+packages/core/src/infra/sqlite/ops.rs:72
+
+## Recommended Fix
+1. Bind parameters instead of concatenating raw input.
+2. Add a regression test for repeated submissions.
+
+## Acceptance Criteria
+- Reject SQL metacharacters in the failing path.
+- Preserve current successful requests.
+
+```rust
+let statement = conn.prepare_cached(SQL)?;
+```
+"#
+    .to_string()
+}
+
+fn abstract_issue_body() -> String {
+    "We should think about this area again later.\nNo concrete path or implementation detail yet."
+        .to_string()
+}
+
+fn actionable_review_issue_fetcher<'a>(
+    _repo_slug: &'a str,
+    _issue: u64,
+    _github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async {
+        Ok(TypedIssueSnapshot {
+            body: actionable_issue_body(),
+            labels: vec!["review".to_string(), "P1".to_string()],
+        })
+    })
+}
+
+fn actionable_no_label_issue_fetcher<'a>(
+    _repo_slug: &'a str,
+    _issue: u64,
+    _github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async {
+        Ok(TypedIssueSnapshot {
+            body: actionable_issue_body(),
+            labels: vec![],
+        })
+    })
+}
+
+fn abstract_review_issue_fetcher<'a>(
+    _repo_slug: &'a str,
+    _issue: u64,
+    _github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async {
+        Ok(TypedIssueSnapshot {
+            body: abstract_issue_body(),
+            labels: vec!["review".to_string()],
+        })
+    })
+}
+
+fn failing_issue_fetcher<'a>(
+    _repo_slug: &'a str,
+    _issue: u64,
+    _github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async { Err(anyhow::anyhow!("simulated GitHub failure")) })
+}
+
+async fn setup_issue_task_harness() -> anyhow::Result<(
+    tempfile::TempDir,
+    Arc<TaskStore>,
+    EventStore,
+    TaskId,
+    CreateTaskRequest,
+    RwLock<harness_skills::store::SkillStore>,
+)> {
+    let dir = tempfile::tempdir()?;
+    let database_url = crate::test_helpers::test_database_url()?;
+    let store =
+        TaskStore::open_with_database_url(&dir.path().join("tasks.db"), Some(&database_url))
+            .await?;
+    let events = EventStore::new(dir.path()).await?;
+    let task_id = TaskId::new();
+    let mut task = crate::task_runner::TaskState::new(task_id.clone());
+    task.task_kind = crate::task_runner::TaskKind::Issue;
+    store.insert(&task).await;
+    let req = CreateTaskRequest {
+        issue: Some(988),
+        turn_timeout_secs: 30,
+        ..CreateTaskRequest::default()
+    };
+    let skills = RwLock::new(harness_skills::store::SkillStore::new());
+    Ok((dir, store, events, task_id, req, skills))
+}
+
+#[tokio::test]
+async fn actionable_review_issue_skip_is_promoted_to_plan() -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    let agent = TriageStaticStreamAgent::new(
+        "Looks abstract.\nCOMPLEXITY=low\nTRIAGE_REASON=agent_skip_review_label\nTRIAGE=SKIP",
+    );
+
+    let outcome = run_triage_plan_pipeline_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        None,
+        None,
+        &HashMap::new(),
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        actionable_review_issue_fetcher,
+    )
+    .await?;
+
+    assert!(matches!(
+        outcome,
+        TriagePlanPipelineOutcome::Continue {
+            plan_output: Some(_),
+            ..
+        }
+    ));
+
+    let events = events
+        .query(&EventFilters {
+            hook: Some("triage_decision".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].detail.as_deref(), Some("result=promote"));
+    assert_eq!(
+        events[0].reason.as_deref(),
+        Some(
+            "actionable_issue_markers:file_line,recommended_section,acceptance_criteria,code_or_steps"
+        )
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn actionable_issue_without_labels_skip_is_promoted_to_plan() -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    let agent = TriageStaticStreamAgent::new(
+        "Skip.\nCOMPLEXITY=medium\nTRIAGE_REASON=agent_skip\nTRIAGE=SKIP",
+    );
+
+    let outcome = run_triage_plan_pipeline_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        None,
+        None,
+        &HashMap::new(),
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        actionable_no_label_issue_fetcher,
+    )
+    .await?;
+
+    assert!(matches!(
+        outcome,
+        TriagePlanPipelineOutcome::Continue { .. }
+    ));
+    let events = events
+        .query(&EventFilters {
+            hook: Some("triage_decision".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(events[0].detail.as_deref(), Some("result=promote"));
+    assert!(
+        events[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("actionable_issue_markers")),
+        "missing actionable promotion reason: {:?}",
+        events[0].reason
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn abstract_issue_skip_stays_skipped() -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    let agent = TriageStaticStreamAgent::new("Not actionable.\nCOMPLEXITY=low\nTRIAGE=SKIP");
+
+    let outcome = run_triage_plan_pipeline_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        None,
+        None,
+        &HashMap::new(),
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        abstract_review_issue_fetcher,
+    )
+    .await?;
+
+    assert!(matches!(outcome, TriagePlanPipelineOutcome::Skipped));
+    let events = events
+        .query(&EventFilters {
+            hook: Some("triage_decision".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(events[0].detail.as_deref(), Some("result=skip"));
+    assert_eq!(
+        events[0].reason.as_deref(),
+        Some("non_actionable_issue_markers:none")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn skip_on_review_label_true_keeps_legacy_skip_reason_for_non_actionable_issue(
+) -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    let agent = TriageStaticStreamAgent::new("Skip.\nCOMPLEXITY=low\nTRIAGE=SKIP");
+    let triage_config = ProjectTriageConfig {
+        skip_on_review_label: Some(true),
+    };
+
+    let outcome = run_triage_plan_pipeline_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        None,
+        Some(&triage_config),
+        &HashMap::new(),
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        abstract_review_issue_fetcher,
+    )
+    .await?;
+
+    assert!(matches!(outcome, TriagePlanPipelineOutcome::Skipped));
+    let events = events
+        .query(&EventFilters {
+            hook: Some("triage_decision".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(
+        events[0].reason.as_deref(),
+        Some("review_label_skip_allowed_non_actionable")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn github_fetch_failure_falls_back_to_agent_skip() -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    let agent = TriageStaticStreamAgent::new(
+        "Skip.\nCOMPLEXITY=low\nTRIAGE_REASON=agent_skip\nTRIAGE=SKIP",
+    );
+
+    let outcome = run_triage_plan_pipeline_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        None,
+        None,
+        &HashMap::new(),
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        failing_issue_fetcher,
+    )
+    .await?;
+
+    assert!(matches!(outcome, TriagePlanPipelineOutcome::Skipped));
+    let events = events
+        .query(&EventFilters {
+            hook: Some("triage_decision".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(events[0].reason.as_deref(), Some("agent_skip"));
+    Ok(())
+}
+
+#[test]
+fn resolve_triage_decision_promotes_only_actionable_skip() {
+    let actionable = TypedIssueSnapshot {
+        body: actionable_issue_body(),
+        labels: vec!["review".to_string()],
+    };
+    let resolved = resolve_triage_decision(
+        prompts::TriageDecision::Skip,
+        Some("agent_skip_review_label"),
+        Some(&actionable),
+        None,
+    );
+    assert_eq!(resolved.decision, prompts::TriageDecision::ProceedWithPlan);
+
+    let abstract_issue = TypedIssueSnapshot {
+        body: abstract_issue_body(),
+        labels: vec!["review".to_string()],
+    };
+    let resolved = resolve_triage_decision(
+        prompts::TriageDecision::Skip,
+        Some("agent_skip_review_label"),
+        Some(&abstract_issue),
+        None,
+    );
+    assert_eq!(resolved.decision, prompts::TriageDecision::Skip);
+    assert_eq!(resolved.reason, "agent_skip_review_label");
 }

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -110,9 +110,18 @@ pub fn test_database_url() -> anyhow::Result<String> {
         return Ok(database_url.clone());
     }
 
-    let database_url = resolve_database_url(None)?;
-    let _ = TEST_DATABASE_URL.set(database_url.clone());
-    Ok(database_url)
+    if let Ok(url) = std::env::var("HARNESS_DATABASE_URL") {
+        let url = url.trim();
+        if !url.is_empty() {
+            let url = url.to_string();
+            let _ = TEST_DATABASE_URL.set(url.clone());
+            return Ok(url);
+        }
+    }
+
+    let url = resolve_database_url(None)?;
+    let _ = TEST_DATABASE_URL.set(url.clone());
+    Ok(url)
 }
 
 pub fn ensure_test_database_url_override() -> anyhow::Result<String> {


### PR DESCRIPTION
Closes #988

Promote actionable triage skips into planned work so skipped actionable items become follow-up tasks instead of being silently dropped.