### PR TITLE
Route legacy feedback sweeps through workflow runtime

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1191,11 +1191,12 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
 }
 
 /// Spawn a background sweeper that turns `pr_open` / `awaiting_feedback`
-/// issue workflows into `pr:N` review tasks.
+/// issue workflows into PR feedback work.
 ///
-/// This reuses the existing PR review loop instead of adding another GitHub API
-/// interpretation layer in the server. The workflow store decides *which* PRs
-/// need attention; the existing `pr:N` task path decides *what* to do.
+/// Runtime-enabled projects are adopted into the workflow runtime and inspected
+/// through the PR feedback child workflow. Runtime-disabled projects still reuse
+/// the existing PR review loop instead of adding another GitHub API
+/// interpretation layer in the server.
 pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
     if state.core.issue_workflow_store.is_none() {
         tracing::debug!("workflow feedback sweeper disabled: issue workflow store unavailable");
@@ -1334,6 +1335,141 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
                     std::path::PathBuf::from(&workflow.project_id)
                 };
 
+                if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+                    let project_workflow_cfg = load_runtime_workflow_config_or_default(
+                        &project_path,
+                        "workflow feedback sweeper",
+                    );
+                    if runtime_pr_feedback_enabled(&project_workflow_cfg) {
+                        match crate::workflow_runtime_pr_feedback::request_pr_feedback_sweep_for_legacy_issue_workflow(
+                            store,
+                            &workflow,
+                        )
+                        .await
+                        {
+                            Ok(crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Requested {
+                                workflow_id,
+                                task_id,
+                            })
+                            | Ok(crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                                workflow_id,
+                                task_id,
+                            }) => {
+                                if let Err(e) = issue_workflows
+                                    .bind_feedback_task_if_claimed(
+                                        &workflow.project_id,
+                                        workflow.repo.as_deref(),
+                                        pr_number,
+                                        &task_id,
+                                    )
+                                    .await
+                                {
+                                    incomplete_projects.insert(project_key.clone());
+                                    tracing::warn!(
+                                        project_id = %workflow.project_id,
+                                        pr = pr_number,
+                                        workflow_id = %workflow_id,
+                                        task_id = %task_id,
+                                        "workflow feedback sweep: failed to bind runtime task handle: {e}"
+                                    );
+                                    continue;
+                                }
+                                tracing::info!(
+                                    project_id = %workflow.project_id,
+                                    pr = pr_number,
+                                    workflow_id = %workflow_id,
+                                    "workflow feedback sweep: runtime PR feedback requested"
+                                );
+                                continue;
+                            }
+                            Ok(crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::NotCandidate {
+                                workflow_id,
+                                state: runtime_state,
+                            }) => {
+                                incomplete_projects.insert(project_key.clone());
+                                let _ = issue_workflows
+                                    .release_feedback_claim(
+                                        &workflow.project_id,
+                                        workflow.repo.as_deref(),
+                                        pr_number,
+                                        &format!(
+                                            "runtime PR feedback skipped non-candidate workflow state {runtime_state}"
+                                        ),
+                                    )
+                                    .await;
+                                tracing::warn!(
+                                    project_id = %workflow.project_id,
+                                    pr = pr_number,
+                                    workflow_id = %workflow_id,
+                                    runtime_state = %runtime_state,
+                                    "workflow feedback sweep: runtime PR feedback skipped non-candidate workflow"
+                                );
+                                continue;
+                            }
+                            Ok(crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Rejected {
+                                workflow_id,
+                                reason,
+                            }) => {
+                                incomplete_projects.insert(project_key.clone());
+                                let _ = issue_workflows
+                                    .release_feedback_claim(
+                                        &workflow.project_id,
+                                        workflow.repo.as_deref(),
+                                        pr_number,
+                                        &format!("runtime PR feedback rejected: {reason}"),
+                                    )
+                                    .await;
+                                tracing::warn!(
+                                    project_id = %workflow.project_id,
+                                    pr = pr_number,
+                                    workflow_id = %workflow_id,
+                                    "workflow feedback sweep: runtime PR feedback rejected: {reason}"
+                                );
+                                if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                                    let _ = project_store
+                                        .record_degraded(
+                                            &workflow.project_id,
+                                            workflow.repo.as_deref(),
+                                            &format!(
+                                                "runtime feedback sweep rejected for pr:{pr_number}: {reason}"
+                                            ),
+                                        )
+                                        .await;
+                                }
+                                continue;
+                            }
+                            Err(e) => {
+                                incomplete_projects.insert(project_key.clone());
+                                let _ = issue_workflows
+                                    .release_feedback_claim(
+                                        &workflow.project_id,
+                                        workflow.repo.as_deref(),
+                                        pr_number,
+                                        &format!("runtime PR feedback request failed: {e}"),
+                                    )
+                                    .await;
+                                tracing::warn!(
+                                    project_id = %workflow.project_id,
+                                    pr = pr_number,
+                                    "workflow feedback sweep: runtime PR feedback request failed: {e}"
+                                );
+                                if let Some(project_store) = state.core.project_workflow_store.as_ref() {
+                                    let _ = project_store
+                                        .record_degraded(
+                                            &workflow.project_id,
+                                            workflow.repo.as_deref(),
+                                            &format!(
+                                                "runtime feedback sweep failed for pr:{pr_number}: {e}"
+                                            ),
+                                        )
+                                        .await;
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                }
+
                 let req = crate::task_runner::CreateTaskRequest {
                     pr: Some(pr_number),
                     project: Some(project_path),
@@ -1443,6 +1579,14 @@ pub(super) fn spawn_issue_workflow_feedback_sweeper(state: &Arc<AppState>) {
             }
         }
     });
