### PR TITLE
Expose runtime submission workflow handles

### DIFF
--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -62,6 +62,7 @@ pub(crate) async fn enqueue_task_background_in_domain(
 pub(crate) struct TaskResponseDetails {
     pub(crate) status: String,
     pub(crate) execution_path: &'static str,
+    pub(crate) workflow_id: Option<String>,
 }
 
 pub(crate) async fn task_response_details(
@@ -78,6 +79,7 @@ pub(crate) async fn task_response_details(
             return Ok(TaskResponseDetails {
                 status: workflow.state,
                 execution_path: "workflow_runtime",
+                workflow_id: Some(workflow.id),
             });
         }
     }
@@ -86,6 +88,7 @@ pub(crate) async fn task_response_details(
         return Ok(TaskResponseDetails {
             status: "queued".to_string(),
             execution_path: "task_runner",
+            workflow_id: None,
         });
     }
 
@@ -100,6 +103,7 @@ pub(crate) async fn task_response_details(
         return Ok(TaskResponseDetails {
             status: "queued".to_string(),
             execution_path: "task_runner",
+            workflow_id: None,
         });
     }
 
@@ -137,6 +141,21 @@ pub struct BatchCreateTaskRequest {
     pub turn_timeout_secs: Option<u64>,
     /// Project root or registry ID applied to all tasks in this batch.
     pub project: Option<std::path::PathBuf>,
+}
+
+fn task_submission_response(
+    task_id: &task_runner::TaskId,
+    details: TaskResponseDetails,
+) -> serde_json::Value {
+    let mut response = json!({
+        "task_id": task_id.0,
+        "status": details.status,
+        "execution_path": details.execution_path,
+    });
+    if let Some(workflow_id) = details.workflow_id {
+        response["workflow_id"] = json!(workflow_id);
+    }
+    response
 }
 
 /// Compute connected conflict groups from per-task file-reference sets.
@@ -312,21 +331,12 @@ pub(super) async fn create_tasks_batch(
                 all_maintenance_window = false;
                 match task_response_details(&state, &task_id, is_issue_submission).await {
                     Ok(details) => {
+                        let mut response = task_submission_response(&task_id, details);
                         if is_serialized {
-                            json!({
-                                "task_id": task_id.0,
-                                "status": details.status,
-                                "serialized": true,
-                                "conflict_files": conflict_files,
-                                "execution_path": details.execution_path,
-                            })
-                        } else {
-                            json!({
-                                "task_id": task_id.0,
-                                "status": details.status,
-                                "execution_path": details.execution_path,
-                            })
+                            response["serialized"] = json!(true);
+                            response["conflict_files"] = json!(conflict_files);
                         }
+                        response
                     }
                     Err(EnqueueTaskError::BadRequest(error)) => json!({ "error": error }),
                     Err(EnqueueTaskError::Internal(error)) => json!({ "error": error }),
@@ -374,11 +384,7 @@ pub(super) async fn create_task(
         Ok(task_id) => match task_response_details(&state, &task_id, is_issue_submission).await {
             Ok(details) => (
                 StatusCode::ACCEPTED,
-                Json(json!({
-                    "task_id": task_id.0,
-                    "status": details.status,
-                    "execution_path": details.execution_path,
-                })),
+                Json(task_submission_response(&task_id, details)),
             )
                 .into_response(),
             Err(EnqueueTaskError::BadRequest(error)) => {

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -833,7 +833,7 @@ async fn assert_runtime_issue_submission(
     repo: Option<&str>,
     issue_number: u64,
     task_id: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     let task_id = task_runner::TaskId::from_str(task_id);
     assert!(
         state
@@ -881,7 +881,7 @@ async fn assert_runtime_issue_submission(
     assert_eq!(runtime_task["status"], "implementing");
     assert_eq!(runtime_task["execution_path"], "workflow_runtime");
     assert_eq!(runtime_task["workflow_id"], workflow_id);
-    Ok(())
+    Ok(workflow_id)
 }
 
 fn webhook_signature(secret: &str, payload: &[u8]) -> String {
@@ -3140,6 +3140,7 @@ async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow
         Some("manual:prompt:http"),
         &task_id,
     );
+    assert_eq!(resp["workflow_id"], workflow_id);
     let instance = store
         .get_instance(&workflow_id)
         .await?
@@ -3291,6 +3292,7 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
         Some("owner/repo"),
         42,
     );
+    assert_eq!(resp["workflow_id"], workflow_id);
     let instance = store
         .get_instance(&workflow_id)
         .await?
@@ -4230,7 +4232,7 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
     for (entry, issue_number) in entries.iter().zip([42_u64, 43]) {
         assert_eq!(entry["status"], "implementing");
         assert_eq!(entry["execution_path"], "workflow_runtime");
-        assert_runtime_issue_submission(
+        let workflow_id = assert_runtime_issue_submission(
             &state,
             &project_root,
             None,
@@ -4240,6 +4242,7 @@ async fn create_tasks_batch_with_issues_returns_runtime_submissions() -> anyhow:
                 .expect("task id should be present"),
         )
         .await?;
+        assert_eq!(entry["workflow_id"], workflow_id);
     }
     assert_eq!(state.core.tasks.count(), before_count);
     Ok(())
@@ -4364,6 +4367,7 @@ async fn create_tasks_batch_with_prompts_returns_runtime_submissions() -> anyhow
             .get_instance_by_task_id(task_id.as_str())
             .await?
             .expect("runtime prompt submission should be persisted");
+        assert_eq!(entry["workflow_id"], instance.id);
         assert_eq!(instance.definition_id, "prompt_task");
         assert_eq!(instance.state, "implementing");
         assert!(instance.data.get("prompt").is_none());

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -140,6 +140,22 @@ export function useCancelTask() {
   });
 }
 
+export function useCancelWorkflowRuntime() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (workflowId: string) =>
+      apiFetch("/api/workflows/runtime/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: workflowId }),
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      await queryClient.invalidateQueries({ queryKey: ["workflow-runtime-tree"] });
+    },
+  });
+}
+
 export interface WorktreeCard {
   taskId: string;
   pathShort: string;

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { Submit } from "./Submit";
 import { SubmitSuccess } from "./SubmitSuccess";
-import { useOverview, useTaskStream, useCancelTask } from "@/lib/queries";
+import { useOverview, useTaskStream, useCancelTask, useCancelWorkflowRuntime } from "@/lib/queries";
 import { apiFetch } from "@/lib/api";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -13,6 +13,7 @@ vi.mock("@/lib/queries", () => ({
   useOverview: vi.fn(),
   useTaskStream: vi.fn(),
   useCancelTask: vi.fn(),
+  useCancelWorkflowRuntime: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -31,6 +32,7 @@ vi.mock("@/lib/api", () => ({
 const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
 const mockUseTaskStream = useTaskStream as ReturnType<typeof vi.fn>;
 const mockUseCancelTask = useCancelTask as ReturnType<typeof vi.fn>;
+const mockUseCancelWorkflowRuntime = useCancelWorkflowRuntime as ReturnType<typeof vi.fn>;
 const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -52,6 +54,7 @@ beforeEach(() => {
   mockUseOverview.mockReturnValue({ data: { projects: PROJECTS } });
   mockUseTaskStream.mockImplementation(() => {});
   mockUseCancelTask.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  mockUseCancelWorkflowRuntime.mockReturnValue({ mutate: vi.fn(), isPending: false });
   mockApiFetch.mockResolvedValue(
     new Response(JSON.stringify({ task_id: "task-xyz", status: "running" }), { status: 200 }),
   );
@@ -296,6 +299,33 @@ describe("<SubmitSuccess>", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockMutate).toHaveBeenCalledWith("task-abc", expect.objectContaining({ onSuccess: expect.any(Function) }));
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it("runtime cancel uses the workflow runtime endpoint handle", () => {
+    const onReset = vi.fn();
+    const mockTaskMutate = vi.fn();
+    const mockRuntimeMutate = vi.fn().mockImplementation((_id: string, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+    mockUseCancelTask.mockReturnValue({ mutate: mockTaskMutate, isPending: false });
+    mockUseCancelWorkflowRuntime.mockReturnValue({ mutate: mockRuntimeMutate, isPending: false });
+
+    wrap(
+      <SubmitSuccess
+        taskId="runtime-correlation"
+        workflowId="workflow-runtime-123"
+        executionPath="workflow_runtime"
+        onReset={onReset}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockRuntimeMutate).toHaveBeenCalledWith(
+      "workflow-runtime-123",
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(mockTaskMutate).not.toHaveBeenCalled();
     expect(onReset).toHaveBeenCalled();
   });
 

--- a/web/src/routes/dashboard/Submit.tsx
+++ b/web/src/routes/dashboard/Submit.tsx
@@ -22,6 +22,12 @@ interface Props {
   projectFilter?: string | null;
 }
 
+interface CreatedSubmission {
+  taskId: string;
+  workflowId: string | null;
+  executionPath: string | null;
+}
+
 function parsePositiveInteger(input: string): number | null {
   const trimmed = input.trim();
   if (!/^[1-9]\d*$/.test(trimmed)) return null;
@@ -329,7 +335,7 @@ export function Submit({ projectFilter }: Props) {
     maxTurns: "",
     turnTimeoutSecs: "",
   });
-  const [createdTaskId, setCreatedTaskId] = useState<string | null>(null);
+  const [createdSubmission, setCreatedSubmission] = useState<CreatedSubmission | null>(null);
   const [busy, setBusy] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -408,7 +414,11 @@ export function Submit({ projectFilter }: Props) {
         body: JSON.stringify({ ...modePayload, ...common }),
       });
       const json = (await resp.json()) as CreateTaskResponse;
-      setCreatedTaskId(json.task_id);
+      setCreatedSubmission({
+        taskId: json.task_id,
+        workflowId: json.workflow_id ?? null,
+        executionPath: json.execution_path ?? null,
+      });
       setStep("success");
     } catch (e) {
       setSubmitError((e as Error).message);
@@ -418,7 +428,7 @@ export function Submit({ projectFilter }: Props) {
   }
 
   function handleReset() {
-    setCreatedTaskId(null);
+    setCreatedSubmission(null);
     setStep("mode");
     setWizardState({
       mode: null,
@@ -472,8 +482,13 @@ export function Submit({ projectFilter }: Props) {
             error={submitError}
           />
         )}
-        {step === "success" && createdTaskId && (
-          <SubmitSuccess taskId={createdTaskId} onReset={handleReset} />
+        {step === "success" && createdSubmission && (
+          <SubmitSuccess
+            taskId={createdSubmission.taskId}
+            workflowId={createdSubmission.workflowId}
+            executionPath={createdSubmission.executionPath}
+            onReset={handleReset}
+          />
         )}
       </div>
     </div>

--- a/web/src/routes/dashboard/SubmitSuccess.tsx
+++ b/web/src/routes/dashboard/SubmitSuccess.tsx
@@ -1,16 +1,23 @@
 import { useState } from "react";
-import { useTaskStream, useCancelTask } from "@/lib/queries";
+import { useTaskStream, useCancelTask, useCancelWorkflowRuntime } from "@/lib/queries";
 import { TOKEN_KEY } from "@/lib/api";
 
 interface Props {
   taskId: string;
+  workflowId?: string | null;
+  executionPath?: string | null;
   onReset: () => void;
 }
 
-export function SubmitSuccess({ taskId, onReset }: Props) {
+export function SubmitSuccess({ taskId, workflowId, executionPath, onReset }: Props) {
   const [output, setOutput] = useState<string>("");
   const [streamError, setStreamError] = useState<string | null>(null);
-  const cancel = useCancelTask();
+  const cancelTask = useCancelTask();
+  const cancelWorkflowRuntime = useCancelWorkflowRuntime();
+  const canCancelWorkflowRuntime = executionPath === "workflow_runtime" && !!workflowId;
+  const cancelPending = canCancelWorkflowRuntime
+    ? cancelWorkflowRuntime.isPending
+    : cancelTask.isPending;
 
   useTaskStream(
     taskId,
@@ -26,7 +33,11 @@ export function SubmitSuccess({ taskId, onReset }: Props) {
   }
 
   function handleCancel() {
-    cancel.mutate(taskId, { onSuccess: onReset });
+    if (canCancelWorkflowRuntime && workflowId) {
+      cancelWorkflowRuntime.mutate(workflowId, { onSuccess: onReset });
+    } else {
+      cancelTask.mutate(taskId, { onSuccess: onReset });
+    }
   }
 
   return (
@@ -50,11 +61,11 @@ export function SubmitSuccess({ taskId, onReset }: Props) {
         </button>
         <button
           type="button"
-          disabled={cancel.isPending}
+          disabled={cancelPending}
           onClick={handleCancel}
           className="font-mono text-[11.5px] px-3 py-1 border border-danger/40 text-danger rounded-[3px] hover:bg-danger/5 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {cancel.isPending ? "Cancelling…" : "Cancel"}
+          {cancelPending ? "Cancelling..." : "Cancel"}
         </button>
         <button
           type="button"

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -91,4 +91,6 @@ export type CreateTaskPayload =
 export interface CreateTaskResponse {
   task_id: string;
   status: string;
+  execution_path?: string;
+  workflow_id?: string | null;
 }


### PR DESCRIPTION
## Summary
- include workflow_id in runtime issue and prompt submission responses, including batch responses
- route submit-success cancellation through the workflow runtime cancel endpoint when a runtime workflow handle is available
- update workflow runtime plan docs and add backend/frontend coverage

## Validation
- `cargo check`
- `cargo test -p harness-server create_task_with_issue_returns_workflow_runtime_submission -- --test-threads=1`
- `cargo test -p harness-server create_task_with_prompt_returns_workflow_runtime_submission -- --test-threads=1`
- `cargo test -p harness-server create_tasks_batch_with_issues_returns_runtime_submissions -- --test-threads=1`
- `cargo test -p harness-server create_tasks_batch_with_prompts_returns_runtime_submissions -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bun run typecheck`
- `bun run test -- Submit.test.tsx`
- `bun run test`
- `rg -n 'Command::new\\("(gh|git)"\\)' crates` (no matches)