### PR TITLE
Honor registry metadata for path-based execution

### DIFF
--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -1,3 +1,4 @@
+use crate::http::builders::intake::effective_issue_project_limits;
 use crate::http::AppState;
 use crate::project_registry::{validate_project_root, Project};
 use axum::{
@@ -24,6 +25,16 @@ pub async fn register_project(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RegisterProjectRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let previous_project = match state.project_svc.get(&req.id).await {
+        Ok(project) => project,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+
     let root = match req.root.canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -56,7 +67,7 @@ pub async fn register_project(
     }
 
     let project = Project {
-        id: req.id,
+        id: req.id.clone(),
         root,
         name: None,
         max_concurrent: req.max_concurrent,
@@ -66,12 +77,52 @@ pub async fn register_project(
     };
 
     match state.project_svc.register(project.clone()).await {
-        Ok(()) => (StatusCode::CREATED, Json(json!(project))),
+        Ok(()) => {
+            match refresh_primary_queue_limits(&state, previous_project.as_ref(), &project).await {
+                Ok(()) => (StatusCode::CREATED, Json(json!(project))),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": e.to_string()})),
+                ),
+            }
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": e.to_string()})),
         ),
     }
+}
+
+async fn refresh_primary_queue_limits(
+    state: &AppState,
+    previous_project: Option<&Project>,
+    project: &Project,
+) -> anyhow::Result<()> {
+    let registry_projects = state.project_svc.list().await?;
+    let effective_limits = effective_issue_project_limits(&state.core.server, &registry_projects);
+    for root in roots_to_refresh(previous_project, project) {
+        if let Some(limit) = effective_limits.get(&root) {
+            state
+                .concurrency
+                .task_queue
+                .set_project_limit(&root, *limit);
+        } else {
+            state.concurrency.task_queue.reset_project_limit(&root);
+        }
+    }
+    Ok(())
+}
+
+fn roots_to_refresh(previous_project: Option<&Project>, project: &Project) -> Vec<String> {
+    let mut roots = Vec::with_capacity(2);
+    if let Some(previous_project) = previous_project {
+        roots.push(previous_project.root.to_string_lossy().into_owned());
+    }
+    let current_root = project.root.to_string_lossy().into_owned();
+    if !roots.iter().any(|root| root == &current_root) {
+        roots.push(current_root);
+    }
+    roots
 }
 
 pub async fn list_projects(
@@ -198,6 +249,11 @@ mod tests {
         Ok(Arc::new(build_app_state(server).await?))
     }
 
+    fn init_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
+        std::fs::create_dir_all(root.join(".git"))?;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn list_projects_includes_task_count_and_project_identity() -> anyhow::Result<()> {
         let _lock = crate::test_helpers::HOME_LOCK.lock().await;
@@ -229,6 +285,104 @@ mod tests {
             );
             assert_eq!(project.get("task_count"), Some(&json!(0)));
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_project_updates_live_issue_queue_limit() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let project_root = crate::test_helpers::tempdir_in_home("projects-handler-live-limit-")?;
+        init_git_repo(project_root.path())?;
+        let data_dir = tempfile::tempdir()?;
+        let state = make_test_state(project_root.path(), data_dir.path()).await?;
+        let canonical_root = project_root.path().canonicalize()?;
+        let queue_key = canonical_root.to_string_lossy().into_owned();
+
+        let (status, _) = register_project(
+            State(state.clone()),
+            Json(RegisterProjectRequest {
+                id: "live-limit".to_string(),
+                root: canonical_root.clone(),
+                max_concurrent: Some(4),
+                default_agent: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            state
+                .concurrency
+                .task_queue
+                .effective_project_limit(&queue_key),
+            4
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_project_reset_restores_fallback_limit() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let project_root = crate::test_helpers::tempdir_in_home("projects-handler-fallback-")?;
+        init_git_repo(project_root.path())?;
+        let canonical_root = project_root.path().canonicalize()?;
+        let queue_key = canonical_root.to_string_lossy().into_owned();
+        let data_dir = tempfile::tempdir()?;
+
+        let mut config = HarnessConfig::default();
+        config.server.project_root = canonical_root.clone();
+        config.server.data_dir = data_dir.path().to_path_buf();
+        config.concurrency.per_project.insert(queue_key.clone(), 3);
+        let server = Arc::new(HarnessServer::new(
+            config,
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        ));
+        let state = Arc::new(build_app_state(server).await?);
+
+        let (status, _) = register_project(
+            State(state.clone()),
+            Json(RegisterProjectRequest {
+                id: "fallback-limit".to_string(),
+                root: canonical_root.clone(),
+                max_concurrent: Some(5),
+                default_agent: None,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            state
+                .concurrency
+                .task_queue
+                .effective_project_limit(&queue_key),
+            5
+        );
+
+        let (status, _) = register_project(
+            State(state.clone()),
+            Json(RegisterProjectRequest {
+                id: "fallback-limit".to_string(),
+                root: canonical_root,
+                max_concurrent: None,
+                default_agent: None,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            state
+                .concurrency
+                .task_queue
+                .effective_project_limit(&queue_key),
+            3
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::{server::HarnessServer, task_runner};
+use crate::{project_registry::Project, server::HarnessServer, task_runner};
 
 use super::{engines::EnginesBundle, registry::RegistryBundle, storage::StorageBundle};
 
@@ -51,7 +51,7 @@ pub(crate) async fn build_intake(
                 tracing::info!(threshold_mb, poll_secs, "memory pressure monitor enabled");
                 crate::memory_monitor::start(threshold_mb, poll_secs)
             });
-    let issue_queue_config = runtime_issue_concurrency_config(server);
+    let issue_queue_config = runtime_issue_concurrency_config(server, registry).await;
     let review_queue_config = runtime_review_concurrency_config(server, registry).await;
     let task_queue = Arc::new(crate::task_queue::TaskQueue::new_with_pressure(
         &issue_queue_config,
@@ -254,20 +254,47 @@ pub(crate) async fn build_intake(
     })
 }
 
-fn runtime_issue_concurrency_config(
+async fn runtime_issue_concurrency_config(
     server: &HarnessServer,
+    registry: &RegistryBundle,
+) -> harness_core::config::misc::ConcurrencyConfig {
+    let registry_projects = load_registry_projects(registry).await;
+    build_runtime_issue_concurrency_config(server, &registry_projects)
+}
+
+pub(crate) fn build_runtime_issue_concurrency_config(
+    server: &HarnessServer,
+    registry_projects: &[Project],
 ) -> harness_core::config::misc::ConcurrencyConfig {
     let mut config = server.config.concurrency.clone();
+    config.per_project = effective_issue_project_limits(server, registry_projects);
+    config
+}
+
+pub(crate) fn effective_issue_project_limits(
+    server: &HarnessServer,
+    registry_projects: &[Project],
+) -> std::collections::HashMap<String, usize> {
+    let mut per_project = canonicalized_config_limits(&server.config.concurrency.per_project);
+
+    for project in registry_projects {
+        let Some(limit) = project.max_concurrent.map(|value| value as usize) else {
+            continue;
+        };
+        if !project.active {
+            continue;
+        }
+        per_project.insert(queue_project_key(&project.root), limit);
+    }
 
     for project in &server.startup_projects {
         let Some(limit) = project.max_concurrent.map(|value| value as usize) else {
             continue;
         };
-        let canonical = queue_project_key(&project.root);
-        config.per_project.insert(canonical, limit);
+        per_project.insert(queue_project_key(&project.root), limit);
     }
 
-    config
+    per_project
 }
 
 async fn runtime_review_concurrency_config(
@@ -308,6 +335,36 @@ async fn runtime_review_concurrency_config(
 
 fn queue_project_key(path: &Path) -> String {
     canonicalize_for_queue(path).to_string_lossy().into_owned()
+}
+
+fn canonicalized_config_limits(
+    limits: &std::collections::HashMap<String, usize>,
+) -> std::collections::HashMap<String, usize> {
+    limits
+        .iter()
+        .map(|(project, limit)| {
+            let path = Path::new(project);
+            let key = if path.is_absolute() {
+                queue_project_key(path)
+            } else {
+                project.clone()
+            };
+            (key, *limit)
+        })
+        .collect()
+}
+
+async fn load_registry_projects(registry: &RegistryBundle) -> Vec<Project> {
+    let Some(project_registry) = registry.project_registry.as_ref() else {
+        return Vec::new();
+    };
+    match project_registry.list().await {
+        Ok(projects) => projects,
+        Err(e) => {
+            tracing::warn!("intake: failed to load project registry for issue queue seeding: {e}");
+            Vec::new()
+        }
+    }
 }
 
 fn canonicalize_for_queue(path: &Path) -> PathBuf {
@@ -351,6 +408,23 @@ mod tests {
         (server, storage, engines, registry)
     }
 
+    fn registry_project(
+        id: &str,
+        root: std::path::PathBuf,
+        max_concurrent: Option<u32>,
+        active: bool,
+    ) -> Project {
+        Project {
+            id: id.to_string(),
+            root,
+            name: Some(id.to_string()),
+            default_agent: None,
+            max_concurrent,
+            active,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
     #[tokio::test]
     async fn no_intake_config_produces_empty_intake() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -376,13 +450,34 @@ mod tests {
     }
 
     #[test]
-    fn runtime_issue_concurrency_uses_startup_project_limits() {
+    fn runtime_issue_concurrency_uses_registry_limits() {
         let mut server = HarnessServer::new(
             HarnessConfig::default(),
             ThreadManager::new(),
             AgentRegistry::new("test"),
         );
         server.config.concurrency.max_concurrent_tasks = 6;
+        let cfg = build_runtime_issue_concurrency_config(
+            &server,
+            &[registry_project(
+                "registry-only",
+                std::path::PathBuf::from("/tmp/registry-only"),
+                Some(5),
+                true,
+            )],
+        );
+
+        assert_eq!(cfg.max_concurrent_tasks, 6);
+        assert_eq!(cfg.per_project.get("/tmp/registry-only"), Some(&5));
+    }
+
+    #[test]
+    fn runtime_issue_concurrency_startup_projects_override_registry() {
+        let mut server = HarnessServer::new(
+            HarnessConfig::default(),
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        );
         server
             .config
             .concurrency
@@ -405,12 +500,48 @@ mod tests {
             },
         ];
 
-        let cfg = runtime_issue_concurrency_config(&server);
+        let cfg = build_runtime_issue_concurrency_config(
+            &server,
+            &[
+                registry_project("a", std::path::PathBuf::from("/tmp/a"), Some(3), true),
+                registry_project("c", std::path::PathBuf::from("/tmp/c"), Some(9), true),
+            ],
+        );
 
-        assert_eq!(cfg.max_concurrent_tasks, 6);
-        assert_eq!(cfg.per_project.len(), 2);
+        assert_eq!(cfg.per_project.len(), 3);
         assert_eq!(cfg.per_project.get("/tmp/a"), Some(&4));
         assert_eq!(cfg.per_project.get("/tmp/b"), Some(&8));
+        assert_eq!(cfg.per_project.get("/tmp/c"), Some(&9));
+    }
+
+    #[test]
+    fn runtime_issue_concurrency_ignores_inactive_and_unlimited_registry_projects() {
+        let server = HarnessServer::new(
+            HarnessConfig::default(),
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        );
+
+        let cfg = build_runtime_issue_concurrency_config(
+            &server,
+            &[
+                registry_project(
+                    "inactive",
+                    std::path::PathBuf::from("/tmp/inactive"),
+                    Some(7),
+                    false,
+                ),
+                registry_project(
+                    "unlimited",
+                    std::path::PathBuf::from("/tmp/unlimited"),
+                    None,
+                    true,
+                ),
+            ],
+        );
+
+        assert!(!cfg.per_project.contains_key("/tmp/inactive"));
+        assert!(!cfg.per_project.contains_key("/tmp/unlimited"));
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -83,6 +83,34 @@ async fn resolve_project_from_registry_passes_through_existing_dir() {
 }
 
 #[tokio::test]
+async fn resolve_project_from_registry_existing_dir_uses_registered_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
+        .await
+        .unwrap();
+    let project_root = dir.path().join("registered-root");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let canonical_root = project_root.canonicalize().unwrap();
+    registry
+        .register(crate::project_registry::Project {
+            id: "registered-root".to_string(),
+            root: canonical_root.clone(),
+            name: Some("registered-root".to_string()),
+            max_concurrent: Some(2),
+            default_agent: Some("opus".to_string()),
+            active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let result = resolve_project_from_registry(Some(&registry), Some(project_root)).await;
+    let (path, agent) = result.unwrap();
+    assert_eq!(path, Some(canonical_root));
+    assert_eq!(agent.as_deref(), Some("opus"));
+}
+
+#[tokio::test]
 async fn resolve_project_from_registry_no_registry_passes_through_nondir() {
     let path = std::path::PathBuf::from("/nonexistent/path");
     let result = resolve_project_from_registry(None, Some(path.clone())).await;
@@ -144,6 +172,38 @@ async fn resolve_project_from_registry_returns_default_agent_from_record() {
     assert_eq!(
         path,
         Some(std::path::PathBuf::from("/home/user/pinned-repo"))
+    );
+    assert_eq!(agent.as_deref(), Some("opus"));
+}
+
+#[tokio::test]
+async fn resolve_project_from_registry_resolves_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = crate::project_registry::ProjectRegistry::open(&dir.path().join("p.db"))
+        .await
+        .unwrap();
+    registry
+        .register(crate::project_registry::Project {
+            id: "named-repo-id".to_string(),
+            root: std::path::PathBuf::from("/home/user/named-repo"),
+            name: Some("named-repo".to_string()),
+            max_concurrent: None,
+            default_agent: Some("opus".to_string()),
+            active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let result = resolve_project_from_registry(
+        Some(&registry),
+        Some(std::path::PathBuf::from("named-repo")),
+    )
+    .await;
+    let (path, agent) = result.unwrap();
+    assert_eq!(
+        path,
+        Some(std::path::PathBuf::from("/home/user/named-repo"))
     );
     assert_eq!(agent.as_deref(), Some("opus"));
 }

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -44,6 +44,12 @@ static PROJECT_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_projects_name_created_at
               ON projects ((data::jsonb ->> 'name'), created_at DESC)",
     },
+    Migration {
+        version: 3,
+        description: "index project root lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_projects_root_created_at
+              ON projects ((data::jsonb ->> 'root'), created_at DESC)",
+    },
 ];
 
 /// Registry of projects backed by Postgres. Survives server restarts.
@@ -137,6 +143,26 @@ impl ProjectRegistry {
              LIMIT 1",
         )
         .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            Some((data,)) => Ok(Some(serde_json::from_str(&data)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Find a project by its canonical root path. Returns the newest match.
+    pub async fn get_by_root(&self, root: &std::path::Path) -> anyhow::Result<Option<Project>> {
+        let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let root_str = canonical_root.to_string_lossy();
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data
+             FROM projects
+             WHERE data::jsonb ->> 'root' = $1
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(root_str.as_ref())
         .fetch_optional(&self.pool)
         .await?;
         match row {
@@ -336,6 +362,36 @@ mod tests {
             .expect("should survive reopen");
         assert_eq!(loaded.max_concurrent, Some(2));
         assert_eq!(loaded.default_agent.as_deref(), Some("claude"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_by_root_returns_canonical_match() -> anyhow::Result<()> {
+        let Some(registry) = open_test_registry("projects.db").await? else {
+            return Ok(());
+        };
+
+        let dir = tempfile::tempdir()?;
+        let canonical_root = dir.path().canonicalize()?;
+        registry
+            .register(Project {
+                id: "root-keyed".to_string(),
+                root: canonical_root.clone(),
+                name: Some("root-keyed".to_string()),
+                max_concurrent: Some(2),
+                default_agent: Some("codex".to_string()),
+                active: true,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await?;
+
+        let loaded = registry
+            .get_by_root(dir.path())
+            .await?
+            .expect("project should resolve by canonical root");
+        assert_eq!(loaded.id, "root-keyed");
+        assert_eq!(loaded.root, canonical_root);
+        assert_eq!(loaded.default_agent.as_deref(), Some("codex"));
         Ok(())
     }
 }

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -181,7 +181,14 @@ pub(crate) async fn resolve_project_from_registry(
         .map(|metadata| metadata.is_dir())
         .unwrap_or(false)
     {
-        return Ok((Some(project_path), None));
+        let canonical_root = tokio::fs::canonicalize(&project_path)
+            .await
+            .unwrap_or(project_path);
+        return match registry.get_by_root(&canonical_root).await {
+            Ok(Some(project)) => Ok((Some(project.root), project.default_agent)),
+            Ok(None) => Ok((Some(canonical_root), None)),
+            Err(e) => Err(EnqueueTaskError::Internal(e.to_string())),
+        };
     }
 
     let id = project_path.to_string_lossy();
@@ -849,8 +856,9 @@ mod tests {
         let svc = make_minimal_svc(store, Some(registry)).await;
 
         let path = dir.path().to_path_buf();
+        let canonical_path = path.canonicalize()?;
         let result = svc.resolve_project(Some(path.clone())).await?;
-        assert_eq!(result.0, Some(path));
+        assert_eq!(result.0, Some(canonical_path));
         assert!(result.1.is_none());
         Ok(())
     }

--- a/crates/harness-workflow/src/task_queue.rs
+++ b/crates/harness-workflow/src/task_queue.rs
@@ -676,6 +676,20 @@ impl TaskQueue {
         }
     }
 
+    /// Remove an explicit project override so the queue falls back to the
+    /// global limit for future acquisitions.
+    pub fn reset_project_limit(&self, project_id: &str) {
+        let old_limit = self.project_limit(project_id);
+        self.project_limits.remove(project_id);
+        let new_limit = self.project_limit(project_id);
+        if let Some(project_queue) = self.project_queues.get(project_id) {
+            project_queue
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .reconfigure_capacity(old_limit, new_limit);
+        }
+    }
+
     /// Snapshot queue pressure for diagnostics and admission-failure logging.
     pub fn diagnostics(&self, project_id: &str) -> QueueDiagnostics {
         let project_limit = self.project_limit(project_id);

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -225,6 +225,26 @@ async fn set_project_limit_reconfigures_existing_project_queue() {
     );
 }
 
+#[tokio::test]
+async fn reset_project_limit_restores_global_fallback() {
+    let mut cfg = config(4, 16);
+    cfg.per_project.insert("proj".to_string(), 2);
+    let q = Arc::new(TaskQueue::new(&cfg));
+
+    let _p1 = q.acquire("proj", 0).await.unwrap();
+    let _p2 = q.acquire("proj", 0).await.unwrap();
+    assert_eq!(q.effective_project_limit("proj"), 2);
+
+    q.reset_project_limit("proj");
+    assert_eq!(q.effective_project_limit("proj"), 4);
+
+    let p3 = timeout(Duration::from_millis(100), q.acquire("proj", 0)).await;
+    assert!(
+        p3.is_ok(),
+        "project should regain the global fallback limit after reset"
+    );
+}
+
 // --- Priority tests ---
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- honor registered project metadata when a task is submitted with an existing project path
- seed live issue queue limits from registry project limits in addition to startup config
- update project registration so queue limits change immediately when project metadata changes

## Testing
- GitHub CI: Format
- GitHub CI: Check
- GitHub CI: Clippy
- GitHub CI: Test
- GitHub CI: RUSTFLAGS/disabled-modules check

Closes #889
