### PR TITLE
Route PR feedback through child workflow runtime

### DIFF
--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1912,6 +1912,126 @@ async fn runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn
 }
 
 #[tokio::test]
+async fn runtime_job_worker_requeues_pr_feedback_child_inspect_after_stale_dedupe(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-pr-feedback-child-retry");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "awaiting_feedback",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:227"),
+    )
+    .with_id("issue-pr-feedback-parent-retry")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+        "issue_number": 227,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-227",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "pr-feedback-sweep:issue-227:77",
+        serde_json::json!({
+            "definition_id": harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
+            "subject_key": "pr:77",
+            "child_activity": harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY,
+            "repo": "owner/repo",
+            "issue_number": 227,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": command.runtime_activity_key(),
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+    let child_id = format!("{}::pr-feedback:{}", parent.id, command_id);
+    let child = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "pending",
+        harness_workflow::runtime::WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id(child_id.clone())
+    .with_parent(parent.id.clone());
+    store.upsert_instance(&child).await?;
+    let stale_dedupe_key = format!("pr-feedback-child:{}:inspect", child_id);
+    let stale_command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+        harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY,
+        stale_dedupe_key.clone(),
+    );
+    let stale_command_id = store
+        .enqueue_command(&child_id, None, &stale_command)
+        .await?;
+    store
+        .mark_command_status(&stale_command_id, "completed")
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    let child = store
+        .get_instance(&child_id)
+        .await?
+        .expect("child workflow should still exist");
+    assert_eq!(child.state, "inspecting");
+    let child_commands = store.commands_for(&child_id).await?;
+    assert_eq!(child_commands.len(), 2);
+    let stale = child_commands
+        .iter()
+        .find(|record| record.id == stale_command_id)
+        .expect("stale command should still be recorded");
+    assert_eq!(stale.status, "completed");
+    let requeued = child_commands
+        .iter()
+        .find(|record| record.id != stale_command_id)
+        .expect("retry command should be recorded");
+    assert_eq!(requeued.status, "pending");
+    assert_eq!(
+        requeued.command.activity_name(),
+        Some(harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY)
+    );
+    assert!(requeued
+        .command
+        .dedupe_key
+        .starts_with(&format!("{}:retry:", stale_dedupe_key)));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_job_worker_auto_submits_repo_backlog_child_workflow() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1217,8 +1217,16 @@ async fn runtime_pr_feedback_sweep_tick_enqueues_runtime_command() -> anyhow::Re
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].status, "pending");
     assert_eq!(
-        commands[0].command.activity_name(),
-        Some("sweep_pr_feedback")
+        commands[0].command.command_type,
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(
+        commands[0].command.command["definition_id"],
+        harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID
+    );
+    assert_eq!(
+        commands[0].command.command["child_activity"],
+        harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY
     );
     Ok(())
 }
