### PR TITLE
Fix release-plz token fallback

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || github.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
           command: release-pr
@@ -36,11 +36,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || github.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
           command: release


### PR DESCRIPTION
## Summary
- Use the repository GitHub token when RELEASE_PLZ_TOKEN is not configured.
- Apply the fallback to checkout and release-plz action authentication.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-plz.yml"); puts "release-plz.yml parses"'
- cargo fmt --all
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test --workspace (fails only on harness-core DB tests because HARNESS_DATABASE_URL is not configured)