### PR TITLE
Route prompt submissions through workflow runtime

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -831,6 +831,7 @@ pub(super) async fn run_runtime_pr_feedback_sweep_tick(
         .list_instances_by_definition(
             harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
             None,
+            None,
         )
         .await?;
     let mut tick = RuntimePrFeedbackSweepTick::default();

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -488,6 +488,12 @@ pub(super) async fn run_runtime_command_dispatch_tick(
         batch_limit,
     )
     .await?;
+    let prompt_release = crate::workflow_runtime_submission::release_ready_prompt_dependencies(
+        store,
+        &state.core.tasks,
+        batch_limit,
+    )
+    .await?;
     if release.released > 0 || release.failed > 0 || release.skipped > 0 {
         tracing::info!(
             released = release.released,
@@ -495,6 +501,15 @@ pub(super) async fn run_runtime_command_dispatch_tick(
             waiting = release.waiting,
             skipped = release.skipped,
             "workflow runtime dependency release tick complete"
+        );
+    }
+    if prompt_release.released > 0 || prompt_release.failed > 0 || prompt_release.skipped > 0 {
+        tracing::info!(
+            released = prompt_release.released,
+            failed = prompt_release.failed,
+            waiting = prompt_release.waiting,
+            skipped = prompt_release.skipped,
+            "workflow runtime prompt dependency release tick complete"
         );
     }
     let fallback_profile_selector = runtime_profiles.into();

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -144,7 +144,7 @@ async fn append_runtime_definition_summaries(
     task_kind: TaskKind,
 ) -> anyhow::Result<()> {
     let workflows = store
-        .list_instances_by_definition(definition_id, None)
+        .list_instances_by_definition(definition_id, None, None)
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()
@@ -186,7 +186,10 @@ fn runtime_workflow_task_summary(
                 .map(|issue_number| format!("issue #{issue_number}"))
                 .unwrap_or_else(|| workflow.subject.subject_key.clone()),
         ),
-        TaskKind::Prompt => runtime_string_field(&workflow.data, "prompt"),
+        TaskKind::Prompt => Some(
+            runtime_string_field(&workflow.data, "prompt_summary")
+                .unwrap_or_else(|| "prompt task".to_string()),
+        ),
         _ => Some(workflow.subject.subject_key.clone()),
     };
     TaskSummary {

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -29,6 +29,7 @@ struct FullTaskResponse {
 struct RuntimeTaskResponse {
     id: String,
     task_id: String,
+    task_kind: TaskKind,
     status: String,
     execution_path: &'static str,
     workflow_id: String,
@@ -97,8 +98,8 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                     };
                 }
             }
-            if let Err(e) = append_runtime_issue_summaries(&state, &mut summaries).await {
-                tracing::error!("list_tasks: failed to append runtime issue summaries: {e}");
+            if let Err(e) = append_runtime_submission_summaries(&state, &mut summaries).await {
+                tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
             }
             Json(summaries).into_response()
         }
@@ -113,18 +114,37 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
-async fn append_runtime_issue_summaries(
+async fn append_runtime_submission_summaries(
     state: &AppState,
     summaries: &mut Vec<TaskSummary>,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(());
     };
+    append_runtime_definition_summaries(
+        store,
+        summaries,
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        TaskKind::Issue,
+    )
+    .await?;
+    append_runtime_definition_summaries(
+        store,
+        summaries,
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+        TaskKind::Prompt,
+    )
+    .await
+}
+
+async fn append_runtime_definition_summaries(
+    store: &harness_workflow::runtime::WorkflowRuntimeStore,
+    summaries: &mut Vec<TaskSummary>,
+    definition_id: &str,
+    task_kind: TaskKind,
+) -> anyhow::Result<()> {
     let workflows = store
-        .list_instances_by_definition(
-            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
-            None,
-        )
+        .list_instances_by_definition(definition_id, None)
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()
@@ -139,14 +159,15 @@ async fn append_runtime_issue_summaries(
         if !listed_ids.insert(task_id.as_str().to_string()) {
             continue;
         }
-        summaries.push(runtime_issue_task_summary(workflow, task_id));
+        summaries.push(runtime_workflow_task_summary(workflow, task_id, task_kind));
     }
     Ok(())
 }
 
-fn runtime_issue_task_summary(
+fn runtime_workflow_task_summary(
     workflow: harness_workflow::runtime::WorkflowInstance,
     task_id: harness_core::types::TaskId,
+    task_kind: TaskKind,
 ) -> TaskSummary {
     let status = runtime_workflow_state_to_task_status(&workflow.state);
     let scheduler = runtime_workflow_scheduler_state(&status);
@@ -154,9 +175,23 @@ fn runtime_issue_task_summary(
         .data
         .get("issue_number")
         .and_then(|value| value.as_u64());
+    let external_id = match task_kind {
+        TaskKind::Issue => issue.map(|issue_number| format!("issue:{issue_number}")),
+        TaskKind::Prompt => runtime_string_field(&workflow.data, "external_id"),
+        _ => None,
+    };
+    let description = match task_kind {
+        TaskKind::Issue => Some(
+            issue
+                .map(|issue_number| format!("issue #{issue_number}"))
+                .unwrap_or_else(|| workflow.subject.subject_key.clone()),
+        ),
+        TaskKind::Prompt => runtime_string_field(&workflow.data, "prompt"),
+        _ => Some(workflow.subject.subject_key.clone()),
+    };
     TaskSummary {
         id: task_id,
-        task_kind: TaskKind::Issue,
+        task_kind,
         status: status.clone(),
         failure_kind: status.is_failure().then_some(TaskFailureKind::Task),
         turn: 0,
@@ -164,13 +199,9 @@ fn runtime_issue_task_summary(
         error: runtime_string_field(&workflow.data, "failure_reason"),
         source: runtime_string_field(&workflow.data, "source"),
         parent_id: None,
-        external_id: issue.map(|issue_number| format!("issue:{issue_number}")),
+        external_id,
         repo: runtime_string_field(&workflow.data, "repo"),
-        description: Some(
-            issue
-                .map(|issue_number| format!("issue #{issue_number}"))
-                .unwrap_or_else(|| workflow.subject.subject_key.clone()),
-        ),
+        description,
         created_at: Some(workflow.created_at.to_rfc3339()),
         phase: runtime_workflow_state_to_task_phase(&workflow.state),
         depends_on: runtime_task_id_array(&workflow.data, "depends_on"),
@@ -292,22 +323,33 @@ async fn runtime_task_response_by_handle(
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(None);
     };
-    let Some(workflow) =
-        crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id).await?
-    else {
+    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
         return Ok(None);
     };
     let issue = workflow
         .data
         .get("issue_number")
         .and_then(|value| value.as_u64());
+    let Some(task_kind) = (match workflow.definition_id.as_str() {
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID => Some(TaskKind::Issue),
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID => Some(TaskKind::Prompt),
+        _ => None,
+    }) else {
+        return Ok(None);
+    };
+    let external_id = match task_kind {
+        TaskKind::Issue => issue.map(|issue_number| format!("issue:{issue_number}")),
+        TaskKind::Prompt => runtime_string_field(&workflow.data, "external_id"),
+        _ => None,
+    };
     Ok(Some(RuntimeTaskResponse {
         id: task_id.as_str().to_string(),
         task_id: task_id.as_str().to_string(),
+        task_kind,
         status: workflow.state.clone(),
         execution_path: "workflow_runtime",
         workflow_id: workflow.id.clone(),
-        external_id: issue.map(|issue_number| format!("issue:{issue_number}")),
+        external_id,
         repo: workflow
             .data
             .get("repo")

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -68,24 +68,24 @@ pub(crate) async fn task_response_details(
     task_id: &task_runner::TaskId,
     is_issue_submission: bool,
 ) -> Result<TaskResponseDetails, EnqueueTaskError> {
-    if !is_issue_submission {
-        return Ok(TaskResponseDetails {
-            status: "queued".to_string(),
-            execution_path: "task_runner",
-        });
-    }
-
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
-        if let Some(workflow) =
-            crate::workflow_runtime_submission::runtime_issue_by_task_id(store, task_id)
-                .await
-                .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        if let Some(workflow) = store
+            .get_instance_by_task_id(task_id.as_str())
+            .await
+            .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
         {
             return Ok(TaskResponseDetails {
                 status: workflow.state,
                 execution_path: "workflow_runtime",
             });
         }
+    }
+
+    if !is_issue_submission {
+        return Ok(TaskResponseDetails {
+            status: "queued".to_string(),
+            execution_path: "task_runner",
+        });
     }
 
     if state

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -256,14 +256,18 @@ pub(super) async fn create_tasks_batch(
     let n = task_requests.len();
     let mut task_semaphores: Vec<Option<Arc<tokio::sync::Semaphore>>> = vec![None; n];
     let mut task_conflict_files: Vec<Vec<String>> = vec![Vec::new(); n];
+    let mut task_conflict_group: Vec<Option<usize>> = vec![None; n];
+    let mut conflict_group_tail: Vec<Option<task_runner::TaskId>> =
+        vec![None; conflict_groups.len()];
 
-    for group in &conflict_groups {
+    for (group_idx, group) in conflict_groups.iter().enumerate() {
         if group.len() < 2 {
             continue;
         }
         let sem = Arc::new(tokio::sync::Semaphore::new(1));
         for &idx in group {
             task_semaphores[idx] = Some(Arc::clone(&sem));
+            task_conflict_group[idx] = Some(group_idx);
             // Collect files from this task that overlap with any other group member.
             let mut shared: std::collections::HashSet<String> = std::collections::HashSet::new();
             for &other in group {
@@ -288,13 +292,22 @@ pub(super) async fn create_tasks_batch(
     let mut results = Vec::with_capacity(n);
     let mut all_maintenance_window = n > 0;
     let mut mw_retry_after: Option<u64> = None;
-    for (i, task_req) in task_requests.into_iter().enumerate() {
+    for (i, mut task_req) in task_requests.into_iter().enumerate() {
         let sem = task_semaphores[i].take();
         let is_serialized = sem.is_some();
         let conflict_files = std::mem::take(&mut task_conflict_files[i]);
+        let conflict_group = task_conflict_group[i];
+        if let Some(group_idx) = conflict_group {
+            if let Some(previous_task_id) = conflict_group_tail[group_idx].clone() {
+                task_req.serialization_depends_on.push(previous_task_id);
+            }
+        }
         let is_issue_submission = task_req.issue.is_some();
         let entry = match enqueue_task_background(state.clone(), task_req, sem).await {
             Ok(task_id) => {
+                if let Some(group_idx) = conflict_group {
+                    conflict_group_tail[group_idx] = Some(task_id.clone());
+                }
                 all_maintenance_window = false;
                 match task_response_details(&state, &task_id, is_issue_submission).await {
                     Ok(details) => {
@@ -435,7 +448,7 @@ pub(super) async fn cancel_task(
             {
                 Ok(Some(workflow)) if workflow.state == "cancelled" => {
                     if let Err(error) =
-                        crate::workflow_runtime_worker::notify_runtime_issue_terminal_workflow(
+                        crate::workflow_runtime_worker::notify_runtime_submission_terminal_workflow(
                             &state,
                             &workflow.id,
                             None,
@@ -444,7 +457,7 @@ pub(super) async fn cancel_task(
                     {
                         tracing::warn!(
                             workflow_id = %workflow.id,
-                            "cancel_task: runtime issue completion notification failed: {error}"
+                            "cancel_task: runtime completion notification failed: {error}"
                         );
                     }
                     (

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1274,7 +1274,11 @@ async fn runtime_repo_backlog_poll_tick_enqueues_runtime_command() -> anyhow::Re
     assert_eq!(tick.skipped, 0);
     assert_eq!(tick.rejected, 0);
     let instances = store
-        .list_instances_by_definition(harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID, None)
+        .list_instances_by_definition(
+            harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+            None,
+            None,
+        )
         .await?;
     assert_eq!(instances.len(), 1);
     let workflow_id = instances[0].id.clone();
@@ -1891,6 +1895,7 @@ async fn runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn
         .list_instances_by_definition(
             harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
             Some(&project_id),
+            None,
         )
         .await?;
     assert_eq!(children.len(), 1);
@@ -3142,7 +3147,19 @@ async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow
     assert_eq!(instance.definition_id, "prompt_task");
     assert_eq!(instance.state, "implementing");
     assert_eq!(instance.data["task_id"], task_id.0);
-    assert_eq!(instance.data["prompt"], "fix the prompt-only bug");
+    assert!(instance.data.get("prompt").is_none());
+    assert_eq!(instance.data["prompt_summary"], "prompt task");
+    assert_eq!(
+        instance.data["prompt_chars"],
+        "fix the prompt-only bug".chars().count()
+    );
+    let prompt_ref = instance.data["prompt_ref"]
+        .as_str()
+        .expect("prompt ref should be persisted");
+    assert_eq!(
+        crate::workflow_runtime_submission::lookup_prompt_submission_prompt(prompt_ref).as_deref(),
+        Some("fix the prompt-only bug")
+    );
     assert_eq!(instance.data["source"], "dashboard");
     assert_eq!(instance.data["external_id"], "manual:prompt:http");
     assert_eq!(instance.data["execution_path"], "workflow_runtime");
@@ -3153,6 +3170,8 @@ async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow
         commands[0].command.activity_name(),
         Some("implement_prompt")
     );
+    assert!(commands[0].command.command.get("prompt").is_none());
+    assert_eq!(commands[0].command.command["prompt_ref"], prompt_ref);
 
     let detail_response = app
         .oneshot(
@@ -3412,7 +3431,7 @@ async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> 
     assert_eq!(runtime_task["status"], "implementing");
     assert_eq!(runtime_task["source"], "dashboard");
     assert_eq!(runtime_task["external_id"], "manual:prompt:list");
-    assert_eq!(runtime_task["description"], "fix listed runtime prompt");
+    assert_eq!(runtime_task["description"], "prompt task");
     assert_eq!(
         runtime_task["project"],
         canonical_project_root.to_string_lossy().as_ref()
@@ -3998,6 +4017,60 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
 }
 
 #[tokio::test]
+async fn create_tasks_batch_with_legacy_conflicts_does_not_add_dependencies() -> anyhow::Result<()>
+{
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    init_fake_git_repo(dir.path())?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("s")).await?;
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": dir.path().display().to_string(),
+                        "tasks": [
+                            { "description": "update src/lib.rs first" },
+                            { "description": "update src/lib.rs second" }
+                        ]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0]["serialized"], true);
+    assert_eq!(entries[1]["serialized"], true);
+    for entry in entries {
+        let task_id = task_runner::TaskId::from_str(
+            entry["task_id"]
+                .as_str()
+                .expect("task id should be present"),
+        );
+        let task = state
+            .core
+            .tasks
+            .get_with_db_fallback(&task_id)
+            .await?
+            .expect("legacy task should be persisted");
+        assert!(task.depends_on.is_empty());
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_tasks_batch_with_prompts_returns_runtime_submissions() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -4064,10 +4137,119 @@ async fn create_tasks_batch_with_prompts_returns_runtime_submissions() -> anyhow
             .expect("runtime prompt submission should be persisted");
         assert_eq!(instance.definition_id, "prompt_task");
         assert_eq!(instance.state, "implementing");
-        assert_eq!(instance.data["prompt"], prompt);
-        assert_eq!(store.commands_for(&instance.id).await?.len(), 1);
+        assert!(instance.data.get("prompt").is_none());
+        assert_eq!(instance.data["prompt_summary"], "prompt task");
+        assert_eq!(instance.data["prompt_chars"], prompt.chars().count());
+        let prompt_ref = instance.data["prompt_ref"]
+            .as_str()
+            .expect("prompt ref should be persisted");
+        assert_eq!(
+            crate::workflow_runtime_submission::lookup_prompt_submission_prompt(prompt_ref)
+                .as_deref(),
+            Some(prompt)
+        );
+        let commands = store.commands_for(&instance.id).await?;
+        assert_eq!(commands.len(), 1);
+        assert!(commands[0].command.command.get("prompt").is_none());
+        assert_eq!(commands[0].command.command["prompt_ref"], prompt_ref);
     }
     assert_eq!(state.core.tasks.count(), before_count);
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_tasks_batch_with_conflicting_runtime_prompts_adds_dependencies(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project_root.display().to_string(),
+                        "tasks": [
+                            { "description": "update src/lib.rs first" },
+                            { "description": "update src/lib.rs second" }
+                        ]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0]["serialized"], true);
+    assert_eq!(entries[1]["serialized"], true);
+    assert_eq!(
+        entries[0]["conflict_files"],
+        serde_json::json!(["src/lib.rs"])
+    );
+    assert_eq!(
+        entries[1]["conflict_files"],
+        serde_json::json!(["src/lib.rs"])
+    );
+    assert_eq!(entries[0]["status"], "implementing");
+    assert!(
+        entries[1]["status"] == "awaiting_dependencies" || entries[1]["status"] == "implementing"
+    );
+
+    let first_task_id = entries[0]["task_id"]
+        .as_str()
+        .expect("first task id should be present");
+    let second_task_id = entries[1]["task_id"]
+        .as_str()
+        .expect("second task id should be present");
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let first = store
+        .get_instance_by_task_id(first_task_id)
+        .await?
+        .expect("first runtime prompt submission should be persisted");
+    let second = store
+        .get_instance_by_task_id(second_task_id)
+        .await?
+        .expect("second runtime prompt submission should be persisted");
+
+    assert_eq!(
+        second.data["depends_on"],
+        serde_json::json!([first_task_id])
+    );
+    assert_eq!(second.data["required_depends_on"], serde_json::json!([]));
+    assert_eq!(
+        second.data["serialization_depends_on"],
+        serde_json::json!([first_task_id])
+    );
+    assert_eq!(store.commands_for(&first.id).await?.len(), 1);
+    let second_commands = store.commands_for(&second.id).await?.len();
+    match second.state.as_str() {
+        "awaiting_dependencies" => assert_eq!(second_commands, 0),
+        "implementing" => assert_eq!(second_commands, 1),
+        state => panic!("unexpected second runtime prompt state {state}"),
+    }
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3075,6 +3075,102 @@ async fn create_task_with_prompt_returns_accepted() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let app = task_app(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "prompt": "fix the prompt-only bug",
+        "source": "dashboard",
+        "external_id": "manual:prompt:http"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let resp = response_json(response).await?;
+    assert!(resp["task_id"].is_string());
+    assert_eq!(resp["status"], "implementing");
+    assert_eq!(resp["execution_path"], "workflow_runtime");
+    let task_id = task_runner::TaskId::from_str(resp["task_id"].as_str().unwrap());
+    assert!(state
+        .core
+        .tasks
+        .get_with_db_fallback(&task_id)
+        .await?
+        .is_none());
+    assert_eq!(state.core.tasks.count(), before_count);
+
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let canonical_project_root = project_root.canonicalize()?;
+    let workflow_id = crate::workflow_runtime_submission::prompt_workflow_id(
+        &canonical_project_root.to_string_lossy(),
+        Some("manual:prompt:http"),
+        &task_id,
+    );
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.definition_id, "prompt_task");
+    assert_eq!(instance.state, "implementing");
+    assert_eq!(instance.data["task_id"], task_id.0);
+    assert_eq!(instance.data["prompt"], "fix the prompt-only bug");
+    assert_eq!(instance.data["source"], "dashboard");
+    assert_eq!(instance.data["external_id"], "manual:prompt:http");
+    assert_eq!(instance.data["execution_path"], "workflow_runtime");
+    let commands = store.commands_for(&workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].status, "pending");
+    assert_eq!(
+        commands[0].command.activity_name(),
+        Some("implement_prompt")
+    );
+
+    let detail_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{}", task_id.as_str()))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(detail_response.status(), StatusCode::OK);
+    let detail = response_json(detail_response).await?;
+    assert_eq!(detail["task_kind"], "prompt");
+    assert_eq!(detail["status"], "implementing");
+    assert_eq!(detail["execution_path"], "workflow_runtime");
+    assert_eq!(detail["workflow_id"], workflow_id);
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_with_issue_reports_task_runner_fallback_without_runtime_store(
 ) -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
@@ -3245,6 +3341,78 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
     assert_eq!(runtime_task["external_id"], "issue:52");
     assert_eq!(runtime_task["repo"], "owner/repo");
     assert_eq!(runtime_task["description"], "issue #52");
+    assert_eq!(
+        runtime_task["project"],
+        canonical_project_root.to_string_lossy().as_ref()
+    );
+    assert_eq!(runtime_task["scheduler"]["authority_state"], "running");
+    assert!(runtime_task.get("workflow").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let app = Router::new()
+        .route("/tasks", get(list_tasks).post(task_routes::create_task))
+        .with_state(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "prompt": "fix listed runtime prompt",
+        "source": "dashboard",
+        "external_id": "manual:prompt:list"
+    });
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(create_response.status(), StatusCode::ACCEPTED);
+    let created = response_json(create_response).await?;
+    let task_id = created["task_id"]
+        .as_str()
+        .expect("runtime submission should return a task handle")
+        .to_string();
+    assert_eq!(state.core.tasks.count(), before_count);
+
+    let list_response = app
+        .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+        .await?;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let listed = response_json(list_response).await?;
+    let tasks = listed.as_array().expect("tasks should be an array");
+    let runtime_task = tasks
+        .iter()
+        .find(|task| task["id"] == task_id)
+        .expect("runtime prompt submission should be listed");
+    let canonical_project_root = project_root.canonicalize()?;
+
+    assert_eq!(runtime_task["task_kind"], "prompt");
+    assert_eq!(runtime_task["status"], "implementing");
+    assert_eq!(runtime_task["source"], "dashboard");
+    assert_eq!(runtime_task["external_id"], "manual:prompt:list");
+    assert_eq!(runtime_task["description"], "fix listed runtime prompt");
     assert_eq!(
         runtime_task["project"],
         canonical_project_root.to_string_lossy().as_ref()
@@ -3824,6 +3992,80 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
                 .expect("task id should be present"),
         )
         .await?;
+    }
+    assert_eq!(state.core.tasks.count(), before_count);
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_tasks_batch_with_prompts_returns_runtime_submissions() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/batch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project": project_root.display().to_string(),
+                        "tasks": [
+                            { "description": "batch prompt 1" },
+                            { "description": "batch prompt 2" }
+                        ]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let batch_json = response_json(response).await?;
+    let entries = batch_json
+        .as_array()
+        .expect("batch response should be an array");
+    assert_eq!(entries.len(), 2);
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    for (entry, prompt) in entries.iter().zip(["batch prompt 1", "batch prompt 2"]) {
+        assert_eq!(entry["status"], "implementing");
+        assert_eq!(entry["execution_path"], "workflow_runtime");
+        let task_id = task_runner::TaskId::from_str(
+            entry["task_id"]
+                .as_str()
+                .expect("task id should be present"),
+        );
+        assert!(state
+            .core
+            .tasks
+            .get_with_db_fallback(&task_id)
+            .await?
+            .is_none());
+        let instance = store
+            .get_instance_by_task_id(task_id.as_str())
+            .await?
+            .expect("runtime prompt submission should be persisted");
+        assert_eq!(instance.definition_id, "prompt_task");
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.data["prompt"], prompt);
+        assert_eq!(store.commands_for(&instance.id).await?.len(), 1);
     }
     assert_eq!(state.core.tasks.count(), before_count);
     Ok(())

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -145,11 +145,17 @@ struct PreparedRuntimeIssueSubmission {
     project_id: String,
 }
 
+struct PreparedRuntimePromptSubmission {
+    req: CreateTaskRequest,
+    project_id: String,
+}
+
 const WORKFLOW_FEEDBACK_SOURCE: &str = "workflow_feedback";
 
 enum PreparedEnqueueResult {
     Existing(TaskId),
     RuntimeIssueSubmission(Box<PreparedRuntimeIssueSubmission>),
+    RuntimePromptSubmission(Box<PreparedRuntimePromptSubmission>),
     Ready(Box<PreparedEnqueue>),
 }
 
@@ -373,6 +379,13 @@ impl DefaultExecutionService {
         workflow_runtime_loops_enabled(project_root)
     }
 
+    fn runtime_prompt_submission_enabled(
+        &self,
+        project_root: &Path,
+    ) -> Result<bool, EnqueueTaskError> {
+        workflow_runtime_loops_enabled(project_root)
+    }
+
     fn queue_for(&self, domain: QueueDomain) -> Arc<TaskQueue> {
         match domain {
             QueueDomain::Primary => self.task_queue.clone(),
@@ -550,6 +563,36 @@ impl DefaultExecutionService {
         Ok(crate::workflow_runtime_submission::runtime_issue_task_handle(&instance))
     }
 
+    async fn check_runtime_prompt_duplicate(
+        &self,
+        project_id: &str,
+        req: &CreateTaskRequest,
+    ) -> Result<Option<TaskId>, EnqueueTaskError> {
+        let Some(external_id) = req.external_id.as_deref() else {
+            return Ok(None);
+        };
+        let Some(store) = self.workflow_runtime_store.as_ref() else {
+            return Ok(None);
+        };
+        let probe_task_id = TaskId::from_str(external_id);
+        let workflow_id = crate::workflow_runtime_submission::prompt_workflow_id(
+            project_id,
+            Some(external_id),
+            &probe_task_id,
+        );
+        let Some(instance) = store
+            .get_instance(&workflow_id)
+            .await
+            .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        if instance.is_terminal() {
+            return Ok(None);
+        }
+        Ok(crate::workflow_runtime_submission::runtime_issue_task_handle(&instance))
+    }
+
     async fn track_pr_workflow(&self, project_id: &str, req: &CreateTaskRequest, task_id: &TaskId) {
         if let Some(pr_number) = req.pr {
             if let Some(workflows) = self.issue_workflow_store.as_ref() {
@@ -638,6 +681,68 @@ impl DefaultExecutionService {
         Ok(task_id)
     }
 
+    async fn submit_prompt_to_workflow_runtime(
+        &self,
+        prepared: PreparedRuntimePromptSubmission,
+    ) -> Result<TaskId, EnqueueTaskError> {
+        let Some(store) = self.workflow_runtime_store.as_deref() else {
+            return Err(EnqueueTaskError::Internal(
+                "workflow runtime store is required for prompt submissions".to_string(),
+            ));
+        };
+        let Some(prompt) = prepared.req.prompt.as_deref() else {
+            return Err(EnqueueTaskError::BadRequest(
+                "prompt submission requires a prompt".to_string(),
+            ));
+        };
+        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await?;
+
+        let task_id = TaskId::new();
+        let project_root = prepared
+            .req
+            .project
+            .as_deref()
+            .unwrap_or_else(|| std::path::Path::new(&prepared.project_id));
+        let record = crate::workflow_runtime_submission::record_prompt_submission(
+            store,
+            crate::workflow_runtime_submission::PromptSubmissionRuntimeContext {
+                project_root,
+                task_id: &task_id,
+                prompt,
+                depends_on: &prepared.req.depends_on,
+                dependencies_blocked,
+                source: prepared.req.source.as_deref(),
+                external_id: prepared.req.external_id.as_deref(),
+            },
+        )
+        .await
+        .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?;
+
+        if !record.accepted {
+            return Err(EnqueueTaskError::BadRequest(format!(
+                "workflow runtime rejected prompt submission for workflow {}: {}",
+                record.workflow_id,
+                record
+                    .rejection_reason
+                    .as_deref()
+                    .unwrap_or("decision rejected")
+            )));
+        }
+        if record.command_ids.is_empty() && !dependencies_blocked {
+            return Err(EnqueueTaskError::Internal(format!(
+                "workflow runtime accepted prompt submission for workflow {} without commands",
+                record.workflow_id
+            )));
+        }
+        tracing::info!(
+            workflow_id = %record.workflow_id,
+            task_id = %task_id.0,
+            command_count = record.command_ids.len(),
+            "execution service: accepted prompt submission into workflow runtime"
+        );
+        Ok(task_id)
+    }
+
     async fn prepare_enqueue(
         &self,
         mut req: CreateTaskRequest,
@@ -686,6 +791,22 @@ impl DefaultExecutionService {
             }
             return Ok(PreparedEnqueueResult::RuntimeIssueSubmission(Box::new(
                 PreparedRuntimeIssueSubmission { req, project_id },
+            )));
+        }
+
+        if req.task_kind() == task_runner::TaskKind::Prompt
+            && req.prompt.is_some()
+            && self.workflow_runtime_store.is_some()
+            && self.runtime_prompt_submission_enabled(&canonical)?
+        {
+            if let Some(existing_id) = self
+                .check_runtime_prompt_duplicate(&project_id, &req)
+                .await?
+            {
+                return Ok(PreparedEnqueueResult::Existing(existing_id));
+            }
+            return Ok(PreparedEnqueueResult::RuntimePromptSubmission(Box::new(
+                PreparedRuntimePromptSubmission { req, project_id },
             )));
         }
 
@@ -751,6 +872,9 @@ impl ExecutionService for DefaultExecutionService {
             PreparedEnqueueResult::RuntimeIssueSubmission(prepared) => {
                 return self.submit_issue_to_workflow_runtime(*prepared).await;
             }
+            PreparedEnqueueResult::RuntimePromptSubmission(prepared) => {
+                return self.submit_prompt_to_workflow_runtime(*prepared).await;
+            }
             PreparedEnqueueResult::Ready(prepared) => *prepared,
         };
 
@@ -808,6 +932,9 @@ impl ExecutionService for DefaultExecutionService {
             PreparedEnqueueResult::Existing(task_id) => return Ok(task_id),
             PreparedEnqueueResult::RuntimeIssueSubmission(prepared) => {
                 return self.submit_issue_to_workflow_runtime(*prepared).await;
+            }
+            PreparedEnqueueResult::RuntimePromptSubmission(prepared) => {
+                return self.submit_prompt_to_workflow_runtime(*prepared).await;
             }
             PreparedEnqueueResult::Ready(prepared) => *prepared,
         };
@@ -1247,6 +1374,126 @@ mod tests {
             "preserve caller guidance"
         );
         assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_prompt_submission_uses_workflow_runtime_without_task_runner(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let task_store = store.clone();
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            prompt: Some("fix the prompt-only bug".to_string()),
+            project: Some(project_root.clone()),
+            source: Some("dashboard".to_string()),
+            external_id: Some("manual:prompt:1".to_string()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        assert!(
+            task_store.get_with_db_fallback(&task_id).await?.is_none(),
+            "workflow runtime prompt submissions must not register legacy task rows"
+        );
+
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = crate::workflow_runtime_submission::prompt_workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("manual:prompt:1"),
+            &task_id,
+        );
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("runtime workflow should be recorded");
+        assert_eq!(instance.definition_id, "prompt_task");
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.data["task_id"], task_id.0);
+        assert_eq!(instance.data["prompt"], "fix the prompt-only bug");
+        assert_eq!(instance.data["source"], "dashboard");
+        assert_eq!(instance.data["external_id"], "manual:prompt:1");
+        assert_eq!(instance.data["execution_path"], "workflow_runtime");
+        let commands = runtime_store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some("implement_prompt")
+        );
+        assert_eq!(
+            commands[0].command.command["prompt"],
+            "fix the prompt-only bug"
+        );
+        assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_prompt_submission_preserves_runtime_dependencies(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let dep_id = TaskId::from_str("dep-prompt-runtime");
+        let dep = crate::task_runner::TaskState::new(dep_id.clone());
+        store.insert(&dep).await;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            prompt: Some("wait for dependency before prompt implementation".to_string()),
+            project: Some(project_root.clone()),
+            external_id: Some("manual:prompt:blocked".to_string()),
+            depends_on: vec![dep_id],
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        let canonical_project_root = project_root.canonicalize()?;
+        let workflow_id = crate::workflow_runtime_submission::prompt_workflow_id(
+            &canonical_project_root.to_string_lossy(),
+            Some("manual:prompt:blocked"),
+            &task_id,
+        );
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("runtime workflow should be recorded");
+
+        assert_eq!(instance.state, "awaiting_dependencies");
+        assert_eq!(instance.data["task_id"], task_id.0);
+        assert_eq!(
+            instance.data["depends_on"],
+            serde_json::json!(["dep-prompt-runtime"])
+        );
+        assert!(runtime_store.commands_for(&workflow_id).await?.is_empty());
         Ok(())
     }
 

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -526,7 +526,37 @@ impl DefaultExecutionService {
             })?;
             if !matches!(
                 status,
-                crate::workflow_runtime_submission::IssueDependencyStatus::Done
+                crate::workflow_runtime_submission::RuntimeDependencyStatus::Done
+            ) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn serialization_dependencies_blocked(
+        &self,
+        req: &CreateTaskRequest,
+    ) -> Result<bool, EnqueueTaskError> {
+        if req.serialization_depends_on.is_empty() {
+            return Ok(false);
+        }
+        for dep_id in &req.serialization_depends_on {
+            let status = crate::workflow_runtime_submission::resolve_issue_dependency_status(
+                self.workflow_runtime_store.as_deref(),
+                &self.tasks,
+                dep_id,
+            )
+            .await
+            .map_err(|error| {
+                EnqueueTaskError::Internal(format!(
+                    "serialization dependency status lookup failed for {}: {error}",
+                    dep_id.as_str()
+                ))
+            })?;
+            if matches!(
+                status,
+                crate::workflow_runtime_submission::RuntimeDependencyStatus::Waiting
             ) {
                 return Ok(true);
             }
@@ -587,7 +617,7 @@ impl DefaultExecutionService {
         else {
             return Ok(None);
         };
-        if instance.is_terminal() {
+        if runtime_prompt_duplicate_allows_resubmission(&instance) {
             return Ok(None);
         }
         Ok(crate::workflow_runtime_submission::runtime_issue_task_handle(&instance))
@@ -629,7 +659,10 @@ impl DefaultExecutionService {
                 "issue submission requires an issue number".to_string(),
             ));
         };
-        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await?;
+        let dependencies_blocked = self.dependencies_blocked(&prepared.req).await?
+            || self
+                .serialization_dependencies_blocked(&prepared.req)
+                .await?;
 
         let task_id = TaskId::new();
         let project_root = prepared
@@ -710,6 +743,7 @@ impl DefaultExecutionService {
                 task_id: &task_id,
                 prompt,
                 depends_on: &prepared.req.depends_on,
+                serialization_depends_on: &prepared.req.serialization_depends_on,
                 dependencies_blocked,
                 source: prepared.req.source.as_deref(),
                 external_id: prepared.req.external_id.as_deref(),
@@ -843,6 +877,12 @@ impl DefaultExecutionService {
             reviewer,
         })))
     }
+}
+
+fn runtime_prompt_duplicate_allows_resubmission(
+    instance: &harness_workflow::runtime::WorkflowInstance,
+) -> bool {
+    instance.is_terminal() || instance.state == "blocked"
 }
 
 fn workflow_runtime_loops_enabled(project_root: &Path) -> Result<bool, EnqueueTaskError> {
@@ -1240,6 +1280,25 @@ mod tests {
         assert!(allows_terminal_pr_duplicate_reuse(&regular_pr_req));
     }
 
+    #[test]
+    fn runtime_prompt_duplicate_allows_blocked_resubmission() {
+        let blocked = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+            1,
+            "blocked",
+            harness_workflow::runtime::WorkflowSubject::new("prompt", "manual:prompt:retry"),
+        );
+        let implementing = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("prompt", "manual:prompt:retry"),
+        );
+
+        assert!(runtime_prompt_duplicate_allows_resubmission(&blocked));
+        assert!(!runtime_prompt_duplicate_allows_resubmission(&implementing));
+    }
+
     #[tokio::test]
     async fn check_allowed_roots_blocks_outside_root() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -1425,7 +1484,20 @@ mod tests {
         assert_eq!(instance.definition_id, "prompt_task");
         assert_eq!(instance.state, "implementing");
         assert_eq!(instance.data["task_id"], task_id.0);
-        assert_eq!(instance.data["prompt"], "fix the prompt-only bug");
+        assert!(instance.data.get("prompt").is_none());
+        assert_eq!(instance.data["prompt_summary"], "prompt task");
+        assert_eq!(
+            instance.data["prompt_chars"],
+            "fix the prompt-only bug".chars().count()
+        );
+        let prompt_ref = instance.data["prompt_ref"]
+            .as_str()
+            .expect("prompt ref should be persisted");
+        assert_eq!(
+            crate::workflow_runtime_submission::lookup_prompt_submission_prompt(prompt_ref)
+                .as_deref(),
+            Some("fix the prompt-only bug")
+        );
         assert_eq!(instance.data["source"], "dashboard");
         assert_eq!(instance.data["external_id"], "manual:prompt:1");
         assert_eq!(instance.data["execution_path"], "workflow_runtime");
@@ -1436,11 +1508,101 @@ mod tests {
             commands[0].command.activity_name(),
             Some("implement_prompt")
         );
-        assert_eq!(
-            commands[0].command.command["prompt"],
-            "fix the prompt-only bug"
-        );
+        assert!(commands[0].command.command.get("prompt").is_none());
+        assert_eq!(commands[0].command.command["prompt_ref"], prompt_ref);
         assert_eq!(runtime_store.pending_commands(10).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_background_prompt_submission_reopens_blocked_runtime_workflow(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let canonical_project_root = project_root.canonicalize()?;
+        let project_id = canonical_project_root.to_string_lossy().into_owned();
+        let external_id = "manual:prompt:retry";
+        let workflow_id = crate::workflow_runtime_submission::prompt_workflow_id(
+            &project_id,
+            Some(external_id),
+            &TaskId::from_str(external_id),
+        );
+        runtime_store
+            .upsert_instance(
+                &harness_workflow::runtime::WorkflowInstance::new(
+                    harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+                    1,
+                    "blocked",
+                    harness_workflow::runtime::WorkflowSubject::new("prompt", external_id),
+                )
+                .with_id(workflow_id.clone())
+                .with_data(serde_json::json!({
+                    "project_id": project_id,
+                    "task_id": "old-prompt-task",
+                    "source": "dashboard",
+                    "external_id": external_id,
+                    "prompt_ref": "old-prompt-ref",
+                })),
+            )
+            .await?;
+        let task_store = store.clone();
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let req = CreateTaskRequest {
+            prompt: Some("retry prompt payload after cache loss".to_string()),
+            project: Some(project_root.clone()),
+            source: Some("dashboard".to_string()),
+            external_id: Some(external_id.to_string()),
+            ..Default::default()
+        };
+
+        let task_id = svc.enqueue_background(req).await?;
+        assert!(
+            task_store.get_with_db_fallback(&task_id).await?.is_none(),
+            "runtime prompt retry must not register a legacy task row"
+        );
+
+        let instance = runtime_store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("blocked workflow should be reopened");
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.data["task_id"], task_id.as_str());
+        assert_eq!(
+            instance.data["task_ids"],
+            serde_json::json!(["old-prompt-task", task_id.as_str()])
+        );
+        assert!(instance.data.get("prompt").is_none());
+        let prompt_ref = instance.data["prompt_ref"]
+            .as_str()
+            .expect("prompt ref should be refreshed");
+        assert_ne!(prompt_ref, "old-prompt-ref");
+        assert_eq!(
+            crate::workflow_runtime_submission::lookup_prompt_submission_prompt(prompt_ref)
+                .as_deref(),
+            Some("retry prompt payload after cache loss")
+        );
+        let commands = runtime_store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some("implement_prompt")
+        );
+        assert_eq!(commands[0].command.command["prompt_ref"], prompt_ref);
         Ok(())
     }
 
@@ -1494,6 +1656,51 @@ mod tests {
             serde_json::json!(["dep-prompt-runtime"])
         );
         assert!(runtime_store.commands_for(&workflow_id).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_prompt_serialization_dependency_blocks_until_predecessor_terminal(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("t.db")).await?;
+        let database_url = crate::test_helpers::test_database_url()?;
+        let runtime_store = Arc::new(
+            harness_workflow::runtime::WorkflowRuntimeStore::open_with_database_url(
+                &dir.path().join("workflow_runtime"),
+                Some(&database_url),
+            )
+            .await?,
+        );
+        let svc = make_svc_with_workflow_runtime(store, runtime_store.clone()).await;
+        let dep_id = TaskId::from_str("runtime-prompt-serialization-waiting");
+        let workflow_id = "runtime-prompt-serialization-waiting-workflow";
+        let mut predecessor = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("prompt", dep_id.as_str()),
+        )
+        .with_id(workflow_id)
+        .with_data(serde_json::json!({
+            "task_id": dep_id.as_str(),
+            "task_ids": [dep_id.as_str()],
+        }));
+        runtime_store.upsert_instance(&predecessor).await?;
+
+        let req = CreateTaskRequest {
+            serialization_depends_on: vec![dep_id.clone()],
+            ..Default::default()
+        };
+        assert!(svc.serialization_dependencies_blocked(&req).await?);
+
+        predecessor.state = "failed".to_string();
+        runtime_store.upsert_instance(&predecessor).await?;
+        assert!(!svc.serialization_dependencies_blocked(&req).await?);
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -74,6 +74,11 @@ pub struct CreateTaskRequest {
     /// Task IDs that must complete (Done) before this task starts.
     #[serde(default)]
     pub depends_on: Vec<TaskId>,
+    /// Internal ordering dependencies for batch conflict serialization.
+    /// Unlike `depends_on`, these only require the upstream task to become
+    /// terminal before this task starts.
+    #[serde(skip)]
+    pub serialization_depends_on: Vec<TaskId>,
     /// Scheduling priority: 0 = normal (default), 1 = high, 2 = critical.
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
@@ -258,6 +263,7 @@ impl Default for CreateTaskRequest {
             labels: Vec::new(),
             parent_task_id: None,
             depends_on: Vec::new(),
+            serialization_depends_on: Vec::new(),
             priority: 0,
             system_input: None,
         }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -342,7 +342,7 @@ async fn has_active_pr_feedback_command(
     }
 
     for instance in store
-        .list_instances_by_definition(PR_FEEDBACK_DEFINITION_ID, None)
+        .list_instances_by_definition(PR_FEEDBACK_DEFINITION_ID, None, None)
         .await?
         .into_iter()
         .filter(|instance| instance.parent_workflow_id.as_deref() == Some(workflow_id))

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -7,16 +7,83 @@ use harness_workflow::runtime::{
     PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
-use std::path::Path;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Mutex, OnceLock},
+};
 
 const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
 const EXECUTION_PATH_WORKFLOW_RUNTIME: &str = "workflow_runtime";
+const PROMPT_TASK_DESCRIPTION: &str = "prompt task";
+
+static PROMPT_SUBMISSION_PROMPTS: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptDependencyReleaseOutcome {
+    Released,
+    MissingPrompt,
+}
+
+pub(crate) fn lookup_prompt_submission_prompt(prompt_ref: &str) -> Option<String> {
+    prompt_submission_prompts()
+        .lock()
+        .ok()
+        .and_then(|prompts| prompts.get(prompt_ref).cloned())
+}
+
+fn cache_prompt_submission_prompt(prompt_ref: &str, prompt: &str) {
+    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
+        prompts.insert(prompt_ref.to_string(), prompt.to_string());
+    }
+}
+
+fn remove_prompt_submission_prompt(prompt_ref: Option<&str>) {
+    let Some(prompt_ref) = prompt_ref else {
+        return;
+    };
+    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
+        prompts.remove(prompt_ref);
+    }
+}
+
+pub(crate) fn remove_terminal_prompt_submission_prompt(instance: &WorkflowInstance) {
+    if instance.definition_id != PROMPT_TASK_DEFINITION_ID || !instance.is_terminal() {
+        return;
+    }
+    remove_prompt_submission_prompt(optional_string_field(&instance.data, "prompt_ref").as_deref());
+}
+
+fn prompt_submission_prompts() -> &'static Mutex<HashMap<String, String>> {
+    PROMPT_SUBMISSION_PROMPTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn prompt_ref_for_submission(
+    project_id: &str,
+    external_id: Option<&str>,
+    task_id: &TaskId,
+    prompt: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(project_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(external_id.unwrap_or("").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(task_id.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(prompt.as_bytes());
+    let digest = hasher.finalize();
+    let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("prompt-memory:{digest_hex}")
+}
 
 pub(crate) struct PromptSubmissionRuntimeContext<'a> {
     pub project_root: &'a Path,
     pub task_id: &'a TaskId,
     pub prompt: &'a str,
     pub depends_on: &'a [TaskId],
+    pub serialization_depends_on: &'a [TaskId],
     pub dependencies_blocked: bool,
     pub source: Option<&'a str>,
     pub external_id: Option<&'a str>,
@@ -37,7 +104,7 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct IssueSubmissionRuntimeRecord {
+pub(crate) struct WorkflowSubmissionRuntimeRecord {
     pub workflow_id: String,
     pub accepted: bool,
     pub decision_id: String,
@@ -48,19 +115,19 @@ pub(crate) struct IssueSubmissionRuntimeRecord {
 pub(crate) async fn record_issue_submission(
     store: &WorkflowRuntimeStore,
     ctx: IssueSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     persist_issue_submission(store, &ctx).await
 }
 
 pub(crate) async fn record_prompt_submission(
     store: &WorkflowRuntimeStore,
     ctx: PromptSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     persist_prompt_submission(store, &ctx).await
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct IssueDependencyReleaseSummary {
+pub(crate) struct DependencyReleaseSummary {
     pub released: usize,
     pub failed: usize,
     pub waiting: usize,
@@ -68,7 +135,7 @@ pub(crate) struct IssueDependencyReleaseSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum IssueDependencyStatus {
+pub(crate) enum RuntimeDependencyStatus {
     Done,
     Failed,
     Cancelled,
@@ -79,26 +146,26 @@ pub(crate) async fn resolve_issue_dependency_status(
     store: Option<&WorkflowRuntimeStore>,
     tasks: &TaskStore,
     task_id: &TaskId,
-) -> anyhow::Result<IssueDependencyStatus> {
+) -> anyhow::Result<RuntimeDependencyStatus> {
     match tasks.dep_status(task_id).await {
-        Some(TaskStatus::Done) => return Ok(IssueDependencyStatus::Done),
-        Some(TaskStatus::Failed) => return Ok(IssueDependencyStatus::Failed),
-        Some(TaskStatus::Cancelled) => return Ok(IssueDependencyStatus::Cancelled),
-        Some(_) => return Ok(IssueDependencyStatus::Waiting),
+        Some(TaskStatus::Done) => return Ok(RuntimeDependencyStatus::Done),
+        Some(TaskStatus::Failed) => return Ok(RuntimeDependencyStatus::Failed),
+        Some(TaskStatus::Cancelled) => return Ok(RuntimeDependencyStatus::Cancelled),
+        Some(_) => return Ok(RuntimeDependencyStatus::Waiting),
         None => {}
     }
 
     let Some(store) = store else {
-        return Ok(IssueDependencyStatus::Waiting);
+        return Ok(RuntimeDependencyStatus::Waiting);
     };
     let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(IssueDependencyStatus::Waiting);
+        return Ok(RuntimeDependencyStatus::Waiting);
     };
     Ok(match instance.state.as_str() {
-        "done" => IssueDependencyStatus::Done,
-        "failed" => IssueDependencyStatus::Failed,
-        "cancelled" => IssueDependencyStatus::Cancelled,
-        _ => IssueDependencyStatus::Waiting,
+        "done" => RuntimeDependencyStatus::Done,
+        "failed" => RuntimeDependencyStatus::Failed,
+        "cancelled" => RuntimeDependencyStatus::Cancelled,
+        _ => RuntimeDependencyStatus::Waiting,
     })
 }
 
@@ -106,7 +173,7 @@ pub(crate) async fn release_ready_issue_dependencies(
     store: &WorkflowRuntimeStore,
     tasks: &TaskStore,
     limit: i64,
-) -> anyhow::Result<IssueDependencyReleaseSummary> {
+) -> anyhow::Result<DependencyReleaseSummary> {
     let instances = store
         .list_instances_by_state(
             GITHUB_ISSUE_PR_DEFINITION_ID,
@@ -114,7 +181,7 @@ pub(crate) async fn release_ready_issue_dependencies(
             limit,
         )
         .await?;
-    let mut summary = IssueDependencyReleaseSummary::default();
+    let mut summary = DependencyReleaseSummary::default();
     for instance in instances {
         let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
             Ok(depends_on) => depends_on,
@@ -132,16 +199,16 @@ pub(crate) async fn release_ready_issue_dependencies(
         let mut terminal_failure: Option<(TaskId, &'static str)> = None;
         for dep_id in &depends_on {
             match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
-                IssueDependencyStatus::Done => {}
-                IssueDependencyStatus::Failed => {
+                RuntimeDependencyStatus::Done => {}
+                RuntimeDependencyStatus::Failed => {
                     terminal_failure = Some((dep_id.clone(), "failed"));
                     break;
                 }
-                IssueDependencyStatus::Cancelled => {
+                RuntimeDependencyStatus::Cancelled => {
                     terminal_failure = Some((dep_id.clone(), "cancelled"));
                     break;
                 }
-                IssueDependencyStatus::Waiting => all_done = false,
+                RuntimeDependencyStatus::Waiting => all_done = false,
             }
         }
         if let Some((dep_id, label)) = terminal_failure {
@@ -162,11 +229,11 @@ pub(crate) async fn release_ready_prompt_dependencies(
     store: &WorkflowRuntimeStore,
     tasks: &TaskStore,
     limit: i64,
-) -> anyhow::Result<IssueDependencyReleaseSummary> {
+) -> anyhow::Result<DependencyReleaseSummary> {
     let instances = store
         .list_instances_by_state(PROMPT_TASK_DEFINITION_ID, "awaiting_dependencies", limit)
         .await?;
-    let mut summary = IssueDependencyReleaseSummary::default();
+    let mut summary = DependencyReleaseSummary::default();
     for instance in instances {
         let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
             Ok(depends_on) => depends_on,
@@ -180,28 +247,63 @@ pub(crate) async fn release_ready_prompt_dependencies(
                 continue;
             }
         };
+        let serialization_depends_on = match task_ids_from_data(
+            &instance.data,
+            "serialization_depends_on",
+        ) {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt serialization data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let required_depends_on = match task_ids_from_data(&instance.data, "required_depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt required dependency data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
         let mut all_done = true;
         let mut terminal_failure: Option<(TaskId, &'static str)> = None;
         for dep_id in &depends_on {
             match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
-                IssueDependencyStatus::Done => {}
-                IssueDependencyStatus::Failed => {
+                RuntimeDependencyStatus::Done => {}
+                RuntimeDependencyStatus::Failed
+                    if serialization_depends_on.iter().any(|id| id == dep_id)
+                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
+                RuntimeDependencyStatus::Failed => {
                     terminal_failure = Some((dep_id.clone(), "failed"));
                     break;
                 }
-                IssueDependencyStatus::Cancelled => {
+                RuntimeDependencyStatus::Cancelled
+                    if serialization_depends_on.iter().any(|id| id == dep_id)
+                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
+                RuntimeDependencyStatus::Cancelled => {
                     terminal_failure = Some((dep_id.clone(), "cancelled"));
                     break;
                 }
-                IssueDependencyStatus::Waiting => all_done = false,
+                RuntimeDependencyStatus::Waiting => all_done = false,
             }
         }
         if let Some((dep_id, label)) = terminal_failure {
             fail_prompt_for_dependency(store, instance, &dep_id, label).await?;
             summary.failed += 1;
         } else if all_done {
-            release_prompt_after_dependencies(store, instance, &depends_on).await?;
-            summary.released += 1;
+            match release_prompt_after_dependencies(store, instance, &depends_on).await? {
+                PromptDependencyReleaseOutcome::Released => summary.released += 1,
+                PromptDependencyReleaseOutcome::MissingPrompt => summary.failed += 1,
+            }
         } else {
             store.touch_instance(&instance.id).await?;
             summary.waiting += 1;
@@ -295,13 +397,18 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
     }
     cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
     store.upsert_instance(&cancelled).await?;
+    if is_prompt {
+        remove_prompt_submission_prompt(
+            optional_string_field(&cancelled.data, "prompt_ref").as_deref(),
+        );
+    }
     Ok(Some(cancelled))
 }
 
 async fn persist_issue_submission(
     store: &WorkflowRuntimeStore,
     ctx: &IssueSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, ctx.issue_number);
@@ -346,7 +453,7 @@ async fn persist_issue_submission(
 async fn persist_prompt_submission(
     store: &WorkflowRuntimeStore,
     ctx: &PromptSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let workflow_id = prompt_workflow_id(&project_id, ctx.external_id, ctx.task_id);
     upsert_prompt_task_definition(store).await?;
@@ -361,15 +468,20 @@ async fn persist_prompt_submission(
             true,
         ),
     };
-    let submitted_data = prompt_submission_data(ctx, &project_id, &instance.data);
+    let prompt_ref =
+        prompt_ref_for_submission(&project_id, ctx.external_id, ctx.task_id, ctx.prompt);
+    let depends_on = prompt_submission_dependency_ids(ctx);
+    let submitted_data =
+        prompt_submission_data(ctx, &project_id, &instance.data, &prompt_ref, &depends_on);
     let output = build_prompt_submission_decision(
         &instance,
         PromptSubmissionDecisionInput {
             task_id: ctx.task_id.as_str(),
             prompt: ctx.prompt,
+            prompt_ref: &prompt_ref,
             source: ctx.source,
             external_id: ctx.external_id,
-            depends_on: &depends_on_strings(ctx.depends_on),
+            depends_on: &depends_on_strings(&depends_on),
             dependencies_blocked: ctx.dependencies_blocked,
         },
     );
@@ -384,6 +496,18 @@ async fn persist_prompt_submission(
     .await
 }
 
+fn prompt_submission_dependency_ids(ctx: &PromptSubmissionRuntimeContext<'_>) -> Vec<TaskId> {
+    let mut depends_on =
+        Vec::with_capacity(ctx.depends_on.len() + ctx.serialization_depends_on.len());
+    depends_on.extend(ctx.depends_on.iter().cloned());
+    for dep_id in ctx.serialization_depends_on {
+        if !depends_on.iter().any(|existing| existing == dep_id) {
+            depends_on.push(dep_id.clone());
+        }
+    }
+    depends_on
+}
+
 async fn apply_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
@@ -391,7 +515,7 @@ async fn apply_decision(
     decision: WorkflowDecision,
     ctx: &IssueSubmissionRuntimeContext<'_>,
     accepted_data: serde_json::Value,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     let validation_context = if instance.is_terminal() {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
@@ -426,7 +550,7 @@ async fn apply_decision(
             let reason = error.to_string();
             let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
             store.record_decision(&record).await?;
-            return Ok(IssueSubmissionRuntimeRecord {
+            return Ok(WorkflowSubmissionRuntimeRecord {
                 workflow_id: instance.id,
                 accepted: false,
                 decision_id: record.id,
@@ -448,7 +572,7 @@ async fn apply_decision(
     instance.version = instance.version.saturating_add(1);
     instance.data = merge_last_decision(accepted_data, &decision.decision);
     store.upsert_instance(&instance).await?;
-    Ok(IssueSubmissionRuntimeRecord {
+    Ok(WorkflowSubmissionRuntimeRecord {
         workflow_id: instance.id,
         accepted: true,
         decision_id: record.id,
@@ -464,7 +588,7 @@ async fn apply_prompt_decision(
     decision: WorkflowDecision,
     ctx: &PromptSubmissionRuntimeContext<'_>,
     accepted_data: serde_json::Value,
-) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
     let validation_context = if instance.is_terminal() {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
@@ -484,6 +608,7 @@ async fn apply_prompt_decision(
                 "task_id": ctx.task_id.as_str(),
                 "prompt_chars": ctx.prompt.chars().count(),
                 "depends_on": depends_on_strings(ctx.depends_on),
+                "serialization_depends_on": depends_on_strings(ctx.serialization_depends_on),
                 "dependencies_blocked": ctx.dependencies_blocked,
                 "source": ctx.source,
                 "external_id": ctx.external_id,
@@ -497,7 +622,7 @@ async fn apply_prompt_decision(
             let reason = error.to_string();
             let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
             store.record_decision(&record).await?;
-            return Ok(IssueSubmissionRuntimeRecord {
+            return Ok(WorkflowSubmissionRuntimeRecord {
                 workflow_id: instance.id,
                 accepted: false,
                 decision_id: record.id,
@@ -507,6 +632,12 @@ async fn apply_prompt_decision(
         }
     };
     store.record_decision(&record).await?;
+    let prompt_ref = string_field(&accepted_data, "prompt_ref")?;
+    let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
+    if previous_prompt_ref.as_deref() != Some(prompt_ref.as_str()) {
+        remove_prompt_submission_prompt(previous_prompt_ref.as_deref());
+    }
+    cache_prompt_submission_prompt(&prompt_ref, ctx.prompt);
     let mut command_ids = Vec::with_capacity(decision.commands.len());
     for command in &decision.commands {
         command_ids.push(
@@ -519,7 +650,7 @@ async fn apply_prompt_decision(
     instance.version = instance.version.saturating_add(1);
     instance.data = merge_last_decision(accepted_data, &decision.decision);
     store.upsert_instance(&instance).await?;
-    Ok(IssueSubmissionRuntimeRecord {
+    Ok(WorkflowSubmissionRuntimeRecord {
         workflow_id: instance.id,
         accepted: true,
         decision_id: record.id,
@@ -621,13 +752,18 @@ async fn release_prompt_after_dependencies(
     store: &WorkflowRuntimeStore,
     instance: WorkflowInstance,
     depends_on: &[TaskId],
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PromptDependencyReleaseOutcome> {
     let fields = prompt_submission_fields(&instance)?;
+    let Some(prompt) = lookup_prompt_submission_prompt(&fields.prompt_ref) else {
+        fail_prompt_for_missing_prompt(store, instance, &fields).await?;
+        return Ok(PromptDependencyReleaseOutcome::MissingPrompt);
+    };
     let output = build_prompt_submission_decision(
         &instance,
         PromptSubmissionDecisionInput {
             task_id: &fields.task_id,
-            prompt: &fields.prompt,
+            prompt: &prompt,
+            prompt_ref: &fields.prompt_ref,
             source: fields.source.as_deref(),
             external_id: fields.external_id.as_deref(),
             depends_on: &depends_on_strings(depends_on),
@@ -648,7 +784,7 @@ async fn release_prompt_after_dependencies(
         .await?;
     let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
     commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
-    Ok(())
+    Ok(PromptDependencyReleaseOutcome::Released)
 }
 
 async fn fail_prompt_for_dependency(
@@ -657,6 +793,7 @@ async fn fail_prompt_for_dependency(
     dependency_id: &TaskId,
     dependency_status: &str,
 ) -> anyhow::Result<()> {
+    let prompt_ref = optional_string_field(&instance.data, "prompt_ref");
     let event = store
         .append_event(
             &instance.id,
@@ -697,6 +834,49 @@ async fn fail_prompt_for_dependency(
         ),
         "dependency_failure_status",
         dependency_status,
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    remove_prompt_submission_prompt(prompt_ref.as_deref());
+    Ok(())
+}
+
+async fn fail_prompt_for_missing_prompt(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    fields: &PromptSubmissionFields,
+) -> anyhow::Result<()> {
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptSubmissionPromptMissing",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id.as_str(),
+                "prompt_ref": fields.prompt_ref.as_str(),
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "prompt_unavailable",
+        "failed",
+        "prompt-only runtime submission cannot resume because its in-memory prompt is unavailable",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("prompt-submit:{}:prompt-missing", fields.task_id),
+        json!({
+            "task_id": fields.task_id.as_str(),
+            "prompt_ref": fields.prompt_ref.as_str(),
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        instance.data.clone(),
+        "failure_reason",
+        "prompt unavailable",
     );
     commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
     Ok(())
@@ -852,6 +1032,8 @@ fn prompt_submission_data(
     ctx: &PromptSubmissionRuntimeContext<'_>,
     project_id: &str,
     existing_data: &serde_json::Value,
+    prompt_ref: &str,
+    depends_on: &[TaskId],
 ) -> serde_json::Value {
     crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
@@ -859,8 +1041,12 @@ fn prompt_submission_data(
             "project_id": project_id,
             "task_id": ctx.task_id.as_str(),
             "task_ids": task_id_history(existing_data, ctx.task_id),
-            "prompt": ctx.prompt,
-            "depends_on": depends_on_strings(ctx.depends_on),
+            "prompt_summary": PROMPT_TASK_DESCRIPTION,
+            "prompt_chars": ctx.prompt.chars().count(),
+            "prompt_ref": prompt_ref,
+            "depends_on": depends_on_strings(depends_on),
+            "required_depends_on": depends_on_strings(ctx.depends_on),
+            "serialization_depends_on": depends_on_strings(ctx.serialization_depends_on),
             "dependencies_blocked": ctx.dependencies_blocked,
             "source": ctx.source,
             "external_id": ctx.external_id,
@@ -911,7 +1097,7 @@ fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueS
 #[derive(Debug)]
 struct PromptSubmissionFields {
     task_id: String,
-    prompt: String,
+    prompt_ref: String,
     source: Option<String>,
     external_id: Option<String>,
 }
@@ -919,7 +1105,7 @@ struct PromptSubmissionFields {
 fn prompt_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<PromptSubmissionFields> {
     Ok(PromptSubmissionFields {
         task_id: string_field(&instance.data, "task_id")?,
-        prompt: string_field(&instance.data, "prompt")?,
+        prompt_ref: string_field(&instance.data, "prompt_ref")?,
         source: optional_string_field(&instance.data, "source"),
         external_id: optional_string_field(&instance.data, "external_id"),
     })
@@ -1114,6 +1300,7 @@ mod tests {
                 task_id: &task_id,
                 prompt: "fix the prompt-only issue",
                 depends_on: &[],
+                serialization_depends_on: &[],
                 dependencies_blocked: false,
                 source: Some("dashboard"),
                 external_id: Some("manual:prompt:1"),
@@ -1141,7 +1328,19 @@ mod tests {
             instance.data["task_ids"],
             serde_json::json!(["prompt-task-1"])
         );
-        assert_eq!(instance.data["prompt"], "fix the prompt-only issue");
+        assert!(instance.data.get("prompt").is_none());
+        assert_eq!(instance.data["prompt_summary"], PROMPT_TASK_DESCRIPTION);
+        assert_eq!(
+            instance.data["prompt_chars"],
+            "fix the prompt-only issue".chars().count()
+        );
+        let prompt_ref = instance.data["prompt_ref"]
+            .as_str()
+            .expect("prompt ref should be persisted");
+        assert_eq!(
+            lookup_prompt_submission_prompt(prompt_ref).as_deref(),
+            Some("fix the prompt-only issue")
+        );
         assert_eq!(instance.data["source"], "dashboard");
         assert_eq!(instance.data["external_id"], "manual:prompt:1");
         assert_eq!(instance.data["last_decision"], "submit_prompt");
@@ -1162,15 +1361,100 @@ mod tests {
             commands[0].command.activity_name(),
             Some("implement_prompt")
         );
-        assert_eq!(
-            commands[0].command.command["prompt"],
-            "fix the prompt-only issue"
-        );
+        assert!(commands[0].command.command.get("prompt").is_none());
+        assert_eq!(commands[0].command.command["prompt_ref"], prompt_ref);
         assert_eq!(store.pending_commands(10).await?.len(), 1);
         assert!(store
             .runtime_jobs_for_command(&commands[0].id)
             .await?
             .is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_prompt_submission_removes_cached_prompt() {
+        let prompt_ref = "prompt-memory:test-cleanup";
+        cache_prompt_submission_prompt(prompt_ref, "sensitive prompt body");
+        let instance = WorkflowInstance::new(
+            PROMPT_TASK_DEFINITION_ID,
+            1,
+            "done",
+            WorkflowSubject::new("prompt", "manual:prompt:cleanup"),
+        )
+        .with_data(json!({
+            "task_id": "runtime-prompt-cleanup",
+            "prompt_ref": prompt_ref,
+        }));
+
+        remove_terminal_prompt_submission_prompt(&instance);
+
+        assert_eq!(lookup_prompt_submission_prompt(prompt_ref), None);
+    }
+
+    #[tokio::test]
+    async fn prompt_resubmission_removes_previous_cached_prompt() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let project_id = project_root.to_string_lossy().into_owned();
+        let task_id = TaskId::from_str("runtime-prompt-cache-retry");
+        let external_id = "manual:prompt:cache-retry";
+        let old_prompt_ref = "prompt-memory:test-resubmit-old";
+        cache_prompt_submission_prompt(old_prompt_ref, "old sensitive prompt body");
+        let workflow_id = prompt_workflow_id(&project_id, Some(external_id), &task_id);
+        store
+            .upsert_instance(
+                &WorkflowInstance::new(
+                    PROMPT_TASK_DEFINITION_ID,
+                    1,
+                    "blocked",
+                    WorkflowSubject::new("prompt", external_id),
+                )
+                .with_id(workflow_id)
+                .with_data(json!({
+                    "project_id": project_id,
+                    "task_id": "old-prompt-task",
+                    "prompt_ref": old_prompt_ref,
+                    "source": "dashboard",
+                    "external_id": external_id,
+                })),
+            )
+            .await?;
+
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "new prompt body",
+                depends_on: &[],
+                serialization_depends_on: &[],
+                dependencies_blocked: false,
+                source: Some("dashboard"),
+                external_id: Some(external_id),
+            },
+        )
+        .await?;
+
+        assert!(result.accepted);
+        assert_eq!(lookup_prompt_submission_prompt(old_prompt_ref), None);
+        let instance = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        let new_prompt_ref = instance.data["prompt_ref"]
+            .as_str()
+            .expect("new prompt ref should be persisted");
+        assert_ne!(new_prompt_ref, old_prompt_ref);
+        assert_eq!(
+            lookup_prompt_submission_prompt(new_prompt_ref).as_deref(),
+            Some("new prompt body")
+        );
         Ok(())
     }
 
@@ -1346,6 +1630,7 @@ mod tests {
                 task_id: &task_id,
                 prompt: "cancel this prompt runtime task",
                 depends_on: &[],
+                serialization_depends_on: &[],
                 dependencies_blocked: false,
                 source: None,
                 external_id: None,
@@ -1570,6 +1855,7 @@ mod tests {
                 task_id: &task_id,
                 prompt: "wait until dependency is done",
                 depends_on: std::slice::from_ref(&dep_id),
+                serialization_depends_on: &[],
                 dependencies_blocked: true,
                 source: None,
                 external_id: None,
@@ -1610,6 +1896,127 @@ mod tests {
         assert_eq!(
             commands[0].command.activity_name(),
             Some("implement_prompt")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prompt_submission_releases_after_failed_serialization_dependency() -> anyhow::Result<()>
+    {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let dep_id = TaskId::from_str("prompt-serialization-dep");
+        let mut dep = crate::task_runner::TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Failed;
+        task_store.insert(&dep).await;
+
+        let task_id = TaskId::from_str("runtime-prompt-serialized");
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "run after serialized predecessor reaches terminal state",
+                depends_on: &[],
+                serialization_depends_on: std::slice::from_ref(&dep_id),
+                dependencies_blocked: true,
+                source: None,
+                external_id: None,
+            },
+        )
+        .await?;
+
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        assert_eq!(workflow.state, "awaiting_dependencies");
+        assert_eq!(
+            workflow.data["depends_on"],
+            serde_json::json!(["prompt-serialization-dep"])
+        );
+        assert_eq!(
+            workflow.data["serialization_depends_on"],
+            serde_json::json!(["prompt-serialization-dep"])
+        );
+
+        let released = release_ready_prompt_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(released.released, 1);
+        assert_eq!(released.failed, 0);
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        assert_eq!(workflow.state, "implementing");
+        assert_eq!(workflow.data["dependencies_blocked"], false);
+        assert_eq!(store.commands_for(&result.workflow_id).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prompt_submission_fails_release_when_in_memory_prompt_is_missing() -> anyhow::Result<()>
+    {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let dep_id = TaskId::from_str("prompt-missing-dep");
+        let mut dep = crate::task_runner::TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Done;
+        task_store.insert(&dep).await;
+
+        let task_id = TaskId::from_str("runtime-prompt-missing-cache");
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "lost after server restart",
+                depends_on: std::slice::from_ref(&dep_id),
+                serialization_depends_on: &[],
+                dependencies_blocked: true,
+                source: None,
+                external_id: None,
+            },
+        )
+        .await?;
+
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        let prompt_ref = workflow.data["prompt_ref"]
+            .as_str()
+            .expect("prompt ref should be persisted")
+            .to_string();
+        remove_prompt_submission_prompt(Some(&prompt_ref));
+
+        let released = release_ready_prompt_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(released.released, 0);
+        assert_eq!(released.failed, 1);
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        assert_eq!(workflow.state, "failed");
+        assert_eq!(workflow.data["failure_reason"], "prompt unavailable");
+        let commands = store.commands_for(&result.workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command.command_type,
+            WorkflowCommandType::MarkFailed
         );
         Ok(())
     }

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,15 +1,26 @@
 use crate::task_runner::{TaskId, TaskStatus, TaskStore};
 use harness_workflow::runtime::{
-    build_issue_submission_decision, DecisionValidator, IssueSubmissionDecisionInput,
-    ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore,
-    WorkflowSubject,
+    build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
+    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
+    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::path::Path;
 
 const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
 const EXECUTION_PATH_WORKFLOW_RUNTIME: &str = "workflow_runtime";
+
+pub(crate) struct PromptSubmissionRuntimeContext<'a> {
+    pub project_root: &'a Path,
+    pub task_id: &'a TaskId,
+    pub prompt: &'a str,
+    pub depends_on: &'a [TaskId],
+    pub dependencies_blocked: bool,
+    pub source: Option<&'a str>,
+    pub external_id: Option<&'a str>,
+}
 
 pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub project_root: &'a Path,
@@ -39,6 +50,13 @@ pub(crate) async fn record_issue_submission(
     ctx: IssueSubmissionRuntimeContext<'_>,
 ) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
     persist_issue_submission(store, &ctx).await
+}
+
+pub(crate) async fn record_prompt_submission(
+    store: &WorkflowRuntimeStore,
+    ctx: PromptSubmissionRuntimeContext<'_>,
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+    persist_prompt_submission(store, &ctx).await
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -140,6 +158,58 @@ pub(crate) async fn release_ready_issue_dependencies(
     Ok(summary)
 }
 
+pub(crate) async fn release_ready_prompt_dependencies(
+    store: &WorkflowRuntimeStore,
+    tasks: &TaskStore,
+    limit: i64,
+) -> anyhow::Result<IssueDependencyReleaseSummary> {
+    let instances = store
+        .list_instances_by_state(PROMPT_TASK_DEFINITION_ID, "awaiting_dependencies", limit)
+        .await?;
+    let mut summary = IssueDependencyReleaseSummary::default();
+    for instance in instances {
+        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let mut all_done = true;
+        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
+        for dep_id in &depends_on {
+            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
+                IssueDependencyStatus::Done => {}
+                IssueDependencyStatus::Failed => {
+                    terminal_failure = Some((dep_id.clone(), "failed"));
+                    break;
+                }
+                IssueDependencyStatus::Cancelled => {
+                    terminal_failure = Some((dep_id.clone(), "cancelled"));
+                    break;
+                }
+                IssueDependencyStatus::Waiting => all_done = false,
+            }
+        }
+        if let Some((dep_id, label)) = terminal_failure {
+            fail_prompt_for_dependency(store, instance, &dep_id, label).await?;
+            summary.failed += 1;
+        } else if all_done {
+            release_prompt_after_dependencies(store, instance, &depends_on).await?;
+            summary.released += 1;
+        } else {
+            store.touch_instance(&instance.id).await?;
+            summary.waiting += 1;
+        }
+    }
+    Ok(summary)
+}
+
 pub(crate) async fn runtime_issue_by_task_id(
     store: &WorkflowRuntimeStore,
     task_id: &TaskId,
@@ -165,10 +235,31 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
     if instance.is_terminal() {
         return Ok(Some(instance));
     }
+    let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
+    let event_type = if is_prompt {
+        "PromptSubmissionCancelled"
+    } else {
+        "IssueSubmissionCancelled"
+    };
+    let decision_name = if is_prompt {
+        "cancel_prompt_submission"
+    } else {
+        "cancel_issue_submission"
+    };
+    let reason = if is_prompt {
+        "operator cancelled the runtime prompt submission"
+    } else {
+        "operator cancelled the runtime issue submission"
+    };
+    let command_prefix = if is_prompt {
+        "prompt-submit"
+    } else {
+        "issue-submit"
+    };
     let event = store
         .append_event(
             &instance.id,
-            "IssueSubmissionCancelled",
+            event_type,
             "workflow_runtime_submission",
             json!({
                 "task_id": task_id.as_str(),
@@ -179,13 +270,13 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
     let decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
-        "cancel_issue_submission",
+        decision_name,
         "cancelled",
-        "operator cancelled the runtime issue submission",
+        reason,
     )
     .with_command(WorkflowCommand::new(
         WorkflowCommandType::MarkCancelled,
-        format!("issue-submit:{}:cancel", task_id.as_str()),
+        format!("{command_prefix}:{}:cancel", task_id.as_str()),
         json!({ "task_id": task_id.as_str() }),
     ))
     .high_confidence();
@@ -252,6 +343,47 @@ async fn persist_issue_submission(
     .await
 }
 
+async fn persist_prompt_submission(
+    store: &WorkflowRuntimeStore,
+    ctx: &PromptSubmissionRuntimeContext<'_>,
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+    let project_id = ctx.project_root.to_string_lossy().into_owned();
+    let workflow_id = prompt_workflow_id(&project_id, ctx.external_id, ctx.task_id);
+    upsert_prompt_task_definition(store).await?;
+    let (instance, new_instance) = match store.get_instance(&workflow_id).await? {
+        Some(instance) => (instance, false),
+        None => (
+            prompt_instance(
+                workflow_id,
+                project_id.clone(),
+                prompt_subject_key(ctx.external_id, ctx.task_id),
+            ),
+            true,
+        ),
+    };
+    let submitted_data = prompt_submission_data(ctx, &project_id, &instance.data);
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: ctx.task_id.as_str(),
+            prompt: ctx.prompt,
+            source: ctx.source,
+            external_id: ctx.external_id,
+            depends_on: &depends_on_strings(ctx.depends_on),
+            dependencies_blocked: ctx.dependencies_blocked,
+        },
+    );
+    apply_prompt_decision(
+        store,
+        instance,
+        new_instance,
+        output.decision,
+        ctx,
+        submitted_data,
+    )
+    .await
+}
+
 async fn apply_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
@@ -284,6 +416,77 @@ async fn apply_decision(
                 "additional_prompt": ctx.additional_prompt,
                 "depends_on": depends_on_strings(ctx.depends_on),
                 "dependencies_blocked": ctx.dependencies_blocked,
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let record = match validation {
+        Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id)),
+        Err(error) => {
+            let reason = error.to_string();
+            let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
+            store.record_decision(&record).await?;
+            return Ok(IssueSubmissionRuntimeRecord {
+                workflow_id: instance.id,
+                accepted: false,
+                decision_id: record.id,
+                command_ids: Vec::new(),
+                rejection_reason: Some(reason),
+            });
+        }
+    };
+    store.record_decision(&record).await?;
+    let mut command_ids = Vec::with_capacity(decision.commands.len());
+    for command in &decision.commands {
+        command_ids.push(
+            store
+                .enqueue_command(&instance.id, Some(&record.id), command)
+                .await?,
+        );
+    }
+    instance.state = decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_last_decision(accepted_data, &decision.decision);
+    store.upsert_instance(&instance).await?;
+    Ok(IssueSubmissionRuntimeRecord {
+        workflow_id: instance.id,
+        accepted: true,
+        decision_id: record.id,
+        command_ids,
+        rejection_reason: None,
+    })
+}
+
+async fn apply_prompt_decision(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    new_instance: bool,
+    decision: WorkflowDecision,
+    ctx: &PromptSubmissionRuntimeContext<'_>,
+    accepted_data: serde_json::Value,
+) -> anyhow::Result<IssueSubmissionRuntimeRecord> {
+    let validation_context = if instance.is_terminal() {
+        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
+    } else {
+        ValidationContext::new("workflow-policy", chrono::Utc::now())
+    };
+    let validation =
+        DecisionValidator::prompt_task().validate(&instance, &decision, &validation_context);
+    if new_instance {
+        store.upsert_instance(&instance).await?;
+    }
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptSubmitted",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": ctx.task_id.as_str(),
+                "prompt_chars": ctx.prompt.chars().count(),
+                "depends_on": depends_on_strings(ctx.depends_on),
+                "dependencies_blocked": ctx.dependencies_blocked,
+                "source": ctx.source,
+                "external_id": ctx.external_id,
                 "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )
@@ -414,6 +617,91 @@ async fn fail_issue_for_dependency(
     Ok(())
 }
 
+async fn release_prompt_after_dependencies(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    depends_on: &[TaskId],
+) -> anyhow::Result<()> {
+    let fields = prompt_submission_fields(&instance)?;
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: &fields.task_id,
+            prompt: &fields.prompt,
+            source: fields.source.as_deref(),
+            external_id: fields.external_id.as_deref(),
+            depends_on: &depends_on_strings(depends_on),
+            dependencies_blocked: false,
+        },
+    );
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptDependenciesSatisfied",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id,
+                "depends_on": depends_on_strings(depends_on),
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
+    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
+async fn fail_prompt_for_dependency(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    dependency_id: &TaskId,
+    dependency_status: &str,
+) -> anyhow::Result<()> {
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptDependencyFailed",
+            "workflow_runtime_submission",
+            json!({
+                "dependency_task_id": dependency_id.as_str(),
+                "dependency_status": dependency_status,
+                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "dependency_failed",
+        "failed",
+        format!(
+            "dependency task {} {} before runtime prompt submission could start",
+            dependency_id.as_str(),
+            dependency_status
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("prompt-submit:{}:dependency-failed", dependency_id.as_str()),
+        json!({
+            "dependency_task_id": dependency_id.as_str(),
+            "dependency_status": dependency_status,
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        set_data_string(
+            instance.data.clone(),
+            "dependency_failure_task_id",
+            dependency_id.as_str(),
+        ),
+        "dependency_failure_status",
+        dependency_status,
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
 async fn commit_runtime_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
@@ -426,9 +714,8 @@ async fn commit_runtime_decision(
     } else {
         ValidationContext::new("workflow-policy", chrono::Utc::now())
     };
-    if let Err(error) =
-        DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context)
-    {
+    let validator = decision_validator_for_instance(&instance)?;
+    if let Err(error) = validator.validate(&instance, &decision, &validation_context) {
         let reason = error.to_string();
         let record = WorkflowDecisionRecord::rejected(decision, Some(event_id), &reason);
         store.record_decision(&record).await?;
@@ -452,12 +739,32 @@ async fn commit_runtime_decision(
     Ok(instance)
 }
 
+fn decision_validator_for_instance(
+    instance: &WorkflowInstance,
+) -> anyhow::Result<DecisionValidator> {
+    match instance.definition_id.as_str() {
+        GITHUB_ISSUE_PR_DEFINITION_ID => Ok(DecisionValidator::github_issue_pr()),
+        PROMPT_TASK_DEFINITION_ID => Ok(DecisionValidator::prompt_task()),
+        other => anyhow::bail!("workflow definition `{other}` cannot be committed by submission"),
+    }
+}
+
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
     store
         .upsert_definition(&WorkflowDefinition::new(
             GITHUB_ISSUE_PR_DEFINITION_ID,
             1,
             "GitHub issue PR workflow",
+        ))
+        .await
+}
+
+async fn upsert_prompt_task_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
+    store
+        .upsert_definition(&WorkflowDefinition::new(
+            PROMPT_TASK_DEFINITION_ID,
+            1,
+            "Prompt task workflow",
         ))
         .await
 }
@@ -482,6 +789,41 @@ fn issue_instance(
     }))
 }
 
+fn prompt_instance(
+    workflow_id: String,
+    project_id: String,
+    subject_key: String,
+) -> WorkflowInstance {
+    WorkflowInstance::new(
+        PROMPT_TASK_DEFINITION_ID,
+        1,
+        "submitted",
+        WorkflowSubject::new("prompt", subject_key),
+    )
+    .with_id(workflow_id)
+    .with_data(json!({
+        "project_id": project_id,
+    }))
+}
+
+pub(crate) fn prompt_workflow_id(
+    project_id: &str,
+    external_id: Option<&str>,
+    task_id: &TaskId,
+) -> String {
+    format!(
+        "{project_id}::prompt:{}",
+        prompt_subject_key(external_id, task_id)
+    )
+}
+
+fn prompt_subject_key(external_id: Option<&str>, task_id: &TaskId) -> String {
+    external_id
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| task_id.as_str())
+        .to_string()
+}
+
 fn issue_submission_data(
     ctx: &IssueSubmissionRuntimeContext<'_>,
     project_id: &str,
@@ -498,6 +840,26 @@ fn issue_submission_data(
             "labels": ctx.labels,
             "force_execute": ctx.force_execute,
             "additional_prompt": ctx.additional_prompt,
+            "depends_on": depends_on_strings(ctx.depends_on),
+            "dependencies_blocked": ctx.dependencies_blocked,
+            "source": ctx.source,
+            "external_id": ctx.external_id,
+        }),
+    )
+}
+
+fn prompt_submission_data(
+    ctx: &PromptSubmissionRuntimeContext<'_>,
+    project_id: &str,
+    existing_data: &serde_json::Value,
+) -> serde_json::Value {
+    crate::workflow_runtime_policy::merge_runtime_retry_policy(
+        ctx.project_root,
+        json!({
+            "project_id": project_id,
+            "task_id": ctx.task_id.as_str(),
+            "task_ids": task_id_history(existing_data, ctx.task_id),
+            "prompt": ctx.prompt,
             "depends_on": depends_on_strings(ctx.depends_on),
             "dependencies_blocked": ctx.dependencies_blocked,
             "source": ctx.source,
@@ -543,6 +905,23 @@ fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueS
             .and_then(|value| value.as_bool())
             .unwrap_or(false),
         additional_prompt: optional_string_field(&instance.data, "additional_prompt"),
+    })
+}
+
+#[derive(Debug)]
+struct PromptSubmissionFields {
+    task_id: String,
+    prompt: String,
+    source: Option<String>,
+    external_id: Option<String>,
+}
+
+fn prompt_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<PromptSubmissionFields> {
+    Ok(PromptSubmissionFields {
+        task_id: string_field(&instance.data, "task_id")?,
+        prompt: string_field(&instance.data, "prompt")?,
+        source: optional_string_field(&instance.data, "source"),
+        external_id: optional_string_field(&instance.data, "external_id"),
     })
 }
 
@@ -716,6 +1095,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_submission_records_pending_runtime_implementation_command() -> anyhow::Result<()>
+    {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("prompt-task-1");
+
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "fix the prompt-only issue",
+                depends_on: &[],
+                dependencies_blocked: false,
+                source: Some("dashboard"),
+                external_id: Some("manual:prompt:1"),
+            },
+        )
+        .await?;
+
+        assert!(result.accepted);
+        assert_eq!(result.command_ids.len(), 1);
+        assert!(result.rejection_reason.is_none());
+
+        let workflow_id = prompt_workflow_id(
+            &project_root.to_string_lossy(),
+            Some("manual:prompt:1"),
+            &task_id,
+        );
+        let instance = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        assert_eq!(instance.definition_id, PROMPT_TASK_DEFINITION_ID);
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.data["task_id"], "prompt-task-1");
+        assert_eq!(
+            instance.data["task_ids"],
+            serde_json::json!(["prompt-task-1"])
+        );
+        assert_eq!(instance.data["prompt"], "fix the prompt-only issue");
+        assert_eq!(instance.data["source"], "dashboard");
+        assert_eq!(instance.data["external_id"], "manual:prompt:1");
+        assert_eq!(instance.data["last_decision"], "submit_prompt");
+        assert_eq!(
+            instance.data["execution_path"],
+            EXECUTION_PATH_WORKFLOW_RUNTIME
+        );
+
+        let events = store.events_for(&workflow_id).await?;
+        assert!(events
+            .iter()
+            .any(|event| event.event_type == "PromptSubmitted"));
+
+        let commands = store.commands_for(&workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some("implement_prompt")
+        );
+        assert_eq!(
+            commands[0].command.command["prompt"],
+            "fix the prompt-only issue"
+        );
+        assert_eq!(store.pending_commands(10).await?.len(), 1);
+        assert!(store
+            .runtime_jobs_for_command(&commands[0].id)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn issue_submission_preserves_prior_task_handles_for_lookup() -> anyhow::Result<()> {
         if !crate::test_helpers::db_tests_enabled().await {
             return Ok(());
@@ -851,6 +1310,74 @@ mod tests {
         let cancelled = cancel_issue_submission_by_task_id(&store, &task_id)
             .await?
             .expect("runtime issue submission should resolve by task id");
+        assert_eq!(cancelled.state, "cancelled");
+
+        let commands = store.commands_for(&result.workflow_id).await?;
+        let original_command = commands
+            .iter()
+            .find(|command| command.id == command_id)
+            .expect("original implementation command should remain visible");
+        assert_eq!(original_command.status, "cancelled");
+        let jobs = store.runtime_jobs_for_command(&command_id).await?;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(
+            jobs[0].status,
+            harness_workflow::runtime::RuntimeJobStatus::Cancelled
+        );
+        assert!(jobs[0].lease.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancel_prompt_submission_cancels_dispatched_runtime_jobs() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("runtime-prompt-handle-cancel");
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "cancel this prompt runtime task",
+                depends_on: &[],
+                dependencies_blocked: false,
+                source: None,
+                external_id: None,
+            },
+        )
+        .await?;
+        let command_id = result
+            .command_ids
+            .first()
+            .expect("prompt submission should enqueue an implementation command")
+            .clone();
+        store
+            .enqueue_runtime_job_for_pending_command(
+                &command_id,
+                harness_workflow::runtime::RuntimeKind::CodexExec,
+                "default",
+                json!({ "task_id": task_id.as_str() }),
+                None,
+            )
+            .await?;
+        assert_eq!(
+            store
+                .get_command(&command_id)
+                .await?
+                .expect("command should exist")
+                .status,
+            "dispatched"
+        );
+
+        let cancelled = cancel_issue_submission_by_task_id(&store, &task_id)
+            .await?
+            .expect("runtime prompt submission should resolve by task id");
         assert_eq!(cancelled.state, "cancelled");
 
         let commands = store.commands_for(&result.workflow_id).await?;
@@ -1015,6 +1542,75 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].status, "pending");
         assert_eq!(commands[0].command.activity_name(), Some("implement_issue"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prompt_submission_waits_for_dependencies_then_releases_runtime_command(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let dep_id = TaskId::from_str("prompt-dep-1");
+        let mut dep = crate::task_runner::TaskState::new(dep_id.clone());
+        dep.status = TaskStatus::Pending;
+        task_store.insert(&dep).await;
+
+        let task_id = TaskId::from_str("runtime-prompt-handle-1");
+        let result = record_prompt_submission(
+            &store,
+            PromptSubmissionRuntimeContext {
+                project_root: &project_root,
+                task_id: &task_id,
+                prompt: "wait until dependency is done",
+                depends_on: std::slice::from_ref(&dep_id),
+                dependencies_blocked: true,
+                source: None,
+                external_id: None,
+            },
+        )
+        .await?;
+
+        assert!(result.accepted);
+        assert!(result.command_ids.is_empty());
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should be persisted");
+        assert_eq!(workflow.state, "awaiting_dependencies");
+        assert_eq!(
+            workflow.data["depends_on"],
+            serde_json::json!(["prompt-dep-1"])
+        );
+        assert!(store.commands_for(&result.workflow_id).await?.is_empty());
+
+        let waiting = release_ready_prompt_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(waiting.waiting, 1);
+        assert_eq!(waiting.released, 0);
+
+        dep.status = TaskStatus::Done;
+        task_store.insert(&dep).await;
+        let released = release_ready_prompt_dependencies(&store, &task_store, 10).await?;
+        assert_eq!(released.released, 1);
+        let workflow = store
+            .get_instance(&result.workflow_id)
+            .await?
+            .expect("workflow should remain persisted");
+        assert_eq!(workflow.state, "implementing");
+        assert_eq!(workflow.data["dependencies_blocked"], false);
+        let commands = store.commands_for(&result.workflow_id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].status, "pending");
+        assert_eq!(
+            commands[0].command.activity_name(),
+            Some("implement_prompt")
+        );
         Ok(())
     }
 

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -14,6 +14,7 @@ use harness_workflow::runtime::{
     WorkflowSubject, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
     QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
     QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
+    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -1060,6 +1061,7 @@ fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionVali
         "github_issue_pr" => Some(DecisionValidator::github_issue_pr()),
         QUALITY_GATE_DEFINITION_ID => Some(DecisionValidator::quality_gate()),
         PR_FEEDBACK_DEFINITION_ID => Some(DecisionValidator::pr_feedback()),
+        PROMPT_TASK_DEFINITION_ID => Some(DecisionValidator::prompt_task()),
         "repo_backlog" => Some(DecisionValidator::repo_backlog()),
         _ => None,
     }
@@ -1155,6 +1157,16 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             },
             "follow_up_event": "PrDetected binds PR metadata and advances the issue workflow."
         }),
+        (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
+            "on_succeeded": {
+                "reducer_next_state": "done",
+                "required_summary": "Include changed files, validation commands, and remaining blockers."
+            },
+            "on_failed": {
+                "reducer_next_state": "failed_or_retry",
+                "retry_policy": "runtime_retry_policy may retry this activity before failure."
+            }
+        }),
         ("repo_backlog", "start_child_workflow") => json!({
             "on_succeeded": {
                 "reducer_next_state": "idle",
@@ -1204,6 +1216,16 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 "pull_request": {
                     "required_when": "A PR was created or reused by the activity.",
                     "fields": ["pr_number", "pr_url"]
+                }
+            }
+        }),
+        (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
+            "must_include": ["changed files", "validation commands", "remaining blockers"],
+            "must_not_include": ["workflow table mutations", "unverified merge claims"],
+            "artifacts": {
+                "validation_report": {
+                    "optional": true,
+                    "fields": ["commands", "passed", "failed", "blocked"]
                 }
             }
         }),

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -8,13 +8,13 @@ use harness_core::config::agents::SandboxMode;
 use harness_core::types::{AgentId, Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
     build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
-    ActivitySignal, DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob,
+    ActivitySignal, ActivityStatus, DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob,
     RuntimeJobExecutor, RuntimeJobStatus, RuntimeKind, RuntimeProfile, RuntimeWorker,
     WorkflowCommandRecord, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
-    WorkflowSubject, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
     QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
     QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -74,17 +74,17 @@ pub(crate) async fn run_runtime_job_worker_tick(
     let executor = ServerRuntimeJobExecutor::new(state.clone());
     let completed = worker.run_once(&executor).await?;
     if let Some(job) = completed.as_ref() {
-        if let Err(error) = notify_runtime_issue_terminal(state, job).await {
+        if let Err(error) = notify_runtime_submission_terminal(state, job).await {
             tracing::warn!(
                 runtime_job_id = %job.id,
-                "workflow runtime issue completion notification failed: {error}"
+                "workflow runtime completion notification failed: {error}"
             );
         }
     }
     Ok(RuntimeJobWorkerTick::from_completed_job(completed))
 }
 
-pub(crate) async fn notify_runtime_issue_terminal(
+pub(crate) async fn notify_runtime_submission_terminal(
     state: &AppState,
     job: &RuntimeJob,
 ) -> anyhow::Result<bool> {
@@ -92,52 +92,67 @@ pub(crate) async fn notify_runtime_issue_terminal(
         return Ok(false);
     };
     let result = runtime_job_activity_result(job);
-    notify_runtime_issue_terminal_workflow(state, workflow_id, result.as_ref()).await
+    notify_runtime_submission_terminal_workflow(state, workflow_id, result.as_ref()).await
 }
 
-pub(crate) async fn notify_runtime_issue_terminal_workflow(
+pub(crate) async fn notify_runtime_submission_terminal_workflow(
     state: &AppState,
     workflow_id: &str,
     result: Option<&ActivityResult>,
 ) -> anyhow::Result<bool> {
-    let Some(callback) = state.intake.completion_callback.as_ref() else {
-        return Ok(false);
-    };
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(false);
     };
     let Some(instance) = store.get_instance(workflow_id).await? else {
         return Ok(false);
     };
-    let Some(task) = runtime_issue_completion_task(&instance, result) else {
+    crate::workflow_runtime_submission::remove_terminal_prompt_submission_prompt(&instance);
+    let Some(callback) = state.intake.completion_callback.as_ref() else {
+        return Ok(false);
+    };
+    let Some(task) = runtime_submission_completion_task(&instance, result) else {
         return Ok(false);
     };
     callback(task).await;
     Ok(true)
 }
 
-fn runtime_issue_completion_task(
+fn runtime_submission_completion_task(
     instance: &WorkflowInstance,
     result: Option<&ActivityResult>,
 ) -> Option<TaskState> {
-    if instance.definition_id != "github_issue_pr" || !instance.is_terminal() {
+    if !instance.is_terminal() {
         return None;
     }
+    let task_kind = match instance.definition_id.as_str() {
+        GITHUB_ISSUE_PR_DEFINITION_ID => TaskKind::Issue,
+        PROMPT_TASK_DEFINITION_ID => TaskKind::Prompt,
+        _ => return None,
+    };
     let source = optional_data_string(instance, "source")?;
     let external_id = optional_data_string(instance, "external_id")?;
     let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(instance)?;
     let status = task_status_for_runtime_state(&instance.state)?;
     let mut task = TaskState::new(task_id);
-    task.task_kind = TaskKind::Issue;
+    task.task_kind = task_kind;
     task.status = status.clone();
     task.failure_kind = runtime_failure_kind(&status, result);
     task.source = Some(source);
     task.external_id = Some(external_id);
     task.repo = optional_data_string(instance, "repo");
-    task.issue = optional_data_u64(instance, "issue_number");
+    task.issue = if task_kind == TaskKind::Issue {
+        optional_data_u64(instance, "issue_number")
+    } else {
+        None
+    };
     task.project_root = optional_data_string(instance, "project_id").map(PathBuf::from);
     task.pr_url = optional_data_string(instance, "last_pr_url");
-    task.description = task.issue.map(|issue| format!("issue #{issue}"));
+    task.description = match task_kind {
+        TaskKind::Issue => task.issue.map(|issue| format!("issue #{issue}")),
+        TaskKind::Prompt => optional_data_string(instance, "prompt_summary")
+            .or_else(|| Some("prompt task".to_string())),
+        _ => None,
+    };
     task.error = runtime_completion_error(&status, result);
     Some(task)
 }
@@ -223,12 +238,16 @@ impl ServerRuntimeJobExecutor {
         let runtime_profile = runtime_profile_for_job(&job)?;
         let sandbox_mode = runtime_profile_sandbox_mode(&runtime_profile)?;
         let approval_policy = runtime_profile_approval_policy(&runtime_profile, job.runtime_kind)?;
+        let prompt_task_request = prompt_task_request_for_job(&job)?;
+        if let PromptTaskRequest::PayloadUnavailable { prompt_ref } = &prompt_task_request {
+            return Ok(prompt_payload_unavailable_result(&job, prompt_ref));
+        }
         let prompt_packet =
             build_runtime_prompt_packet(&job, workflow.as_ref(), &project_root, &runtime_profile);
         let prompt_packet_digest = prompt_packet_digest(&prompt_packet);
         self.record_prompt_packet_prepared(&job, &prompt_packet, &prompt_packet_digest)
             .await?;
-        let prompt = build_runtime_job_prompt(&prompt_packet);
+        let prompt = build_runtime_job_prompt(&prompt_packet, prompt_task_request.prompt_text());
         let thread_id = self
             .state
             .core
@@ -940,7 +959,7 @@ fn build_runtime_prompt_packet(
     })
 }
 
-fn build_runtime_job_prompt(prompt_packet: &Value) -> String {
+fn build_runtime_job_prompt(prompt_packet: &Value, prompt_task_request: Option<&str>) -> String {
     let prompt_packet_json = pretty_json(prompt_packet);
     let activity = prompt_packet
         .get("runtime_job")
@@ -962,7 +981,7 @@ fn build_runtime_job_prompt(prompt_packet: &Value) -> String {
         .and_then(|runtime_job| runtime_job.get("id"))
         .and_then(Value::as_str)
         .unwrap_or("");
-    format!(
+    let mut prompt = format!(
         "You are executing a Harness workflow runtime job.\n\n\
          Runtime contract:\n\
          - Treat the workflow database as the source of orchestration state, but do not edit workflow tables directly.\n\
@@ -977,7 +996,13 @@ fn build_runtime_job_prompt(prompt_packet: &Value) -> String {
          Runtime profile: {runtime_profile}\n\
          Activity: {activity}\n\n\
          Prompt packet:\n{prompt_packet_json}\n",
-    )
+    );
+    if let Some(prompt_task_request) = prompt_task_request {
+        prompt.push_str("\nPrompt task request:\n");
+        prompt.push_str(prompt_task_request);
+        prompt.push('\n');
+    }
+    prompt
 }
 
 fn activity_result_schema(job: &RuntimeJob, workflow: Option<&WorkflowInstance>) -> Value {
@@ -1522,6 +1547,68 @@ fn activity_name(job: &RuntimeJob) -> String {
         .to_string()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PromptTaskRequest {
+    NotPromptActivity,
+    Ready(String),
+    PayloadUnavailable { prompt_ref: String },
+}
+
+impl PromptTaskRequest {
+    fn prompt_text(&self) -> Option<&str> {
+        match self {
+            Self::Ready(prompt) => Some(prompt.as_str()),
+            Self::NotPromptActivity | Self::PayloadUnavailable { .. } => None,
+        }
+    }
+}
+
+fn prompt_task_request_for_job(job: &RuntimeJob) -> anyhow::Result<PromptTaskRequest> {
+    if activity_name(job) != PROMPT_TASK_IMPLEMENT_ACTIVITY {
+        return Ok(PromptTaskRequest::NotPromptActivity);
+    }
+    let Some(prompt_ref) = job
+        .input
+        .get("command")
+        .and_then(|command| command.get("prompt_ref"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        anyhow::bail!("runtime prompt task command is missing prompt_ref");
+    };
+    Ok(
+        match crate::workflow_runtime_submission::lookup_prompt_submission_prompt(prompt_ref) {
+            Some(prompt) => PromptTaskRequest::Ready(prompt),
+            None => PromptTaskRequest::PayloadUnavailable {
+                prompt_ref: prompt_ref.to_string(),
+            },
+        },
+    )
+}
+
+fn prompt_payload_unavailable_result(job: &RuntimeJob, prompt_ref: &str) -> ActivityResult {
+    let activity = activity_name(job);
+    let error = format!(
+        "Runtime prompt payload `{prompt_ref}` is unavailable because prompt text is only held in the current Harness process."
+    );
+    ActivityResult {
+        activity,
+        status: ActivityStatus::Blocked,
+        summary: "Runtime prompt task is blocked until the prompt is resubmitted.".to_string(),
+        artifacts: vec![ActivityArtifact::new(
+            "prompt_payload_unavailable",
+            json!({
+                "prompt_ref": prompt_ref,
+                "recovery": "Resubmit the prompt task so Harness can rebuild the runtime prompt payload."
+            }),
+        )],
+        signals: Vec::new(),
+        validation: Vec::new(),
+        error: Some(error),
+        error_kind: Some(ActivityErrorKind::Configuration),
+    }
+}
+
 fn is_builtin_lifecycle_activity(job: &RuntimeJob) -> bool {
     matches!(
         activity_name(job).as_str(),
@@ -1760,6 +1847,45 @@ mod tests {
         );
 
         assert_eq!(activity_name(&job), "start_child_workflow");
+    }
+
+    #[test]
+    fn prompt_task_request_blocks_when_cached_payload_is_unavailable() -> anyhow::Result<()> {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "command": {
+                    "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                    "prompt_ref": "prompt-submission:cache-miss-test"
+                }
+            }),
+        );
+
+        let request = prompt_task_request_for_job(&job)?;
+        assert_eq!(
+            request,
+            PromptTaskRequest::PayloadUnavailable {
+                prompt_ref: "prompt-submission:cache-miss-test".to_string()
+            }
+        );
+
+        let result = prompt_payload_unavailable_result(&job, "prompt-submission:cache-miss-test");
+        assert_eq!(result.status, ActivityStatus::Blocked);
+        assert_eq!(result.activity, PROMPT_TASK_IMPLEMENT_ACTIVITY);
+        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("only held in the current Harness process"));
+        assert_eq!(
+            result.artifacts[0].artifact_type,
+            "prompt_payload_unavailable"
+        );
+        Ok(())
     }
 
     #[test]
@@ -2168,7 +2294,7 @@ mod profile_tests {
     use super::*;
 
     #[test]
-    fn runtime_issue_completion_task_preserves_intake_identity() {
+    fn runtime_submission_completion_task_preserves_issue_intake_identity() {
         let instance = WorkflowInstance::new(
             "github_issue_pr",
             1,
@@ -2185,7 +2311,7 @@ mod profile_tests {
         }));
         let result = ActivityResult::cancelled("implement_issue", "Runtime job was cancelled.");
 
-        let task = runtime_issue_completion_task(&instance, Some(&result))
+        let task = runtime_submission_completion_task(&instance, Some(&result))
             .expect("terminal runtime issue should map to an intake task");
 
         assert_eq!(task.id.as_str(), "runtime-task-42");
@@ -2198,7 +2324,36 @@ mod profile_tests {
     }
 
     #[test]
-    fn runtime_issue_completion_task_marks_retryable_failures_as_transient() {
+    fn runtime_submission_completion_task_preserves_prompt_intake_identity() {
+        let instance = WorkflowInstance::new(
+            PROMPT_TASK_DEFINITION_ID,
+            1,
+            "done",
+            WorkflowSubject::new("prompt", "manual:prompt:42"),
+        )
+        .with_data(json!({
+            "task_id": "runtime-prompt-42",
+            "project_id": "/tmp/project",
+            "prompt_summary": "prompt task",
+            "source": "dashboard",
+            "external_id": "manual:prompt:42",
+        }));
+        let result = ActivityResult::succeeded("implement_prompt", "Prompt task completed.");
+
+        let task = runtime_submission_completion_task(&instance, Some(&result))
+            .expect("terminal runtime prompt should map to an intake task");
+
+        assert_eq!(task.id.as_str(), "runtime-prompt-42");
+        assert_eq!(task.task_kind, TaskKind::Prompt);
+        assert_eq!(task.status, TaskStatus::Done);
+        assert_eq!(task.source.as_deref(), Some("dashboard"));
+        assert_eq!(task.external_id.as_deref(), Some("manual:prompt:42"));
+        assert_eq!(task.issue, None);
+        assert_eq!(task.description.as_deref(), Some("prompt task"));
+    }
+
+    #[test]
+    fn runtime_submission_completion_task_marks_retryable_failures_as_transient() {
         let instance = WorkflowInstance::new(
             "github_issue_pr",
             1,
@@ -2220,7 +2375,7 @@ mod profile_tests {
         )
         .with_error_kind(ActivityErrorKind::ExternalDependency);
 
-        let task = runtime_issue_completion_task(&instance, Some(&result))
+        let task = runtime_submission_completion_task(&instance, Some(&result))
             .expect("terminal runtime issue should map to an intake task");
 
         assert_eq!(task.status, TaskStatus::Failed);

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -9,6 +9,7 @@ pub mod dispatcher;
 pub mod model;
 pub mod plan_issue;
 pub mod pr_feedback;
+pub mod prompt_task;
 pub mod quality_gate;
 pub mod reducer;
 pub mod repo_backlog;
@@ -39,6 +40,11 @@ pub use pr_feedback::{
     PrFeedbackDecisionOutput, PrFeedbackInspectDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PR_FEEDBACK_DEFINITION_ID,
     PR_FEEDBACK_INSPECT_ACTIVITY,
+};
+pub use prompt_task::{
+    build_prompt_submission_decision, PromptSubmissionDecisionInput,
+    PromptSubmissionDecisionOutput, PromptTaskWorkflowAction, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 pub use quality_gate::{
     build_quality_gate_run_decision, quality_gate_workflow_id, QualityGateDecisionInput,

--- a/crates/harness-workflow/src/runtime/prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/prompt_task.rs
@@ -1,0 +1,95 @@
+use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
+
+pub const PROMPT_TASK_DEFINITION_ID: &str = "prompt_task";
+pub const PROMPT_TASK_IMPLEMENT_ACTIVITY: &str = "implement_prompt";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptTaskWorkflowAction {
+    RunImplementation,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PromptSubmissionDecisionInput<'a> {
+    pub task_id: &'a str,
+    pub prompt: &'a str,
+    pub source: Option<&'a str>,
+    pub external_id: Option<&'a str>,
+    pub depends_on: &'a [String],
+    pub dependencies_blocked: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct PromptSubmissionDecisionOutput {
+    pub action: PromptTaskWorkflowAction,
+    pub decision: WorkflowDecision,
+}
+
+pub fn build_prompt_submission_decision(
+    instance: &WorkflowInstance,
+    input: PromptSubmissionDecisionInput<'_>,
+) -> PromptSubmissionDecisionOutput {
+    let next_state = if input.dependencies_blocked {
+        "awaiting_dependencies"
+    } else {
+        "implementing"
+    };
+    let reason = if input.dependencies_blocked {
+        "operator submitted the prompt task and it is waiting for dependencies"
+    } else {
+        "operator submitted the prompt task for implementation"
+    };
+    let mut decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "submit_prompt",
+        next_state,
+        reason,
+    );
+    if !input.dependencies_blocked {
+        decision = decision.with_command(WorkflowCommand::new(
+            super::model::WorkflowCommandType::EnqueueActivity,
+            format!(
+                "prompt-submit:{}:task:{}:implement",
+                subject_key(input),
+                input.task_id
+            ),
+            serde_json::json!({
+                "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "prompt": input.prompt,
+                "source": input.source,
+                "external_id": input.external_id,
+                "task_id": input.task_id,
+            }),
+        ));
+    }
+    let decision = decision
+        .with_evidence(WorkflowEvidence::new(
+            "prompt_submission",
+            format!(
+                "task_id={} prompt_chars={} source={} external_id={} depends_on={} dependencies_blocked={}",
+                input.task_id,
+                input.prompt.chars().count(),
+                input.source.unwrap_or("<none>"),
+                input.external_id.unwrap_or("<none>"),
+                depends_on_summary(input.depends_on),
+                input.dependencies_blocked
+            ),
+        ))
+        .high_confidence();
+
+    PromptSubmissionDecisionOutput {
+        action: PromptTaskWorkflowAction::RunImplementation,
+        decision,
+    }
+}
+
+fn subject_key(input: PromptSubmissionDecisionInput<'_>) -> &str {
+    input.external_id.unwrap_or(input.task_id)
+}
+
+fn depends_on_summary(depends_on: &[String]) -> String {
+    if depends_on.is_empty() {
+        return "<none>".to_string();
+    }
+    depends_on.join(",")
+}

--- a/crates/harness-workflow/src/runtime/prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/prompt_task.rs
@@ -12,6 +12,7 @@ pub enum PromptTaskWorkflowAction {
 pub struct PromptSubmissionDecisionInput<'a> {
     pub task_id: &'a str,
     pub prompt: &'a str,
+    pub prompt_ref: &'a str,
     pub source: Option<&'a str>,
     pub external_id: Option<&'a str>,
     pub depends_on: &'a [String],
@@ -55,7 +56,8 @@ pub fn build_prompt_submission_decision(
             ),
             serde_json::json!({
                 "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
-                "prompt": input.prompt,
+                "prompt_ref": input.prompt_ref,
+                "prompt_chars": input.prompt.chars().count(),
                 "source": input.source,
                 "external_id": input.external_id,
                 "task_id": input.task_id,

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -6,6 +6,7 @@ use super::pr_feedback::{
     build_pr_feedback_decision, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
+use super::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
 use super::repo_backlog::{
     REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
@@ -138,14 +139,33 @@ fn reduce_success(
             "quality_passed",
             "quality gate activity completed successfully",
         ),
+        (PROMPT_TASK_DEFINITION_ID, "implementing", PROMPT_TASK_IMPLEMENT_ACTIVITY) => (
+            "done",
+            "finish_prompt_task",
+            "prompt implementation activity completed successfully",
+        ),
         _ => return None,
     };
 
-    Some(
+    let mut workflow_decision =
         WorkflowDecision::new(&instance.id, &instance.state, decision, next_state, reason)
-            .with_evidence(runtime_completion_evidence(event, result))
-            .high_confidence(),
-    )
+            .with_evidence(runtime_completion_evidence(event, result));
+    if instance.definition_id == PROMPT_TASK_DEFINITION_ID
+        && instance.state == "implementing"
+        && result.activity == PROMPT_TASK_IMPLEMENT_ACTIVITY
+        && next_state == "done"
+    {
+        workflow_decision = workflow_decision.with_command(WorkflowCommand::new(
+            WorkflowCommandType::MarkDone,
+            format!("prompt-task:{}:done", instance.id),
+            json!({
+                "activity": result.activity,
+                "workflow_id": instance.id,
+            }),
+        ));
+    }
+
+    Some(workflow_decision.high_confidence())
 }
 
 fn workflow_decision_from_activity_result(
@@ -1191,6 +1211,7 @@ fn supports_same_state_activity_retry(definition_id: &str, state: &str) -> bool 
             REPO_BACKLOG_DEFINITION_ID,
             "dispatching" | "reconciling" | "planning_batch"
         ) | (PR_FEEDBACK_DEFINITION_ID, "inspecting")
+            | (PROMPT_TASK_DEFINITION_ID, "implementing")
             | (QUALITY_GATE_DEFINITION_ID, "checking")
     )
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -331,15 +331,19 @@ impl WorkflowRuntimeStore {
         &self,
         definition_id: &str,
         project_id: Option<&str>,
+        limit: Option<i64>,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let limit = limit.map(|value| value.clamp(1, 500));
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT data::text FROM workflow_instances
              WHERE definition_id = $1
                AND ($2::text IS NULL OR data->'data'->>'project_id' = $2)
-             ORDER BY updated_at DESC",
+             ORDER BY updated_at DESC
+             LIMIT COALESCE($3, 2147483647)",
         )
         .bind(definition_id)
         .bind(project_id)
+        .bind(limit)
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -10,15 +10,17 @@ use super::{
     build_issue_submission_decision, build_merged_pr_decision,
     build_open_issue_without_workflow_decision, build_plan_issue_decision,
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
-    build_quality_gate_run_decision, build_repo_backlog_poll_decision,
-    build_stale_active_workflow_decision, reduce_runtime_job_completed, CommandDispatchOutcome,
-    InMemoryWorkflowBus, IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction,
-    MergedPrDecisionInput, OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
+    build_prompt_submission_decision, build_quality_gate_run_decision,
+    build_repo_backlog_poll_decision, build_stale_active_workflow_decision,
+    reduce_runtime_job_completed, CommandDispatchOutcome, InMemoryWorkflowBus,
+    IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction, MergedPrDecisionInput,
+    OpenIssueDecisionInput, PlanIssueDecisionInput, PlanIssueWorkflowAction,
     PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
-    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, QualityGateDecisionInput,
-    QualityGateWorkflowAction, RepoBacklogPollDecisionInput, RepoBacklogWorkflowAction,
-    RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
-    StaleWorkflowDecisionInput, WorkflowRuntimeStore, PR_FEEDBACK_DEFINITION_ID,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptSubmissionDecisionInput,
+    QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogPollDecisionInput,
+    RepoBacklogWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
+    RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowRuntimeStore,
+    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
     PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
     REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
@@ -55,6 +57,15 @@ fn quality_gate_instance(state: &str) -> WorkflowInstance {
         1,
         state,
         WorkflowSubject::new("quality_gate", "issue:123"),
+    )
+}
+
+fn prompt_task_instance(state: &str) -> WorkflowInstance {
+    WorkflowInstance::new(
+        PROMPT_TASK_DEFINITION_ID,
+        1,
+        state,
+        WorkflowSubject::new("prompt", "task-123"),
     )
 }
 
@@ -173,6 +184,68 @@ fn issue_submission_decision_waits_for_dependencies_without_runtime_command() {
             &ValidationContext::new("workflow-policy", Utc::now()),
         )
         .expect("blocked issue submission should validate without dispatching");
+}
+
+#[test]
+fn prompt_submission_decision_starts_runtime_implementation() {
+    let instance = prompt_task_instance("submitted");
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: "task-prompt-1",
+            prompt: "Fix the flaky login test.",
+            source: None,
+            external_id: Some("manual-prompt-1"),
+            depends_on: &[],
+            dependencies_blocked: false,
+        },
+    );
+
+    assert_eq!(output.decision.decision, "submit_prompt");
+    assert_eq!(output.decision.next_state, "implementing");
+    assert_eq!(output.decision.commands.len(), 1);
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some(PROMPT_TASK_IMPLEMENT_ACTIVITY)
+    );
+    assert_eq!(
+        output.decision.commands[0].command["prompt"],
+        "Fix the flaky login test."
+    );
+    DecisionValidator::prompt_task()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("prompt submission decision should validate");
+}
+
+#[test]
+fn prompt_submission_decision_waits_for_dependencies_without_runtime_command() {
+    let depends_on = vec!["task-upstream".to_string()];
+    let instance = prompt_task_instance("submitted");
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: "task-prompt-2",
+            prompt: "Refactor the settings panel.",
+            source: None,
+            external_id: None,
+            depends_on: &depends_on,
+            dependencies_blocked: true,
+        },
+    );
+
+    assert_eq!(output.decision.next_state, "awaiting_dependencies");
+    assert!(output.decision.commands.is_empty());
+    DecisionValidator::prompt_task()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("blocked prompt submission should validate without dispatching");
 }
 
 #[test]
@@ -542,6 +615,45 @@ fn runtime_completion_reducer_returns_none_for_unmapped_success() {
     assert!(reduce_runtime_job_completed(&instance, &event)
         .expect("event should parse")
         .is_none());
+}
+
+#[test]
+fn runtime_completion_reducer_finishes_prompt_task_after_implementation() {
+    let instance = prompt_task_instance("implementing");
+    let result = ActivityResult::succeeded(
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "Prompt implementation completed.",
+    );
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("prompt implementation completion should produce a decision");
+
+    assert_eq!(decision.decision, "finish_prompt_task");
+    assert_eq!(decision.next_state, "done");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkDone
+    );
+    DecisionValidator::prompt_task()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("prompt completion decision should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -194,6 +194,7 @@ fn prompt_submission_decision_starts_runtime_implementation() {
         PromptSubmissionDecisionInput {
             task_id: "task-prompt-1",
             prompt: "Fix the flaky login test.",
+            prompt_ref: "prompt-ref-1",
             source: None,
             external_id: Some("manual-prompt-1"),
             depends_on: &[],
@@ -209,8 +210,13 @@ fn prompt_submission_decision_starts_runtime_implementation() {
         Some(PROMPT_TASK_IMPLEMENT_ACTIVITY)
     );
     assert_eq!(
-        output.decision.commands[0].command["prompt"],
-        "Fix the flaky login test."
+        output.decision.commands[0].command["prompt_ref"],
+        "prompt-ref-1"
+    );
+    assert!(output.decision.commands[0].command.get("prompt").is_none());
+    assert_eq!(
+        output.decision.commands[0].command["prompt_chars"],
+        "Fix the flaky login test.".chars().count()
     );
     DecisionValidator::prompt_task()
         .validate(
@@ -230,6 +236,7 @@ fn prompt_submission_decision_waits_for_dependencies_without_runtime_command() {
         PromptSubmissionDecisionInput {
             task_id: "task-prompt-2",
             prompt: "Refactor the settings panel.",
+            prompt_ref: "prompt-ref-2",
             source: None,
             external_id: None,
             depends_on: &depends_on,
@@ -246,6 +253,37 @@ fn prompt_submission_decision_waits_for_dependencies_without_runtime_command() {
             &ValidationContext::new("workflow-policy", Utc::now()),
         )
         .expect("blocked prompt submission should validate without dispatching");
+}
+
+#[test]
+fn prompt_submission_decision_reopens_blocked_prompt_task() {
+    let instance = prompt_task_instance("blocked");
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: "task-prompt-retry",
+            prompt: "Retry the prompt task after payload loss.",
+            prompt_ref: "prompt-ref-retry",
+            source: None,
+            external_id: Some("manual-prompt-retry"),
+            depends_on: &[],
+            dependencies_blocked: false,
+        },
+    );
+
+    assert_eq!(output.decision.next_state, "implementing");
+    assert_eq!(output.decision.commands.len(), 1);
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some(PROMPT_TASK_IMPLEMENT_ACTIVITY)
+    );
+    DecisionValidator::prompt_task()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("blocked prompt task resubmission should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -295,6 +295,32 @@ impl TransitionAllowlist {
             .allow_from_any("failed", [MarkFailed])
             .allow_from_any("cancelled", [MarkCancelled])
     }
+
+    pub fn prompt_task_defaults() -> Self {
+        use WorkflowCommandType::{
+            EnqueueActivity, MarkBlocked, MarkCancelled, MarkDone, MarkFailed,
+            RequestOperatorAttention, Wait,
+        };
+
+        Self::default()
+            .allow("submitted", "awaiting_dependencies", [Wait])
+            .allow("failed", "awaiting_dependencies", [Wait])
+            .allow("cancelled", "awaiting_dependencies", [Wait])
+            .allow("awaiting_dependencies", "awaiting_dependencies", [Wait])
+            .allow(
+                "awaiting_dependencies",
+                "implementing",
+                [EnqueueActivity, Wait],
+            )
+            .allow("submitted", "implementing", [EnqueueActivity, Wait])
+            .allow("failed", "implementing", [EnqueueActivity, Wait])
+            .allow("cancelled", "implementing", [EnqueueActivity, Wait])
+            .allow("implementing", "implementing", [EnqueueActivity, Wait])
+            .allow("implementing", "done", [MarkDone])
+            .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])
+            .allow_from_any("failed", [MarkFailed])
+            .allow_from_any("cancelled", [MarkCancelled])
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -412,6 +438,10 @@ impl DecisionValidator {
 
     pub fn pr_feedback() -> Self {
         Self::new(TransitionAllowlist::pr_feedback_defaults())
+    }
+
+    pub fn prompt_task() -> Self {
+        Self::new(TransitionAllowlist::prompt_task_defaults())
     }
 
     pub fn validate(

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -316,6 +316,8 @@ impl TransitionAllowlist {
             .allow("failed", "implementing", [EnqueueActivity, Wait])
             .allow("cancelled", "implementing", [EnqueueActivity, Wait])
             .allow("implementing", "implementing", [EnqueueActivity, Wait])
+            .allow("blocked", "awaiting_dependencies", [Wait])
+            .allow("blocked", "implementing", [EnqueueActivity, Wait])
             .allow("implementing", "done", [MarkDone])
             .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])
             .allow_from_any("failed", [MarkFailed])

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -202,6 +202,7 @@ impl<'a> RuntimeWorker<'a> {
             super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
             super::quality_gate::QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
             super::pr_feedback::PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
+            super::prompt_task::PROMPT_TASK_DEFINITION_ID => DecisionValidator::prompt_task(),
             super::repo_backlog::REPO_BACKLOG_DEFINITION_ID => DecisionValidator::repo_backlog(),
             _ => return Ok(()),
         };


### PR DESCRIPTION
## Summary
- Add a `prompt_task` workflow runtime contract for prompt-only task submissions.
- Route prompt `POST /tasks` and batch submissions through workflow runtime instead of legacy task rows when runtime loops are enabled.
- Expose runtime prompt submissions through task create/list/detail/cancel paths and dependency release.
- Document the completed prompt submission phase in `docs/workflow-runtime-decoupling-plan.md`.

Stacked on #1052.

## Testing
- `cargo check`
- `cargo test -p harness-workflow prompt_submission`
- `cargo test -p harness-workflow runtime_completion_reducer_finishes_prompt_task_after_implementation`
- `cargo test -p harness-server prompt_submission`
- `cargo test -p harness-server create_task_with_prompt_returns_workflow_runtime_submission`
- `cargo test -p harness-server create_tasks_batch_with_prompts_returns_runtime_submissions`
- `cargo test -p harness-server list_tasks_includes_runtime_issue_submissions`
- `cargo test -p harness-server issue_submission`
- `cargo test -p harness-server prompt_task`
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "Command::new\(\"(gh|git)\"\)" crates`