+}
+
+fn runtime_pr_feedback_enabled(
+    workflow_cfg: &harness_core::config::workflow::WorkflowConfig,
+) -> bool {
+    workflow_cfg.pr_feedback.enabled
+        && workflow_cfg.runtime_dispatch.enabled
+        && workflow_cfg.runtime_worker.enabled
 }
 
 /// Re-dispatch tasks that were recovered to pending after server restart.

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -1,4 +1,7 @@
 use crate::task_runner::TaskId;
+use harness_workflow::issue_lifecycle::{
+    is_feedback_claim_placeholder, IssueLifecycleState, IssueWorkflowInstance,
+};
 use harness_workflow::runtime::{
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
@@ -31,10 +34,41 @@ pub(crate) struct PrFeedbackRuntimeContext<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PrFeedbackSweepRequestOutcome {
-    Requested { workflow_id: String },
-    NotCandidate { workflow_id: String, state: String },
-    ActiveCommandExists { workflow_id: String },
-    Rejected { workflow_id: String, reason: String },
+    Requested {
+        workflow_id: String,
+        task_id: String,
+    },
+    NotCandidate {
+        workflow_id: String,
+        state: String,
+    },
+    ActiveCommandExists {
+        workflow_id: String,
+        task_id: String,
+    },
+    Rejected {
+        workflow_id: String,
+        reason: String,
+    },
+}
+
+fn runtime_task_id_from_instance(instance: &WorkflowInstance) -> String {
+    instance
+        .data
+        .get("task_id")
+        .and_then(|value| value.as_str())
+        .filter(|task_id| !task_id.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("runtime:{}", instance.id))
+}
+
+fn runtime_task_id_for_legacy_issue_workflow(workflow: &IssueWorkflowInstance) -> String {
+    workflow
+        .active_task_id
+        .as_deref()
+        .filter(|task_id| !is_feedback_claim_placeholder(task_id))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("runtime:{}", workflow.id))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,11 +144,60 @@ pub(crate) async fn request_pr_feedback_sweep(
         });
     }
     if has_active_pr_feedback_command(store, &instance.id).await? {
+        let task_id = runtime_task_id_from_instance(&instance);
         return Ok(PrFeedbackSweepRequestOutcome::ActiveCommandExists {
             workflow_id: instance.id,
+            task_id,
         });
     }
     persist_pr_feedback_sweep_request(store, instance).await
