### PR TITLE
Route repo backlog polling through workflow runtime

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -6,6 +6,10 @@ pr_feedback:
   enabled: true
   sweep_interval_secs: 60
   claim_stale_after_secs: 300
+repo_backlog:
+  enabled: true
+  poll_interval_secs: 60
+  batch_limit: 128
 runtime_dispatch:
   enabled: true
   interval_secs: 30
@@ -45,6 +49,17 @@ Current externally configurable rules:
   - Maximum age for a `feedback_claimed` placeholder before the sweeper reclaims it
     after an interrupted enqueue path. This does not reclaim live
     `addressing_feedback` tasks with a real `active_task_id`.
+
+- `repo_backlog.enabled`
+  - Enables workflow-owned GitHub backlog polling. When the workflow runtime,
+    dispatcher, and worker are enabled, GitHub issue intake is delegated to the
+    `repo_backlog` workflow instead of the legacy server poller.
+
+- `repo_backlog.poll_interval_secs`
+  - Background interval for requesting repo backlog scan activities.
+
+- `repo_backlog.batch_limit`
+  - Maximum configured GitHub repos considered by the repo backlog poller per tick.
 
 - `runtime_dispatch.enabled`
   - Enables the workflow command outbox dispatcher. It is enabled by default

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -26,6 +26,16 @@ pub struct PrFeedbackPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoBacklogPolicy {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_repo_backlog_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+    #[serde(default = "default_repo_backlog_batch_limit")]
+    pub batch_limit: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeDispatchPolicy {
     #[serde(default)]
     pub enabled: bool,
@@ -126,6 +136,8 @@ pub struct WorkflowConfig {
     #[serde(default)]
     pub issue_workflow: IssueWorkflowPolicy,
     #[serde(default)]
+    pub repo_backlog: RepoBacklogPolicy,
+    #[serde(default)]
     pub pr_feedback: PrFeedbackPolicy,
     #[serde(default)]
     pub runtime_dispatch: RuntimeDispatchPolicy,
@@ -159,6 +171,16 @@ impl Default for PrFeedbackPolicy {
             enabled: default_true(),
             sweep_interval_secs: default_feedback_sweep_interval_secs(),
             claim_stale_after_secs: default_feedback_claim_stale_after_secs(),
+        }
+    }
+}
+
+impl Default for RepoBacklogPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: default_true(),
+            poll_interval_secs: default_repo_backlog_poll_interval_secs(),
+            batch_limit: default_repo_backlog_batch_limit(),
         }
     }
 }
