### PR TITLE
Route dashboard merge approvals through workflow runtime

### DIFF
--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -67,6 +67,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             get(get_workflow_runtime_tree),
         )
         .route(
+            "/api/workflows/runtime/merge",
+            post(task_mutation_routes::merge_workflow_runtime),
+        )
+        .route(
             "/api/runtime-hosts",
             get(crate::handlers::runtime_hosts::list_runtime_hosts),
         )

--- a/crates/harness-server/src/http/task_mutation_routes.rs
+++ b/crates/harness-server/src/http/task_mutation_routes.rs
@@ -1,8 +1,14 @@
 use super::AppState;
 use axum::{extract::State, http::StatusCode, Json};
 use harness_workflow::issue_lifecycle::IssueLifecycleState;
+use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct WorkflowRuntimeMergeRequest {
+    pub workflow_id: String,
+}
 
 /// POST /tasks/{id}/merge — human-gate approval to transition a `ready_to_merge`
 /// workflow to `done`.
@@ -19,10 +25,7 @@ pub(super) async fn merge_task(
     let task = match state.core.tasks.get_with_db_fallback(&task_id).await {
         Ok(Some(t)) => t,
         Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({ "error": "task not found" })),
-            );
+            return merge_runtime_task_handle(&state, task_id.as_str()).await;
         }
         Err(e) => {
             tracing::error!("merge_task: DB lookup failed for {task_id:?}: {e}");
@@ -115,5 +118,111 @@ pub(super) async fn merge_task(
                 Json(json!({ "error": "failed to record merge approval" })),
             )
         }
+    }
+}
+
+pub(super) async fn merge_workflow_runtime(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<WorkflowRuntimeMergeRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "workflow runtime store unavailable" })),
+        );
+    };
+    match crate::workflow_runtime_pr_feedback::approve_runtime_merge_by_workflow_id(
+        store,
+        &request.workflow_id,
+    )
+    .await
+    {
+        Ok(outcome) => runtime_merge_response(outcome),
+        Err(error) => {
+            tracing::error!("merge_workflow_runtime: approval failed: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to approve workflow runtime merge" })),
+            )
+        }
+    }
+}
+
+async fn merge_runtime_task_handle(
+    state: &AppState,
+    task_id: &str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "task not found" })),
+        );
+    };
+    match crate::workflow_runtime_pr_feedback::approve_runtime_merge_by_task_id(store, task_id)
+        .await
+    {
+        Ok(crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "task not found" })),
+        ),
+        Ok(outcome) => runtime_merge_response(outcome),
+        Err(error) => {
+            tracing::error!("merge_task: runtime workflow approval failed: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to approve workflow runtime merge" })),
+            )
+        }
+    }
+}
+
+fn runtime_merge_response(
+    outcome: crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match outcome {
+        crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::Approved {
+            workflow_id,
+        } => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "status": "merge_approved",
+                "execution_path": "workflow_runtime",
+                "workflow_id": workflow_id,
+            })),
+        ),
+        crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "workflow not found" })),
+        ),
+        crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::NotCandidate {
+            definition_id,
+            ..
+        } => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "workflow is not a GitHub issue PR workflow",
+                "definition_id": definition_id,
+            })),
+        ),
+        crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::NotReady {
+            state,
+            ..
+        } => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "workflow not in ready_to_merge state",
+                "state": state,
+            })),
+        ),
+        crate::workflow_runtime_pr_feedback::RuntimeMergeApprovalOutcome::Rejected {
+            reason,
+            ..
+        } => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "workflow runtime merge approval rejected",
+                "reason": reason,
+            })),
+        ),
     }
 }

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -22,7 +22,7 @@ struct FullTaskResponse {
     #[serde(flatten)]
     inner: crate::task_runner::TaskState,
     #[serde(skip_serializing_if = "Option::is_none")]
-    workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
+    workflow: Option<TaskWorkflowSummary>,
 }
 
 #[derive(Serialize)]
@@ -41,7 +41,8 @@ struct RuntimeTaskResponse {
     project: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     issue: Option<u64>,
-    workflow: harness_workflow::runtime::WorkflowInstance,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow: Option<TaskWorkflowSummary>,
 }
 
 pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
@@ -216,7 +217,7 @@ fn runtime_workflow_task_summary(
         workspace_owner: None,
         run_generation: 0,
         workflow: (task_kind == TaskKind::Issue)
-            .then(|| TaskWorkflowSummary::from_runtime_issue(&workflow)),
+            .then(|| TaskWorkflowSummary::from_runtime(&workflow)),
         scheduler,
     }
 }
