### PR TITLE
Shadow issue submissions in workflow runtime

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,13 +7,13 @@ pr_feedback:
   sweep_interval_secs: 60
   claim_stale_after_secs: 300
 runtime_dispatch:
-  enabled: false
+  enabled: true
   interval_secs: 30
   batch_limit: 25
   runtime_kind: codex_jsonrpc
   runtime_profile: codex-default
 runtime_worker:
-  enabled: false
+  enabled: true
   interval_secs: 5
   concurrency: 1
   lease_ttl_secs: 900
@@ -47,8 +47,8 @@ Current externally configurable rules:
     `addressing_feedback` tasks with a real `active_task_id`.
 
 - `runtime_dispatch.enabled`
-  - Enables the experimental workflow command outbox dispatcher. It is disabled
-    by default while workflow runtime execution remains opt-in.
+  - Enables the workflow command outbox dispatcher. It is enabled by default
+    so accepted workflow commands become runtime jobs.
 
 - `runtime_dispatch.interval_secs`
   - Background interval for converting pending workflow commands into runtime jobs.
@@ -65,8 +65,8 @@ Current externally configurable rules:
   - Runtime profile name stored on newly created runtime jobs.
 
 - `runtime_worker.enabled`
-  - Enables the experimental server-owned runtime job worker. It is disabled
-    by default while workflow migration remains opt-in.
+  - Enables the server-owned runtime job worker. It is enabled by default so
+    pending runtime jobs are claimed and executed by registered runtime agents.
 
 - `runtime_worker.interval_secs`
   - Background interval for claiming pending runtime jobs.

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -166,7 +166,7 @@ impl Default for PrFeedbackPolicy {
 impl Default for RuntimeDispatchPolicy {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             interval_secs: default_runtime_dispatch_interval_secs(),
             batch_limit: default_runtime_dispatch_batch_limit(),
             runtime_kind: default_runtime_dispatch_kind(),
@@ -187,7 +187,7 @@ impl Default for RuntimeDispatchPolicy {
 impl Default for RuntimeWorkerPolicy {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             interval_secs: default_runtime_worker_interval_secs(),
             concurrency: default_runtime_worker_concurrency(),
             lease_ttl_secs: default_runtime_worker_lease_ttl_secs(),
@@ -316,7 +316,7 @@ mod tests {
         assert!(cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
         assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 300);
-        assert!(!cfg.runtime_dispatch.enabled);
+        assert!(cfg.runtime_dispatch.enabled);
         assert_eq!(cfg.runtime_dispatch.interval_secs, 30);
         assert_eq!(cfg.runtime_dispatch.batch_limit, 25);
         assert_eq!(cfg.runtime_dispatch.runtime_kind, "codex_jsonrpc");
@@ -330,7 +330,7 @@ mod tests {
         assert!(cfg.runtime_dispatch.workflow_profiles.is_empty());
         assert!(cfg.runtime_dispatch.activity_profiles.is_empty());
         assert!(cfg.runtime_dispatch.workflow_activity_profiles.is_empty());
-        assert!(!cfg.runtime_worker.enabled);
+        assert!(cfg.runtime_worker.enabled);
         assert_eq!(cfg.runtime_worker.interval_secs, 5);
         assert_eq!(cfg.runtime_worker.concurrency, 1);
         assert_eq!(cfg.runtime_worker.lease_ttl_secs, 900);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -481,6 +481,21 @@ pub(super) async fn run_runtime_command_dispatch_tick(
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(RuntimeCommandDispatchTick::default());
     };
+    let release = crate::workflow_runtime_submission::release_ready_issue_dependencies(
+        store,
+        &state.core.tasks,
+        batch_limit,
+    )
+    .await?;
+    if release.released > 0 || release.failed > 0 || release.skipped > 0 {
+        tracing::info!(
+            released = release.released,
+            failed = release.failed,
+            waiting = release.waiting,
+            skipped = release.skipped,
+            "workflow runtime dependency release tick complete"
+        );
+    }
     let outcomes = RuntimeCommandDispatcher::with_profile_selector(store, runtime_profiles.into())
         .with_batch_limit(batch_limit)
         .dispatch_pending()

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
@@ -7,7 +8,7 @@ use harness_workflow::issue_lifecycle::{
 };
 use harness_workflow::runtime::{
     CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeKind, RuntimeProfile,
-    RuntimeProfileSelector,
+    RuntimeProfileSelector, WorkflowCommandRecord, WorkflowInstance, WorkflowRuntimeStore,
 };
 
 fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
@@ -496,11 +497,127 @@ pub(super) async fn run_runtime_command_dispatch_tick(
             "workflow runtime dependency release tick complete"
         );
     }
-    let outcomes = RuntimeCommandDispatcher::with_profile_selector(store, runtime_profiles.into())
-        .with_batch_limit(batch_limit)
-        .dispatch_pending()
-        .await?;
+    let fallback_profile_selector = runtime_profiles.into();
+    let commands = store.pending_commands(batch_limit).await?;
+    let mut outcomes = Vec::with_capacity(commands.len());
+    for command in commands {
+        outcomes.push(
+            dispatch_runtime_command_with_project_policy(
+                state,
+                store,
+                command,
+                fallback_profile_selector.clone(),
+            )
+            .await?,
+        );
+    }
     Ok(RuntimeCommandDispatchTick::from_outcomes(&outcomes))
+}
+
+async fn dispatch_runtime_command_with_project_policy(
+    state: &Arc<AppState>,
+    store: &WorkflowRuntimeStore,
+    command: WorkflowCommandRecord,
+    fallback_profile_selector: RuntimeProfileSelector,
+) -> anyhow::Result<CommandDispatchOutcome> {
+    if !command.command.requires_runtime_job() {
+        return RuntimeCommandDispatcher::with_profile_selector(store, fallback_profile_selector)
+            .dispatch_command(command)
+            .await;
+    }
+
+    let Some(profile_selector) =
+        runtime_dispatch_profile_selector_for_command(state, store, &command).await?
+    else {
+        let command_id = command.id.clone();
+        let skipped = store
+            .mark_pending_command_status(&command_id, "skipped")
+            .await?;
+        let reason = if skipped {
+            "workflow runtime dispatch or worker is disabled for the command project".to_string()
+        } else {
+            "command status changed before workflow runtime policy dispatch".to_string()
+        };
+        return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
+    };
+
+    RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
+        .dispatch_command(command)
+        .await
+}
+
+async fn runtime_dispatch_profile_selector_for_command(
+    state: &Arc<AppState>,
+    store: &WorkflowRuntimeStore,
+    command: &WorkflowCommandRecord,
+) -> anyhow::Result<Option<RuntimeProfileSelector>> {
+    let project_root =
+        runtime_command_project_root(store, command, &state.core.project_root).await?;
+    let workflow_cfg = load_runtime_workflow_config_or_default(
+        &project_root,
+        "workflow runtime command dispatcher",
+    );
+    if !workflow_cfg.runtime_dispatch.enabled || !workflow_cfg.runtime_worker.enabled {
+        tracing::debug!(
+            workflow_id = %command.workflow_id,
+            command_id = %command.id,
+            project_root = %project_root.display(),
+            dispatch_enabled = workflow_cfg.runtime_dispatch.enabled,
+            worker_enabled = workflow_cfg.runtime_worker.enabled,
+            "workflow runtime command skipped by project runtime policy"
+        );
+        return Ok(None);
+    }
+    Ok(Some(runtime_dispatch_profile_selector(
+        &workflow_cfg.runtime_dispatch,
+    )))
+}
+
+async fn runtime_command_project_root(
+    store: &WorkflowRuntimeStore,
+    command: &WorkflowCommandRecord,
+    fallback_project_root: &Path,
+) -> anyhow::Result<PathBuf> {
+    let Some(instance) = store.get_instance(&command.workflow_id).await? else {
+        tracing::warn!(
+            workflow_id = %command.workflow_id,
+            command_id = %command.id,
+            fallback_project_root = %fallback_project_root.display(),
+            "workflow runtime command has no workflow instance; using fallback project root"
+        );
+        return Ok(fallback_project_root.to_path_buf());
+    };
+    Ok(workflow_project_root(&instance).unwrap_or_else(|| {
+        tracing::warn!(
+            workflow_id = %command.workflow_id,
+            command_id = %command.id,
+            fallback_project_root = %fallback_project_root.display(),
+            "workflow runtime command workflow has no project_id; using fallback project root"
+        );
+        fallback_project_root.to_path_buf()
+    }))
+}
+
+fn workflow_project_root(instance: &WorkflowInstance) -> Option<PathBuf> {
+    instance
+        .data
+        .get("project_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|project_id| !project_id.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+fn load_runtime_workflow_config_or_default(
+    project_root: &Path,
+    subsystem: &str,
+) -> harness_core::config::workflow::WorkflowConfig {
+    harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_else(|e| {
+        tracing::warn!(
+            project_root = %project_root.display(),
+            "{subsystem}: failed to load WORKFLOW.md, using default config: {e}"
+        );
+        harness_core::config::workflow::WorkflowConfig::default()
+    })
 }
 
 fn runtime_kind_from_config(value: &str) -> Option<RuntimeKind> {
@@ -651,40 +768,32 @@ pub(super) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg =
-                harness_core::config::workflow::load_workflow_config(&state.core.project_root)
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            "workflow runtime command dispatcher: failed to load WORKFLOW.md, using default config: {e}"
-                        );
-                        harness_core::config::workflow::WorkflowConfig::default()
-                    });
+            let workflow_cfg = load_runtime_workflow_config_or_default(
+                &state.core.project_root,
+                "workflow runtime command dispatcher",
+            );
             let policy = workflow_cfg.runtime_dispatch;
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
-            if policy.enabled {
-                let profile_selector = runtime_dispatch_profile_selector(&policy);
-                match run_runtime_command_dispatch_tick(
-                    &state,
-                    profile_selector,
-                    i64::from(policy.batch_limit.max(1)),
-                )
-                .await
-                {
-                    Ok(tick) if tick.touched_anything() => {
-                        tracing::info!(
-                            enqueued = tick.enqueued,
-                            already_dispatched = tick.already_dispatched,
-                            skipped = tick.skipped,
-                            "workflow runtime command dispatcher tick complete"
-                        );
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        tracing::warn!("workflow runtime command dispatcher tick failed: {e}");
-                    }
+            let profile_selector = runtime_dispatch_profile_selector(&policy);
+            match run_runtime_command_dispatch_tick(
+                &state,
+                profile_selector,
+                i64::from(policy.batch_limit.max(1)),
+            )
+            .await
+            {
+                Ok(tick) if tick.touched_anything() => {
+                    tracing::info!(
+                        enqueued = tick.enqueued,
+                        already_dispatched = tick.already_dispatched,
+                        skipped = tick.skipped,
+                        "workflow runtime command dispatcher tick complete"
+                    );
                 }
-            } else {
-                tracing::debug!("workflow runtime command dispatcher disabled by WORKFLOW.md");
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("workflow runtime command dispatcher tick failed: {e}");
+                }
             }
             tokio::time::sleep(interval).await;
         }
@@ -696,6 +805,16 @@ fn runtime_worker_lease_ttl(
 ) -> chrono::Duration {
     let lease_ttl_secs = i64::try_from(policy.lease_ttl_secs.max(1)).unwrap_or(i64::MAX);
     chrono::Duration::seconds(lease_ttl_secs)
+}
+
+fn runtime_worker_loop_policy(
+    policy: harness_core::config::workflow::RuntimeWorkerPolicy,
+) -> harness_core::config::workflow::RuntimeWorkerPolicy {
+    if policy.enabled {
+        policy
+    } else {
+        harness_core::config::workflow::RuntimeWorkerPolicy::default()
+    }
 }
 
 pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
@@ -711,51 +830,43 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg =
-                harness_core::config::workflow::load_workflow_config(&state.core.project_root)
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            "workflow runtime job workers: failed to load WORKFLOW.md, using default config: {e}"
-                        );
-                        harness_core::config::workflow::WorkflowConfig::default()
-                    });
-            let policy = workflow_cfg.runtime_worker;
+            let workflow_cfg = load_runtime_workflow_config_or_default(
+                &state.core.project_root,
+                "workflow runtime job workers",
+            );
+            let policy = runtime_worker_loop_policy(workflow_cfg.runtime_worker);
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
-            if policy.enabled {
-                let concurrency = policy.concurrency.max(1);
-                let lease_ttl = runtime_worker_lease_ttl(&policy);
-                let mut handles = Vec::with_capacity(concurrency as usize);
-                for worker_idx in 0..concurrency {
-                    let state = state.clone();
-                    let owner = format!("server-runtime-worker-{worker_idx}");
-                    handles.push(tokio::spawn(async move {
-                        crate::workflow_runtime_worker::run_runtime_job_worker_tick(
-                            &state, owner, lease_ttl,
-                        )
-                        .await
-                    }));
-                }
-                for handle in handles {
-                    match handle.await {
-                        Ok(Ok(tick)) if tick.touched_anything() => {
-                            tracing::info!(
-                                succeeded = tick.succeeded,
-                                failed = tick.failed,
-                                cancelled = tick.cancelled,
-                                "workflow runtime job worker tick complete"
-                            );
-                        }
-                        Ok(Ok(_)) => {}
-                        Ok(Err(e)) => {
-                            tracing::warn!("workflow runtime job worker tick failed: {e}");
-                        }
-                        Err(e) => {
-                            tracing::warn!("workflow runtime job worker task panicked: {e}");
-                        }
+            let concurrency = policy.concurrency.max(1);
+            let lease_ttl = runtime_worker_lease_ttl(&policy);
+            let mut handles = Vec::with_capacity(concurrency as usize);
+            for worker_idx in 0..concurrency {
+                let state = state.clone();
+                let owner = format!("server-runtime-worker-{worker_idx}");
+                handles.push(tokio::spawn(async move {
+                    crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+                        &state, owner, lease_ttl,
+                    )
+                    .await
+                }));
+            }
+            for handle in handles {
+                match handle.await {
+                    Ok(Ok(tick)) if tick.touched_anything() => {
+                        tracing::info!(
+                            succeeded = tick.succeeded,
+                            failed = tick.failed,
+                            cancelled = tick.cancelled,
+                            "workflow runtime job worker tick complete"
+                        );
+                    }
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => {
+                        tracing::warn!("workflow runtime job worker tick failed: {e}");
+                    }
+                    Err(e) => {
+                        tracing::warn!("workflow runtime job worker task panicked: {e}");
                     }
                 }
-            } else {
-                tracing::debug!("workflow runtime job workers disabled by WORKFLOW.md");
             }
             tokio::time::sleep(interval).await;
         }
@@ -2114,6 +2225,21 @@ mod tests {
         assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
         assert_eq!(profile.name, "claude-default");
         assert_eq!(profile.approval_policy, None);
+    }
+
+    #[test]
+    fn runtime_worker_loop_policy_keeps_polling_when_server_root_disables_worker() {
+        let policy = harness_core::config::workflow::RuntimeWorkerPolicy {
+            enabled: false,
+            concurrency: 8,
+            ..Default::default()
+        };
+
+        let effective = runtime_worker_loop_policy(policy);
+
+        assert!(effective.enabled);
+        assert_eq!(effective.concurrency, 1);
+        assert_eq!(effective.interval_secs, 5);
     }
 
     // ARCH-GH-EXEMPT test double: mirrors the logic of fetch_pr_state_by_url in

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -110,12 +110,18 @@ pub(crate) async fn build_intake(
                 "intake: GitHub Issues poller registered"
             );
             let key = format!("github:{}", repo_cfg.repo);
+            let task_checker = Arc::new(
+                crate::intake::github_issues::RuntimeAwareDispatchedTaskChecker::new(
+                    tasks.clone(),
+                    registry.workflow_runtime_store.clone(),
+                ),
+            );
             let poller = crate::intake::github_issues::GitHubIssuesPoller::new_with_token(
                 &repo_cfg,
                 Some(data_dir),
                 server.config.server.github_token.clone(),
             )
-            .with_task_checker(tasks.clone());
+            .with_task_checker(task_checker);
             match poller.reconcile_dispatched_with_store().await {
                 Ok(pruned) if pruned > 0 => tracing::info!(
                     repo = %repo_cfg.repo,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -723,13 +723,15 @@ pub(crate) async fn github_webhook(
         });
     }
 
+    let is_issue_submission = req.issue.is_some();
     match task_routes::enqueue_task(&state, req).await {
         Ok(task_id) => (
             StatusCode::ACCEPTED,
             Json(json!({
-                "status": "accepted",
+                "status": if is_issue_submission { "scheduled" } else { "accepted" },
                 "reason": reason,
                 "task_id": task_id.0,
+                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
             })),
         ),
         Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -725,15 +725,36 @@ pub(crate) async fn github_webhook(
 
     let is_issue_submission = req.issue.is_some();
     match task_routes::enqueue_task(&state, req).await {
-        Ok(task_id) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "status": if is_issue_submission { "scheduled" } else { "accepted" },
-                "reason": reason,
-                "task_id": task_id.0,
-                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
-            })),
-        ),
+        Ok(task_id) => {
+            match task_routes::task_response_details(&state, &task_id, is_issue_submission).await {
+                Ok(details) => (
+                    StatusCode::ACCEPTED,
+                    Json(json!({
+                        "status": if details.execution_path == "workflow_runtime" {
+                            details.status
+                        } else {
+                            "accepted".to_string()
+                        },
+                        "reason": reason,
+                        "task_id": task_id.0,
+                        "execution_path": details.execution_path,
+                    })),
+                ),
+                Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
+                    (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
+                }
+                Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": error })),
+                ),
+                Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
+                    retry_after_secs,
+                }) => (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
+                ),
+            }
+        }
         Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
             (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
         }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -177,12 +177,12 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // enqueue `pr:N` tasks so PR feedback is handled without manual resubmission.
     background::spawn_issue_workflow_feedback_sweeper(&state);
 
-    // Optionally convert workflow command outbox rows into runtime jobs.
-    // Workflow runtime execution remains opt-in while the migration is staged.
+    // Convert workflow command outbox rows into runtime jobs when the workflow
+    // policy keeps the dispatcher enabled.
     background::spawn_runtime_command_dispatcher(&state);
 
-    // Optionally execute pending workflow runtime jobs through registered agent
-    // runtimes. This is also disabled by default while workflow mode is opt-in.
+    // Execute pending workflow runtime jobs through registered agent runtimes
+    // when the workflow policy keeps the worker enabled.
     background::spawn_runtime_job_workers(&state);
 
     let initial_grade = {

--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -33,13 +33,26 @@ pub(crate) async fn stream_task_sse(
         Some(rx) => rx,
         None => {
             match state.core.tasks.get_with_db_fallback(&task_id).await {
-                Ok(None) => {
-                    return (
-                        StatusCode::NOT_FOUND,
-                        Json(json!({"error": "task not found"})),
-                    )
-                        .into_response();
-                }
+                Ok(None) => match runtime_task_sse_replay(&state, &task_id).await {
+                    Ok(Some(events)) => {
+                        return Sse::new(futures::stream::iter(events)).into_response();
+                    }
+                    Ok(None) => {
+                        return (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({"error": "task not found"})),
+                        )
+                            .into_response();
+                    }
+                    Err(e) => {
+                        tracing::error!("stream_task_sse: runtime workflow lookup failed: {e}");
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({"error": "internal server error"})),
+                        )
+                            .into_response();
+                    }
+                },
                 Err(e) => {
                     tracing::error!("stream_task_sse: database error: {e}");
                     return (
@@ -117,4 +130,49 @@ pub(crate) async fn stream_task_sse(
                 .text("heartbeat"),
         )
         .into_response()
+}
+
+async fn runtime_task_sse_replay(
+    state: &AppState,
+    task_id: &harness_core::types::TaskId,
+) -> anyhow::Result<Option<Vec<Result<Event, std::convert::Infallible>>>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(None);
+    };
+    let Some(workflow) =
+        crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id).await?
+    else {
+        return Ok(None);
+    };
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "[workflow] {} state={}",
+        workflow.id, workflow.state
+    ));
+    for event in store.events_for(&workflow.id).await? {
+        lines.push(format!(
+            "[event {}] {} {}",
+            event.sequence, event.event_type, event.event
+        ));
+    }
+    for command in store.commands_for(&workflow.id).await? {
+        lines.push(format!(
+            "[command] {} status={} activity={}",
+            command.id,
+            command.status,
+            command.command.runtime_activity_key()
+        ));
+    }
+    let mut events: Vec<Result<Event, std::convert::Infallible>> = lines
+        .into_iter()
+        .filter_map(|text| {
+            serde_json::to_string(&StreamItem::MessageDelta { text })
+                .ok()
+                .map(|data| Ok(Event::default().data(data)))
+        })
+        .collect();
+    if let Ok(data) = serde_json::to_string(&StreamItem::Done) {
+        events.push(Ok(Event::default().data(data)));
+    }
+    Ok(Some(events))
 }

--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -10,7 +10,14 @@ use axum::{
 };
 use harness_core::agent::StreamItem;
 use serde_json::json;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, VecDeque},
+    convert::Infallible,
+    sync::Arc,
+    time::Duration,
+};
+
+use futures::{stream::BoxStream, StreamExt};
 
 /// GET /tasks/{id}/stream — real-time SSE stream of agent execution events.
 ///