@@ -213,6 +235,14 @@ fn default_feedback_sweep_interval_secs() -> u64 {
 
 fn default_feedback_claim_stale_after_secs() -> u64 {
     300
+}
+
+fn default_repo_backlog_poll_interval_secs() -> u64 {
+    60
+}
+
+fn default_repo_backlog_batch_limit() -> u32 {
+    128
 }
 
 fn default_runtime_dispatch_interval_secs() -> u64 {
@@ -316,6 +346,9 @@ mod tests {
         assert!(cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
         assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 300);
+        assert!(cfg.repo_backlog.enabled);
+        assert_eq!(cfg.repo_backlog.poll_interval_secs, 60);
+        assert_eq!(cfg.repo_backlog.batch_limit, 128);
         assert!(cfg.runtime_dispatch.enabled);
         assert_eq!(cfg.runtime_dispatch.interval_secs, 30);
         assert_eq!(cfg.runtime_dispatch.batch_limit, 25);
@@ -355,6 +388,10 @@ pr_feedback:
   enabled: false
   sweep_interval_secs: 15
   claim_stale_after_secs: 45
+repo_backlog:
+  enabled: false
+  poll_interval_secs: 20
+  batch_limit: 9
 runtime_dispatch:
   enabled: true
   interval_secs: 5
@@ -420,6 +457,9 @@ Body
         assert!(!cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
         assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 45);
+        assert!(!cfg.repo_backlog.enabled);
+        assert_eq!(cfg.repo_backlog.poll_interval_secs, 20);
+        assert_eq!(cfg.repo_backlog.batch_limit, 9);
         assert!(cfg.runtime_dispatch.enabled);
         assert_eq!(cfg.runtime_dispatch.interval_secs, 5);
         assert_eq!(cfg.runtime_dispatch.batch_limit, 7);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -621,6 +621,174 @@ fn load_runtime_workflow_config_or_default(
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RuntimeRepoBacklogPollTick {
+    pub requested: usize,
+    pub active_command_exists: usize,
+    pub skipped: usize,
+    pub rejected: usize,
+}
+
+impl RuntimeRepoBacklogPollTick {
+    fn touched_anything(&self) -> bool {
+        self.requested > 0
+            || self.active_command_exists > 0
+            || self.skipped > 0
+            || self.rejected > 0
+    }
+}
+
+pub(super) async fn run_runtime_repo_backlog_poll_tick(
+    state: &Arc<AppState>,
+    limit: usize,
+) -> anyhow::Result<RuntimeRepoBacklogPollTick> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(RuntimeRepoBacklogPollTick::default());
+    };
+    let Some(github_config) = state
+        .core
+        .server
+        .config
+        .intake
+        .github
+        .as_ref()
+        .filter(|config| config.enabled)
+    else {
+        return Ok(RuntimeRepoBacklogPollTick::default());
+    };
+
+    let mut tick = RuntimeRepoBacklogPollTick::default();
+    let mut considered_repos = 0usize;
+    for repo_config in github_config.effective_repos() {
+        if considered_repos >= limit.max(1) {
+            break;
+        }
+        let project_root = repo_backlog_project_root(&repo_config, &state.core.project_root).await;
+        if !project_root.exists() {
+            tracing::warn!(
+                repo = %repo_config.repo,
+                project_root = %project_root.display(),
+                "workflow runtime repo backlog poll skipped unresolvable project path"
+            );
+            tick.skipped += 1;
+            continue;
+        }
+        let workflow_cfg = load_runtime_workflow_config_or_default(
+            &project_root,
+            "workflow runtime repo backlog poller",
+        );
+        if !workflow_cfg.repo_backlog.enabled
+            || !workflow_cfg.runtime_dispatch.enabled
+            || !workflow_cfg.runtime_worker.enabled
+        {
+            tick.skipped += 1;
+            continue;
+        }
+        considered_repos += 1;
+        match crate::workflow_runtime_repo_backlog::request_repo_backlog_poll(
+            store,
+            crate::workflow_runtime_repo_backlog::RepoBacklogPollRuntimeContext {
+                project_root: &project_root,
+                repo: Some(repo_config.repo.as_str()),
+                label: Some(repo_config.label.as_str()),
+            },
+        )
+        .await?
+        {
+            crate::workflow_runtime_repo_backlog::RepoBacklogPollRequestOutcome::Requested {
+                ..
+            } => tick.requested += 1,
+            crate::workflow_runtime_repo_backlog::RepoBacklogPollRequestOutcome::ActiveCommandExists {
+                ..
+            } => tick.active_command_exists += 1,
+            crate::workflow_runtime_repo_backlog::RepoBacklogPollRequestOutcome::NotCandidate {
+                ..
+            } => tick.skipped += 1,
+            crate::workflow_runtime_repo_backlog::RepoBacklogPollRequestOutcome::Rejected {
+                ..
+            } => tick.rejected += 1,
+        }
+    }
+    Ok(tick)
+}
+
+async fn repo_backlog_project_root(
+    repo_config: &harness_core::config::intake::GitHubRepoConfig,
+    fallback: &Path,
+) -> PathBuf {
+    let configured = repo_config
+        .project_root
+        .as_ref()
+        .filter(|path| !path.trim().is_empty())
+        .map(|path| expand_home_path(path))
+        .unwrap_or_else(|| fallback.to_path_buf());
+    match task_runner::resolve_canonical_project(Some(configured.clone())).await {
+        Ok(path) => path,
+        Err(error) => {
+            tracing::warn!(
+                repo = %repo_config.repo,
+                project_root = %configured.display(),
+                "workflow runtime repo backlog poller failed to canonicalize project root: {error}"
+            );
+            configured
+        }
+    }
+}
+
+fn expand_home_path(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+pub(super) fn spawn_runtime_repo_backlog_poller(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("workflow runtime repo backlog poller disabled: store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let state = match weak_state.upgrade() {
+                Some(state) => state,
+                None => break,
+            };
+            let workflow_cfg = load_runtime_workflow_config_or_default(
+                &state.core.project_root,
+                "workflow runtime repo backlog poller",
+            );
+            let interval =
+                std::time::Duration::from_secs(workflow_cfg.repo_backlog.poll_interval_secs.max(1));
+            let batch_limit = workflow_cfg.repo_backlog.batch_limit.max(1) as usize;
+            match run_runtime_repo_backlog_poll_tick(&state, batch_limit).await {
+                Ok(tick) if tick.touched_anything() => {
+                    tracing::info!(
+                        requested = tick.requested,
+                        active_command_exists = tick.active_command_exists,
+                        skipped = tick.skipped,
+                        rejected = tick.rejected,
+                        "workflow runtime repo backlog poller tick complete"
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!("workflow runtime repo backlog poller tick failed: {error}");
+                }
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct RuntimePrFeedbackSweepTick {
     pub requested: usize,
     pub active_command_exists: usize,

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -251,14 +251,16 @@ fn runtime_repo_backlog_owns_github_polling(
         .filter(|path| !path.trim().is_empty())
         .map(expand_home_path)
         .unwrap_or_else(|| fallback_project_root.to_path_buf());
-    let workflow_cfg = harness_core::config::workflow::load_workflow_config(&project_root)
-        .unwrap_or_else(|error| {
+    let workflow_cfg = match harness_core::config::workflow::load_workflow_config(&project_root) {
+        Ok(config) => config,
+        Err(error) => {
             tracing::warn!(
                 project_root = %project_root.display(),
-                "intake: failed to load WORKFLOW.md for runtime repo backlog handoff, using default config: {error}"
+                "intake: failed to load WORKFLOW.md for runtime repo backlog handoff; runtime ownership disabled: {error}"
             );
-            harness_core::config::workflow::WorkflowConfig::default()
-        });
+            return false;
+        }
+    };
     workflow_cfg.repo_backlog.enabled
         && workflow_cfg.runtime_dispatch.enabled
         && workflow_cfg.runtime_worker.enabled
@@ -523,6 +525,34 @@ mod tests {
             !bundle.legacy_github_fallback_enabled,
             "configured GitHub intake should not fall back to legacy server polling"
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_repo_backlog_ownership_disabled_when_workflow_config_unreadable(
+    ) -> anyhow::Result<()> {
+        if harness_core::db::resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let (_, _, _, registry) = make_minimal_bundles(dir.path()).await;
+        if registry.workflow_runtime_store.is_none() {
+            return Ok(());
+        }
+        let unreadable_root = dir.path().join("not-a-directory");
+        std::fs::write(&unreadable_root, "not a directory")?;
+        let repo_config = harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: Some(unreadable_root.to_string_lossy().into_owned()),
+        };
+
+        assert!(!runtime_repo_backlog_owns_github_polling(
+            dir.path(),
+            &repo_config,
+            &registry
+        ));
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -13,6 +13,7 @@ pub(crate) struct IntakeBundle {
     /// GitHub pollers keyed as `"github:{owner/repo}"` for per-repo routing.
     /// The same `Arc` instances are shared with the completion callback.
     pub github_pollers: Vec<(String, Arc<dyn crate::intake::IntakeSource>)>,
+    pub legacy_github_fallback_enabled: bool,
     pub completion_callback: Option<task_runner::CompletionCallback>,
 }
 
@@ -27,13 +28,8 @@ pub(crate) async fn build_intake(
     engines: &EnginesBundle,
     registry: &RegistryBundle,
     project_root: &Path,
-    data_dir: &Path,
+    _data_dir: &Path,
 ) -> anyhow::Result<IntakeBundle> {
-    let tasks = storage
-        .tasks
-        .as_ref()
-        .expect("build_intake requires a ready task store")
-        .clone();
     let events = engines
         .events
         .as_ref()
@@ -88,14 +84,12 @@ pub(crate) async fn build_intake(
         )))
     });
 
-    // ── GitHub pollers ────────────────────────────────────────────────────────
-    // Build ALL GitHub pollers once. The same Arc instances are shared between
-    // the completion callback and the orchestrator, so on_task_complete operates
-    // on the live poller's dispatched map rather than a detached clone.
-    // Keyed as "github:{owner/repo}" for per-repo routing in the callback;
-    // a "github" fallback entry (first poller) supports tasks persisted before
-    // this multi-repo routing was introduced.
-    let mut github_pollers: Vec<(String, Arc<dyn crate::intake::IntakeSource>)> = Vec::new();
+    // ── GitHub backlog ownership ──────────────────────────────────────────────
+    // GitHub issue polling is workflow-owned. The server does not register the
+    // legacy GitHub poller; repo backlog scans are requested through runtime
+    // commands and executed by agents.
+    let github_pollers: Vec<(String, Arc<dyn crate::intake::IntakeSource>)> = Vec::new();
+    let mut legacy_github_fallback_enabled = true;
     if let Some(cfg) = server
         .config
         .intake
@@ -103,39 +97,21 @@ pub(crate) async fn build_intake(
         .as_ref()
         .filter(|cfg| cfg.enabled)
     {
+        legacy_github_fallback_enabled = false;
         for repo_cfg in cfg.effective_repos() {
-            tracing::info!(
-                repo = %repo_cfg.repo,
-                label = %repo_cfg.label,
-                "intake: GitHub Issues poller registered"
-            );
-            let key = format!("github:{}", repo_cfg.repo);
-            let task_checker = Arc::new(
-                crate::intake::github_issues::RuntimeAwareDispatchedTaskChecker::new(
-                    tasks.clone(),
-                    registry.workflow_runtime_store.clone(),
-                ),
-            );
-            let poller = crate::intake::github_issues::GitHubIssuesPoller::new_with_token(
-                &repo_cfg,
-                Some(data_dir),
-                server.config.server.github_token.clone(),
-            )
-            .with_task_checker(task_checker);
-            match poller.reconcile_dispatched_with_store().await {
-                Ok(pruned) if pruned > 0 => tracing::info!(
+            if runtime_repo_backlog_owns_github_polling(project_root, &repo_cfg, registry) {
+                tracing::info!(
                     repo = %repo_cfg.repo,
-                    pruned,
-                    "intake: pruned stale GitHub dispatched entries at startup"
-                ),
-                Ok(_) => {}
-                Err(e) => tracing::warn!(
+                    label = %repo_cfg.label,
+                    "intake: GitHub issue polling owned by workflow runtime repo backlog"
+                );
+            } else {
+                tracing::warn!(
                     repo = %repo_cfg.repo,
-                    "intake: failed to reconcile GitHub dispatched entries at startup: {e}"
-                ),
+                    label = %repo_cfg.label,
+                    "intake: GitHub issue polling disabled because workflow runtime repo backlog is unavailable or disabled"
+                );
             }
-            let poller = Arc::new(poller) as Arc<dyn crate::intake::IntakeSource>;
-            github_pollers.push((key, poller));
         }
     }
 
@@ -256,8 +232,50 @@ pub(crate) async fn build_intake(
         review_task_queue,
         feishu_intake,
         github_pollers,
+        legacy_github_fallback_enabled,
         completion_callback,
     })
+}
+
+fn runtime_repo_backlog_owns_github_polling(
+    fallback_project_root: &Path,
+    repo_config: &harness_core::config::intake::GitHubRepoConfig,
+    registry: &RegistryBundle,
+) -> bool {
+    if registry.workflow_runtime_store.is_none() {
+        return false;
+    }
+    let project_root = repo_config
+        .project_root
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+        .map(expand_home_path)
+        .unwrap_or_else(|| fallback_project_root.to_path_buf());
+    let workflow_cfg = harness_core::config::workflow::load_workflow_config(&project_root)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                project_root = %project_root.display(),
+                "intake: failed to load WORKFLOW.md for runtime repo backlog handoff, using default config: {error}"
+            );
+            harness_core::config::workflow::WorkflowConfig::default()
+        });
+    workflow_cfg.repo_backlog.enabled
+        && workflow_cfg.runtime_dispatch.enabled
+        && workflow_cfg.runtime_worker.enabled
+}
+
+fn expand_home_path(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
 }
 
 async fn runtime_issue_concurrency_config(
@@ -452,6 +470,58 @@ mod tests {
         assert!(
             bundle.github_pollers.is_empty(),
             "github_pollers should be empty without config"
+        );
+    }
+
+    #[tokio::test]
+    async fn github_intake_is_owned_by_runtime_not_legacy_poller() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = HarnessConfig::default();
+        config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+            enabled: true,
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            ..Default::default()
+        });
+        let server = Arc::new(HarnessServer::new(
+            config,
+            ThreadManager::new(),
+            AgentRegistry::new("test"),
+        ));
+        let storage = crate::http::builders::storage::build_storage(dir.path())
+            .await
+            .expect("storage");
+        let engines =
+            crate::http::builders::engines::build_engines(&server, dir.path(), dir.path())
+                .await
+                .expect("engines");
+        let registry = crate::http::builders::registry::build_registry(
+            &server,
+            dir.path(),
+            dir.path(),
+            storage.tasks.as_ref().expect("tasks store"),
+        )
+        .await
+        .expect("registry");
+
+        let bundle = build_intake(
+            &server,
+            &storage,
+            &engines,
+            &registry,
+            dir.path(),
+            dir.path(),
+        )
+        .await
+        .expect("build_intake");
+
+        assert!(
+            bundle.github_pollers.is_empty(),
+            "configured GitHub intake should not register legacy pollers"
+        );
+        assert!(
+            !bundle.legacy_github_fallback_enabled,
+            "configured GitHub intake should not fall back to legacy server polling"
         );
     }
 

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -332,6 +332,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         intake: IntakeServices {
             feishu_intake: intake.feishu_intake,
             github_pollers: intake.github_pollers.into_iter().map(|(_, p)| p).collect(),
+            legacy_github_fallback_enabled: intake.legacy_github_fallback_enabled,
             completion_callback: intake.completion_callback,
         },
         project_svc: services.project_svc,

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -181,6 +181,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // workflow command outbox rows instead of legacy PR tasks.
     background::spawn_runtime_pr_feedback_sweeper(&state);
 
+    // Periodically ask repo backlog workflows to scan GitHub through runtime
+    // jobs so GitHub intake becomes workflow-owned when the runtime is enabled.
+    background::spawn_runtime_repo_backlog_poller(&state);
+
     // Convert workflow command outbox rows into runtime jobs when the workflow
     // policy keeps the dispatcher enabled.
     background::spawn_runtime_command_dispatcher(&state);
@@ -223,6 +227,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
         )),
         state.intake.feishu_intake.clone(),
         github_sources,