@@ -367,7 +368,7 @@ async fn runtime_task_response_by_handle(
             .and_then(|value| value.as_str())
             .map(ToOwned::to_owned),
         issue,
-        workflow,
+        workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
     }))
 }
 
@@ -376,7 +377,7 @@ async fn runtime_task_response_by_handle(
 async fn enrich_task_workflow(
     state: &AppState,
     task: &crate::task_runner::TaskState,
-) -> Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance> {
+) -> Option<TaskWorkflowSummary> {
     let workflow_store = state.core.issue_workflow_store.as_ref()?;
     let project_id = task.project_root.as_ref()?.to_string_lossy().into_owned();
 
@@ -403,14 +404,16 @@ async fn enrich_task_workflow(
             .unwrap_or_else(|e| {
                 tracing::warn!("get_task: workflow lookup by issue failed: {e}");
                 None
-            }),
+            })
+            .map(TaskWorkflowSummary::from),
         (None, Some(pr)) => workflow_store
             .get_by_pr(&project_id, task.repo.as_deref(), pr)
             .await
             .unwrap_or_else(|e| {
                 tracing::warn!("get_task: workflow lookup by PR failed: {e}");
                 None
-            }),
+            })
+            .map(TaskWorkflowSummary::from),
         (None, None) => None,
     }
 }

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use super::state::AppState;
 use crate::task_runner::{
     SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskStatus,
-    TaskSummary,
+    TaskSummary, TaskWorkflowSummary,
 };
 
 /// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
@@ -90,10 +90,12 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                     summary.workflow = match (by_issue, by_pr) {
                         (Some(issue), _) => workflows_by_issue
                             .get(&(project_id.to_owned(), summary.repo.clone(), issue))
-                            .cloned(),
+                            .cloned()
+                            .map(TaskWorkflowSummary::from),
                         (None, Some(pr)) => workflows_by_pr
                             .get(&(project_id.to_owned(), summary.repo.clone(), pr))
-                            .cloned(),
+                            .cloned()
+                            .map(TaskWorkflowSummary::from),
                         (None, None) => None,
                     };
                 }
@@ -213,7 +215,8 @@ fn runtime_workflow_task_summary(
         workspace_path: None,
         workspace_owner: None,
         run_generation: 0,
-        workflow: None,
+        workflow: (task_kind == TaskKind::Issue)
+            .then(|| TaskWorkflowSummary::from_runtime_issue(&workflow)),
         scheduler,
     }
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3365,7 +3365,145 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
         canonical_project_root.to_string_lossy().as_ref()
     );
     assert_eq!(runtime_task["scheduler"]["authority_state"], "running");
-    assert!(runtime_task.get("workflow").is_none());
+    assert!(runtime_task["workflow"]["id"]
+        .as_str()
+        .is_some_and(|id| id.ends_with("::repo:owner/repo::issue:52")));
+    assert_eq!(runtime_task["workflow"]["definition_id"], "github_issue_pr");
+    assert_eq!(runtime_task["workflow"]["state"], "implementing");
+    assert_eq!(runtime_task["workflow"]["issue_number"], 52);
+    Ok(())
+}
+
+#[tokio::test]
+async fn merge_task_accepts_runtime_workflow_task_handle() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "ready_to_merge",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:53"),
+    )
+    .with_id("runtime-ready-53")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 53,
+        "pr_number": 125,
+        "pr_url": "https://github.com/owner/repo/pull/125",
+        "task_id": "runtime-ready-task",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let app = Router::new()
+        .route("/tasks/{id}/merge", post(task_mutation_routes::merge_task))
+        .with_state(state.clone());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks/runtime-ready-task/merge")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let body = response_json(response).await?;
+    assert_eq!(body["status"], "merge_approved");
+    assert_eq!(body["execution_path"], "workflow_runtime");
+    let updated = store
+        .get_instance("runtime-ready-53")
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(updated.state, "done");
+    assert_eq!(updated.data["last_decision"], "approve_merge");
+    assert_eq!(updated.data["merge_approved_task_id"], "runtime-ready-task");
+    let events = store.events_for("runtime-ready-53").await?;
+    assert!(events
+        .iter()
+        .any(|event| event.event_type == "MergeApproved"));
+    let decisions = store.decisions_for("runtime-ready-53").await?;
+    assert!(decisions
+        .iter()
+        .any(|record| record.accepted && record.decision.decision == "approve_merge"));
+    let commands = store.commands_for("runtime-ready-53").await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].command.command_type,
+        harness_workflow::runtime::WorkflowCommandType::MarkDone
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_runtime_merge_endpoint_approves_ready_workflow() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "ready_to_merge",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:54"),
+    )
+    .with_id("runtime-ready-54")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 54,
+        "pr_number": 126,
+        "pr_url": "https://github.com/owner/repo/pull/126",
+        "task_id": "runtime-ready-task-54",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let app = Router::new()
+        .route(
+            "/api/workflows/runtime/merge",
+            post(task_mutation_routes::merge_workflow_runtime),
+        )
+        .with_state(state.clone());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/workflows/runtime/merge")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "workflow_id": "runtime-ready-54" }).to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let body = response_json(response).await?;
+    assert_eq!(body["workflow_id"], "runtime-ready-54");
+    let updated = store
+        .get_instance("runtime-ready-54")
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(updated.state, "done");
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -5168,6 +5168,10 @@ async fn list_tasks_enriches_workflows_for_issue_and_pr_tasks() -> anyhow::Resul
 
 #[tokio::test]
 async fn list_tasks_exposes_workflow_fallback_metadata() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
     let dir = tempfile::tempdir()?;
     let state = make_test_state_with_issue_workflows(dir.path()).await?;
     let app = Router::new()

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3186,6 +3186,14 @@ async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow
     assert_eq!(detail["status"], "implementing");
     assert_eq!(detail["execution_path"], "workflow_runtime");
     assert_eq!(detail["workflow_id"], workflow_id);