@@ -33,9 +40,11 @@ pub(crate) async fn stream_task_sse(
         Some(rx) => rx,
         None => {
             match state.core.tasks.get_with_db_fallback(&task_id).await {
-                Ok(None) => match runtime_task_sse_replay(&state, &task_id).await {
-                    Ok(Some(events)) => {
-                        return Sse::new(futures::stream::iter(events)).into_response();
+                Ok(None) => match runtime_task_sse_stream(state.clone(), task_id.clone()).await {
+                    Ok(Some(stream)) => {
+                        return Sse::new(stream)
+                            .keep_alive(sse_keep_alive())
+                            .into_response();
                     }
                     Ok(None) => {
                         return (
@@ -124,55 +133,146 @@ pub(crate) async fn stream_task_sse(
     // Send a heartbeat comment every 30 s so reverse proxies (nginx default
     // 60 s idle timeout) don't drop the connection while the agent is silent.
     Sse::new(stream)
-        .keep_alive(
-            KeepAlive::new()
-                .interval(std::time::Duration::from_secs(30))
-                .text("heartbeat"),
-        )
+        .keep_alive(sse_keep_alive())
         .into_response()
 }
 
-async fn runtime_task_sse_replay(
-    state: &AppState,
-    task_id: &harness_core::types::TaskId,
-) -> anyhow::Result<Option<Vec<Result<Event, std::convert::Infallible>>>> {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+fn sse_keep_alive() -> KeepAlive {
+    KeepAlive::new()
+        .interval(Duration::from_secs(30))
+        .text("heartbeat")
+}
+
+type SseEvent = Result<Event, Infallible>;
+
+async fn runtime_task_sse_stream(
+    state: Arc<AppState>,
+    task_id: harness_core::types::TaskId,
+) -> anyhow::Result<Option<BoxStream<'static, SseEvent>>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref().cloned() else {
         return Ok(None);
     };
     let Some(workflow) =
-        crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id).await?
+        crate::workflow_runtime_submission::runtime_issue_by_task_id(&store, &task_id).await?
     else {
         return Ok(None);
     };
-    let mut lines = Vec::new();
-    lines.push(format!(
-        "[workflow] {} state={}",
-        workflow.id, workflow.state
-    ));
-    for event in store.events_for(&workflow.id).await? {
-        lines.push(format!(
-            "[event {}] {} {}",
-            event.sequence, event.event_type, event.event
-        ));
-    }
-    for command in store.commands_for(&workflow.id).await? {
-        lines.push(format!(
-            "[command] {} status={} activity={}",
-            command.id,
-            command.status,
-            command.command.runtime_activity_key()
-        ));
-    }
-    let mut events: Vec<Result<Event, std::convert::Infallible>> = lines
-        .into_iter()
-        .filter_map(|text| {
-            serde_json::to_string(&StreamItem::MessageDelta { text })
-                .ok()
-                .map(|data| Ok(Event::default().data(data)))
+
+    let mut cursor = RuntimeTaskSseCursor::new(store, workflow.id);
+    cursor.refresh().await?;
+    Ok(Some(
+        futures::stream::unfold(cursor, |mut cursor| async move {
+            loop {
+                if let Some(event) = cursor.pending.pop_front() {
+                    return Some((event, cursor));
+                }
+                if cursor.finished {
+                    return None;
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                if let Err(error) = cursor.refresh().await {
+                    tracing::error!(
+                        "runtime_task_sse_stream: runtime workflow refresh failed: {error}"
+                    );
+                    cursor.push_item(StreamItem::Error {
+                        message: "runtime workflow stream failed".to_string(),
+                    });
+                    cursor.finished = true;
+                }
+            }
         })
-        .collect();
-    if let Ok(data) = serde_json::to_string(&StreamItem::Done) {
-        events.push(Ok(Event::default().data(data)));
+        .boxed(),
+    ))
+}
+
+struct RuntimeTaskSseCursor {
+    store: Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+    workflow_id: String,
+    pending: VecDeque<SseEvent>,
+    last_state: Option<String>,
+    last_event_sequence: u64,
+    command_statuses: HashMap<String, String>,
+    finished: bool,
+}
+
+impl RuntimeTaskSseCursor {
+    fn new(
+        store: Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+        workflow_id: String,
+    ) -> Self {
+        Self {
+            store,
+            workflow_id,
+            pending: VecDeque::new(),
+            last_state: None,
+            last_event_sequence: 0,
+            command_statuses: HashMap::new(),
+            finished: false,
+        }
     }
-    Ok(Some(events))
+
+    async fn refresh(&mut self) -> anyhow::Result<()> {
+        let Some(workflow) = self.store.get_instance(&self.workflow_id).await? else {
+            self.push_item(StreamItem::Error {
+                message: "runtime workflow not found".to_string(),
+            });
+            self.finished = true;
+            return Ok(());
+        };
+
+        if self.last_state.as_deref() != Some(workflow.state.as_str()) {
+            self.push_text(format!(
+                "[workflow] {} state={}",
+                workflow.id, workflow.state
+            ));
+            self.last_state = Some(workflow.state.clone());
+        }
+
+        for event in self.store.events_for(&workflow.id).await? {
+            if event.sequence <= self.last_event_sequence {
+                continue;
+            }
+            self.push_text(format!(
+                "[event {}] {} {}",
+                event.sequence, event.event_type, event.event
+            ));
+            self.last_event_sequence = event.sequence;
+        }
+
+        for command in self.store.commands_for(&workflow.id).await? {
+            let changed = self
+                .command_statuses
+                .get(&command.id)
+                .is_none_or(|status| status != &command.status);
+            if changed {
+                self.push_text(format!(
+                    "[command] {} status={} activity={}",
+                    command.id,
+                    command.status,
+                    command.command.runtime_activity_key()
+                ));
+                self.command_statuses
+                    .insert(command.id.clone(), command.status.clone());
+            }
+        }
+
+        if workflow.is_terminal() {
+            self.push_item(StreamItem::Done);
+            self.finished = true;
+        }
+        Ok(())
+    }
+
+    fn push_text(&mut self, text: String) {
+        self.push_item(StreamItem::MessageDelta { text });
+    }
+
+    fn push_item(&mut self, item: StreamItem) {
+        match serde_json::to_string(&item) {
+            Ok(data) => self.pending.push_back(Ok(Event::default().data(data))),
+            Err(error) => {
+                tracing::warn!("runtime_task_sse_stream: failed to serialize event: {error}")
+            }
+        }
+    }
 }

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -6,10 +6,14 @@ use axum::{
 };
 use serde::Serialize;
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::state::AppState;
+use crate::task_runner::{
+    SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskStatus,
+    TaskSummary,
+};
 
 /// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
 /// that requires a separate workflow-store lookup (not persisted on `TaskState` itself).
@@ -93,6 +97,9 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                     };
                 }
             }
+            if let Err(e) = append_runtime_issue_summaries(&state, &mut summaries).await {
+                tracing::error!("list_tasks: failed to append runtime issue summaries: {e}");
+            }
             Json(summaries).into_response()
         }
         Err(e) => {
@@ -104,6 +111,137 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                 .into_response()
         }
     }
+}
+
+async fn append_runtime_issue_summaries(
+    state: &AppState,
+    summaries: &mut Vec<TaskSummary>,
+) -> anyhow::Result<()> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(());
+    };
+    let workflows = store
+        .list_instances_by_definition(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            None,
+        )
+        .await?;
+    let mut listed_ids: HashSet<String> = summaries
+        .iter()
+        .map(|summary| summary.id.as_str().to_string())
+        .collect();
+    for workflow in workflows {
+        let Some(task_id) =
+            crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
+        else {
+            continue;
+        };
+        if !listed_ids.insert(task_id.as_str().to_string()) {
+            continue;
+        }
+        summaries.push(runtime_issue_task_summary(workflow, task_id));
+    }
+    Ok(())
+}
+
+fn runtime_issue_task_summary(
+    workflow: harness_workflow::runtime::WorkflowInstance,
+    task_id: harness_core::types::TaskId,
+) -> TaskSummary {
+    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    let scheduler = runtime_workflow_scheduler_state(&status);
+    let issue = workflow
+        .data
+        .get("issue_number")
+        .and_then(|value| value.as_u64());
+    TaskSummary {
+        id: task_id,
+        task_kind: TaskKind::Issue,
+        status: status.clone(),
+        failure_kind: status.is_failure().then_some(TaskFailureKind::Task),
+        turn: 0,
+        pr_url: runtime_string_field(&workflow.data, "pr_url"),
+        error: runtime_string_field(&workflow.data, "failure_reason"),
+        source: runtime_string_field(&workflow.data, "source"),
+        parent_id: None,
+        external_id: issue.map(|issue_number| format!("issue:{issue_number}")),
+        repo: runtime_string_field(&workflow.data, "repo"),
+        description: Some(
+            issue
+                .map(|issue_number| format!("issue #{issue_number}"))
+                .unwrap_or_else(|| workflow.subject.subject_key.clone()),
+        ),
+        created_at: Some(workflow.created_at.to_rfc3339()),
+        phase: runtime_workflow_state_to_task_phase(&workflow.state),
+        depends_on: runtime_task_id_array(&workflow.data, "depends_on"),
+        subtask_ids: Vec::new(),
+        project: runtime_string_field(&workflow.data, "project_id"),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        workflow: None,
+        scheduler,
+    }
+}
+
+fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
+    match state {
+        "awaiting_dependencies" => TaskStatus::AwaitingDeps,
+        "scheduled" | "discovered" => TaskStatus::Pending,
+        "implementing" | "replanning" | "addressing_feedback" => TaskStatus::Implementing,
+        "pr_open" | "awaiting_feedback" | "ready_to_merge" | "blocked" => TaskStatus::Waiting,
+        "done" | "passed" => TaskStatus::Done,
+        "failed" => TaskStatus::Failed,
+        "cancelled" => TaskStatus::Cancelled,
+        _ => TaskStatus::Waiting,
+    }
+}
+
+fn runtime_workflow_state_to_task_phase(state: &str) -> TaskPhase {
+    match state {
+        "done" | "passed" | "failed" | "cancelled" => TaskPhase::Terminal,
+        "pr_open" | "awaiting_feedback" | "ready_to_merge" => TaskPhase::Review,
+        "replanning" | "blocked" => TaskPhase::Plan,
+        _ => TaskPhase::Implement,
+    }
+}
+
+fn runtime_workflow_scheduler_state(status: &TaskStatus) -> TaskSchedulerState {
+    match status {
+        TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
+        TaskStatus::Pending => TaskSchedulerState::queued(),
+        TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => {
+            let mut scheduler = TaskSchedulerState::queued();
+            scheduler.mark_terminal(status);
+            scheduler
+        }
+        _ => TaskSchedulerState {
+            authority_state: SchedulerAuthorityState::Running,
+            owner: None,
+            run_generation: 0,
+            recovery_generation: 0,
+            lease_expires_at: None,
+        },
+    }
+}
+
+fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn runtime_task_id_array(
+    data: &serde_json::Value,
+    field: &str,
+) -> Vec<harness_core::types::TaskId> {
+    data.get(field)
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str())
+        .map(harness_core::types::TaskId::from_str)
+        .collect()
 }
 
 pub(crate) async fn get_task(

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -21,6 +21,24 @@ struct FullTaskResponse {
     workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
 }
 
+#[derive(Serialize)]
+struct RuntimeTaskResponse {
+    id: String,
+    task_id: String,
+    status: String,
+    execution_path: &'static str,
+    workflow_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    external_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue: Option<u64>,
+    workflow: harness_workflow::runtime::WorkflowInstance,
+}
+
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(mut summaries) => {
@@ -92,12 +110,8 @@ pub(crate) async fn get_task(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    match state
-        .core
-        .tasks
-        .get_with_db_fallback(&harness_core::types::TaskId(id))
-        .await
-    {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
         Ok(Some(task)) => {
             let workflow = enrich_task_workflow(&state, &task).await;
             Json(FullTaskResponse {
@@ -106,11 +120,22 @@ pub(crate) async fn get_task(
             })
             .into_response()
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "task not found"})),
-        )
-            .into_response(),
+        Ok(None) => match runtime_task_response_by_handle(&state, &task_id).await {
+            Ok(Some(runtime_task)) => Json(runtime_task).into_response(),
+            Ok(None) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response(),
+            Err(e) => {
+                tracing::error!("get_task: runtime workflow lookup failed: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "internal server error"})),
+                )
+                    .into_response()
+            }
+        },
         Err(e) => {
             tracing::error!("get_task: database error: {e}");
             (
@@ -120,6 +145,44 @@ pub(crate) async fn get_task(
                 .into_response()
         }
     }
+}
+
+async fn runtime_task_response_by_handle(
+    state: &AppState,
+    task_id: &harness_core::types::TaskId,
+) -> anyhow::Result<Option<RuntimeTaskResponse>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(None);
+    };
+    let Some(workflow) =
+        crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id).await?
+    else {
+        return Ok(None);
+    };
+    let issue = workflow
+        .data
+        .get("issue_number")
+        .and_then(|value| value.as_u64());
+    Ok(Some(RuntimeTaskResponse {
+        id: task_id.as_str().to_string(),
+        task_id: task_id.as_str().to_string(),
+        status: workflow.state.clone(),
+        execution_path: "workflow_runtime",
+        workflow_id: workflow.id.clone(),
+        external_id: issue.map(|issue_number| format!("issue:{issue_number}")),
+        repo: workflow
+            .data
+            .get("repo")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned),
+        project: workflow
+            .data
+            .get("project_id")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned),
+        issue,
+        workflow,
+    }))
 }
 
 /// Look up the issue-workflow instance for a task using targeted store queries.

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -58,30 +58,54 @@ pub(crate) async fn enqueue_task_background_in_domain(
         .await
 }
 
-async fn task_response_status(
+pub(crate) struct TaskResponseDetails {
+    pub(crate) status: String,
+    pub(crate) execution_path: &'static str,
+}
+
+pub(crate) async fn task_response_details(
     state: &AppState,
     task_id: &task_runner::TaskId,
     is_issue_submission: bool,
-) -> Result<String, EnqueueTaskError> {
+) -> Result<TaskResponseDetails, EnqueueTaskError> {
     if !is_issue_submission {
-        return Ok("queued".to_string());
+        return Ok(TaskResponseDetails {
+            status: "queued".to_string(),
+            execution_path: "task_runner",
+        });
     }
 
-    let store = state.core.workflow_runtime_store.as_ref().ok_or_else(|| {
-        EnqueueTaskError::Internal(
-            "workflow runtime store is required for GitHub issue submissions".to_string(),
-        )
-    })?;
-    let workflow = crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id)
+    if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+        if let Some(workflow) =
+            crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id)
+                .await
+                .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        {
+            return Ok(TaskResponseDetails {
+                status: workflow.state,
+                execution_path: "workflow_runtime",
+            });
+        }
+    }
+
+    if state
+        .core
+        .tasks
+        .get_with_db_fallback(task_id)
         .await
         .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
-        .ok_or_else(|| {
-            EnqueueTaskError::Internal(format!(
-                "workflow runtime submission not found for task {}",
-                task_id.as_str()
-            ))
-        })?;
-    Ok(workflow.state)
+        .is_some()
+    {
+        return Ok(TaskResponseDetails {
+            status: "queued".to_string(),
+            execution_path: "task_runner",
+        });
+    }
+
+    Err(EnqueueTaskError::Internal(format!(
+        "submission not found for task {}",
+        task_id.as_str()
+    )))
 }
 
 /// A single task entry in the detailed batch format.
@@ -272,21 +296,21 @@ pub(super) async fn create_tasks_batch(
         let entry = match enqueue_task_background(state.clone(), task_req, sem).await {
             Ok(task_id) => {
                 all_maintenance_window = false;
-                match task_response_status(&state, &task_id, is_issue_submission).await {
-                    Ok(status) => {
+                match task_response_details(&state, &task_id, is_issue_submission).await {
+                    Ok(details) => {
                         if is_serialized {
                             json!({
                                 "task_id": task_id.0,
-                                "status": status,
+                                "status": details.status,
                                 "serialized": true,
                                 "conflict_files": conflict_files,
-                                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
+                                "execution_path": details.execution_path,
                             })
                         } else {
                             json!({
                                 "task_id": task_id.0,
-                                "status": status,
-                                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
+                                "status": details.status,
+                                "execution_path": details.execution_path,
                             })
                         }
                     }
@@ -333,13 +357,13 @@ pub(super) async fn create_task(
 ) -> Response {
     let is_issue_submission = req.issue.is_some();
     match enqueue_task_background(state.clone(), req, None).await {
-        Ok(task_id) => match task_response_status(&state, &task_id, is_issue_submission).await {
-            Ok(status) => (
+        Ok(task_id) => match task_response_details(&state, &task_id, is_issue_submission).await {
+            Ok(details) => (
                 StatusCode::ACCEPTED,
                 Json(json!({
                     "task_id": task_id.0,
-                    "status": status,
-                    "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" }
+                    "status": details.status,
+                    "execution_path": details.execution_path,
                 })),
             )
                 .into_response(),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -58,6 +58,32 @@ pub(crate) async fn enqueue_task_background_in_domain(
         .await
 }
 
+async fn task_response_status(
+    state: &AppState,
+    task_id: &task_runner::TaskId,
+    is_issue_submission: bool,
+) -> Result<String, EnqueueTaskError> {
+    if !is_issue_submission {
+        return Ok("queued".to_string());
+    }
+
+    let store = state.core.workflow_runtime_store.as_ref().ok_or_else(|| {
+        EnqueueTaskError::Internal(
+            "workflow runtime store is required for GitHub issue submissions".to_string(),
+        )
+    })?;
+    let workflow = crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id)
+        .await
+        .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        .ok_or_else(|| {
+            EnqueueTaskError::Internal(format!(
+                "workflow runtime submission not found for task {}",
+                task_id.as_str()
+            ))
+        })?;
+    Ok(workflow.state)
+}
+
 /// A single task entry in the detailed batch format.
 #[derive(Debug, Deserialize)]
 pub struct BatchTaskItem {
@@ -246,25 +272,30 @@ pub(super) async fn create_tasks_batch(
         let entry = match enqueue_task_background(state.clone(), task_req, sem).await {
             Ok(task_id) => {
                 all_maintenance_window = false;
-                let status = if is_issue_submission {
-                    "scheduled"
-                } else {
-                    "queued"
-                };
-                if is_serialized {
-                    json!({
-                        "task_id": task_id.0,
-                        "status": status,
-                        "serialized": true,
-                        "conflict_files": conflict_files,
-                        "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
-                    })
-                } else {
-                    json!({
-                        "task_id": task_id.0,
-                        "status": status,
-                        "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
-                    })
+                match task_response_status(&state, &task_id, is_issue_submission).await {
+                    Ok(status) => {
+                        if is_serialized {
+                            json!({
+                                "task_id": task_id.0,
+                                "status": status,
+                                "serialized": true,
+                                "conflict_files": conflict_files,
+                                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
+                            })
+                        } else {
+                            json!({
+                                "task_id": task_id.0,
+                                "status": status,
+                                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
+                            })
+                        }
+                    }
+                    Err(EnqueueTaskError::BadRequest(error)) => json!({ "error": error }),
+                    Err(EnqueueTaskError::Internal(error)) => json!({ "error": error }),
+                    Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => {
+                        mw_retry_after.get_or_insert(retry_after_secs);
+                        json!({ "error": "maintenance_window", "retry_after": retry_after_secs })
+                    }
                 }
             }
             Err(EnqueueTaskError::BadRequest(error)) => {
@@ -301,16 +332,35 @@ pub(super) async fn create_task(
     Json(req): Json<task_runner::CreateTaskRequest>,
 ) -> Response {
     let is_issue_submission = req.issue.is_some();
-    match enqueue_task_background(state, req, None).await {
-        Ok(task_id) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "task_id": task_id.0,
-                "status": if is_issue_submission { "scheduled" } else { "queued" },
-                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" }
-            })),
-        )
-            .into_response(),
+    match enqueue_task_background(state.clone(), req, None).await {
+        Ok(task_id) => match task_response_status(&state, &task_id, is_issue_submission).await {
+            Ok(status) => (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "task_id": task_id.0,
+                    "status": status,
+                    "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" }
+                })),
+            )
+                .into_response(),
+            Err(EnqueueTaskError::BadRequest(error)) => {
+                (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
+            }
+            Err(EnqueueTaskError::Internal(error)) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": error })),
+            )
+                .into_response(),
+            Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(
+                    axum::http::header::RETRY_AFTER,
+                    retry_after_secs.to_string(),
+                )],
+                Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
+            )
+                .into_response(),
+        },
         Err(EnqueueTaskError::BadRequest(error)) => {
             (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
         }

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -433,14 +433,29 @@ pub(super) async fn cancel_task(
             )
             .await
             {
-                Ok(Some(workflow)) if workflow.state == "cancelled" => (
-                    StatusCode::OK,
-                    Json(json!({
-                        "status": "cancelled",
-                        "execution_path": "workflow_runtime",
-                        "workflow_id": workflow.id,
-                    })),
-                ),
+                Ok(Some(workflow)) if workflow.state == "cancelled" => {
+                    if let Err(error) =
+                        crate::workflow_runtime_worker::notify_runtime_issue_terminal_workflow(
+                            &state,
+                            &workflow.id,
+                            None,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            workflow_id = %workflow.id,
+                            "cancel_task: runtime issue completion notification failed: {error}"
+                        );
+                    }
+                    (
+                        StatusCode::OK,
+                        Json(json!({
+                            "status": "cancelled",
+                            "execution_path": "workflow_runtime",
+                            "workflow_id": workflow.id,
+                        })),
+                    )
+                }
                 Ok(Some(_)) => (
                     StatusCode::CONFLICT,
                     Json(json!({ "error": "task already in terminal state" })),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -242,18 +242,29 @@ pub(super) async fn create_tasks_batch(
         let sem = task_semaphores[i].take();
         let is_serialized = sem.is_some();
         let conflict_files = std::mem::take(&mut task_conflict_files[i]);
+        let is_issue_submission = task_req.issue.is_some();
         let entry = match enqueue_task_background(state.clone(), task_req, sem).await {
             Ok(task_id) => {
                 all_maintenance_window = false;
+                let status = if is_issue_submission {
+                    "scheduled"
+                } else {
+                    "queued"
+                };
                 if is_serialized {
                     json!({
                         "task_id": task_id.0,
-                        "status": "queued",
+                        "status": status,
                         "serialized": true,
                         "conflict_files": conflict_files,
+                        "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
                     })
                 } else {
-                    json!({ "task_id": task_id.0, "status": "queued" })
+                    json!({
+                        "task_id": task_id.0,
+                        "status": status,
+                        "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" },
+                    })
                 }
             }
             Err(EnqueueTaskError::BadRequest(error)) => {
@@ -289,12 +300,14 @@ pub(super) async fn create_task(
     State(state): State<Arc<AppState>>,
     Json(req): Json<task_runner::CreateTaskRequest>,
 ) -> Response {
+    let is_issue_submission = req.issue.is_some();
     match enqueue_task_background(state, req, None).await {
         Ok(task_id) => (
             StatusCode::ACCEPTED,
             Json(json!({
                 "task_id": task_id.0,
-                "status": "queued"
+                "status": if is_issue_submission { "scheduled" } else { "queued" },
+                "execution_path": if is_issue_submission { "workflow_runtime" } else { "task_runner" }
             })),
         )
             .into_response(),

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -347,10 +347,44 @@ pub(super) async fn cancel_task(
     let task = match state.core.tasks.get_with_db_fallback(&task_id).await {
         Ok(Some(t)) => t,
         Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({ "error": "task not found" })),
-            );
+            let Some(runtime_store) = state.core.workflow_runtime_store.as_ref() else {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({ "error": "task not found" })),
+                );
+            };
+            return match crate::workflow_runtime_submission::cancel_issue_submission_by_task_id(
+                runtime_store,
+                &task_id,
+            )
+            .await
+            {
+                Ok(Some(workflow)) if workflow.state == "cancelled" => (
+                    StatusCode::OK,
+                    Json(json!({
+                        "status": "cancelled",
+                        "execution_path": "workflow_runtime",
+                        "workflow_id": workflow.id,
+                    })),
+                ),
+                Ok(Some(_)) => (
+                    StatusCode::CONFLICT,
+                    Json(json!({ "error": "task already in terminal state" })),
+                ),
+                Ok(None) => (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({ "error": "task not found" })),
+                ),
+                Err(e) => {
+                    tracing::error!(
+                        "cancel_task: runtime workflow lookup failed for {task_id:?}: {e}"
+                    );
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": "failed to cancel runtime workflow" })),
+                    )
+                }
+            };
         }
         Err(e) => {
             tracing::error!("cancel_task: DB lookup failed for {task_id:?}: {e}");

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -856,7 +856,7 @@ async fn assert_runtime_issue_submission(
         .get_instance(&workflow_id)
         .await?
         .expect("runtime workflow should be persisted");
-    assert_eq!(instance.state, "scheduled");
+    assert_eq!(instance.state, "implementing");
     assert_eq!(instance.data["task_id"], task_id.0);
     assert_eq!(instance.data["execution_path"], "workflow_runtime");
     let commands = store.commands_for(&workflow_id).await?;
@@ -875,7 +875,7 @@ async fn assert_runtime_issue_submission(
     assert_eq!(get_response.status(), StatusCode::OK);
     let runtime_task = response_json(get_response).await?;
     assert_eq!(runtime_task["task_id"], task_id.0);
-    assert_eq!(runtime_task["status"], "scheduled");
+    assert_eq!(runtime_task["status"], "implementing");
     assert_eq!(runtime_task["execution_path"], "workflow_runtime");
     assert_eq!(runtime_task["workflow_id"], workflow_id);
     Ok(())
@@ -1994,7 +1994,7 @@ async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["status"], "implementing");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_eq!(state.core.tasks.count(), before_count);
     assert_runtime_issue_submission(
@@ -2357,7 +2357,7 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let resp = response_json(response).await?;
     assert!(resp["task_id"].is_string());
-    assert_eq!(resp["status"], "scheduled");
+    assert_eq!(resp["status"], "implementing");
     assert_eq!(resp["execution_path"], "workflow_runtime");
     let task_id = task_runner::TaskId::from_str(resp["task_id"].as_str().unwrap());
     assert!(state
@@ -2383,7 +2383,7 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
         .get_instance(&workflow_id)
         .await?
         .expect("runtime workflow should be persisted");
-    assert_eq!(instance.state, "scheduled");
+    assert_eq!(instance.state, "implementing");
     assert_eq!(instance.data["task_id"], task_id.0);
     assert_eq!(instance.data["execution_path"], "workflow_runtime");
     let commands = store.commands_for(&workflow_id).await?;
@@ -2452,7 +2452,7 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
     let canonical_project_root = project_root.canonicalize()?;
 
     assert_eq!(runtime_task["task_kind"], "issue");
-    assert_eq!(runtime_task["status"], "pending");
+    assert_eq!(runtime_task["status"], "implementing");
     assert_eq!(runtime_task["external_id"], "issue:52");
     assert_eq!(runtime_task["repo"], "owner/repo");
     assert_eq!(runtime_task["description"], "issue #52");
@@ -2460,7 +2460,7 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
         runtime_task["project"],
         canonical_project_root.to_string_lossy().as_ref()
     );
-    assert_eq!(runtime_task["scheduler"]["authority_state"], "queued");
+    assert_eq!(runtime_task["scheduler"]["authority_state"], "running");
     assert!(runtime_task.get("workflow").is_none());
     Ok(())
 }
@@ -3023,7 +3023,7 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
         .expect("batch response should be an array");
     assert_eq!(entries.len(), 2);
     for (entry, issue_number) in entries.iter().zip([42_u64, 43]) {
-        assert_eq!(entry["status"], "scheduled");
+        assert_eq!(entry["status"], "implementing");
         assert_eq!(entry["execution_path"], "workflow_runtime");
         assert_runtime_issue_submission(
             &state,
@@ -4040,7 +4040,7 @@ async fn webhook_issues_opened_with_mention_schedules_runtime_issue() -> anyhow:
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["status"], "implementing");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_eq!(state.core.tasks.count(), before_count);
     assert_runtime_issue_submission(
@@ -4156,7 +4156,7 @@ async fn webhook_routes_runtime_issue_to_repo_specific_project_root() -> anyhow:
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["status"], "implementing");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_runtime_issue_submission(
         &state,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2360,6 +2360,69 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
 }
 
 #[tokio::test]
+async fn create_task_with_blocked_issue_returns_runtime_state() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = task_app(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "repo": "owner/repo",
+        "issue": 43,
+        "depends_on": ["missing-dependency"]
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let resp = response_json(response).await?;
+    assert!(resp["task_id"].is_string());
+    assert_eq!(resp["status"], "awaiting_dependencies");
+    assert_eq!(resp["execution_path"], "workflow_runtime");
+
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let canonical_project_root = project_root.canonicalize()?;
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &canonical_project_root.to_string_lossy(),
+        Some("owner/repo"),
+        43,
+    );
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.state, "awaiting_dependencies");
+    assert_eq!(
+        instance.data["depends_on"],
+        serde_json::json!(["missing-dependency"])
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_empty_request_returns_bad_request() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
@@ -3030,6 +3093,95 @@ async fn closed_task_sse_replay_includes_observability_fields() -> anyhow::Resul
     assert!(saw_timeout_failure);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn runtime_issue_sse_stream_keeps_active_workflow_open_without_done() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+
+    let create_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project_root.display().to_string(),
+                        "repo": "owner/repo",
+                        "issue": 44,
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(create_response.status(), StatusCode::ACCEPTED);
+    let create_json = response_json(create_response).await?;
+    let task_id = create_json["task_id"]
+        .as_str()
+        .expect("task id should be present");
+
+    let response = Router::new()
+        .route("/tasks/{id}/stream", get(stream_task_sse))
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{task_id}/stream"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    use http_body_util::BodyExt;
+    let mut body = response.into_body();
+    let mut body_text = String::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while !body_text.contains("[workflow]") && tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, body.frame()).await {
+            Ok(Some(Ok(frame))) => {
+                if let Ok(data) = frame.into_data() {
+                    body_text.push_str(&String::from_utf8_lossy(&data));
+                }
+            }
+            Ok(Some(Err(error))) => return Err(error.into()),
+            Ok(None) => anyhow::bail!("active runtime workflow stream closed before replay"),
+            Err(_) => break,
+        }
+    }
+    assert!(body_text.contains("[workflow]"));
+    assert!(!body_text.contains("\"type\":\"done\""));
+    assert!(!body_text.contains("\"type\":\"Done\""));
+
+    for _ in 0..8 {
+        match tokio::time::timeout(Duration::from_millis(100), body.frame()).await {
+            Ok(Some(Ok(frame))) => {
+                if let Ok(data) = frame.into_data() {
+                    body_text.push_str(&String::from_utf8_lossy(&data));
+                    assert!(!body_text.contains("\"type\":\"done\""));
+                    assert!(!body_text.contains("\"type\":\"Done\""));
+                }
+            }
+            Ok(Some(Err(error))) => return Err(error.into()),
+            Ok(None) => anyhow::bail!("active runtime workflow stream closed"),
+            Err(_) => return Ok(()),
+        }
+    }
+
+    anyhow::bail!("active runtime workflow stream did not become idle")
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1111,6 +1111,12 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
     }
 
     let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-a");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: true\n  runtime_profile: codex-high\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
     let state = make_test_state_with_workflow_runtime(dir.path()).await?;
     let store = state
         .core
@@ -1125,7 +1131,7 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
     )
     .with_id("issue-123")
     .with_data(serde_json::json!({
-        "project_id": "/project-a",
+        "project_id": project_root,
         "repo": "owner/repo",
         "issue_number": 123,
     }));
@@ -1154,6 +1160,136 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
         store.commands_for(&workflow.id).await?[0].status,
         "dispatched"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_command_dispatch_tick_uses_command_project_policy_when_server_root_disabled(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let server_root = dir.path().join("server-root");
+    let project_root = dir.path().join("project-root");
+    std::fs::create_dir(&server_root)?;
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        server_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: false\n  runtime_profile: server-disabled\nruntime_worker:\n  enabled: false\n---\n",
+    )?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: true\n  runtime_profile: project-runtime\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &server_root,
+        harness_core::config::HarnessConfig::default(),
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:224"),
+    )
+    .with_id("issue-224")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 224,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("implement_issue", "impl-224");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+
+    let tick = super::background::run_runtime_command_dispatch_tick(
+        &state,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "server-disabled",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+        10,
+    )
+    .await?;
+
+    assert_eq!(tick.enqueued, 1);
+    assert_eq!(tick.already_dispatched, 0);
+    assert_eq!(tick.skipped, 0);
+    let jobs = store.runtime_jobs_for_command(&command_id).await?;
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].runtime_profile, "project-runtime");
+    assert_eq!(
+        store.commands_for(&workflow.id).await?[0].status,
+        "dispatched"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_command_dispatch_tick_skips_when_command_project_runtime_disabled(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-root");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: true\n  runtime_profile: project-runtime\nruntime_worker:\n  enabled: false\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:225"),
+    )
+    .with_id("issue-225")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 225,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("implement_issue", "impl-225");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+
+    let tick = super::background::run_runtime_command_dispatch_tick(
+        &state,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "server-fallback",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+        10,
+    )
+    .await?;
+
+    assert_eq!(tick.enqueued, 0);
+    assert_eq!(tick.already_dispatched, 0);
+    assert_eq!(tick.skipped, 1);
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    assert_eq!(store.commands_for(&workflow.id).await?[0].status, "skipped");
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2360,6 +2360,78 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
 }
 
 #[tokio::test]
+async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let app = Router::new()
+        .route("/tasks", get(list_tasks).post(task_routes::create_task))
+        .with_state(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "repo": "owner/repo",
+        "issue": 52,
+        "labels": ["bug"]
+    });
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(create_response.status(), StatusCode::ACCEPTED);
+    let created = response_json(create_response).await?;
+    let task_id = created["task_id"]
+        .as_str()
+        .expect("runtime submission should return a task handle")
+        .to_string();
+    assert_eq!(state.core.tasks.count(), before_count);
+
+    let list_response = app
+        .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+        .await?;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let listed = response_json(list_response).await?;
+    let tasks = listed.as_array().expect("tasks should be an array");
+    let runtime_task = tasks
+        .iter()
+        .find(|task| task["id"] == task_id)
+        .expect("runtime issue submission should be listed");
+    let canonical_project_root = project_root.canonicalize()?;
+
+    assert_eq!(runtime_task["task_kind"], "issue");
+    assert_eq!(runtime_task["status"], "pending");
+    assert_eq!(runtime_task["external_id"], "issue:52");
+    assert_eq!(runtime_task["repo"], "owner/repo");
+    assert_eq!(runtime_task["description"], "issue #52");
+    assert_eq!(
+        runtime_task["project"],
+        canonical_project_root.to_string_lossy().as_ref()
+    );
+    assert_eq!(runtime_task["scheduler"]["authority_state"], "queued");
+    assert!(runtime_task.get("workflow").is_none());
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_with_blocked_issue_returns_runtime_state() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -827,7 +827,7 @@ async fn wait_for_task_project_root(
 async fn assert_runtime_issue_submission(
     state: &Arc<AppState>,
     project_root: &std::path::Path,
-    repo: &str,
+    repo: Option<&str>,
     issue_number: u64,
     task_id: &str,
 ) -> anyhow::Result<()> {
@@ -849,7 +849,7 @@ async fn assert_runtime_issue_submission(
     let canonical_project_root = project_root.canonicalize()?;
     let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
         &canonical_project_root.to_string_lossy(),
-        Some(repo),
+        repo,
         issue_number,
     );
     let instance = store
@@ -1985,7 +1985,7 @@ async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     assert_runtime_issue_submission(
         &state,
         dir.path(),
-        "majiayu000/harness",
+        Some("majiayu000/harness"),
         106,
         json["task_id"].as_str().expect("task id should be present"),
     )
@@ -2796,6 +2796,63 @@ async fn create_tasks_batch_remains_queued_under_saturation() -> anyhow::Result<
     let mut all_task_ids = vec![blocker_task_id];
     all_task_ids.extend(queued_task_ids);
     wait_for_task_statuses(&state, &all_task_ids, task_runner::TaskStatus::Done).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project_root.display().to_string(),
+                        "issues": [42, 43],
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+    for (entry, issue_number) in entries.iter().zip([42_u64, 43]) {
+        assert_eq!(entry["status"], "scheduled");
+        assert_eq!(entry["execution_path"], "workflow_runtime");
+        assert_runtime_issue_submission(
+            &state,
+            &project_root,
+            None,
+            issue_number,
+            entry["task_id"]
+                .as_str()
+                .expect("task id should be present"),
+        )
+        .await?;
+    }
+    assert_eq!(state.core.tasks.count(), before_count);
     Ok(())
 }
 
@@ -3678,7 +3735,7 @@ async fn webhook_issues_opened_with_mention_schedules_runtime_issue() -> anyhow:
     assert_runtime_issue_submission(
         &state,
         dir.path(),
-        "org/repo",
+        Some("org/repo"),
         77,
         json["task_id"].as_str().expect("task id should be present"),
     )
@@ -3743,7 +3800,7 @@ async fn webhook_routes_runtime_issue_to_repo_specific_project_root() -> anyhow:
     assert_runtime_issue_submission(
         &state,
         repo_b_dir.path(),
-        "org/repo-b",
+        Some("org/repo-b"),
         77,
         json["task_id"].as_str().expect("task id should be present"),
     )

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -475,12 +475,29 @@ async fn make_test_state_with_workflow_runtime_and_registry(
     config.server.database_url = Some(crate::test_helpers::test_database_url()?);
     let state =
         make_test_state_with_project_root(dir, project_root, config, agent_registry).await?;
-    let workflow_runtime_store =
+    let workflow_runtime_store = Arc::new(
         harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir, "workflow_runtime"),
             Some(&crate::test_helpers::test_database_url()?),
         )
-        .await?;
+        .await?,
+    );
+    let execution_svc = crate::services::execution::DefaultExecutionService::new(
+        state.core.tasks.clone(),
+        state.core.server.agent_registry.clone(),
+        Arc::new(state.core.server.config.clone()),
+        state.engines.skills.clone(),
+        state.observability.events.clone(),
+        state.interceptors.clone(),
+        None,
+        state.concurrency.task_queue.clone(),
+        state.concurrency.review_task_queue.clone(),
+        None,
+        None,
+        Some(workflow_runtime_store.clone()),
+        None,
+        vec![],
+    );
     Ok(Arc::new(AppState {
         core: crate::http::CoreServices {
             server: state.core.server.clone(),
@@ -492,7 +509,7 @@ async fn make_test_state_with_workflow_runtime_and_registry(
             plan_cache: state.core.plan_cache.clone(),
             issue_workflow_store: None,
             project_workflow_store: None,
-            workflow_runtime_store: Some(Arc::new(workflow_runtime_store)),
+            workflow_runtime_store: Some(workflow_runtime_store),
             project_registry: None,
             runtime_state_store: None,
             q_values: None,
@@ -539,7 +556,7 @@ async fn make_test_state_with_workflow_runtime_and_registry(
         },
         project_svc: state.project_svc.clone(),
         task_svc: state.task_svc.clone(),
-        execution_svc: state.execution_svc.clone(),
+        execution_svc,
     }))
 }
 
@@ -2172,6 +2189,80 @@ async fn create_task_with_prompt_returns_accepted() -> anyhow::Result<()> {
     assert!(resp["task_id"].is_string());
     assert_eq!(resp["status"], "queued");
     assert_eq!(state.core.tasks.count(), before_count + 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let app = task_app(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "repo": "owner/repo",
+        "issue": 42,
+        "labels": ["bug"]
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let resp = response_json(response).await?;
+    assert!(resp["task_id"].is_string());
+    assert_eq!(resp["status"], "scheduled");
+    assert_eq!(resp["execution_path"], "workflow_runtime");
+    let task_id = task_runner::TaskId::from_str(resp["task_id"].as_str().unwrap());
+    assert!(state
+        .core
+        .tasks
+        .get_with_db_fallback(&task_id)
+        .await?
+        .is_none());
+    assert_eq!(state.core.tasks.count(), before_count);
+
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let canonical_project_root = project_root.canonicalize()?;
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &canonical_project_root.to_string_lossy(),
+        Some("owner/repo"),
+        42,
+    );
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.state, "scheduled");
+    assert_eq!(instance.data["task_id"], task_id.0);
+    assert_eq!(instance.data["execution_path"], "workflow_runtime");
+    let commands = store.commands_for(&workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].status, "pending");
+    assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -471,8 +471,21 @@ async fn make_test_state_with_workflow_runtime_and_registry(
     project_root: &std::path::Path,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
-    let mut config = harness_core::config::HarnessConfig::default();
-    config.server.database_url = Some(crate::test_helpers::test_database_url()?);
+    make_test_state_with_workflow_runtime_config_and_registry(
+        dir,
+        project_root,
+        harness_core::config::HarnessConfig::default(),
+        agent_registry,
+    )
+    .await
+}
+
+async fn make_test_state_with_workflow_runtime_config_and_registry(
+    dir: &std::path::Path,
+    project_root: &std::path::Path,
+    config: harness_core::config::HarnessConfig,
+    agent_registry: harness_agents::registry::AgentRegistry,
+) -> anyhow::Result<Arc<AppState>> {
     let state =
         make_test_state_with_project_root(dir, project_root, config, agent_registry).await?;
     let workflow_runtime_store = Arc::new(
@@ -809,6 +822,48 @@ async fn wait_for_task_project_root(
     }
 
     anyhow::bail!("task {task_id} did not resolve a project root")
+}
+
+async fn assert_runtime_issue_submission(
+    state: &Arc<AppState>,
+    project_root: &std::path::Path,
+    repo: &str,
+    issue_number: u64,
+    task_id: &str,
+) -> anyhow::Result<()> {
+    let task_id = task_runner::TaskId::from_str(task_id);
+    assert!(
+        state
+            .core
+            .tasks
+            .get_with_db_fallback(&task_id)
+            .await?
+            .is_none(),
+        "workflow runtime issue submissions must not register legacy task rows"
+    );
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let canonical_project_root = project_root.canonicalize()?;
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &canonical_project_root.to_string_lossy(),
+        Some(repo),
+        issue_number,
+    );
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.state, "scheduled");
+    assert_eq!(instance.data["task_id"], task_id.0);
+    assert_eq!(instance.data["execution_path"], "workflow_runtime");
+    let commands = store.commands_for(&workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].status, "pending");
+    assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+    Ok(())
 }
 
 fn webhook_signature(secret: &str, payload: &[u8]) -> String {
@@ -1881,11 +1936,23 @@ async fn token_usage_route_is_registered() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn webhook_issue_mention_creates_issue_task() -> anyhow::Result<()> {
+async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let secret = "secret";
-    let (state, _agent) =
-        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "majiayu000/harness").await?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.github_webhook_secret = Some(secret.to_string());
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repo: "majiayu000/harness".to_string(),
+        ..Default::default()
+    });
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -1911,7 +1978,18 @@ async fn webhook_issue_mention_creates_issue_task() -> anyhow::Result<()> {
         .await?;
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
-    assert_eq!(state.core.tasks.count(), before_count + 1);
+    let json = response_json(response).await?;
+    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["execution_path"], "workflow_runtime");
+    assert_eq!(state.core.tasks.count(), before_count);
+    assert_runtime_issue_submission(
+        &state,
+        dir.path(),
+        "majiayu000/harness",
+        106,
+        json["task_id"].as_str().expect("task id should be present"),
+    )
+    .await?;
     Ok(())
 }
 
