### PR TITLE
feat: use command-scoped cargo target dirs in Rust prompts

### DIFF
--- a/crates/harness-core/src/lang_detect.rs
+++ b/crates/harness-core/src/lang_detect.rs
@@ -44,6 +44,29 @@ fn is_rust_workspace(project_root: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn rust_cargo_scope(project_root: &Path) -> &'static str {
+    if is_rust_workspace(project_root) {
+        "--workspace --all-targets"
+    } else {
+        "--all-targets"
+    }
+}
+
+fn rust_command_with_scoped_target(
+    subdir: &str,
+    args_before_separator: &str,
+    args_after_separator: Option<&str>,
+) -> String {
+    match args_after_separator {
+        Some(args_after_separator) => format!(
+            "base=\"${{CARGO_TARGET_DIR:-target}}\" && CARGO_TARGET_DIR=\"$base/{subdir}\" cargo {args_before_separator} -j 6 -- {args_after_separator}"
+        ),
+        None => format!(
+            "base=\"${{CARGO_TARGET_DIR:-target}}\" && CARGO_TARGET_DIR=\"$base/{subdir}\" cargo {args_before_separator} -j 6"
+        ),
+    }
+}
+
 // ── TypeScript helpers ────────────────────────────────────────────────────────
 
 /// Detect the package manager from lock-file presence.
@@ -196,14 +219,15 @@ pub fn validation_prompt_instructions(lang: Language, project_root: &Path) -> St
 pub fn default_pre_commit_commands(lang: Language, project_root: &Path) -> Vec<String> {
     match lang {
         Language::Rust => {
-            let scope = if is_rust_workspace(project_root) {
-                "--workspace --all-targets"
-            } else {
-                "--all-targets"
-            };
+            let scope = rust_cargo_scope(project_root);
             vec![
                 "cargo fmt --all".to_string(),
-                format!("cargo clippy {scope} -- -D warnings"),
+                rust_command_with_scoped_target("cargo-check", &format!("check {scope}"), None),
+                rust_command_with_scoped_target(
+                    "cargo-clippy",
+                    &format!("clippy {scope}"),
+                    Some("-D warnings"),
+                ),
             ]
         }
         Language::Go => vec![
@@ -251,9 +275,13 @@ pub fn default_pre_push_commands(lang: Language, project_root: &Path) -> Vec<Str
     match lang {
         Language::Rust => {
             if is_rust_workspace(project_root) {
-                vec!["cargo test --workspace".to_string()]
+                vec![rust_command_with_scoped_target(
+                    "cargo-test",
+                    "test --workspace",
+                    None,
+                )]
             } else {
-                vec!["cargo test".to_string()]
+                vec![rust_command_with_scoped_target("cargo-test", "test", None)]
             }
         }
         Language::Go => vec!["go test ./...".to_string()],
@@ -415,7 +443,8 @@ mod tests {
             cmds,
             vec![
                 "cargo fmt --all",
-                "cargo clippy --all-targets -- -D warnings"
+                "base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-check\" cargo check --all-targets -j 6",
+                "base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-clippy\" cargo clippy --all-targets -j 6 -- -D warnings"
             ]
         );
     }
@@ -429,10 +458,13 @@ mod tests {
         )
         .unwrap();
         let cmds = default_pre_commit_commands(Language::Rust, dir.path());
-        assert!(!cmds.iter().any(|c| c.contains("cargo check")));
+        assert!(cmds.iter().any(|c| c.contains("cargo-check")));
         assert!(cmds
             .iter()
-            .any(|c| c.contains("--workspace") && c.contains("cargo clippy")));
+            .any(|c| c.contains("--workspace") && c.contains("cargo check")));
+        assert!(cmds.iter().any(|c| {
+            c.contains("--workspace") && c.contains("cargo clippy") && c.contains("cargo-clippy")
+        }));
         assert!(cmds.iter().any(|c| c.contains("--all-targets")));
     }
 
@@ -445,7 +477,12 @@ mod tests {
         )
         .unwrap();
         let cmds = default_pre_push_commands(Language::Rust, dir.path());
-        assert_eq!(cmds, vec!["cargo test --workspace"]);
+        assert_eq!(
+            cmds,
+            vec![
+                "base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-test\" cargo test --workspace -j 6"
+            ]
+        );
     }
 
     #[test]
@@ -453,7 +490,10 @@ mod tests {
         let dir = tmpdir();
         fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"foo\"").unwrap();
         let cmds = default_pre_push_commands(Language::Rust, dir.path());
-        assert_eq!(cmds, vec!["cargo test"]);
+        assert_eq!(
+            cmds,
+            vec!["base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-test\" cargo test -j 6"]
+        );
     }
 
     // ── Go commands ───────────────────────────────────────────────────────────
