### PR TITLE
Route repo sprint planning through workflow runtime

### DIFF
--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1901,6 +1901,107 @@ async fn runtime_job_worker_auto_submits_repo_backlog_child_workflow() -> anyhow
 }
 
 #[tokio::test]
+async fn runtime_job_worker_auto_submits_repo_backlog_child_with_dependencies() -> anyhow::Result<()>
+{
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-auto-submit-deps");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+        1,
+        "dispatching",
+        harness_workflow::runtime::WorkflowSubject::new("repo", "owner/repo"),
+    )
+    .with_id("repo-backlog-auto-submit-deps")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "repo-backlog:owner/repo:issue:128:start",
+        serde_json::json!({
+            "definition_id": "github_issue_pr",
+            "subject_key": "issue:128",
+            "repo": "owner/repo",
+            "labels": ["harness"],
+            "depends_on": [127],
+            "source": "github",
+            "external_id": "128",
+            "auto_submit": true,
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    let activity = command.runtime_activity_key().to_string();
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": activity,
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    let child_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 128);
+    let child = store
+        .get_instance(&child_id)
+        .await?
+        .expect("child workflow should be created");
+    assert_eq!(child.state, "awaiting_dependencies");
+    assert_eq!(
+        child.data["depends_on"][0],
+        "repo-backlog:owner/repo:issue:127"
+    );
+    let child_commands = store.commands_for(&child_id).await?;
+    assert!(
+        child_commands.is_empty(),
+        "dependent issue should not enqueue implement_issue until dependencies release"
+    );
+    let completed = store
+        .get_runtime_job(&runtime_job.id)
+        .await?
+        .expect("runtime job should exist");
+    let output: harness_workflow::runtime::ActivityResult = serde_json::from_value(
+        completed
+            .output
+            .expect("activity result should be recorded"),
+    )?;
+    assert!(output
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "child_submission"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_job_worker_marks_bound_issue_done_without_agent_turn() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -418,7 +418,7 @@ impl ServerRuntimeJobExecutor {
             let source = optional_string(command, "source").unwrap_or_else(|| "github".to_string());
             let external_id =
                 optional_string(command, "external_id").unwrap_or_else(|| issue_number.to_string());
-            let depends_on: Vec<TaskId> = Vec::new();
+            let depends_on = dependency_task_ids_from_command(command, repo);
             let submission = crate::workflow_runtime_submission::record_issue_submission(
                 store,
                 crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
@@ -430,7 +430,7 @@ impl ServerRuntimeJobExecutor {
                     force_execute,
                     additional_prompt: None,
                     depends_on: &depends_on,
-                    dependencies_blocked: false,
+                    dependencies_blocked: !depends_on.is_empty(),
                     source: Some(source.as_str()),
                     external_id: Some(external_id.as_str()),
                 },
@@ -891,13 +891,28 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         }),
         ("repo_backlog", "poll_repo_backlog") => json!({
             "on_succeeded": {
-                "reducer_next_state": "dispatching_when_IssueDiscovered_signals_exist_else_idle",
+                "reducer_next_state": "planning_batch_when_IssueDiscovered_signals_exist_else_idle",
                 "accepted_signals": ["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
                 "required_summary": "Describe the GitHub issue query, existing workflow checks, and new issue workflow candidates."
             },
             "structured_decision": {
                 "optional": true,
-                "description": "A workflow_decision artifact may propose start_child_workflow commands, but IssueDiscovered signals are sufficient."
+                "description": "A workflow_decision artifact may propose a plan_repo_sprint activity command, but IssueDiscovered signals are sufficient."
+            },
+            "on_failed": {
+                "reducer_next_state": "failed_or_retry",
+                "retry_policy": "runtime_retry_policy may retry this activity before failure."
+            }
+        }),
+        ("repo_backlog", "plan_repo_sprint") => json!({
+            "on_succeeded": {
+                "reducer_next_state": "dispatching_when_SprintTaskSelected_signals_exist_else_idle",
+                "accepted_signals": ["SprintTaskSelected", "IssueSkipped", "NoSprintTaskSelected"],
+                "required_summary": "Describe dependency planning, skipped issues, and selected issue workflow dispatch order."
+            },
+            "structured_decision": {
+                "optional": true,
+                "description": "A workflow_decision artifact may propose start_child_workflow commands, but SprintTaskSelected signals are sufficient."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -990,14 +1005,34 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_include": ["repo and label queried", "open issues inspected", "existing workflow checks", "new issue workflow candidates", "next workflow action"],
             "must_not_include": ["repository code changes", "workflow table mutations", "server-side GitHub polling changes"],
             "signals": {
-                "IssueDiscovered": "Use for each open GitHub issue that needs a child github_issue_pr workflow. Include issue_number, issue_url, repo, title, and labels when available.",
+                "IssueDiscovered": "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available.",
                 "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason.",
                 "NoOpenIssueFound": "Use when the repo/label query found no candidate issues."
             },
             "artifacts": {
                 "workflow_decision": {
                     "optional": true,
-                    "allowed_decisions": ["start_issue_workflows_from_scan", "finish_repo_backlog_scan"]
+                    "allowed_decisions": ["plan_repo_sprint_from_scan", "finish_repo_backlog_scan"]
+                }
+            }
+        }),
+        ("repo_backlog", "plan_repo_sprint") => json!({
+            "must_include": ["issues considered", "dependency reasoning", "selected tasks", "skipped issues", "next workflow action"],
+            "must_not_include": ["repository code changes", "workflow table mutations", "server-side task queue changes"],
+            "signals": {
+                "SprintTaskSelected": "Use once for each issue selected for execution. Include issue_number, issue_url, repo, labels, and depends_on as issue numbers.",
+                "IssueSkipped": "Use for discovered issues intentionally skipped by planning. Include issue_number and reason.",
+                "NoSprintTaskSelected": "Use when no issue should be dispatched from this sprint plan."
+            },
+            "artifacts": {
+                "sprint_plan": {
+                    "optional": true,
+                    "fields": ["tasks", "skip"],
+                    "task_fields": ["issue", "depends_on"]
+                },
+                "workflow_decision": {
+                    "optional": true,
+                    "allowed_decisions": ["start_issue_workflows_from_sprint_plan", "finish_repo_sprint_plan"]
                 }
             }
         }),
@@ -1272,6 +1307,35 @@ fn string_vec(value: &Value, field: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn dependency_task_ids_from_command(command: &Value, repo: Option<&str>) -> Vec<TaskId> {
+    command
+        .get("depends_on")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| dependency_task_id(value, repo))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn dependency_task_id(value: &Value, repo: Option<&str>) -> Option<TaskId> {
+    if let Some(issue_number) = value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|raw| raw.parse::<u64>().ok()))
+    {
+        return Some(TaskId::from_str(&format!(
+            "repo-backlog:{}:issue:{issue_number}",
+            repo.unwrap_or("<none>")
+        )));
+    }
+    value
+        .as_str()
+        .filter(|raw| !raw.trim().is_empty())
+        .map(TaskId::from_str)
+}
+
 fn force_execute_from_project_policy(project_id: &str, labels: &[String]) -> bool {
     let workflow_cfg = harness_core::config::workflow::load_workflow_config(Path::new(project_id))
         .unwrap_or_default();
@@ -1404,6 +1468,27 @@ mod tests {
     }
 
     #[test]
+    fn dependency_task_ids_from_command_maps_issue_numbers_to_repo_handles() {
+        let command = json!({
+            "depends_on": [42, "43", "explicit-task-id"]
+        });
+
+        let dependencies = dependency_task_ids_from_command(&command, Some("owner/repo"));
+
+        assert_eq!(
+            dependencies
+                .iter()
+                .map(|task_id| task_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "repo-backlog:owner/repo:issue:42",
+                "repo-backlog:owner/repo:issue:43",
+                "explicit-task-id"
+            ]
+        );
+    }
+
+    #[test]
     fn activity_result_schema_describes_quality_gate_contract() {
         let job = RuntimeJob::pending(
             "command-1",
@@ -1470,7 +1555,43 @@ mod tests {
         );
         assert_eq!(
             schema["agent_summary_contract"]["signals"]["IssueDiscovered"],
-            "Use for each open GitHub issue that needs a child github_issue_pr workflow. Include issue_number, issue_url, repo, title, and labels when available."
+            "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available."
+        );
+        assert!(schema["workflow_decision_contract"]["allowed_transitions"]
+            .as_array()
+            .expect("allowed transitions should be an array")
+            .iter()
+            .any(|transition| transition["next_state"] == "planning_batch"));
+    }
+
+    #[test]
+    fn activity_result_schema_describes_repo_sprint_plan_contract() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": harness_workflow::runtime::REPO_BACKLOG_SPRINT_PLAN_ACTIVITY
+            }),
+        );
+        let workflow = WorkflowInstance::new(
+            "repo_backlog",
+            1,
+            "planning_batch",
+            WorkflowSubject::new("repo", "owner/repo"),
+        )
+        .with_id("repo-backlog-1");
+
+        let schema = activity_result_schema(&job, Some(&workflow));
+
+        assert_eq!(schema["workflow_definition"], "repo_backlog");
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["accepted_signals"][0],
+            "SprintTaskSelected"
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["signals"]["SprintTaskSelected"],
+            "Use once for each issue selected for execution. Include issue_number, issue_url, repo, labels, and depends_on as issue numbers."
         );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -1006,7 +1006,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["repository code changes", "workflow table mutations", "server-side GitHub polling changes"],
             "signals": {
                 "IssueDiscovered": "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available.",
-                "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason.",
+                "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason. When an issue already has a workflow, include workflow_state.",
                 "NoOpenIssueFound": "Use when the repo/label query found no candidate issues."
             },
             "artifacts": {

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -53,6 +53,7 @@ pub use repo_backlog::{
     repo_backlog_workflow_id, MergedPrDecisionInput, OpenIssueDecisionInput,
     RepoBacklogDecisionOutput, RepoBacklogPollDecisionInput, RepoBacklogWorkflowAction,
     StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 pub use store::WorkflowRuntimeStore;
 pub use submission::{

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -175,12 +175,18 @@ fn repo_backlog_poll_decision_from_activity_result(
     let parent_repo = optional_data_string(instance, "repo");
     let discovered =
         issue_candidates_from_signals(result, "IssueDiscovered", parent_repo.as_deref());
+    let known_dependencies =
+        known_dependency_candidates_from_skipped_signals(result, parent_repo.as_deref());
 
     if discovered.is_empty() {
         return None;
     }
 
     let issue_payloads = discovered
+        .iter()
+        .map(RepoBacklogIssueCandidate::to_command_value)
+        .collect::<Vec<_>>();
+    let known_dependency_payloads = known_dependencies
         .iter()
         .map(RepoBacklogIssueCandidate::to_command_value)
         .collect::<Vec<_>>();
@@ -201,6 +207,7 @@ fn repo_backlog_poll_decision_from_activity_result(
             "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
             "repo": parent_repo,
             "issues": issue_payloads,
+            "known_dependencies": known_dependency_payloads,
         }),
     ))
     .with_evidence(runtime_completion_evidence(event, result));
@@ -230,11 +237,10 @@ fn repo_backlog_sprint_plan_decision_from_activity_result(
     }
 
     let parent_repo = optional_data_string(instance, "repo");
-    let selected = normalize_selected_sprint_dependencies(sprint_plan_selected_issues(
-        result,
-        event,
-        parent_repo.as_deref(),
-    ));
+    let selected = normalize_selected_sprint_dependencies(
+        sprint_plan_selected_issues(result, event, parent_repo.as_deref()),
+        &sprint_plan_known_dependency_inputs(event, parent_repo.as_deref()),
+    );
     if selected.is_empty() {
         return None;
     }
@@ -346,7 +352,9 @@ impl RepoBacklogIssueCandidate {
         if !labels.is_empty() {
             candidate.labels = labels;
         }
-        candidate.depends_on = u64_array_field(value, "depends_on");
+        if value.get("depends_on").is_some() {
+            candidate.depends_on = u64_array_field(value, "depends_on");
+        }
         Some(candidate)
     }
 
@@ -357,7 +365,22 @@ impl RepoBacklogIssueCandidate {
             "issue_url": self.issue_url,
             "title": self.title,
             "labels": self.labels,
+            "depends_on": self.depends_on,
         })
+    }
+
+    fn merge_from(&mut self, other: Self) {
+        if self.repo.is_none() {
+            self.repo = other.repo;
+        }
+        if self.issue_url.is_none() {
+            self.issue_url = other.issue_url;
+        }
+        if self.title.is_none() {
+            self.title = other.title;
+        }
+        append_missing_strings(&mut self.labels, other.labels);
+        append_missing_u64s(&mut self.depends_on, other.depends_on);
     }
 
     fn github_issue_evidence(&self) -> WorkflowEvidence {
@@ -385,6 +408,42 @@ fn issue_candidates_from_signals(
         .collect()
 }
 
+fn known_dependency_candidates_from_skipped_signals(
+    result: &ActivityResult,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == "IssueSkipped")
+        .filter(|signal| skipped_issue_has_known_workflow(&signal.signal))
+        .filter_map(|signal| RepoBacklogIssueCandidate::from_value(&signal.signal, parent_repo))
+        .collect()
+}
+
+fn skipped_issue_has_known_workflow(value: &Value) -> bool {
+    value
+        .get("existing_workflow")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("has_workflow")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        || value
+            .get("workflow_state")
+            .and_then(non_empty_json_string)
+            .is_some()
+        || value
+            .get("runtime_workflow_state")
+            .and_then(non_empty_json_string)
+            .is_some()
+        || value
+            .get("issue_workflow_state")
+            .and_then(non_empty_json_string)
+            .is_some()
+}
+
 fn sprint_plan_selected_issues(
     result: &ActivityResult,
     event: &WorkflowEvent,
@@ -399,6 +458,28 @@ fn sprint_plan_selected_issues(
         parent_repo,
     ));
     dedupe_issue_candidates(selected)