@@ -3548,12 +3626,24 @@ async fn feishu_webhook_rejects_invalid_token() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Result<()> {
+async fn webhook_issues_opened_with_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     init_fake_git_repo(dir.path())?;
     let secret = "secret";
-    let (state, _agent) =
-        make_test_state_with_agent_and_repo(dir.path(), Some(secret), "org/repo").await?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.github_webhook_secret = Some(secret.to_string());
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repo: "org/repo".to_string(),
+        ..Default::default()
+    });
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
     let before_count = state.core.tasks.count();
     let app = webhook_app(state.clone());
 
@@ -3581,12 +3671,23 @@ async fn webhook_issues_opened_with_mention_creates_issue_task() -> anyhow::Resu
         .await?;
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
-    assert_eq!(state.core.tasks.count(), before_count + 1);
+    let json = response_json(response).await?;
+    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["execution_path"], "workflow_runtime");
+    assert_eq!(state.core.tasks.count(), before_count);
+    assert_runtime_issue_submission(
+        &state,
+        dir.path(),
+        "org/repo",
+        77,
+        json["task_id"].as_str().expect("task id should be present"),
+    )
+    .await?;
     Ok(())
 }
 
 #[tokio::test]
-async fn webhook_routes_issue_tasks_to_repo_specific_project_root() -> anyhow::Result<()> {
+async fn webhook_routes_runtime_issue_to_repo_specific_project_root() -> anyhow::Result<()> {
     let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let repo_a_dir = crate::test_helpers::tempdir_in_home("webhook-repo-a-")?;
     let repo_b_dir = crate::test_helpers::tempdir_in_home("webhook-repo-b-")?;
@@ -3603,8 +3704,13 @@ async fn webhook_routes_issue_tasks_to_repo_specific_project_root() -> anyhow::R
         ..Default::default()
     });
 