+    assert_eq!(detail["workflow"]["id"], workflow_id);
+    assert_eq!(detail["workflow"]["definition_id"], "prompt_task");
+    assert_eq!(detail["workflow"]["state"], "implementing");
+    assert_eq!(
+        detail["workflow"]["project_id"],
+        canonical_project_root.to_string_lossy().as_ref()
+    );
+    assert!(detail["workflow"].get("data").is_none());
     Ok(())
 }
 
@@ -4981,6 +4989,7 @@ async fn list_tasks_exposes_task_kind_and_non_implementation_statuses() -> anyho
     state.core.tasks.insert(&planner_task).await;
 
     let response = app
+        .clone()
         .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -5129,6 +5138,7 @@ async fn list_tasks_enriches_workflows_for_issue_and_pr_tasks() -> anyhow::Resul
         .with_state(state);
 
     let response = app
+        .clone()
         .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -5162,6 +5172,7 @@ async fn list_tasks_exposes_workflow_fallback_metadata() -> anyhow::Result<()> {
     let state = make_test_state_with_issue_workflows(dir.path()).await?;
     let app = Router::new()
         .route("/tasks", get(list_tasks))
+        .route("/tasks/{id}", get(get_task))
         .with_state(state.clone());
 
     let task = task_runner::TaskState {
@@ -5236,6 +5247,7 @@ async fn list_tasks_exposes_workflow_fallback_metadata() -> anyhow::Result<()> {
         .await?;
 
     let response = app
+        .clone()
         .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
@@ -5249,6 +5261,20 @@ async fn list_tasks_exposes_workflow_fallback_metadata() -> anyhow::Result<()> {
     assert_eq!(task["workflow"]["review_fallback"]["tier"], "c");
     assert_eq!(task["workflow"]["review_fallback"]["trigger"], "silence");
     assert_eq!(task["workflow"]["review_fallback"]["active_bot"], "codex");
+
+    let detail_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{}", task["id"].as_str().expect("task id")))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(detail_response.status(), StatusCode::OK);
+    let detail_body = axum::body::to_bytes(detail_response.into_body(), usize::MAX).await?;
+    let detail: serde_json::Value = serde_json::from_slice(&detail_body)?;
+    assert_eq!(detail["workflow"]["state"], "ready_to_merge");
+    assert_eq!(detail["workflow"]["review_fallback"]["tier"], "c");
+    assert!(detail["workflow"].get("events").is_none());
     Ok(())
 }
 

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -25,7 +25,7 @@ pub use spawn::{
 };
 pub use state::{
     RecentFailureTask, RoundResult, SchedulerAuthorityState, SchedulerOwner, SchedulerOwnerKind,
-    TaskSchedulerState, TaskState, TaskSummary,
+    TaskSchedulerState, TaskState, TaskSummary, TaskWorkflowSummary,
 };
 pub use store::{mutate_and_persist, update_status, TaskStore};
 pub use types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -331,7 +331,7 @@ pub struct TaskSummary {
     pub run_generation: u32,
     /// Issue workflow state summary, when this task belongs to an issue workflow.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow: Option<harness_workflow::issue_lifecycle::IssueWorkflowInstance>,
+    pub workflow: Option<TaskWorkflowSummary>,
     /// Canonical scheduler authority for ownership, recovery, and retry state.
     #[serde(default)]
     pub scheduler: TaskSchedulerState,
@@ -356,6 +356,75 @@ pub struct RecentFailureTask {
     pub error: Option<String>,
     #[serde(default)]
     pub failed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskWorkflowSummary {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_id: Option<String>,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_execute: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_concern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_fallback: Option<harness_workflow::issue_lifecycle::ReviewFallbackSnapshot>,
+}
+
+impl TaskWorkflowSummary {
+    pub fn from_runtime_issue(workflow: &harness_workflow::runtime::WorkflowInstance) -> Self {
+        Self {
+            id: workflow.id.clone(),
+            definition_id: Some(workflow.definition_id.clone()),
+            state: workflow.state.clone(),
+            project_id: string_data(&workflow.data, "project_id"),
+            issue_number: u64_data(&workflow.data, "issue_number"),
+            pr_number: u64_data(&workflow.data, "pr_number"),
+            force_execute: bool_data(&workflow.data, "force_execute"),
+            plan_concern: string_data(&workflow.data, "plan_concern"),
+            review_fallback: None,
+        }
+    }
+}
+
+impl From<harness_workflow::issue_lifecycle::IssueWorkflowInstance> for TaskWorkflowSummary {
+    fn from(workflow: harness_workflow::issue_lifecycle::IssueWorkflowInstance) -> Self {
+        Self {
+            id: workflow.id,
+            definition_id: None,
+            state: serde_json::to_value(workflow.state)
+                .ok()
+                .and_then(|value| value.as_str().map(ToOwned::to_owned))
+                .unwrap_or_else(|| "unknown".to_string()),
+            project_id: Some(workflow.project_id),
+            issue_number: Some(workflow.issue_number),
+            pr_number: workflow.pr_number,
+            force_execute: Some(workflow.force_execute),
+            plan_concern: workflow.plan_concern,
+            review_fallback: workflow.review_fallback,
+        }
+    }
+}
+
+fn string_data(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn u64_data(data: &serde_json::Value, field: &str) -> Option<u64> {
+    data.get(field).and_then(|value| value.as_u64())
+}
+
+fn bool_data(data: &serde_json::Value, field: &str) -> Option<bool> {
+    data.get(field).and_then(|value| value.as_bool())
 }
 
 impl TaskState {

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -379,7 +379,7 @@ pub struct TaskWorkflowSummary {
 }
 
 impl TaskWorkflowSummary {
-    pub fn from_runtime_issue(workflow: &harness_workflow::runtime::WorkflowInstance) -> Self {
+    pub fn from_runtime(workflow: &harness_workflow::runtime::WorkflowInstance) -> Self {
         Self {
             id: workflow.id.clone(),
             definition_id: Some(workflow.definition_id.clone()),

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -3,7 +3,7 @@ use harness_workflow::runtime::{
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, ValidationContext, WorkflowDecision, WorkflowDecisionRecord,
-    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    WorkflowDefinition, WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
@@ -35,6 +35,26 @@ pub(crate) enum PrFeedbackSweepRequestOutcome {
     NotCandidate { workflow_id: String, state: String },
     ActiveCommandExists { workflow_id: String },
     Rejected { workflow_id: String, reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeMergeApprovalOutcome {
+    Approved {
+        workflow_id: String,
+    },
+    NotFound,
+    NotCandidate {
+        workflow_id: String,
+        definition_id: String,
+    },
+    NotReady {
+        workflow_id: String,
+        state: String,
+    },
+    Rejected {
+        workflow_id: String,
+        reason: String,
+    },
 }
 
 pub(crate) async fn record_pr_detected(
@@ -95,6 +115,26 @@ pub(crate) async fn request_pr_feedback_sweep(
         });
     }
     persist_pr_feedback_sweep_request(store, instance).await
+}
+
+pub(crate) async fn approve_runtime_merge_by_task_id(
+    store: &WorkflowRuntimeStore,
+    task_id: &str,
+) -> anyhow::Result<RuntimeMergeApprovalOutcome> {
+    let Some(instance) = store.get_instance_by_task_id(task_id).await? else {
+        return Ok(RuntimeMergeApprovalOutcome::NotFound);
+    };
+    approve_runtime_merge(store, instance, Some(task_id)).await
+}
+
+pub(crate) async fn approve_runtime_merge_by_workflow_id(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<RuntimeMergeApprovalOutcome> {
+    let Some(instance) = store.get_instance(workflow_id).await? else {
+        return Ok(RuntimeMergeApprovalOutcome::NotFound);
+    };
+    approve_runtime_merge(store, instance, None).await
 }
 
 async fn persist_pr_detected(
@@ -279,6 +319,91 @@ async fn persist_pr_feedback(
     apply_decision(store, instance, output.decision, Some(event.id)).await
 }
 
+async fn approve_runtime_merge(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    task_id: Option<&str>,
+) -> anyhow::Result<RuntimeMergeApprovalOutcome> {
+    if instance.definition_id != harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID {
+        return Ok(RuntimeMergeApprovalOutcome::NotCandidate {
+            workflow_id: instance.id,
+            definition_id: instance.definition_id,
+        });
+    }
+    if instance.state != "ready_to_merge" {
+        return Ok(RuntimeMergeApprovalOutcome::NotReady {
+            workflow_id: instance.id,
+            state: instance.state,
+        });
+    }
+
+    let event = store
+        .append_event(
+            &instance.id,
+            "MergeApproved",
+            "workflow_runtime_dashboard",
+            json!({
+                "task_id": task_id,
+                "issue_number": instance.data.get("issue_number").and_then(|value| value.as_u64()),
+                "repo": optional_string_field(&instance.data, "repo"),
+                "pr_number": instance.data.get("pr_number").and_then(|value| value.as_u64()),
+                "pr_url": optional_string_field(&instance.data, "pr_url"),
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "approve_merge",
+        "done",
+        "operator approved the ready-to-merge workflow",
+    )
+    .with_command(harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::MarkDone,
+        format!("merge-approved:{}:{}", instance.id, event.id),
+        json!({
+            "workflow_id": instance.id,
+            "task_id": task_id,
+            "approved_by": "dashboard",
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "operator_approval",
+        "dashboard merge approval for ready-to-merge workflow",
+    ))
+    .high_confidence();
+    let validator = DecisionValidator::github_issue_pr();
+    let validation = validator.validate(
+        &instance,
+        &decision,
+        &ValidationContext::new("workflow-policy", chrono::Utc::now()),
+    );
+    let record = match validation {
+        Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id)),
+        Err(error) => {
+            let reason = error.to_string();
+            let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
+            store.record_decision(&record).await?;
+            return Ok(RuntimeMergeApprovalOutcome::Rejected {
+                workflow_id: instance.id,
+                reason,
+            });
+        }
+    };
+    store.record_decision(&record).await?;
+    for command in &decision.commands {
+        store
+            .enqueue_command(&instance.id, Some(&record.id), command)
+            .await?;
+    }
+    instance.state = decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_runtime_merge_data(instance.data, &decision.decision, task_id);
+    let workflow_id = instance.id.clone();
+    store.upsert_instance(&instance).await?;
+    Ok(RuntimeMergeApprovalOutcome::Approved { workflow_id })
+}
+
 async fn apply_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
@@ -422,6 +547,21 @@ fn issue_instance(
 fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_json::Value {
     if let Some(object) = data.as_object_mut() {
         object.insert("last_decision".to_string(), json!(decision));
+    }
+    data
+}
+
+fn merge_runtime_merge_data(
+    mut data: serde_json::Value,
+    decision: &str,
+    task_id: Option<&str>,
+) -> serde_json::Value {
+    if let Some(object) = data.as_object_mut() {
+        object.insert("last_decision".to_string(), json!(decision));
+        object.insert("merge_approved_at".to_string(), json!(chrono::Utc::now()));
+        if let Some(task_id) = task_id {
+            object.insert("merge_approved_task_id".to_string(), json!(task_id));
+        }
     }
     data
 }

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -98,6 +98,8 @@ Implemented now:
 
 Still intentionally not moved yet:
 
+- legacy issue-workflow feedback fallback still uses existing PR task routes when no runtime
+  workflow exists
 - non-runtime dashboard task actions still use existing task routes
 
 ## Non-Goals

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -170,6 +170,31 @@ describe("<Active>", () => {
     expect(screen.queryByTestId("task-slideover")).not.toBeInTheDocument();
   });
 
+  it("uses the workflow runtime merge endpoint for runtime issue workflows", async () => {
+    const ready = {
+      ...makeTask("runtime-task", "harness", "waiting"),
+      pr_url: "https://github.com/owner/repo/pull/124",
+      workflow: {
+        id: "runtime-workflow-124",
+        definition_id: "github_issue_pr",
+        state: "ready_to_merge",
+        pr_number: 124,
+      },
+    };
+    mockUseTasks.mockReturnValue({ data: [ready], isLoading: false, isError: false });
+
+    wrap(<Active projectFilter="harness" />);
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/workflows/runtime/merge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: "runtime-workflow-124" }),
+      });
+    });
+  });
+
   it("groups planner and review lifecycle statuses outside implementing", () => {
     mockUseTasks.mockReturnValue({
       data: [

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -133,6 +133,11 @@ function runtimeJobLabel(command: WorkflowRuntimeCommandNode): string {
   return `${command.runtime_jobs.length} jobs - ${job.status}${notBefore}${latestEvent}${promptDigest}`;
 }
 
+function runtimeMergeWorkflowId(workflow?: WorkflowSummary | null): string | null {
+  if (workflow?.definition_id === "github_issue_pr" && workflow.id) return workflow.id;
+  return null;
+}
+
 function rejectedDecisions(decisions: WorkflowRuntimeDecisionRecord[]) {
   return decisions.filter((decision) => !decision.accepted);
 }
@@ -268,7 +273,7 @@ function TaskCard({
   task: Task;
   workflow?: WorkflowSummary | null;
   onClick: () => void;
-  onMerge?: (taskId: string) => void;
+  onMerge?: (taskId: string, workflow?: WorkflowSummary | null) => void;
   merging?: boolean;
 }) {
   const title = task.description?.trim() || task.repo || task.id.slice(0, 8);
@@ -337,7 +342,7 @@ function TaskCard({
           disabled={merging}
           onClick={(e) => {
             e.stopPropagation();
-            onMerge(task.id);
+            onMerge(task.id, workflow);
           }}
           className="mt-2 w-full border border-line bg-bg-1 px-2 py-1 font-mono text-[10px] text-ink-2 hover:border-line-3 hover:text-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
@@ -359,11 +364,21 @@ export function Active({ projectFilter }: Props) {
   const { data: dashboard } = useDashboard();
   const queryClient = useQueryClient();
 
-  const handleMerge = async (taskId: string) => {
+  const handleMerge = async (taskId: string, workflow?: WorkflowSummary | null) => {
     setMerging((prev) => new Set(prev).add(taskId));
     try {
-      await apiFetch(`/tasks/${taskId}/merge`, { method: "POST" });
+      const runtimeWorkflowId = runtimeMergeWorkflowId(workflow);
+      if (runtimeWorkflowId) {
+        await apiFetch("/api/workflows/runtime/merge", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workflow_id: runtimeWorkflowId }),
+        });
+      } else {
+        await apiFetch(`/tasks/${taskId}/merge`, { method: "POST" });
+      }
       await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      await queryClient.invalidateQueries({ queryKey: ["workflow-runtime-tree"] });
     } finally {
       setMerging((prev) => {
         const next = new Set(prev);

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -44,7 +44,10 @@ export function isTerminal(status: string): boolean {
 }
 
 export interface WorkflowSummary {
+  id?: string | null;
+  definition_id?: string | null;
   state: string;
+  project_id?: string | null;
   issue_number?: number | null;
   pr_number?: number | null;
   force_execute?: boolean;


### PR DESCRIPTION
## Summary
- expose runtime issue workflow summaries in task list rows so dashboard cards can group and act on runtime workflow state
- add a workflow-runtime merge approval endpoint that records `MergeApproved`, accepts an `approve_merge` decision, enqueues `mark_done`, and moves ready issue workflows to `done`
- route dashboard ready-to-merge runtime issue cards to the runtime merge API while preserving the legacy task merge path
- update the workflow runtime decoupling plan status

## Validation
- cargo check
- cargo test -p harness-server merge_task_accepts_runtime_workflow_task_handle -- --test-threads=1
- cargo test -p harness-server workflow_runtime_merge_endpoint_approves_ready_workflow -- --test-threads=1
- cargo test -p harness-server list_tasks_includes_runtime_issue_submissions -- --test-threads=1
- cargo test -- --test-threads=1
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check
- bun run typecheck
- bun run test -- Active.test.tsx
- bun run test
- rg -n 'Command::new\("(gh|git)"\)' crates