+}
+
+fn sprint_plan_known_dependency_inputs(
+    event: &WorkflowEvent,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    event_workflow_command(event)
+        .and_then(|command| {
+            command
+                .command
+                .get("known_dependencies")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|value| {
+                            RepoBacklogIssueCandidate::from_value(value, parent_repo)
+                        })
+                        .collect()
+                })
+        })
+        .unwrap_or_default()
 }
 
 fn sprint_plan_candidate_inputs(
@@ -470,23 +551,28 @@ fn sprint_plan_selected_artifacts(
 fn dedupe_issue_candidates(
     candidates: Vec<RepoBacklogIssueCandidate>,
 ) -> Vec<RepoBacklogIssueCandidate> {
-    let mut seen = std::collections::BTreeSet::new();
-    candidates
-        .into_iter()
-        .filter(|candidate| {
-            let key = (
-                candidate.repo.clone().unwrap_or_default(),
-                candidate.issue_number,
-            );
-            seen.insert(key)
-        })
-        .collect()
+    let mut index_by_key = std::collections::BTreeMap::<(String, u64), usize>::new();
+    let mut merged = Vec::<RepoBacklogIssueCandidate>::new();
+    for candidate in candidates {
+        let key = (
+            candidate.repo.clone().unwrap_or_default(),
+            candidate.issue_number,
+        );
+        if let Some(index) = index_by_key.get(&key).copied() {
+            merged[index].merge_from(candidate);
+        } else {
+            index_by_key.insert(key, merged.len());
+            merged.push(candidate);
+        }
+    }
+    merged
 }
 
 fn normalize_selected_sprint_dependencies(
     mut candidates: Vec<RepoBacklogIssueCandidate>,
+    known_dependencies: &[RepoBacklogIssueCandidate],
 ) -> Vec<RepoBacklogIssueCandidate> {
-    let selected: std::collections::BTreeSet<_> = candidates
+    let mut valid_dependencies: std::collections::BTreeSet<_> = candidates
         .iter()
         .map(|candidate| {
             (
@@ -495,6 +581,12 @@ fn normalize_selected_sprint_dependencies(
             )
         })
         .collect();
+    valid_dependencies.extend(known_dependencies.iter().map(|candidate| {
+        (
+            candidate.repo.clone().unwrap_or_default(),
+            candidate.issue_number,
+        )
+    }));
 
     for candidate in &mut candidates {
         let repo = candidate.repo.clone().unwrap_or_default();
@@ -502,12 +594,28 @@ fn normalize_selected_sprint_dependencies(
         let issue_number = candidate.issue_number;
         candidate.depends_on.retain(|dependency| {
             *dependency != issue_number
-                && selected.contains(&(repo.clone(), *dependency))
+                && valid_dependencies.contains(&(repo.clone(), *dependency))
                 && seen.insert(*dependency)
         });
     }
 
     candidates
+}
+
+fn append_missing_strings(target: &mut Vec<String>, values: Vec<String>) {
+    for value in values {
+        if !target.contains(&value) {
+            target.push(value);
+        }
+    }
+}
+
+fn append_missing_u64s(target: &mut Vec<u64>, values: Vec<u64>) {
+    for value in values {
+        if !target.contains(&value) {
+            target.push(value);
+        }
+    }
 }
 
 fn structured_decision_validates(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -230,7 +230,11 @@ fn repo_backlog_sprint_plan_decision_from_activity_result(
     }
 
     let parent_repo = optional_data_string(instance, "repo");
-    let selected = sprint_plan_selected_issues(result, event, parent_repo.as_deref());
+    let selected = normalize_selected_sprint_dependencies(sprint_plan_selected_issues(
+        result,
+        event,
+        parent_repo.as_deref(),
+    ));
     if selected.is_empty() {
         return None;
     }
@@ -477,6 +481,33 @@ fn dedupe_issue_candidates(
             seen.insert(key)
         })
         .collect()
+}
+
+fn normalize_selected_sprint_dependencies(
+    mut candidates: Vec<RepoBacklogIssueCandidate>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    let selected: std::collections::BTreeSet<_> = candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.repo.clone().unwrap_or_default(),
+                candidate.issue_number,
+            )
+        })
+        .collect();
+
+    for candidate in &mut candidates {
+        let repo = candidate.repo.clone().unwrap_or_default();
+        let mut seen = std::collections::BTreeSet::new();
+        let issue_number = candidate.issue_number;
+        candidate.depends_on.retain(|dependency| {
+            *dependency != issue_number
+                && selected.contains(&(repo.clone(), *dependency))
+                && seen.insert(*dependency)
+        });
+    }
+
+    candidates
 }
 
 fn structured_decision_validates(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -4,7 +4,9 @@ use super::model::{
 };
 use super::pr_feedback::{build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome};
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
-use super::repo_backlog::{REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY};
+use super::repo_backlog::{
+    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+};
 use super::validator::{DecisionValidator, ValidationContext};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::{json, Value};
@@ -65,6 +67,12 @@ fn reduce_success(
         return Some(decision);
     }
 
+    if let Some(decision) =
+        repo_backlog_sprint_plan_decision_from_activity_result(instance, event, result)
+    {
+        return Some(decision);
+    }
+
     if repo_backlog_child_dispatch_still_active(instance, event) {
         return None;
     }
@@ -111,6 +119,11 @@ fn reduce_success(
             "idle",
             "finish_repo_backlog_scan",
             "repo backlog scan completed without new child workflow commands",
+        ),
+        (REPO_BACKLOG_DEFINITION_ID, "planning_batch", REPO_BACKLOG_SPRINT_PLAN_ACTIVITY) => (
+            "idle",
+            "finish_repo_sprint_plan",
+            "repo sprint planning completed without selected issue workflow commands",
         ),
         (QUALITY_GATE_DEFINITION_ID, "checking", QUALITY_GATE_ACTIVITY) => (
             "passed",
@@ -160,93 +173,310 @@ fn repo_backlog_poll_decision_from_activity_result(
     }
 
     let parent_repo = optional_data_string(instance, "repo");
-    let discovered = result
-        .signals
-        .iter()
-        .filter(|signal| signal.signal_type == "IssueDiscovered")
-        .filter_map(|signal| {
-            let issue_number = signal.signal.get("issue_number").and_then(json_value_u64)?;
-            let repo = signal
-                .signal
-                .get("repo")
-                .and_then(|value| value.as_str())
-                .filter(|value| !value.trim().is_empty())
-                .map(ToOwned::to_owned)
-                .or_else(|| parent_repo.clone());
-            let issue_url = signal
-                .signal
-                .get("issue_url")
-                .and_then(|value| value.as_str())
-                .filter(|value| !value.trim().is_empty())
-                .map(ToOwned::to_owned);
-            let title = signal
-                .signal
-                .get("title")
-                .and_then(|value| value.as_str())
-                .filter(|value| !value.trim().is_empty())
-                .map(ToOwned::to_owned);
-            let labels = signal
-                .signal
-                .get("labels")
-                .and_then(|value| value.as_array())
-                .map(|values| {
-                    values
-                        .iter()
-                        .filter_map(|value| value.as_str())
-                        .filter(|value| !value.trim().is_empty())
-                        .map(ToOwned::to_owned)
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            Some((issue_number, repo, issue_url, title, labels))
-        })
-        .collect::<Vec<_>>();
+    let discovered =
+        issue_candidates_from_signals(result, "IssueDiscovered", parent_repo.as_deref());
 
     if discovered.is_empty() {
+        return None;
+    }
+
+    let issue_payloads = discovered
+        .iter()
+        .map(RepoBacklogIssueCandidate::to_command_value)
+        .collect::<Vec<_>>();
+    let mut decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "plan_repo_sprint_from_scan",
+        "planning_batch",
+        format!(
+            "repo backlog scan discovered {} open issue(s); runtime sprint planning must select dispatch order",
+            discovered.len()
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        format!("runtime-completion:{}:plan-repo-sprint", event.id),
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "repo": parent_repo,
+            "issues": issue_payloads,
+        }),
+    ))
+    .with_evidence(runtime_completion_evidence(event, result));
+
+    for candidate in discovered {
+        decision = decision.with_evidence(candidate.github_issue_evidence());
+    }
+
+    Some(decision.high_confidence())
+}
+
+fn repo_backlog_sprint_plan_decision_from_activity_result(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        REPO_BACKLOG_DEFINITION_ID,
+        "planning_batch",
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    ) {
+        return None;
+    }
+
+    let parent_repo = optional_data_string(instance, "repo");
+    let selected = sprint_plan_selected_issues(result, event, parent_repo.as_deref());
+    if selected.is_empty() {
         return None;
     }
 
     let mut decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