@@ -1798,6 +1806,107 @@ async fn runtime_job_worker_starts_child_workflow_without_agent_turn() -> anyhow
             .runtime_turns_started_for_workflow(&parent.id, None)
             .await?,
         0
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-pr-feedback-child");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "awaiting_feedback",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:226"),
+    )
+    .with_id("issue-pr-feedback-parent")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+        "issue_number": 226,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-226",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "pr-feedback-sweep:issue-226:77",
+        serde_json::json!({
+            "definition_id": harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
+            "subject_key": "pr:77",
+            "child_activity": harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY,
+            "repo": "owner/repo",
+            "issue_number": 226,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": command.runtime_activity_key(),
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    assert_eq!(
+        store
+            .runtime_turns_started_for_workflow(&parent.id, None)
+            .await?,
+        0
+    );
+    let children = store
+        .list_instances_by_definition(
+            harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
+            Some(&project_id),
+        )
+        .await?;
+    assert_eq!(children.len(), 1);
+    let child = &children[0];
+    assert_eq!(child.state, "inspecting");
+    assert_eq!(
+        child.parent_workflow_id.as_deref(),
+        Some("issue-pr-feedback-parent")
+    );
+    assert_eq!(child.data["pr_number"], 77);
+    assert_eq!(child.data["started_by_runtime_job_id"], runtime_job.id);
+    let child_commands = store.commands_for(&child.id).await?;
+    assert_eq!(child_commands.len(), 1);
+    assert_eq!(
+        child_commands[0].command.activity_name(),
+        Some(harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY)
     );
     Ok(())
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -4,7 +4,7 @@ use harness_workflow::runtime::{
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, ValidationContext, WorkflowDecision, WorkflowDecisionRecord,
     WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
-    PR_FEEDBACK_DEFINITION_ID,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -316,34 +316,59 @@ async fn has_active_pr_feedback_command(
     store: &WorkflowRuntimeStore,
     workflow_id: &str,
 ) -> anyhow::Result<bool> {
+    let parent_has_active_command =
+        store
+            .commands_for(workflow_id)
+            .await?
+            .into_iter()
+            .any(|record| {
+                matches!(record.status.as_str(), "pending" | "dispatched")
+                    && matches!(
+                        record.command.activity_name(),
+                        Some("sweep_pr_feedback" | "address_pr_feedback")
+                    )
+                    || matches!(record.status.as_str(), "pending" | "dispatched")
+                        && record.command.command_type
+                            == harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
+                        && record
+                            .command
+                            .command
+                            .get("definition_id")
+                            .and_then(|value| value.as_str())
+                            == Some(PR_FEEDBACK_DEFINITION_ID)
+            });
+    if parent_has_active_command {
+        return Ok(true);
+    }
+
+    for instance in store
+        .list_instances_by_definition(PR_FEEDBACK_DEFINITION_ID, None)
+        .await?
+        .into_iter()
+        .filter(|instance| instance.parent_workflow_id.as_deref() == Some(workflow_id))
+    {
+        if matches!(instance.state.as_str(), "pending" | "inspecting")
+            && has_active_child_pr_feedback_command(store, &instance.id).await?
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+async fn has_active_child_pr_feedback_command(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
     Ok(store
         .commands_for(workflow_id)
         .await?
         .into_iter()
         .any(|record| {
             matches!(record.status.as_str(), "pending" | "dispatched")
-                && matches!(
-                    record.command.activity_name(),
-                    Some("sweep_pr_feedback" | "address_pr_feedback")
-                )
-                || matches!(record.status.as_str(), "pending" | "dispatched")
-                    && record.command.command_type
-                        == harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
-                    && record
-                        .command
-                        .command
-                        .get("definition_id")
-                        .and_then(|value| value.as_str())
-                        == Some(PR_FEEDBACK_DEFINITION_ID)
-        })
-        || store
-            .list_instances_by_definition(PR_FEEDBACK_DEFINITION_ID, None)
-            .await?
-            .into_iter()
-            .any(|instance| {
-                instance.parent_workflow_id.as_deref() == Some(workflow_id)
-                    && matches!(instance.state.as_str(), "pending" | "inspecting")
-            }))
+                && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
+        }))
 }
 
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -619,6 +644,146 @@ mod tests {
             }
         );
         assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn completed_inspecting_child_does_not_block_next_feedback_sweep() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            123,
+        );
+        upsert_github_issue_pr_definition(&store).await?;
+        let parent = issue_instance(
+            workflow_id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "awaiting_feedback",
+        );
+        store.upsert_instance(&parent).await?;
+        let child = WorkflowInstance::new(
+            PR_FEEDBACK_DEFINITION_ID,
+            1,
+            "inspecting",
+            WorkflowSubject::new("pr", "pr:77"),
+        )
+        .with_id("pr-feedback-child-completed")
+        .with_parent(workflow_id.clone());
+        store.upsert_instance(&child).await?;
+
+        assert!(
+            !has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "an inspecting child with no active command should not suppress future sweeps"
+        );
+
+        let command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "inspect-pr-feedback-77",
+        );
+        store.enqueue_command(&child.id, None, &command).await?;
+
+        assert!(
+            has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "an inspecting child with a pending command should still suppress duplicate sweeps"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn orphan_pending_child_does_not_block_next_feedback_sweep() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            123,
+        );
+        upsert_github_issue_pr_definition(&store).await?;
+        let parent = issue_instance(
+            workflow_id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "awaiting_feedback",
+        )
+        .with_data(json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 123,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "task-1",
+        }));
+        store.upsert_instance(&parent).await?;
+        let child = WorkflowInstance::new(
+            PR_FEEDBACK_DEFINITION_ID,
+            1,
+            "pending",
+            WorkflowSubject::new("pr", "pr:77"),
+        )
+        .with_id("pr-feedback-child-orphan")
+        .with_parent(workflow_id.clone());
+        store.upsert_instance(&child).await?;
+
+        assert!(
+            !has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "a pending child without an active inspection command should not suppress future sweeps"
+        );
+
+        let child_command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "inspect-pr-feedback-77",
+        );
+        let child_command_id = store
+            .enqueue_command(&child.id, None, &child_command)
+            .await?;
+
+        assert!(
+            has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "a pending child with an active inspection command should still suppress duplicate sweeps"
+        );
+
+        store
+            .mark_command_status(&child_command_id, "completed")
+            .await?;
+        assert!(
+            !has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "a pending child with no active inspection command should stop suppressing sweeps"
+        );
+
+        let outcome = request_pr_feedback_sweep(&store, &workflow_id).await?;
+        assert_eq!(
+            outcome,
+            PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id: workflow_id.clone()
+            }
+        );
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -4,6 +4,7 @@ use harness_workflow::runtime::{
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, ValidationContext, WorkflowDecision, WorkflowDecisionRecord,
     WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    PR_FEEDBACK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::path::Path;
@@ -325,7 +326,24 @@ async fn has_active_pr_feedback_command(
                     record.command.activity_name(),
                     Some("sweep_pr_feedback" | "address_pr_feedback")
                 )
-        }))
+                || matches!(record.status.as_str(), "pending" | "dispatched")
+                    && record.command.command_type
+                        == harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
+                    && record
+                        .command
+                        .command
+                        .get("definition_id")
+                        .and_then(|value| value.as_str())
+                        == Some(PR_FEEDBACK_DEFINITION_ID)
+        })
+        || store
+            .list_instances_by_definition(PR_FEEDBACK_DEFINITION_ID, None)
+            .await?
+            .into_iter()
+            .any(|instance| {
+                instance.parent_workflow_id.as_deref() == Some(workflow_id)
+                    && matches!(instance.state.as_str(), "pending" | "inspecting")
+            }))
 }
 
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -580,8 +598,16 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].status, "pending");
         assert_eq!(
-            commands[0].command.activity_name(),
-            Some("sweep_pr_feedback")
+            commands[0].command.command_type,
+            harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
+        );
+        assert_eq!(
+            commands[0].command.command["definition_id"],
+            PR_FEEDBACK_DEFINITION_ID
+        );
+        assert_eq!(
+            commands[0].command.command["child_activity"],
+            harness_workflow::runtime::PR_FEEDBACK_INSPECT_ACTIVITY
         );
         assert_eq!(commands[0].command.command["pr_number"], 77);
 

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -10,10 +10,10 @@ use harness_workflow::runtime::{
     build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
     ActivitySignal, DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob,
     RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowSubject,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
-    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    QUALITY_PASSED_SIGNAL,
+    WorkflowCommandRecord, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
+    WorkflowSubject, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -575,10 +575,25 @@ impl ServerRuntimeJobExecutor {
                     }),
                 )
                 .await?;
+            let stable_inspect_dedupe_key = format!("pr-feedback-child:{}:inspect", child.id);
+            let existing_child_commands = store.commands_for(&child.id).await?;
+            let active_inspect_command = existing_child_commands
+                .iter()
+                .find(|record| is_active_pr_feedback_inspect_command(record));
+            let inspect_dedupe_key = match active_inspect_command {
+                Some(record) => record.command.dedupe_key.clone(),
+                None if existing_child_commands
+                    .iter()
+                    .any(is_pr_feedback_inspect_command) =>
+                {
+                    format!("{}:retry:{}", stable_inspect_dedupe_key, event.id)
+                }
+                None => stable_inspect_dedupe_key,
+            };
             let output = build_pr_feedback_inspect_decision(
                 &child,
                 PrFeedbackInspectDecisionInput {
-                    dedupe_key: &format!("pr-feedback-child:{}:inspect", child.id),
+                    dedupe_key: &inspect_dedupe_key,
                     pr_number,
                     pr_url,
                     issue_number,
@@ -615,11 +630,19 @@ impl ServerRuntimeJobExecutor {
             store.record_decision(&record).await?;
             let mut command_ids = Vec::new();
             for command in &output.decision.commands {
-                command_ids.push(
-                    store
-                        .enqueue_command(&child.id, Some(&record.id), command)
-                        .await?,
-                );
+                let command_id = store
+                    .enqueue_command(&child.id, Some(&record.id), command)
+                    .await?;
+                let command_record = store
+                    .get_command(&command_id)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("workflow command `{command_id}` not found"))?;
+                if !is_active_pr_feedback_inspect_command(&command_record) {
+                    anyhow::bail!(
+                        "pr_feedback child inspect command `{command_id}` was not queued for dispatch"
+                    );
+                }
+                command_ids.push(command_id);
             }
             child.state = output.decision.next_state;
             child.version = child.version.saturating_add(1);
@@ -811,6 +834,15 @@ impl ServerRuntimeJobExecutor {
         }
         Ok(self.state.core.project_root.clone())
     }
+}
+
+fn is_active_pr_feedback_inspect_command(record: &WorkflowCommandRecord) -> bool {
+    matches!(record.status.as_str(), "pending" | "dispatched")
+        && is_pr_feedback_inspect_command(record)
+}
+
+fn is_pr_feedback_inspect_command(record: &WorkflowCommandRecord) -> bool {
+    record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
 }
 
 #[async_trait]

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -7,9 +7,11 @@ use chrono::Duration;
 use harness_core::config::agents::SandboxMode;
 use harness_core::types::{AgentId, Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, DecisionValidator,
-    RuntimeJob, RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
-    WorkflowDefinition, WorkflowInstance, WorkflowSubject, QUALITY_BLOCKED_SIGNAL,
+    build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
+    ActivitySignal, DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob,
+    RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowSubject,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
     QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
     QUALITY_PASSED_SIGNAL,
 };