-    let (state, _agent) =
-        make_test_state_with_agent_and_config(repo_a_dir.path(), repo_a_dir.path(), config).await?;
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        repo_a_dir.path(),
+        repo_a_dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
     let app = webhook_app(state.clone());
 
     let payload = serde_json::json!({
@@ -3632,12 +3738,16 @@ async fn webhook_routes_issue_tasks_to_repo_specific_project_root() -> anyhow::R
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    let task_root = wait_for_task_project_root(
+    assert_eq!(json["status"], "scheduled");
+    assert_eq!(json["execution_path"], "workflow_runtime");
+    assert_runtime_issue_submission(
         &state,
+        repo_b_dir.path(),
+        "org/repo-b",
+        77,
         json["task_id"].as_str().expect("task id should be present"),
     )
     .await?;
-    assert_eq!(task_root.canonicalize()?, repo_b_dir.path().canonicalize()?);
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -863,6 +863,21 @@ async fn assert_runtime_issue_submission(
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].status, "pending");
     assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+
+    let get_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/tasks/{}", task_id.0))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let runtime_task = response_json(get_response).await?;
+    assert_eq!(runtime_task["task_id"], task_id.0);
+    assert_eq!(runtime_task["status"], "scheduled");
+    assert_eq!(runtime_task["execution_path"], "workflow_runtime");
+    assert_eq!(runtime_task["workflow_id"], workflow_id);
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2286,6 +2286,40 @@ async fn create_task_with_prompt_returns_accepted() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn create_task_with_issue_reports_task_runner_fallback_without_runtime_store(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    init_fake_git_repo(dir.path())?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
+    let before_count = state.core.tasks.count();
+    let app = task_app(state.clone());
+
+    let body = serde_json::json!({
+        "repo": "owner/repo",
+        "issue": 42,
+        "labels": ["bug"]
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let resp = response_json(response).await?;
+    assert!(resp["task_id"].is_string());
+    assert_eq!(resp["status"], "queued");
+    assert_eq!(resp["execution_path"], "task_runner");
+    assert_eq!(state.core.tasks.count(), before_count + 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -3003,6 +3037,44 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
         .await?;
     }
     assert_eq!(state.core.tasks.count(), before_count);
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_tasks_batch_with_issues_reports_task_runner_fallback_without_runtime_store(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    init_fake_git_repo(dir.path())?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
+    let before_count = state.core.tasks.count();
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "issues": [42, 43],
+                        "repo": "owner/repo",
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+    for entry in entries {
+        assert_eq!(entry["status"], "queued");
+        assert_eq!(entry["execution_path"], "task_runner");
+        assert!(entry["task_id"].is_string());
+    }
+    assert_eq!(state.core.tasks.count(), before_count + 2);
     Ok(())
 }
 
@@ -3979,6 +4051,56 @@ async fn webhook_issues_opened_with_mention_schedules_runtime_issue() -> anyhow:
         json["task_id"].as_str().expect("task id should be present"),
     )
     .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn webhook_issues_opened_reports_task_runner_fallback_without_runtime_store(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    init_fake_git_repo(dir.path())?;
+    let secret = "secret";
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.github_webhook_secret = Some(secret.to_string());
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repo: "org/repo".to_string(),
+        ..Default::default()
+    });
+    let (state, _agent) =
+        make_test_state_with_agent_and_config(dir.path(), dir.path(), config).await?;
+    let before_count = state.core.tasks.count();
+    let app = webhook_app(state.clone());
+
+    let payload = serde_json::json!({
+        "action": "opened",
+        "issue": {
+            "number": 77,
+            "body": "@harness please implement this feature"
+        },
+        "repository": { "full_name": "org/repo" }
+    });
+    let payload_body = payload.to_string();
+    let signature = webhook_signature(secret, payload_body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("x-github-event", "issues")
+                .header("x-hub-signature-256", signature)
+                .header("content-type", "application/json")
+                .body(Body::from(payload_body))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let json = response_json(response).await?;
+    assert_eq!(json["status"], "accepted");
+    assert_eq!(json["execution_path"], "task_runner");
+    assert_eq!(state.core.tasks.count(), before_count + 1);
+    assert!(json["task_id"].is_string());
     Ok(())
 }
 

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -21,6 +21,39 @@ impl DispatchedTaskChecker for crate::task_runner::TaskStore {
     }
 }
 
+pub(crate) struct RuntimeAwareDispatchedTaskChecker {
+    tasks: Arc<crate::task_runner::TaskStore>,
+    workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+}
+
+impl RuntimeAwareDispatchedTaskChecker {
+    pub(crate) fn new(
+        tasks: Arc<crate::task_runner::TaskStore>,
+        workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    ) -> Self {
+        Self {
+            tasks,
+            workflow_runtime_store,
+        }
+    }
+}
+
+#[async_trait]
+impl DispatchedTaskChecker for RuntimeAwareDispatchedTaskChecker {
+    async fn exists(&self, task_id: &TaskId) -> anyhow::Result<bool> {
+        if self.tasks.exists_with_db_fallback(task_id).await? {
+            return Ok(true);
+        }
+        let Some(store) = self.workflow_runtime_store.as_ref() else {
+            return Ok(false);
+        };
+        Ok(store
+            .get_instance_by_task_id(task_id.as_str())
+            .await?
+            .is_some())
+    }
+}
+
 pub struct GitHubIssuesPoller {
     repo: String,
     label: String,
@@ -818,6 +851,58 @@ mod tests {
 
         assert_eq!(pruned, 0);
         assert!(poller.dispatched.contains_key("1"));
+    }
+
+    #[tokio::test]
+    async fn runtime_aware_checker_preserves_runtime_issue_handles() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let _db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
+        let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+        let dir = tempfile::tempdir()?;
+        let tasks = crate::task_runner::TaskStore::open_with_database_url(
+            &harness_core::config::dirs::default_db_path(dir.path(), "tasks"),
+            Some(&database_url),
+        )
+        .await?;
+        let runtime_store =
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("runtime-issue-handle");
+        let labels = vec!["bug".to_string()];
+
+        crate::workflow_runtime_submission::record_issue_submission(
+            &runtime_store,
+            crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 42,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+            },
+        )
+        .await?;
+
+        let checker = RuntimeAwareDispatchedTaskChecker::new(tasks, Some(Arc::new(runtime_store)));
+
+        assert!(checker.exists(&task_id).await?);
+        assert!(
+            !checker
+                .exists(&TaskId::from_str("missing-runtime-handle"))
+                .await?
+        );
+        Ok(())
     }
 
     // Surface 3 regression guard: the dispatched JSON file stores only

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -890,6 +890,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -1061,6 +1061,13 @@ enum SprintIssueOutcome {
     Cancelled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeSprintIssueLookup {
+    Missing,
+    ActiveOrUnknown,
+    Outcome(SprintIssueOutcome),
+}
+
 impl SprintIssueOutcome {
     fn as_str(self) -> &'static str {
         match self {
@@ -1088,12 +1095,12 @@ async fn workflow_sprint_issue_outcome(
     repo: &str,
     issue_num: u64,
 ) -> Option<SprintIssueOutcome> {
-    if let Some(outcome) =
-        issue_workflow_sprint_issue_outcome(store, project_id, repo, issue_num).await
-    {
-        return Some(outcome);
+    match runtime_workflow_sprint_issue_outcome(runtime_store, project_id, repo, issue_num).await {
+        RuntimeSprintIssueLookup::Outcome(outcome) => return Some(outcome),
+        RuntimeSprintIssueLookup::ActiveOrUnknown => return None,
+        RuntimeSprintIssueLookup::Missing => {}
     }
-    runtime_workflow_sprint_issue_outcome(runtime_store, project_id, repo, issue_num).await
+    issue_workflow_sprint_issue_outcome(store, project_id, repo, issue_num).await
 }
 
 async fn issue_workflow_sprint_issue_outcome(
@@ -1123,8 +1130,10 @@ async fn runtime_workflow_sprint_issue_outcome(
     project_id: &str,
     repo: &str,
     issue_num: u64,
-) -> Option<SprintIssueOutcome> {
-    let store = store?;
+) -> RuntimeSprintIssueLookup {
+    let Some(store) = store else {
+        return RuntimeSprintIssueLookup::Missing;
+    };
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(project_id, Some(repo), issue_num);
     let workflow = match store.get_instance(&workflow_id).await {
@@ -1136,10 +1145,15 @@ async fn runtime_workflow_sprint_issue_outcome(
                 workflow_id,
                 "intake: failed to load runtime workflow state for running issue: {e}"
             );
-            return None;
+            return RuntimeSprintIssueLookup::ActiveOrUnknown;
         }
-    }?;
+    };
+    let Some(workflow) = workflow else {
+        return RuntimeSprintIssueLookup::Missing;
+    };
     runtime_workflow_state_to_sprint_outcome(&workflow.state)
+        .map(RuntimeSprintIssueLookup::Outcome)
+        .unwrap_or(RuntimeSprintIssueLookup::ActiveOrUnknown)
 }
 
 fn issue_workflow_state_to_sprint_outcome(
@@ -1740,6 +1754,71 @@ mod tests {
             workflow_sprint_issue_outcome(None, Some(&store), project_id, repo, issue).await;
 
         assert_eq!(outcome, Some(SprintIssueOutcome::UnblocksDependents));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn workflow_sprint_issue_outcome_prefers_active_runtime_over_stale_legacy(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let issue_store =
+            harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
+                &dir.path().join("issue_workflows.db"),
+                Some(&database_url),
+            )
+            .await?;
+        let runtime_store =
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime.db"),
+                Some(&database_url),
+            )
+            .await?;
+        let project_id = "/projects/runtime-sprint-active";
+        let repo = "owner/repo";
+        let issue = 43;
+        issue_store
+            .record_issue_scheduled(project_id, Some(repo), issue, "legacy-task", &[], false)
+            .await?;
+        issue_store
+            .record_terminal_for_issue(
+                project_id,
+                Some(repo),
+                issue,
+                harness_workflow::issue_lifecycle::IssueLifecycleState::Done,
+                Some("stale legacy terminal state"),
+            )
+            .await?;
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(project_id, Some(repo), issue);
+        let instance = harness_workflow::runtime::WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:43"),
+        )
+        .with_id(workflow_id)
+        .with_data(serde_json::json!({
+            "project_id": project_id,
+            "repo": repo,
+            "issue_number": issue,
+        }));
+        runtime_store.upsert_instance(&instance).await?;
+
+        let outcome = workflow_sprint_issue_outcome(
+            Some(&issue_store),
+            Some(&runtime_store),
+            project_id,
+            repo,
+            issue,
+        )
+        .await;
+
+        assert_eq!(outcome, None);
         Ok(())
     }
 

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -926,6 +926,7 @@ async fn run_repo_sprint(
         for (&issue_num, task_id) in &running {
             if let Some(outcome) = workflow_sprint_issue_outcome(
                 state.core.issue_workflow_store.as_deref(),
+                state.core.workflow_runtime_store.as_deref(),
                 &project_id,
                 repo,
                 issue_num,
@@ -1082,6 +1083,21 @@ fn workflow_state_unblocks_dependents(
 
 async fn workflow_sprint_issue_outcome(
     store: Option<&harness_workflow::issue_lifecycle::IssueWorkflowStore>,
+    runtime_store: Option<&harness_workflow::runtime::WorkflowRuntimeStore>,
+    project_id: &str,
+    repo: &str,
+    issue_num: u64,
+) -> Option<SprintIssueOutcome> {
+    if let Some(outcome) =
+        issue_workflow_sprint_issue_outcome(store, project_id, repo, issue_num).await
+    {
+        return Some(outcome);
+    }
+    runtime_workflow_sprint_issue_outcome(runtime_store, project_id, repo, issue_num).await
+}
+
+async fn issue_workflow_sprint_issue_outcome(
+    store: Option<&harness_workflow::issue_lifecycle::IssueWorkflowStore>,
     project_id: &str,
     repo: &str,
     issue_num: u64,
@@ -1093,21 +1109,59 @@ async fn workflow_sprint_issue_outcome(
             tracing::warn!(
                 repo,
                 issue = issue_num,
-                "intake: failed to load workflow state for running issue: {e}"
+                "intake: failed to load issue workflow state for running issue: {e}"
             );
             return None;
         }
     }?;
 
-    if workflow_state_unblocks_dependents(workflow.state) {
+    issue_workflow_state_to_sprint_outcome(workflow.state)
+}
+
+async fn runtime_workflow_sprint_issue_outcome(
+    store: Option<&harness_workflow::runtime::WorkflowRuntimeStore>,
+    project_id: &str,
+    repo: &str,
+    issue_num: u64,
+) -> Option<SprintIssueOutcome> {
+    let store = store?;
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(project_id, Some(repo), issue_num);
+    let workflow = match store.get_instance(&workflow_id).await {
+        Ok(workflow) => workflow,
+        Err(e) => {
+            tracing::warn!(
+                repo,
+                issue = issue_num,
+                workflow_id,
+                "intake: failed to load runtime workflow state for running issue: {e}"
+            );
+            return None;
+        }
+    }?;
+    runtime_workflow_state_to_sprint_outcome(&workflow.state)
+}
+
+fn issue_workflow_state_to_sprint_outcome(
+    state: harness_workflow::issue_lifecycle::IssueLifecycleState,
+) -> Option<SprintIssueOutcome> {
+    if workflow_state_unblocks_dependents(state) {
         Some(SprintIssueOutcome::UnblocksDependents)
     } else if matches!(
-        workflow.state,
+        state,
         harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
     ) {
         Some(SprintIssueOutcome::Cancelled)
     } else {
         None
+    }
+}
+
+fn runtime_workflow_state_to_sprint_outcome(state: &str) -> Option<SprintIssueOutcome> {
+    match state {
+        "ready_to_merge" | "done" | "failed" => Some(SprintIssueOutcome::UnblocksDependents),
+        "cancelled" => Some(SprintIssueOutcome::Cancelled),
+        _ => None,
     }
 }
 
@@ -1623,6 +1677,70 @@ mod tests {
         assert!(!workflow_state_unblocks_dependents(
             IssueLifecycleState::AddressingFeedback
         ));
+    }
+
+    #[test]
+    fn runtime_workflow_ready_to_merge_and_terminals_unblock_dependents() {
+        assert_eq!(
+            runtime_workflow_state_to_sprint_outcome("ready_to_merge"),
+            Some(SprintIssueOutcome::UnblocksDependents)
+        );
+        assert_eq!(
+            runtime_workflow_state_to_sprint_outcome("done"),
+            Some(SprintIssueOutcome::UnblocksDependents)
+        );
+        assert_eq!(
+            runtime_workflow_state_to_sprint_outcome("failed"),
+            Some(SprintIssueOutcome::UnblocksDependents)
+        );
+        assert_eq!(
+            runtime_workflow_state_to_sprint_outcome("cancelled"),
+            Some(SprintIssueOutcome::Cancelled)
+        );
+        assert_eq!(runtime_workflow_state_to_sprint_outcome("pr_open"), None);
+        assert_eq!(
+            runtime_workflow_state_to_sprint_outcome("addressing_feedback"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn workflow_sprint_issue_outcome_reads_runtime_workflow_state() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let store = harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+            dir.path(),
+            Some(&database_url),
+        )
+        .await?;
+        let project_id = "/projects/runtime-sprint";
+        let repo = "owner/repo";
+        let issue = 42;
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(project_id, Some(repo), issue);
+        let instance = harness_workflow::runtime::WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "ready_to_merge",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+        )
+        .with_id(workflow_id)
+        .with_data(serde_json::json!({
+            "project_id": project_id,
+            "repo": repo,
+            "issue_number": issue,
+        }));
+        store.upsert_instance(&instance).await?;
+
+        let outcome =
+            workflow_sprint_issue_outcome(None, Some(&store), project_id, repo, issue).await;
+
+        assert_eq!(outcome, Some(SprintIssueOutcome::UnblocksDependents));
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -57,6 +57,7 @@ pub(crate) mod workflow_runtime_plan_issue;
 pub(crate) mod workflow_runtime_policy;
 pub(crate) mod workflow_runtime_pr_feedback;
 pub(crate) mod workflow_runtime_repo_backlog;
+pub(crate) mod workflow_runtime_submission;
 pub(crate) mod workflow_runtime_worker;
 pub use harness_workflow::task_queue;
 pub mod task_runner;

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -684,6 +684,30 @@ mod tests {
         let mut registry = AgentRegistry::new("test");
         registry.register("test", Arc::new(RetryTestAgent));
         let mut state = test_helpers::make_test_state_with_registry(dir.path(), registry).await?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+                Some(&test_helpers::test_database_url()?),
+            )
+            .await?,
+        );
+        state.core.workflow_runtime_store = Some(runtime_store.clone());
+        state.execution_svc = crate::services::execution::DefaultExecutionService::new(
+            state.core.tasks.clone(),
+            state.core.server.agent_registry.clone(),
+            Arc::new(state.core.server.config.clone()),
+            state.engines.skills.clone(),
+            state.observability.events.clone(),
+            state.interceptors.clone(),
+            None,
+            state.concurrency.task_queue.clone(),
+            state.concurrency.review_task_queue.clone(),
+            None,
+            None,
+            Some(runtime_store.clone()),
+            None,
+            vec![],
+        );
 
         let workspace_root = dir.path().join("workspaces");
         let workspace_mgr = Arc::new(crate::workspace::WorkspaceManager::new(
@@ -732,8 +756,23 @@ mod tests {
             "original stalled task should be cancelled before retry"
         );
         assert!(
-            tasks.iter().any(|t| t.id != task_id),
-            "retry tick should enqueue a successor task after cleanup even if it finishes quickly"
+            tasks.iter().all(|t| t.id == task_id),
+            "runtime-first issue retry should not enqueue a successor task row"
+        );
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(dir.path().to_str().unwrap(), None, 42);
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("retry should submit the issue to workflow runtime");
+        assert_eq!(instance.data["execution_path"], "workflow_runtime");
+        let commands = runtime_store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(commands[0].command.command["activity"], "implement_issue");
+        assert!(
+            commands[0].id != task_id.0,
+            "runtime command id should be independent of the cancelled legacy task"
         );
         Ok(())
     }

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -366,8 +366,11 @@ impl DefaultExecutionService {
             .map_err(EnqueueTaskError::BadRequest)
     }
 
-    fn runtime_issue_submission_enabled(&self) -> Result<bool, EnqueueTaskError> {
-        workflow_runtime_loops_enabled(&self.server_config.server.project_root)
+    fn runtime_issue_submission_enabled(
+        &self,
+        project_root: &Path,
+    ) -> Result<bool, EnqueueTaskError> {
+        workflow_runtime_loops_enabled(project_root)
     }
 
     fn queue_for(&self, domain: QueueDomain) -> Arc<TaskQueue> {
@@ -659,7 +662,7 @@ impl DefaultExecutionService {
         self.check_allowed_roots(&canonical)?;
 
         let project_id = canonical.to_string_lossy().into_owned();
-        req.project = Some(canonical);
+        req.project = Some(canonical.clone());
 
         task_runner::fill_missing_repo_from_project(&mut req).await;
         Self::populate_external_id(&mut req);
@@ -673,7 +676,7 @@ impl DefaultExecutionService {
 
         if req.issue.is_some()
             && self.workflow_runtime_store.is_some()
-            && self.runtime_issue_submission_enabled()?
+            && self.runtime_issue_submission_enabled(&canonical)?
         {
             if let Some(existing_id) = self
                 .check_runtime_issue_duplicate(&project_id, &req)
@@ -1228,7 +1231,7 @@ mod tests {
             .get_instance(&workflow_id)
             .await?
             .expect("runtime workflow should be recorded");
-        assert_eq!(instance.state, "scheduled");
+        assert_eq!(instance.state, "implementing");
         assert_eq!(instance.data["task_id"], task_id.0);
         assert_eq!(
             instance.data["additional_prompt"],
@@ -1256,7 +1259,9 @@ mod tests {
 
         let dir = tempfile::tempdir()?;
         let project_root = dir.path().join("project");
+        let server_root = dir.path().join("server-root");
         std::fs::create_dir(&project_root)?;
+        std::fs::create_dir(&server_root)?;
         std::fs::write(
             project_root.join("WORKFLOW.md"),
             "---\nruntime_dispatch:\n  enabled: false\nruntime_worker:\n  enabled: true\n---\n",
@@ -1272,7 +1277,7 @@ mod tests {
             .await?,
         );
         let mut config = HarnessConfig::default();
-        config.server.project_root = project_root.clone();
+        config.server.project_root = server_root;
         let svc =
             make_svc_with_workflow_runtime_agent_and_config(store, runtime_store.clone(), config)
                 .await;
@@ -1301,6 +1306,64 @@ mod tests {
             runtime_store.get_instance(&workflow_id).await?.is_none(),
             "disabled runtime loops must not create a pending runtime workflow"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_issue_submission_uses_request_project_runtime_policy(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        let server_root = dir.path().join("server-root");
+        std::fs::create_dir(&project_root)?;
+        std::fs::create_dir(&server_root)?;
+        std::fs::write(
+            server_root.join("WORKFLOW.md"),
+            "---\nruntime_dispatch:\n  enabled: false\nruntime_worker:\n  enabled: true\n---\n",
+        )?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let task_store = store.clone();
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let mut config = HarnessConfig::default();
+        config.server.project_root = server_root;
+        let svc =
+            make_svc_with_workflow_runtime_agent_and_config(store, runtime_store.clone(), config)
+                .await;
+        let req = CreateTaskRequest {
+            issue: Some(43),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        assert!(
+            task_store.get_with_db_fallback(&task_id).await?.is_none(),
+            "enabled request project runtime loops should bypass the task runner path"
+        );
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            43,
+        );
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("runtime workflow should be recorded for the request project");
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.data["task_id"], task_id.0);
         Ok(())
     }
 
@@ -1524,7 +1587,7 @@ mod tests {
             .get_instance(&dependent_workflow_id)
             .await?
             .expect("dependent workflow should be recorded");
-        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.state, "implementing");
         assert_eq!(workflow.data["task_id"], dependent_id.0);
         assert_eq!(workflow.data["depends_on"], serde_json::json!([dep_handle]));
         assert_eq!(

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -140,10 +140,16 @@ struct PreparedEnqueue {
     reviewer: Option<Arc<dyn CodeAgent>>,
 }
 
+struct PreparedRuntimeIssueSubmission {
+    req: CreateTaskRequest,
+    project_id: String,
+}
+
 const WORKFLOW_FEEDBACK_SOURCE: &str = "workflow_feedback";
 
 enum PreparedEnqueueResult {
     Existing(TaskId),
+    RuntimeIssueSubmission(Box<PreparedRuntimeIssueSubmission>),
     Ready(Box<PreparedEnqueue>),
 }
 
@@ -493,50 +499,7 @@ impl DefaultExecutionService {
         false
     }
 
-    async fn track_issue_workflow(
-        &self,
-        project_id: &str,
-        req: &CreateTaskRequest,
-        task_id: &TaskId,
-    ) {
-        if let Some(issue_number) = req.issue {
-            if let Some(workflows) = self.issue_workflow_store.as_ref() {
-                if let Err(e) = workflows
-                    .record_issue_scheduled(
-                        project_id,
-                        req.repo.as_deref(),
-                        issue_number,
-                        &task_id.0,
-                        &req.labels,
-                        req.force_execute,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        issue = issue_number,
-                        task_id = %task_id.0,
-                        "issue workflow enqueue tracking failed: {e}"
-                    );
-                }
-            }
-            let project_root = req
-                .project
-                .as_deref()
-                .unwrap_or_else(|| std::path::Path::new(project_id));
-            crate::workflow_runtime_submission::record_issue_submission(
-                self.workflow_runtime_store.as_deref(),
-                crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
-                    project_root,
-                    repo: req.repo.as_deref(),
-                    issue_number,
-                    task_id,
-                    labels: &req.labels,
-                    force_execute: req.force_execute,
-                },
-            )
-            .await;
-            return;
-        }
+    async fn track_pr_workflow(&self, project_id: &str, req: &CreateTaskRequest, task_id: &TaskId) {
         if let Some(pr_number) = req.pr {
             if let Some(workflows) = self.issue_workflow_store.as_ref() {
                 if let Err(e) = workflows
@@ -556,6 +519,66 @@ impl DefaultExecutionService {
                 }
             }
         }
+    }
+
+    async fn submit_issue_to_workflow_runtime(
+        &self,
+        prepared: PreparedRuntimeIssueSubmission,
+    ) -> Result<TaskId, EnqueueTaskError> {
+        let Some(store) = self.workflow_runtime_store.as_deref() else {
+            return Err(EnqueueTaskError::Internal(
+                "workflow runtime store is required for GitHub issue submissions".to_string(),
+            ));
+        };
+        let Some(issue_number) = prepared.req.issue else {
+            return Err(EnqueueTaskError::BadRequest(
+                "issue submission requires an issue number".to_string(),
+            ));
+        };
+
+        let task_id = TaskId::new();
+        let project_root = prepared
+            .req
+            .project
+            .as_deref()
+            .unwrap_or_else(|| std::path::Path::new(&prepared.project_id));
+        let record = crate::workflow_runtime_submission::record_issue_submission(
+            store,
+            crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+                project_root,
+                repo: prepared.req.repo.as_deref(),
+                issue_number,
+                task_id: &task_id,
+                labels: &prepared.req.labels,
+                force_execute: prepared.req.force_execute,
+            },
+        )
+        .await
+        .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?;
+
+        if !record.accepted {
+            return Err(EnqueueTaskError::BadRequest(format!(
+                "workflow runtime rejected issue submission for workflow {}: {}",
+                record.workflow_id,
+                record
+                    .rejection_reason
+                    .as_deref()
+                    .unwrap_or("decision rejected")
+            )));
+        }
+        if record.command_ids.is_empty() {
+            return Err(EnqueueTaskError::Internal(format!(
+                "workflow runtime accepted issue submission for workflow {} without commands",
+                record.workflow_id
+            )));
+        }
+        tracing::info!(
+            workflow_id = %record.workflow_id,
+            task_id = %task_id.0,
+            command_count = record.command_ids.len(),
+            "execution service: accepted issue submission into workflow runtime"
+        );
+        Ok(task_id)
     }
 
     async fn prepare_enqueue(
@@ -587,6 +610,23 @@ impl DefaultExecutionService {
         task_runner::fill_missing_repo_from_project(&mut req).await;
         Self::populate_external_id(&mut req);
 
+        if req.issue.is_some() {
+            if !req.depends_on.is_empty() {
+                return Err(EnqueueTaskError::BadRequest(
+                    "workflow runtime issue submissions do not support task dependencies"
+                        .to_string(),
+                ));
+            }
+            if self.workflow_runtime_store.is_none() {
+                return Err(EnqueueTaskError::Internal(
+                    "workflow runtime store is required for GitHub issue submissions".to_string(),
+                ));
+            }
+            return Ok(PreparedEnqueueResult::RuntimeIssueSubmission(Box::new(
+                PreparedRuntimeIssueSubmission { req, project_id },
+            )));
+        }
+
         if let Some(existing_id) = self.check_workflow_duplicate(&project_id, &req).await {
             return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
@@ -602,7 +642,7 @@ impl DefaultExecutionService {
             let task_id = task_runner::spawn_task_awaiting_deps(self.tasks.clone(), req)
                 .await
                 .map_err(|e| EnqueueTaskError::BadRequest(e.to_string()))?;
-            self.track_issue_workflow(&project_id, &workflow_req, &task_id)
+            self.track_pr_workflow(&project_id, &workflow_req, &task_id)
                 .await;
             return Ok(PreparedEnqueueResult::Existing(task_id));
         }
@@ -641,6 +681,9 @@ impl ExecutionService for DefaultExecutionService {
     ) -> Result<TaskId, EnqueueTaskError> {
         let prepared = match self.prepare_enqueue(req).await? {
             PreparedEnqueueResult::Existing(task_id) => return Ok(task_id),
+            PreparedEnqueueResult::RuntimeIssueSubmission(prepared) => {
+                return self.submit_issue_to_workflow_runtime(*prepared).await;
+            }
             PreparedEnqueueResult::Ready(prepared) => *prepared,
         };
 
@@ -678,7 +721,7 @@ impl ExecutionService for DefaultExecutionService {
         )
         .await;
 
-        self.track_issue_workflow(&prepared.project_id, &workflow_req, &task_id)
+        self.track_pr_workflow(&prepared.project_id, &workflow_req, &task_id)
             .await;
 
         Ok(task_id)
@@ -696,6 +739,9 @@ impl ExecutionService for DefaultExecutionService {
     ) -> Result<TaskId, EnqueueTaskError> {
         let prepared = match self.prepare_enqueue(req).await? {
             PreparedEnqueueResult::Existing(task_id) => return Ok(task_id),
+            PreparedEnqueueResult::RuntimeIssueSubmission(prepared) => {
+                return self.submit_issue_to_workflow_runtime(*prepared).await;
+            }
             PreparedEnqueueResult::Ready(prepared) => *prepared,
         };
 
@@ -725,7 +771,7 @@ impl ExecutionService for DefaultExecutionService {
         let allowed_project_roots = self.allowed_project_roots.clone();
         let task_id2 = task_id.clone();
         let project_id = prepared.project_id;
-        self.track_issue_workflow(&project_id, &prepared.req, &task_id)
+        self.track_pr_workflow(&project_id, &prepared.req, &task_id)
             .await;
         let req = prepared.req;
         let agent = prepared.agent;
@@ -994,7 +1040,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn track_issue_workflow_records_runtime_submission() -> anyhow::Result<()> {
+    async fn enqueue_background_issue_submission_uses_workflow_runtime_without_task_runner(
+    ) -> anyhow::Result<()> {
         if !crate::test_helpers::db_tests_enabled().await {
             return Ok(());
         }
@@ -1003,6 +1050,7 @@ mod tests {
         let project_root = dir.path().join("project");
         std::fs::create_dir(&project_root)?;
         let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let task_store = store.clone();
         let database_url = crate::test_helpers::test_database_url()?;
         let runtime_store = Arc::new(
             harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
@@ -1019,13 +1067,16 @@ mod tests {
             labels: vec!["bug".to_string()],
             ..Default::default()
         };
-        let task_id = TaskId::from_str("task-1");
 
-        svc.track_issue_workflow(&project_root.to_string_lossy(), &req, &task_id)
-            .await;
+        let task_id = svc.enqueue_background(req).await?;
+        assert!(
+            task_store.get_with_db_fallback(&task_id).await?.is_none(),
+            "workflow runtime issue submissions must not register legacy task rows"
+        );
 
+        let canonical_project_root = project_root.canonicalize()?;
         let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
-            &project_root.to_string_lossy(),
+            &canonical_project_root.to_string_lossy(),
             Some("owner/repo"),
             42,
         );
@@ -1034,10 +1085,13 @@ mod tests {
             .await?
             .expect("runtime workflow should be recorded");
         assert_eq!(instance.state, "scheduled");
+        assert_eq!(instance.data["task_id"], task_id.0);
+        assert_eq!(instance.data["execution_path"], "workflow_runtime");
         let commands = runtime_store.commands_for(&workflow_id).await?;
         assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].status, "handled_inline");
+        assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
         Ok(())
     }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -16,7 +16,7 @@ use harness_skills::store::SkillStore;
 use harness_workflow::issue_lifecycle::{
     is_feedback_claim_placeholder, IssueLifecycleState, IssueWorkflowInstance,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
 
@@ -366,6 +366,10 @@ impl DefaultExecutionService {
             .map_err(EnqueueTaskError::BadRequest)
     }
 
+    fn runtime_issue_submission_enabled(&self) -> Result<bool, EnqueueTaskError> {
+        workflow_runtime_loops_enabled(&self.server_config.server.project_root)
+    }
+
     fn queue_for(&self, domain: QueueDomain) -> Arc<TaskQueue> {
         match domain {
             QueueDomain::Primary => self.task_queue.clone(),
@@ -599,6 +603,8 @@ impl DefaultExecutionService {
                 additional_prompt: prepared.req.prompt.as_deref(),
                 depends_on: &prepared.req.depends_on,
                 dependencies_blocked,
+                source: prepared.req.source.as_deref(),
+                external_id: prepared.req.external_id.as_deref(),
             },
         )
         .await
@@ -665,7 +671,10 @@ impl DefaultExecutionService {
             return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
 
-        if req.issue.is_some() && self.workflow_runtime_store.is_some() {
+        if req.issue.is_some()
+            && self.workflow_runtime_store.is_some()
+            && self.runtime_issue_submission_enabled()?
+        {
             if let Some(existing_id) = self
                 .check_runtime_issue_duplicate(&project_id, &req)
                 .await?
@@ -710,6 +719,17 @@ impl DefaultExecutionService {
             reviewer,
         })))
     }
+}
+
+fn workflow_runtime_loops_enabled(project_root: &Path) -> Result<bool, EnqueueTaskError> {
+    let workflow_cfg =
+        harness_core::config::workflow::load_workflow_config(project_root).map_err(|error| {
+            EnqueueTaskError::Internal(format!(
+                "failed to load workflow runtime config at {}: {error}",
+                project_root.display()
+            ))
+        })?;
+    Ok(workflow_cfg.runtime_dispatch.enabled && workflow_cfg.runtime_worker.enabled)
 }
 
 #[async_trait]
@@ -1228,6 +1248,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enqueue_background_issue_submission_falls_back_when_runtime_loops_disabled(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        std::fs::write(
+            project_root.join("WORKFLOW.md"),
+            "---\nruntime_dispatch:\n  enabled: false\nruntime_worker:\n  enabled: true\n---\n",
+        )?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let task_store = store.clone();
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let mut config = HarnessConfig::default();
+        config.server.project_root = project_root.clone();
+        let svc =
+            make_svc_with_workflow_runtime_agent_and_config(store, runtime_store.clone(), config)
+                .await;
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        let task = task_store
+            .get_with_db_fallback(&task_id)
+            .await?
+            .expect("disabled runtime loops should use the task runner path");
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            42,
+        );
+
+        assert_eq!(task.task_kind, task_runner::TaskKind::Issue);
+        assert_eq!(task.external_id.as_deref(), Some("issue:42"));
+        assert!(
+            runtime_store.get_instance(&workflow_id).await?.is_none(),
+            "disabled runtime loops must not create a pending runtime workflow"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn enqueue_background_issue_submission_reuses_active_runtime_handle() -> anyhow::Result<()>
     {
         if !crate::test_helpers::db_tests_enabled().await {
@@ -1559,6 +1636,31 @@ mod tests {
             store,
             agent_registry,
             config,
+            Default::default(),
+            make_event_store_noop().await,
+            vec![],
+            None,
+            make_task_queue(),
+            make_task_queue(),
+            None,
+            None,
+            Some(runtime_store),
+            None,
+            vec![],
+        )
+    }
+
+    async fn make_svc_with_workflow_runtime_agent_and_config(
+        store: Arc<TaskStore>,
+        runtime_store: Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+        config: HarnessConfig,
+    ) -> Arc<DefaultExecutionService> {
+        let mut agent_registry = AgentRegistry::new("test");
+        agent_registry.register("test", Arc::new(NoopAgent));
+        DefaultExecutionService::new(
+            store,
+            Arc::new(agent_registry),
+            Arc::new(config),
             Default::default(),
             make_event_store_noop().await,
             vec![],

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -658,6 +658,13 @@ impl DefaultExecutionService {
         task_runner::fill_missing_repo_from_project(&mut req).await;
         Self::populate_external_id(&mut req);
 
+        if let Some(existing_id) = self.check_workflow_duplicate(&project_id, &req).await {
+            return Ok(PreparedEnqueueResult::Existing(existing_id));
+        }
+        if let Some(existing_id) = self.check_duplicate(&project_id, &req).await {
+            return Ok(PreparedEnqueueResult::Existing(existing_id));
+        }
+
         if req.issue.is_some() && self.workflow_runtime_store.is_some() {
             if let Some(existing_id) = self
                 .check_runtime_issue_duplicate(&project_id, &req)
@@ -670,12 +677,6 @@ impl DefaultExecutionService {
             )));
         }
 
-        if let Some(existing_id) = self.check_workflow_duplicate(&project_id, &req).await {
-            return Ok(PreparedEnqueueResult::Existing(existing_id));
-        }
-        if let Some(existing_id) = self.check_duplicate(&project_id, &req).await {
-            return Ok(PreparedEnqueueResult::Existing(existing_id));
-        }
         if let Some(existing_id) = self.check_pr_duplicate(&project_id, &req).await {
             return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
@@ -1268,6 +1269,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enqueue_background_issue_submission_reuses_active_legacy_issue_task_before_runtime(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let canonical_project_root = project_root.canonicalize()?;
+        let project_id = canonical_project_root.to_string_lossy().into_owned();
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let issue_store = Arc::new(
+            harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_database_url(
+                &dir.path().join("issue_workflows"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let legacy_req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(canonical_project_root.clone()),
+            external_id: Some("issue:42".to_string()),
+            ..Default::default()
+        };
+        let legacy_task_id = task_runner::register_pending_task(store.clone(), &legacy_req).await;
+        issue_store
+            .record_issue_scheduled(
+                &project_id,
+                Some("owner/repo"),
+                42,
+                legacy_task_id.as_str(),
+                &[],
+                false,
+            )
+            .await?;
+        let svc =
+            make_svc_with_issue_workflow_and_runtime(store, issue_store, runtime_store.clone())
+                .await;
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+
+        assert_eq!(task_id, legacy_task_id);
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 42);
+        assert!(
+            runtime_store.get_instance(&workflow_id).await?.is_none(),
+            "legacy duplicate reuse should not create a parallel runtime workflow"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn enqueue_background_issue_submission_preserves_runtime_dependencies(
     ) -> anyhow::Result<()> {
         if !crate::test_helpers::db_tests_enabled().await {
@@ -1498,6 +1567,31 @@ mod tests {
             make_task_queue(),
             None,
             None,
+            Some(runtime_store),
+            None,
+            vec![],
+        )
+    }
+
+    async fn make_svc_with_issue_workflow_and_runtime(
+        store: Arc<TaskStore>,
+        issue_store: Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>,
+        runtime_store: Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+    ) -> Arc<DefaultExecutionService> {
+        let config = Arc::new(HarnessConfig::default());
+        let agent_registry = Arc::new(AgentRegistry::new("test"));
+        DefaultExecutionService::new(
+            store,
+            agent_registry,
+            config,
+            Default::default(),
+            make_event_store_noop().await,
+            vec![],
+            None,
+            make_task_queue(),
+            make_task_queue(),
+            None,
+            Some(issue_store),
             Some(runtime_store),
             None,
             vec![],

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -658,12 +658,7 @@ impl DefaultExecutionService {
         task_runner::fill_missing_repo_from_project(&mut req).await;
         Self::populate_external_id(&mut req);
 
-        if req.issue.is_some() {
-            if self.workflow_runtime_store.is_none() {
-                return Err(EnqueueTaskError::Internal(
-                    "workflow runtime store is required for GitHub issue submissions".to_string(),
-                ));
-            }
+        if req.issue.is_some() && self.workflow_runtime_store.is_some() {
             if let Some(existing_id) = self
                 .check_runtime_issue_duplicate(&project_id, &req)
                 .await?
@@ -887,6 +882,10 @@ impl ExecutionService for DefaultExecutionService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_core::{
+        agent::{AgentRequest, AgentResponse, StreamItem},
+        types::{Capability, TokenUsage},
+    };
     use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Minimal mock that always succeeds without touching any infrastructure.
@@ -903,6 +902,47 @@ mod tests {
                 }),
                 called,
             )
+        }
+    }
+
+    struct NoopAgent;
+
+    #[async_trait]
+    impl CodeAgent for NoopAgent {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn capabilities(&self) -> Vec<Capability> {
+            Vec::new()
+        }
+
+        async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+            Ok(noop_agent_response())
+        }
+
+        async fn execute_stream(
+            &self,
+            _req: AgentRequest,
+            _tx: tokio::sync::mpsc::Sender<StreamItem>,
+        ) -> harness_core::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn noop_agent_response() -> AgentResponse {
+        AgentResponse {
+            output: String::new(),
+            stderr: String::new(),
+            items: Vec::new(),
+            token_usage: TokenUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+                cost_usd: 0.0,
+            },
+            model: "test".to_string(),
+            exit_code: Some(0),
         }
     }
 
@@ -1084,6 +1124,40 @@ mod tests {
         let svc = make_svc_with_allowed_roots(store, vec![]).await;
         let any = PathBuf::from("/anywhere/repo");
         assert!(svc.check_allowed_roots(&any).is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_issue_submission_falls_back_without_runtime_store(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let task_store = store.clone();
+        let svc = make_svc_with_agent_without_workflow_runtime(store).await;
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        let task = task_store
+            .get_with_db_fallback(&task_id)
+            .await?
+            .expect("issue submission should fall back to a task runner row");
+        let canonical_project_root = project_root.canonicalize()?;
+
+        assert_eq!(task.id, task_id);
+        assert_eq!(task.task_kind, task_runner::TaskKind::Issue);
+        assert_eq!(task.external_id.as_deref(), Some("issue:42"));
+        assert_eq!(task.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(
+            task.project_root.as_deref(),
+            Some(canonical_project_root.as_path())
+        );
         Ok(())
     }
 
@@ -1379,6 +1453,30 @@ mod tests {
             None,
             None,
             allowed,
+        )
+    }
+
+    async fn make_svc_with_agent_without_workflow_runtime(
+        store: Arc<TaskStore>,
+    ) -> Arc<DefaultExecutionService> {
+        let config = Arc::new(HarnessConfig::default());
+        let mut agent_registry = AgentRegistry::new("test");
+        agent_registry.register("test", Arc::new(NoopAgent));
+        DefaultExecutionService::new(
+            store,
+            Arc::new(agent_registry),
+            config,
+            Default::default(),
+            make_event_store_noop().await,
+            vec![],
+            None,
+            make_task_queue(),
+            make_task_queue(),
+            None,
+            None,
+            None,
+            None,
+            vec![],
         )
     }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -484,19 +484,63 @@ impl DefaultExecutionService {
         Some(existing_id)
     }
 
-    async fn dependencies_blocked(&self, req: &CreateTaskRequest) -> bool {
+    async fn dependencies_blocked(
+        &self,
+        req: &CreateTaskRequest,
+    ) -> Result<bool, EnqueueTaskError> {
         if req.depends_on.is_empty() {
-            return false;
+            return Ok(false);
         }
         for dep_id in &req.depends_on {
+            let status = crate::workflow_runtime_submission::resolve_issue_dependency_status(
+                self.workflow_runtime_store.as_deref(),
+                &self.tasks,
+                dep_id,
+            )
+            .await
+            .map_err(|error| {
+                EnqueueTaskError::Internal(format!(
+                    "dependency status lookup failed for {}: {error}",
+                    dep_id.as_str()
+                ))
+            })?;
             if !matches!(
-                self.tasks.dep_status(dep_id).await,
-                Some(task_runner::TaskStatus::Done)
+                status,
+                crate::workflow_runtime_submission::IssueDependencyStatus::Done
             ) {
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
+    }
+
+    async fn check_runtime_issue_duplicate(
+        &self,
+        project_id: &str,
+        req: &CreateTaskRequest,
+    ) -> Result<Option<TaskId>, EnqueueTaskError> {
+        let Some(issue_number) = req.issue else {
+            return Ok(None);
+        };
+        let Some(store) = self.workflow_runtime_store.as_ref() else {
+            return Ok(None);
+        };
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            project_id,
+            req.repo.as_deref(),
+            issue_number,
+        );
+        let Some(instance) = store
+            .get_instance(&workflow_id)
+            .await
+            .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        if instance.is_terminal() {
+            return Ok(None);
+        }
+        Ok(crate::workflow_runtime_submission::runtime_issue_task_handle(&instance))
     }
 
     async fn track_pr_workflow(&self, project_id: &str, req: &CreateTaskRequest, task_id: &TaskId) {
@@ -535,7 +579,7 @@ impl DefaultExecutionService {
                 "issue submission requires an issue number".to_string(),
             ));
         };
-        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await;
+        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await?;
 
         let task_id = TaskId::new();
         let project_root = prepared
@@ -620,6 +664,12 @@ impl DefaultExecutionService {
                     "workflow runtime store is required for GitHub issue submissions".to_string(),
                 ));
             }
+            if let Some(existing_id) = self
+                .check_runtime_issue_duplicate(&project_id, &req)
+                .await?
+            {
+                return Ok(PreparedEnqueueResult::Existing(existing_id));
+            }
             return Ok(PreparedEnqueueResult::RuntimeIssueSubmission(Box::new(
                 PreparedRuntimeIssueSubmission { req, project_id },
             )));
@@ -635,7 +685,7 @@ impl DefaultExecutionService {
             return Ok(PreparedEnqueueResult::Existing(existing_id));
         }
 
-        if self.dependencies_blocked(&req).await {
+        if self.dependencies_blocked(&req).await? {
             let workflow_req = req.clone();
             let task_id = task_runner::spawn_task_awaiting_deps(self.tasks.clone(), req)
                 .await
@@ -1103,6 +1153,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enqueue_background_issue_submission_reuses_active_runtime_handle() -> anyhow::Result<()>
+    {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+
+        let first = svc.enqueue_background(req.clone()).await?;
+        let second = svc.enqueue_background(req).await?;
+
+        assert_eq!(second, first);
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            42,
+        );
+        assert_eq!(runtime_store.commands_for(&workflow_id).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn enqueue_background_issue_submission_preserves_runtime_dependencies(
     ) -> anyhow::Result<()> {
         if !crate::test_helpers::db_tests_enabled().await {
@@ -1152,6 +1243,77 @@ mod tests {
             serde_json::json!(["dep-issue-runtime"])
         );
         assert!(runtime_store.commands_for(&workflow_id).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_issue_submission_accepts_completed_runtime_dependency(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let dep_req = CreateTaskRequest {
+            issue: Some(44),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            ..Default::default()
+        };
+        let dep_id = svc.enqueue_background(dep_req).await?;
+        let canonical_project_root = project_root.canonicalize()?;
+        let dep_workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            44,
+        );
+        let mut dep_workflow = runtime_store
+            .get_instance(&dep_workflow_id)
+            .await?
+            .expect("dependency workflow should be recorded");
+        dep_workflow.state = "done".to_string();
+        runtime_store.upsert_instance(&dep_workflow).await?;
+        let dep_handle = dep_id.as_str().to_string();
+
+        let dependent_req = CreateTaskRequest {
+            issue: Some(45),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            depends_on: vec![dep_id],
+            ..Default::default()
+        };
+        let dependent_id = svc.enqueue_background(dependent_req).await?;
+        let dependent_workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            45,
+        );
+        let workflow = runtime_store
+            .get_instance(&dependent_workflow_id)
+            .await?
+            .expect("dependent workflow should be recorded");
+        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.data["task_id"], dependent_id.0);
+        assert_eq!(workflow.data["depends_on"], serde_json::json!([dep_handle]));
+        assert_eq!(
+            runtime_store
+                .commands_for(&dependent_workflow_id)
+                .await?
+                .len(),
+            1
+        );
         Ok(())
     }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -535,6 +535,7 @@ impl DefaultExecutionService {
                 "issue submission requires an issue number".to_string(),
             ));
         };
+        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await;
 
         let task_id = TaskId::new();
         let project_root = prepared
@@ -552,6 +553,8 @@ impl DefaultExecutionService {
                 labels: &prepared.req.labels,
                 force_execute: prepared.req.force_execute,
                 additional_prompt: prepared.req.prompt.as_deref(),
+                depends_on: &prepared.req.depends_on,
+                dependencies_blocked,
             },
         )
         .await
@@ -567,7 +570,7 @@ impl DefaultExecutionService {
                     .unwrap_or("decision rejected")
             )));
         }
-        if record.command_ids.is_empty() {
+        if record.command_ids.is_empty() && !dependencies_blocked {
             return Err(EnqueueTaskError::Internal(format!(
                 "workflow runtime accepted issue submission for workflow {} without commands",
                 record.workflow_id
@@ -612,12 +615,6 @@ impl DefaultExecutionService {
         Self::populate_external_id(&mut req);
 
         if req.issue.is_some() {
-            if !req.depends_on.is_empty() {
-                return Err(EnqueueTaskError::BadRequest(
-                    "workflow runtime issue submissions do not support task dependencies"
-                        .to_string(),
-                ));
-            }
             if self.workflow_runtime_store.is_none() {
                 return Err(EnqueueTaskError::Internal(
                     "workflow runtime store is required for GitHub issue submissions".to_string(),
@@ -1102,6 +1099,59 @@ mod tests {
             "preserve caller guidance"
         );
         assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_issue_submission_preserves_runtime_dependencies(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let dep_id = TaskId::from_str("dep-issue-runtime");
+        let dep = crate::task_runner::TaskState::new(dep_id.clone());
+        store.insert(&dep).await;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            issue: Some(43),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            depends_on: vec![dep_id],
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("owner/repo"),
+            43,
+        );
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("runtime workflow should be recorded");
+
+        assert_eq!(instance.state, "awaiting_dependencies");
+        assert_eq!(instance.data["task_id"], task_id.0);
+        assert_eq!(
+            instance.data["depends_on"],
+            serde_json::json!(["dep-issue-runtime"])
+        );
+        assert!(runtime_store.commands_for(&workflow_id).await?.is_empty());
         Ok(())
     }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -499,44 +499,61 @@ impl DefaultExecutionService {
         req: &CreateTaskRequest,
         task_id: &TaskId,
     ) {
-        let Some(workflows) = self.issue_workflow_store.as_ref() else {
-            return;
-        };
         if let Some(issue_number) = req.issue {
-            if let Err(e) = workflows
-                .record_issue_scheduled(
-                    project_id,
-                    req.repo.as_deref(),
-                    issue_number,
-                    &task_id.0,
-                    &req.labels,
-                    req.force_execute,
-                )
-                .await
-            {
-                tracing::warn!(
-                    issue = issue_number,
-                    task_id = %task_id.0,
-                    "issue workflow enqueue tracking failed: {e}"
-                );
+            if let Some(workflows) = self.issue_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_issue_scheduled(
+                        project_id,
+                        req.repo.as_deref(),
+                        issue_number,
+                        &task_id.0,
+                        &req.labels,
+                        req.force_execute,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        issue = issue_number,
+                        task_id = %task_id.0,
+                        "issue workflow enqueue tracking failed: {e}"
+                    );
+                }
             }
+            let project_root = req
+                .project
+                .as_deref()
+                .unwrap_or_else(|| std::path::Path::new(project_id));
+            crate::workflow_runtime_submission::record_issue_submission(
+                self.workflow_runtime_store.as_deref(),
+                crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+                    project_root,
+                    repo: req.repo.as_deref(),
+                    issue_number,
+                    task_id,
+                    labels: &req.labels,
+                    force_execute: req.force_execute,
+                },
+            )
+            .await;
             return;
         }
         if let Some(pr_number) = req.pr {
-            if let Err(e) = workflows
-                .record_feedback_task_scheduled(
-                    project_id,
-                    req.repo.as_deref(),
-                    pr_number,
-                    &task_id.0,
-                )
-                .await
-            {
-                tracing::warn!(
-                    pr = pr_number,
-                    task_id = %task_id.0,
-                    "issue workflow PR enqueue tracking failed: {e}"
-                );
+            if let Some(workflows) = self.issue_workflow_store.as_ref() {
+                if let Err(e) = workflows
+                    .record_feedback_task_scheduled(
+                        project_id,
+                        req.repo.as_deref(),
+                        pr_number,
+                        &task_id.0,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        pr = pr_number,
+                        task_id = %task_id.0,
+                        "issue workflow PR enqueue tracking failed: {e}"
+                    );
+                }
             }
         }
     }
@@ -976,6 +993,54 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn track_issue_workflow_records_runtime_submission() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            issue: Some(42),
+            repo: Some("owner/repo".to_string()),
+            project: Some(project_root.clone()),
+            labels: vec!["bug".to_string()],
+            ..Default::default()
+        };
+        let task_id = TaskId::from_str("task-1");
+
+        svc.track_issue_workflow(&project_root.to_string_lossy(), &req, &task_id)
+            .await;
+
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            42,
+        );
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("runtime workflow should be recorded");
+        assert_eq!(instance.state, "scheduled");
+        let commands = runtime_store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "handled_inline");
+        assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        Ok(())
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     async fn make_event_store_noop() -> Arc<harness_observe::event_store::EventStore> {
@@ -1038,6 +1103,30 @@ mod tests {
             None,
             None,
             allowed,
+        )
+    }
+
+    async fn make_svc_with_workflow_runtime(
+        store: Arc<TaskStore>,
+        runtime_store: Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+    ) -> Arc<DefaultExecutionService> {
+        let config = Arc::new(HarnessConfig::default());
+        let agent_registry = Arc::new(AgentRegistry::new("test"));
+        DefaultExecutionService::new(
+            store,
+            agent_registry,
+            config,
+            Default::default(),
+            make_event_store_noop().await,
+            vec![],
+            None,
+            make_task_queue(),
+            make_task_queue(),
+            None,
+            None,
+            Some(runtime_store),
+            None,
+            vec![],
         )
     }
 }

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -551,6 +551,7 @@ impl DefaultExecutionService {
                 task_id: &task_id,
                 labels: &prepared.req.labels,
                 force_execute: prepared.req.force_execute,
+                additional_prompt: prepared.req.prompt.as_deref(),
             },
         )
         .await
@@ -1061,6 +1062,7 @@ mod tests {
         );
         let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
         let req = CreateTaskRequest {
+            prompt: Some("preserve caller guidance".to_string()),
             issue: Some(42),
             repo: Some("owner/repo".to_string()),
             project: Some(project_root.clone()),
@@ -1086,11 +1088,19 @@ mod tests {
             .expect("runtime workflow should be recorded");
         assert_eq!(instance.state, "scheduled");
         assert_eq!(instance.data["task_id"], task_id.0);
+        assert_eq!(
+            instance.data["additional_prompt"],
+            "preserve caller guidance"
+        );
         assert_eq!(instance.data["execution_path"], "workflow_runtime");
         let commands = runtime_store.commands_for(&workflow_id).await?;
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        assert_eq!(
+            commands[0].command.command["additional_prompt"],
+            "preserve caller guidance"
+        );
         assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
         Ok(())
     }

--- a/crates/harness-server/src/workflow_runtime_plan_issue.rs
+++ b/crates/harness-server/src/workflow_runtime_plan_issue.rs
@@ -150,12 +150,18 @@ async fn persist_plan_issue_decision(
     };
     store.record_decision(&record).await?;
     for command in &output.decision.commands {
-        let command_id = store
-            .enqueue_command(&instance.id, Some(&record.id), command)
-            .await?;
         if command.requires_runtime_job() {
             store
-                .mark_pending_command_status(&command_id, COMMAND_STATUS_HANDLED_INLINE)
+                .enqueue_command_with_status(
+                    &instance.id,
+                    Some(&record.id),
+                    command,
+                    COMMAND_STATUS_HANDLED_INLINE,
+                )
+                .await?;
+        } else {
+            store
+                .enqueue_command(&instance.id, Some(&record.id), command)
                 .await?;
         }
     }

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -43,13 +43,16 @@ async fn persist_issue_submission(
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, ctx.issue_number);
     upsert_github_issue_pr_definition(store).await?;
-    let instance = match store.get_instance(&workflow_id).await? {
-        Some(instance) => instance,
-        None => issue_instance(
-            workflow_id,
-            project_id.clone(),
-            ctx.repo.map(ToOwned::to_owned),
-            ctx.issue_number,
+    let (instance, new_instance) = match store.get_instance(&workflow_id).await? {
+        Some(instance) => (instance, false),
+        None => (
+            issue_instance(
+                workflow_id,
+                project_id.clone(),
+                ctx.repo.map(ToOwned::to_owned),
+                ctx.issue_number,
+            ),
+            true,
         ),
     };
     let submitted_data = issue_submission_data(ctx, &project_id);
@@ -63,12 +66,21 @@ async fn persist_issue_submission(
             force_execute: ctx.force_execute,
         },
     );
-    apply_decision(store, instance, output.decision, ctx, submitted_data).await
+    apply_decision(
+        store,
+        instance,
+        new_instance,
+        output.decision,
+        ctx,
+        submitted_data,
+    )
+    .await
 }
 
 async fn apply_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
+    new_instance: bool,
     decision: WorkflowDecision,
     ctx: &IssueSubmissionRuntimeContext<'_>,
     accepted_data: serde_json::Value,
@@ -80,6 +92,9 @@ async fn apply_decision(
     };
     let validation =
         DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context);
+    if new_instance {
+        store.upsert_instance(&instance).await?;
+    }
     let event = store
         .append_event(
             &instance.id,

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -21,6 +21,8 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub additional_prompt: Option<&'a str>,
     pub depends_on: &'a [TaskId],
     pub dependencies_blocked: bool,
+    pub source: Option<&'a str>,
+    pub external_id: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -498,6 +500,8 @@ fn issue_submission_data(
             "additional_prompt": ctx.additional_prompt,
             "depends_on": depends_on_strings(ctx.depends_on),
             "dependencies_blocked": ctx.dependencies_blocked,
+            "source": ctx.source,
+            "external_id": ctx.external_id,
         }),
     )
 }
@@ -656,6 +660,8 @@ mod tests {
                 additional_prompt: Some("include the regression test first"),
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: Some("github"),
+                external_id: Some("issue:42"),
             },
         )
         .await?;
@@ -680,6 +686,8 @@ mod tests {
             instance.data["additional_prompt"],
             "include the regression test first"
         );
+        assert_eq!(instance.data["source"], "github");
+        assert_eq!(instance.data["external_id"], "issue:42");
         assert_eq!(instance.data["last_decision"], "submit_issue");
         assert_eq!(
             instance.data["execution_path"],
@@ -733,6 +741,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -748,6 +758,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -808,6 +820,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -900,6 +914,8 @@ mod tests {
                 additional_prompt: Some("do not clobber existing metadata"),
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -965,6 +981,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: std::slice::from_ref(&dep_id),
                 dependencies_blocked: true,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -1026,6 +1044,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: &[],
                 dependencies_blocked: false,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -1049,6 +1069,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: std::slice::from_ref(&dep_id),
                 dependencies_blocked: true,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -1093,6 +1115,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: std::slice::from_ref(&old_dep_id),
                 dependencies_blocked: true,
+                source: None,
+                external_id: None,
             },
         )
         .await?;
@@ -1116,6 +1140,8 @@ mod tests {
                 additional_prompt: None,
                 depends_on: std::slice::from_ref(&ready_dep_id),
                 dependencies_blocked: true,
+                source: None,
+                external_id: None,
             },
         )
         .await?;

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,0 +1,324 @@
+use crate::task_runner::TaskId;
+use harness_workflow::runtime::{
+    build_issue_submission_decision, DecisionValidator, IssueSubmissionDecisionInput,
+    ValidationContext, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+};
+use serde_json::json;
+use std::path::Path;
+
+const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
+const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
+
+pub(crate) struct IssueSubmissionRuntimeContext<'a> {
+    pub project_root: &'a Path,
+    pub repo: Option<&'a str>,
+    pub issue_number: u64,
+    pub task_id: &'a TaskId,
+    pub labels: &'a [String],
+    pub force_execute: bool,
+}
+
+pub(crate) async fn record_issue_submission(
+    store: Option<&WorkflowRuntimeStore>,
+    ctx: IssueSubmissionRuntimeContext<'_>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    if let Err(error) = persist_issue_submission(store, &ctx).await {
+        tracing::warn!(
+            issue = ctx.issue_number,
+            repo = ctx.repo,
+            task_id = %ctx.task_id.0,
+            "workflow runtime issue submission write failed: {error}"
+        );
+    }
+}
+
+async fn persist_issue_submission(
+    store: &WorkflowRuntimeStore,
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+) -> anyhow::Result<()> {
+    let project_id = ctx.project_root.to_string_lossy().into_owned();
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, ctx.issue_number);
+    upsert_github_issue_pr_definition(store).await?;
+    let instance = match store.get_instance(&workflow_id).await? {
+        Some(instance) => instance,
+        None => issue_instance(
+            workflow_id,
+            project_id.clone(),
+            ctx.repo.map(ToOwned::to_owned),
+            ctx.issue_number,
+        ),
+    };
+    let submitted_data = issue_submission_data(ctx, &project_id);
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: ctx.task_id.as_str(),
+            repo: ctx.repo,
+            issue_number: ctx.issue_number,
+            labels: ctx.labels,
+            force_execute: ctx.force_execute,
+        },
+    );
+    apply_decision(store, instance, output.decision, ctx, submitted_data).await
+}
+
+async fn apply_decision(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    decision: WorkflowDecision,
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+    accepted_data: serde_json::Value,
+) -> anyhow::Result<()> {
+    let validation_context = if instance.is_terminal() {
+        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
+    } else {
+        ValidationContext::new("workflow-policy", chrono::Utc::now())
+    };
+    let validation =
+        DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context);
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueSubmitted",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": ctx.task_id.as_str(),
+                "repo": ctx.repo,
+                "issue_number": ctx.issue_number,
+                "labels": ctx.labels,
+                "force_execute": ctx.force_execute,
+                "execution_path": "legacy_task_runner",
+            }),
+        )
+        .await?;
+    let record = match validation {
+        Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id)),
+        Err(error) => {
+            let reason = error.to_string();
+            let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
+            store.record_decision(&record).await?;
+            return Ok(());
+        }
+    };
+    store.record_decision(&record).await?;
+    for command in &decision.commands {
+        if command.requires_runtime_job() {
+            store
+                .enqueue_command_with_status(
+                    &instance.id,
+                    Some(&record.id),
+                    command,
+                    COMMAND_STATUS_HANDLED_INLINE,
+                )
+                .await?;
+        } else {
+            store
+                .enqueue_command(&instance.id, Some(&record.id), command)
+                .await?;
+        }
+    }
+    instance.state = decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_last_decision(accepted_data, &decision.decision);
+    store.upsert_instance(&instance).await
+}
+
+async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
+    store
+        .upsert_definition(&WorkflowDefinition::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "GitHub issue PR workflow",
+        ))
+        .await
+}
+
+fn issue_instance(
+    workflow_id: String,
+    project_id: String,
+    repo: Option<String>,
+    issue_number: u64,
+) -> WorkflowInstance {
+    WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "discovered",
+        WorkflowSubject::new("issue", format!("issue:{issue_number}")),
+    )
+    .with_id(workflow_id)
+    .with_data(json!({
+        "project_id": project_id,
+        "repo": repo,
+        "issue_number": issue_number,
+    }))
+}
+
+fn issue_submission_data(
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+    project_id: &str,
+) -> serde_json::Value {
+    crate::workflow_runtime_policy::merge_runtime_retry_policy(
+        ctx.project_root,
+        json!({
+            "project_id": project_id,
+            "repo": ctx.repo,
+            "issue_number": ctx.issue_number,
+            "task_id": ctx.task_id.as_str(),
+            "labels": ctx.labels,
+            "force_execute": ctx.force_execute,
+        }),
+    )
+}
+
+fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_json::Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert("last_decision".to_string(), json!(decision));
+        object.insert("execution_path".to_string(), json!("legacy_task_runner"));
+    }
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::db::resolve_database_url;
+
+    async fn open_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
+        let database_url = resolve_database_url(None)?;
+        WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url)).await
+    }
+
+    #[tokio::test]
+    async fn issue_submission_records_inline_implementation_command() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("task-1");
+        let labels = vec!["bug".to_string(), "force-execute".to_string()];
+
+        record_issue_submission(
+            Some(&store),
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 42,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: true,
+            },
+        )
+        .await;
+
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            42,
+        );
+        let instance = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        assert_eq!(instance.state, "scheduled");
+        assert_eq!(instance.data["task_id"], "task-1");
+        assert_eq!(instance.data["last_decision"], "submit_issue");
+        assert_eq!(instance.data["execution_path"], "legacy_task_runner");
+
+        let events = store.events_for(&workflow_id).await?;
+        assert!(events
+            .iter()
+            .any(|event| event.event_type == "IssueSubmitted"));
+
+        let commands = store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, COMMAND_STATUS_HANDLED_INLINE);
+        assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        assert!(
+            store.pending_commands(10).await?.is_empty(),
+            "inline implementation command should not be visible as pending"
+        );
+        assert!(store
+            .runtime_jobs_for_command(&commands[0].id)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejected_issue_submission_keeps_existing_runtime_data() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let project_id = project_root.to_string_lossy().into_owned();
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 42);
+        let mut existing = issue_instance(
+            workflow_id.clone(),
+            project_id,
+            Some("owner/repo".to_string()),
+            42,
+        );
+        existing.state = "pr_open".to_string();
+        existing.data = serde_json::json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 42,
+            "task_id": "older-task",
+            "pr_url": "https://github.com/owner/repo/pull/99",
+            "last_decision": "bind_pr"
+        });
+        let original_data = existing.data.clone();
+        store.upsert_instance(&existing).await?;
+
+        let task_id = TaskId::from_str("new-task");
+        let labels = vec!["bug".to_string()];
+        record_issue_submission(
+            Some(&store),
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 42,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: false,
+            },
+        )
+        .await;
+
+        let persisted = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("existing workflow should remain persisted");
+        assert_eq!(persisted.state, "pr_open");
+        assert_eq!(persisted.data, original_data);
+        assert!(store.commands_for(&workflow_id).await?.is_empty());
+
+        let decisions = store.decisions_for(&workflow_id).await?;
+        assert_eq!(decisions.len(), 1);
+        assert!(!decisions[0].accepted);
+        assert!(decisions[0]
+            .rejection_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("TransitionNotAllowed")));
+
+        let events = store.events_for(&workflow_id).await?;
+        assert!(events
+            .iter()
+            .any(|event| event.event_type == "IssueSubmitted"));
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -679,7 +679,7 @@ mod tests {
             .get_instance(&workflow_id)
             .await?
             .expect("workflow should be persisted");
-        assert_eq!(instance.state, "scheduled");
+        assert_eq!(instance.state, "implementing");
         assert_eq!(instance.data["task_id"], "task-1");
         assert_eq!(instance.data["task_ids"], serde_json::json!(["task-1"]));
         assert_eq!(
@@ -1009,7 +1009,7 @@ mod tests {
             .get_instance(&result.workflow_id)
             .await?
             .expect("workflow should remain persisted");
-        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.state, "implementing");
         assert_eq!(workflow.data["dependencies_blocked"], false);
         let commands = store.commands_for(&result.workflow_id).await?;
         assert_eq!(commands.len(), 1);
@@ -1081,7 +1081,7 @@ mod tests {
             .get_instance(&blocked.workflow_id)
             .await?
             .expect("dependent workflow should remain persisted");
-        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.state, "implementing");
         assert_eq!(store.commands_for(&blocked.workflow_id).await?.len(), 1);
         Ok(())
     }
@@ -1155,7 +1155,7 @@ mod tests {
             .get_instance(&ready.workflow_id)
             .await?
             .expect("ready workflow should remain persisted");
-        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.state, "implementing");
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -190,8 +190,14 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
     let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
     let commands = store.commands_for(&cancelled.id).await?;
     for command in commands {
-        if command.status == "pending" {
-            store.mark_command_status(&command.id, "cancelled").await?;
+        if matches!(command.status.as_str(), "pending" | "dispatched") {
+            store
+                .cancel_command_and_unfinished_runtime_jobs(
+                    &command.id,
+                    "cancel_issue_submission",
+                    "Runtime issue submission was cancelled before execution.",
+                )
+                .await?;
         }
     }
     cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
@@ -775,6 +781,77 @@ mod tests {
                 .id,
             workflow.id
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancel_issue_submission_cancels_dispatched_runtime_jobs() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("runtime-handle-cancel");
+        let labels = vec!["bug".to_string()];
+        let result = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 42,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+            },
+        )
+        .await?;
+        let command_id = result
+            .command_ids
+            .first()
+            .expect("issue submission should enqueue an implementation command")
+            .clone();
+        store
+            .enqueue_runtime_job_for_pending_command(
+                &command_id,
+                harness_workflow::runtime::RuntimeKind::CodexExec,
+                "default",
+                json!({ "task_id": task_id.as_str() }),
+                None,
+            )
+            .await?;
+        assert_eq!(
+            store
+                .get_command(&command_id)
+                .await?
+                .expect("command should exist")
+                .status,
+            "dispatched"
+        );
+
+        let cancelled = cancel_issue_submission_by_task_id(&store, &task_id)
+            .await?
+            .expect("runtime issue submission should resolve by task id");
+        assert_eq!(cancelled.state, "cancelled");
+
+        let commands = store.commands_for(&result.workflow_id).await?;
+        let original_command = commands
+            .iter()
+            .find(|command| command.id == command_id)
+            .expect("original implementation command should remain visible");
+        assert_eq!(original_command.status, "cancelled");
+        let jobs = store.runtime_jobs_for_command(&command_id).await?;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(
+            jobs[0].status,
+            harness_workflow::runtime::RuntimeJobStatus::Cancelled
+        );
+        assert!(jobs[0].lease.is_none());
         Ok(())
     }
 

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -47,6 +47,41 @@ pub(crate) struct IssueDependencyReleaseSummary {
     pub skipped: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IssueDependencyStatus {
+    Done,
+    Failed,
+    Cancelled,
+    Waiting,
+}
+
+pub(crate) async fn resolve_issue_dependency_status(
+    store: Option<&WorkflowRuntimeStore>,
+    tasks: &TaskStore,
+    task_id: &TaskId,
+) -> anyhow::Result<IssueDependencyStatus> {
+    match tasks.dep_status(task_id).await {
+        Some(TaskStatus::Done) => return Ok(IssueDependencyStatus::Done),
+        Some(TaskStatus::Failed) => return Ok(IssueDependencyStatus::Failed),
+        Some(TaskStatus::Cancelled) => return Ok(IssueDependencyStatus::Cancelled),
+        Some(_) => return Ok(IssueDependencyStatus::Waiting),
+        None => {}
+    }
+
+    let Some(store) = store else {
+        return Ok(IssueDependencyStatus::Waiting);
+    };
+    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(IssueDependencyStatus::Waiting);
+    };
+    Ok(match instance.state.as_str() {
+        "done" => IssueDependencyStatus::Done,
+        "failed" => IssueDependencyStatus::Failed,
+        "cancelled" => IssueDependencyStatus::Cancelled,
+        _ => IssueDependencyStatus::Waiting,
+    })
+}
+
 pub(crate) async fn release_ready_issue_dependencies(
     store: &WorkflowRuntimeStore,
     tasks: &TaskStore,
@@ -69,23 +104,24 @@ pub(crate) async fn release_ready_issue_dependencies(
                     "workflow runtime dependency release skipped malformed issue data: {error}"
                 );
                 summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
                 continue;
             }
         };
         let mut all_done = true;
         let mut terminal_failure: Option<(TaskId, &'static str)> = None;
         for dep_id in &depends_on {
-            match tasks.dep_status(dep_id).await {
-                Some(TaskStatus::Done) => {}
-                Some(TaskStatus::Failed) => {
+            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
+                IssueDependencyStatus::Done => {}
+                IssueDependencyStatus::Failed => {
                     terminal_failure = Some((dep_id.clone(), "failed"));
                     break;
                 }
-                Some(TaskStatus::Cancelled) => {
+                IssueDependencyStatus::Cancelled => {
                     terminal_failure = Some((dep_id.clone(), "cancelled"));
                     break;
                 }
-                _ => all_done = false,
+                IssueDependencyStatus::Waiting => all_done = false,
             }
         }
         if let Some((dep_id, label)) = terminal_failure {
@@ -95,6 +131,7 @@ pub(crate) async fn release_ready_issue_dependencies(
             release_issue_after_dependencies(store, instance, &depends_on).await?;
             summary.released += 1;
         } else {
+            store.touch_instance(&instance.id).await?;
             summary.waiting += 1;
         }
     }
@@ -106,6 +143,14 @@ pub(crate) async fn runtime_issue_by_task_id(
     task_id: &TaskId,
 ) -> anyhow::Result<Option<WorkflowInstance>> {
     store.get_instance_by_task_id(task_id.as_str()).await
+}
+
+pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<TaskId> {
+    string_array_field(&instance.data, "task_ids")
+        .ok()
+        .and_then(|task_ids| task_ids.into_iter().next())
+        .or_else(|| optional_string_field(&instance.data, "task_id"))
+        .map(|task_id| TaskId::from_str(&task_id))
 }
 
 pub(crate) async fn cancel_issue_submission_by_task_id(
@@ -174,7 +219,7 @@ async fn persist_issue_submission(
             true,
         ),
     };
-    let submitted_data = issue_submission_data(ctx, &project_id);
+    let submitted_data = issue_submission_data(ctx, &project_id, &instance.data);
     let output = build_issue_submission_decision(
         &instance,
         IssueSubmissionDecisionInput {
@@ -432,6 +477,7 @@ fn issue_instance(
 fn issue_submission_data(
     ctx: &IssueSubmissionRuntimeContext<'_>,
     project_id: &str,
+    existing_data: &serde_json::Value,
 ) -> serde_json::Value {
     crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
@@ -440,6 +486,7 @@ fn issue_submission_data(
             "repo": ctx.repo,
             "issue_number": ctx.issue_number,
             "task_id": ctx.task_id.as_str(),
+            "task_ids": task_id_history(existing_data, ctx.task_id),
             "labels": ctx.labels,
             "force_execute": ctx.force_execute,
             "additional_prompt": ctx.additional_prompt,
@@ -494,6 +541,26 @@ fn task_ids_from_data(data: &serde_json::Value, field: &str) -> anyhow::Result<V
         .into_iter()
         .map(|task_id| TaskId::from_str(&task_id))
         .collect())
+}
+
+fn task_id_history(existing_data: &serde_json::Value, new_task_id: &TaskId) -> Vec<String> {
+    let mut task_ids = Vec::new();
+    if let Ok(existing_ids) = string_array_field(existing_data, "task_ids") {
+        for task_id in existing_ids {
+            push_unique_task_id(&mut task_ids, task_id);
+        }
+    }
+    if let Some(task_id) = optional_string_field(existing_data, "task_id") {
+        push_unique_task_id(&mut task_ids, task_id);
+    }
+    push_unique_task_id(&mut task_ids, new_task_id.as_str().to_string());
+    task_ids
+}
+
+fn push_unique_task_id(task_ids: &mut Vec<String>, task_id: String) {
+    if !task_ids.iter().any(|existing| existing == &task_id) {
+        task_ids.push(task_id);
+    }
 }
 
 fn depends_on_strings(depends_on: &[TaskId]) -> Vec<String> {
@@ -602,6 +669,7 @@ mod tests {
             .expect("workflow should be persisted");
         assert_eq!(instance.state, "scheduled");
         assert_eq!(instance.data["task_id"], "task-1");
+        assert_eq!(instance.data["task_ids"], serde_json::json!(["task-1"]));
         assert_eq!(
             instance.data["additional_prompt"],
             "include the regression test first"
@@ -630,6 +698,83 @@ mod tests {
             .runtime_jobs_for_command(&commands[0].id)
             .await?
             .is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_submission_preserves_prior_task_handles_for_lookup() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let labels = vec!["bug".to_string()];
+        let first_task_id = TaskId::from_str("runtime-handle-first");
+        let second_task_id = TaskId::from_str("runtime-handle-second");
+
+        record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 44,
+                task_id: &first_task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+            },
+        )
+        .await?;
+        let result = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 44,
+                task_id: &second_task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+            },
+        )
+        .await?;
+
+        assert!(result.accepted);
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        assert_eq!(
+            workflow.data["task_ids"],
+            serde_json::json!(["runtime-handle-first", "runtime-handle-second"])
+        );
+        assert_eq!(
+            runtime_issue_task_handle(&workflow)
+                .expect("runtime workflow should expose a stable handle")
+                .as_str(),
+            "runtime-handle-first"
+        );
+        assert_eq!(
+            runtime_issue_by_task_id(&store, &first_task_id)
+                .await?
+                .expect("first handle should resolve")
+                .id,
+            workflow.id
+        );
+        assert_eq!(
+            runtime_issue_by_task_id(&store, &second_task_id)
+                .await?
+                .expect("second handle should resolve")
+                .id,
+            workflow.id
+        );
         Ok(())
     }
 
@@ -775,6 +920,139 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_submission_releases_dependency_on_completed_runtime_handle() -> anyhow::Result<()>
+    {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let labels = vec!["bug".to_string()];
+        let dep_id = TaskId::from_str("runtime-dep-handle");
+        let dep_result = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 78,
+                task_id: &dep_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+            },
+        )
+        .await?;
+        let mut dep_workflow = store
+            .get_instance(&dep_result.workflow_id)
+            .await?
+            .expect("dependency workflow should exist");
+        dep_workflow.state = "done".to_string();
+        store.upsert_instance(&dep_workflow).await?;
+
+        let task_id = TaskId::from_str("runtime-dependent-handle");
+        let blocked = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 79,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: std::slice::from_ref(&dep_id),
+                dependencies_blocked: true,
+            },
+        )
+        .await?;
+
+        let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(released.released, 1);
+        let workflow = store
+            .get_instance(&blocked.workflow_id)
+            .await?
+            .expect("dependent workflow should remain persisted");
+        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(store.commands_for(&blocked.workflow_id).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dependency_release_rotates_waiting_rows_to_prevent_starvation() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let labels = vec!["bug".to_string()];
+
+        let old_dep_id = TaskId::from_str("old-blocked-dep");
+        let old_dep = crate::task_runner::TaskState::new(old_dep_id.clone());
+        task_store.insert(&old_dep).await;
+        let old_task_id = TaskId::from_str("old-waiting-handle");
+        record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 80,
+                task_id: &old_task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: std::slice::from_ref(&old_dep_id),
+                dependencies_blocked: true,
+            },
+        )
+        .await?;
+
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        let ready_dep_id = TaskId::from_str("ready-dep");
+        let mut ready_dep = crate::task_runner::TaskState::new(ready_dep_id.clone());
+        ready_dep.status = TaskStatus::Done;
+        task_store.insert(&ready_dep).await;
+        let ready_task_id = TaskId::from_str("ready-waiting-handle");
+        let ready = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 81,
+                task_id: &ready_task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: std::slice::from_ref(&ready_dep_id),
+                dependencies_blocked: true,
+            },
+        )
+        .await?;
+
+        let first = release_ready_issue_dependencies(&store, &task_store, 1).await?;
+        assert_eq!(first.waiting, 1);
+        assert_eq!(first.released, 0);
+        let second = release_ready_issue_dependencies(&store, &task_store, 1).await?;
+        assert_eq!(second.released, 1);
+        let workflow = store
+            .get_instance(&ready.workflow_id)
+            .await?
+            .expect("ready workflow should remain persisted");
+        assert_eq!(workflow.state, "scheduled");
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -17,6 +17,7 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub task_id: &'a TaskId,
     pub labels: &'a [String],
     pub force_execute: bool,