-        "start_issue_workflows_from_scan",
+        "start_issue_workflows_from_sprint_plan",
         "dispatching",
         format!(
-            "repo backlog scan discovered {} open issue(s) without runtime workflows",
-            discovered.len()
+            "runtime sprint planner selected {} issue workflow(s) for dispatch",
+            selected.len()
         ),
     )
     .with_evidence(runtime_completion_evidence(event, result));
 
-    for (issue_number, repo, issue_url, title, labels) in discovered {
-        let repo_key = repo.as_deref().unwrap_or("<none>");
+    for candidate in selected {
+        let issue_number = candidate.issue_number;
+        let repo_key = candidate.repo.as_deref().unwrap_or("<none>");
         decision = decision
             .with_command(WorkflowCommand::new(
                 WorkflowCommandType::StartChildWorkflow,
-                format!("repo-backlog-scan:{repo_key}:issue:{issue_number}:start"),
+                format!("repo-sprint-plan:{repo_key}:issue:{issue_number}:start"),
                 json!({
                     "definition_id": "github_issue_pr",
                     "subject_key": format!("issue:{issue_number}"),
-                    "repo": repo,
+                    "repo": candidate.repo,
                     "issue_number": issue_number,
-                    "issue_url": issue_url.clone(),
-                    "title": title,
-                    "labels": labels,
+                    "issue_url": candidate.issue_url,
+                    "title": candidate.title,
+                    "labels": candidate.labels,
+                    "depends_on": candidate.depends_on,
                     "source": "github",
                     "external_id": issue_number.to_string(),
                     "auto_submit": true,
                 }),
             ))
-            .with_evidence(WorkflowEvidence::new(
-                "github_issue",
-                match issue_url {
-                    Some(url) => format!("repo={repo_key} issue={issue_number} url={url}"),
-                    None => format!("repo={repo_key} issue={issue_number}"),
-                },
-            ));
+            .with_evidence(candidate.github_issue_evidence());
     }
 
     Some(decision.high_confidence())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoBacklogIssueCandidate {
+    issue_number: u64,
+    repo: Option<String>,
+    issue_url: Option<String>,
+    title: Option<String>,
+    labels: Vec<String>,
+    depends_on: Vec<u64>,
+}
+
+impl RepoBacklogIssueCandidate {
+    fn from_value(value: &Value, parent_repo: Option<&str>) -> Option<Self> {
+        let issue_number = value
+            .get("issue_number")
+            .or_else(|| value.get("issue"))
+            .and_then(json_value_u64)?;
+        let repo = value
+            .get("repo")
+            .and_then(non_empty_json_string)
+            .or_else(|| parent_repo.map(ToOwned::to_owned));
+        let issue_url = value.get("issue_url").and_then(non_empty_json_string);
+        let title = value.get("title").and_then(non_empty_json_string);
+        let labels = string_array_field(value, "labels");
+        let depends_on = u64_array_field(value, "depends_on");
+        Some(Self {
+            issue_number,
+            repo,
+            issue_url,
+            title,
+            labels,
+            depends_on,
+        })
+    }
+
+    fn from_sprint_task(
+        value: &Value,
+        candidates: &[Self],
+        parent_repo: Option<&str>,
+    ) -> Option<Self> {
+        let issue_number = value
+            .get("issue_number")
+            .or_else(|| value.get("issue"))
+            .and_then(json_value_u64)?;
+        let mut candidate = candidates
+            .iter()
+            .find(|candidate| candidate.issue_number == issue_number)
+            .cloned()
+            .unwrap_or(Self {
+                issue_number,
+                repo: parent_repo.map(ToOwned::to_owned),
+                issue_url: None,
+                title: None,
+                labels: Vec::new(),
+                depends_on: Vec::new(),
+            });
+        if let Some(repo) = value.get("repo").and_then(non_empty_json_string) {
+            candidate.repo = Some(repo);
+        }
+        if let Some(issue_url) = value.get("issue_url").and_then(non_empty_json_string) {
+            candidate.issue_url = Some(issue_url);
+        }
+        if let Some(title) = value.get("title").and_then(non_empty_json_string) {
+            candidate.title = Some(title);
+        }
+        let labels = string_array_field(value, "labels");
+        if !labels.is_empty() {
+            candidate.labels = labels;
+        }
+        candidate.depends_on = u64_array_field(value, "depends_on");
+        Some(candidate)
+    }
+
+    fn to_command_value(&self) -> Value {
+        json!({
+            "issue_number": self.issue_number,
+            "repo": self.repo,
+            "issue_url": self.issue_url,
+            "title": self.title,
+            "labels": self.labels,
+        })
+    }
+
+    fn github_issue_evidence(&self) -> WorkflowEvidence {
+        let repo_key = self.repo.as_deref().unwrap_or("<none>");
+        WorkflowEvidence::new(
+            "github_issue",
+            match self.issue_url.as_deref() {
+                Some(url) => format!("repo={repo_key} issue={} url={url}", self.issue_number),
+                None => format!("repo={repo_key} issue={}", self.issue_number),
+            },
+        )
+    }
+}
+
+fn issue_candidates_from_signals(
+    result: &ActivityResult,
+    signal_type: &str,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == signal_type)
+        .filter_map(|signal| RepoBacklogIssueCandidate::from_value(&signal.signal, parent_repo))
+        .collect()
+}
+
+fn sprint_plan_selected_issues(
+    result: &ActivityResult,
+    event: &WorkflowEvent,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    let mut scan_candidates = sprint_plan_candidate_inputs(event, parent_repo);
+    scan_candidates.extend(sprint_plan_candidate_artifacts(result, parent_repo));
+    let mut selected = sprint_plan_selected_signals(result, &scan_candidates, parent_repo);
+    selected.extend(sprint_plan_selected_artifacts(
+        result,
+        &scan_candidates,
+        parent_repo,
+    ));
+    dedupe_issue_candidates(selected)
+}
+
+fn sprint_plan_candidate_inputs(
+    event: &WorkflowEvent,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    event_workflow_command(event)
+        .and_then(|command| {
+            command
+                .command
+                .get("issues")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|value| {
+                            RepoBacklogIssueCandidate::from_value(value, parent_repo)
+                        })
+                        .collect()
+                })
+        })
+        .unwrap_or_default()
+}
+
+fn sprint_plan_candidate_artifacts(
+    result: &ActivityResult,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "repo_backlog_candidates")
+        .flat_map(|artifact| array_items(&artifact.artifact, "issues"))
+        .filter_map(|value| RepoBacklogIssueCandidate::from_value(value, parent_repo))
+        .collect()
+}
+
+fn sprint_plan_selected_signals(
+    result: &ActivityResult,
+    candidates: &[RepoBacklogIssueCandidate],
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == "SprintTaskSelected")
+        .filter_map(|signal| {
+            RepoBacklogIssueCandidate::from_sprint_task(&signal.signal, candidates, parent_repo)
+        })
+        .collect()
+}
+
+fn sprint_plan_selected_artifacts(
+    result: &ActivityResult,
+    candidates: &[RepoBacklogIssueCandidate],
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "sprint_plan")
+        .flat_map(|artifact| array_items(&artifact.artifact, "tasks"))
+        .filter_map(|value| {
+            RepoBacklogIssueCandidate::from_sprint_task(value, candidates, parent_repo)
+        })
+        .collect()
+}
+
+fn dedupe_issue_candidates(
+    candidates: Vec<RepoBacklogIssueCandidate>,
+) -> Vec<RepoBacklogIssueCandidate> {
+    let mut seen = std::collections::BTreeSet::new();
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            let key = (
+                candidate.repo.clone().unwrap_or_default(),
+                candidate.issue_number,
+            );
+            seen.insert(key)
+        })
+        .collect()
 }
 
 fn structured_decision_validates(
@@ -435,6 +665,42 @@ fn json_value_u64(value: &Value) -> Option<u64> {
     value
         .as_u64()
         .or_else(|| value.as_str().and_then(|raw| raw.parse::<u64>().ok()))
+}
+
+fn non_empty_json_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn string_array_field(value: &Value, field: &str) -> Vec<String> {
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(non_empty_json_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn u64_array_field(value: &Value, field: &str) -> Vec<u64> {
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|values| values.iter().filter_map(json_value_u64).collect::<Vec<_>>())
+        .unwrap_or_default()
+}
+
+fn array_items<'a>(value: &'a Value, field: &str) -> Vec<&'a Value> {
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().collect())
+        .unwrap_or_default()
 }
 
 fn runtime_blocked_decision(
@@ -727,8 +993,10 @@ fn supports_same_state_activity_retry(definition_id: &str, state: &str) -> bool 
         (
             GITHUB_ISSUE_PR_DEFINITION_ID,
             "implementing" | "awaiting_feedback" | "addressing_feedback"
-        ) | (REPO_BACKLOG_DEFINITION_ID, "dispatching" | "reconciling")
-            | (QUALITY_GATE_DEFINITION_ID, "checking")
+        ) | (
+            REPO_BACKLOG_DEFINITION_ID,
+            "dispatching" | "reconciling" | "planning_batch"
+        ) | (QUALITY_GATE_DEFINITION_ID, "checking")
     )
 }
 