@@ -342,6 +344,11 @@ impl ServerRuntimeJobExecutor {
             .ok_or_else(|| anyhow::anyhow!("start_child_workflow command payload is missing"))?;
         let definition_id = required_string(command, "definition_id")?;
         let subject_key = required_string(command, "subject_key")?;
+        if definition_id == PR_FEEDBACK_DEFINITION_ID {
+            return self
+                .execute_start_pr_feedback_child_workflow(job, parent, command, subject_key)
+                .await;
+        }
         if definition_id != "github_issue_pr" {
             anyhow::bail!("start_child_workflow definition `{definition_id}` is not supported yet");
         }
@@ -468,6 +475,179 @@ impl ServerRuntimeJobExecutor {
             ));
         }
         Ok(result)
+    }
+
+    async fn execute_start_pr_feedback_child_workflow(
+        &self,
+        job: &RuntimeJob,
+        parent: Option<&WorkflowInstance>,
+        command: &Value,
+        subject_key: &str,
+    ) -> anyhow::Result<ActivityResult> {
+        let Some(store) = self.state.core.workflow_runtime_store.as_ref() else {
+            anyhow::bail!("workflow runtime store is unavailable");
+        };
+        let parent = parent
+            .ok_or_else(|| anyhow::anyhow!("pr_feedback child workflow requires a parent"))?;
+        let pr_number = parse_pr_subject_key(subject_key)
+            .or_else(|| command.get("pr_number").and_then(Value::as_u64))
+            .ok_or_else(|| anyhow::anyhow!("pr_feedback child workflow pr_number is missing"))?;
+        let project_id = parent
+            .data
+            .get("project_id")
+            .and_then(Value::as_str)
+            .or_else(|| job.input.get("project_id").and_then(Value::as_str))
+            .ok_or_else(|| anyhow::anyhow!("pr_feedback child workflow project_id is missing"))?;
+        let repo = command
+            .get("repo")
+            .and_then(Value::as_str)
+            .or_else(|| parent.data.get("repo").and_then(Value::as_str));
+        let pr_url = command
+            .get("pr_url")
+            .and_then(Value::as_str)
+            .or_else(|| parent.data.get("pr_url").and_then(Value::as_str));
+        let issue_number = command
+            .get("issue_number")
+            .and_then(Value::as_u64)
+            .or_else(|| parent.data.get("issue_number").and_then(Value::as_u64));
+        let child_id = format!("{}::pr-feedback:{}", parent.id, job.command_id);
+        store
+            .upsert_definition(&WorkflowDefinition::new(
+                PR_FEEDBACK_DEFINITION_ID,
+                1,
+                "PR feedback workflow",
+            ))
+            .await?;
+        let mut child = match store.get_instance(&child_id).await? {
+            Some(instance) => instance,
+            None => WorkflowInstance::new(
+                PR_FEEDBACK_DEFINITION_ID,
+                1,
+                "pending",
+                WorkflowSubject::new("pr", subject_key),
+            )
+            .with_id(child_id.clone()),
+        };
+        if child.parent_workflow_id.is_none() {
+            child.parent_workflow_id = Some(parent.id.clone());
+        }
+        child.data = merge_pr_feedback_child_data(
+            child.data,
+            PrFeedbackChildData {
+                project_id,
+                repo,
+                issue_number,
+                pr_number,
+                pr_url,
+                parent_workflow_id: parent.id.as_str(),
+                runtime_job_id: job.id.as_str(),
+                command_id: job.command_id.as_str(),
+            },
+        );
+        store.upsert_instance(&child).await?;
+        store
+            .append_event(
+                &child.id,
+                "ChildWorkflowStarted",
+                "workflow_runtime_worker",
+                json!({
+                    "parent_workflow_id": parent.id.as_str(),
+                    "runtime_job_id": job.id.as_str(),
+                    "command_id": job.command_id.as_str(),
+                    "definition_id": PR_FEEDBACK_DEFINITION_ID,
+                    "subject_key": subject_key,
+                }),
+            )
+            .await?;
+
+        let child_command_ids = if child.state == "pending" {
+            let event = store
+                .append_event(
+                    &child.id,
+                    "PrFeedbackInspectionRequested",
+                    "workflow_runtime_worker",
+                    json!({
+                        "parent_workflow_id": parent.id.as_str(),
+                        "pr_number": pr_number,
+                        "pr_url": pr_url,
+                        "issue_number": issue_number,
+                        "repo": repo,
+                    }),
+                )
+                .await?;
+            let output = build_pr_feedback_inspect_decision(
+                &child,
+                PrFeedbackInspectDecisionInput {
+                    dedupe_key: &format!("pr-feedback-child:{}:inspect", child.id),
+                    pr_number,
+                    pr_url,
+                    issue_number,
+                    repo,
+                    parent_workflow_id: Some(parent.id.as_str()),
+                    summary: "PR feedback child workflow requested runtime inspection.",
+                },
+            );
+            let validation = DecisionValidator::pr_feedback().validate(
+                &child,
+                &output.decision,
+                &harness_workflow::runtime::ValidationContext::new(
+                    "workflow_runtime_worker",
+                    chrono::Utc::now(),
+                ),
+            );
+            let record = match validation {
+                Ok(()) => WorkflowDecisionRecord::accepted(output.decision.clone(), Some(event.id)),
+                Err(error) => {
+                    let record = WorkflowDecisionRecord::rejected(
+                        output.decision,
+                        Some(event.id),
+                        error.to_string(),
+                    );
+                    store.record_decision(&record).await?;
+                    return Ok(ActivityResult::failed(
+                        activity_name(job),
+                        "PR feedback child workflow inspection request was rejected.",
+                        error.to_string(),
+                    )
+                    .with_error_kind(ActivityErrorKind::Configuration));
+                }
+            };
+            store.record_decision(&record).await?;
+            let mut command_ids = Vec::new();
+            for command in &output.decision.commands {
+                command_ids.push(
+                    store
+                        .enqueue_command(&child.id, Some(&record.id), command)
+                        .await?,
+                );
+            }
+            child.state = output.decision.next_state;
+            child.version = child.version.saturating_add(1);
+            store.upsert_instance(&child).await?;
+            command_ids
+        } else {
+            Vec::new()
+        };
+
+        Ok(ActivityResult::succeeded(
+            activity_name(job),
+            format!("PR feedback child workflow `{}` started.", child.id),
+        )
+        .with_artifact(ActivityArtifact::new(
+            "child_workflow",
+            json!({
+                "workflow_id": child.id,
+                "definition_id": child.definition_id,
+                "state": child.state,
+                "subject_key": child.subject.subject_key,
+            }),
+        ))
+        .with_artifact(ActivityArtifact::new(
+            "child_commands",
+            json!({
+                "command_ids": child_command_ids,
+            }),
+        )))
     }
 
     async fn execute_mark_bound_issue_done(
@@ -847,6 +1027,7 @@ fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionVali
     match definition_id {
         "github_issue_pr" => Some(DecisionValidator::github_issue_pr()),
         QUALITY_GATE_DEFINITION_ID => Some(DecisionValidator::quality_gate()),
+        PR_FEEDBACK_DEFINITION_ID => Some(DecisionValidator::pr_feedback()),
         "repo_backlog" => Some(DecisionValidator::repo_backlog()),
         _ => None,
     }
@@ -874,7 +1055,8 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
                 "retry_policy": "runtime_retry_policy may retry this activity before failure."
             }
         }),