+        state.intake.legacy_github_fallback_enabled,
         state.core.server.config.server.github_token.clone(),
     )
     .start(state.clone());

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -129,6 +129,7 @@ pub struct IntakeServices {
     /// `on_task_complete` (e.g. evicting a failed issue from `dispatched`)
     /// operates on the live poller rather than a detached clone.
     pub github_pollers: Vec<Arc<dyn crate::intake::IntakeSource>>,
+    pub legacy_github_fallback_enabled: bool,
     /// Completion callback invoked when a task reaches a terminal state.
     pub completion_callback: Option<task_runner::CompletionCallback>,
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -366,6 +366,7 @@ async fn make_test_state_with_project_root(
         intake: crate::http::IntakeServices {
             feishu_intake,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc,
@@ -447,6 +448,7 @@ async fn make_test_state_with_issue_workflows(
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc: state.project_svc.clone(),
@@ -565,6 +567,7 @@ async fn make_test_state_with_workflow_runtime_config_and_registry(
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc: state.project_svc.clone(),
@@ -1221,6 +1224,68 @@ async fn runtime_pr_feedback_sweep_tick_enqueues_runtime_command() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn runtime_repo_backlog_poll_tick_enqueues_runtime_command() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-backlog");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nrepo_backlog:\n  enabled: true\n  batch_limit: 5\nruntime_dispatch:\n  enabled: true\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repos: vec![harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: Some(project_root.to_string_lossy().into_owned()),
+        }],
+        ..Default::default()
+    });
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+
+    let tick = super::background::run_runtime_repo_backlog_poll_tick(&state, 10).await?;
+
+    assert_eq!(tick.requested, 1);
+    assert_eq!(tick.active_command_exists, 0);
+    assert_eq!(tick.skipped, 0);
+    assert_eq!(tick.rejected, 0);
+    let instances = store
+        .list_instances_by_definition(harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID, None)
+        .await?;
+    assert_eq!(instances.len(), 1);
+    let workflow_id = instances[0].id.clone();
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("repo backlog workflow should exist");
+    assert_eq!(instance.state, "scanning");
+    assert_eq!(instance.data["label"], "harness");
+    let commands = store.commands_for(&workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].command.activity_name(),
+        Some(harness_workflow::runtime::REPO_BACKLOG_POLL_ACTIVITY)
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_pr_feedback_sweep_limit_ignores_skipped_workflows() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -1734,6 +1799,104 @@ async fn runtime_job_worker_starts_child_workflow_without_agent_turn() -> anyhow
             .await?,
         0
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_worker_auto_submits_repo_backlog_child_workflow() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-auto-submit");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+        1,
+        "dispatching",
+        harness_workflow::runtime::WorkflowSubject::new("repo", "owner/repo"),
+    )
+    .with_id("repo-backlog-auto-submit")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "repo-backlog:owner/repo:issue:127:start",
+        serde_json::json!({
+            "definition_id": "github_issue_pr",
+            "subject_key": "issue:127",
+            "repo": "owner/repo",
+            "labels": ["harness"],
+            "source": "github",
+            "external_id": "127",
+            "auto_submit": true,
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    let activity = command.runtime_activity_key().to_string();
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": activity,
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    let child_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 127);
+    let child = store
+        .get_instance(&child_id)
+        .await?
+        .expect("child workflow should be created");
+    assert_eq!(child.state, "implementing");
+    assert_eq!(child.data["source"], "github");
+    assert_eq!(child.data["external_id"], "127");
+    let child_commands = store.commands_for(&child_id).await?;
+    assert_eq!(child_commands.len(), 1);
+    assert_eq!(
+        child_commands[0].command.activity_name(),
+        Some("implement_issue")
+    );
+    let completed = store
+        .get_runtime_job(&runtime_job.id)
+        .await?
+        .expect("runtime job should exist");
+    let output: harness_workflow::runtime::ActivityResult = serde_json::from_value(
+        completed
+            .output
+            .expect("activity result should be recorded"),
+    )?;
+    assert!(output
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "child_submission"));
     Ok(())
 }
 

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -21,11 +21,13 @@ impl DispatchedTaskChecker for crate::task_runner::TaskStore {
     }
 }
 