+    pub additional_prompt: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,6 +65,7 @@ async fn persist_issue_submission(
             issue_number: ctx.issue_number,
             labels: ctx.labels,
             force_execute: ctx.force_execute,
+            additional_prompt: ctx.additional_prompt,
         },
     );
     apply_decision(
@@ -106,6 +108,7 @@ async fn apply_decision(
                 "issue_number": ctx.issue_number,
                 "labels": ctx.labels,
                 "force_execute": ctx.force_execute,
+                "additional_prompt": ctx.additional_prompt,
                 "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )
@@ -190,6 +193,7 @@ fn issue_submission_data(
             "task_id": ctx.task_id.as_str(),
             "labels": ctx.labels,
             "force_execute": ctx.force_execute,
+            "additional_prompt": ctx.additional_prompt,
         }),
     )
 }
@@ -238,6 +242,7 @@ mod tests {
                 task_id: &task_id,
                 labels: &labels,
                 force_execute: true,
+                additional_prompt: Some("include the regression test first"),
             },
         )
         .await?;
@@ -257,6 +262,10 @@ mod tests {
             .expect("workflow should be persisted");
         assert_eq!(instance.state, "scheduled");
         assert_eq!(instance.data["task_id"], "task-1");
+        assert_eq!(
+            instance.data["additional_prompt"],
+            "include the regression test first"
+        );
         assert_eq!(instance.data["last_decision"], "submit_issue");
         assert_eq!(
             instance.data["execution_path"],
@@ -272,6 +281,10 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        assert_eq!(
+            commands[0].command.command["additional_prompt"],
+            "include the regression test first"
+        );
         assert_eq!(store.pending_commands(10).await?.len(), 1);
         assert!(store
             .runtime_jobs_for_command(&commands[0].id)
@@ -322,6 +335,7 @@ mod tests {
                 task_id: &task_id,
                 labels: &labels,
                 force_execute: false,
+                additional_prompt: Some("do not clobber existing metadata"),
             },
         )
         .await?;

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,8 +1,9 @@
-use crate::task_runner::TaskId;
+use crate::task_runner::{TaskId, TaskStatus, TaskStore};
 use harness_workflow::runtime::{
     build_issue_submission_decision, DecisionValidator, IssueSubmissionDecisionInput,
-    ValidationContext, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
-    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore,
+    WorkflowSubject,
 };
 use serde_json::json;
 use std::path::Path;
@@ -18,6 +19,8 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub labels: &'a [String],
     pub force_execute: bool,
     pub additional_prompt: Option<&'a str>,
+    pub depends_on: &'a [TaskId],
+    pub dependencies_blocked: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,6 +37,121 @@ pub(crate) async fn record_issue_submission(
     ctx: IssueSubmissionRuntimeContext<'_>,
 ) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
     persist_issue_submission(store, &ctx).await
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IssueDependencyReleaseSummary {
+    pub released: usize,
+    pub failed: usize,
+    pub waiting: usize,
+    pub skipped: usize,
+}
+
+pub(crate) async fn release_ready_issue_dependencies(
+    store: &WorkflowRuntimeStore,
+    tasks: &TaskStore,
+    limit: i64,
+) -> anyhow::Result<IssueDependencyReleaseSummary> {
+    let instances = store
+        .list_instances_by_state(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            "awaiting_dependencies",
+            limit,
+        )
+        .await?;
+    let mut summary = IssueDependencyReleaseSummary::default();
+    for instance in instances {
+        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed issue data: {error}"
+                );
+                summary.skipped += 1;
+                continue;
+            }
+        };
+        let mut all_done = true;
+        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
+        for dep_id in &depends_on {
+            match tasks.dep_status(dep_id).await {
+                Some(TaskStatus::Done) => {}
+                Some(TaskStatus::Failed) => {
+                    terminal_failure = Some((dep_id.clone(), "failed"));
+                    break;
+                }
+                Some(TaskStatus::Cancelled) => {
+                    terminal_failure = Some((dep_id.clone(), "cancelled"));
+                    break;
+                }
+                _ => all_done = false,
+            }
+        }
+        if let Some((dep_id, label)) = terminal_failure {
+            fail_issue_for_dependency(store, instance, &dep_id, label).await?;
+            summary.failed += 1;
+        } else if all_done {
+            release_issue_after_dependencies(store, instance, &depends_on).await?;
+            summary.released += 1;
+        } else {
+            summary.waiting += 1;
+        }
+    }
+    Ok(summary)
+}
+
+pub(crate) async fn runtime_issue_by_task_id(
+    store: &WorkflowRuntimeStore,
+    task_id: &TaskId,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    store.get_instance_by_task_id(task_id.as_str()).await
+}
+
+pub(crate) async fn cancel_issue_submission_by_task_id(
+    store: &WorkflowRuntimeStore,
+    task_id: &TaskId,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(None);
+    };
+    if instance.is_terminal() {
+        return Ok(Some(instance));
+    }
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueSubmissionCancelled",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": task_id.as_str(),
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "cancel_issue_submission",
+        "cancelled",
+        "operator cancelled the runtime issue submission",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkCancelled,
+        format!("issue-submit:{}:cancel", task_id.as_str()),
+        json!({ "task_id": task_id.as_str() }),
+    ))
+    .high_confidence();
+    let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
+    let commands = store.commands_for(&cancelled.id).await?;
+    for command in commands {
+        if command.status == "pending" {
+            store.mark_command_status(&command.id, "cancelled").await?;
+        }
+    }
+    cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
+    store.upsert_instance(&cancelled).await?;
+    Ok(Some(cancelled))
 }
 
 async fn persist_issue_submission(
@@ -66,6 +184,8 @@ async fn persist_issue_submission(
             labels: ctx.labels,
             force_execute: ctx.force_execute,
             additional_prompt: ctx.additional_prompt,
+            depends_on: &depends_on_strings(ctx.depends_on),
+            dependencies_blocked: ctx.dependencies_blocked,
         },
     );
     apply_decision(
@@ -109,6 +229,8 @@ async fn apply_decision(
                 "labels": ctx.labels,
                 "force_execute": ctx.force_execute,
                 "additional_prompt": ctx.additional_prompt,
+                "depends_on": depends_on_strings(ctx.depends_on),
+                "dependencies_blocked": ctx.dependencies_blocked,
                 "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )
@@ -148,6 +270,133 @@ async fn apply_decision(
         command_ids,
         rejection_reason: None,
     })
+}
+
+async fn release_issue_after_dependencies(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    depends_on: &[TaskId],
+) -> anyhow::Result<()> {
+    let fields = issue_submission_fields(&instance)?;
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: &fields.task_id,
+            repo: fields.repo.as_deref(),
+            issue_number: fields.issue_number,
+            labels: &fields.labels,
+            force_execute: fields.force_execute,
+            additional_prompt: fields.additional_prompt.as_deref(),
+            depends_on: &depends_on_strings(depends_on),
+            dependencies_blocked: false,
+        },
+    );
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueDependenciesSatisfied",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id,
+                "repo": fields.repo,
+                "issue_number": fields.issue_number,
+                "depends_on": depends_on_strings(depends_on),
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
+    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
+async fn fail_issue_for_dependency(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    dependency_id: &TaskId,
+    dependency_status: &str,
+) -> anyhow::Result<()> {
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueDependencyFailed",
+            "workflow_runtime_submission",
+            json!({
+                "dependency_task_id": dependency_id.as_str(),
+                "dependency_status": dependency_status,
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "dependency_failed",
+        "failed",
+        format!(
+            "dependency task {} {} before runtime issue submission could start",
+            dependency_id.as_str(),
+            dependency_status
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("issue-submit:{}:dependency-failed", dependency_id.as_str()),
+        json!({
+            "dependency_task_id": dependency_id.as_str(),
+            "dependency_status": dependency_status,
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        set_data_string(
+            instance.data.clone(),
+            "dependency_failure_task_id",
+            dependency_id.as_str(),
+        ),
+        "dependency_failure_status",
+        dependency_status,
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
+async fn commit_runtime_decision(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    decision: WorkflowDecision,
+    event_id: String,
+    accepted_data: Option<serde_json::Value>,
+) -> anyhow::Result<WorkflowInstance> {
+    let validation_context = if instance.is_terminal() {
+        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
+    } else {
+        ValidationContext::new("workflow-policy", chrono::Utc::now())
+    };
+    if let Err(error) =
+        DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context)
+    {
+        let reason = error.to_string();
+        let record = WorkflowDecisionRecord::rejected(decision, Some(event_id), &reason);
+        store.record_decision(&record).await?;
+        anyhow::bail!(reason);
+    }
+
+    let record = WorkflowDecisionRecord::accepted(decision.clone(), Some(event_id));
+    store.record_decision(&record).await?;
+    for command in &decision.commands {
+        store
+            .enqueue_command(&instance.id, Some(&record.id), command)
+            .await?;
+    }
+    instance.state = decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_last_decision(
+        accepted_data.unwrap_or_else(|| instance.data.clone()),
+        &decision.decision,
+    );
+    store.upsert_instance(&instance).await?;
+    Ok(instance)
 }
 
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -194,6 +443,8 @@ fn issue_submission_data(
             "labels": ctx.labels,
             "force_execute": ctx.force_execute,
             "additional_prompt": ctx.additional_prompt,
+            "depends_on": depends_on_strings(ctx.depends_on),
+            "dependencies_blocked": ctx.dependencies_blocked,
         }),
     )
 }
@@ -205,6 +456,93 @@ fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_jso
             "execution_path".to_string(),
             json!(EXECUTION_PATH_WORKFLOW_RUNTIME),
         );
+    }
+    data
+}
+
+#[derive(Debug)]
+struct IssueSubmissionFields {
+    task_id: String,
+    repo: Option<String>,
+    issue_number: u64,
+    labels: Vec<String>,
+    force_execute: bool,
+    additional_prompt: Option<String>,
+}
+
+fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueSubmissionFields> {
+    Ok(IssueSubmissionFields {
+        task_id: string_field(&instance.data, "task_id")?,
+        repo: optional_string_field(&instance.data, "repo"),
+        issue_number: instance
+            .data
+            .get("issue_number")
+            .and_then(|value| value.as_u64())
+            .ok_or_else(|| anyhow::anyhow!("runtime issue workflow is missing issue_number"))?,
+        labels: string_array_field(&instance.data, "labels")?,
+        force_execute: instance
+            .data
+            .get("force_execute")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        additional_prompt: optional_string_field(&instance.data, "additional_prompt"),
+    })
+}
+
+fn task_ids_from_data(data: &serde_json::Value, field: &str) -> anyhow::Result<Vec<TaskId>> {
+    Ok(string_array_field(data, field)?
+        .into_iter()
+        .map(|task_id| TaskId::from_str(&task_id))
+        .collect())
+}
+
+fn depends_on_strings(depends_on: &[TaskId]) -> Vec<String> {
+    depends_on
+        .iter()
+        .map(|task_id| task_id.as_str().to_string())
+        .collect()
+}
+
+fn string_field(data: &serde_json::Value, field: &str) -> anyhow::Result<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("runtime issue workflow is missing {field}"))
+}
+
+fn optional_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn string_array_field(data: &serde_json::Value, field: &str) -> anyhow::Result<Vec<String>> {
+    let Some(value) = data.get(field) else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = value.as_array() else {
+        anyhow::bail!("runtime issue workflow field {field} must be an array");
+    };
+    items
+        .iter()
+        .map(|item| {
+            item.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                anyhow::anyhow!("runtime issue workflow field {field} must contain strings")
+            })
+        })
+        .collect()
+}
+
+fn set_data_bool(mut data: serde_json::Value, key: &str, value: bool) -> serde_json::Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert(key.to_string(), json!(value));
+    }
+    data
+}
+
+fn set_data_string(mut data: serde_json::Value, key: &str, value: &str) -> serde_json::Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert(key.to_string(), json!(value));
     }
     data
 }
