### PR TITLE
Route PR feedback sweeps through workflow runtime

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -620,6 +620,136 @@ fn load_runtime_workflow_config_or_default(
     })
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RuntimePrFeedbackSweepTick {
+    pub requested: usize,
+    pub active_command_exists: usize,
+    pub skipped: usize,
+    pub rejected: usize,
+}
+
+impl RuntimePrFeedbackSweepTick {
+    fn touched_anything(&self) -> bool {
+        self.requested > 0
+            || self.active_command_exists > 0
+            || self.skipped > 0
+            || self.rejected > 0
+    }
+}
+
+pub(super) async fn run_runtime_pr_feedback_sweep_tick(
+    state: &Arc<AppState>,
+    limit: usize,
+) -> anyhow::Result<RuntimePrFeedbackSweepTick> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(RuntimePrFeedbackSweepTick::default());
+    };
+    let workflows = store
+        .list_instances_by_definition(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            None,
+        )
+        .await?;
+    let mut tick = RuntimePrFeedbackSweepTick::default();
+    let mut considered_candidates = 0usize;
+    for workflow in workflows {
+        if !matches!(workflow.state.as_str(), "pr_open" | "awaiting_feedback") {
+            continue;
+        }
+        if workflow
+            .data
+            .get("pr_number")
+            .and_then(serde_json::Value::as_u64)
+            .is_none()
+        {
+            tick.skipped += 1;
+            continue;
+        }
+        let Some(project_root) = workflow_project_root(&workflow) else {
+            tick.skipped += 1;
+            continue;
+        };
+        if !project_root.exists() {
+            tracing::warn!(
+                workflow_id = %workflow.id,
+                project_root = %project_root.display(),
+                "workflow runtime PR feedback sweep skipped unresolvable project path"
+            );
+            tick.skipped += 1;
+            continue;
+        }
+        let workflow_cfg = load_runtime_workflow_config_or_default(
+            &project_root,
+            "workflow runtime PR feedback sweeper",
+        );
+        if !workflow_cfg.pr_feedback.enabled {
+            tick.skipped += 1;
+            continue;
+        }
+        if considered_candidates >= limit.max(1) {
+            break;
+        }
+        considered_candidates += 1;
+
+        match crate::workflow_runtime_pr_feedback::request_pr_feedback_sweep(store, &workflow.id)
+            .await?
+        {
+            crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Requested {
+                ..
+            } => tick.requested += 1,
+            crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                ..
+            } => tick.active_command_exists += 1,
+            crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::NotCandidate {
+                ..
+            } => tick.skipped += 1,
+            crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Rejected {
+                ..
+            } => tick.rejected += 1,
+        }
+    }
+    Ok(tick)
+}
+
+pub(super) fn spawn_runtime_pr_feedback_sweeper(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("workflow runtime PR feedback sweeper disabled: store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let state = match weak_state.upgrade() {
+                Some(state) => state,
+                None => break,
+            };
+            let workflow_cfg = load_runtime_workflow_config_or_default(
+                &state.core.project_root,
+                "workflow runtime PR feedback sweeper",
+            );
+            let interval =
+                std::time::Duration::from_secs(workflow_cfg.pr_feedback.sweep_interval_secs.max(1));
+            match run_runtime_pr_feedback_sweep_tick(&state, 128).await {
+                Ok(tick) if tick.touched_anything() => {
+                    tracing::info!(
+                        requested = tick.requested,
+                        active_command_exists = tick.active_command_exists,
+                        skipped = tick.skipped,
+                        rejected = tick.rejected,
+                        "workflow runtime PR feedback sweeper tick complete"
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!("workflow runtime PR feedback sweeper tick failed: {error}");
+                }
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
 fn runtime_kind_from_config(value: &str) -> Option<RuntimeKind> {
     match value {
         "codex_exec" => Some(RuntimeKind::CodexExec),

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -682,7 +682,10 @@ pub(super) async fn run_runtime_pr_feedback_sweep_tick(
             &project_root,
             "workflow runtime PR feedback sweeper",
         );
-        if !workflow_cfg.pr_feedback.enabled {
+        if !workflow_cfg.pr_feedback.enabled
+            || !workflow_cfg.runtime_dispatch.enabled
+            || !workflow_cfg.runtime_worker.enabled
+        {
             tick.skipped += 1;
             continue;
         }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -177,6 +177,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // enqueue `pr:N` tasks so PR feedback is handled without manual resubmission.
     background::spawn_issue_workflow_feedback_sweeper(&state);
 
+    // Periodically sweep runtime issue workflows with attached PRs and emit
+    // workflow command outbox rows instead of legacy PR tasks.
+    background::spawn_runtime_pr_feedback_sweeper(&state);
+
     // Convert workflow command outbox rows into runtime jobs when the workflow
     // policy keeps the dispatcher enabled.
     background::spawn_runtime_command_dispatcher(&state);

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1280,6 +1280,50 @@ async fn runtime_pr_feedback_sweep_limit_ignores_skipped_workflows() -> anyhow::
 }
 
 #[tokio::test]
+async fn runtime_pr_feedback_sweep_respects_project_runtime_policy() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-feedback-disabled-runtime");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\npr_feedback:\n  enabled: true\nruntime_dispatch:\n  enabled: false\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:229"),
+    )
+    .with_id("issue-229")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 229,
+        "pr_number": 79,
+        "pr_url": "https://github.com/owner/repo/pull/79",
+        "task_id": "runtime-task-229",
+    }));
+    store.upsert_instance(&workflow).await?;
+
+    let tick = super::background::run_runtime_pr_feedback_sweep_tick(&state, 10).await?;
+
+    assert_eq!(tick.requested, 0);
+    assert_eq!(tick.skipped, 1);
+    assert!(store.commands_for(&workflow.id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_command_dispatch_tick_uses_command_project_policy_when_server_root_disabled(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1164,6 +1164,122 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
 }
 
 #[tokio::test]
+async fn runtime_pr_feedback_sweep_tick_enqueues_runtime_command() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-feedback");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\npr_feedback:\n  enabled: true\nruntime_dispatch:\n  enabled: true\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:226"),
+    )
+    .with_id("issue-226")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 226,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-226",
+    }));
+    store.upsert_instance(&workflow).await?;
+
+    let tick = super::background::run_runtime_pr_feedback_sweep_tick(&state, 10).await?;
+
+    assert_eq!(tick.requested, 1);
+    assert_eq!(tick.active_command_exists, 0);
+    assert_eq!(tick.skipped, 0);
+    assert_eq!(tick.rejected, 0);
+    let updated = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(updated.state, "awaiting_feedback");
+    let commands = store.commands_for(&workflow.id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].status, "pending");
+    assert_eq!(
+        commands[0].command.activity_name(),
+        Some("sweep_pr_feedback")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_pr_feedback_sweep_limit_ignores_skipped_workflows() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-feedback-limit");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\npr_feedback:\n  enabled: true\nruntime_dispatch:\n  enabled: true\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let valid_workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:227"),
+    )
+    .with_id("issue-227")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 227,
+        "pr_number": 78,
+        "pr_url": "https://github.com/owner/repo/pull/78",
+        "task_id": "runtime-task-227",
+    }));
+    store.upsert_instance(&valid_workflow).await?;
+    let skipped_workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:228"),
+    )
+    .with_id("issue-228")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 228,
+        "task_id": "runtime-task-228",
+    }));
+    store.upsert_instance(&skipped_workflow).await?;
+
+    let tick = super::background::run_runtime_pr_feedback_sweep_tick(&state, 1).await?;
+
+    assert_eq!(tick.requested, 1);
+    assert_eq!(tick.skipped, 1);
+    assert_eq!(store.commands_for(&valid_workflow.id).await?.len(), 1);
+    assert!(store.commands_for(&skipped_workflow.id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_command_dispatch_tick_uses_command_project_policy_when_server_root_disabled(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -1,9 +1,9 @@
 use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
-    build_pr_detected_decision, build_pr_feedback_decision, DecisionValidator,
-    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome, ValidationContext,
-    WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
-    WorkflowRuntimeStore, WorkflowSubject,
+    build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
+    DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, ValidationContext, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
 };
 use serde_json::json;
 use std::path::Path;
@@ -26,6 +26,14 @@ pub(crate) struct PrFeedbackRuntimeContext<'a> {
     pub pr_url: Option<&'a str>,
     pub outcome: PrFeedbackOutcome,
     pub summary: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PrFeedbackSweepRequestOutcome {
+    Requested { workflow_id: String },
+    NotCandidate { workflow_id: String, state: String },
+    ActiveCommandExists { workflow_id: String },
+    Rejected { workflow_id: String, reason: String },
 }
 
 pub(crate) async fn record_pr_detected(
@@ -63,6 +71,29 @@ pub(crate) async fn record_pr_feedback(
             "workflow runtime PR feedback write failed: {error}"
         );
     }
+}
+
+pub(crate) async fn request_pr_feedback_sweep(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    let Some(instance) = store.get_instance(workflow_id).await? else {
+        anyhow::bail!("workflow runtime instance `{workflow_id}` was not found");
+    };
+    if instance.definition_id != "github_issue_pr"
+        || !matches!(instance.state.as_str(), "pr_open" | "awaiting_feedback")
+    {
+        return Ok(PrFeedbackSweepRequestOutcome::NotCandidate {
+            workflow_id: instance.id,
+            state: instance.state,
+        });
+    }
+    if has_active_pr_feedback_command(store, &instance.id).await? {
+        return Ok(PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+            workflow_id: instance.id,
+        });
+    }
+    persist_pr_feedback_sweep_request(store, instance).await
 }
 
 async fn persist_pr_detected(
@@ -117,6 +148,74 @@ async fn persist_pr_detected(
         },
     );
     apply_decision(store, instance, output.decision, Some(event.id)).await