+#[cfg(test)]
 pub(crate) struct RuntimeAwareDispatchedTaskChecker {
     tasks: Arc<crate::task_runner::TaskStore>,
     workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
 }
 
+#[cfg(test)]
 impl RuntimeAwareDispatchedTaskChecker {
     pub(crate) fn new(
         tasks: Arc<crate::task_runner::TaskStore>,
@@ -38,6 +40,7 @@ impl RuntimeAwareDispatchedTaskChecker {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl DispatchedTaskChecker for RuntimeAwareDispatchedTaskChecker {
     async fn exists(&self, task_id: &TaskId) -> anyhow::Result<bool> {
@@ -93,6 +96,7 @@ impl GitHubIssuesPoller {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn with_task_checker(
         mut self,
         task_checker: Arc<dyn DispatchedTaskChecker>,

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -1244,6 +1244,7 @@ pub fn build_orchestrator(
     data_dir: Option<&std::path::Path>,
     feishu_intake: Option<Arc<feishu::FeishuIntake>>,
     github_sources: Vec<Arc<dyn IntakeSource>>,
+    allow_github_fallback: bool,
     github_token: Option<String>,
 ) -> IntakeOrchestrator {
     let mut sources: Vec<Arc<dyn IntakeSource>> = Vec::new();
@@ -1264,7 +1265,7 @@ pub fn build_orchestrator(
                     .retry_backoff_max_secs
                     .max(gh_config.retry_backoff_base_secs),
             );
-            if github_sources.is_empty() {
+            if github_sources.is_empty() && allow_github_fallback {
                 // Fallback: build fresh pollers when no shared instances are supplied
                 // (e.g. during testing or when called without pre-built sources).
                 for repo_cfg in gh_config.effective_repos() {
@@ -1911,7 +1912,7 @@ mod tests {
     #[test]
     fn build_orchestrator_with_no_config_returns_empty_orchestrator() {
         let config = harness_core::config::intake::IntakeConfig::default();
-        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], true, None);
         assert!(orchestrator.sources.is_empty());
     }
 
@@ -1923,7 +1924,7 @@ mod tests {
             repo: "owner/repo".to_string(),
             ..Default::default()
         });
-        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], true, None);
         assert!(orchestrator.sources.is_empty());
     }
 
@@ -1940,13 +1941,28 @@ mod tests {
             retry_backoff_max_secs: 90,
             ..Default::default()
         });
-        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], true, None);
         assert_eq!(orchestrator.sources.len(), 1);
         assert_eq!(orchestrator.sources[0].name(), "github");
         assert_eq!(orchestrator.poll_interval, Duration::from_secs(60));
         assert_eq!(orchestrator.sprint_timeout, Duration::from_secs(7200));
         assert_eq!(orchestrator.retry_backoff_base, Duration::from_secs(10));
         assert_eq!(orchestrator.retry_backoff_max, Duration::from_secs(90));
+    }
+
+    #[test]
+    fn build_orchestrator_with_disabled_github_fallback_registers_no_source() {
+        let mut config = harness_core::config::intake::IntakeConfig::default();
+        config.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+            enabled: true,
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            ..Default::default()
+        });
+
+        let orchestrator = build_orchestrator(&config, None, None, vec![], false, None);
+
+        assert!(orchestrator.sources.is_empty());
     }
 
     #[test]
@@ -1961,7 +1977,7 @@ mod tests {
             default_repo: None,
         });
 