@@ -243,6 +581,8 @@ mod tests {
                 labels: &labels,
                 force_execute: true,
                 additional_prompt: Some("include the regression test first"),
+                depends_on: &[],
+                dependencies_blocked: false,
             },
         )
         .await?;
@@ -336,6 +676,8 @@ mod tests {
                 labels: &labels,
                 force_execute: false,
                 additional_prompt: Some("do not clobber existing metadata"),
+                depends_on: &[],
+                dependencies_blocked: false,
             },
         )
         .await?;
@@ -367,6 +709,72 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.event_type == "IssueSubmitted"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_submission_waits_for_dependencies_then_releases_runtime_command(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let dep_id = TaskId::from_str("dep-1");
+        let mut dep = crate::task_runner::TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Pending;
+        task_store.insert(&dep).await;
+
+        let task_id = TaskId::from_str("runtime-handle-1");
+        let labels = vec!["bug".to_string()];
+        let result = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 77,
+                task_id: &task_id,
+                labels: &labels,
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: std::slice::from_ref(&dep_id),
+                dependencies_blocked: true,
+            },
+        )
+        .await?;
+
+        assert!(result.accepted);
+        assert!(result.command_ids.is_empty());
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        assert_eq!(workflow.state, "awaiting_dependencies");
+        assert_eq!(workflow.data["depends_on"], serde_json::json!(["dep-1"]));
+        assert!(store.commands_for(&result.workflow_id).await?.is_empty());
+
+        let waiting = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(waiting.waiting, 1);
+        assert_eq!(waiting.released, 0);
+
+        dep.status = TaskStatus::Done;
+        task_store.insert(&dep).await;
+        let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(released.released, 1);
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        assert_eq!(workflow.state, "scheduled");
+        assert_eq!(workflow.data["dependencies_blocked"], false);
+        let commands = store.commands_for(&result.workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -7,8 +7,8 @@ use harness_workflow::runtime::{
 use serde_json::json;
 use std::path::Path;
 
-const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
 const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
+const EXECUTION_PATH_WORKFLOW_RUNTIME: &str = "workflow_runtime";
 
 pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub project_root: &'a Path,
@@ -19,27 +19,26 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub force_execute: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IssueSubmissionRuntimeRecord {
+    pub workflow_id: String,
+    pub accepted: bool,
+    pub decision_id: String,
+    pub command_ids: Vec<String>,
+    pub rejection_reason: Option<String>,
+}
+
 pub(crate) async fn record_issue_submission(
-    store: Option<&WorkflowRuntimeStore>,
+    store: &WorkflowRuntimeStore,
     ctx: IssueSubmissionRuntimeContext<'_>,
-) {
-    let Some(store) = store else {
-        return;
-    };
-    if let Err(error) = persist_issue_submission(store, &ctx).await {
-        tracing::warn!(
-            issue = ctx.issue_number,
-            repo = ctx.repo,
-            task_id = %ctx.task_id.0,
-            "workflow runtime issue submission write failed: {error}"
-        );
-    }
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+    persist_issue_submission(store, &ctx).await
 }
 
 async fn persist_issue_submission(
     store: &WorkflowRuntimeStore,
     ctx: &IssueSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, ctx.issue_number);
@@ -73,7 +72,7 @@ async fn apply_decision(
     decision: WorkflowDecision,
     ctx: &IssueSubmissionRuntimeContext<'_>,
     accepted_data: serde_json::Value,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
     let validation_context = if instance.is_terminal() {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
@@ -92,7 +91,7 @@ async fn apply_decision(
                 "issue_number": ctx.issue_number,
                 "labels": ctx.labels,
                 "force_execute": ctx.force_execute,
-                "execution_path": "legacy_task_runner",
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )
         .await?;
@@ -102,30 +101,35 @@ async fn apply_decision(
             let reason = error.to_string();
             let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
             store.record_decision(&record).await?;
-            return Ok(());
+            return Ok(IssueSubmissionRuntimeRecord {
+                workflow_id: instance.id,
+                accepted: false,
+                decision_id: record.id,
+                command_ids: Vec::new(),
+                rejection_reason: Some(reason),
+            });
         }
     };
     store.record_decision(&record).await?;
+    let mut command_ids = Vec::with_capacity(decision.commands.len());
     for command in &decision.commands {
-        if command.requires_runtime_job() {
-            store
-                .enqueue_command_with_status(
-                    &instance.id,
-                    Some(&record.id),
-                    command,
-                    COMMAND_STATUS_HANDLED_INLINE,
-                )
-                .await?;
-        } else {
+        command_ids.push(
             store
                 .enqueue_command(&instance.id, Some(&record.id), command)
-                .await?;
-        }
+                .await?,
+        );
     }
     instance.state = decision.next_state.clone();
     instance.version = instance.version.saturating_add(1);
     instance.data = merge_last_decision(accepted_data, &decision.decision);
-    store.upsert_instance(&instance).await
+    store.upsert_instance(&instance).await?;
+    Ok(IssueSubmissionRuntimeRecord {
+        workflow_id: instance.id,
+        accepted: true,
+        decision_id: record.id,
+        command_ids,
+        rejection_reason: None,
+    })
 }
 
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -178,7 +182,10 @@ fn issue_submission_data(
 fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_json::Value {
     if let Some(object) = data.as_object_mut() {
         object.insert("last_decision".to_string(), json!(decision));
-        object.insert("execution_path".to_string(), json!("legacy_task_runner"));
+        object.insert(
+            "execution_path".to_string(),
+            json!(EXECUTION_PATH_WORKFLOW_RUNTIME),
+        );
     }
     data
 }
@@ -194,7 +201,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn issue_submission_records_inline_implementation_command() -> anyhow::Result<()> {
+    async fn issue_submission_records_pending_runtime_implementation_command() -> anyhow::Result<()>
+    {
         if !crate::test_helpers::db_tests_enabled().await {
             return Ok(());
         }
@@ -206,8 +214,8 @@ mod tests {
         let task_id = TaskId::from_str("task-1");
         let labels = vec!["bug".to_string(), "force-execute".to_string()];
 
-        record_issue_submission(
-            Some(&store),
+        let result = record_issue_submission(
+            &store,
             IssueSubmissionRuntimeContext {
                 project_root: &project_root,
                 repo: Some("owner/repo"),
@@ -217,7 +225,11 @@ mod tests {
                 force_execute: true,
             },
         )
-        .await;
+        .await?;
+
+        assert!(result.accepted);
+        assert_eq!(result.command_ids.len(), 1);
+        assert!(result.rejection_reason.is_none());
 
         let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
             &project_root.to_string_lossy(),
@@ -231,7 +243,10 @@ mod tests {
         assert_eq!(instance.state, "scheduled");
         assert_eq!(instance.data["task_id"], "task-1");
         assert_eq!(instance.data["last_decision"], "submit_issue");
-        assert_eq!(instance.data["execution_path"], "legacy_task_runner");
+        assert_eq!(
+            instance.data["execution_path"],
+            EXECUTION_PATH_WORKFLOW_RUNTIME
+        );
 
         let events = store.events_for(&workflow_id).await?;
         assert!(events
@@ -240,12 +255,9 @@ mod tests {
 
         let commands = store.commands_for(&workflow_id).await?;
         assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].status, COMMAND_STATUS_HANDLED_INLINE);
+        assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
-        assert!(
-            store.pending_commands(10).await?.is_empty(),
-            "inline implementation command should not be visible as pending"
-        );
+        assert_eq!(store.pending_commands(10).await?.len(), 1);
         assert!(store
             .runtime_jobs_for_command(&commands[0].id)
             .await?
@@ -286,8 +298,8 @@ mod tests {
 
         let task_id = TaskId::from_str("new-task");
         let labels = vec!["bug".to_string()];
-        record_issue_submission(
-            Some(&store),
+        let result = record_issue_submission(
+            &store,
             IssueSubmissionRuntimeContext {
                 project_root: &project_root,
                 repo: Some("owner/repo"),
@@ -297,7 +309,14 @@ mod tests {
                 force_execute: false,
             },
         )
-        .await;
+        .await?;
+
+        assert!(!result.accepted);
+        assert!(result.command_ids.is_empty());
+        assert!(result
+            .rejection_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("TransitionNotAllowed")));
 
         let persisted = store
             .get_instance(&workflow_id)

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -1,13 +1,14 @@
 use crate::http::AppState;
 use crate::task_executor::turn_lifecycle::TurnLifecycleOptions;
+use crate::task_runner::{TaskFailureKind, TaskKind, TaskState, TaskStatus};
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Duration;
 use harness_core::config::agents::SandboxMode;
 use harness_core::types::{AgentId, Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, ActivitySignal, DecisionValidator, RuntimeJob,
-    RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
+    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, DecisionValidator,
+    RuntimeJob, RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
     WorkflowDefinition, WorkflowInstance, WorkflowSubject, QUALITY_BLOCKED_SIGNAL,
     QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
     QUALITY_PASSED_SIGNAL,
@@ -69,7 +70,121 @@ pub(crate) async fn run_runtime_job_worker_tick(
     let worker = RuntimeWorker::new(store.as_ref(), owner).with_lease_ttl(lease_ttl);
     let executor = ServerRuntimeJobExecutor::new(state.clone());
     let completed = worker.run_once(&executor).await?;
+    if let Some(job) = completed.as_ref() {
+        if let Err(error) = notify_runtime_issue_terminal(state, job).await {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                "workflow runtime issue completion notification failed: {error}"
+            );
+        }
+    }
     Ok(RuntimeJobWorkerTick::from_completed_job(completed))
+}
+
+pub(crate) async fn notify_runtime_issue_terminal(
+    state: &AppState,
+    job: &RuntimeJob,
+) -> anyhow::Result<bool> {
+    let Some(workflow_id) = job.input.get("workflow_id").and_then(Value::as_str) else {
+        return Ok(false);
+    };
+    let result = runtime_job_activity_result(job);
+    notify_runtime_issue_terminal_workflow(state, workflow_id, result.as_ref()).await
+}
+
+pub(crate) async fn notify_runtime_issue_terminal_workflow(
+    state: &AppState,
+    workflow_id: &str,
+    result: Option<&ActivityResult>,
+) -> anyhow::Result<bool> {
+    let Some(callback) = state.intake.completion_callback.as_ref() else {
+        return Ok(false);
+    };
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(false);
+    };
+    let Some(instance) = store.get_instance(workflow_id).await? else {
+        return Ok(false);
+    };
+    let Some(task) = runtime_issue_completion_task(&instance, result) else {
+        return Ok(false);
+    };
+    callback(task).await;
+    Ok(true)
+}
+
+fn runtime_issue_completion_task(
+    instance: &WorkflowInstance,
+    result: Option<&ActivityResult>,
+) -> Option<TaskState> {
+    if instance.definition_id != "github_issue_pr" || !instance.is_terminal() {
+        return None;
+    }
+    let source = optional_data_string(instance, "source")?;
+    let external_id = optional_data_string(instance, "external_id")?;
+    let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(instance)?;
+    let status = task_status_for_runtime_state(&instance.state)?;
+    let mut task = TaskState::new(task_id);
+    task.task_kind = TaskKind::Issue;
+    task.status = status.clone();
+    task.failure_kind = runtime_failure_kind(&status, result);
+    task.source = Some(source);
+    task.external_id = Some(external_id);
+    task.repo = optional_data_string(instance, "repo");
+    task.issue = optional_data_u64(instance, "issue_number");
+    task.project_root = optional_data_string(instance, "project_id").map(PathBuf::from);
+    task.pr_url = optional_data_string(instance, "last_pr_url");
+    task.description = task.issue.map(|issue| format!("issue #{issue}"));
+    task.error = runtime_completion_error(&status, result);
+    Some(task)
+}
+
+fn task_status_for_runtime_state(state: &str) -> Option<TaskStatus> {
+    match state {
+        "done" => Some(TaskStatus::Done),
+        "failed" => Some(TaskStatus::Failed),
+        "cancelled" => Some(TaskStatus::Cancelled),
+        _ => None,
+    }
+}
+
+fn runtime_job_activity_result(job: &RuntimeJob) -> Option<ActivityResult> {
+    job.output
+        .as_ref()
+        .and_then(|output| serde_json::from_value(output.clone()).ok())
+}
+
+fn runtime_failure_kind(
+    status: &TaskStatus,
+    result: Option<&ActivityResult>,
+) -> Option<TaskFailureKind> {
+    if !status.is_failure() {
+        return None;
+    }
+    match result.and_then(|result| result.error_kind) {
+        Some(ActivityErrorKind::Retryable | ActivityErrorKind::ExternalDependency) => {
+            Some(TaskFailureKind::WorkspaceLifecycle)
+        }
+        _ => Some(TaskFailureKind::Task),
+    }
+}
+
+fn runtime_completion_error(
+    status: &TaskStatus,
+    result: Option<&ActivityResult>,
+) -> Option<String> {
+    if !status.is_failure() {
+        return None;
+    }
+    result
+        .and_then(|result| {
+            result
+                .error
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| (!result.summary.trim().is_empty()).then_some(result.summary.trim()))
+        })
+        .map(ToOwned::to_owned)
 }
 
 struct ServerRuntimeJobExecutor {
@@ -1042,6 +1157,15 @@ fn optional_data_u64(workflow: &WorkflowInstance, field: &str) -> Option<u64> {
     })
 }
 
+fn optional_data_string(workflow: &WorkflowInstance, field: &str) -> Option<String> {
+    workflow
+        .data
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn parse_issue_subject_key(subject_key: &str) -> anyhow::Result<u64> {
     subject_key
         .strip_prefix("issue:")
@@ -1407,6 +1531,70 @@ where
 #[cfg(test)]
 mod profile_tests {
     use super::*;
+
+    #[test]
+    fn runtime_issue_completion_task_preserves_intake_identity() {
+        let instance = WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "cancelled",
+            WorkflowSubject::new("issue", "issue:42"),
+        )
+        .with_data(json!({
+            "task_id": "runtime-task-42",
+            "project_id": "/tmp/project",
+            "repo": "owner/repo",
+            "issue_number": 42,
+            "source": "github",
+            "external_id": "issue:42",
+        }));
+        let result = ActivityResult::cancelled("implement_issue", "Runtime job was cancelled.");
+
+        let task = runtime_issue_completion_task(&instance, Some(&result))
+            .expect("terminal runtime issue should map to an intake task");
+
+        assert_eq!(task.id.as_str(), "runtime-task-42");
+        assert_eq!(task.task_kind, TaskKind::Issue);
+        assert_eq!(task.status, TaskStatus::Cancelled);
+        assert_eq!(task.source.as_deref(), Some("github"));
+        assert_eq!(task.external_id.as_deref(), Some("issue:42"));
+        assert_eq!(task.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(task.issue, Some(42));
+    }
+
+    #[test]
+    fn runtime_issue_completion_task_marks_retryable_failures_as_transient() {
+        let instance = WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "failed",
+            WorkflowSubject::new("issue", "issue:42"),
+        )
+        .with_data(json!({
+            "task_id": "runtime-task-42",
+            "project_id": "/tmp/project",
+            "repo": "owner/repo",
+            "issue_number": 42,
+            "source": "github",
+            "external_id": "issue:42",
+        }));
+        let result = ActivityResult::failed(
+            "implement_issue",
+            "Runtime dependency failed.",
+            "provider temporarily unavailable",
+        )
+        .with_error_kind(ActivityErrorKind::ExternalDependency);
+
+        let task = runtime_issue_completion_task(&instance, Some(&result))
+            .expect("terminal runtime issue should map to an intake task");
+
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert_eq!(task.failure_kind, Some(TaskFailureKind::WorkspaceLifecycle));
+        assert_eq!(
+            task.error.as_deref(),
+            Some("provider temporarily unavailable")
+        );
+    }
 
     #[test]
     fn runtime_profile_approval_policy_accepts_codex_values() {

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -142,7 +142,7 @@ impl<'a> RuntimeCommandDispatcher<'a> {
         Ok(outcomes)
     }
 
-    async fn dispatch_command(
+    pub async fn dispatch_command(
         &self,
         command: WorkflowCommandRecord,
     ) -> anyhow::Result<CommandDispatchOutcome> {

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -13,6 +13,7 @@ pub mod quality_gate;
 pub mod reducer;
 pub mod repo_backlog;
 pub mod store;
+pub mod submission;
 pub mod validator;
 pub mod worker;
 
@@ -52,6 +53,10 @@ pub use repo_backlog::{
     StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID,
 };
 pub use store::WorkflowRuntimeStore;
+pub use submission::{
+    build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
+    IssueSubmissionWorkflowAction,
+};
 pub use validator::{
     DecisionValidator, TransitionAllowlist, TransitionRule, ValidationContext,
     WorkflowDecisionRejection, WorkflowDecisionRejectionKind,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -422,11 +422,21 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<String> {
         let data = to_jsonb_string(command)?;
         let command_type = enum_str(&command.command_type)?;
-        let row: Option<(String,)> = sqlx::query_as(
+        let (id,): (String,) = sqlx::query_as(
             "INSERT INTO workflow_commands
                 (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
              VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-             ON CONFLICT (workflow_id, dedupe_key) DO NOTHING
+             ON CONFLICT (workflow_id, dedupe_key) DO UPDATE SET
+                status = CASE
+                    WHEN workflow_commands.status = 'pending' THEN EXCLUDED.status
+                    ELSE workflow_commands.status
+                END,
+                updated_at = CASE
+                    WHEN workflow_commands.status = 'pending'
+                         AND workflow_commands.status <> EXCLUDED.status
+                    THEN CURRENT_TIMESTAMP
+                    ELSE workflow_commands.updated_at
+                END
              RETURNING id",
         )
         .bind(Uuid::new_v4().to_string())
@@ -436,19 +446,6 @@ impl WorkflowRuntimeStore {
         .bind(&command.dedupe_key)
         .bind(status)
         .bind(&data)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if let Some((id,)) = row {
-            return Ok(id);
-        }
-
-        let (id,): (String,) = sqlx::query_as(
-            "SELECT id FROM workflow_commands
-             WHERE workflow_id = $1 AND dedupe_key = $2",
-        )
-        .bind(workflow_id)
-        .bind(&command.dedupe_key)
         .fetch_one(&self.pool)
         .await?;
         Ok(id)

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -409,12 +409,23 @@ impl WorkflowRuntimeStore {
         decision_id: Option<&str>,
         command: &WorkflowCommand,
     ) -> anyhow::Result<String> {
+        self.enqueue_command_with_status(workflow_id, decision_id, command, "pending")
+            .await
+    }
+
+    pub async fn enqueue_command_with_status(
+        &self,
+        workflow_id: &str,
+        decision_id: Option<&str>,
+        command: &WorkflowCommand,
+        status: &str,
+    ) -> anyhow::Result<String> {
         let data = to_jsonb_string(command)?;
         let command_type = enum_str(&command.command_type)?;
         let row: Option<(String,)> = sqlx::query_as(
             "INSERT INTO workflow_commands
                 (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
-             VALUES ($1, $2, $3, $4, $5, 'pending', $6::jsonb)
+             VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
              ON CONFLICT (workflow_id, dedupe_key) DO NOTHING
              RETURNING id",
         )
@@ -423,6 +434,7 @@ impl WorkflowRuntimeStore {
         .bind(decision_id)
         .bind(&command_type)
         .bind(&command.dedupe_key)
+        .bind(status)
         .bind(&data)
         .fetch_optional(&self.pool)
         .await?;

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -327,6 +327,26 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn list_instances_by_definition(
+        &self,
+        definition_id: &str,
+        project_id: Option<&str>,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE definition_id = $1
+               AND ($2::text IS NULL OR data->'data'->>'project_id' = $2)
+             ORDER BY updated_at DESC",
+        )
+        .bind(definition_id)
+        .bind(project_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
     pub async fn append_event(
         &self,
         workflow_id: &str,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -130,6 +130,14 @@ static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
               CREATE INDEX IF NOT EXISTS idx_runtime_jobs_ready
               ON runtime_jobs (status, not_before, created_at)",
     },
+    Migration {
+        version: 4,
+        description: "index runtime workflow handle lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_state
+              ON workflow_instances (definition_id, state, updated_at);
+              CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_id
+              ON workflow_instances ((data->'data'->>'task_id'))",
+    },
 ];
 
 pub struct WorkflowRuntimeStore {
@@ -239,6 +247,48 @@ impl WorkflowRuntimeStore {
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
+    }
+
+    pub async fn get_instance_by_task_id(
+        &self,
+        task_id: &str,
+    ) -> anyhow::Result<Option<WorkflowInstance>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE data->'data'->>'task_id' = $1
+             ORDER BY updated_at DESC
+             LIMIT 1",
+        )
+        .bind(task_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn list_instances_by_state(
+        &self,
+        definition_id: &str,
+        state: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let limit = limit.clamp(1, 500);
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE definition_id = $1
+               AND state = $2
+             ORDER BY updated_at ASC
+             LIMIT $3",
+        )
+        .bind(definition_id)
+        .bind(state)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
     }
 
     pub async fn list_instances(

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -994,6 +994,59 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn cancel_command_and_unfinished_runtime_jobs(
+        &self,
+        command_id: &str,
+        activity: &str,
+        summary: &str,
+    ) -> anyhow::Result<usize> {
+        let mut tx = self.pool.begin().await?;
+        let _command_row: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM workflow_commands WHERE id = $1 FOR UPDATE")
+                .bind(command_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, data::text FROM runtime_jobs
+             WHERE command_id = $1
+               AND status IN ('pending', 'running')
+             FOR UPDATE",
+        )
+        .bind(command_id)
+        .fetch_all(&mut *tx)
+        .await?;
+        let mut cancelled = 0usize;
+        for (id, data) in rows {
+            let mut job: RuntimeJob = serde_json::from_str(&data)?;
+            job.complete(&ActivityResult::cancelled(activity, summary))?;
+            let updated = to_jsonb_string(&job)?;
+            let status = enum_str(&job.status)?;
+            sqlx::query(
+                "UPDATE runtime_jobs
+                 SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = $4",
+            )
+            .bind(&status)
+            .bind(job.not_before)
+            .bind(&updated)
+            .bind(&id)
+            .execute(&mut *tx)
+            .await?;
+            cancelled += 1;
+        }
+        sqlx::query(
+            "UPDATE workflow_commands
+             SET status = 'cancelled', updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1
+               AND status IN ('pending', 'dispatched')",
+        )
+        .bind(command_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(cancelled)
+    }
+
     pub async fn runtime_jobs_for_commands(
         &self,
         command_ids: &[String],

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -138,6 +138,12 @@ static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
               CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_id
               ON workflow_instances ((data->'data'->>'task_id'))",
     },
+    Migration {
+        version: 5,
+        description: "index runtime workflow handle history",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_ids
+              ON workflow_instances USING GIN ((data->'data'->'task_ids'))",
+    },
 ];
 
 pub struct WorkflowRuntimeStore {
@@ -256,6 +262,7 @@ impl WorkflowRuntimeStore {
         let row: Option<(String,)> = sqlx::query_as(
             "SELECT data::text FROM workflow_instances
              WHERE data->'data'->>'task_id' = $1
+                OR data->'data'->'task_ids' ? $1
              ORDER BY updated_at DESC
              LIMIT 1",
         )
@@ -289,6 +296,14 @@ impl WorkflowRuntimeStore {
         rows.into_iter()
             .map(|(data,)| Ok(serde_json::from_str(&data)?))
             .collect()
+    }
+
+    pub async fn touch_instance(&self, workflow_id: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE workflow_instances SET updated_at = clock_timestamp() WHERE id = $1")
+            .bind(workflow_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     pub async fn list_instances(

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -13,6 +13,8 @@ pub struct IssueSubmissionDecisionInput<'a> {
     pub labels: &'a [String],
     pub force_execute: bool,
     pub additional_prompt: Option<&'a str>,
+    pub depends_on: &'a [String],
+    pub dependencies_blocked: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -25,36 +27,50 @@ pub fn build_issue_submission_decision(
     instance: &WorkflowInstance,
     input: IssueSubmissionDecisionInput<'_>,
 ) -> IssueSubmissionDecisionOutput {
-    let decision = WorkflowDecision::new(
+    let next_state = if input.dependencies_blocked {
+        "awaiting_dependencies"
+    } else {
+        "scheduled"
+    };
+    let reason = if input.dependencies_blocked {
+        "operator submitted the GitHub issue and it is waiting for dependencies"
+    } else {
+        "operator submitted the GitHub issue for implementation"
+    };
+    let mut decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
         "submit_issue",
-        "scheduled",
-        "operator submitted the GitHub issue for implementation",
-    )
-    .with_command(WorkflowCommand::new(
-        super::model::WorkflowCommandType::EnqueueActivity,
-        format!(
-            "issue-submit:{}:issue:{}:task:{}:implement",
-            repo_key(input.repo),
-            input.issue_number,
-            input.task_id
-        ),
-        serde_json::json!({
-            "activity": "implement_issue",
-            "additional_prompt": input.additional_prompt,
-        }),
-    ))
-    .with_evidence(WorkflowEvidence::new(
+        next_state,
+        reason,
+    );
+    if !input.dependencies_blocked {
+        decision = decision.with_command(WorkflowCommand::new(
+            super::model::WorkflowCommandType::EnqueueActivity,
+            format!(
+                "issue-submit:{}:issue:{}:task:{}:implement",
+                repo_key(input.repo),
+                input.issue_number,
+                input.task_id
+            ),
+            serde_json::json!({
+                "activity": "implement_issue",
+                "additional_prompt": input.additional_prompt,
+            }),
+        ));
+    }
+    let decision = decision.with_evidence(WorkflowEvidence::new(
         "task_submission",
         format!(
-            "task_id={} repo={} issue={} labels={} force_execute={} additional_prompt={}",
+            "task_id={} repo={} issue={} labels={} force_execute={} additional_prompt={} depends_on={} dependencies_blocked={}",
             input.task_id,
             repo_key(input.repo),
             input.issue_number,
             labels_summary(input.labels),
             input.force_execute,
-            input.additional_prompt.is_some()
+            input.additional_prompt.is_some(),
+            depends_on_summary(input.depends_on),
+            input.dependencies_blocked
         ),
     ))
     .high_confidence();
@@ -70,6 +86,13 @@ fn labels_summary(labels: &[String]) -> String {
         return "<none>".to_string();
     }
     labels.join(",")
+}
+
+fn depends_on_summary(depends_on: &[String]) -> String {
+    if depends_on.is_empty() {
+        return "<none>".to_string();
+    }
+    depends_on.join(",")
 }
 
 fn repo_key(repo: Option<&str>) -> &str {

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -12,6 +12,7 @@ pub struct IssueSubmissionDecisionInput<'a> {
     pub issue_number: u64,
     pub labels: &'a [String],
     pub force_execute: bool,
+    pub additional_prompt: Option<&'a str>,
 }
 
 #[derive(Debug, Clone)]
@@ -31,24 +32,29 @@ pub fn build_issue_submission_decision(
         "scheduled",
         "operator submitted the GitHub issue for implementation",
     )
-    .with_command(WorkflowCommand::enqueue_activity(
-        "implement_issue",
+    .with_command(WorkflowCommand::new(
+        super::model::WorkflowCommandType::EnqueueActivity,
         format!(
             "issue-submit:{}:issue:{}:task:{}:implement",
             repo_key(input.repo),
             input.issue_number,
             input.task_id
         ),
+        serde_json::json!({
+            "activity": "implement_issue",
+            "additional_prompt": input.additional_prompt,
+        }),
     ))
     .with_evidence(WorkflowEvidence::new(
         "task_submission",
         format!(
-            "task_id={} repo={} issue={} labels={} force_execute={}",
+            "task_id={} repo={} issue={} labels={} force_execute={} additional_prompt={}",
             input.task_id,
             repo_key(input.repo),
             input.issue_number,
             labels_summary(input.labels),
-            input.force_execute
+            input.force_execute,
+            input.additional_prompt.is_some()
         ),
     ))
     .high_confidence();

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -30,7 +30,7 @@ pub fn build_issue_submission_decision(
     let next_state = if input.dependencies_blocked {
         "awaiting_dependencies"
     } else {
-        "scheduled"
+        "implementing"
     };
     let reason = if input.dependencies_blocked {
         "operator submitted the GitHub issue and it is waiting for dependencies"

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -1,0 +1,71 @@
+use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueSubmissionWorkflowAction {
+    RunImplementation,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IssueSubmissionDecisionInput<'a> {
+    pub task_id: &'a str,
+    pub repo: Option<&'a str>,
+    pub issue_number: u64,
+    pub labels: &'a [String],
+    pub force_execute: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct IssueSubmissionDecisionOutput {
+    pub action: IssueSubmissionWorkflowAction,
+    pub decision: WorkflowDecision,
+}
+
+pub fn build_issue_submission_decision(
+    instance: &WorkflowInstance,
+    input: IssueSubmissionDecisionInput<'_>,
+) -> IssueSubmissionDecisionOutput {
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "submit_issue",
+        "scheduled",
+        "operator submitted the GitHub issue for implementation",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "implement_issue",
+        format!(
+            "issue-submit:{}:issue:{}:task:{}:implement",
+            repo_key(input.repo),
+            input.issue_number,
+            input.task_id
+        ),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "task_submission",
+        format!(
+            "task_id={} repo={} issue={} labels={} force_execute={}",
+            input.task_id,
+            repo_key(input.repo),
+            input.issue_number,
+            labels_summary(input.labels),
+            input.force_execute
+        ),
+    ))
+    .high_confidence();
+
+    IssueSubmissionDecisionOutput {
+        action: IssueSubmissionWorkflowAction::RunImplementation,
+        decision,
+    }
+}
+
+fn labels_summary(labels: &[String]) -> String {
+    if labels.is_empty() {
+        return "<none>".to_string();
+    }
+    labels.join(",")
+}
+
+fn repo_key(repo: Option<&str>) -> &str {
+    repo.unwrap_or("<none>")
+}

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -2458,6 +2458,70 @@ async fn runtime_store_can_insert_non_pending_command_atomically() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn runtime_store_non_pending_status_updates_existing_pending_command() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = project_issue_instance("/project-a", 123, "scheduled");
+    store.upsert_instance(&instance).await?;
+    let command =
+        WorkflowCommand::enqueue_activity("implement_issue", "issue-123-implement-inline");
+    let pending_id = store.enqueue_command(&instance.id, None, &command).await?;
+    let inline_id = store
+        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .await?;
+
+    assert_eq!(inline_id, pending_id);
+    let commands = store.commands_for(&instance.id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].status, "handled_inline");
+    assert!(
+        store.pending_commands(10).await?.is_empty(),
+        "dedupe conflict must not leave an inline command visible as pending"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_dedupe_status_update_does_not_regress_dispatched_command(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = project_issue_instance("/project-a", 123, "replanning");
+    store.upsert_instance(&instance).await?;
+    let command = WorkflowCommand::enqueue_activity("replan_issue", "issue-123-replan-dispatched");
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    let outcome = store
+        .enqueue_runtime_job_for_pending_command(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({"activity": "replan_issue"}),
+            None,
+        )
+        .await?;
+    assert!(matches!(outcome, RuntimeJobEnqueueOutcome::Enqueued(_)));
+
+    let duplicate_id = store
+        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .await?;
+
+    assert_eq!(duplicate_id, command_id);
+    assert_eq!(
+        store.commands_for(&instance.id).await?[0].status,
+        "dispatched"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_store_pending_command_enqueue_is_idempotent_across_concurrent_claims(
 ) -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -7,10 +7,11 @@ use super::model::{
 use super::store::RuntimeJobEnqueueOutcome;
 use super::validator::{DecisionValidator, ValidationContext, WorkflowDecisionRejectionKind};
 use super::{
-    build_merged_pr_decision, build_open_issue_without_workflow_decision,
-    build_plan_issue_decision, build_pr_detected_decision, build_pr_feedback_decision,
-    build_quality_gate_run_decision, build_stale_active_workflow_decision,
-    reduce_runtime_job_completed, CommandDispatchOutcome, InMemoryWorkflowBus,
+    build_issue_submission_decision, build_merged_pr_decision,
+    build_open_issue_without_workflow_decision, build_plan_issue_decision,
+    build_pr_detected_decision, build_pr_feedback_decision, build_quality_gate_run_decision,
+    build_stale_active_workflow_decision, reduce_runtime_job_completed, CommandDispatchOutcome,
+    InMemoryWorkflowBus, IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction,
     MergedPrDecisionInput, OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
     PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome, PrFeedbackWorkflowAction,
     QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogWorkflowAction,
@@ -69,6 +70,69 @@ fn project_issue_instance(project_id: &str, issue_number: u64, state: &str) -> W
 }
 
 #[test]
+fn issue_submission_decision_schedules_discovered_issue() {
+    let labels = vec!["bug".to_string(), "p1".to_string()];
+    let instance = issue_instance("discovered");
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: "task-1",
+            repo: Some("owner/repo"),
+            issue_number: 123,
+            labels: &labels,
+            force_execute: false,
+        },
+    );
+
+    assert_eq!(
+        output.action,
+        IssueSubmissionWorkflowAction::RunImplementation
+    );
+    assert_eq!(output.decision.decision, "submit_issue");
+    assert_eq!(output.decision.next_state, "scheduled");
+    assert_eq!(output.decision.commands.len(), 1);
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some("implement_issue")
+    );
+    assert_eq!(
+        output.decision.commands[0].dedupe_key,
+        "issue-submit:owner/repo:issue:123:task:task-1:implement"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("issue submission decision should validate");
+}
+
+#[test]
+fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
+    let labels = Vec::new();
+    let instance = issue_instance("failed");
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: "task-2",
+            repo: None,
+            issue_number: 124,
+            labels: &labels,
+            force_execute: true,
+        },
+    );
+
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()).allow_terminal_reopen(),
+        )
+        .expect("explicit issue submission should reopen failed workflows");
+}
+
+#[test]
 fn plan_issue_decision_runs_replan_when_policy_allows() {
     let instance = issue_instance("implementing");
     let output = build_plan_issue_decision(
@@ -96,6 +160,32 @@ fn plan_issue_decision_runs_replan_when_policy_allows() {
 }
 
 #[test]
+fn plan_issue_decision_replans_after_shadow_issue_submission() {
+    let instance = issue_instance("scheduled");
+    let output = build_plan_issue_decision(
+        &instance,
+        PlanIssueDecisionInput {
+            task_id: "task-1",
+            plan_issue: "plan missed rollback",
+            force_execute: false,
+            auto_replan_on_plan_issue: true,
+            replan_already_attempted: false,
+            turn_budget_exhausted: false,
+        },
+    );
+
+    assert_eq!(output.action, PlanIssueWorkflowAction::RunReplan);
+    assert_eq!(output.decision.next_state, "replanning");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("shadow-submitted issues should be allowed to replan");
+}
+
+#[test]
 fn plan_issue_decision_force_execute_continues_implementation() {
     let instance = issue_instance("implementing");
     let output = build_plan_issue_decision(
@@ -120,6 +210,32 @@ fn plan_issue_decision_force_execute_continues_implementation() {
             &ValidationContext::new("workflow-policy", Utc::now()),
         )
         .expect("force continue decision should validate");
+}
+
+#[test]
+fn plan_issue_force_continue_after_shadow_issue_submission() {
+    let instance = issue_instance("scheduled");
+    let output = build_plan_issue_decision(
+        &instance,
+        PlanIssueDecisionInput {
+            task_id: "task-1",
+            plan_issue: "plan missed rollback",
+            force_execute: true,
+            auto_replan_on_plan_issue: true,
+            replan_already_attempted: false,
+            turn_budget_exhausted: false,
+        },
+    );
+
+    assert_eq!(output.action, PlanIssueWorkflowAction::ForceContinue);
+    assert_eq!(output.decision.next_state, "implementing");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("shadow-submitted issues should allow force continue");
 }
 
 #[test]
@@ -189,6 +305,29 @@ fn pr_detected_decision_binds_pr_from_implementation() {
             &ValidationContext::new("workflow-policy", Utc::now()),
         )
         .expect("PR binding decision should validate");
+}
+
+#[test]
+fn pr_detected_decision_binds_pr_after_shadow_issue_submission() {
+    let instance = issue_instance("scheduled");
+    let output = build_pr_detected_decision(
+        &instance,
+        PrDetectedDecisionInput {
+            task_id: "task-1",
+            pr_number: 77,
+            pr_url: "https://github.com/owner/repo/pull/77",
+        },
+    );
+
+    assert_eq!(output.action, PrFeedbackWorkflowAction::BindPr);
+    assert_eq!(output.decision.next_state, "pr_open");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("shadow-submitted issues should bind a produced PR");
 }
 
 #[test]
@@ -1306,6 +1445,31 @@ fn rejects_pr_open_transition_without_bind_pr_command() {
 }
 
 #[test]
+fn rejects_scheduled_pr_open_transition_without_bind_pr_command() {
+    let instance = issue_instance("scheduled");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "scheduled",
+        "agent_reported_pr_open",
+        "pr_open",
+        "The legacy implementation produced a PR without binding PR metadata.",
+    )
+    .with_command(WorkflowCommand::wait(
+        "PR metadata was omitted.",
+        "issue-123-pr-open-wait",
+    ));
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(&instance, &decision, &validation_context())
+        .expect_err("scheduled -> pr_open should require BindPr");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::RequiredCommandMissing
+    );
+}
+
+#[test]
 fn rejects_done_transition_without_mark_done_command() {
     let instance = issue_instance("ready_to_merge");
     let decision = WorkflowDecision::new(
@@ -2263,6 +2427,33 @@ async fn runtime_command_dispatcher_enqueues_runtime_job_for_activity_command() 
         "dispatched"
     );
     assert!(dispatcher.dispatch_once().await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_can_insert_non_pending_command_atomically() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = project_issue_instance("/project-a", 123, "scheduled");
+    store.upsert_instance(&instance).await?;
+    let command =
+        WorkflowCommand::enqueue_activity("implement_issue", "issue-123-implement-inline");
+    let command_id = store
+        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .await?;
+
+    let commands = store.commands_for(&instance.id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].id, command_id);
+    assert_eq!(commands[0].status, "handled_inline");
+    assert!(
+        store.pending_commands(10).await?.is_empty(),
+        "inline commands must never be visible to the dispatcher as pending"
+    );
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -70,7 +70,7 @@ fn project_issue_instance(project_id: &str, issue_number: u64, state: &str) -> W
 }
 
 #[test]
-fn issue_submission_decision_schedules_discovered_issue() {
+fn issue_submission_decision_starts_discovered_issue_implementation() {
     let labels = vec!["bug".to_string(), "p1".to_string()];
     let instance = issue_instance("discovered");
     let output = build_issue_submission_decision(
@@ -92,7 +92,7 @@ fn issue_submission_decision_schedules_discovered_issue() {
         IssueSubmissionWorkflowAction::RunImplementation
     );
     assert_eq!(output.decision.decision, "submit_issue");
-    assert_eq!(output.decision.next_state, "scheduled");
+    assert_eq!(output.decision.next_state, "implementing");
     assert_eq!(output.decision.commands.len(), 1);
     assert_eq!(
         output.decision.commands[0].activity_name(),

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -81,6 +81,7 @@ fn issue_submission_decision_schedules_discovered_issue() {
             issue_number: 123,
             labels: &labels,
             force_execute: false,
+            additional_prompt: Some("prefer a minimal patch"),
         },
     );
 
@@ -98,6 +99,10 @@ fn issue_submission_decision_schedules_discovered_issue() {
     assert_eq!(
         output.decision.commands[0].dedupe_key,
         "issue-submit:owner/repo:issue:123:task:task-1:implement"
+    );
+    assert_eq!(
+        output.decision.commands[0].command["additional_prompt"],
+        "prefer a minimal patch"
     );
     DecisionValidator::github_issue_pr()
         .validate(
@@ -120,6 +125,7 @@ fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
             issue_number: 124,
             labels: &labels,
             force_execute: true,
+            additional_prompt: None,
         },
     );
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -82,6 +82,8 @@ fn issue_submission_decision_schedules_discovered_issue() {
             labels: &labels,
             force_execute: false,
             additional_prompt: Some("prefer a minimal patch"),
+            depends_on: &[],
+            dependencies_blocked: false,
         },
     );
 
@@ -126,6 +128,8 @@ fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
             labels: &labels,
             force_execute: true,
             additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
         },
     );
 
@@ -136,6 +140,36 @@ fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
             &ValidationContext::new("workflow-policy", Utc::now()).allow_terminal_reopen(),
         )
         .expect("explicit issue submission should reopen failed workflows");
+}
+
+#[test]
+fn issue_submission_decision_waits_for_dependencies_without_runtime_command() {
+    let labels = Vec::new();
+    let depends_on = vec!["task-upstream".to_string()];
+    let instance = issue_instance("discovered");
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: "task-3",
+            repo: Some("owner/repo"),
+            issue_number: 125,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &depends_on,
+            dependencies_blocked: true,
+        },
+    );
+
+    assert_eq!(output.decision.next_state, "awaiting_dependencies");
+    assert!(output.decision.commands.is_empty());
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("blocked issue submission should validate without dispatching");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -98,6 +98,15 @@ impl TransitionAllowlist {
         };
 
         Self::default()
+            .allow("discovered", "awaiting_dependencies", [Wait])
+            .allow("failed", "awaiting_dependencies", [Wait])
+            .allow("cancelled", "awaiting_dependencies", [Wait])
+            .allow("awaiting_dependencies", "awaiting_dependencies", [Wait])
+            .allow(
+                "awaiting_dependencies",
+                "scheduled",
+                [EnqueueActivity, Wait],
+            )
             .allow("discovered", "scheduled", [EnqueueActivity, Wait])
             .allow("scheduled", "scheduled", [EnqueueActivity, Wait])
             .allow("failed", "scheduled", [EnqueueActivity, Wait])

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -99,8 +99,20 @@ impl TransitionAllowlist {
 
         Self::default()
             .allow("discovered", "scheduled", [EnqueueActivity, Wait])
+            .allow("scheduled", "scheduled", [EnqueueActivity, Wait])
+            .allow("failed", "scheduled", [EnqueueActivity, Wait])
+            .allow("cancelled", "scheduled", [EnqueueActivity, Wait])
             .allow("scheduled", "planning", [EnqueueActivity, Wait])
-            .allow("scheduled", "implementing", [EnqueueActivity, Wait])
+            .allow(
+                "scheduled",
+                "implementing",
+                [EnqueueActivity, RecordPlanConcern, Wait],
+            )
+            .allow(
+                "scheduled",
+                "replanning",
+                [EnqueueActivity, RecordPlanConcern, MarkBlocked, Wait],
+            )
             .allow("planning", "implementing", [EnqueueActivity, MarkBlocked])
             .allow(
                 "implementing",
@@ -119,6 +131,11 @@ impl TransitionAllowlist {
             )
             .allow(
                 "implementing",
+                "pr_open",
+                [BindPr, EnqueueActivity, StartChildWorkflow, Wait],
+            )
+            .allow(
+                "scheduled",
                 "pr_open",
                 [BindPr, EnqueueActivity, StartChildWorkflow, Wait],
             )
@@ -541,7 +558,7 @@ fn required_command_for_transition(
     to_state: &str,
 ) -> Option<WorkflowCommandType> {
     match (from_state, to_state) {
-        ("implementing", "pr_open") => Some(WorkflowCommandType::BindPr),
+        (from_state, "pr_open") if from_state != "pr_open" => Some(WorkflowCommandType::BindPr),
         (_, "done") => Some(WorkflowCommandType::MarkDone),
         (_, "blocked") => Some(WorkflowCommandType::MarkBlocked),
         (_, "failed") => Some(WorkflowCommandType::MarkFailed),

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -107,10 +107,18 @@ impl TransitionAllowlist {
                 "scheduled",
                 [EnqueueActivity, Wait],
             )
+            .allow(
+                "awaiting_dependencies",
+                "implementing",
+                [EnqueueActivity, Wait],
+            )
             .allow("discovered", "scheduled", [EnqueueActivity, Wait])
+            .allow("discovered", "implementing", [EnqueueActivity, Wait])
             .allow("scheduled", "scheduled", [EnqueueActivity, Wait])
             .allow("failed", "scheduled", [EnqueueActivity, Wait])
+            .allow("failed", "implementing", [EnqueueActivity, Wait])
             .allow("cancelled", "scheduled", [EnqueueActivity, Wait])
+            .allow("cancelled", "implementing", [EnqueueActivity, Wait])
             .allow("scheduled", "planning", [EnqueueActivity, Wait])
             .allow(
                 "scheduled",

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -31,8 +31,8 @@ Implemented now:
 - runtime tree API and dashboard runtime job rows include runtime event counts, latest event type,
   retry cooldown, and prompt packet digest summaries
 - workflow command outbox dispatcher that converts pending runtime commands into runtime jobs
-- opt-in server background loop for workflow command dispatch
-- opt-in server background runtime worker that executes runtime jobs through registered agents
+- default-enabled server background loop for workflow command dispatch
+- default-enabled server background runtime worker that executes runtime jobs through registered agents
 - runtime job completion writes back command status and workflow completion events
 - runtime completion reducer advances known workflow states from activity output
 - runtime completion reducer returns repo backlog workflows to `idle` after successful dispatch or
@@ -66,20 +66,18 @@ Implemented now:
   next states and command types for structured `workflow_decision` artifacts
 - `quality_gate` is registered as a first-class runtime workflow contract with a run decision
   helper, transition validator, completion reducer, retry support, and activity result schema
-- issue `POST /tasks` submissions now shadow-write `github_issue_pr` workflow runtime state with
-  `IssueSubmitted`, a validated `submit_issue` decision, and an inline-handled `implement_issue`
-  command while the legacy task runner remains the execution path
+- issue `POST /tasks` submissions now write `github_issue_pr` workflow runtime state with
+  `IssueSubmitted`, a validated `submit_issue` decision, and a pending `implement_issue`
+  command that is dispatched to runtime jobs instead of the legacy task runner
 
 Still intentionally not moved yet:
 
-- existing task runner ownership of process execution
 - repo backlog polling as the primary controller
-- full workflow-first replacement for legacy task submission routes
+- prompt-only and PR feedback task submissions still use the existing task routes
 - dashboard write actions still use existing task routes
 
 ## Non-Goals
 
-- Do not replace the current task execution path in the first change.
 - Do not remove existing Codex, Claude, workspace, queue, dashboard, or recovery code.
 - Do not introduce a YAML workflow DSL before the runtime contract is proven.
 - Do not make Rust code interpret GitHub PR feedback as product policy.
@@ -517,14 +515,14 @@ Tests:
 
 Status: partially implemented.
 
-Run the command outbox dispatcher from the server as an opt-in background loop.
+Run the command outbox dispatcher from the server as a policy-controlled background loop.
 
 Implemented now:
 
 - `WORKFLOW.md` supports `runtime_dispatch` policy fields
 - the server spawns a weak-reference runtime command dispatcher loop when the workflow runtime store
   is available
-- the loop is disabled by default while workflow runtime execution remains opt-in
+- the loop is enabled by default and can be disabled explicitly in `WORKFLOW.md`
 - each tick converts pending command rows into runtime jobs using the configured runtime profile
 
 Still intentionally not moved yet:
@@ -542,8 +540,7 @@ Tests:
 
 Status: partially implemented.
 
-Run claimed runtime jobs through the existing agent turn lifecycle while keeping the workflow
-runtime opt-in.
+Run claimed runtime jobs through the existing agent turn lifecycle under workflow policy control.
 
 Implemented now:
 
@@ -847,12 +844,12 @@ Tests:
 - runtime worker passes profile approval policy into the agent request
 - runtime worker rejects unknown approval policies and non-Codex approval policy usage
 
-### Phase 18: Workflow-First Task Submission Shadow
+### Phase 18: Workflow-First Task Submission
 
-Status: partially implemented.
+Status: implemented for GitHub issue submissions.
 
-Record operator task submissions in the workflow runtime before replacing the legacy task runner as
-the execution path.
+Route operator GitHub issue submissions through the workflow runtime instead of the legacy task
+runner.
 
 Implemented now:
 
@@ -862,24 +859,23 @@ Implemented now:
   `scheduled`, `failed`, or `cancelled` to `scheduled`
 - the accepted decision writes an `implement_issue` command with task-scoped dedupe so explicit
   resubmissions create a new auditable workflow command
-- the command is marked `handled_inline` so the existing task runner can execute the work without
-  the runtime dispatcher starting a duplicate agent turn
-- runtime submission tracking is independent from the legacy issue workflow store, so runtime state
-  is still recorded when only `WorkflowRuntimeStore` is configured
+- the command is left `pending` so the runtime dispatcher can materialize it into a runtime job
+- issue submission requires `WorkflowRuntimeStore`; missing runtime storage is a hard server error
+- issue submissions no longer register legacy task rows or call the legacy task runner
 
 Still intentionally not moved yet:
 
 - prompt-only submissions remain task-runner native
 - PR feedback submissions remain on the existing PR feedback sweep/task path
-- `POST /tasks` still returns task ids and starts the legacy task runner for execution
-- pending submission commands are not yet materialized into runtime jobs by default
+- the `task_id` returned for issue submissions is now a workflow submission correlation id, not a
+  legacy task row id
 
 Tests:
 
 - issue submission decisions validate in the workflow contract layer
 - failed issue workflows can be explicitly reopened by operator submission
-- server submission tracking records `IssueSubmitted`, scheduled state, and an inline-handled
-  `implement_issue` command without creating a runtime job
+- server submission tracking records `IssueSubmitted`, scheduled state, and a pending
+  `implement_issue` command without registering a legacy task row
 
 ## Test Strategy
 

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -66,12 +66,15 @@ Implemented now:
   next states and command types for structured `workflow_decision` artifacts
 - `quality_gate` is registered as a first-class runtime workflow contract with a run decision
   helper, transition validator, completion reducer, retry support, and activity result schema
+- issue `POST /tasks` submissions now shadow-write `github_issue_pr` workflow runtime state with
+  `IssueSubmitted`, a validated `submit_issue` decision, and an inline-handled `implement_issue`
+  command while the legacy task runner remains the execution path
 
 Still intentionally not moved yet:
 
 - existing task runner ownership of process execution
 - repo backlog polling as the primary controller
-- workflow-first replacement for legacy task submission routes
+- full workflow-first replacement for legacy task submission routes
 - dashboard write actions still use existing task routes
 
 ## Non-Goals
@@ -843,6 +846,40 @@ Tests:
 - Codex app-server thread and turn payloads include `approvalPolicy`
 - runtime worker passes profile approval policy into the agent request
 - runtime worker rejects unknown approval policies and non-Codex approval policy usage
+
+### Phase 18: Workflow-First Task Submission Shadow
+
+Status: partially implemented.
+
+Record operator task submissions in the workflow runtime before replacing the legacy task runner as
+the execution path.
+
+Implemented now:
+
+- issue `POST /tasks` submissions write an `IssueSubmitted` event to the matching
+  `github_issue_pr` workflow instance
+- the workflow policy records a validated `submit_issue` decision from `discovered`,
+  `scheduled`, `failed`, or `cancelled` to `scheduled`
+- the accepted decision writes an `implement_issue` command with task-scoped dedupe so explicit
+  resubmissions create a new auditable workflow command
+- the command is marked `handled_inline` so the existing task runner can execute the work without
+  the runtime dispatcher starting a duplicate agent turn
+- runtime submission tracking is independent from the legacy issue workflow store, so runtime state
+  is still recorded when only `WorkflowRuntimeStore` is configured
+
+Still intentionally not moved yet:
+
+- prompt-only submissions remain task-runner native
+- PR feedback submissions remain on the existing PR feedback sweep/task path
+- `POST /tasks` still returns task ids and starts the legacy task runner for execution
+- pending submission commands are not yet materialized into runtime jobs by default
+
+Tests:
+
+- issue submission decisions validate in the workflow contract layer
+- failed issue workflows can be explicitly reopened by operator submission
+- server submission tracking records `IssueSubmitted`, scheduled state, and an inline-handled
+  `implement_issue` command without creating a runtime job
 
 ## Test Strategy
 

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -447,12 +447,12 @@ Implemented now:
 - `RuntimeWorker` that claims one pending runtime job, records claim/result events, executes the
   adapter, and completes the durable job
 - `ActivityResult::cancelled` so cancellation can be represented as a structured runtime result
+- command outbox rows are automatically converted into runtime jobs by the server dispatch loop
+- server-owned runtime workers claim pending runtime jobs through registered agent runtimes
 
 Still intentionally not moved yet:
 
-- Codex exec/jsonrpc and Claude Code adapters still run through the current task executor
-- command outbox rows are not yet automatically converted into runtime jobs
-- runtime workers are not yet spawned as server-owned background processes
+- prompt-only and PR feedback submissions still use the current task executor
 
 Tests:
 


### PR DESCRIPTION
## Summary

- Add a workflow-runtime issue submission decision that records `IssueSubmitted` and a validated `submit_issue` transition.
- Wire issue `POST /tasks` tracking to persist `github_issue_pr` runtime state independently from the legacy issue workflow store.
- Mark the emitted `implement_issue` command as `handled_inline` so the existing task runner remains the execution path without duplicate runtime dispatch.
- Document this as the next partial workflow-first migration phase.

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo test -p harness-workflow issue_submission`
- `cargo test -p harness-server workflow_runtime_submission::tests::issue_submission_records_inline_implementation_command`
- `cargo test -p harness-server services::execution::tests::track_issue_workflow_records_runtime_submission`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