-        ("github_issue_pr", "sweep_pr_feedback") => json!({
+        ("github_issue_pr", "sweep_pr_feedback")
+        | ("github_issue_pr", PR_FEEDBACK_INSPECT_ACTIVITY) => json!({
             "on_succeeded": {
                 "reducer_next_state": "derived_from_structured_decision_or_signals",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
@@ -883,6 +1065,21 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "structured_decision": {
                 "preferred": true,
                 "description": "Return a workflow_decision artifact for address_pr_feedback, wait_for_pr_feedback, or mark_ready_to_merge."
+            },
+            "on_failed": {
+                "reducer_next_state": "failed_or_retry",
+                "retry_policy": "runtime_retry_policy may retry this activity before failure."
+            }
+        }),
+        (PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => json!({
+            "on_succeeded": {
+                "reducer_next_state": "feedback_found_or_no_actionable_feedback_or_ready_to_merge_from_signals",
+                "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
+                "parent_propagation": "The same activity result is propagated to the parent github_issue_pr workflow."
+            },
+            "structured_decision": {
+                "optional": true,
+                "description": "A workflow_decision artifact may update the pr_feedback child workflow, but signals are sufficient."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -986,7 +1183,9 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_include": ["review feedback addressed", "changed files", "validation commands"],
             "must_not_include": ["claiming review approval without a fresh review signal"],
         }),
-        ("github_issue_pr", "sweep_pr_feedback") => json!({
+        ("github_issue_pr", "sweep_pr_feedback")
+        | ("github_issue_pr", PR_FEEDBACK_INSPECT_ACTIVITY)
+        | (PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => json!({
             "must_include": ["PR comments reviewed", "review states", "check status", "mergeability", "next workflow action"],
             "must_not_include": ["repository code changes", "workflow table mutations", "unverified approval claims"],
             "artifacts": {
@@ -1381,6 +1580,14 @@ fn parse_issue_subject_key(subject_key: &str) -> anyhow::Result<u64> {
         .with_context(|| format!("start_child_workflow subject_key `{subject_key}` is invalid"))
 }
 
+fn parse_pr_subject_key(subject_key: &str) -> Option<u64> {
+    subject_key
+        .strip_prefix("pr:")
+        .unwrap_or(subject_key)
+        .parse::<u64>()
+        .ok()
+}
+
 fn merge_child_issue_data(
     mut data: Value,
     project_id: &str,
@@ -1403,6 +1610,40 @@ fn merge_child_issue_data(
         object.insert("started_by_command_id".to_string(), json!(command_id));
     }
     crate::workflow_runtime_policy::merge_runtime_retry_policy(Path::new(project_id), data)
+}
+
+struct PrFeedbackChildData<'a> {
+    project_id: &'a str,
+    repo: Option<&'a str>,
+    issue_number: Option<u64>,
+    pr_number: u64,
+    pr_url: Option<&'a str>,
+    parent_workflow_id: &'a str,
+    runtime_job_id: &'a str,
+    command_id: &'a str,
+}
+
+fn merge_pr_feedback_child_data(mut data: Value, input: PrFeedbackChildData<'_>) -> Value {
+    if !data.is_object() {
+        data = json!({});
+    }
+    if let Some(object) = data.as_object_mut() {
+        object.insert("project_id".to_string(), json!(input.project_id));
+        object.insert("repo".to_string(), json!(input.repo));
+        object.insert("issue_number".to_string(), json!(input.issue_number));
+        object.insert("pr_number".to_string(), json!(input.pr_number));
+        object.insert("pr_url".to_string(), json!(input.pr_url));
+        object.insert(
+            "parent_workflow_id".to_string(),
+            json!(input.parent_workflow_id),
+        );
+        object.insert(
+            "started_by_runtime_job_id".to_string(),
+            json!(input.runtime_job_id),
+        );
+        object.insert("started_by_command_id".to_string(), json!(input.command_id));
+    }
+    crate::workflow_runtime_policy::merge_runtime_retry_policy(Path::new(input.project_id), data)
 }
 
 fn merge_json_object(target: &mut Value, update: Value) {
@@ -1598,6 +1839,46 @@ mod tests {
             .expect("allowed transitions should be an array")
             .iter()
             .any(|transition| transition["next_state"] == "dispatching"));
+    }
+
+    #[test]
+    fn activity_result_schema_describes_pr_feedback_child_contract() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": PR_FEEDBACK_INSPECT_ACTIVITY
+            }),
+        );
+        let workflow = WorkflowInstance::new(
+            PR_FEEDBACK_DEFINITION_ID,
+            1,
+            "inspecting",
+            WorkflowSubject::new("pr", "pr:77"),
+        )
+        .with_id("pr-feedback-1");
+
+        let schema = activity_result_schema(&job, Some(&workflow));
+
+        assert_eq!(schema["workflow_definition"], PR_FEEDBACK_DEFINITION_ID);
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["accepted_signals"][0],
+            "FeedbackFound"
+        );
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["parent_propagation"],
+            "The same activity result is propagated to the parent github_issue_pr workflow."
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["signals"]["PrReadyToMerge"],
+            "Use only when review, checks, and mergeability are all ready."
+        );
+        assert!(schema["workflow_decision_contract"]["allowed_transitions"]
+            .as_array()
+            .expect("allowed transitions should be an array")
+            .iter()
+            .any(|transition| transition["next_state"] == "feedback_found"));
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -34,9 +34,11 @@ pub use plan_issue::{
     PlanIssueWorkflowAction,
 };
 pub use pr_feedback::{
-    build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
-    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackDecisionOutput, PrFeedbackOutcome,
-    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction,
+    build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_inspect_decision,
+    build_pr_feedback_sweep_decision, PrDetectedDecisionInput, PrFeedbackDecisionInput,
+    PrFeedbackDecisionOutput, PrFeedbackInspectDecisionInput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PR_FEEDBACK_DEFINITION_ID,
+    PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 pub use quality_gate::{
     build_quality_gate_run_decision, quality_gate_workflow_id, QualityGateDecisionInput,

--- a/crates/harness-workflow/src/runtime/pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/pr_feedback.rs
@@ -1,9 +1,13 @@
 use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
 
+pub const PR_FEEDBACK_DEFINITION_ID: &str = "pr_feedback";
+pub const PR_FEEDBACK_INSPECT_ACTIVITY: &str = "inspect_pr_feedback";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrFeedbackWorkflowAction {
     BindPr,
     SweepFeedback,
+    InspectFeedback,
     AddressFeedback,
     AwaitFeedback,
     ReadyToMerge,
@@ -39,6 +43,17 @@ pub struct PrFeedbackSweepDecisionInput<'a> {
     pub pr_url: Option<&'a str>,
     pub issue_number: Option<u64>,
     pub repo: Option<&'a str>,
+    pub summary: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrFeedbackInspectDecisionInput<'a> {
+    pub dedupe_key: &'a str,
+    pub pr_number: u64,
+    pub pr_url: Option<&'a str>,
+    pub issue_number: Option<u64>,
+    pub repo: Option<&'a str>,
+    pub parent_workflow_id: Option<&'a str>,
     pub summary: &'a str,
 }
 
@@ -144,10 +159,12 @@ pub fn build_pr_feedback_sweep_decision(
         input.summary,
     )
     .with_command(WorkflowCommand::new(
-        super::model::WorkflowCommandType::EnqueueActivity,
+        super::model::WorkflowCommandType::StartChildWorkflow,
         input.dedupe_key,
         serde_json::json!({
-            "activity": "sweep_pr_feedback",
+            "definition_id": PR_FEEDBACK_DEFINITION_ID,
+            "subject_key": format!("pr:{}", input.pr_number),
+            "child_activity": PR_FEEDBACK_INSPECT_ACTIVITY,
             "pr_number": input.pr_number,
             "pr_url": input.pr_url,
             "issue_number": input.issue_number,
@@ -166,12 +183,65 @@ pub fn build_pr_feedback_sweep_decision(
     }
 }
 
+pub fn build_pr_feedback_inspect_decision(
+    instance: &WorkflowInstance,
+    input: PrFeedbackInspectDecisionInput<'_>,
+) -> PrFeedbackDecisionOutput {
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "inspect_pr_feedback",
+        "inspecting",
+        input.summary,
+    )
+    .with_command(WorkflowCommand::new(
+        super::model::WorkflowCommandType::EnqueueActivity,
+        input.dedupe_key,
+        serde_json::json!({
+            "activity": PR_FEEDBACK_INSPECT_ACTIVITY,
+            "pr_number": input.pr_number,
+            "pr_url": input.pr_url,
+            "issue_number": input.issue_number,
+            "repo": input.repo,
+            "parent_workflow_id": input.parent_workflow_id,
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "pr_feedback_child",
+        feedback_inspect_summary(input),
+    ))
+    .high_confidence();
+
+    PrFeedbackDecisionOutput {
+        action: PrFeedbackWorkflowAction::InspectFeedback,
+        decision,
+    }
+}
+
 fn feedback_evidence(input: PrFeedbackDecisionInput<'_>) -> WorkflowEvidence {
     let summary = match input.pr_url {
         Some(pr_url) => format!("pr={} url={} {}", input.pr_number, pr_url, input.summary),
         None => format!("pr={} {}", input.pr_number, input.summary),
     };
     WorkflowEvidence::new("pr_feedback", summary)
+}
+
+fn feedback_inspect_summary(input: PrFeedbackInspectDecisionInput<'_>) -> String {
+    let mut parts = vec![format!("pr={}", input.pr_number)];
+    if let Some(pr_url) = input.pr_url {
+        parts.push(format!("url={pr_url}"));
+    }
+    if let Some(issue_number) = input.issue_number {
+        parts.push(format!("issue={issue_number}"));
+    }
+    if let Some(repo) = input.repo {
+        parts.push(format!("repo={repo}"));
+    }
+    if let Some(parent_workflow_id) = input.parent_workflow_id {
+        parts.push(format!("parent={parent_workflow_id}"));
+    }
+    parts.push(input.summary.to_string());
+    parts.join(" ")
 }
 
 fn feedback_sweep_summary(input: PrFeedbackSweepDecisionInput<'_>) -> String {

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -634,6 +634,7 @@ fn structured_decision_validates(
     let validator = match instance.definition_id.as_str() {
         GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
         QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
+        PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
         REPO_BACKLOG_DEFINITION_ID => DecisionValidator::repo_backlog(),
         _ => return true,
     };

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -2,7 +2,10 @@ use super::model::{
     ActivityErrorKind, ActivityResult, ActivityStatus, WorkflowCommand, WorkflowCommandType,
     WorkflowDecision, WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
-use super::pr_feedback::{build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome};
+use super::pr_feedback::{
+    build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+};
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
 use super::repo_backlog::{
     REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
@@ -58,6 +61,11 @@ fn reduce_success(
     }
 
     if let Some(decision) = pr_feedback_sweep_decision_from_activity_result(instance, event, result)
+    {
+        return Some(decision);
+    }
+
+    if let Some(decision) = pr_feedback_child_decision_from_activity_result(instance, event, result)
     {
         return Some(decision);
     }
@@ -712,7 +720,10 @@ fn pr_feedback_sweep_decision_from_activity_result(
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
     if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID
-        || result.activity != "sweep_pr_feedback"
+        || !matches!(
+            result.activity.as_str(),
+            "sweep_pr_feedback" | PR_FEEDBACK_INSPECT_ACTIVITY
+        )
     {
         return None;
     }
@@ -747,6 +758,49 @@ fn pr_feedback_sweep_decision_from_activity_result(
         )
         .decision
         .with_evidence(runtime_completion_evidence(event, result)),
+    )
+}
+
+fn pr_feedback_child_decision_from_activity_result(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        PR_FEEDBACK_DEFINITION_ID,
+        "inspecting",
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+    ) {
+        return None;
+    }
+
+    let outcome = pr_feedback_outcome_from_signals(result)?;
+    let (next_state, decision, reason) = match outcome {
+        PrFeedbackOutcome::BlockingFeedback => (
+            "feedback_found",
+            "record_feedback_found",
+            "PR feedback inspection found actionable feedback.",
+        ),
+        PrFeedbackOutcome::NoActionableFeedback => (
+            "no_actionable_feedback",
+            "record_no_actionable_feedback",
+            "PR feedback inspection found no actionable feedback.",
+        ),
+        PrFeedbackOutcome::ReadyToMerge => (
+            "ready_to_merge",
+            "record_ready_to_merge",
+            "PR feedback inspection found the PR ready to merge.",
+        ),
+    };
+
+    Some(
+        WorkflowDecision::new(&instance.id, &instance.state, decision, next_state, reason)
+            .with_evidence(runtime_completion_evidence(event, result))
+            .high_confidence(),
     )
 }
 
@@ -1135,7 +1189,8 @@ fn supports_same_state_activity_retry(definition_id: &str, state: &str) -> bool 
         ) | (
             REPO_BACKLOG_DEFINITION_ID,
             "dispatching" | "reconciling" | "planning_batch"
-        ) | (QUALITY_GATE_DEFINITION_ID, "checking")
+        ) | (PR_FEEDBACK_DEFINITION_ID, "inspecting")
+            | (QUALITY_GATE_DEFINITION_ID, "checking")
     )
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -18,9 +18,9 @@ use super::{
     PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, QualityGateDecisionInput,
     QualityGateWorkflowAction, RepoBacklogPollDecisionInput, RepoBacklogWorkflowAction,
     RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
-    StaleWorkflowDecisionInput, WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY,
-    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
-    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    StaleWorkflowDecisionInput, WorkflowRuntimeStore, PR_FEEDBACK_DEFINITION_ID,
+    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -400,7 +400,7 @@ fn pr_feedback_decision_addresses_blocking_feedback() {
 }
 
 #[test]
-fn pr_feedback_sweep_decision_enqueues_runtime_activity() {
+fn pr_feedback_sweep_decision_starts_child_workflow() {
     let instance = issue_instance("pr_open");
     let output = build_pr_feedback_sweep_decision(
         &instance,
@@ -420,11 +420,15 @@ fn pr_feedback_sweep_decision_enqueues_runtime_activity() {
     assert_eq!(output.decision.commands.len(), 1);
     assert_eq!(
         output.decision.commands[0].command_type,
-        WorkflowCommandType::EnqueueActivity
+        WorkflowCommandType::StartChildWorkflow
     );
     assert_eq!(
-        output.decision.commands[0].activity_name(),
-        Some("sweep_pr_feedback")
+        output.decision.commands[0].command["definition_id"],
+        PR_FEEDBACK_DEFINITION_ID
+    );
+    assert_eq!(
+        output.decision.commands[0].command["child_activity"],
+        PR_FEEDBACK_INSPECT_ACTIVITY
     );
     assert_eq!(output.decision.commands[0].command["pr_number"], 77);
     DecisionValidator::github_issue_pr()
@@ -754,6 +758,98 @@ fn runtime_completion_reducer_maps_pr_feedback_sweep_signal_to_address_command()
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("feedback sweep signal decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_maps_pr_feedback_child_signal_to_parent_decision() {
+    let instance = issue_instance("awaiting_feedback").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-1",
+    }));
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow found actionable PR feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "count": 2, "pr_number": 77 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "child-command-1",
+        "runtime_job_id": "child-job-1",
+        "child_workflow_id": "pr-feedback-child-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("child feedback signal should reduce on parent issue workflow");
+
+    assert_eq!(decision.decision, "address_pr_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("child feedback signal decision should validate on parent");
+}
+
+#[test]
+fn runtime_completion_reducer_updates_pr_feedback_child_from_inspection_signal() {
+    let instance = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-1");
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow found no actionable PR feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "NoFeedbackFound",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "child-command-1",
+        "runtime_job_id": "child-job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("child feedback inspection signal should reduce");
+
+    assert_eq!(decision.decision, "record_no_actionable_feedback");
+    assert_eq!(decision.next_state, "no_actionable_feedback");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::pr_feedback()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("child feedback inspection decision should validate");
 }
 
 #[test]
@@ -2830,6 +2926,172 @@ async fn runtime_worker_keeps_repo_backlog_dispatching_until_child_starts_finish
 
     let commands = store.commands_for(&workflow.id).await?;
     assert!(commands.iter().all(|command| command.status == "completed"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+    let child = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child")
+    .with_parent(parent.id.clone());
+    store.upsert_instance(&child).await?;
+    let command =
+        WorkflowCommand::enqueue_activity(PR_FEEDBACK_INSPECT_ACTIVITY, "inspect-pr-feedback-77");
+    let command_id = store.enqueue_command(&child.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": PR_FEEDBACK_INSPECT_ACTIVITY }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "PR feedback child found actionable feedback.",
+        )
+        .with_signal(ActivitySignal::new(
+            "FeedbackFound",
+            json!({ "pr_number": 77, "count": 1 }),
+        )),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance(&child.id)
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "feedback_found");
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "addressing_feedback");
+    let parent_commands = store.commands_for(&parent.id).await?;
+    assert_eq!(parent_commands.len(), 1);
+    assert_eq!(
+        parent_commands[0].command.activity_name(),
+        Some("address_pr_feedback")
+    );
+    let parent_events = store.events_for(&parent.id).await?;
+    assert!(parent_events.iter().any(|event| {
+        event.event_type == "RuntimeJobCompleted"
+            && event.event["child_workflow_id"] == "pr-feedback-child"
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_does_not_propagate_retrying_pr_feedback_child() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent-retry")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+    let child = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-retry")
+    .with_parent(parent.id.clone())
+    .with_data(json!({
+        "runtime_retry_policy": {
+            "activity_retries": {
+                "inspect_pr_feedback": {
+                    "max_failed_activity_retries": 2,
+                    "retry_delay_secs": 1
+                }
+            }
+        }
+    }));
+    store.upsert_instance(&child).await?;
+    let command =
+        WorkflowCommand::enqueue_activity(PR_FEEDBACK_INSPECT_ACTIVITY, "inspect-pr-feedback-77");
+    let command_id = store.enqueue_command(&child.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": PR_FEEDBACK_INSPECT_ACTIVITY }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::failed(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "PR feedback inspection hit a transient API error.",
+            "temporary GitHub API error",
+        )
+        .with_error_kind(ActivityErrorKind::Retryable),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance(&child.id)
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "inspecting");
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "awaiting_feedback");
+    let parent_events = store.events_for(&parent.id).await?;
+    assert!(
+        parent_events
+            .iter()
+            .all(|event| event.event_type != "RuntimeJobCompleted"),
+        "retrying child failure must not propagate to parent"
+    );
+    let child_commands = store.commands_for(&child.id).await?;
+    assert!(child_commands.iter().any(|record| {
+        record.status == "pending"
+            && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
+            && record.command.command["retry_attempt"] == 1
+    }));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -853,6 +853,66 @@ fn runtime_completion_reducer_updates_pr_feedback_child_from_inspection_signal()
 }
 
 #[test]
+fn runtime_completion_reducer_uses_pr_feedback_child_signal_when_structured_decision_is_invalid() {
+    let instance = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-1");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "inspecting",
+        "invalid_child_feedback_decision",
+        "addressing_feedback",
+        "This child decision targets the parent workflow state.",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "address_pr_feedback",
+        "invalid-child-feedback",
+    ));
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow found actionable PR feedback.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ))
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "child-command-1",
+        "runtime_job_id": "child-job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("child feedback inspection signal should reduce");
+
+    assert_eq!(decision.decision, "record_feedback_found");
+    assert_eq!(decision.next_state, "feedback_found");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::pr_feedback()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("child feedback inspection decision should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_prefers_blocking_pr_feedback_over_ready_signal() {
     let instance = issue_instance("awaiting_feedback").with_data(json!({
         "pr_number": 77,
@@ -2966,11 +3026,23 @@ async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> a
         )
         .await?;
     let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let malformed_parent_decision = WorkflowDecision::new(
+        &parent.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "Child inspection emitted a stale parent decision.",
+    )
+    .high_confidence();
     let executor = StaticRuntimeExecutor {
         result: ActivityResult::succeeded(
             PR_FEEDBACK_INSPECT_ACTIVITY,
             "PR feedback child found actionable feedback.",
         )
+        .with_artifact(ActivityArtifact::new(
+            "workflow_decision",
+            serde_json::to_value(&malformed_parent_decision)?,
+        ))
         .with_signal(ActivitySignal::new(
             "FeedbackFound",
             json!({ "pr_number": 77, "count": 1 }),
@@ -3000,10 +3072,89 @@ async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> a
         Some("address_pr_feedback")
     );
     let parent_events = store.events_for(&parent.id).await?;
-    assert!(parent_events.iter().any(|event| {
-        event.event_type == "RuntimeJobCompleted"
-            && event.event["child_workflow_id"] == "pr-feedback-child"
-    }));
+    let propagated_event = parent_events
+        .iter()
+        .find(|event| {
+            event.event_type == "RuntimeJobCompleted"
+                && event.event["child_workflow_id"] == "pr-feedback-child"
+        })
+        .expect("child completion should propagate to parent");
+    assert!(propagated_event.event["activity_result"]["artifacts"]
+        .as_array()
+        .expect("activity artifacts should be an array")
+        .iter()
+        .all(|artifact| artifact["artifact_type"] != "workflow_decision"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_does_not_propagate_still_inspecting_pr_feedback_child() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent-still-inspecting")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+    let child = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-still-inspecting")
+    .with_parent(parent.id.clone());
+    store.upsert_instance(&child).await?;
+    let command =
+        WorkflowCommand::enqueue_activity(PR_FEEDBACK_INSPECT_ACTIVITY, "inspect-pr-feedback-77");
+    let command_id = store.enqueue_command(&child.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": PR_FEEDBACK_INSPECT_ACTIVITY }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "PR feedback inspection produced no accepted outcome signal.",
+        ),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance(&child.id)
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "inspecting");
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "awaiting_feedback");
+    let parent_events = store.events_for(&parent.id).await?;
+    assert!(
+        parent_events
+            .iter()
+            .all(|event| event.event_type != "RuntimeJobCompleted"),
+        "still-inspecting child success must not propagate to parent"
+    );
     Ok(())
 }
 
@@ -3092,6 +3243,79 @@ async fn runtime_worker_does_not_propagate_retrying_pr_feedback_child() -> anyho
             && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
             && record.command.command["retry_attempt"] == 1
     }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_does_not_propagate_terminal_pr_feedback_child_failure() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent-failed-child")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+    let child = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-failed")
+    .with_parent(parent.id.clone());
+    store.upsert_instance(&child).await?;
+    let command =
+        WorkflowCommand::enqueue_activity(PR_FEEDBACK_INSPECT_ACTIVITY, "inspect-pr-feedback-77");
+    let command_id = store.enqueue_command(&child.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": PR_FEEDBACK_INSPECT_ACTIVITY }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::failed(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "PR feedback inspection failed permanently.",
+            "invalid PR feedback response",
+        )
+        .with_error_kind(ActivityErrorKind::Fatal),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance(&child.id)
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "failed");
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "awaiting_feedback");
+    let parent_events = store.events_for(&parent.id).await?;
+    assert!(
+        parent_events
+            .iter()
+            .all(|event| event.event_type != "RuntimeJobCompleted"),
+        "terminal child failure must not propagate to parent"
+    );
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -276,6 +276,25 @@ impl TransitionAllowlist {
             .allow_from_any("failed", [MarkFailed])
             .allow_from_any("cancelled", [MarkCancelled])
     }
+
+    pub fn pr_feedback_defaults() -> Self {
+        use WorkflowCommandType::{
+            EnqueueActivity, MarkBlocked, MarkCancelled, MarkFailed, RequestOperatorAttention, Wait,
+        };
+
+        Self::default()
+            .allow("pending", "inspecting", [EnqueueActivity, Wait])
+            .allow("inspecting", "inspecting", [EnqueueActivity, Wait])
+            .allow("inspecting", "feedback_found", std::iter::empty())
+            .allow("inspecting", "no_actionable_feedback", std::iter::empty())
+            .allow("inspecting", "ready_to_merge", std::iter::empty())
+            .allow("feedback_found", "done", [Wait])
+            .allow("no_actionable_feedback", "done", [Wait])
+            .allow("ready_to_merge", "done", [Wait])
+            .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])
+            .allow_from_any("failed", [MarkFailed])
+            .allow_from_any("cancelled", [MarkCancelled])
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -389,6 +408,10 @@ impl DecisionValidator {
 
     pub fn quality_gate() -> Self {
         Self::new(TransitionAllowlist::quality_gate_defaults())
+    }
+
+    pub fn pr_feedback() -> Self {
+        Self::new(TransitionAllowlist::pr_feedback_defaults())
     }
 
     pub fn validate(

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -164,6 +164,9 @@ impl<'a> RuntimeWorker<'a> {
         if child.definition_id != super::pr_feedback::PR_FEEDBACK_DEFINITION_ID {
             return Ok(());
         }
+        if !runtime_event_result_succeeded(event) {
+            return Ok(());
+        }
         if matches!(child.state.as_str(), "pending" | "inspecting") {
             return Ok(());
         }
@@ -267,6 +270,15 @@ impl<'a> RuntimeWorker<'a> {
     }
 }
 
+fn runtime_event_result_succeeded(event: &super::model::WorkflowEvent) -> bool {
+    event
+        .event
+        .get("activity_result")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<ActivityResult>(value).ok())
+        .is_some_and(|result| result.status == ActivityStatus::Succeeded)
+}
+
 fn merge_child_completion_payload(
     event: &super::model::WorkflowEvent,
     child_workflow_id: &str,
@@ -277,6 +289,19 @@ fn merge_child_completion_payload(
             "child_workflow_id".to_string(),
             serde_json::json!(child_workflow_id),
         );
+        if let Some(artifacts) = object
+            .get_mut("activity_result")
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|activity_result| activity_result.get_mut("artifacts"))
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            artifacts.retain(|artifact| {
+                artifact
+                    .get("artifact_type")
+                    .and_then(serde_json::Value::as_str)
+                    != Some("workflow_decision")
+            });
+        }
     }
     payload
 }

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -132,6 +132,8 @@ impl<'a> RuntimeWorker<'a> {
             .await?;
         self.apply_runtime_completion_reducer(&command.workflow_id, &event)
             .await?;
+        self.propagate_pr_feedback_child_completion(&command.workflow_id, &event)
+            .await?;
         Ok(())
     }
 
@@ -151,6 +153,36 @@ impl<'a> RuntimeWorker<'a> {
             .count())
     }
 
+    async fn propagate_pr_feedback_child_completion(
+        &self,
+        workflow_id: &str,
+        event: &super::model::WorkflowEvent,
+    ) -> anyhow::Result<()> {
+        let Some(child) = self.store.get_instance(workflow_id).await? else {
+            return Ok(());
+        };
+        if child.definition_id != super::pr_feedback::PR_FEEDBACK_DEFINITION_ID {
+            return Ok(());
+        }
+        if matches!(child.state.as_str(), "pending" | "inspecting") {
+            return Ok(());
+        }
+        let Some(parent_workflow_id) = child.parent_workflow_id.as_deref() else {
+            return Ok(());
+        };
+        let parent_event = self
+            .store
+            .append_event(
+                parent_workflow_id,
+                "RuntimeJobCompleted",
+                &self.owner,
+                merge_child_completion_payload(event, &child.id),
+            )
+            .await?;
+        self.apply_runtime_completion_reducer(parent_workflow_id, &parent_event)
+            .await
+    }
+
     async fn apply_runtime_completion_reducer(
         &self,
         workflow_id: &str,
@@ -166,6 +198,7 @@ impl<'a> RuntimeWorker<'a> {
         let validator = match instance.definition_id.as_str() {
             super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
             super::quality_gate::QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
+            super::pr_feedback::PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
             super::repo_backlog::REPO_BACKLOG_DEFINITION_ID => DecisionValidator::repo_backlog(),
             _ => return Ok(()),
         };
@@ -232,6 +265,20 @@ impl<'a> RuntimeWorker<'a> {
             max_turns,
         )))
     }
+}
+
+fn merge_child_completion_payload(
+    event: &super::model::WorkflowEvent,
+    child_workflow_id: &str,
+) -> serde_json::Value {
+    let mut payload = event.event.clone();
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            "child_workflow_id".to_string(),
+            serde_json::json!(child_workflow_id),
+        );
+    }
+    payload
 }
 
 fn command_status_for_activity(status: ActivityStatus) -> &'static str {