-        let orchestrator = build_orchestrator(&config, None, None, vec![], None);
+        let orchestrator = build_orchestrator(&config, None, None, vec![], true, None);
         assert!(orchestrator.sources.is_empty());
     }
 }

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -127,6 +127,7 @@ async fn make_test_state_with_config_and_registry(
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc,
@@ -1467,6 +1468,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc,

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -289,6 +289,7 @@ mod tests {
             intake: crate::http::IntakeServices {
                 feishu_intake: None,
                 github_pollers: vec![],
+                legacy_github_fallback_enabled: true,
                 completion_callback: None,
             },
             project_svc,

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -327,6 +327,7 @@ async fn make_state_inner(
         intake: crate::http::IntakeServices {
             feishu_intake: None,
             github_pollers: vec![],
+            legacy_github_fallback_enabled: true,
             completion_callback: None,
         },
         project_svc,

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -383,6 +383,7 @@ mod tests {
             intake: crate::http::IntakeServices {
                 feishu_intake: None,
                 github_pollers: vec![],
+                legacy_github_fallback_enabled: true,
                 completion_callback: None,
             },
             project_svc,

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -1,10 +1,11 @@
 use harness_workflow::issue_lifecycle::IssueWorkflowStore;
 use harness_workflow::runtime::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,
-    build_stale_active_workflow_decision, repo_backlog_workflow_id, DecisionValidator,
-    MergedPrDecisionInput, OpenIssueDecisionInput, StaleWorkflowDecisionInput, ValidationContext,
-    WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
-    WorkflowRuntimeStore, WorkflowSubject, REPO_BACKLOG_DEFINITION_ID,
+    build_repo_backlog_poll_decision, build_stale_active_workflow_decision,
+    repo_backlog_workflow_id, DecisionValidator, MergedPrDecisionInput, OpenIssueDecisionInput,
+    RepoBacklogPollDecisionInput, StaleWorkflowDecisionInput, ValidationContext, WorkflowDecision,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore,
+    WorkflowSubject, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -32,6 +33,39 @@ pub(crate) struct StaleWorkflowRuntimeContext<'a> {
     pub active_task_id: Option<&'a str>,
     pub observed_state: &'a str,
     pub reason: &'a str,
+}
+
+pub(crate) struct RepoBacklogPollRuntimeContext<'a> {
+    pub project_root: &'a Path,
+    pub repo: Option<&'a str>,
+    pub label: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RepoBacklogPollRequestOutcome {
+    Requested { workflow_id: String },
+    ActiveCommandExists { workflow_id: String },
+    NotCandidate { workflow_id: String, state: String },
+    Rejected { workflow_id: String, reason: String },
+}
+
+pub(crate) async fn request_repo_backlog_poll(
+    store: &WorkflowRuntimeStore,
+    ctx: RepoBacklogPollRuntimeContext<'_>,
+) -> anyhow::Result<RepoBacklogPollRequestOutcome> {
+    let instance = load_or_repo_backlog_instance(store, ctx.project_root, ctx.repo).await?;
+    if instance.state != "idle" {
+        return Ok(RepoBacklogPollRequestOutcome::NotCandidate {
+            workflow_id: instance.id,
+            state: instance.state,
+        });
+    }
+    if has_active_repo_backlog_poll_command(store, &instance.id).await? {
+        return Ok(RepoBacklogPollRequestOutcome::ActiveCommandExists {
+            workflow_id: instance.id,
+        });
+    }
+    persist_repo_backlog_poll_request(store, instance, &ctx).await
 }
 
 pub(crate) async fn record_open_issue_without_workflow(
@@ -100,6 +134,55 @@ pub(crate) async fn record_stale_active_workflow(
             "workflow runtime repo backlog recovery write failed: {error}"
         );
     }
+}
+
+async fn persist_repo_backlog_poll_request(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    ctx: &RepoBacklogPollRuntimeContext<'_>,
+) -> anyhow::Result<RepoBacklogPollRequestOutcome> {
+    instance.data = merge_repo_data(
+        instance.data,
+        ctx.project_root,
+        ctx.repo,
+        json!({
+            "label": ctx.label,
+        }),
+    );
+    store.upsert_instance(&instance).await?;
+    let event = store
+        .append_event(
+            &instance.id,
+            "RepoBacklogPollRequested",
+            "workflow_runtime_repo_backlog",
+            json!({
+                "repo": ctx.repo,
+                "label": ctx.label,
+            }),
+        )
+        .await?;
+    let output = build_repo_backlog_poll_decision(
+        &instance,
+        RepoBacklogPollDecisionInput {
+            repo: ctx.repo,
+            label: ctx.label,
+            dedupe_key: &format!("repo-backlog-poll:{}:{}", instance.id, event.id),
+        },
+    );
+    let outcome =
+        apply_decision_with_outcome(store, instance, output.decision, Some(event.id)).await?;
+    Ok(match outcome {
+        ApplyDecisionOutcome::Accepted { workflow_id } => {
+            RepoBacklogPollRequestOutcome::Requested { workflow_id }
+        }
+        ApplyDecisionOutcome::Rejected {
+            workflow_id,
+            reason,
+        } => RepoBacklogPollRequestOutcome::Rejected {
+            workflow_id,
+            reason,
+        },
+    })
 }
 
 async fn persist_open_issue_without_workflow(
@@ -256,10 +339,26 @@ async fn load_or_repo_backlog_instance(
 
 async fn apply_decision(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
     decision: WorkflowDecision,
     event_id: Option<String>,
 ) -> anyhow::Result<()> {
+    apply_decision_with_outcome(store, instance, decision, event_id)
+        .await
+        .map(|_| ())
+}
+
+enum ApplyDecisionOutcome {
+    Accepted { workflow_id: String },
+    Rejected { workflow_id: String, reason: String },
+}
+
+async fn apply_decision_with_outcome(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    decision: WorkflowDecision,
+    event_id: Option<String>,
+) -> anyhow::Result<ApplyDecisionOutcome> {
     let validation = DecisionValidator::repo_backlog().validate(
         &instance,
         &decision,
@@ -271,7 +370,10 @@ async fn apply_decision(
             let reason = error.to_string();
             let record = WorkflowDecisionRecord::rejected(decision, event_id, &reason);
             store.record_decision(&record).await?;
-            return Ok(());
+            return Ok(ApplyDecisionOutcome::Rejected {
+                workflow_id: instance.id,
+                reason,
+            });
         }
     };
     store.record_decision(&record).await?;
@@ -283,7 +385,23 @@ async fn apply_decision(
     instance.state = decision.next_state.clone();
     instance.version = instance.version.saturating_add(1);
     instance.data = merge_last_decision(instance.data, &decision.decision);
-    store.upsert_instance(&instance).await
+    let workflow_id = instance.id.clone();
+    store.upsert_instance(&instance).await?;
+    Ok(ApplyDecisionOutcome::Accepted { workflow_id })
+}
+
+async fn has_active_repo_backlog_poll_command(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
+    Ok(store
+        .commands_for(workflow_id)
+        .await?
+        .into_iter()
+        .any(|record| {
+            matches!(record.status.as_str(), "pending" | "dispatched")
+                && record.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
+        }))
 }
 
 async fn upsert_repo_backlog_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -369,6 +487,67 @@ mod tests {
         assert_eq!(
             store.events_for(&workflow_id).await?[0].event_type,
             "IssueDiscovered"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repo_backlog_poll_request_records_runtime_command() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = match open_runtime_store(dir.path()).await {
+            Ok(store) => store,
+            Err(_) => return Ok(()),
+        };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+
+        let outcome = request_repo_backlog_poll(
+            &store,
+            RepoBacklogPollRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                label: Some("harness"),
+            },
+        )
+        .await?;
+
+        let workflow_id =
+            repo_backlog_workflow_id(&project_root.to_string_lossy(), Some("owner/repo"));
+        assert_eq!(
+            outcome,
+            RepoBacklogPollRequestOutcome::Requested {
+                workflow_id: workflow_id.clone()
+            }
+        );
+        let instance = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("repo backlog workflow instance should be persisted");
+        assert_eq!(instance.state, "scanning");
+        assert_eq!(instance.data["label"], "harness");
+        assert_eq!(instance.data["last_decision"], "poll_repo_backlog");
+        let commands = store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some(REPO_BACKLOG_POLL_ACTIVITY)
+        );
+
+        let second = request_repo_backlog_poll(
+            &store,
+            RepoBacklogPollRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                label: Some("harness"),
+            },
+        )
+        .await?;
+        assert_eq!(
+            second,
+            RepoBacklogPollRequestOutcome::NotCandidate {
+                workflow_id,
+                state: "scanning".to_string()
+            }
         );
         Ok(())
     }

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -1,6 +1,6 @@
 use crate::http::AppState;
 use crate::task_executor::turn_lifecycle::TurnLifecycleOptions;
-use crate::task_runner::{TaskFailureKind, TaskKind, TaskState, TaskStatus};
+use crate::task_runner::{TaskFailureKind, TaskId, TaskKind, TaskState, TaskStatus};
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Duration;
@@ -403,7 +403,46 @@ impl ServerRuntimeJobExecutor {
             )
             .await?;
 
-        Ok(ActivityResult::succeeded(
+        let mut child_submission = None;
+        if command
+            .get("auto_submit")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            let labels = string_vec(command, "labels");
+            let force_execute = force_execute_from_project_policy(project_id, &labels);
+            let task_id = TaskId::from_str(&format!(
+                "repo-backlog:{}:issue:{issue_number}",
+                repo.unwrap_or("<none>")
+            ));
+            let source = optional_string(command, "source").unwrap_or_else(|| "github".to_string());
+            let external_id =
+                optional_string(command, "external_id").unwrap_or_else(|| issue_number.to_string());
+            let depends_on: Vec<TaskId> = Vec::new();
+            let submission = crate::workflow_runtime_submission::record_issue_submission(
+                store,
+                crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+                    project_root: Path::new(project_id),
+                    repo,
+                    issue_number,
+                    task_id: &task_id,
+                    labels: &labels,
+                    force_execute,
+                    additional_prompt: None,
+                    depends_on: &depends_on,
+                    dependencies_blocked: false,
+                    source: Some(source.as_str()),
+                    external_id: Some(external_id.as_str()),
+                },
+            )
+            .await?;
+            child_submission = Some(submission);
+            if let Some(updated) = store.get_instance(&child.id).await? {
+                child = updated;
+            }
+        }
+
+        let mut result = ActivityResult::succeeded(
             activity_name(job),
             format!("Child workflow `{}` started.", child.id),
         )
@@ -415,7 +454,20 @@ impl ServerRuntimeJobExecutor {
                 "state": child.state,
                 "subject_key": child.subject.subject_key,
             }),
-        )))
+        ));
+        if let Some(submission) = child_submission {
+            result = result.with_artifact(ActivityArtifact::new(
+                "child_submission",
+                json!({
+                    "workflow_id": submission.workflow_id,
+                    "accepted": submission.accepted,
+                    "decision_id": submission.decision_id,
+                    "command_ids": submission.command_ids,
+                    "rejection_reason": submission.rejection_reason,
+                }),
+            ));
+        }
+        Ok(result)
     }
 
     async fn execute_mark_bound_issue_done(
@@ -837,6 +889,21 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
                 "retry_policy": "runtime_retry_policy may retry this activity before failure."
             }
         }),