+}
+
+pub(crate) async fn request_pr_feedback_sweep_for_legacy_issue_workflow(
+    store: &WorkflowRuntimeStore,
+    workflow: &IssueWorkflowInstance,
+) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    if store.get_instance(&workflow.id).await?.is_some() {
+        return request_pr_feedback_sweep(store, &workflow.id).await;
+    }
+
+    let Some(state) = runtime_state_for_legacy_feedback_candidate(workflow.state) else {
+        return Ok(PrFeedbackSweepRequestOutcome::NotCandidate {
+            workflow_id: workflow.id.clone(),
+            state: legacy_issue_state_label(workflow.state),
+        });
+    };
+    let Some(pr_number) = workflow.pr_number else {
+        return Ok(PrFeedbackSweepRequestOutcome::NotCandidate {
+            workflow_id: workflow.id.clone(),
+            state: "missing_pr_number".to_string(),
+        });
+    };
+
+    upsert_github_issue_pr_definition(store).await?;
+    let task_id = runtime_task_id_for_legacy_issue_workflow(workflow);
+    let instance = issue_instance(
+        workflow.id.clone(),
+        workflow.project_id.clone(),
+        workflow.repo.clone(),
+        workflow.issue_number,
+        state,
+    )
+    .with_data(crate::workflow_runtime_policy::merge_runtime_retry_policy(
+        Path::new(&workflow.project_id),
+        json!({
+            "project_id": workflow.project_id,
+            "repo": workflow.repo,
+            "issue_number": workflow.issue_number,
+            "task_id": task_id,
+            "pr_number": pr_number,
+            "pr_url": workflow.pr_url,
+            "execution_path": "workflow_runtime",
+            "legacy_issue_workflow_state": legacy_issue_state_label(workflow.state),
+        }),
+    ));
+    store.upsert_instance(&instance).await?;
+    request_pr_feedback_sweep(store, &workflow.id).await
 }
 
 pub(crate) async fn approve_runtime_merge_by_task_id(
@@ -195,6 +278,8 @@ async fn persist_pr_feedback_sweep_request(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
 ) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    let workflow_id = instance.id.clone();
+    let task_id = runtime_task_id_from_instance(&instance);
     let pr_number = required_u64_field(&instance.data, "pr_number")?;
     let pr_url = optional_string_field(&instance.data, "pr_url");
     let issue_number = instance
@@ -255,7 +340,8 @@ async fn persist_pr_feedback_sweep_request(
     instance.data = merge_last_decision(instance.data, &output.decision.decision);
     store.upsert_instance(&instance).await?;
     Ok(PrFeedbackSweepRequestOutcome::Requested {
-        workflow_id: instance.id,
+        workflow_id,
+        task_id,
     })
 }
 
@@ -544,6 +630,41 @@ fn issue_instance(
     ))
 }
 