@@ -648,7 +688,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             primary_test_command(dir.path()),
-            Some("cargo test --workspace".to_string())
+            Some(
+                "base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-test\" cargo test --workspace -j 6"
+                    .to_string()
+            )
         );
     }
 
@@ -658,7 +701,10 @@ mod tests {
         fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"foo\"").unwrap();
         assert_eq!(
             primary_test_command(dir.path()),
-            Some("cargo test".to_string())
+            Some(
+                "base=\"${CARGO_TARGET_DIR:-target}\" && CARGO_TARGET_DIR=\"$base/cargo-test\" cargo test -j 6"
+                    .to_string()
+            )
         );
     }
 
@@ -685,9 +731,12 @@ mod tests {
         fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"foo\"").unwrap();
         let instructions = validation_prompt_instructions(Language::Rust, dir.path());
         assert!(instructions.contains("cargo fmt"));
-        assert!(!instructions.contains("cargo check"));
+        assert!(instructions.contains("cargo-check"));
+        assert!(instructions.contains("cargo check"));
         assert!(instructions.contains("cargo clippy"));
         assert!(instructions.contains("cargo test"));
+        assert!(!instructions.contains("cargo_fast"));
+        assert!(!instructions.contains("target-dir = "));
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -149,7 +149,7 @@ pub fn implement_from_issue(
              1. Read the issue: `gh issue view {issue}`\n\
              2. Understand the requirements and existing code\n\
              3. Implement the change with the minimum necessary modifications\n\
-             4. Run `cargo check` and `cargo test` — fix any failures before proceeding\n\
+             4. Run the project's validation commands before proceeding — fix any failures first\n\
              5. Create a feature branch, commit with a descriptive message, push\n\
              6. Create a PR with `gh pr create` (see the mandatory PR body contract below).\n"
         ),
@@ -282,7 +282,7 @@ mod tests {
         assert!(s.contains("issue #42"));
         assert!(s.contains("PR_URL=<full PR URL>"));
         assert!(s.contains("Senior Engineer"));
-        assert!(s.contains("cargo check"));
+        assert!(s.contains("validation commands"));
         assert!(s.contains("gh pr create"));
         // The Closes-keyword contract lives in dynamic_payload; assert it
         // survives round-tripping through to_prompt_string so tasks that

--- a/crates/harness-core/src/prompts/pr.rs
+++ b/crates/harness-core/src/prompts/pr.rs
@@ -26,7 +26,7 @@ pub fn continue_existing_pr(issue: u64, pr_number: u64, branch: &str, repo: &str
          3. Read the original issue requirements: `gh issue view {issue}`\n\
          4. Fix any unresolved review comments and continue the implementation if incomplete.\n\
             All editing must happen inside `/tmp/harness-pr-{pr_number}`.\n\
-         5. Run `cd /tmp/harness-pr-{pr_number} && cargo check && cargo test`\n\
+         5. Run the project's validation commands inside `/tmp/harness-pr-{pr_number}` and fix any failures before pushing.\n\
          6. Commit and push from the worktree to the SAME branch `{branch}` — do NOT create a new PR:\n\
             `cd /tmp/harness-pr-{pr_number} && git push origin {branch}`\n\
          7. Clean up: `git worktree remove /tmp/harness-pr-{pr_number}`\n\n\
@@ -245,6 +245,7 @@ mod tests {
         assert!(p.contains("PR #50"));
         assert!(p.contains("fix/issue-29"));
         assert!(p.contains("do NOT create a new PR"));
+        assert!(p.contains("validation commands"));
         assert!(p.contains("PR_URL=https://github.com/owner/repo/pull/50"));
         assert!(p.contains("repos/owner/repo/pulls/50/comments"));
         // Worktree isolation: must use worktree, must not bare-checkout in main repo


### PR DESCRIPTION
## Signal report
The Rust prompt generator emitted plain `cargo check`, `cargo clippy`, and `cargo test` commands, and some static prompt text still hardcoded plain Cargo validation steps. When multiple Cargo subcommands ran in the same task, they could share one target directory and contend on the same build lock.

## Summary
- scope generated Rust `cargo check`, `cargo clippy`, and `cargo test` commands to command-specific `CARGO_TARGET_DIR` subdirectories while preserving any existing base target dir
- remove stale hardcoded plain-Cargo wording from issue and PR prompts so injected validation instructions remain authoritative
- update Rust prompt tests for workspace and non-workspace command text

## Validation
- `cargo fmt --all`
- `base="${CARGO_TARGET_DIR:-target}" && CARGO_TARGET_DIR="$base/cargo-clippy" cargo clippy --workspace --all-targets -j 6 -- -D warnings`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace -j 6`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets -j 6`

Closes #1024