+        ("repo_backlog", "poll_repo_backlog") => json!({
+            "on_succeeded": {
+                "reducer_next_state": "dispatching_when_IssueDiscovered_signals_exist_else_idle",
+                "accepted_signals": ["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
+                "required_summary": "Describe the GitHub issue query, existing workflow checks, and new issue workflow candidates."
+            },
+            "structured_decision": {
+                "optional": true,
+                "description": "A workflow_decision artifact may propose start_child_workflow commands, but IssueDiscovered signals are sufficient."
+            },
+            "on_failed": {
+                "reducer_next_state": "failed_or_retry",
+                "retry_policy": "runtime_retry_policy may retry this activity before failure."
+            }
+        }),
         ("github_issue_pr", "implement_issue") => json!({
             "on_succeeded": {
                 "reducer_next_state": "unchanged_until_pr_detected",
@@ -917,6 +984,21 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 "FeedbackFound": "Use when actionable feedback, requested changes, or failed checks require a fix round.",
                 "NoFeedbackFound": "Use when no actionable feedback is present yet.",
                 "PrReadyToMerge": "Use only when review, checks, and mergeability are all ready."
+            }
+        }),
+        ("repo_backlog", "poll_repo_backlog") => json!({
+            "must_include": ["repo and label queried", "open issues inspected", "existing workflow checks", "new issue workflow candidates", "next workflow action"],
+            "must_not_include": ["repository code changes", "workflow table mutations", "server-side GitHub polling changes"],
+            "signals": {
+                "IssueDiscovered": "Use for each open GitHub issue that needs a child github_issue_pr workflow. Include issue_number, issue_url, repo, title, and labels when available.",
+                "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason.",
+                "NoOpenIssueFound": "Use when the repo/label query found no candidate issues."
+            },
+            "artifacts": {
+                "workflow_decision": {
+                    "optional": true,
+                    "allowed_decisions": ["start_issue_workflows_from_scan", "finish_repo_backlog_scan"]
+                }
             }
         }),
         (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => json!({
@@ -1167,6 +1249,37 @@ fn required_string<'a>(value: &'a Value, field: &str) -> anyhow::Result<&'a str>
         .ok_or_else(|| anyhow::anyhow!("start_child_workflow `{field}` is missing"))
 }
 
+fn optional_string(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn string_vec(value: &Value, field: &str) -> Vec<String> {
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn force_execute_from_project_policy(project_id: &str, labels: &[String]) -> bool {
+    let workflow_cfg = harness_core::config::workflow::load_workflow_config(Path::new(project_id))
+        .unwrap_or_default();
+    labels
+        .iter()
+        .any(|label| label == &workflow_cfg.issue_workflow.force_execute_label)
+}
+
 fn required_data_string<'a>(
     workflow: &'a WorkflowInstance,
     field: &str,
@@ -1328,6 +1441,42 @@ mod tests {
             .expect("allowed transitions should be an array")
             .iter()
             .any(|transition| transition["next_state"] == "passed"));
+    }
+
+    #[test]
+    fn activity_result_schema_describes_repo_backlog_poll_contract() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "poll_repo_backlog"
+            }),
+        );
+        let workflow = WorkflowInstance::new(
+            "repo_backlog",
+            1,
+            "scanning",
+            WorkflowSubject::new("repo", "owner/repo"),
+        )
+        .with_id("repo-backlog-1");
+
+        let schema = activity_result_schema(&job, Some(&workflow));
+
+        assert_eq!(schema["workflow_definition"], "repo_backlog");
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["accepted_signals"][0],
+            "IssueDiscovered"
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["signals"]["IssueDiscovered"],
+            "Use for each open GitHub issue that needs a child github_issue_pr workflow. Include issue_number, issue_url, repo, title, and labels when available."
+        );
+        assert!(schema["workflow_decision_contract"]["allowed_transitions"]
+            .as_array()
+            .expect("allowed transitions should be an array")
+            .iter()
+            .any(|transition| transition["next_state"] == "dispatching"));
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -49,9 +49,10 @@ pub use reducer::{
 };
 pub use repo_backlog::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,