+fn runtime_state_for_legacy_feedback_candidate(state: IssueLifecycleState) -> Option<&'static str> {
+    match state {
+        IssueLifecycleState::PrOpen => Some("pr_open"),
+        IssueLifecycleState::AwaitingFeedback
+        | IssueLifecycleState::FeedbackClaimed
+        | IssueLifecycleState::AddressingFeedback => Some("awaiting_feedback"),
+        IssueLifecycleState::Discovered
+        | IssueLifecycleState::Scheduled
+        | IssueLifecycleState::Implementing
+        | IssueLifecycleState::ReadyToMerge
+        | IssueLifecycleState::Blocked
+        | IssueLifecycleState::Done
+        | IssueLifecycleState::Failed
+        | IssueLifecycleState::Cancelled => None,
+    }
+}
+
+fn legacy_issue_state_label(state: IssueLifecycleState) -> String {
+    match state {
+        IssueLifecycleState::Discovered => "discovered",
+        IssueLifecycleState::Scheduled => "scheduled",
+        IssueLifecycleState::Implementing => "implementing",
+        IssueLifecycleState::PrOpen => "pr_open",
+        IssueLifecycleState::AwaitingFeedback => "awaiting_feedback",
+        IssueLifecycleState::FeedbackClaimed => "feedback_claimed",
+        IssueLifecycleState::AddressingFeedback => "addressing_feedback",
+        IssueLifecycleState::ReadyToMerge => "ready_to_merge",
+        IssueLifecycleState::Blocked => "blocked",
+        IssueLifecycleState::Done => "done",
+        IssueLifecycleState::Failed => "failed",
+        IssueLifecycleState::Cancelled => "cancelled",
+    }
+    .to_string()
+}
+
 fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_json::Value {
     if let Some(object) = data.as_object_mut() {
         object.insert("last_decision".to_string(), json!(decision));
@@ -750,7 +871,8 @@ mod tests {
         assert_eq!(
             outcome,
             PrFeedbackSweepRequestOutcome::Requested {
-                workflow_id: workflow_id.clone()
+                workflow_id: workflow_id.clone(),
+                task_id: "task-1".to_string(),
             }
         );
         let updated = store
@@ -780,7 +902,8 @@ mod tests {
         assert_eq!(
             second,
             PrFeedbackSweepRequestOutcome::ActiveCommandExists {
-                workflow_id: workflow_id.clone()
+                workflow_id: workflow_id.clone(),
+                task_id: "task-1".to_string(),
             }
         );
         assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
@@ -921,9 +1044,135 @@ mod tests {
         assert_eq!(
             outcome,
             PrFeedbackSweepRequestOutcome::Requested {
-                workflow_id: workflow_id.clone()
+                workflow_id: workflow_id.clone(),
+                task_id: "task-1".to_string(),
             }
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_issue_workflow_feedback_candidate_is_adopted_into_runtime() -> anyhow::Result<()>
+    {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let mut legacy = IssueWorkflowInstance::new(
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+        );
+        legacy.state = IssueLifecycleState::FeedbackClaimed;
+        legacy.active_task_id = Some("claim:legacy-workflow-123".to_string());
+        legacy.pr_number = Some(77);
+        legacy.pr_url = Some("https://github.com/owner/repo/pull/77".to_string());
+        let expected_task_id = format!("runtime:{}", legacy.id);
+
+        let outcome = request_pr_feedback_sweep_for_legacy_issue_workflow(&store, &legacy).await?;
+        assert_eq!(
+            outcome,
+            PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id: legacy.id.clone(),
+                task_id: expected_task_id.clone(),
+            }
+        );
+        let instance = store
+            .get_instance(&legacy.id)
+            .await?
+            .expect("legacy issue workflow should be adopted");
+        assert_eq!(instance.definition_id, "github_issue_pr");
+        assert_eq!(instance.state, "awaiting_feedback");
+        assert_eq!(
+            instance.data["project_id"].as_str(),
+            Some(project_root.to_string_lossy().as_ref())
+        );
+        assert_eq!(instance.data["repo"], "owner/repo");
+        assert_eq!(instance.data["issue_number"], 123);
+        assert_eq!(instance.data["pr_number"], 77);
+        assert_eq!(
+            instance.data["pr_url"],
+            "https://github.com/owner/repo/pull/77"
+        );
+        assert_eq!(instance.data["task_id"], expected_task_id);
+        assert_eq!(instance.data["execution_path"], "workflow_runtime");
+        assert_eq!(
+            instance.data["legacy_issue_workflow_state"],
+            "feedback_claimed"
+        );
+        let commands = store.commands_for(&legacy.id).await?;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command.command["definition_id"],
+            PR_FEEDBACK_DEFINITION_ID
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_issue_workflow_feedback_candidate_reuses_existing_runtime_task_id(
+    ) -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let mut legacy = IssueWorkflowInstance::new(
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+        );
+        legacy.state = IssueLifecycleState::FeedbackClaimed;
+        legacy.pr_number = Some(77);
+        legacy.pr_url = Some("https://github.com/owner/repo/pull/77".to_string());
+        upsert_github_issue_pr_definition(&store).await?;
+        let instance = issue_instance(
+            legacy.id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "awaiting_feedback",
+        )
+        .with_data(json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 123,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-existing-task",
+        }));
+        store.upsert_instance(&instance).await?;
+
+        let outcome = request_pr_feedback_sweep_for_legacy_issue_workflow(&store, &legacy).await?;
+        assert_eq!(
+            outcome,
+            PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id: legacy.id.clone(),
+                task_id: "runtime-existing-task".to_string(),
+            }
+        );
+        let updated = store
+            .get_instance(&legacy.id)
+            .await?
+            .expect("runtime workflow should still exist");
+        assert_eq!(updated.data["task_id"], "runtime-existing-task");
         Ok(())
     }
 }

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -98,8 +98,6 @@ Implemented now:
 
 Still intentionally not moved yet:
 
-- legacy issue-workflow feedback fallback still uses existing PR task routes when no runtime
-  workflow exists
 - non-runtime dashboard task actions still use existing task routes
 
 ## Non-Goals


### PR DESCRIPTION
## Summary
- adopt legacy issue-workflow PR feedback candidates into `github_issue_pr` runtime workflows when runtime feedback is enabled
- route adopted candidates through the runtime `pr_feedback` child workflow instead of registering a legacy `pr:N` task
- update the workflow runtime decoupling plan and add coverage for legacy adoption

## Validation
- `cargo check`
- `cargo test -p harness-server workflow_runtime_pr_feedback::tests -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'Command::new\\(\"(gh|git)\"\\)' crates` (no matches)