### PR TITLE
Route Worktrees runtime cancel through workflow API

### DIFF
--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -216,8 +216,7 @@ fn runtime_workflow_task_summary(
         workspace_path: None,
         workspace_owner: None,
         run_generation: 0,
-        workflow: (task_kind == TaskKind::Issue)
-            .then(|| TaskWorkflowSummary::from_runtime(&workflow)),
+        workflow: Some(TaskWorkflowSummary::from_runtime_workflow(&workflow)),
         scheduler,
     }
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3668,7 +3668,9 @@ async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> 
         canonical_project_root.to_string_lossy().as_ref()
     );
     assert_eq!(runtime_task["scheduler"]["authority_state"], "running");
-    assert!(runtime_task.get("workflow").is_none());
+    assert_eq!(runtime_task["workflow"]["id"], created["workflow_id"]);
+    assert_eq!(runtime_task["workflow"]["definition_id"], "prompt_task");
+    assert_eq!(runtime_task["workflow"]["state"], "implementing");
     Ok(())
 }
 

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -380,6 +380,10 @@ pub struct TaskWorkflowSummary {
 
 impl TaskWorkflowSummary {
     pub fn from_runtime(workflow: &harness_workflow::runtime::WorkflowInstance) -> Self {
+        Self::from_runtime_workflow(workflow)
+    }
+
+    pub fn from_runtime_workflow(workflow: &harness_workflow::runtime::WorkflowInstance) -> Self {
         Self {
             id: workflow.id.clone(),
             definition_id: Some(workflow.definition_id.clone()),

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -14,7 +14,13 @@ function makeWrapper() {
   return Wrapper;
 }
 
-type TaskStub = { id: string; status: string; turn?: number; project?: null };
+type TaskStub = {
+  id: string;
+  status: string;
+  turn?: number;
+  project?: null;
+  workflow?: { id?: string | null; definition_id?: string | null } | null;
+};
 
 function mockFetch(tasks: TaskStub[]) {
   const overview = { projects: [], runtimes: [], kpi: { active_tasks: 0 } };
@@ -71,6 +77,29 @@ describe("useWorktrees – active-status filtering", () => {
     const { result } = renderHook(() => useWorktrees(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.cards).toHaveLength(0);
+  });
+
+  it("carries runtime workflow ids for runtime-backed tasks", async () => {
+    mockFetch([
+      {
+        id: "runtime-task-1",
+        status: "implementing",
+        turn: 1,
+        project: null,
+        workflow: { id: "runtime-workflow-1", definition_id: "quality_gate" },
+      },
+      {
+        id: "legacy-task-1",
+        status: "implementing",
+        turn: 1,
+        project: null,
+        workflow: { id: "legacy-workflow-1", definition_id: null },
+      },
+    ]);
+    const { result } = renderHook(() => useWorktrees(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.cards[0].runtimeWorkflowId).toBe("runtime-workflow-1");
+    expect(result.current.cards[1].runtimeWorkflowId).toBeNull();
   });
 });
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -158,6 +158,7 @@ export function useCancelWorkflowRuntime() {
 
 export interface WorktreeCard {
   taskId: string;
+  runtimeWorkflowId: string | null;
   pathShort: string;
   branch: string;
   status: string;
@@ -209,6 +210,7 @@ export function useWorktrees(): { cards: WorktreeCard[]; isLoading: boolean; err
 
     return {
       taskId: task.id,
+      runtimeWorkflowId: task.workflow?.definition_id ? (task.workflow.id ?? null) : null,
       pathShort,
       branch: "—",
       status: task.status,

--- a/web/src/routes/Worktrees.test.tsx
+++ b/web/src/routes/Worktrees.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { PaletteProvider } from "@/lib/palette";
 import { DOCS_URL } from "@/lib/links";
 import { Worktrees } from "./Worktrees";
@@ -11,13 +11,23 @@ vi.mock("@/lib/queries", () => ({
   useOverview: vi.fn(),
 }));
 
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+  TOKEN_KEY: "harness_token",
+}));
+
 import { useOverview, useWorktrees } from "@/lib/queries";
+import { apiFetch } from "@/lib/api";
 
 const mockUseWorktrees = useWorktrees as ReturnType<typeof vi.fn>;
 const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
 
-function wrap(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: React.ReactElement, qc = makeQueryClient()) {
   return render(
     <QueryClientProvider client={qc}>
       <PaletteProvider>
@@ -47,5 +57,89 @@ describe("<Worktrees>", () => {
     wrap(<Worktrees />);
 
     expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute("href", DOCS_URL);
+  });
+
+  it("cancels runtime worktrees through the workflow runtime endpoint", async () => {
+    mockUseWorktrees.mockReturnValue({
+      cards: [
+        {
+          taskId: "runtime-task-1",
+          runtimeWorkflowId: "runtime-workflow-1",
+          pathShort: "repo/project",
+          branch: "—",
+          status: "implementing",
+          turn: 1,
+          maxTurns: null,
+          cpuPct: null,
+          ramPct: null,
+          diskBytes: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUseOverview.mockReturnValue({
+      data: {
+        projects: [],
+        runtimes: [],
+        kpi: {
+          active_tasks: 1,
+        },
+      },
+    });
+    mockApiFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    wrap(<Worktrees />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/workflows/runtime/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: "runtime-workflow-1" }),
+      });
+    });
+  });
+
+  it("refreshes worktree data when runtime cancellation fails", async () => {
+    const qc = makeQueryClient();
+    const invalidateQueries = vi.spyOn(qc, "invalidateQueries");
+    mockUseWorktrees.mockReturnValue({
+      cards: [
+        {
+          taskId: "runtime-task-2",
+          runtimeWorkflowId: "runtime-workflow-2",
+          pathShort: "repo/project",
+          branch: "—",
+          status: "implementing",
+          turn: 1,
+          maxTurns: null,
+          cpuPct: null,
+          ramPct: null,
+          diskBytes: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUseOverview.mockReturnValue({
+      data: {
+        projects: [],
+        runtimes: [],
+        kpi: {
+          active_tasks: 1,
+        },
+      },
+    });
+    mockApiFetch.mockRejectedValueOnce(new Error("workflow already terminal"));
+
+    wrap(<Worktrees />, qc);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("workflow already terminal");
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workflow-runtime-tree"] });
+    });
   });
 });

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -46,7 +46,7 @@ function openStream(taskId: string): void {
 
 interface CardProps {
   card: WorktreeCard;
-  onCancel: (taskId: string) => void;
+  onCancel: (card: WorktreeCard) => void;
   cancelling: boolean;
 }
 
@@ -123,10 +123,10 @@ function WorktreeCardItem({ card, onCancel, cancelling }: CardProps) {
         <button
           type="button"
           disabled={cancelling}
-          onClick={() => onCancel(card.taskId)}
+          onClick={() => onCancel(card)}
           className="ml-auto font-mono text-[11.5px] px-3 py-1 border border-danger/40 text-danger rounded-[3px] hover:bg-danger/5 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {cancelling ? "Cancelling…" : "Cancel"}
+          {cancelling ? "Cancelling..." : "Cancel"}
         </button>
       </div>
     </div>
@@ -141,18 +141,37 @@ export function Worktrees() {
   const [cancelling, setCancelling] = React.useState<Set<string>>(new Set());
   const [cancelError, setCancelError] = React.useState<string | null>(null);
 
-  const handleCancel = async (taskId: string) => {
+  const handleCancel = async (card: WorktreeCard) => {
+    const cancelKey = card.runtimeWorkflowId ?? card.taskId;
+    const refreshRuntimeTree = !!card.runtimeWorkflowId;
     setCancelError(null);
-    setCancelling((prev) => new Set(prev).add(taskId));
+    setCancelling((prev) => new Set(prev).add(cancelKey));
     try {
-      await apiFetch(`/tasks/${taskId}/cancel`, { method: "POST" });
-      await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      if (card.runtimeWorkflowId) {
+        await apiFetch("/api/workflows/runtime/cancel", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workflow_id: card.runtimeWorkflowId }),
+        });
+      } else {
+        await apiFetch(`/tasks/${card.taskId}/cancel`, { method: "POST" });
+      }
     } catch (err) {
       setCancelError(err instanceof Error ? err.message : "Cancel failed");
     } finally {
+      const refreshes = [queryClient.invalidateQueries({ queryKey: ["tasks"] })];
+      if (refreshRuntimeTree) {
+        refreshes.push(queryClient.invalidateQueries({ queryKey: ["workflow-runtime-tree"] }));
+      }
+      const refreshResults = await Promise.allSettled(refreshes);
+      for (const result of refreshResults) {
+        if (result.status === "rejected") {
+          console.error("Failed to refresh worktree data after cancellation", result.reason);
+        }
+      }
       setCancelling((prev) => {
         const next = new Set(prev);
-        next.delete(taskId);
+        next.delete(cancelKey);
         return next;
       });
     }
@@ -206,7 +225,10 @@ export function Worktrees() {
               </div>
             )}
             {cancelError && (
-              <div className="mb-4 px-3 py-2 border border-danger/40 text-danger font-mono text-[12px] rounded-[3px] bg-danger/5">
+              <div
+                role="alert"
+                className="mb-4 px-3 py-2 border border-danger/40 text-danger font-mono text-[12px] rounded-[3px] bg-danger/5"
+              >
                 {cancelError}
               </div>
             )}
@@ -221,7 +243,7 @@ export function Worktrees() {
                     key={card.taskId}
                     card={card}
                     onCancel={handleCancel}
-                    cancelling={cancelling.has(card.taskId)}
+                    cancelling={cancelling.has(card.runtimeWorkflowId ?? card.taskId)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- expose runtime workflow summaries for prompt submissions in GET /tasks
- carry runtime workflow handles into Worktrees cards
- cancel runtime-backed Worktrees cards through the workflow runtime cancel API

## Validation
- `cargo check`
- `cargo test -p harness-server list_tasks_includes_runtime_prompt_submissions -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bun run typecheck`
- `bun run test -- queries.test.ts Worktrees.test.tsx`
- `bun run test`
- `rg -n 'Command::new\\("(gh|git)"\\)' crates` (no matches)