-    build_stale_active_workflow_decision, repo_backlog_workflow_id, MergedPrDecisionInput,
-    OpenIssueDecisionInput, RepoBacklogDecisionOutput, RepoBacklogWorkflowAction,
-    StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID,
+    build_repo_backlog_poll_decision, build_stale_active_workflow_decision,
+    repo_backlog_workflow_id, MergedPrDecisionInput, OpenIssueDecisionInput,
+    RepoBacklogDecisionOutput, RepoBacklogPollDecisionInput, RepoBacklogWorkflowAction,
+    StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
 };
 pub use store::WorkflowRuntimeStore;
 pub use submission::{

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -65,6 +65,10 @@ fn reduce_success(
         return Some(decision);
     }
 
+    if repo_backlog_child_dispatch_still_active(instance, event) {
+        return None;
+    }
+
     if let Some(decision) = structured_decision {
         return Some(decision);
     }
@@ -263,6 +267,21 @@ fn structured_decision_validates(
             &ValidationContext::new(event.source.as_str(), Utc::now()),
         )
         .is_ok()
+}
+
+fn repo_backlog_child_dispatch_still_active(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+) -> bool {
+    instance.definition_id == REPO_BACKLOG_DEFINITION_ID
+        && instance.state == "dispatching"
+        && event_command_type(event) == Some("start_child_workflow")
+        && event
+            .event
+            .get("active_start_child_workflow_commands")
+            .and_then(Value::as_u64)
+            .unwrap_or(1)
+            > 0
 }
 
 fn bind_pr_from_activity_result(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -4,7 +4,7 @@ use super::model::{
 };
 use super::pr_feedback::{build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome};
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
-use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
+use super::repo_backlog::{REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY};
 use super::validator::{DecisionValidator, ValidationContext};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::{json, Value};
@@ -60,6 +60,11 @@ fn reduce_success(
         return Some(decision);
     }
 
+    if let Some(decision) = repo_backlog_poll_decision_from_activity_result(instance, event, result)
+    {
+        return Some(decision);
+    }
+
     if let Some(decision) = structured_decision {
         return Some(decision);
     }
@@ -98,6 +103,11 @@ fn reduce_success(
             "finish_issue_workflow_recovery",
             "issue workflow recovery activity completed",
         ),
+        (REPO_BACKLOG_DEFINITION_ID, "scanning", REPO_BACKLOG_POLL_ACTIVITY) => (
+            "idle",
+            "finish_repo_backlog_scan",
+            "repo backlog scan completed without new child workflow commands",
+        ),
         (QUALITY_GATE_DEFINITION_ID, "checking", QUALITY_GATE_ACTIVITY) => (
             "passed",
             "quality_passed",
@@ -126,6 +136,113 @@ fn workflow_decision_from_activity_result(
             serde_json::from_value::<WorkflowDecision>(artifact.artifact.clone()).ok()
         })
         .map(|decision| decision.with_evidence(runtime_completion_evidence(event, result)))
+}
+
+fn repo_backlog_poll_decision_from_activity_result(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        REPO_BACKLOG_DEFINITION_ID,
+        "scanning",
+        REPO_BACKLOG_POLL_ACTIVITY,
+    ) {
+        return None;
+    }
+
+    let parent_repo = optional_data_string(instance, "repo");
+    let discovered = result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == "IssueDiscovered")
+        .filter_map(|signal| {
+            let issue_number = signal.signal.get("issue_number").and_then(json_value_u64)?;
+            let repo = signal
+                .signal
+                .get("repo")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| parent_repo.clone());
+            let issue_url = signal
+                .signal
+                .get("issue_url")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned);
+            let title = signal
+                .signal
+                .get("title")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned);
+            let labels = signal
+                .signal
+                .get("labels")
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str())
+                        .filter(|value| !value.trim().is_empty())
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            Some((issue_number, repo, issue_url, title, labels))
+        })
+        .collect::<Vec<_>>();
+
+    if discovered.is_empty() {
+        return None;
+    }
+
+    let mut decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "start_issue_workflows_from_scan",
+        "dispatching",
+        format!(
+            "repo backlog scan discovered {} open issue(s) without runtime workflows",
+            discovered.len()
+        ),
+    )
+    .with_evidence(runtime_completion_evidence(event, result));
+
+    for (issue_number, repo, issue_url, title, labels) in discovered {
+        let repo_key = repo.as_deref().unwrap_or("<none>");
+        decision = decision
+            .with_command(WorkflowCommand::new(
+                WorkflowCommandType::StartChildWorkflow,
+                format!("repo-backlog-scan:{repo_key}:issue:{issue_number}:start"),
+                json!({
+                    "definition_id": "github_issue_pr",
+                    "subject_key": format!("issue:{issue_number}"),
+                    "repo": repo,
+                    "issue_number": issue_number,
+                    "issue_url": issue_url.clone(),
+                    "title": title,
+                    "labels": labels,
+                    "source": "github",
+                    "external_id": issue_number.to_string(),
+                    "auto_submit": true,
+                }),
+            ))
+            .with_evidence(WorkflowEvidence::new(
+                "github_issue",
+                match issue_url {
+                    Some(url) => format!("repo={repo_key} issue={issue_number} url={url}"),
+                    None => format!("repo={repo_key} issue={issue_number}"),
+                },
+            ));
+    }
+
+    Some(decision.high_confidence())
 }
 
 fn structured_decision_validates(
@@ -272,7 +389,7 @@ fn result_signal_u64(result: &ActivityResult, field: &str) -> Option<u64> {
     result
         .signals
         .iter()
-        .find_map(|signal| signal.signal.get(field).and_then(|value| value.as_u64()))
+        .find_map(|signal| signal.signal.get(field).and_then(json_value_u64))
 }
 
 fn result_signal_string(result: &ActivityResult, field: &str) -> Option<String> {
@@ -293,6 +410,12 @@ fn optional_data_string(instance: &WorkflowInstance, field: &str) -> Option<Stri
         .and_then(|value| value.as_str())
         .filter(|value| !value.trim().is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn json_value_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|raw| raw.parse::<u64>().ok()))
 }
 
 fn runtime_blocked_decision(

--- a/crates/harness-workflow/src/runtime/repo_backlog.rs
+++ b/crates/harness-workflow/src/runtime/repo_backlog.rs
@@ -1,12 +1,23 @@
-use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
+use super::model::{
+    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
+};
 
 pub const REPO_BACKLOG_DEFINITION_ID: &str = "repo_backlog";
+pub const REPO_BACKLOG_POLL_ACTIVITY: &str = "poll_repo_backlog";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepoBacklogWorkflowAction {
+    PollBacklog,
     StartIssueWorkflow,
     MarkBoundIssueDone,
     RequestRecovery,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RepoBacklogPollDecisionInput<'a> {
+    pub repo: Option<&'a str>,
+    pub label: Option<&'a str>,
+    pub dedupe_key: &'a str,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -41,6 +52,42 @@ pub struct RepoBacklogDecisionOutput {
 
 pub fn repo_backlog_workflow_id(project_id: &str, repo: Option<&str>) -> String {
     format!("{project_id}::repo:{}::backlog", repo.unwrap_or("<none>"))
+}
+
+pub fn build_repo_backlog_poll_decision(
+    instance: &WorkflowInstance,
+    input: RepoBacklogPollDecisionInput<'_>,
+) -> RepoBacklogDecisionOutput {
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "poll_repo_backlog",
+        "scanning",
+        "repo backlog polling should be executed by a runtime agent",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        input.dedupe_key,
+        serde_json::json!({
+            "activity": REPO_BACKLOG_POLL_ACTIVITY,
+            "repo": input.repo,
+            "label": input.label,
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "repo_backlog_poll",
+        format!(
+            "repo={} label={}",
+            repo_key(input.repo),
+            input.label.unwrap_or("<none>")
+        ),
+    ))
+    .high_confidence();
+
+    RepoBacklogDecisionOutput {
+        action: RepoBacklogWorkflowAction::PollBacklog,
+        decision,
+    }
 }
 
 pub fn build_open_issue_without_workflow_decision(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -10,16 +10,16 @@ use super::{
     build_issue_submission_decision, build_merged_pr_decision,
     build_open_issue_without_workflow_decision, build_plan_issue_decision,
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
-    build_quality_gate_run_decision, build_stale_active_workflow_decision,
-    reduce_runtime_job_completed, CommandDispatchOutcome, InMemoryWorkflowBus,
-    IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction, MergedPrDecisionInput,
-    OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
+    build_quality_gate_run_decision, build_repo_backlog_poll_decision,
+    build_stale_active_workflow_decision, reduce_runtime_job_completed, CommandDispatchOutcome,
+    InMemoryWorkflowBus, IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction,
+    MergedPrDecisionInput, OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
     PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, QualityGateDecisionInput,
-    QualityGateWorkflowAction, RepoBacklogWorkflowAction, RuntimeCommandDispatcher,
-    RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput,
-    WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    REPO_BACKLOG_DEFINITION_ID,
+    QualityGateWorkflowAction, RepoBacklogPollDecisionInput, RepoBacklogWorkflowAction,
+    RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
+    StaleWorkflowDecisionInput, WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -1210,6 +1210,34 @@ fn repo_backlog_open_issue_without_workflow_starts_child_workflow() {
 }
 
 #[test]
+fn repo_backlog_poll_decision_starts_runtime_scan() {
+    let instance = repo_backlog_instance("idle");
+    let output = build_repo_backlog_poll_decision(
+        &instance,
+        RepoBacklogPollDecisionInput {
+            repo: Some("owner/repo"),
+            label: Some("harness"),
+            dedupe_key: "repo-backlog-poll:owner/repo",
+        },
+    );
+
+    assert_eq!(output.action, RepoBacklogWorkflowAction::PollBacklog);
+    assert_eq!(output.decision.decision, "poll_repo_backlog");
+    assert_eq!(output.decision.next_state, "scanning");
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some(REPO_BACKLOG_POLL_ACTIVITY)
+    );
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("repo backlog poll decision should validate");
+}
+
+#[test]
 fn repo_backlog_merged_pr_marks_bound_issue_done() {
     let instance = repo_backlog_instance("idle");
     let output = build_merged_pr_decision(
@@ -1366,6 +1394,106 @@ fn runtime_completion_reducer_idles_repo_backlog_after_reconciliation() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("repo backlog reconciliation completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
+    let instance = repo_backlog_instance("scanning").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Found one open issue without a runtime workflow.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueDiscovered",
+        json!({
+            "issue_number": "42",
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "labels": ["harness"]
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("repo backlog scan signals should start issue workflows");
+
+    assert_eq!(decision.decision, "start_issue_workflows_from_scan");
+    assert_eq!(decision.next_state, "dispatching");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(decision.commands[0].command["auto_submit"], true);
+    assert_eq!(decision.commands[0].command["labels"][0], "harness");
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog scan dispatch should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_idles_repo_backlog_after_empty_scan() {
+    let instance = repo_backlog_instance("scanning");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "No open issues require a new runtime workflow.",
+    )
+    .with_signal(ActivitySignal::new(
+        "NoOpenIssueFound",
+        json!({"repo": "owner/repo"}),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("empty repo backlog scan should idle workflow");
+
+    assert_eq!(decision.decision, "finish_repo_backlog_scan");
+    assert_eq!(decision.next_state, "idle");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog scan idle completion should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1337,6 +1337,7 @@ fn runtime_completion_reducer_idles_repo_backlog_after_dispatch() {
         "command_id": "command-1",
         "command": command,
         "runtime_job_id": "job-1",
+        "active_start_child_workflow_commands": 0,
         "activity_result": result,
     }));
 
@@ -1354,6 +1355,37 @@ fn runtime_completion_reducer_idles_repo_backlog_after_dispatch() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("repo backlog dispatch completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_keeps_repo_backlog_dispatching_until_child_dispatch_drains() {
+    let instance = repo_backlog_instance("dispatching");
+    let command = WorkflowCommand::start_child_workflow(
+        "github_issue_pr",
+        "issue:123",
+        "repo-backlog:owner/repo:issue:123:start",
+    );
+    let result = ActivityResult::succeeded("workflow_activity", "Child workflow started.");
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "active_start_child_workflow_commands": 1,
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "repo backlog should stay dispatching until every child-start command is terminal"
+    );
 }
 
 #[test]
@@ -2284,6 +2316,84 @@ async fn runtime_worker_records_completion_event_and_command_status() -> anyhow:
     assert!(decisions
         .iter()
         .any(|record| record.decision.decision == "resume_implementation_after_replan"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_keeps_repo_backlog_dispatching_until_child_starts_finish(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = repo_backlog_instance("dispatching");
+    store.upsert_instance(&workflow).await?;
+    let first_command = WorkflowCommand::start_child_workflow(
+        "github_issue_pr",
+        "issue:123",
+        "repo-backlog:owner/repo:issue:123:start",
+    );
+    let first_command_id = store
+        .enqueue_command(&workflow.id, None, &first_command)
+        .await?;
+    let second_command = WorkflowCommand::start_child_workflow(
+        "github_issue_pr",
+        "issue:124",
+        "repo-backlog:owner/repo:issue:124:start",
+    );
+    let second_command_id = store
+        .enqueue_command(&workflow.id, None, &second_command)
+        .await?;
+    for command_id in [&first_command_id, &second_command_id] {
+        store
+            .enqueue_runtime_job_for_pending_command(
+                command_id,
+                RuntimeKind::CodexJsonrpc,
+                "codex-default",
+                json!({ "activity": "start_child_workflow" }),
+                None,
+            )
+            .await?;
+    }
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded("workflow_activity", "Child workflow started."),
+    };
+
+    worker
+        .run_once(&executor)
+        .await?
+        .expect("first child dispatch job should complete");
+    let first_update = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(first_update.state, "dispatching");
+    let first_completion = store
+        .events_for(&workflow.id)
+        .await?
+        .into_iter()
+        .find(|event| event.event_type == "RuntimeJobCompleted")
+        .expect("first completion event should exist");
+    assert_eq!(
+        first_completion.event["active_start_child_workflow_commands"],
+        1
+    );
+
+    worker
+        .run_once(&executor)
+        .await?
+        .expect("second child dispatch job should complete");
+    let final_update = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(final_update.state, "idle");
+
+    let commands = store.commands_for(&workflow.id).await?;
+    assert!(commands.iter().all(|command| command.status == "completed"));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -221,6 +221,8 @@ impl TransitionAllowlist {
                 "dispatching",
                 [StartChildWorkflow, EnqueueActivity, Wait],
             )
+            .allow("idle", "scanning", [EnqueueActivity, Wait])
+            .allow("scanning", "scanning", [EnqueueActivity, Wait])
             .allow("idle", "reconciling", [EnqueueActivity, Wait])
             .allow(
                 "scanning",
@@ -228,6 +230,7 @@ impl TransitionAllowlist {
                 [StartChildWorkflow, EnqueueActivity, Wait],
             )
             .allow("scanning", "reconciling", [EnqueueActivity, Wait])
+            .allow("scanning", "idle", [Wait])
             .allow(
                 "dispatching",
                 "dispatching",

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -1,5 +1,6 @@
 use super::model::{
     ActivityResult, ActivityStatus, RuntimeJob, RuntimeProfile, WorkflowCommandRecord,
+    WorkflowCommandType,
 };
 use super::reducer::reduce_runtime_job_completed;
 use super::store::WorkflowRuntimeStore;
@@ -106,6 +107,13 @@ impl<'a> RuntimeWorker<'a> {
         self.store
             .mark_command_status(&command.id, command_status_for_activity(result.status))
             .await?;
+        let active_start_child_workflow_commands =
+            if command.command.command_type == WorkflowCommandType::StartChildWorkflow {
+                self.active_start_child_workflow_commands(&command.workflow_id)
+                    .await?
+            } else {
+                0
+            };
         let event = self
             .store
             .append_event(
@@ -117,6 +125,7 @@ impl<'a> RuntimeWorker<'a> {
                     "command": command.command,
                     "runtime_job_id": job.id,
                     "runtime_job_status": job.status,
+                    "active_start_child_workflow_commands": active_start_child_workflow_commands,
                     "activity_result": result,
                 }),
             )
@@ -124,6 +133,22 @@ impl<'a> RuntimeWorker<'a> {
         self.apply_runtime_completion_reducer(&command.workflow_id, &event)
             .await?;
         Ok(())
+    }
+
+    async fn active_start_child_workflow_commands(
+        &self,
+        workflow_id: &str,
+    ) -> anyhow::Result<usize> {
+        Ok(self
+            .store
+            .commands_for(workflow_id)
+            .await?
+            .into_iter()
+            .filter(|record| {
+                record.command.command_type == WorkflowCommandType::StartChildWorkflow
+                    && matches!(record.status.as_str(), "pending" | "dispatched")
+            })
+            .count())
     }
 
     async fn apply_runtime_completion_reducer(


### PR DESCRIPTION
## Summary
- route configured GitHub backlog polling through the repo_backlog workflow runtime instead of the legacy server poller
- add poll_repo_backlog decisions, reducer handling for IssueDiscovered signals, and auto-submission of child issue workflows
- document repo_backlog runtime policy and remove the legacy GitHub polling fallback when runtime is unavailable

## Validation
- cargo check
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check