--- a/crates/harness-workflow/src/runtime/repo_backlog.rs
+++ b/crates/harness-workflow/src/runtime/repo_backlog.rs
@@ -4,10 +4,12 @@ use super::model::{
 
 pub const REPO_BACKLOG_DEFINITION_ID: &str = "repo_backlog";
 pub const REPO_BACKLOG_POLL_ACTIVITY: &str = "poll_repo_backlog";
+pub const REPO_BACKLOG_SPRINT_PLAN_ACTIVITY: &str = "plan_repo_sprint";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepoBacklogWorkflowAction {
     PollBacklog,
+    PlanSprint,
     StartIssueWorkflow,
     MarkBoundIssueDone,
     RequestRecovery,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1615,7 +1615,7 @@ fn runtime_completion_reducer_uses_scan_candidates_for_sprint_plan_artifact() {
         "Move sprint planning into runtime"
     );
     assert_eq!(decision.commands[0].command["labels"][0], "runtime");
-    assert_eq!(decision.commands[0].command["depends_on"][0], 42);
+    assert_eq!(decision.commands[0].command["depends_on"], json!([]));
 }
 
 #[test]
@@ -1675,7 +1675,7 @@ fn runtime_completion_reducer_uses_scan_candidates_for_sprint_task_signal() {
         "Dispatch sprint tasks"
     );
     assert_eq!(decision.commands[0].command["labels"][0], "runtime");
-    assert_eq!(decision.commands[0].command["depends_on"][0], 44);
+    assert_eq!(decision.commands[0].command["depends_on"], json!([]));
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -20,6 +20,7 @@ use super::{
     RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
     StaleWorkflowDecisionInput, WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY,
     QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -1464,17 +1465,23 @@ fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
 
     let decision = reduce_runtime_job_completed(&instance, &event)
         .expect("event should parse")
-        .expect("repo backlog scan signals should start issue workflows");
+        .expect("repo backlog scan signals should start sprint planning");
 
-    assert_eq!(decision.decision, "start_issue_workflows_from_scan");
-    assert_eq!(decision.next_state, "dispatching");
+    assert_eq!(decision.decision, "plan_repo_sprint_from_scan");
+    assert_eq!(decision.next_state, "planning_batch");
     assert_eq!(decision.commands.len(), 1);
     assert_eq!(
         decision.commands[0].command_type,
-        WorkflowCommandType::StartChildWorkflow
+        WorkflowCommandType::EnqueueActivity
     );
-    assert_eq!(decision.commands[0].command["auto_submit"], true);
-    assert_eq!(decision.commands[0].command["labels"][0], "harness");
+    assert_eq!(
+        decision.commands[0].command["activity"],
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY
+    );
+    assert_eq!(
+        decision.commands[0].command["issues"][0]["labels"][0],
+        "harness"
+    );
     DecisionValidator::repo_backlog()
         .validate(
             &instance,
@@ -1482,6 +1489,237 @@ fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("repo backlog scan dispatch should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_dispatches_repo_backlog_sprint_plan() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "repo-backlog:owner/repo:plan",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Selected two issues for sprint dispatch.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({
+            "issue_number": 42,
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "labels": ["harness"],
+            "depends_on": []
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({
+            "issue": "43",
+            "issue_url": "https://github.com/owner/repo/issues/43",
+            "labels": ["harness"],
+            "depends_on": [42]
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint plan should start selected issue workflows");
+
+    assert_eq!(decision.decision, "start_issue_workflows_from_sprint_plan");
+    assert_eq!(decision.next_state, "dispatching");
+    assert_eq!(decision.commands.len(), 2);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(decision.commands[0].command["auto_submit"], true);
+    assert_eq!(decision.commands[0].command["labels"][0], "harness");
+    assert_eq!(decision.commands[1].command["depends_on"][0], 42);
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog sprint dispatch should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_uses_scan_candidates_for_sprint_plan_artifact() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [{
+                "issue_number": 44,
+                "issue_url": "https://github.com/owner/repo/issues/44",
+                "labels": ["runtime"],
+                "title": "Move sprint planning into runtime"
+            }]
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Returned a sprint plan artifact.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "sprint_plan",
+        json!({
+            "tasks": [{ "issue": 44, "depends_on": [42] }],
+            "skip": []
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint plan artifact should start selected issue workflows");
+
+    assert_eq!(decision.decision, "start_issue_workflows_from_sprint_plan");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command["issue_url"],
+        "https://github.com/owner/repo/issues/44"
+    );
+    assert_eq!(
+        decision.commands[0].command["title"],
+        "Move sprint planning into runtime"
+    );
+    assert_eq!(decision.commands[0].command["labels"][0], "runtime");
+    assert_eq!(decision.commands[0].command["depends_on"][0], 42);
+}
+
+#[test]
+fn runtime_completion_reducer_uses_scan_candidates_for_sprint_task_signal() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [{
+                "issue_number": 45,
+                "issue_url": "https://github.com/owner/repo/issues/45",
+                "labels": ["runtime"],
+                "title": "Dispatch sprint tasks"
+            }]
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Selected a sprint task signal.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({
+            "issue": 45,
+            "depends_on": [44]
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint task signal should start selected issue workflow");
+
+    assert_eq!(decision.decision, "start_issue_workflows_from_sprint_plan");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command["issue_url"],
+        "https://github.com/owner/repo/issues/45"
+    );
+    assert_eq!(
+        decision.commands[0].command["title"],
+        "Dispatch sprint tasks"
+    );
+    assert_eq!(decision.commands[0].command["labels"][0], "runtime");
+    assert_eq!(decision.commands[0].command["depends_on"][0], 44);
+}
+
+#[test]
+fn runtime_completion_reducer_idles_repo_backlog_after_empty_sprint_plan() {
+    let instance = repo_backlog_instance("planning_batch");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "repo-backlog:owner/repo:plan",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "No sprint tasks were selected.",
+    )
+    .with_signal(ActivitySignal::new(
+        "NoSprintTaskSelected",
+        json!({"repo": "owner/repo"}),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("empty sprint plan should idle workflow");
+
+    assert_eq!(decision.decision, "finish_repo_sprint_plan");
+    assert_eq!(decision.next_state, "idle");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog sprint idle completion should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1443,6 +1443,15 @@ fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
         "Found one open issue without a runtime workflow.",
     )
     .with_signal(ActivitySignal::new(
+        "IssueSkipped",
+        json!({
+            "issue_number": 41,
+            "repo": "owner/repo",
+            "reason": "already has a runtime workflow",
+            "workflow_state": "implementing"
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
         "IssueDiscovered",
         json!({
             "issue_number": "42",
@@ -1481,6 +1490,10 @@ fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
     assert_eq!(
         decision.commands[0].command["issues"][0]["labels"][0],
         "harness"
+    );
+    assert_eq!(
+        decision.commands[0].command["known_dependencies"][0]["issue_number"],
+        41
     );
     DecisionValidator::repo_backlog()
         .validate(
@@ -1676,6 +1689,191 @@ fn runtime_completion_reducer_uses_scan_candidates_for_sprint_task_signal() {
     );
     assert_eq!(decision.commands[0].command["labels"][0], "runtime");
     assert_eq!(decision.commands[0].command["depends_on"], json!([]));
+}
+
+#[test]
+fn runtime_completion_reducer_preserves_candidate_dependencies_when_signal_omits_depends_on() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [
+                {
+                    "issue_number": 42,
+                    "issue_url": "https://github.com/owner/repo/issues/42",
+                    "labels": ["runtime"],
+                    "title": "Build base runtime"
+                },
+                {
+                    "issue_number": 43,
+                    "issue_url": "https://github.com/owner/repo/issues/43",
+                    "labels": ["runtime"],
+                    "title": "Build dependent runtime",
+                    "depends_on": [42]
+                }
+            ]
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Selected sprint tasks without repeating inherited dependencies.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({ "issue": 42 }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({ "issue": 43 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint task signals should start selected issue workflows");
+
+    let dependent = decision
+        .commands
+        .iter()
+        .find(|command| command.command["issue_number"] == json!(43))
+        .expect("dependent issue should be selected");
+    assert_eq!(dependent.command["depends_on"], json!([42]));
+}
+
+#[test]
+fn runtime_completion_reducer_merges_artifact_dependencies_when_signal_omits_depends_on() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [
+                {
+                    "issue_number": 42,
+                    "issue_url": "https://github.com/owner/repo/issues/42",
+                    "labels": ["runtime"],
+                    "title": "Build base runtime"
+                },
+                {
+                    "issue_number": 43,
+                    "issue_url": "https://github.com/owner/repo/issues/43",
+                    "labels": ["runtime"],
+                    "title": "Build dependent runtime"
+                }
+            ]
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Returned both selected signals and a sprint plan artifact.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({ "issue": 42 }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({ "issue": 43 }),
+    ))
+    .with_artifact(ActivityArtifact::new(
+        "sprint_plan",
+        json!({
+            "tasks": [{ "issue": 43, "depends_on": [42] }],
+            "skip": []
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint plan should start selected issue workflows");
+
+    let dependent = decision
+        .commands
+        .iter()
+        .find(|command| command.command["issue_number"] == json!(43))
+        .expect("dependent issue should be selected");
+    assert_eq!(dependent.command["depends_on"], json!([42]));
+}
+
+#[test]
+fn runtime_completion_reducer_preserves_known_workflow_dependencies_outside_selection() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [{
+                "issue_number": 43,
+                "issue_url": "https://github.com/owner/repo/issues/43",
+                "labels": ["runtime"],
+                "title": "Build dependent runtime"
+            }],
+            "known_dependencies": [{
+                "issue_number": 42,
+                "repo": "owner/repo",
+                "workflow_state": "implementing"
+            }]
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Selected a task gated by an issue that already has a workflow.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({ "issue": 43, "depends_on": [42, 99] }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint plan should start selected issue workflow");
+
+    assert_eq!(decision.commands[0].command["depends_on"], json!([42]));
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -223,6 +223,14 @@ impl TransitionAllowlist {
             )
             .allow("idle", "scanning", [EnqueueActivity, Wait])
             .allow("scanning", "scanning", [EnqueueActivity, Wait])
+            .allow("scanning", "planning_batch", [EnqueueActivity, Wait])
+            .allow("planning_batch", "planning_batch", [EnqueueActivity, Wait])
+            .allow(
+                "planning_batch",
+                "dispatching",
+                [StartChildWorkflow, EnqueueActivity, Wait],
+            )
+            .allow("planning_batch", "idle", [Wait])
             .allow("idle", "reconciling", [EnqueueActivity, Wait])
             .allow(
                 "scanning",


### PR DESCRIPTION
## Summary
- Route repo backlog scan results through a runtime-owned `plan_repo_sprint` activity before child issue dispatch.
- Convert sprint planning signals/artifacts into child `github_issue_pr` workflows with dependency metadata.
- Make auto-submitted child workflows wait on declared dependencies before enqueueing implementation runtime jobs.
- Update the workflow runtime decoupling plan to reflect runtime-owned repo sprint planning.

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test -p harness-workflow runtime_completion_reducer_uses_scan_candidates_for_sprint_task_signal`
- `cargo test`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `git diff --check`
- `rg -n 'Command::new\\(\"(gh|git)\"\\)' crates` (no matches)\n\nStacked on #1050 / `codex/workflow-runtime-repo-backlog`.