### PR TITLE
feat(observe): persist serve runtime logs by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ version = "0.6.33"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap",
  "harness-agents",
  "harness-core",

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ cargo run -p harness-cli -- serve --transport http --port 9800
 curl http://127.0.0.1:9800/health
 ```
 
+`harness serve` persists its runtime log under `server.data_dir/logs/` as
+`harness-serve-<startup-timestamp>-pid<PID>.log`. `/health` exposes a redacted
+`runtime_logs.path_hint`, while `/api/operator-snapshot` includes the full
+active path for operators.
+
 **Stdio (for MCP integration):**
 
 ```bash
@@ -393,6 +398,10 @@ curl http://127.0.0.1:9800/api/dashboard
 ```bash
 curl http://127.0.0.1:9800/health
 ```
+
+The response includes a `runtime_logs` block with the logging state, retention
+window, and a redacted `logs/<filename>` hint instead of the full absolute
+path.
 
 ## Server Startup
 

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
+chrono = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -348,6 +348,7 @@ struct LoggingBootstrap {
     runtime_logs: RuntimeLogMetadata,
     runtime_log_file: Option<Arc<Mutex<File>>>,
     setup_warning: Option<String>,
+    retention_warnings: Vec<String>,
 }
 
 fn load_config(
@@ -417,6 +418,9 @@ fn log_runtime_log_status(bootstrap: &LoggingBootstrap) {
                     "runtime logs persisted to file"
                 );
             }
+            for warning in &bootstrap.retention_warnings {
+                tracing::warn!(warning = %warning, "runtime log retention cleanup skipped an entry");
+            }
         }
         harness_server::server::RuntimeLogState::Degraded => {
             tracing::warn!(
@@ -447,6 +451,7 @@ fn prepare_logging(
             runtime_logs: RuntimeLogMetadata::disabled(config.observe.log_retention_days),
             runtime_log_file: None,
             setup_warning: None,
+            retention_warnings: Vec::new(),
         },
     }
 }
@@ -460,15 +465,17 @@ fn prepare_runtime_logs(
     let path_hint = RuntimeLogMetadata::public_path_hint(&log_path);
 
     match open_runtime_log_file(&log_path, retention_days, started_at) {
-        Ok(file) => LoggingBootstrap {
+        Ok((file, retention_warnings)) => LoggingBootstrap {
             runtime_logs: RuntimeLogMetadata::enabled(log_path, retention_days),
             runtime_log_file: Some(Arc::new(Mutex::new(file))),
             setup_warning: None,
+            retention_warnings,
         },
         Err(error) => LoggingBootstrap {
             runtime_logs: RuntimeLogMetadata::degraded(Some(path_hint), retention_days),
             runtime_log_file: None,
             setup_warning: Some(error.to_string()),
+            retention_warnings: Vec::new(),
         },
     }
 }
@@ -484,27 +491,60 @@ fn open_runtime_log_file(
     log_path: &Path,
     retention_days: u32,
     started_at: DateTime<Utc>,
-) -> io::Result<File> {
+) -> io::Result<(File, Vec<String>)> {
     let logs_dir = log_path
         .parent()
         .ok_or_else(|| io::Error::other("runtime log path missing parent directory"))?;
-    purge_stale_runtime_logs(logs_dir, retention_days, started_at)?;
     fs::create_dir_all(logs_dir)?;
-    OpenOptions::new().create(true).append(true).open(log_path)
+    let retention_warnings = purge_stale_runtime_logs(logs_dir, retention_days, started_at);
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    Ok((file, retention_warnings))
 }
 
 fn purge_stale_runtime_logs(
     logs_dir: &Path,
     retention_days: u32,
     now: DateTime<Utc>,
-) -> io::Result<()> {
+) -> Vec<String> {
+    purge_stale_runtime_logs_with(logs_dir, retention_days, now, |path| fs::remove_file(path))
+}
+
+fn purge_stale_runtime_logs_with(
+    logs_dir: &Path,
+    retention_days: u32,
+    now: DateTime<Utc>,
+    mut remove_file: impl FnMut(&Path) -> io::Result<()>,
+) -> Vec<String> {
     if !logs_dir.exists() {
-        return Ok(());
+        return Vec::new();
     }
 
+    let mut warnings = Vec::new();
     let cutoff = now - chrono::Duration::days(i64::from(retention_days));
-    for entry in fs::read_dir(logs_dir)? {
-        let entry = entry?;
+    let entries = match fs::read_dir(logs_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warnings.push(format!(
+                "failed to scan runtime log directory {}: {error}",
+                logs_dir.display()
+            ));
+            return warnings;
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warnings.push(format!(
+                    "failed to read runtime log directory entry in {}: {error}",
+                    logs_dir.display()
+                ));
+                continue;
+            }
+        };
         let path = entry.path();
         if !path.is_file() {
             continue;
@@ -517,11 +557,16 @@ fn purge_stale_runtime_logs(
             continue;
         };
         if started_at < cutoff {
-            fs::remove_file(path)?;
+            if let Err(error) = remove_file(&path) {
+                warnings.push(format!(
+                    "failed to delete stale runtime log {}: {error}",
+                    path.display()
+                ));
+            }
         }
     }
 
-    Ok(())
+    warnings
 }
 
 fn parse_runtime_log_started_at(file_name: &str) -> Option<DateTime<Utc>> {
@@ -1381,11 +1426,57 @@ mod tests {
         fs::write(&fresh, "fresh").expect("write fresh");
         fs::write(&unrelated, "keep").expect("write unrelated");
 
-        purge_stale_runtime_logs(&logs_dir, 30, now).expect("purge");
+        let warnings = purge_stale_runtime_logs(&logs_dir, 30, now);
 
+        assert!(warnings.is_empty(), "purge should not warn: {warnings:?}");
         assert!(!stale.exists(), "stale runtime log should be deleted");
         assert!(fresh.exists(), "fresh runtime log should be kept");
         assert!(unrelated.exists(), "non-matching files should be kept");
+    }
+
+    #[test]
+    fn purge_stale_runtime_logs_reports_delete_errors_without_stopping() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let logs_dir = tempdir.path().join("logs");
+        fs::create_dir_all(&logs_dir).expect("create logs dir");
+        let now = Utc
+            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+            .single()
+            .expect("timestamp");
+        let stale = runtime_log_path(
+            tempdir.path(),
+            Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+                .single()
+                .expect("stale timestamp"),
+            10,
+        );
+        let fresh = runtime_log_path(
+            tempdir.path(),
+            Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
+                .single()
+                .expect("fresh timestamp"),
+            11,
+        );
+        fs::write(&stale, "stale").expect("write stale");
+        fs::write(&fresh, "fresh").expect("write fresh");
+
+        let warnings = purge_stale_runtime_logs_with(&logs_dir, 30, now, |path| {
+            if path == stale.as_path() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "simulated delete failure",
+                ));
+            }
+            fs::remove_file(path)
+        });
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("failed to delete stale runtime log"),
+            "warning should identify delete failure: {warnings:?}"
+        );
+        assert!(stale.exists(), "failed delete should leave stale file");
+        assert!(fresh.exists(), "fresh runtime log should be kept");
     }
 
     #[test]

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -1,9 +1,18 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
 use clap::{ArgAction, Args, Parser, Subcommand};