+}
+
+async fn persist_pr_feedback_sweep_request(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    let pr_number = required_u64_field(&instance.data, "pr_number")?;
+    let pr_url = optional_string_field(&instance.data, "pr_url");
+    let issue_number = instance
+        .data
+        .get("issue_number")
+        .and_then(|value| value.as_u64());
+    let repo = optional_string_field(&instance.data, "repo");
+    let event = store
+        .append_event(
+            &instance.id,
+            "PrFeedbackSweepRequested",
+            "workflow_runtime_pr_feedback",
+            json!({
+                "issue_number": issue_number,
+                "repo": repo.as_deref(),
+                "pr_number": pr_number,
+                "pr_url": pr_url.as_deref(),
+            }),
+        )
+        .await?;
+    let output = build_pr_feedback_sweep_decision(
+        &instance,
+        PrFeedbackSweepDecisionInput {
+            dedupe_key: &format!("pr-feedback-sweep:{}:{}", instance.id, event.id),
+            pr_number,
+            pr_url: pr_url.as_deref(),
+            issue_number,
+            repo: repo.as_deref(),
+            summary: "Runtime workflow requested a PR feedback sweep.",
+        },
+    );
+    let validator = DecisionValidator::github_issue_pr();
+    let validation = validator.validate(
+        &instance,
+        &output.decision,
+        &ValidationContext::new("workflow-policy", chrono::Utc::now()),
+    );
+    let record = match validation {
+        Ok(()) => WorkflowDecisionRecord::accepted(output.decision.clone(), Some(event.id)),
+        Err(error) => {
+            let reason = error.to_string();
+            let record = WorkflowDecisionRecord::rejected(output.decision, Some(event.id), &reason);
+            store.record_decision(&record).await?;
+            return Ok(PrFeedbackSweepRequestOutcome::Rejected {
+                workflow_id: instance.id,
+                reason,
+            });
+        }
+    };
+    store.record_decision(&record).await?;
+    for command in &output.decision.commands {
+        store
+            .enqueue_command(&instance.id, Some(&record.id), command)
+            .await?;
+    }
+    instance.state = output.decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_last_decision(instance.data, &output.decision.decision);
+    store.upsert_instance(&instance).await?;
+    Ok(PrFeedbackSweepRequestOutcome::Requested {
+        workflow_id: instance.id,
+    })
 }
 
 async fn persist_pr_feedback(
@@ -212,6 +311,23 @@ async fn apply_decision(
     store.upsert_instance(&instance).await
 }
 
+async fn has_active_pr_feedback_command(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
+    Ok(store
+        .commands_for(workflow_id)
+        .await?
+        .into_iter()
+        .any(|record| {
+            matches!(record.status.as_str(), "pending" | "dispatched")
+                && matches!(
+                    record.command.activity_name(),
+                    Some("sweep_pr_feedback" | "address_pr_feedback")
+                )
+        }))
+}
+
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
     store
         .upsert_definition(&WorkflowDefinition::new(
@@ -265,6 +381,19 @@ fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_jso
         object.insert("last_decision".to_string(), json!(decision));
     }
     data
+}
+
+fn optional_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn required_u64_field(data: &serde_json::Value, field: &str) -> anyhow::Result<u64> {
+    data.get(field)
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("runtime issue workflow is missing {field}"))
 }
 
 fn event_type(outcome: PrFeedbackOutcome) -> &'static str {