### PR DESCRIPTION
## Summary
- Start dedicated `pr_feedback` child workflows from issue PR feedback sweeps.
- Have child workflows enqueue `inspect_pr_feedback` runtime jobs and propagate structured results back to the parent issue workflow only after the child leaves pending inspection.
- Add transition validation, reducer support, runtime prompt schema, server worker lifecycle handling, and tests for the child feedback path.
- Update the workflow runtime decoupling plan to reflect runtime-owned PR feedback inspection.

## Testing
- `cargo fmt --all`
- `cargo check -p harness-workflow -p harness-server`
- `cargo check`
- `cargo test -p harness-workflow pr_feedback`
- `cargo test -p harness-server workflow_runtime_pr_feedback`
- `cargo test -p harness-server runtime_pr_feedback_sweep_tick_enqueues_runtime_command`
- `cargo test -p harness-server runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn`
- `cargo test -p harness-server activity_result_schema_describes_pr_feedback_child_contract`
- `cargo test -p harness-workflow runtime_worker_propagates_pr_feedback_child_completion_to_parent`
- `cargo test -p harness-workflow runtime_worker_does_not_propagate_retrying_pr_feedback_child`
- `cargo test` initially hit Postgres pool timeouts in four unrelated server tests; each failed test passed when rerun serially.
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'Command::new\\("(gh|git)"\\)' crates` (no matches)\n\nStacked on #1051 / `codex/workflow-runtime-sprint-planning`.