-use std::path::PathBuf;
+use harness_server::server::RuntimeLogMetadata;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::writer::MakeWriter;
 
 mod exec;
 mod reconcile;
 mod serve;
+
+const RUNTIME_LOG_PREFIX: &str = "harness-serve-";
+const RUNTIME_LOG_SUFFIX: &str = ".log";
 
 #[derive(Parser)]
 #[command(name = "harness", about = "Harness — AI Code Agent Platform")]
@@ -281,39 +290,260 @@ fn configured_skill_store(
     Ok(store)
 }
 
-pub async fn run(cli: Cli) -> anyhow::Result<()> {
-    // Load config
-    let mut config: harness_core::config::HarnessConfig = if let Some(config_path) = &cli.config {
-        let content = std::fs::read_to_string(config_path)?;
-        tracing::info!(
-            "config loaded from --config flag: {}",
-            config_path.display()
-        );
-        let mut cfg: harness_core::config::HarnessConfig = toml::from_str(&content)?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ConfigSource {
+    Flag(PathBuf),
+    Discovered(PathBuf),
+    BuiltInDefaults,
+}
+
+#[derive(Clone)]
+struct TeeMakeWriter {
+    runtime_log_file: Option<Arc<Mutex<File>>>,
+}
+
+struct TeeWriter {
+    stderr: io::Stderr,
+    runtime_log_file: Option<Arc<Mutex<File>>>,
+}
+
+impl<'a> MakeWriter<'a> for TeeMakeWriter {
+    type Writer = TeeWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        TeeWriter {
+            stderr: io::stderr(),
+            runtime_log_file: self.runtime_log_file.clone(),
+        }
+    }
+}
+
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.stderr.write_all(buf)?;
+        if let Some(file) = &self.runtime_log_file {
+            let mut guard = match file.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard.write_all(buf)?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stderr.flush()?;
+        if let Some(file) = &self.runtime_log_file {
+            let mut guard = match file.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard.flush()?;
+        }
+        Ok(())
+    }
+}
+
+struct LoggingBootstrap {
+    runtime_logs: RuntimeLogMetadata,
+    runtime_log_file: Option<Arc<Mutex<File>>>,
+    setup_warning: Option<String>,
+}
+
+fn load_config(
+    config_path: Option<&Path>,
+) -> anyhow::Result<(harness_core::config::HarnessConfig, ConfigSource)> {
+    if let Some(config_path) = config_path {
+        let content = fs::read_to_string(config_path)?;
+        let mut config: harness_core::config::HarnessConfig = toml::from_str(&content)?;
         if let Some(dir) = config_path.parent() {
-            cfg.rebase_relative_paths(dir);
+            config.rebase_relative_paths(dir);
         }
-        cfg
-    } else if let Some(discovered) = harness_core::config::dirs::find_config_file() {
-        let content = std::fs::read_to_string(&discovered)?;
-        tracing::info!("config loaded from {}", discovered.display());
-        let mut cfg: harness_core::config::HarnessConfig = toml::from_str(&content)?;
-        // Rebase relative paths against the config file's directory so that a
-        // global config like `project_root = "."` resolves relative to the
-        // config file rather than the operator's working directory.
+        return Ok((config, ConfigSource::Flag(config_path.to_path_buf())));
+    }
+
+    if let Some(discovered) = harness_core::config::dirs::find_config_file() {
+        let content = fs::read_to_string(&discovered)?;
+        let mut config: harness_core::config::HarnessConfig = toml::from_str(&content)?;
         if let Some(dir) = discovered.parent() {
-            cfg.rebase_relative_paths(dir);
+            config.rebase_relative_paths(dir);
         }
-        cfg
-    } else {
-        tracing::warn!("no config file found, using built-in defaults");
-        harness_core::config::HarnessConfig::default()
-    };
+        return Ok((config, ConfigSource::Discovered(discovered)));
+    }
+
+    Ok((
+        harness_core::config::HarnessConfig::default(),
+        ConfigSource::BuiltInDefaults,
+    ))
+}
+
+fn init_tracing(bootstrap: &LoggingBootstrap) -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::ChronoLocal::new(
+            "%Y-%m-%dT%H:%M:%S%.3f%:z".to_string(),
+        ))
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "harness=info,warn".into()),
+        )
+        .with_writer(TeeMakeWriter {
+            runtime_log_file: bootstrap.runtime_log_file.clone(),
+        })
+        .try_init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize tracing subscriber: {error}"))
+}
+
+fn log_config_source(source: &ConfigSource) {
+    match source {
+        ConfigSource::Flag(path) => {
+            tracing::info!("config loaded from --config flag: {}", path.display());
+        }
+        ConfigSource::Discovered(path) => {
+            tracing::info!("config loaded from {}", path.display());
+        }
+        ConfigSource::BuiltInDefaults => {
+            tracing::warn!("no config file found, using built-in defaults");
+        }
+    }
+}
+
+fn log_runtime_log_status(bootstrap: &LoggingBootstrap) {
+    match bootstrap.runtime_logs.state {
+        harness_server::server::RuntimeLogState::Enabled => {
+            if let Some(path) = bootstrap.runtime_logs.active_path.as_ref() {
+                tracing::info!(
+                    path = %path.display(),
+                    retention_days = bootstrap.runtime_logs.retention_days,
+                    "runtime logs persisted to file"
+                );
+            }
+        }
+        harness_server::server::RuntimeLogState::Degraded => {
+            tracing::warn!(
+                path_hint = bootstrap
+                    .runtime_logs
+                    .path_hint
+                    .as_deref()
+                    .unwrap_or("logs"),
+                retention_days = bootstrap.runtime_logs.retention_days,
+                error = bootstrap
+                    .setup_warning
+                    .as_deref()
+                    .unwrap_or("unknown setup error"),
+                "runtime log persistence unavailable; continuing with console logging only"
+            );
+        }
+        harness_server::server::RuntimeLogState::Disabled => {}
+    }
+}
+
+fn prepare_logging(
+    command: &Command,
+    config: &harness_core::config::HarnessConfig,
+) -> LoggingBootstrap {
+    match command {
+        Command::Serve { .. } => prepare_runtime_logs(config, Utc::now()),
+        _ => LoggingBootstrap {
+            runtime_logs: RuntimeLogMetadata::disabled(config.observe.log_retention_days),
+            runtime_log_file: None,
+            setup_warning: None,
+        },
+    }
+}
+
+fn prepare_runtime_logs(
+    config: &harness_core::config::HarnessConfig,
+    started_at: DateTime<Utc>,
+) -> LoggingBootstrap {
+    let retention_days = config.observe.log_retention_days;
+    let log_path = runtime_log_path(&config.server.data_dir, started_at, std::process::id());
+    let path_hint = RuntimeLogMetadata::public_path_hint(&log_path);
+
+    match open_runtime_log_file(&log_path, retention_days, started_at) {
+        Ok(file) => LoggingBootstrap {
+            runtime_logs: RuntimeLogMetadata::enabled(log_path, retention_days),
+            runtime_log_file: Some(Arc::new(Mutex::new(file))),
+            setup_warning: None,
+        },
+        Err(error) => LoggingBootstrap {
+            runtime_logs: RuntimeLogMetadata::degraded(Some(path_hint), retention_days),
+            runtime_log_file: None,
+            setup_warning: Some(error.to_string()),
+        },
+    }
+}
+
+fn runtime_log_path(data_dir: &Path, started_at: DateTime<Utc>, pid: u32) -> PathBuf {
+    data_dir.join("logs").join(format!(
+        "{RUNTIME_LOG_PREFIX}{}-pid{pid}{RUNTIME_LOG_SUFFIX}",
+        started_at.format("%Y%m%dT%H%M%SZ")
+    ))
+}
+
+fn open_runtime_log_file(
+    log_path: &Path,
+    retention_days: u32,
+    started_at: DateTime<Utc>,
+) -> io::Result<File> {
+    let logs_dir = log_path
+        .parent()
+        .ok_or_else(|| io::Error::other("runtime log path missing parent directory"))?;
+    purge_stale_runtime_logs(logs_dir, retention_days, started_at)?;
+    fs::create_dir_all(logs_dir)?;
+    OpenOptions::new().create(true).append(true).open(log_path)
+}
+
+fn purge_stale_runtime_logs(
+    logs_dir: &Path,
+    retention_days: u32,
+    now: DateTime<Utc>,
+) -> io::Result<()> {
+    if !logs_dir.exists() {
+        return Ok(());
+    }
+
+    let cutoff = now - chrono::Duration::days(i64::from(retention_days));
+    for entry in fs::read_dir(logs_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(started_at) = parse_runtime_log_started_at(file_name) else {
+            continue;
+        };
+        if started_at < cutoff {
+            fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_runtime_log_started_at(file_name: &str) -> Option<DateTime<Utc>> {
+    let trimmed = file_name
+        .strip_prefix(RUNTIME_LOG_PREFIX)?
+        .strip_suffix(RUNTIME_LOG_SUFFIX)?;
+    let (timestamp, _) = trimmed.rsplit_once("-pid")?;
+    let naive = NaiveDateTime::parse_from_str(timestamp, "%Y%m%dT%H%M%SZ").ok()?;
+    Some(DateTime::from_naive_utc_and_offset(naive, Utc))
+}
+
+pub async fn run(cli: Cli) -> anyhow::Result<()> {
+    let (mut config, config_source) = load_config(cli.config.as_deref())?;
     // Apply env var overrides for all subcommands so that HARNESS_DATA_DIR,
     // HARNESS_PROJECT_ROOT, etc. are respected by gc, rule check, and skill
     // commands — not just `serve`.
     config.apply_env_overrides()?;
     harness_core::db::configure_pg_pool_from_server(&config.server);
+    let logging = prepare_logging(&cli.command, &config);
+    init_tracing(&logging)?;
+    log_config_source(&config_source);
+    log_runtime_log_status(&logging);
 
     match cli.command {
         Command::Serve {
@@ -330,6 +560,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_root,
                 projects,
                 default_project,
+                logging.runtime_logs.clone(),
             )
             .await?;
         }
@@ -574,6 +805,7 @@ mod tests {
         enforce_exec_privilege_policy_with, normalize_allow_list, resolve_exec_output_path,
         ExecSandboxMode,
     };
+    use chrono::TimeZone;
     use std::path::Path;
 
     #[test]
@@ -1084,5 +1316,85 @@ mod tests {
             }
             _ => panic!("expected Serve command"),
         }
+    }
+
+    #[test]
+    fn prepare_logging_creates_runtime_log_for_serve() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let mut config = harness_core::config::HarnessConfig::default();
+        config.server.data_dir = tempdir.path().to_path_buf();
+
+        let bootstrap = prepare_logging(
+            &Command::Serve {
+                transport: None,
+                port: None,
+                project_root: None,
+                projects: vec![],
+                default_project: None,
+            },
+            &config,
+        );
+
+        assert_eq!(bootstrap.runtime_logs.state.as_str(), "enabled");
+        let active_path = bootstrap
+            .runtime_logs
+            .active_path
+            .as_ref()
+            .expect("active path");
+        assert!(active_path.starts_with(tempdir.path().join("logs")));
+        assert!(active_path.exists(), "runtime log file should be created");
+        assert_eq!(
+            bootstrap.runtime_logs.path_hint.as_deref(),
+            active_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| format!("logs/{name}"))
+                .as_deref()
+        );
+    }
+
+    #[test]
+    fn purge_stale_runtime_logs_keeps_current_and_non_matching_files() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let logs_dir = tempdir.path().join("logs");
+        fs::create_dir_all(&logs_dir).expect("create logs dir");
+        let now = Utc
+            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+            .single()
+            .expect("timestamp");
+        let stale = runtime_log_path(
+            tempdir.path(),
+            Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+                .single()
+                .expect("stale timestamp"),
+            10,
+        );
+        let fresh = runtime_log_path(
+            tempdir.path(),
+            Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
+                .single()
+                .expect("fresh timestamp"),
+            11,
+        );
+        let unrelated = logs_dir.join("notes.txt");
+        fs::write(&stale, "stale").expect("write stale");
+        fs::write(&fresh, "fresh").expect("write fresh");
+        fs::write(&unrelated, "keep").expect("write unrelated");
+
+        purge_stale_runtime_logs(&logs_dir, 30, now).expect("purge");
+
+        assert!(!stale.exists(), "stale runtime log should be deleted");
+        assert!(fresh.exists(), "fresh runtime log should be kept");
+        assert!(unrelated.exists(), "non-matching files should be kept");
+    }
+
+    #[test]
+    fn prepare_logging_disables_file_persistence_for_non_serve_commands() {
+        let config = harness_core::config::HarnessConfig::default();
+        let bootstrap = prepare_logging(&Command::Version, &config);
+
+        assert_eq!(bootstrap.runtime_logs.state.as_str(), "disabled");
+        assert!(bootstrap.runtime_logs.active_path.is_none());
+        assert!(bootstrap.runtime_log_file.is_none());
     }
 }

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -54,6 +54,7 @@ pub async fn run(
     project_root: Option<PathBuf>,
     projects: Vec<String>,
     default_project: Option<String>,
+    runtime_logs: harness_server::server::RuntimeLogMetadata,
 ) -> Result<()> {
     // On macOS, sandbox-exec (Seatbelt) with deny-default policy causes SIGTRAP
     // in Claude Code CLI. Only enforce danger-full-access when a Claude path
@@ -242,6 +243,7 @@ pub async fn run(
         thread_manager,
         agent_registry,
     );
+    server.runtime_logs = runtime_logs;
     server.startup_projects = parsed_projects;
     server.startup_default_project = startup_default_project;
 

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -7,16 +7,6 @@ mod commands;
 mod gc;
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_timer(tracing_subscriber::fmt::time::ChronoLocal::new(
-            "%Y-%m-%dT%H:%M:%S%.3f%:z".to_string(),
-        ))
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "harness=info,warn".into()),
-        )
-        .init();
-
     let cli = commands::Cli::parse();
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/harness-server/src/handlers/operator_snapshot.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot.rs
@@ -143,6 +143,7 @@ pub async fn operator_snapshot(State(state): State<Arc<AppState>>) -> (StatusCod
 
     // ---- recent failures section ----
     let failures_json: Vec<Value> = failed_tasks.iter().map(recent_failure_json).collect();
+    let runtime_logs = &state.core.server.runtime_logs;
 
     let body = json!({
         "generated_at": generated_at.to_rfc3339(),
@@ -161,6 +162,15 @@ pub async fn operator_snapshot(State(state): State<Arc<AppState>>) -> (StatusCod
             },
         },
         "recent_failures": failures_json,
+        "runtime_logs": {
+            "state": runtime_logs.state.as_str(),
+            "active_path": runtime_logs
+                .active_path
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            "path_hint": runtime_logs.path_hint.clone(),
+            "retention_days": runtime_logs.retention_days,
+        },
     });
 
     (StatusCode::OK, Json(body))
@@ -199,13 +209,20 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
         let body: serde_json::Value = serde_json::from_slice(&bytes)?;
 
-        for key in ["generated_at", "retry", "rate_limits", "recent_failures"] {
+        for key in [
+            "generated_at",
+            "retry",
+            "rate_limits",
+            "recent_failures",
+            "runtime_logs",
+        ] {
             assert!(body.get(key).is_some(), "missing top-level key: {key}");
         }
         assert!(body["retry"].get("last_tick").is_some());
         assert!(body["retry"].get("stalled_tasks").is_some());
         assert!(body["rate_limits"].get("signal_ingestion").is_some());
         assert!(body["rate_limits"].get("password_reset").is_some());
+        assert_eq!(body["runtime_logs"]["state"], "disabled");
         Ok(())
     }
 
@@ -590,6 +607,77 @@ mod tests {
         let error_str = failures[0]["error"].as_str().expect("string");
         // Result must be valid UTF-8 (serde_json already guarantees this) and bounded.
         assert!(error_str.len() <= MAX_ERROR_LEN + 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_logs_returns_full_active_path_when_enabled() -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-op-snap-runtime-log-")?;
+        let mut state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+        let state_mut = Arc::get_mut(&mut state).expect("unique state");
+        let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
+        server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(
+            dir.path()
+                .join("logs/harness-serve-20260430T120000Z-pid1.log"),
+            30,
+        );
+
+        let app = Router::new()
+            .route("/api/operator-snapshot", get(operator_snapshot))
+            .with_state(state);
+        let req = axum::http::Request::builder()
+            .uri("/api/operator-snapshot")
+            .body(axum::body::Body::empty())?;
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        assert_eq!(body["runtime_logs"]["state"], "enabled");
+        assert_eq!(
+            body["runtime_logs"]["active_path"],
+            serde_json::Value::String(
+                dir.path()
+                    .join("logs/harness-serve-20260430T120000Z-pid1.log")
+                    .display()
+                    .to_string(),
+            )
+        );
+        assert_eq!(
+            body["runtime_logs"]["path_hint"],
+            serde_json::Value::String("logs/harness-serve-20260430T120000Z-pid1.log".to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_logs_reports_degraded_state_without_active_path() -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-op-snap-runtime-log-degraded-")?;
+        let mut state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+        let state_mut = Arc::get_mut(&mut state).expect("unique state");
+        let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
+        server.runtime_logs = crate::server::RuntimeLogMetadata::degraded(
+            Some("logs/harness-serve-20260430T120000Z-pid1.log".to_string()),
+            30,
+        );
+
+        let app = Router::new()
+            .route("/api/operator-snapshot", get(operator_snapshot))
+            .with_state(state);
+        let req = axum::http::Request::builder()
+            .uri("/api/operator-snapshot")
+            .body(axum::body::Body::empty())?;
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        assert_eq!(body["runtime_logs"]["state"], "degraded");
+        assert!(body["runtime_logs"]["active_path"].is_null());
+        assert_eq!(
+            body["runtime_logs"]["path_hint"],
+            serde_json::Value::String("logs/harness-serve-20260430T120000Z-pid1.log".to_string())
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -36,6 +36,7 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
     let count = state.core.tasks.count();
     let dirty = state.is_runtime_state_dirty();
     let degraded = &state.degraded_subsystems;
+    let runtime_logs = &state.core.server.runtime_logs;
     let startup_statuses: Vec<serde_json::Value> = state
         .startup_statuses
         .iter()
@@ -62,6 +63,11 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
             "startup": {
                 "stores": startup_statuses,
             }
+        },
+        "runtime_logs": {
+            "state": runtime_logs.state.as_str(),
+            "path_hint": runtime_logs.path_hint.clone(),
+            "retention_days": runtime_logs.retention_days,
         }
     }))
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -633,6 +633,7 @@ struct HealthResponse {
     status: String,
     tasks: u64,
     persistence: PersistenceBlock,
+    runtime_logs: RuntimeLogsBlock,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -653,6 +654,13 @@ struct StoreHealth {
     critical: bool,
     ready: bool,
     error: Option<String>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct RuntimeLogsBlock {
+    state: String,
+    path_hint: Option<String>,
+    retention_days: u32,
 }
 
 async fn call_health(state: Arc<AppState>) -> anyhow::Result<HealthResponse> {
@@ -679,6 +687,7 @@ async fn health_endpoint_returns_ok_and_task_count() -> anyhow::Result<()> {
     assert!(health.persistence.degraded_subsystems.is_empty());
     assert!(!health.persistence.runtime_state_dirty);
     assert!(health.persistence.startup.stores.is_empty());
+    assert_eq!(health.runtime_logs.state, "disabled");
     Ok(())
 }
 
@@ -705,6 +714,54 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
     assert_eq!(health.status, "degraded");
     assert!(health.persistence.degraded_subsystems.is_empty());
     assert!(health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_runtime_logs_redacts_absolute_path() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique state");
+    let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
+    server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(
+        dir.path()
+            .join("logs/harness-serve-20260430T120000Z-pid1.log"),
+        45,
+    );
+
+    let health = call_health(state).await?;
+    assert_eq!(health.runtime_logs.state, "enabled");
+    assert_eq!(
+        health.runtime_logs.path_hint.as_deref(),
+        Some("logs/harness-serve-20260430T120000Z-pid1.log")
+    );
+    assert_eq!(health.runtime_logs.retention_days, 45);
+    assert!(
+        !format!("{health:?}").contains(&dir.path().display().to_string()),
+        "health response must not expose an absolute runtime log path"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_runtime_logs_can_report_degraded_without_raw_error_text() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_test_state(dir.path()).await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique state");
+    let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
+    server.runtime_logs = crate::server::RuntimeLogMetadata::degraded(
+        Some("logs/harness-serve-20260430T120000Z-pid1.log".to_string()),
+        7,
+    );
+
+    let health = call_health(state).await?;
+    assert_eq!(health.runtime_logs.state, "degraded");
+    assert_eq!(
+        health.runtime_logs.path_hint.as_deref(),
+        Some("logs/harness-serve-20260430T120000Z-pid1.log")
+    );
+    assert_eq!(health.runtime_logs.retention_days, 7);
+    assert!(!format!("{health:?}").contains("permission denied"));
     Ok(())
 }
 

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -2,12 +2,74 @@ use crate::thread_manager::ThreadManager;
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::{HarnessConfig, ProjectEntry};
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeLogState {
+    Disabled,
+    Enabled,
+    Degraded,
+}
+
+impl RuntimeLogState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Enabled => "enabled",
+            Self::Degraded => "degraded",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeLogMetadata {
+    pub state: RuntimeLogState,
+    pub active_path: Option<PathBuf>,
+    pub path_hint: Option<String>,
+    pub retention_days: u32,
+}
+
+impl RuntimeLogMetadata {
+    pub fn disabled(retention_days: u32) -> Self {
+        Self {
+            state: RuntimeLogState::Disabled,
+            active_path: None,
+            path_hint: None,
+            retention_days,
+        }
+    }
+
+    pub fn enabled(active_path: PathBuf, retention_days: u32) -> Self {
+        Self {
+            state: RuntimeLogState::Enabled,
+            path_hint: Some(Self::public_path_hint(&active_path)),
+            active_path: Some(active_path),
+            retention_days,
+        }
+    }
+
+    pub fn degraded(path_hint: Option<String>, retention_days: u32) -> Self {
+        Self {
+            state: RuntimeLogState::Degraded,
+            active_path: None,
+            path_hint,
+            retention_days,
+        }
+    }
+
+    pub fn public_path_hint(path: &Path) -> String {
+        path.file_name()
+            .map(|name| format!("logs/{}", name.to_string_lossy()))
+            .unwrap_or_else(|| "logs".to_string())
+    }
+}
 
 pub struct HarnessServer {
     pub config: HarnessConfig,
     pub thread_manager: ThreadManager,
     pub agent_registry: Arc<AgentRegistry>,
+    pub runtime_logs: RuntimeLogMetadata,
     /// Projects to register in the project registry at startup.
     pub startup_projects: Vec<ProjectEntry>,
     /// The startup project selected as the effective default project root.
@@ -21,10 +83,12 @@ impl HarnessServer {
         agent_registry: AgentRegistry,
     ) -> Self {
         config.apply_derived_defaults();
+        let retention_days = config.observe.log_retention_days;
         Self {
             config,
             thread_manager,
             agent_registry: Arc::new(agent_registry),
+            runtime_logs: RuntimeLogMetadata::disabled(retention_days),
             startup_projects: Vec::new(),
             startup_default_project: None,
         }

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -264,6 +264,9 @@ curl -N http://127.0.0.1:9800/tasks/{task_id}/stream
 curl http://127.0.0.1:9800/health
 ```
 
+The public health payload includes a `runtime_logs` block with the current
+logging state, retention window, and a redacted `logs/<filename>` hint.
+
 ## Project Management API
 
 ### List Projects
@@ -302,7 +305,7 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 |-------|---------|-------------|
 | `transport` | `"stdio"` | Transport protocol: `stdio`, `http`, or `web_socket` |
 | `http_addr` | `"127.0.0.1:9800"` | HTTP listen address |
-| `data_dir` | `"~/.local/share/harness"` | Data directory for Harness server state and database metadata |
+| `data_dir` | `"~/.local/share/harness"` | Data directory for Harness server state, database metadata, and persisted `harness serve` runtime logs under `logs/` |
 | `project_root` | `"."` | Default project root (single-project mode) |
 | `github_webhook_secret` | — | HMAC-SHA256 secret for GitHub webhook verification |
 | `notification_broadcast_capacity` | `256` | Internal notification channel capacity |

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -96,6 +96,12 @@ function makeSnapshot(): OperatorSnapshotPayload {
       },
     },
     recent_failures: [],
+    runtime_logs: {
+      state: "disabled",
+      active_path: null,
+      path_hint: null,
+      retention_days: 30,
+    },
   };
 }
 

--- a/web/src/routes/overview/OperatorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorPanel.test.tsx
@@ -51,6 +51,12 @@ function makeSnapshot(): OperatorSnapshotPayload {
         failed_at: null,
       },
     ],
+    runtime_logs: {
+      state: "enabled",
+      active_path: "/tmp/harness/logs/harness-serve-20260430T120000Z-pid1.log",
+      path_hint: "logs/harness-serve-20260430T120000Z-pid1.log",
+      retention_days: 30,
+    },
   };
 }
 
@@ -63,7 +69,7 @@ describe("<OperatorPanel>", () => {
 
     wrap(<OperatorPanel />);
 
-    expect(screen.getAllByText("Operator snapshot unavailable.").length).toBe(3);
+    expect(screen.getAllByText("Operator snapshot unavailable.").length).toBe(4);
     expect(screen.queryByText("No retry ticks recorded yet.")).not.toBeInTheDocument();
     expect(screen.queryByText("No recent failures.")).not.toBeInTheDocument();
     expect(screen.queryByText("/ 0 /min")).not.toBeInTheDocument();
@@ -82,5 +88,26 @@ describe("<OperatorPanel>", () => {
     expect(screen.queryByText("Operator snapshot unavailable.")).not.toBeInTheDocument();
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
     expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("/tmp/harness/logs/harness-serve-20260430T120000Z-pid1.log"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows fallback copy when runtime-log metadata is unavailable", () => {
+    const snapshot = makeSnapshot();
+    snapshot.runtime_logs = {
+      state: "degraded",
+      active_path: null,
+      path_hint: "logs/harness-serve-20260430T120000Z-pid1.log",
+      retention_days: 30,
+    };
+    mockUseOperatorSnapshot.mockReturnValue({
+      data: snapshot,
+      isError: false,
+    });
+
+    wrap(<OperatorPanel />);
+
+    expect(screen.getByText("Runtime log path unavailable.")).toBeInTheDocument();
   });
 });

--- a/web/src/routes/overview/OperatorPanel.tsx
+++ b/web/src/routes/overview/OperatorPanel.tsx
@@ -51,9 +51,26 @@ export function OperatorPanel() {
   const sig = data?.rate_limits.signal_ingestion;
   const pw = data?.rate_limits.password_reset;
   const failures = data?.recent_failures ?? [];
+  const runtimeLogs = data?.runtime_logs;
+  const runtimeLogPath = runtimeLogs?.active_path ?? null;
 
   return (
     <Panel title="Operator snapshot" sub="retry · rate limits · recent failures" id="operator">
+      <div className="border-b border-line">
+        <div className="px-4 py-2 font-mono text-[10px] text-ink-3 uppercase tracking-wider border-b border-line">
+          Runtime logs
+        </div>
+        {isError ? (
+          <p className="px-4 py-3 font-mono text-[11px] text-danger">Operator snapshot unavailable.</p>
+        ) : runtimeLogPath ? (
+          <div className="px-4 py-3 font-mono text-[11px] text-ink-1 break-all">{runtimeLogPath}</div>
+        ) : (
+          <p className="px-4 py-3 font-mono text-[11px] text-ink-4">
+            Runtime log path unavailable.
+          </p>
+        )}
+      </div>
+
       {/* Retry pressure */}
       <div className="border-b border-line">
         <div className="px-4 py-2 font-mono text-[10px] text-ink-3 uppercase tracking-wider border-b border-line">

--- a/web/src/types/operator_snapshot.ts
+++ b/web/src/types/operator_snapshot.ts
@@ -32,6 +32,13 @@ export interface PasswordResetLimits {
   limit_per_hour: number;
 }
 
+export interface RuntimeLogsStatus {
+  state: "disabled" | "enabled" | "degraded";
+  active_path: string | null;
+  path_hint: string | null;
+  retention_days: number;
+}
+
 export interface OperatorSnapshotPayload {
   generated_at: string;
   retry: {
@@ -43,4 +50,5 @@ export interface OperatorSnapshotPayload {
     password_reset: PasswordResetLimits;
   };
   recent_failures: RecentFailure[];
+  runtime_logs: RuntimeLogsStatus;
 }


### PR DESCRIPTION
## Summary
- persist `harness serve` runtime logs under `server.data_dir/logs` while preserving console output
- expose runtime log state through `/health`, `/api/operator-snapshot`, and the overview operator panel
- keep retention cleanup bounded by `observe.log_retention_days` without degrading runtime logging when stale-file deletion fails

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1045-target cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1045-target cargo test -p harness-cli purge_stale_runtime_logs -- --nocapture`
- `bun run test -- Overview.test.tsx OperatorPanel.test.tsx`
- `bun run build`
- `CARGO_TARGET_DIR=/private/tmp/harness-review-1045-target cargo test --workspace -j 6`
- `RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR=/private/tmp/harness-review-1045-target cargo check --workspace --all-targets`

Closes #1002