@@ -393,6 +522,77 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.event_type == "PrReadyToMerge"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_pr_feedback_sweep_records_runtime_command() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            123,
+        );
+        upsert_github_issue_pr_definition(&store).await?;
+        let instance = issue_instance(
+            workflow_id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "pr_open",
+        )
+        .with_data(json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 123,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "task-1",
+        }));
+        store.upsert_instance(&instance).await?;
+
+        let outcome = request_pr_feedback_sweep(&store, &workflow_id).await?;
+        assert_eq!(
+            outcome,
+            PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id: workflow_id.clone()
+            }
+        );
+        let updated = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("workflow should still exist");
+        assert_eq!(updated.state, "awaiting_feedback");
+        assert_eq!(updated.data["last_decision"], "sweep_pr_feedback");
+        let commands = store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some("sweep_pr_feedback")
+        );
+        assert_eq!(commands[0].command.command["pr_number"], 77);
+
+        let second = request_pr_feedback_sweep(&store, &workflow_id).await?;
+        assert_eq!(
+            second,
+            PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                workflow_id: workflow_id.clone()
+            }
+        );
+        assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -822,6 +822,21 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
                 "retry_policy": "runtime_retry_policy may retry this activity before failure."
             }
         }),
+        ("github_issue_pr", "sweep_pr_feedback") => json!({
+            "on_succeeded": {
+                "reducer_next_state": "derived_from_structured_decision_or_signals",
+                "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
+                "required_summary": "Describe inspected PR feedback, review state, checks, and mergeability."
+            },
+            "structured_decision": {
+                "preferred": true,
+                "description": "Return a workflow_decision artifact for address_pr_feedback, wait_for_pr_feedback, or mark_ready_to_merge."
+            },
+            "on_failed": {
+                "reducer_next_state": "failed_or_retry",
+                "retry_policy": "runtime_retry_policy may retry this activity before failure."
+            }
+        }),
         ("github_issue_pr", "implement_issue") => json!({
             "on_succeeded": {
                 "reducer_next_state": "unchanged_until_pr_detected",
@@ -888,6 +903,21 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
         ("github_issue_pr", "address_pr_feedback") => json!({
             "must_include": ["review feedback addressed", "changed files", "validation commands"],
             "must_not_include": ["claiming review approval without a fresh review signal"],
+        }),
+        ("github_issue_pr", "sweep_pr_feedback") => json!({
+            "must_include": ["PR comments reviewed", "review states", "check status", "mergeability", "next workflow action"],
+            "must_not_include": ["repository code changes", "workflow table mutations", "unverified approval claims"],
+            "artifacts": {
+                "workflow_decision": {
+                    "preferred": true,
+                    "allowed_decisions": ["address_pr_feedback", "wait_for_pr_feedback", "mark_ready_to_merge"]
+                }
+            },
+            "signals": {
+                "FeedbackFound": "Use when actionable feedback, requested changes, or failed checks require a fix round.",
+                "NoFeedbackFound": "Use when no actionable feedback is present yet.",
+                "PrReadyToMerge": "Use only when review, checks, and mergeability are all ready."
+            }
         }),
         (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => json!({
             "must_include": ["validation commands", "pass/fail evidence", "remaining blockers"],

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -34,8 +34,9 @@ pub use plan_issue::{
     PlanIssueWorkflowAction,
 };
 pub use pr_feedback::{
-    build_pr_detected_decision, build_pr_feedback_decision, PrDetectedDecisionInput,
-    PrFeedbackDecisionInput, PrFeedbackDecisionOutput, PrFeedbackOutcome, PrFeedbackWorkflowAction,
+    build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
+    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackDecisionOutput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction,
 };
 pub use quality_gate::{
     build_quality_gate_run_decision, quality_gate_workflow_id, QualityGateDecisionInput,

--- a/crates/harness-workflow/src/runtime/pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/pr_feedback.rs
@@ -3,6 +3,7 @@ use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, Workflow
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrFeedbackWorkflowAction {
     BindPr,
+    SweepFeedback,
     AddressFeedback,
     AwaitFeedback,
     ReadyToMerge,
@@ -28,6 +29,16 @@ pub struct PrFeedbackDecisionInput<'a> {
     pub pr_number: u64,
     pub pr_url: Option<&'a str>,
     pub outcome: PrFeedbackOutcome,
+    pub summary: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrFeedbackSweepDecisionInput<'a> {
+    pub dedupe_key: &'a str,
+    pub pr_number: u64,
+    pub pr_url: Option<&'a str>,
+    pub issue_number: Option<u64>,
+    pub repo: Option<&'a str>,
     pub summary: &'a str,
 }
 
@@ -121,10 +132,59 @@ pub fn build_pr_feedback_decision(
     }
 }
 
+pub fn build_pr_feedback_sweep_decision(
+    instance: &WorkflowInstance,
+    input: PrFeedbackSweepDecisionInput<'_>,
+) -> PrFeedbackDecisionOutput {
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "sweep_pr_feedback",
+        "awaiting_feedback",
+        input.summary,
+    )
+    .with_command(WorkflowCommand::new(
+        super::model::WorkflowCommandType::EnqueueActivity,
+        input.dedupe_key,
+        serde_json::json!({
+            "activity": "sweep_pr_feedback",
+            "pr_number": input.pr_number,
+            "pr_url": input.pr_url,
+            "issue_number": input.issue_number,
+            "repo": input.repo,
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "pr_feedback_sweep",
+        feedback_sweep_summary(input),
+    ))
+    .high_confidence();
+
+    PrFeedbackDecisionOutput {
+        action: PrFeedbackWorkflowAction::SweepFeedback,
+        decision,
+    }
+}
+
 fn feedback_evidence(input: PrFeedbackDecisionInput<'_>) -> WorkflowEvidence {
     let summary = match input.pr_url {
         Some(pr_url) => format!("pr={} url={} {}", input.pr_number, pr_url, input.summary),
         None => format!("pr={} {}", input.pr_number, input.summary),
     };
     WorkflowEvidence::new("pr_feedback", summary)
+}
+
+fn feedback_sweep_summary(input: PrFeedbackSweepDecisionInput<'_>) -> String {
+    let mut parts = vec![format!("pr={}", input.pr_number)];
+    if let Some(pr_url) = input.pr_url {
+        parts.push(format!("url={pr_url}"));
+    }
+    if let Some(issue_number) = input.issue_number {
+        parts.push(format!("issue={issue_number}"));
+    }
+    if let Some(repo) = input.repo {
+        parts.push(format!("repo={repo}"));
+    }
+    parts.push(input.summary.to_string());
+    parts.join(" ")
 }

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -2,6 +2,7 @@ use super::model::{
     ActivityErrorKind, ActivityResult, ActivityStatus, WorkflowCommand, WorkflowCommandType,
     WorkflowDecision, WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
+use super::pr_feedback::{build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome};
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
 use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
 use super::validator::{DecisionValidator, ValidationContext};
@@ -51,6 +52,11 @@ fn reduce_success(
     }
 
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
+        return Some(decision);
+    }
+
+    if let Some(decision) = pr_feedback_sweep_decision_from_activity_result(instance, event, result)
+    {
         return Some(decision);
     }
 
@@ -193,6 +199,100 @@ fn pull_request_artifact(result: &ActivityResult) -> Option<(u64, String)> {
                 .to_string();
             Some((pr_number, pr_url))
         })
+}
+
+fn pr_feedback_sweep_decision_from_activity_result(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID
+        || result.activity != "sweep_pr_feedback"
+    {
+        return None;
+    }
+    if !matches!(
+        instance.state.as_str(),
+        "pr_open" | "awaiting_feedback" | "addressing_feedback"
+    ) {
+        return None;
+    }
+    let outcome = pr_feedback_outcome_from_signals(result)?;
+    let pr_number = result_signal_u64(result, "pr_number").or_else(|| {
+        instance
+            .data
+            .get("pr_number")
+            .and_then(|value| value.as_u64())
+    })?;
+    let pr_url =
+        result_signal_string(result, "pr_url").or_else(|| optional_data_string(instance, "pr_url"));
+    let task_id = event_field_string(event, "runtime_job_id")
+        .or_else(|| optional_data_string(instance, "task_id"))
+        .unwrap_or_else(|| event.id.clone());
+    Some(
+        build_pr_feedback_decision(
+            instance,
+            PrFeedbackDecisionInput {
+                task_id: &task_id,
+                pr_number,
+                pr_url: pr_url.as_deref(),
+                outcome,
+                summary: result.summary.as_str(),
+            },
+        )
+        .decision
+        .with_evidence(runtime_completion_evidence(event, result)),
+    )
+}
+
+fn pr_feedback_outcome_from_signals(result: &ActivityResult) -> Option<PrFeedbackOutcome> {
+    if has_signal(result, "PrReadyToMerge") {
+        return Some(PrFeedbackOutcome::ReadyToMerge);
+    }
+    if has_signal(result, "FeedbackFound")
+        || has_signal(result, "ChangesRequested")
+        || has_signal(result, "ChecksFailed")
+    {
+        return Some(PrFeedbackOutcome::BlockingFeedback);
+    }
+    if has_signal(result, "NoFeedbackFound") {
+        return Some(PrFeedbackOutcome::NoActionableFeedback);
+    }
+    None
+}
+
+fn has_signal(result: &ActivityResult, signal_type: &str) -> bool {
+    result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == signal_type)
+}
+
+fn result_signal_u64(result: &ActivityResult, field: &str) -> Option<u64> {
+    result
+        .signals
+        .iter()
+        .find_map(|signal| signal.signal.get(field).and_then(|value| value.as_u64()))
+}
+
+fn result_signal_string(result: &ActivityResult, field: &str) -> Option<String> {
+    result.signals.iter().find_map(|signal| {
+        signal
+            .signal
+            .get(field)
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn optional_data_string(instance: &WorkflowInstance, field: &str) -> Option<String> {
+    instance
+        .data
+        .get(field)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn runtime_blocked_decision(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -246,14 +246,14 @@ fn pr_feedback_sweep_decision_from_activity_result(
 }
 
 fn pr_feedback_outcome_from_signals(result: &ActivityResult) -> Option<PrFeedbackOutcome> {
-    if has_signal(result, "PrReadyToMerge") {
-        return Some(PrFeedbackOutcome::ReadyToMerge);
-    }
     if has_signal(result, "FeedbackFound")
         || has_signal(result, "ChangesRequested")
         || has_signal(result, "ChecksFailed")
     {
         return Some(PrFeedbackOutcome::BlockingFeedback);
+    }
+    if has_signal(result, "PrReadyToMerge") {
+        return Some(PrFeedbackOutcome::ReadyToMerge);
     }
     if has_signal(result, "NoFeedbackFound") {
         return Some(PrFeedbackOutcome::NoActionableFeedback);

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -9,15 +9,17 @@ use super::validator::{DecisionValidator, ValidationContext, WorkflowDecisionRej
 use super::{
     build_issue_submission_decision, build_merged_pr_decision,
     build_open_issue_without_workflow_decision, build_plan_issue_decision,
-    build_pr_detected_decision, build_pr_feedback_decision, build_quality_gate_run_decision,
-    build_stale_active_workflow_decision, reduce_runtime_job_completed, CommandDispatchOutcome,
-    InMemoryWorkflowBus, IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction,
-    MergedPrDecisionInput, OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
-    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome, PrFeedbackWorkflowAction,
-    QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogWorkflowAction,
-    RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
-    StaleWorkflowDecisionInput, WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY,
-    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID,
+    build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
+    build_quality_gate_run_decision, build_stale_active_workflow_decision,
+    reduce_runtime_job_completed, CommandDispatchOutcome, InMemoryWorkflowBus,
+    IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction, MergedPrDecisionInput,
+    OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
+    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, QualityGateDecisionInput,
+    QualityGateWorkflowAction, RepoBacklogWorkflowAction, RuntimeCommandDispatcher,
+    RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput,
+    WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    REPO_BACKLOG_DEFINITION_ID,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -397,6 +399,43 @@ fn pr_feedback_decision_addresses_blocking_feedback() {
 }
 
 #[test]
+fn pr_feedback_sweep_decision_enqueues_runtime_activity() {
+    let instance = issue_instance("pr_open");
+    let output = build_pr_feedback_sweep_decision(
+        &instance,
+        PrFeedbackSweepDecisionInput {
+            dedupe_key: "pr-feedback-sweep:123:77",
+            pr_number: 77,
+            pr_url: Some("https://github.com/owner/repo/pull/77"),
+            issue_number: Some(123),
+            repo: Some("owner/repo"),
+            summary: "Runtime workflow requested a PR feedback sweep.",
+        },
+    );
+
+    assert_eq!(output.action, PrFeedbackWorkflowAction::SweepFeedback);
+    assert_eq!(output.decision.decision, "sweep_pr_feedback");
+    assert_eq!(output.decision.next_state, "awaiting_feedback");
+    assert_eq!(output.decision.commands.len(), 1);
+    assert_eq!(
+        output.decision.commands[0].command_type,
+        WorkflowCommandType::EnqueueActivity
+    );
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some("sweep_pr_feedback")
+    );
+    assert_eq!(output.decision.commands[0].command["pr_number"], 77);
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("PR feedback sweep decision should validate");
+}
+
+#[test]
 fn pr_feedback_decision_waits_when_no_actionable_feedback_exists() {
     let instance = issue_instance("pr_open");
     let output = build_pr_feedback_decision(
@@ -667,6 +706,53 @@ fn runtime_completion_reducer_accepts_structured_workflow_decision_artifact() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("structured workflow decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_maps_pr_feedback_sweep_signal_to_address_command() {
+    let instance = issue_instance("awaiting_feedback").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-1",
+    }));
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent found actionable PR feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "count": 2, "pr_number": 77 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("feedback sweep signal should reduce");
+
+    assert_eq!(decision.decision, "address_pr_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("feedback sweep signal decision should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -756,6 +756,56 @@ fn runtime_completion_reducer_maps_pr_feedback_sweep_signal_to_address_command()
 }
 
 #[test]
+fn runtime_completion_reducer_prefers_blocking_pr_feedback_over_ready_signal() {
+    let instance = issue_instance("awaiting_feedback").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-1",
+    }));
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent emitted mixed PR feedback signals.",
+    )
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "ChecksFailed",
+        json!({ "pr_number": 77, "failed": 1 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("mixed feedback sweep signals should reduce conservatively");
+
+    assert_eq!(decision.decision, "address_pr_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("blocking feedback should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_returns_invalid_structured_workflow_decision_for_audit() {
     let instance = issue_instance("pr_open");
     let proposed_decision = WorkflowDecision::new(

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -69,11 +69,16 @@ Implemented now:
 - issue `POST /tasks` submissions now write `github_issue_pr` workflow runtime state with
   `IssueSubmitted`, a validated `submit_issue` decision, and a pending `implement_issue`
   command that is dispatched to runtime jobs instead of the legacy task runner
+- runtime issue workflows with bound PRs now request `sweep_pr_feedback` through the workflow
+  command outbox; runtime agents inspect GitHub and return structured `workflow_decision`
+  artifacts or reducer-visible feedback signals
 
 Still intentionally not moved yet:
 
 - repo backlog polling as the primary controller
-- prompt-only and PR feedback task submissions still use the existing task routes
+- prompt-only task submissions still use the existing task routes
+- legacy issue-workflow feedback fallback still uses existing PR task routes when no runtime
+  workflow exists
 - dashboard write actions still use existing task routes
 
 ## Non-Goals
@@ -392,11 +397,15 @@ Implemented now:
 - review waits record `NoFeedbackFound` / `wait_for_pr_feedback`
 - actionable review or validation failures record `FeedbackFound` / `address_pr_feedback`
 - approved reviews and graduated low-risk exits record `PrReadyToMerge` / `mark_ready_to_merge`
+- runtime `github_issue_pr` workflows with attached PRs are swept by a server background loop that
+  writes a validated `sweep_pr_feedback` decision and pending runtime command instead of enqueueing
+  a legacy `pr:N` task
+- `sweep_pr_feedback` runtime completions can advance the parent workflow through structured
+  `workflow_decision` artifacts or explicit feedback signals
 
 Still intentionally not moved yet:
 
-- GitHub signal interpretation still runs in the existing review loop
-- feedback fix execution still runs through task runner turns
+- legacy task-runner PR feedback still runs the existing review loop
 - `pr_feedback` is not yet a separate child workflow with its own runtime job
 
 Tests:
@@ -404,6 +413,8 @@ Tests:
 - feedback report with blocking items moves parent workflow to `addressing_feedback`
 - no actionable feedback keeps parent workflow in `awaiting_feedback`
 - approved and checks-passed events can move parent workflow to `ready_to_merge`
+- runtime PR feedback sweep requests enqueue a `sweep_pr_feedback` command and suppress duplicate
+  active sweep commands
 
 ### Phase 4: Repo Backlog Workflow
 
@@ -452,7 +463,9 @@ Implemented now:
 
 Still intentionally not moved yet:
 
-- prompt-only and PR feedback submissions still use the current task executor
+- prompt-only submissions still use the current task executor
+- legacy issue-workflow feedback fallback still uses the current PR task executor when no runtime
+  workflow exists
 
 Tests:
 
@@ -866,7 +879,8 @@ Implemented now:
 Still intentionally not moved yet:
 
 - prompt-only submissions remain task-runner native
-- PR feedback submissions remain on the existing PR feedback sweep/task path
+- legacy issue-workflow PR feedback remains on the existing PR feedback sweep/task path when no
+  runtime workflow exists
 - the `task_id` returned for issue submissions is now a workflow submission correlation id, not a
   legacy task row id
 


### PR DESCRIPTION
## Summary
- add runtime workflow decisions and command outbox support for sweep_pr_feedback
- run a workflow-runtime PR feedback sweeper that enqueues runtime commands instead of legacy PR task rows for runtime issue workflows
- map sweep activity results back into PR feedback workflow decisions and document the remaining legacy gaps

## Tests
- cargo fmt --all -- --check
- cargo check -p harness-server
- cargo check -p harness-workflow
- cargo test -p harness-workflow
- cargo test -p harness-server runtime_pr_feedback_sweep -- --nocapture
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets