### PR TITLE
Add runtime workflow cancellation from dashboard

### DIFF
--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -71,6 +71,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             post(task_mutation_routes::merge_workflow_runtime),
         )
         .route(
+            "/api/workflows/runtime/cancel",
+            post(task_mutation_routes::cancel_workflow_runtime),
+        )
+        .route(
             "/api/runtime-hosts",
             get(crate::handlers::runtime_hosts::list_runtime_hosts),
         )

--- a/crates/harness-server/src/http/task_mutation_routes.rs
+++ b/crates/harness-server/src/http/task_mutation_routes.rs
@@ -1,4 +1,7 @@
 use super::AppState;
+use crate::workflow_runtime_submission::{
+    RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome,
+};
 use axum::{extract::State, http::StatusCode, Json};
 use harness_workflow::issue_lifecycle::IssueLifecycleState;
 use serde::Deserialize;
@@ -7,6 +10,11 @@ use std::sync::Arc;
 
 #[derive(Debug, Deserialize)]
 pub(super) struct WorkflowRuntimeMergeRequest {
+    pub workflow_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct WorkflowRuntimeCancelRequest {
     pub workflow_id: String,
 }
 
@@ -143,6 +151,74 @@ pub(super) async fn merge_workflow_runtime(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "error": "failed to approve workflow runtime merge" })),
+            )
+        }
+    }
+}
+
+pub(super) async fn cancel_workflow_runtime(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<WorkflowRuntimeCancelRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "workflow runtime store unavailable" })),
+        );
+    };
+
+    match crate::workflow_runtime_submission::cancel_submission_by_workflow_id(
+        store,
+        &request.workflow_id,
+    )
+    .await
+    {
+        Ok(RuntimeSubmissionCancelOutcome::Cancelled(workflow)) => {
+            if let Err(error) =
+                crate::workflow_runtime_worker::notify_runtime_submission_terminal_workflow(
+                    &state,
+                    &workflow.id,
+                    None,
+                )
+                .await
+            {
+                tracing::warn!(
+                    workflow_id = %workflow.id,
+                    "cancel_workflow_runtime: terminal notification failed: {error}"
+                );
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "status": "cancelled",
+                    "execution_path": "workflow_runtime",
+                    "workflow_id": workflow.id,
+                })),
+            )
+        }
+        Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(workflow)) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "workflow already terminal",
+                "state": workflow.state,
+            })),
+        ),
+        Ok(RuntimeSubmissionCancelOutcome::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "workflow not found" })),
+        ),
+        Err(RuntimeSubmissionCancelError::UnsupportedDefinition { definition_id }) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "workflow cannot be cancelled as a runtime submission",
+                "definition_id": definition_id,
+            })),
+        ),
+        Err(error) => {
+            tracing::error!("cancel_workflow_runtime: cancellation failed: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to cancel workflow runtime submission" })),
             )
         }
     }

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -2,6 +2,7 @@ use super::AppState;
 use crate::{
     services::execution::{EnqueueBackgroundOptions, EnqueueTaskError},
     task_runner,
+    workflow_runtime_submission::{RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome},
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Response, Json};
 use serde::Deserialize;
@@ -446,7 +447,7 @@ pub(super) async fn cancel_task(
             )
             .await
             {
-                Ok(Some(workflow)) if workflow.state == "cancelled" => {
+                Ok(RuntimeSubmissionCancelOutcome::Cancelled(workflow)) => {
                     if let Err(error) =
                         crate::workflow_runtime_worker::notify_runtime_submission_terminal_workflow(
                             &state,
@@ -469,13 +470,20 @@ pub(super) async fn cancel_task(
                         })),
                     )
                 }
-                Ok(Some(_)) => (
+                Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(_)) => (
                     StatusCode::CONFLICT,
                     Json(json!({ "error": "task already in terminal state" })),
                 ),
-                Ok(None) => (
+                Ok(RuntimeSubmissionCancelOutcome::NotFound) => (
                     StatusCode::NOT_FOUND,
                     Json(json!({ "error": "task not found" })),
+                ),
+                Err(RuntimeSubmissionCancelError::UnsupportedDefinition { definition_id }) => (
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "error": "task cannot be cancelled as a runtime submission",
+                        "definition_id": definition_id,
+                    })),
                 ),
                 Err(e) => {
                     tracing::error!(

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3516,6 +3516,89 @@ async fn workflow_runtime_merge_endpoint_approves_ready_workflow() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn workflow_runtime_cancel_endpoint_cancels_issue_workflow() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = harness_core::types::TaskId::from_str("runtime-cancel-task-55");
+    let submission = crate::workflow_runtime_submission::record_issue_submission(
+        store,
+        crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 55,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let app = Router::new()
+        .route(
+            "/api/workflows/runtime/cancel",
+            post(task_mutation_routes::cancel_workflow_runtime),
+        )
+        .with_state(state.clone());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/workflows/runtime/cancel")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "workflow_id": submission.workflow_id }).to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["status"], "cancelled");
+    assert_eq!(body["execution_path"], "workflow_runtime");
+    let updated = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(updated.state, "cancelled");
+    assert_eq!(updated.data["last_decision"], "cancel_issue_submission");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/workflows/runtime/cancel")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "workflow_id": submission.workflow_id }).to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "workflow already terminal");
+    assert_eq!(body["state"], "cancelled");
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::{
     collections::HashMap,
+    fmt,
     path::Path,
     sync::{Mutex, OnceLock},
 };
@@ -327,17 +328,76 @@ pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<T
         .map(|task_id| TaskId::from_str(&task_id))
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeSubmissionCancelOutcome {
+    Cancelled(WorkflowInstance),
+    AlreadyTerminal(WorkflowInstance),
+    NotFound,
+}
+
+#[derive(Debug)]
+pub(crate) enum RuntimeSubmissionCancelError {
+    UnsupportedDefinition { definition_id: String },
+    Store(anyhow::Error),
+}
+
+impl fmt::Display for RuntimeSubmissionCancelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedDefinition { definition_id } => write!(
+                formatter,
+                "workflow definition `{definition_id}` cannot be cancelled as a runtime submission"
+            ),
+            Self::Store(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeSubmissionCancelError {}
+
+impl From<anyhow::Error> for RuntimeSubmissionCancelError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Store(error)
+    }
+}
+
 pub(crate) async fn cancel_issue_submission_by_task_id(
     store: &WorkflowRuntimeStore,
     task_id: &TaskId,
-) -> anyhow::Result<Option<WorkflowInstance>> {
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
     let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(None);
+        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
     };
+    cancel_submission_instance(store, instance, task_id.as_str()).await
+}
+
+pub(crate) async fn cancel_submission_by_workflow_id(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    let Some(instance) = store.get_instance(workflow_id).await? else {
+        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
+    };
+    let correlation_id = runtime_issue_task_handle(&instance)
+        .map(|task_id| task_id.0)
+        .unwrap_or_else(|| format!("workflow:{workflow_id}"));
+    cancel_submission_instance(store, instance, &correlation_id).await
+}
+
+async fn cancel_submission_instance(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    correlation_id: &str,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
     if instance.is_terminal() {
-        return Ok(Some(instance));
+        return Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance));
     }
     let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
+    if !is_prompt && instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
+        return Err(RuntimeSubmissionCancelError::UnsupportedDefinition {
+            definition_id: instance.definition_id,
+        });
+    }
     let event_type = if is_prompt {
         "PromptSubmissionCancelled"
     } else {
@@ -364,7 +424,7 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
             event_type,
             "workflow_runtime_submission",
             json!({
-                "task_id": task_id.as_str(),
+                "task_id": correlation_id,
                 "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )
@@ -378,8 +438,8 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
     )
     .with_command(WorkflowCommand::new(
         WorkflowCommandType::MarkCancelled,
-        format!("{command_prefix}:{}:cancel", task_id.as_str()),
-        json!({ "task_id": task_id.as_str() }),
+        format!("{command_prefix}:{correlation_id}:cancel"),
+        json!({ "task_id": correlation_id }),
     ))
     .high_confidence();
     let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
@@ -389,8 +449,8 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
             store
                 .cancel_command_and_unfinished_runtime_jobs(
                     &command.id,
-                    "cancel_issue_submission",
-                    "Runtime issue submission was cancelled before execution.",
+                    decision_name,
+                    "Runtime submission was cancelled before execution.",
                 )
                 .await?;
         }
@@ -402,7 +462,7 @@ pub(crate) async fn cancel_issue_submission_by_task_id(
             optional_string_field(&cancelled.data, "prompt_ref").as_deref(),
         );
     }
-    Ok(Some(cancelled))
+    Ok(RuntimeSubmissionCancelOutcome::Cancelled(cancelled))
 }
 
 async fn persist_issue_submission(
@@ -1199,6 +1259,16 @@ mod tests {
         WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url)).await
     }
 
+    fn expect_cancelled(
+        outcome: RuntimeSubmissionCancelOutcome,
+        context: &str,
+    ) -> WorkflowInstance {
+        match outcome {
+            RuntimeSubmissionCancelOutcome::Cancelled(workflow) => workflow,
+            other => panic!("{context}: expected cancelled workflow, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn issue_submission_records_pending_runtime_implementation_command() -> anyhow::Result<()>
     {
@@ -1591,9 +1661,10 @@ mod tests {
             "dispatched"
         );
 
-        let cancelled = cancel_issue_submission_by_task_id(&store, &task_id)
-            .await?
-            .expect("runtime issue submission should resolve by task id");
+        let cancelled = expect_cancelled(
+            cancel_issue_submission_by_task_id(&store, &task_id).await?,
+            "runtime issue submission should resolve by task id",
+        );
         assert_eq!(cancelled.state, "cancelled");
 
         let commands = store.commands_for(&result.workflow_id).await?;
@@ -1609,6 +1680,50 @@ mod tests {
             harness_workflow::runtime::RuntimeJobStatus::Cancelled
         );
         assert!(jobs[0].lease.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancel_issue_submission_by_workflow_id_uses_stable_runtime_handle(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = open_runtime_store(dir.path()).await?;
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("runtime-handle-cancel-by-workflow");
+        let result = record_issue_submission(
+            &store,
+            IssueSubmissionRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                issue_number: 43,
+                task_id: &task_id,
+                labels: &[],
+                force_execute: false,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+                source: None,
+                external_id: None,
+            },
+        )
+        .await?;
+
+        let cancelled = expect_cancelled(
+            cancel_submission_by_workflow_id(&store, &result.workflow_id).await?,
+            "runtime issue submission should resolve by workflow id",
+        );
+        assert_eq!(cancelled.state, "cancelled");
+        assert_eq!(cancelled.data["cancelled"], true);
+        assert_eq!(cancelled.data["last_decision"], "cancel_issue_submission");
+        let events = store.events_for(&result.workflow_id).await?;
+        assert!(events
+            .iter()
+            .any(|event| event.event_type == "IssueSubmissionCancelled"));
         Ok(())
     }
 
@@ -1660,9 +1775,10 @@ mod tests {
             "dispatched"
         );
 
-        let cancelled = cancel_issue_submission_by_task_id(&store, &task_id)
-            .await?
-            .expect("runtime prompt submission should resolve by task id");
+        let cancelled = expect_cancelled(
+            cancel_issue_submission_by_task_id(&store, &task_id).await?,
+            "runtime prompt submission should resolve by task id",
+        );
         assert_eq!(cancelled.state, "cancelled");
 
         let commands = store.commands_for(&result.workflow_id).await?;

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -69,8 +69,11 @@ function columnCount(label: string): string {
   return within(header).getAllByText(/\d+/)[0].textContent ?? "";
 }
 
-function wrap(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: React.ReactElement, qc = makeQueryClient()) {
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>{ui}</MemoryRouter>
@@ -343,6 +346,101 @@ describe("<Active>", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("rejected: replan limit exhausted")).toBeInTheDocument();
+  });
+
+  it("cancels a non-terminal runtime issue workflow from the runtime panel", async () => {
+    mockUseTasks.mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseWorkflowRuntimeTree.mockReturnValue({
+      data: {
+        total_workflows: 1,
+        workflows: [
+          {
+            workflow: {
+              id: "runtime-issue-901",
+              definition_id: "github_issue_pr",
+              definition_version: 1,
+              state: "implementing",
+              subject: { subject_type: "issue", subject_key: "issue:901" },
+              data: { task_id: "runtime-task-901" },
+              version: 1,
+              created_at: "2026-04-30T00:00:00Z",
+              updated_at: "2026-04-30T00:00:00Z",
+            },
+            events: [],
+            decisions: [],
+            commands: [],
+            children: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    wrap(<Active projectFilter="harness" />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/workflows/runtime/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: "runtime-issue-901" }),
+      });
+    });
+  });
+
+  it("refreshes runtime data when workflow cancellation returns a conflict", async () => {
+    mockApiFetch.mockRejectedValueOnce(new Error("workflow already terminal"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const qc = makeQueryClient();
+    const invalidateQueries = vi.spyOn(qc, "invalidateQueries");
+    mockUseTasks.mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseWorkflowRuntimeTree.mockReturnValue({
+      data: {
+        total_workflows: 1,
+        workflows: [
+          {
+            workflow: {
+              id: "runtime-issue-conflict",
+              definition_id: "github_issue_pr",
+              definition_version: 1,
+              state: "implementing",
+              subject: { subject_type: "issue", subject_key: "issue:902" },
+              data: { task_id: "runtime-task-902" },
+              version: 1,
+              created_at: "2026-04-30T00:00:00Z",
+              updated_at: "2026-04-30T00:00:00Z",
+            },
+            events: [],
+            decisions: [],
+            commands: [],
+            children: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    wrap(<Active projectFilter="harness" />, qc);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/workflows/runtime/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: "runtime-issue-conflict" }),
+      });
+    });
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workflow-runtime-tree"] });
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to cancel runtime workflow",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
   });
 
   it("clicking a standard task card opens the slide-over with that task's id", () => {

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -138,6 +138,13 @@ function runtimeMergeWorkflowId(workflow?: WorkflowSummary | null): string | nul
   return null;
 }
 
+function runtimeWorkflowCanCancel(workflow: WorkflowRuntimeTreeNode["workflow"]): boolean {
+  return (
+    (workflow.definition_id === "github_issue_pr" || workflow.definition_id === "prompt_task") &&
+    !TERMINAL_STATUSES.has(workflow.state)
+  );
+}
+
 function rejectedDecisions(decisions: WorkflowRuntimeDecisionRecord[]) {
   return decisions.filter((decision) => !decision.accepted);
 }
@@ -159,12 +166,24 @@ function workflowRuntimeCounts(nodes: WorkflowRuntimeTreeNode[]) {
   return { workflows, commands, jobs, rejected };
 }
 
-function WorkflowRuntimeNode({ node, depth = 0 }: { node: WorkflowRuntimeTreeNode; depth?: number }) {
+function WorkflowRuntimeNode({
+  node,
+  depth = 0,
+  onCancel,
+  cancellingWorkflowIds,
+}: {
+  node: WorkflowRuntimeTreeNode;
+  depth?: number;
+  onCancel?: (workflowId: string) => void;
+  cancellingWorkflowIds?: Set<string>;
+}) {
   const rejected = rejectedDecisions(node.decisions);
+  const canCancel = runtimeWorkflowCanCancel(node.workflow);
+  const cancelling = cancellingWorkflowIds?.has(node.workflow.id) ?? false;
   return (
     <div className="border-t border-line first:border-t-0 py-2">
       <div
-        className="grid grid-cols-[minmax(120px,1fr)_auto_auto] items-start gap-2"
+        className="grid grid-cols-[minmax(120px,1fr)_auto_auto_auto] items-start gap-2"
         style={{ paddingLeft: `${depth * 14}px` }}
       >
         <div className="min-w-0">
@@ -182,6 +201,19 @@ function WorkflowRuntimeNode({ node, depth = 0 }: { node: WorkflowRuntimeTreeNod
           <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
             rejected {rejected.length}
           </span>
+        ) : null}
+        {canCancel && onCancel ? (
+          <button
+            type="button"
+            disabled={cancelling}
+            onClick={(event) => {
+              event.stopPropagation();
+              onCancel(node.workflow.id);
+            }}
+            className="border border-line bg-bg px-1.5 py-[1px] font-mono text-[10px] text-ink-2 hover:border-rust/60 hover:text-rust transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {cancelling ? "Cancelling..." : "Cancel"}
+          </button>
         ) : null}
       </div>
       {node.commands.length > 0 ? (
@@ -213,7 +245,13 @@ function WorkflowRuntimeNode({ node, depth = 0 }: { node: WorkflowRuntimeTreeNod
       {node.children.length > 0 ? (
         <div className="mt-2">
           {node.children.map((child) => (
-            <WorkflowRuntimeNode key={child.workflow.id} node={child} depth={depth + 1} />
+            <WorkflowRuntimeNode
+              key={child.workflow.id}
+              node={child}
+              depth={depth + 1}
+              onCancel={onCancel}
+              cancellingWorkflowIds={cancellingWorkflowIds}
+            />
           ))}
         </div>
       ) : null}
@@ -225,10 +263,14 @@ function WorkflowRuntimePanel({
   payload,
   isLoading,
   isError,
+  onCancel,
+  cancellingWorkflowIds,
 }: {
   payload?: WorkflowRuntimeTreePayload;
   isLoading: boolean;
   isError: boolean;
+  onCancel?: (workflowId: string) => void;
+  cancellingWorkflowIds?: Set<string>;
 }) {
   const workflows = payload?.workflows ?? [];
   const counts = workflowRuntimeCounts(workflows);
@@ -256,7 +298,14 @@ function WorkflowRuntimePanel({
         ) : empty ? (
           <div className="py-3 font-mono text-[11px] text-ink-4">—</div>
         ) : (
-          workflows.map((node) => <WorkflowRuntimeNode key={node.workflow.id} node={node} />)
+          workflows.map((node) => (
+            <WorkflowRuntimeNode
+              key={node.workflow.id}
+              node={node}
+              onCancel={onCancel}
+              cancellingWorkflowIds={cancellingWorkflowIds}
+            />
+          ))
         )}
       </div>
     </section>
@@ -360,6 +409,7 @@ interface Props {
 export function Active({ projectFilter }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [merging, setMerging] = useState<Set<string>>(new Set());
+  const [cancellingWorkflows, setCancellingWorkflows] = useState<Set<string>>(new Set());
   const { data, isLoading, isError } = useTasks();
   const { data: dashboard } = useDashboard();
   const queryClient = useQueryClient();
@@ -383,6 +433,37 @@ export function Active({ projectFilter }: Props) {
       setMerging((prev) => {
         const next = new Set(prev);
         next.delete(taskId);
+        return next;
+      });
+    }
+  };
+
+  const handleCancelWorkflow = async (workflowId: string) => {
+    setCancellingWorkflows((prev) => new Set(prev).add(workflowId));
+    try {
+      await apiFetch("/api/workflows/runtime/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: workflowId }),
+      });
+    } catch (error) {
+      console.error("Failed to cancel runtime workflow", error);
+    } finally {
+      const refreshResults = await Promise.allSettled([
+        queryClient.invalidateQueries({ queryKey: ["tasks"] }),
+        queryClient.invalidateQueries({ queryKey: ["workflow-runtime-tree"] }),
+      ]);
+      for (const result of refreshResults) {
+        if (result.status === "rejected") {
+          console.error(
+            "Failed to refresh dashboard after runtime workflow cancellation",
+            result.reason,
+          );
+        }
+      }
+      setCancellingWorkflows((prev) => {
+        const next = new Set(prev);
+        next.delete(workflowId);
         return next;
       });
     }
@@ -413,6 +494,8 @@ export function Active({ projectFilter }: Props) {
         payload={workflowRuntime.data}
         isLoading={workflowRuntime.isLoading}
         isError={workflowRuntime.isError}
+        onCancel={handleCancelWorkflow}
+        cancellingWorkflowIds={cancellingWorkflows}
       />
       <div
         className="grid gap-3"


### PR DESCRIPTION
## Summary
- add a workflow-runtime cancel endpoint for issue and prompt runtime submissions
- expose Cancel on non-terminal runtime issue/prompt nodes in the dashboard runtime tree
- update workflow runtime plan docs and add backend/frontend coverage

## Validation
- `cargo check`
- `cargo test -p harness-server cancel_issue_submission_by_workflow_id_uses_stable_runtime_handle -- --test-threads=1`
- `cargo test -p harness-server workflow_runtime_cancel_endpoint_cancels_issue_workflow -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bun run typecheck`
- `bun run test -- Active.test.tsx`
- `bun run test`
- `rg -n 'Command::new\\("(gh|git)"\\)' crates` (no matches)