### PR TITLE
Fix workflow runtime workspace and Codex recovery

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,4 +1,21 @@
 ---
+workflow:
+  id: github_issue_pr
+  version: 1
+source:
+  kind: github
+  repo: majiayu000/harness
+base:
+  remote: origin
+  branch: main
+  require_remote_head: true
+workspace:
+  strategy: worktree
+  branch_prefix: harness/
+  reuse_existing_workspace: false
+  cleanup: on_terminal
+hooks:
+  timeout_secs: 60
 issue_workflow:
   force_execute_label: force-execute
   auto_replan_on_plan_issue: true
@@ -25,80 +42,47 @@ runtime_retry_policy:
   activity_retries: {}
 storage:
   schema_namespace: workflow
+activities:
+  implement_issue:
+    prompt: default
+    validation:
+      - cargo fmt --all -- --check
+      - cargo check
+      - cargo test
+      - RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
+  inspect_pr_feedback:
+    prompt: pr_feedback
+  quality_gate:
+    prompt: quality_gate
 ---
 
-# Harness Workflow
+# Harness Workflow Prompt
 
-This file defines high-level workflow policy for Harness.
+You are executing a Harness workflow activity for this repository.
 
-Current externally configurable rules:
+Runtime invariants:
 
-- `issue_workflow.force_execute_label`
-  - GitHub issue label that forces execution even when the agent raises a plan concern.
+- Work only inside the workspace path supplied by Harness.
+- The workspace is admitted by the runtime from the configured remote base before your turn starts.
+- Do not switch to or edit the source repository path.
+- Treat the workflow database and prompt packet as orchestration state. Do not edit workflow tables directly.
 
-- `issue_workflow.auto_replan_on_plan_issue`
-  - Whether `PLAN_ISSUE` should trigger an automatic replan by default.
+Issue implementation flow:
 
-- `pr_feedback.sweep_interval_secs`
-  - Background interval for sweeping issue workflows with attached PRs and enqueuing `pr:N` review/fix tasks.
+1. Read the GitHub issue and existing linked PRs when the activity requires implementation.
+2. Reproduce or confirm the issue signal before changing code.
+3. Make the smallest correct code change.
+4. Run the activity validation commands that apply to the touched scope.
+5. Commit, push, and open or update a PR targeting the configured base branch.
+6. Include the issue closing line in the PR body when working from an issue.
 
-- `pr_feedback.enabled`
-  - Enables or disables automatic background PR feedback sweeping.
+PR feedback flow:
 
-- `pr_feedback.claim_stale_after_secs`
-  - Maximum age for a `feedback_claimed` placeholder before the sweeper reclaims it
-    after an interrupted enqueue path. This does not reclaim live
-    `addressing_feedback` tasks with a real `active_task_id`.
+1. Inspect top-level PR comments, inline review comments, review states, checks, and mergeability.
+2. Treat actionable feedback as blocking until it is fixed or explicitly answered with a justified response.
+3. Re-run validation after feedback-driven changes.
 
-- `repo_backlog.enabled`
-  - Enables workflow-owned GitHub backlog polling. When the workflow runtime,
-    dispatcher, and worker are enabled, GitHub issue intake is delegated to the
-    `repo_backlog` workflow instead of the legacy server poller.
+Final response:
 
-- `repo_backlog.poll_interval_secs`
-  - Background interval for requesting repo backlog scan activities.
-
-- `repo_backlog.batch_limit`
-  - Maximum configured GitHub repos considered by the repo backlog poller per tick.
-
-- `runtime_dispatch.enabled`
-  - Enables the workflow command outbox dispatcher. It is enabled by default
-    so accepted workflow commands become runtime jobs.
-
-- `runtime_dispatch.interval_secs`
-  - Background interval for converting pending workflow commands into runtime jobs.
-
-- `runtime_dispatch.batch_limit`
-  - Maximum command outbox rows dispatched per tick.
-
-- `runtime_dispatch.runtime_kind`
-  - Runtime kind for newly created runtime jobs. Supported values are
-    `codex_exec`, `codex_jsonrpc`, `claude_code`, `anthropic_api`, and
-    `remote_host`.
-
-- `runtime_dispatch.runtime_profile`
-  - Runtime profile name stored on newly created runtime jobs.
-
-- `runtime_worker.enabled`
-  - Enables the server-owned runtime job worker. It is enabled by default so
-    pending runtime jobs are claimed and executed by registered runtime agents.
-
-- `runtime_worker.interval_secs`
-  - Background interval for claiming pending runtime jobs.
-
-- `runtime_worker.concurrency`
-  - Number of runtime job claims attempted per worker tick.
-
-- `runtime_worker.lease_ttl_secs`
-  - Lease duration recorded on claimed runtime jobs.
-
-- `runtime_retry_policy.max_failed_activity_retries`
-  - Optional global retry budget for failed workflow runtime activities. When
-    unset or zero, failed runtime activities fail the workflow immediately.
-
-- `runtime_retry_policy.activity_retries.<activity>.max_failed_activity_retries`
-  - Optional activity-specific retry budget that overrides the global runtime
-    activity retry budget for that activity.
-
-- `storage.schema_namespace`
-  - Stable namespace used for workflow persistence in Postgres so multiple instances do not split by local `data_dir` path.
+- Include changed files, validation commands, and remaining blockers.
+- End with a fenced `harness-activity-result` JSON block matching the prompt packet schema.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -12,7 +12,7 @@ base:
 workspace:
   strategy: worktree
   branch_prefix: harness/
-  reuse_existing_workspace: false
+  reuse_existing_workspace: true
   cleanup: on_terminal
 hooks:
   timeout_secs: 60

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -33,6 +33,7 @@ runtime_dispatch:
   batch_limit: 25
   runtime_kind: codex_jsonrpc
   runtime_profile: codex-default
+  approval_policy: never
 runtime_worker:
   enabled: true
   interval_secs: 5

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -43,6 +43,21 @@ impl AdapterState {
         self.next_id += 1;
         id
     }
+
+    fn child_ready(&self) -> bool {
+        self.child.is_some() && self.stdin.is_some() && self.stdout_lines.is_some()
+    }
+
+    async fn reset_child(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+        self.stdin = None;
+        self.stdout_lines = None;
+        self.thread_id = None;
+        self.active_turn_id = None;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -146,8 +161,14 @@ impl CodexAdapter {
         req: &TurnRequest,
         state: &mut AdapterState,
     ) -> harness_core::error::Result<()> {
-        if state.child.is_some() {
+        if state.child_ready() {
             return Ok(());
+        }
+        if state.child.is_some() {
+            tracing::warn!(
+                "codex app-server state is incomplete; restarting before starting a new turn"
+            );
+            state.reset_child().await;
         }
 
         let mut cmd = tokio::process::Command::new(&self.cli_path);
@@ -937,5 +958,27 @@ mod tests {
         adapter.clear_active_turn_id().await;
 
         assert_eq!(adapter.state.lock().await.active_turn_id, None);
+    }
+
+    #[tokio::test]
+    async fn adapter_state_reports_incomplete_child_when_stdout_reader_is_missing() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("sleep process should spawn");
+        let stdout = child.stdout.take().expect("stdout should be piped");
+        let stdin = child.stdin.take().expect("stdin should be piped");
+        let mut state = AdapterState::new();
+        state.child = Some(child);
+        state.stdin = Some(stdin);
+        state.stdout_lines = Some(BufReader::new(stdout).lines());
+
+        assert!(state.child_ready());
+        state.stdout_lines = None;
+        assert!(!state.child_ready());
+
+        state.reset_child().await;
     }
 }

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -2,6 +2,82 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowDocument {
+    #[serde(default)]
+    pub config: WorkflowConfig,
+    #[serde(default)]
+    pub prompt_template: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowIdentityPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default = "default_workflow_version")]
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowSourcePolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub active_labels: Vec<String>,
+    #[serde(default)]
+    pub ignore_labels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowBasePolicy {
+    #[serde(default = "default_base_remote")]
+    pub remote: String,
+    #[serde(default = "default_base_branch")]
+    pub branch: String,
+    #[serde(default = "default_true")]
+    pub require_remote_head: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowWorkspacePolicy {
+    #[serde(default = "default_workspace_strategy")]
+    pub strategy: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root: Option<String>,
+    #[serde(default = "default_workspace_branch_prefix")]
+    pub branch_prefix: String,
+    #[serde(default)]
+    pub reuse_existing_workspace: bool,
+    #[serde(default = "default_workspace_cleanup")]
+    pub cleanup: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowHooksPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_create: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_run: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_run: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_remove: Option<String>,
+    #[serde(default = "default_hook_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowActivityPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub validation: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueWorkflowPolicy {
     #[serde(default = "default_force_execute_label")]
@@ -134,6 +210,16 @@ pub struct RuntimeActivityRetryPolicy {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkflowConfig {
     #[serde(default)]
+    pub workflow: WorkflowIdentityPolicy,
+    #[serde(default)]
+    pub source: WorkflowSourcePolicy,
+    #[serde(default)]
+    pub base: WorkflowBasePolicy,
+    #[serde(default)]
+    pub workspace: WorkflowWorkspacePolicy,
+    #[serde(default)]
+    pub hooks: WorkflowHooksPolicy,
+    #[serde(default)]
     pub issue_workflow: IssueWorkflowPolicy,
     #[serde(default)]
     pub repo_backlog: RepoBacklogPolicy,
@@ -147,6 +233,8 @@ pub struct WorkflowConfig {
     pub runtime_retry_policy: RuntimeRetryPolicy,
     #[serde(default)]
     pub storage: WorkflowStoragePolicy,
+    #[serde(default)]
+    pub activities: BTreeMap<String, WorkflowActivityPolicy>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -225,6 +313,77 @@ impl Default for WorkflowStoragePolicy {
     }
 }
 
+impl Default for WorkflowIdentityPolicy {
+    fn default() -> Self {
+        Self {
+            id: None,
+            version: default_workflow_version(),
+        }
+    }
+}
+
+impl Default for WorkflowBasePolicy {
+    fn default() -> Self {
+        Self {
+            remote: default_base_remote(),
+            branch: default_base_branch(),
+            require_remote_head: true,
+        }
+    }
+}
+
+impl Default for WorkflowWorkspacePolicy {
+    fn default() -> Self {
+        Self {
+            strategy: default_workspace_strategy(),
+            root: None,
+            branch_prefix: default_workspace_branch_prefix(),
+            reuse_existing_workspace: false,
+            cleanup: default_workspace_cleanup(),
+        }
+    }
+}
+
+impl Default for WorkflowHooksPolicy {
+    fn default() -> Self {
+        Self {
+            after_create: None,
+            before_run: None,
+            after_run: None,
+            before_remove: None,
+            timeout_secs: default_hook_timeout_secs(),
+        }
+    }
+}
+
+fn default_workflow_version() -> u32 {
+    1
+}
+
+fn default_base_remote() -> String {
+    "origin".to_string()
+}
+
+fn default_base_branch() -> String {
+    "main".to_string()
+}
+
+fn default_workspace_strategy() -> String {
+    "worktree".to_string()
+}
+
+fn default_workspace_branch_prefix() -> String {
+    "harness/".to_string()
+}
+
+fn default_workspace_cleanup() -> String {
+    "on_terminal".to_string()
+}
+
+fn default_hook_timeout_secs() -> u64 {
+    60
+}
+
 fn default_force_execute_label() -> String {
     "force-execute".to_string()
 }
@@ -286,32 +445,50 @@ fn default_true() -> bool {
 /// Only the YAML front matter is parsed. Missing files or missing front matter
 /// fall back to defaults.
 pub fn load_workflow_config(project_root: &Path) -> anyhow::Result<WorkflowConfig> {
+    load_workflow_document(project_root).map(|document| document.config)
+}
+
+/// Load the workflow policy and prompt template from `{project_root}/WORKFLOW.md`.
+///
+/// Missing files fall back to defaults with an empty prompt template. Files
+/// without front matter use default config and treat the whole body as the
+/// repository workflow prompt template.
+pub fn load_workflow_document(project_root: &Path) -> anyhow::Result<WorkflowDocument> {
     let path = project_root.join("WORKFLOW.md");
     let contents = match std::fs::read_to_string(&path) {
         Ok(contents) => contents,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(WorkflowConfig::default()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(WorkflowDocument::default());
+        }
         Err(e) => return Err(e.into()),
     };
 
-    let Some(front_matter) = extract_front_matter(&contents) else {
-        return Ok(WorkflowConfig::default());
+    let (front_matter, prompt_template) = split_front_matter_and_body(&contents);
+    let config = match front_matter {
+        None => WorkflowConfig::default(),
+        Some(front_matter) if front_matter.trim().is_empty() => WorkflowConfig::default(),
+        Some(front_matter) => serde_yaml::from_str(front_matter).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to parse workflow front matter at {}: {e}",
+                path.display()
+            )
+        })?,
     };
-    if front_matter.trim().is_empty() {
-        return Ok(WorkflowConfig::default());
-    }
 
-    serde_yaml::from_str(front_matter).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to parse workflow front matter at {}: {e}",
-            path.display()
-        )
+    Ok(WorkflowDocument {
+        config,
+        prompt_template: prompt_template.trim().to_string(),
+        source_path: Some(path.display().to_string()),
     })
 }
 
-fn extract_front_matter(contents: &str) -> Option<&str> {
+fn split_front_matter_and_body(contents: &str) -> (Option<&str>, &str) {
     let rest = contents
         .strip_prefix("---\r\n")
-        .or_else(|| contents.strip_prefix("---\n"))?;
+        .or_else(|| contents.strip_prefix("---\n"));
+    let Some(rest) = rest else {
+        return (None, contents);
+    };
 
     let mut search_start = 0;
     while let Some(relative_idx) = rest[search_start..].find("---") {
@@ -322,16 +499,19 @@ fn extract_front_matter(contents: &str) -> Option<&str> {
             after.starts_with("\r\n") || after.starts_with('\n') || after.is_empty();
         if at_line_start && delimiter_ends_line {
             let front_matter = &rest[..idx];
-            return Some(
-                front_matter
-                    .strip_suffix("\r\n")
-                    .or_else(|| front_matter.strip_suffix('\n'))
-                    .unwrap_or(front_matter),
-            );
+            let front_matter = front_matter
+                .strip_suffix("\r\n")
+                .or_else(|| front_matter.strip_suffix('\n'))
+                .unwrap_or(front_matter);
+            let body = after
+                .strip_prefix("\r\n")
+                .or_else(|| after.strip_prefix('\n'))
+                .unwrap_or(after);
+            return (Some(front_matter), body);
         }
         search_start = idx + 3;
     }
-    None
+    (None, contents)
 }
 
 #[cfg(test)]
@@ -342,6 +522,25 @@ mod tests {
     fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let cfg = load_workflow_config(dir.path())?;
+        assert_eq!(cfg.workflow.version, 1);
+        assert_eq!(cfg.workflow.id, None);
+        assert_eq!(cfg.source.kind, None);
+        assert_eq!(cfg.source.repo, None);
+        assert!(cfg.source.active_labels.is_empty());
+        assert!(cfg.source.ignore_labels.is_empty());
+        assert_eq!(cfg.base.remote, "origin");
+        assert_eq!(cfg.base.branch, "main");
+        assert!(cfg.base.require_remote_head);
+        assert_eq!(cfg.workspace.strategy, "worktree");
+        assert_eq!(cfg.workspace.root, None);
+        assert_eq!(cfg.workspace.branch_prefix, "harness/");
+        assert!(!cfg.workspace.reuse_existing_workspace);
+        assert_eq!(cfg.workspace.cleanup, "on_terminal");
+        assert_eq!(cfg.hooks.after_create, None);
+        assert_eq!(cfg.hooks.before_run, None);
+        assert_eq!(cfg.hooks.after_run, None);
+        assert_eq!(cfg.hooks.before_remove, None);
+        assert_eq!(cfg.hooks.timeout_secs, 60);
         assert_eq!(cfg.issue_workflow.force_execute_label, "force-execute");
         assert!(cfg.pr_feedback.enabled);
         assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
@@ -371,6 +570,7 @@ mod tests {
         assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
         assert_eq!(cfg.storage.schema_namespace, "workflow");
         assert!(!cfg.issue_workflow.require_human_gate_before_merge);
+        assert!(cfg.activities.is_empty());
         Ok(())
     }
 
@@ -380,6 +580,32 @@ mod tests {
         std::fs::write(
             dir.path().join("WORKFLOW.md"),
             r#"---
+workflow:
+  id: github_issue_pr
+  version: 2
+source:
+  kind: github
+  repo: owner/repo
+  active_labels:
+    - ready
+  ignore_labels:
+    - wontfix
+base:
+  remote: upstream
+  branch: trunk
+  require_remote_head: false
+workspace:
+  strategy: worktree
+  root: /tmp/harness-workspaces
+  branch_prefix: task/
+  reuse_existing_workspace: true
+  cleanup: never
+hooks:
+  after_create: echo after-create
+  before_run: echo before-run
+  after_run: echo after-run
+  before_remove: echo before-remove
+  timeout_secs: 9
 issue_workflow:
   force_execute_label: do-not-second-guess
   auto_replan_on_plan_issue: false
@@ -441,6 +667,11 @@ runtime_retry_policy:
       max_retry_delay_secs: 60
 storage:
   schema_namespace: orchestration
+activities:
+  implement_issue:
+    prompt: issue-default
+    validation:
+      - cargo check
 ---
 
 Body
@@ -448,6 +679,31 @@ Body
         )?;
 
         let cfg = load_workflow_config(dir.path())?;
+        assert_eq!(cfg.workflow.id.as_deref(), Some("github_issue_pr"));
+        assert_eq!(cfg.workflow.version, 2);
+        assert_eq!(cfg.source.kind.as_deref(), Some("github"));
+        assert_eq!(cfg.source.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(cfg.source.active_labels, vec!["ready"]);
+        assert_eq!(cfg.source.ignore_labels, vec!["wontfix"]);
+        assert_eq!(cfg.base.remote, "upstream");
+        assert_eq!(cfg.base.branch, "trunk");
+        assert!(!cfg.base.require_remote_head);
+        assert_eq!(cfg.workspace.strategy, "worktree");
+        assert_eq!(
+            cfg.workspace.root.as_deref(),
+            Some("/tmp/harness-workspaces")
+        );
+        assert_eq!(cfg.workspace.branch_prefix, "task/");
+        assert!(cfg.workspace.reuse_existing_workspace);
+        assert_eq!(cfg.workspace.cleanup, "never");
+        assert_eq!(cfg.hooks.after_create.as_deref(), Some("echo after-create"));
+        assert_eq!(cfg.hooks.before_run.as_deref(), Some("echo before-run"));
+        assert_eq!(cfg.hooks.after_run.as_deref(), Some("echo after-run"));
+        assert_eq!(
+            cfg.hooks.before_remove.as_deref(),
+            Some("echo before-remove")
+        );
+        assert_eq!(cfg.hooks.timeout_secs, 9);
         assert_eq!(
             cfg.issue_workflow.force_execute_label,
             "do-not-second-guess"
@@ -559,6 +815,41 @@ Body
             Some(60)
         );
         assert_eq!(cfg.storage.schema_namespace, "orchestration");
+        let activity = cfg
+            .activities
+            .get("implement_issue")
+            .expect("activity should parse");
+        assert_eq!(activity.prompt.as_deref(), Some("issue-default"));
+        assert_eq!(activity.validation, vec!["cargo check"]);
+        Ok(())
+    }
+
+    #[test]
+    fn load_workflow_document_reads_prompt_template_body() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            "---\nworkflow:\n  id: prompt-test\n---\nUse issue {{ issue.number }}.\n",
+        )?;
+
+        let document = load_workflow_document(dir.path())?;
+        assert_eq!(document.config.workflow.id.as_deref(), Some("prompt-test"));
+        assert_eq!(document.prompt_template, "Use issue {{ issue.number }}.");
+        assert!(document
+            .source_path
+            .as_deref()
+            .is_some_and(|path| { path.ends_with("WORKFLOW.md") }));
+        Ok(())
+    }
+
+    #[test]
+    fn load_workflow_document_uses_body_as_prompt_without_front_matter() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("WORKFLOW.md"), "Plain prompt\n")?;
+
+        let document = load_workflow_document(dir.path())?;
+        assert_eq!(document.config.base.branch, "main");
+        assert_eq!(document.prompt_template, "Plain prompt");
         Ok(())
     }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1583,6 +1583,10 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
     let dir = tempfile::tempdir()?;
     let project_root = dir.path().join("project");
     std::fs::create_dir_all(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nworkspace:\n  strategy: source\n---\n",
+    )?;
     let agent = RuntimeStreamAgent::new();
     let mut registry = harness_agents::registry::AgentRegistry::new("codex");
     registry.register("codex", agent.clone());
@@ -2535,6 +2539,10 @@ async fn runtime_job_worker_applies_runtime_profile_timeout() -> anyhow::Result<
     let dir = tempfile::tempdir()?;
     let project_root = dir.path().join("project");
     std::fs::create_dir_all(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nworkspace:\n  strategy: source\n---\n",
+    )?;
     let mut registry = harness_agents::registry::AgentRegistry::new("codex");
     registry.register("codex", BlockingAgent::new());
     let state =

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -54,7 +54,7 @@ pub(crate) async fn request_repo_backlog_poll(
     ctx: RepoBacklogPollRuntimeContext<'_>,
 ) -> anyhow::Result<RepoBacklogPollRequestOutcome> {
     let instance = load_or_repo_backlog_instance(store, ctx.project_root, ctx.repo).await?;
-    if instance.state != "idle" {
+    if !repo_backlog_poll_candidate_state(&instance.state) {
         return Ok(RepoBacklogPollRequestOutcome::NotCandidate {
             workflow_id: instance.id,
             state: instance.state,
@@ -66,6 +66,10 @@ pub(crate) async fn request_repo_backlog_poll(
         });
     }
     persist_repo_backlog_poll_request(store, instance, &ctx).await
+}
+
+fn repo_backlog_poll_candidate_state(state: &str) -> bool {
+    matches!(state, "idle" | "failed")
 }
 
 pub(crate) async fn record_open_issue_without_workflow(
@@ -359,11 +363,9 @@ async fn apply_decision_with_outcome(
     decision: WorkflowDecision,
     event_id: Option<String>,
 ) -> anyhow::Result<ApplyDecisionOutcome> {
-    let validation = DecisionValidator::repo_backlog().validate(
-        &instance,
-        &decision,
-        &ValidationContext::new("workflow-policy", chrono::Utc::now()),
-    );
+    let validation_context = repo_backlog_validation_context(&instance, &decision);
+    let validation =
+        DecisionValidator::repo_backlog().validate(&instance, &decision, &validation_context);
     let record = match validation {
         Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), event_id),
         Err(error) => {
@@ -388,6 +390,20 @@ async fn apply_decision_with_outcome(
     let workflow_id = instance.id.clone();
     store.upsert_instance(&instance).await?;
     Ok(ApplyDecisionOutcome::Accepted { workflow_id })
+}
+
+fn repo_backlog_validation_context(
+    instance: &WorkflowInstance,
+    decision: &WorkflowDecision,
+) -> ValidationContext {
+    let context = ValidationContext::new("workflow-policy", chrono::Utc::now());
+    if instance.state == "failed"
+        && decision.decision == "poll_repo_backlog"
+        && decision.next_state == "scanning"
+    {
+        return context.allow_terminal_reopen();
+    }
+    context
 }
 
 async fn has_active_repo_backlog_poll_command(
@@ -545,10 +561,39 @@ mod tests {
         assert_eq!(
             second,
             RepoBacklogPollRequestOutcome::NotCandidate {
-                workflow_id,
+                workflow_id: workflow_id.clone(),
                 state: "scanning".to_string()
             }
         );
+        store.mark_command_status(&commands[0].id, "failed").await?;
+        let mut failed_instance = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("repo backlog workflow instance should still exist");
+        failed_instance.state = "failed".to_string();
+        store.upsert_instance(&failed_instance).await?;
+
+        let retry = request_repo_backlog_poll(
+            &store,
+            RepoBacklogPollRuntimeContext {
+                project_root: &project_root,
+                repo: Some("owner/repo"),
+                label: Some("harness"),
+            },
+        )
+        .await?;
+        assert_eq!(
+            retry,
+            RepoBacklogPollRequestOutcome::Requested {
+                workflow_id: workflow_id.clone()
+            }
+        );
+        let retry_instance = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("repo backlog workflow instance should still be persisted");
+        assert_eq!(retry_instance.state, "scanning");
+        assert_eq!(store.commands_for(&workflow_id).await?.len(), 2);
         Ok(())
     }
 

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Duration;
 use harness_core::config::agents::SandboxMode;
+use harness_core::config::workflow::WorkflowDocument;
 use harness_core::types::{AgentId, Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
     build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
@@ -20,6 +21,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tokio::time::{timeout, Duration as TokioDuration};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RuntimeJobWorkerTick {
@@ -211,6 +213,15 @@ struct ServerRuntimeJobExecutor {
     state: Arc<AppState>,
 }
 
+struct PreparedRuntimeWorkspace {
+    run_project: PathBuf,
+    task_id: Option<TaskId>,
+    after_run_hook: Option<String>,
+    before_remove_hook: Option<String>,
+    hook_timeout_secs: u64,
+    cleanup: String,
+}
+
 impl ServerRuntimeJobExecutor {
     fn new(state: Arc<AppState>) -> Self {
         Self { state }
@@ -224,7 +235,9 @@ impl ServerRuntimeJobExecutor {
         {
             return Ok(result);
         }
-        let project_root = self.project_root_for_job(&job, workflow.as_ref())?;
+        let source_project_root = self.project_root_for_job(&job, workflow.as_ref())?;
+        let workflow_document =
+            harness_core::config::workflow::load_workflow_document(&source_project_root)?;
         let agent_name = agent_name_for_runtime_kind(job.runtime_kind)?;
         if self
             .state
@@ -244,61 +257,108 @@ impl ServerRuntimeJobExecutor {
         if let PromptTaskRequest::PayloadUnavailable { prompt_ref } = &prompt_task_request {
             return Ok(prompt_payload_unavailable_result(&job, prompt_ref));
         }
-        let prompt_packet =
-            build_runtime_prompt_packet(&job, workflow.as_ref(), &project_root, &runtime_profile);
-        let prompt_packet_digest = prompt_packet_digest(&prompt_packet);
-        self.record_prompt_packet_prepared(&job, &prompt_packet, &prompt_packet_digest)
+
+        let runtime_workspace = self
+            .prepare_runtime_workspace(
+                &job,
+                workflow.as_ref(),
+                &source_project_root,
+                &workflow_document,
+            )
             .await?;
-        let prompt = build_runtime_job_prompt(&prompt_packet, prompt_task_request.prompt_text());
-        let thread_id = self
-            .state
-            .core
-            .server
-            .thread_manager
-            .start_thread(project_root.clone());
-        let turn_id = self.state.core.server.thread_manager.start_turn(
-            &thread_id,
-            prompt.clone(),
-            AgentId::from_str(agent_name),
-        )?;
-        persist_created_thread(&self.state, &thread_id).await;
+        let activity_result: anyhow::Result<ActivityResult> = async {
+            let project_root = runtime_workspace.run_project.clone();
+            let prompt_packet = build_runtime_prompt_packet(
+                &job,
+                workflow.as_ref(),
+                &project_root,
+                &source_project_root,
+                &runtime_profile,
+                &workflow_document,
+            );
+            let prompt_packet_digest = prompt_packet_digest(&prompt_packet);
+            self.record_prompt_packet_prepared(&job, &prompt_packet, &prompt_packet_digest)
+                .await?;
+            let prompt =
+                build_runtime_job_prompt(&prompt_packet, prompt_task_request.prompt_text());
+            let thread_id = self
+                .state
+                .core
+                .server
+                .thread_manager
+                .start_thread(project_root.clone());
+            let turn_id = self.state.core.server.thread_manager.start_turn(
+                &thread_id,
+                prompt.clone(),
+                AgentId::from_str(agent_name),
+            )?;
+            persist_created_thread(&self.state, &thread_id).await;
 
-        crate::task_executor::turn_lifecycle::run_turn_lifecycle_with_options(
-            self.state.core.server.clone(),
-            self.state.core.thread_db.clone(),
-            self.state.notifications.notify_tx.clone(),
-            self.state.notifications.notification_tx.clone(),
-            thread_id.clone(),
-            turn_id.clone(),
-            prompt,
-            agent_name.to_string(),
-            TurnLifecycleOptions {
-                model: runtime_profile.model.clone(),
-                reasoning_effort: runtime_profile.reasoning_effort.clone(),
-                sandbox_mode,
-                approval_policy,
-                timeout_secs: runtime_profile.timeout_secs,
-            },
-        )
+            crate::task_executor::turn_lifecycle::run_turn_lifecycle_with_options(
+                self.state.core.server.clone(),
+                self.state.core.thread_db.clone(),
+                self.state.notifications.notify_tx.clone(),
+                self.state.notifications.notification_tx.clone(),
+                thread_id.clone(),
+                turn_id.clone(),
+                prompt,
+                agent_name.to_string(),
+                TurnLifecycleOptions {
+                    model: runtime_profile.model.clone(),
+                    reasoning_effort: runtime_profile.reasoning_effort.clone(),
+                    sandbox_mode,
+                    approval_policy,
+                    timeout_secs: runtime_profile.timeout_secs,
+                },
+            )
+            .await;
+
+            let turn = self
+                .state
+                .core
+                .server
+                .thread_manager
+                .get_turn(&thread_id, &turn_id)
+                .ok_or_else(|| anyhow::anyhow!("runtime turn disappeared before completion"))?;
+            Ok(activity_result_from_turn(
+                &job,
+                &turn.status,
+                &turn.items,
+                &thread_id,
+                &turn_id,
+                agent_name,
+                &project_root,
+                &prompt_packet_digest,
+            ))
+        }
         .await;
-
-        let turn = self
-            .state
-            .core
-            .server
-            .thread_manager
-            .get_turn(&thread_id, &turn_id)
-            .ok_or_else(|| anyhow::anyhow!("runtime turn disappeared before completion"))?;
-        Ok(activity_result_from_turn(
-            &job,
-            &turn.status,
-            &turn.items,
-            &thread_id,
-            &turn_id,
-            agent_name,
-            &project_root,
-            &prompt_packet_digest,
-        ))
+        let finish_result = self.finish_runtime_workspace(&runtime_workspace).await;
+        match (activity_result, finish_result) {
+            (Ok(mut result), Err(error)) => {
+                tracing::warn!(
+                    runtime_job_id = %job.id,
+                    workspace_path = %runtime_workspace.run_project.display(),
+                    "runtime workspace finalization failed: {error}"
+                );
+                result = result.with_artifact(ActivityArtifact::new(
+                    "runtime_workspace_finalization_warning",
+                    json!({ "error": error.to_string() }),
+                ));
+                Ok(result)
+            }
+            (Ok(result), Ok(())) => Ok(result),
+            (Err(error), Err(finish_error)) => {
+                tracing::warn!(
+                    runtime_job_id = %job.id,
+                    workspace_path = %runtime_workspace.run_project.display(),
+                    "runtime workspace finalization failed after runtime error: {finish_error}"
+                );
+                Err(error.context(format!(
+                    "runtime workspace finalization also failed: {finish_error}"
+                )))
+            }
+            (Err(error), Ok(())) => Err(error),
+        }
     }
 
     async fn workflow_for_job(&self, job: &RuntimeJob) -> anyhow::Result<Option<WorkflowInstance>> {
@@ -856,6 +916,184 @@ impl ServerRuntimeJobExecutor {
         }
         Ok(self.state.core.project_root.clone())
     }
+
+    async fn prepare_runtime_workspace(
+        &self,
+        job: &RuntimeJob,
+        workflow: Option<&WorkflowInstance>,
+        source_project_root: &Path,
+        workflow_document: &WorkflowDocument,
+    ) -> anyhow::Result<PreparedRuntimeWorkspace> {
+        validate_workspace_cleanup_policy(&workflow_document.config.workspace.cleanup)?;
+        match workflow_document.config.workspace.strategy.as_str() {
+            "worktree" => {}
+            "source" => {
+                if let Some(hook) = workflow_document.config.hooks.before_run.as_deref() {
+                    run_workflow_hook(
+                        "before_run",
+                        hook,
+                        source_project_root,
+                        workflow_document.config.hooks.timeout_secs,
+                    )
+                    .await?;
+                }
+                return Ok(PreparedRuntimeWorkspace {
+                    run_project: source_project_root.to_path_buf(),
+                    task_id: None,
+                    after_run_hook: workflow_document.config.hooks.after_run.clone(),
+                    before_remove_hook: None,
+                    hook_timeout_secs: workflow_document.config.hooks.timeout_secs,
+                    cleanup: workflow_document.config.workspace.cleanup.clone(),
+                });
+            }
+            strategy => anyhow::bail!("unsupported workflow workspace strategy: {strategy}"),
+        }
+
+        let Some(workspace_mgr) = self.state.concurrency.workspace_mgr.as_ref() else {
+            anyhow::bail!("workflow runtime workspace manager is unavailable");
+        };
+        let task_id = TaskId::from_str(&format!("runtime-job-{}", job.id));
+        let external_id = workflow.map(|workflow| workflow.subject.subject_key.as_str());
+        let repo = workflow
+            .and_then(|workflow| workflow.data.get("repo"))
+            .and_then(Value::as_str)
+            .or_else(|| job.input.get("repo").and_then(Value::as_str))
+            .or(workflow_document.config.source.repo.as_deref());
+        let options = crate::workspace::WorkspaceCreateOptions {
+            require_remote_head: workflow_document.config.base.require_remote_head,
+            reuse_existing_workspace: workflow_document.config.workspace.reuse_existing_workspace,
+            after_create_hook: workflow_document.config.hooks.after_create.clone(),
+            hook_timeout_secs: Some(workflow_document.config.hooks.timeout_secs),
+            branch_prefix: workflow_document.config.workspace.branch_prefix.clone(),
+        };
+        let lease = workspace_mgr
+            .create_workspace_with_options(
+                &task_id,
+                source_project_root,
+                &workflow_document.config.base.remote,
+                &workflow_document.config.base.branch,
+                1,
+                external_id,
+                repo,
+                options,
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+        if let Some(hook) = workflow_document.config.hooks.before_run.as_deref() {
+            if let Err(error) = run_workflow_hook(
+                "before_run",
+                hook,
+                &lease.workspace_path,
+                workflow_document.config.hooks.timeout_secs,
+            )
+            .await
+            {
+                if let Some(hook) = workflow_document.config.hooks.before_remove.as_deref() {
+                    if let Err(remove_hook_error) = run_workflow_hook(
+                        "before_remove",
+                        hook,
+                        &lease.workspace_path,
+                        workflow_document.config.hooks.timeout_secs,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            runtime_job_id = %job.id,
+                            workspace_path = %lease.workspace_path.display(),
+                            "before_remove hook failed during before_run cleanup: {remove_hook_error}"
+                        );
+                    }
+                }
+                if let Err(cleanup_error) = workspace_mgr.remove_workspace(&task_id).await {
+                    tracing::warn!(
+                        runtime_job_id = %job.id,
+                        workspace_path = %lease.workspace_path.display(),
+                        "failed to clean up workspace after before_run hook failure: {cleanup_error}"
+                    );
+                }
+                return Err(error);
+            }
+        }
+
+        Ok(PreparedRuntimeWorkspace {
+            run_project: lease.workspace_path,
+            task_id: Some(task_id),
+            after_run_hook: workflow_document.config.hooks.after_run.clone(),
+            before_remove_hook: workflow_document.config.hooks.before_remove.clone(),
+            hook_timeout_secs: workflow_document.config.hooks.timeout_secs,
+            cleanup: workflow_document.config.workspace.cleanup.clone(),
+        })
+    }
+
+    async fn finish_runtime_workspace(
+        &self,
+        workspace: &PreparedRuntimeWorkspace,
+    ) -> anyhow::Result<()> {
+        let hook_result = if let Some(hook) = workspace.after_run_hook.as_deref() {
+            run_workflow_hook(
+                "after_run",
+                hook,
+                &workspace.run_project,
+                workspace.hook_timeout_secs,
+            )
+            .await
+        } else {
+            Ok(())
+        };
+
+        let Some(task_id) = workspace.task_id.as_ref() else {
+            return hook_result;
+        };
+        let Some(workspace_mgr) = self.state.concurrency.workspace_mgr.as_ref() else {
+            return hook_result;
+        };
+        if workspace.cleanup == "after_run" {
+            if let Some(hook) = workspace.before_remove_hook.as_deref() {
+                if let Err(error) = run_workflow_hook(
+                    "before_remove",
+                    hook,
+                    &workspace.run_project,
+                    workspace.hook_timeout_secs,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        workspace_path = %workspace.run_project.display(),
+                        "before_remove hook failed during runtime workspace cleanup: {error}"
+                    );
+                }
+            }
+            workspace_mgr.remove_workspace(task_id).await?;
+        } else {
+            workspace_mgr.release_workspace(task_id);
+        }
+        hook_result
+    }
+}
+
+fn validate_workspace_cleanup_policy(cleanup: &str) -> anyhow::Result<()> {
+    match cleanup {
+        "after_run" | "on_terminal" => Ok(()),
+        cleanup => anyhow::bail!("unsupported workflow workspace cleanup policy: {cleanup}"),
+    }
+}
+
+async fn run_workflow_hook(
+    hook_name: &str,
+    hook: &str,
+    cwd: &Path,
+    timeout_secs: u64,
+) -> anyhow::Result<()> {
+    let hook_timeout = TokioDuration::from_secs(timeout_secs.max(1));
+    match timeout(hook_timeout, crate::workspace::run_hook(hook, cwd)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(anyhow::anyhow!("{hook_name} hook failed: {error}")),
+        Err(_) => Err(anyhow::anyhow!(
+            "{hook_name} hook timed out after {}s",
+            hook_timeout.as_secs()
+        )),
+    }
 }
 
 fn is_active_pr_feedback_inspect_command(record: &WorkflowCommandRecord) -> bool {
@@ -913,7 +1151,9 @@ fn build_runtime_prompt_packet(
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
     project_root: &Path,
+    source_project_root: &Path,
     runtime_profile: &RuntimeProfile,
+    workflow_document: &WorkflowDocument,
 ) -> Value {
     json!({
         "schema": "harness.runtime.prompt_packet.v1",
@@ -927,6 +1167,7 @@ fn build_runtime_prompt_packet(
         "runtime_profile": runtime_profile,
         "project": {
             "root": project_root.display().to_string(),
+            "source_root": source_project_root.display().to_string(),
             "repo": workflow
                 .and_then(|workflow| workflow.data.get("repo"))
                 .and_then(Value::as_str)
@@ -944,6 +1185,11 @@ fn build_runtime_prompt_packet(
                 "data": workflow.data,
             })
         }),
+        "workflow_file": {
+            "source_path": &workflow_document.source_path,
+            "config": &workflow_document.config,
+            "prompt_template": &workflow_document.prompt_template,
+        },
         "command_input": job.input,
         "runtime_contract": {
             "orchestration_source": "workflow_database",
@@ -1002,6 +1248,16 @@ fn build_runtime_job_prompt(prompt_packet: &Value, prompt_task_request: Option<&
     if let Some(prompt_task_request) = prompt_task_request {
         prompt.push_str("\nPrompt task request:\n");
         prompt.push_str(prompt_task_request);
+        prompt.push('\n');
+    }
+    if let Some(template) = prompt_packet
+        .get("workflow_file")
+        .and_then(|workflow_file| workflow_file.get("prompt_template"))
+        .and_then(Value::as_str)
+        .filter(|template| !template.trim().is_empty())
+    {
+        prompt.push_str("\nRepository workflow prompt template:\n");
+        prompt.push_str(template);
         prompt.push('\n');
     }
     prompt
@@ -2069,6 +2325,44 @@ mod tests {
             .expect("allowed transitions should be an array")
             .iter()
             .any(|transition| transition["next_state"] == "feedback_found"));
+    }
+
+    #[test]
+    fn runtime_prompt_packet_includes_workflow_file_contract() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue",
+                "runtime_profile": RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc)
+            }),
+        );
+        let workflow_document = WorkflowDocument {
+            prompt_template: "Follow the repository workflow prompt.".to_string(),
+            source_path: Some("/repo/WORKFLOW.md".to_string()),
+            ..Default::default()
+        };
+        let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+
+        let packet = build_runtime_prompt_packet(
+            &job,
+            None,
+            Path::new("/workspaces/job-1"),
+            Path::new("/repo"),
+            &runtime_profile,
+            &workflow_document,
+        );
+        assert_eq!(packet["project"]["root"], "/workspaces/job-1");
+        assert_eq!(packet["project"]["source_root"], "/repo");
+        assert_eq!(
+            packet["workflow_file"]["prompt_template"],
+            "Follow the repository workflow prompt."
+        );
+
+        let prompt = build_runtime_job_prompt(&packet, None);
+        assert!(prompt.contains("Repository workflow prompt template:"));
+        assert!(prompt.contains("Follow the repository workflow prompt."));
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -15,7 +15,8 @@ use harness_workflow::runtime::{
     WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
     PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
     QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
-    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID,
+    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -219,7 +220,13 @@ struct PreparedRuntimeWorkspace {
     after_run_hook: Option<String>,
     before_remove_hook: Option<String>,
     hook_timeout_secs: u64,
-    cleanup: String,
+    finish_action: RuntimeWorkspaceFinishAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeWorkspaceFinishAction {
+    Remove,
+    Release,
 }
 
 impl ServerRuntimeJobExecutor {
@@ -943,7 +950,7 @@ impl ServerRuntimeJobExecutor {
                     after_run_hook: workflow_document.config.hooks.after_run.clone(),
                     before_remove_hook: None,
                     hook_timeout_secs: workflow_document.config.hooks.timeout_secs,
-                    cleanup: workflow_document.config.workspace.cleanup.clone(),
+                    finish_action: RuntimeWorkspaceFinishAction::Release,
                 });
             }
             strategy => anyhow::bail!("unsupported workflow workspace strategy: {strategy}"),
@@ -952,16 +959,17 @@ impl ServerRuntimeJobExecutor {
         let Some(workspace_mgr) = self.state.concurrency.workspace_mgr.as_ref() else {
             anyhow::bail!("workflow runtime workspace manager is unavailable");
         };
-        let task_id = TaskId::from_str(&format!("runtime-job-{}", job.id));
+        let task_id = stable_runtime_workspace_task_id(job, workflow);
         let external_id = workflow.map(|workflow| workflow.subject.subject_key.as_str());
         let repo = workflow
             .and_then(|workflow| workflow.data.get("repo"))
             .and_then(Value::as_str)
             .or_else(|| job.input.get("repo").and_then(Value::as_str))
             .or(workflow_document.config.source.repo.as_deref());
+        let reuse_existing_workspace = workflow_document.config.workspace.reuse_existing_workspace;
         let options = crate::workspace::WorkspaceCreateOptions {
             require_remote_head: workflow_document.config.base.require_remote_head,
-            reuse_existing_workspace: workflow_document.config.workspace.reuse_existing_workspace,
+            reuse_existing_workspace,
             after_create_hook: workflow_document.config.hooks.after_create.clone(),
             hook_timeout_secs: Some(workflow_document.config.hooks.timeout_secs),
             branch_prefix: workflow_document.config.workspace.branch_prefix.clone(),
@@ -1022,7 +1030,12 @@ impl ServerRuntimeJobExecutor {
             after_run_hook: workflow_document.config.hooks.after_run.clone(),
             before_remove_hook: workflow_document.config.hooks.before_remove.clone(),
             hook_timeout_secs: workflow_document.config.hooks.timeout_secs,
-            cleanup: workflow_document.config.workspace.cleanup.clone(),
+            finish_action: runtime_workspace_finish_action(
+                &workflow_document.config.workspace.cleanup,
+                reuse_existing_workspace,
+                job,
+                workflow,
+            ),
         })
     }
 
@@ -1048,7 +1061,7 @@ impl ServerRuntimeJobExecutor {
         let Some(workspace_mgr) = self.state.concurrency.workspace_mgr.as_ref() else {
             return hook_result;
         };
-        if workspace.cleanup == "after_run" {
+        if workspace.finish_action == RuntimeWorkspaceFinishAction::Remove {
             if let Some(hook) = workspace.before_remove_hook.as_deref() {
                 if let Err(error) = run_workflow_hook(
                     "before_remove",
@@ -1077,6 +1090,78 @@ fn validate_workspace_cleanup_policy(cleanup: &str) -> anyhow::Result<()> {
         "after_run" | "on_terminal" => Ok(()),
         cleanup => anyhow::bail!("unsupported workflow workspace cleanup policy: {cleanup}"),
     }
+}
+
+fn runtime_workspace_finish_action(
+    cleanup: &str,
+    reuse_existing_workspace: bool,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> RuntimeWorkspaceFinishAction {
+    if cleanup == "after_run"
+        || !reuse_existing_workspace
+        || runtime_workspace_activity_is_ephemeral(&activity_name(job), workflow)
+    {
+        RuntimeWorkspaceFinishAction::Remove
+    } else {
+        RuntimeWorkspaceFinishAction::Release
+    }
+}
+
+fn runtime_workspace_activity_is_ephemeral(
+    activity: &str,
+    workflow: Option<&WorkflowInstance>,
+) -> bool {
+    let Some(workflow) = workflow else {
+        return false;
+    };
+    matches!(
+        (workflow.definition_id.as_str(), activity),
+        (REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY)
+            | (
+                REPO_BACKLOG_DEFINITION_ID,
+                REPO_BACKLOG_SPRINT_PLAN_ACTIVITY
+            )
+            | (PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY)
+            | (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY)
+    )
+}
+
+fn stable_runtime_workspace_task_id(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> TaskId {
+    if let Some(workflow) = workflow {
+        let definition = sanitize_workspace_id_component(&workflow.definition_id);
+        return TaskId::from_str(&format!(
+            "runtime-wf-{definition}-{}",
+            stable_hash_8(&workflow.id)
+        ));
+    }
+    TaskId::from_str(&format!("runtime-job-{}", stable_hash_8(&job.id)))
+}
+
+fn sanitize_workspace_id_component(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    sanitized.trim_matches('-').to_string()
+}
+
+fn stable_hash_8(value: &str) -> String {
+    let mut hash: u32 = 0x811c9dc5;
+    for byte in value.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    format!("{hash:08x}")
 }
 
 async fn run_workflow_hook(
@@ -2172,6 +2257,100 @@ mod tests {
                 "repo-backlog:owner/repo:issue:43",
                 "explicit-task-id"
             ]
+        );
+    }
+
+    #[test]
+    fn stable_runtime_workspace_task_id_reuses_workflow_identity_across_jobs() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:124"),
+        )
+        .with_id("/repo/root::repo:owner/repo::issue:124");
+        let first_job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        );
+        let second_job = RuntimeJob::pending(
+            "command-2",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "inspect_pr_feedback" }),
+        );
+
+        let first = stable_runtime_workspace_task_id(&first_job, Some(&workflow));
+        let second = stable_runtime_workspace_task_id(&second_job, Some(&workflow));
+
+        assert_eq!(first, second);
+        assert!(first.as_str().starts_with("runtime-wf-github-issue-pr-"));
+        assert!(first
+            .as_str()
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-'));
+    }
+
+    #[test]
+    fn runtime_workspace_finish_action_preserves_reusable_issue_workspaces() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        );
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:124"),
+        )
+        .with_id("issue-124");
+
+        assert_eq!(
+            runtime_workspace_finish_action("on_terminal", true, &job, Some(&workflow)),
+            RuntimeWorkspaceFinishAction::Release
+        );
+    }
+
+    #[test]
+    fn runtime_workspace_finish_action_removes_ephemeral_or_non_reused_workspaces() {
+        let backlog_job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
+        );
+        let backlog = WorkflowInstance::new(
+            REPO_BACKLOG_DEFINITION_ID,
+            1,
+            "scanning",
+            WorkflowSubject::new("repo", "owner/repo"),
+        )
+        .with_id("repo-backlog-owner-repo");
+        assert_eq!(
+            runtime_workspace_finish_action("on_terminal", true, &backlog_job, Some(&backlog)),
+            RuntimeWorkspaceFinishAction::Remove
+        );
+
+        let issue_job = RuntimeJob::pending(
+            "command-2",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        );
+        let issue = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:124"),
+        )
+        .with_id("issue-124");
+        assert_eq!(
+            runtime_workspace_finish_action("on_terminal", false, &issue_job, Some(&issue)),
+            RuntimeWorkspaceFinishAction::Remove
         );
     }
 

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -51,6 +51,27 @@ pub(crate) struct ActiveWorkspace {
     pub(crate) run_generation: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceCreateOptions {
+    pub(crate) require_remote_head: bool,
+    pub(crate) reuse_existing_workspace: bool,
+    pub(crate) after_create_hook: Option<String>,
+    pub(crate) hook_timeout_secs: Option<u64>,
+    pub(crate) branch_prefix: String,
+}
+
+impl Default for WorkspaceCreateOptions {
+    fn default() -> Self {
+        Self {
+            require_remote_head: true,
+            reuse_existing_workspace: true,
+            after_create_hook: None,
+            hook_timeout_secs: None,
+            branch_prefix: "harness/".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct WorkspaceOwnerRecord {
     task_id: String,
@@ -238,6 +259,30 @@ impl WorkspaceManager {
         external_id: Option<&str>,
         repo: Option<&str>,
     ) -> Result<WorkspaceLease, WorkspaceLifecycleError> {
+        self.create_workspace_with_options(
+            task_id,
+            source_repo,
+            remote,
+            base_branch,
+            run_generation,
+            external_id,
+            repo,
+            WorkspaceCreateOptions::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn create_workspace_with_options(
+        &self,
+        task_id: &TaskId,
+        source_repo: &Path,
+        remote: &str,
+        base_branch: &str,
+        run_generation: u32,
+        external_id: Option<&str>,
+        repo: Option<&str>,
+        options: WorkspaceCreateOptions,
+    ) -> Result<WorkspaceLease, WorkspaceLifecycleError> {
         let workspace_key = derive_workspace_key(task_id, external_id, repo, Some(source_repo));
         // Validate inputs to prevent unexpected git behavior.
         if !is_valid_branch_name(base_branch) {
@@ -355,10 +400,12 @@ impl WorkspaceManager {
                 });
             }
 
-            if owner_record.as_ref().is_some_and(|record| {
-                owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
-                    && record.owner_session == owner_session
-            }) {
+            if options.reuse_existing_workspace
+                && owner_record.as_ref().is_some_and(|record| {
+                    owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
+                        && record.owner_session == owner_session
+                })
+            {
                 let owner_record = WorkspaceOwnerRecord {
                     task_id: task_id.0.clone(),
                     run_generation,
@@ -426,16 +473,38 @@ impl WorkspaceManager {
 
         if !fetch_output.status.success() {
             let stderr = String::from_utf8_lossy(&fetch_output.stderr);
-            tracing::warn!(
-                "git fetch {remote} {base_branch} failed (continuing with local): {}",
-                stderr.trim()
-            );
+            if options.require_remote_head {
+                self.remove_active_workspace(task_id);
+                return Err(WorkspaceLifecycleError::CreateFailed {
+                    workspace_path: workspace_path.clone(),
+                    workspace_owner: Some(owner_session.clone()),
+                    message: format!(
+                        "git fetch {remote} {base_branch} failed for task {}: {}",
+                        task_id.0,
+                        stderr.trim()
+                    ),
+                });
+            } else {
+                tracing::warn!(
+                    "git fetch {remote} {base_branch} failed (continuing with local): {}",
+                    stderr.trim()
+                );
+            }
         }
 
         // Create git worktree based on remote/base_branch (latest upstream).
-        // Falls back to local base_branch if fetch failed above.
+        // Falls back to local base_branch only when strict remote-head
+        // admission is disabled.
         let remote_ref = format!("{remote}/{base_branch}");
-        let branch = format!("harness/{}", task_id.0);
+        let branch = format!("{}{}", options.branch_prefix, task_id.0);
+        if !is_valid_branch_name(&branch) {
+            self.remove_active_workspace(task_id);
+            return Err(WorkspaceLifecycleError::CreateFailed {
+                workspace_path: workspace_path.clone(),
+                workspace_owner: Some(owner_session.clone()),
+                message: format!("invalid workspace branch: {branch:?}"),
+            });
+        }
         let output = match git_command()
             .args([
                 "-C",
@@ -462,6 +531,19 @@ impl WorkspaceManager {
         };
 
         if !output.status.success() {
+            if options.require_remote_head {
+                self.remove_active_workspace(task_id);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(WorkspaceLifecycleError::CreateFailed {
+                    workspace_path: workspace_path.clone(),
+                    workspace_owner: Some(owner_session.clone()),
+                    message: format!(
+                        "git worktree add from {remote_ref} failed for task {}: {}",
+                        task_id.0,
+                        stderr.trim()
+                    ),
+                });
+            }
             // Fallback: try local base_branch (useful for repos without remotes, e.g. tests).
             let fallback = match git_command()
                 .args([
@@ -527,8 +609,14 @@ impl WorkspaceManager {
         }
 
         // Run after_create_hook if set. Fatal on failure: cleanup partial worktree.
-        if let Some(hook) = &self.config.after_create_hook {
-            let timeout_secs = self.config.hook_timeout_secs;
+        let after_create_hook = options
+            .after_create_hook
+            .as_deref()
+            .or(self.config.after_create_hook.as_deref());
+        if let Some(hook) = after_create_hook {
+            let timeout_secs = options
+                .hook_timeout_secs
+                .unwrap_or(self.config.hook_timeout_secs);
             let hook_error = match timeout(
                 Duration::from_secs(timeout_secs),
                 run_hook(hook, &workspace_path),
@@ -1124,7 +1212,7 @@ fn repo_slug_from_workspace_key(key: &str) -> Option<String> {
 
 /// Returns true when the git worktree at `path` is currently on `branch`.
 /// Used to distinguish crash-recovery (same task's worktree) from a true collision.
-async fn run_hook(script: &str, cwd: &Path) -> anyhow::Result<()> {
+pub(crate) async fn run_hook(script: &str, cwd: &Path) -> anyhow::Result<()> {
     crate::post_validator::validate_command_safety(script).map_err(|e| anyhow::anyhow!("{e}"))?;
     let output = tokio::process::Command::new("sh")
         .arg("-c")
@@ -1468,6 +1556,14 @@ mod tests {
             "--allow-empty",
             "-m",
             "init",
+        ]);
+        run(&[
+            "-C",
+            &dir.to_string_lossy(),
+            "remote",
+            "add",
+            "origin",
+            &dir.to_string_lossy(),
         ]);
     }
 
@@ -1907,6 +2003,115 @@ mod tests {
             .await
             .expect("create");
         assert!(ws_path.workspace_path.is_dir());
+
+        mgr.remove_workspace(&task_id).await.expect("remove");
+    }
+
+    #[tokio::test]
+    async fn create_workspace_requires_remote_head_by_default() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+        run_git(&[
+            "-C",
+            &source.path().to_string_lossy(),
+            "remote",
+            "remove",
+            "origin",
+        ]);
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let task_id = harness_core::types::TaskId("missing-remote-head".to_string());
+
+        let err = mgr
+            .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
+            .await
+            .expect_err("missing remote head should fail admission");
+        assert!(
+            err.to_string().contains("git fetch origin"),
+            "error should report the failed remote fetch: {err}"
+        );
+        assert!(mgr.get_workspace(&task_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn create_workspace_can_opt_into_local_base_fallback() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+        run_git(&[
+            "-C",
+            &source.path().to_string_lossy(),
+            "remote",
+            "remove",
+            "origin",
+        ]);
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let task_id = harness_core::types::TaskId("local-base-fallback".to_string());
+
+        let lease = mgr
+            .create_workspace_with_options(
+                &task_id,
+                source.path(),
+                "origin",
+                &branch,
+                1,
+                None,
+                None,
+                WorkspaceCreateOptions {
+                    require_remote_head: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("explicit local fallback should be allowed");
+        assert!(lease.workspace_path.is_dir());
+
+        mgr.remove_workspace(&task_id).await.expect("remove");
+    }
+
+    #[tokio::test]
+    async fn create_workspace_uses_custom_branch_prefix() {
+        let source = tempfile::tempdir().expect("tempdir");
+        init_git_repo(source.path());
+        let branch = current_branch(source.path());
+
+        let workspaces = tempfile::tempdir().expect("tempdir");
+        let config = WorkspaceConfig {
+            root: workspaces.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mgr = WorkspaceManager::new(config).expect("new");
+        let task_id = harness_core::types::TaskId("custom-prefix".to_string());
+
+        let lease = mgr
+            .create_workspace_with_options(
+                &task_id,
+                source.path(),
+                "origin",
+                &branch,
+                1,
+                None,
+                None,
+                WorkspaceCreateOptions {
+                    branch_prefix: "task/".to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("workspace should be created with custom branch prefix");
+        assert_eq!(current_branch(&lease.workspace_path), "task/custom-prefix");
 
         mgr.remove_workspace(&task_id).await.expect("remove");
     }

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -222,6 +222,7 @@ impl TransitionAllowlist {
                 [StartChildWorkflow, EnqueueActivity, Wait],
             )
             .allow("idle", "scanning", [EnqueueActivity, Wait])
+            .allow("failed", "scanning", [EnqueueActivity, Wait])
             .allow("scanning", "scanning", [EnqueueActivity, Wait])
             .allow("scanning", "planning_batch", [EnqueueActivity, Wait])
             .allow("planning_batch", "planning_batch", [EnqueueActivity, Wait])


### PR DESCRIPTION
## Summary

- Load `WORKFLOW.md` as both workflow configuration and runtime prompt guidance, including base, workspace, hook, activity, and runtime dispatch policy.
- Run workflow runtime jobs in configured workspaces created from the configured remote base, and include the workflow file contract in the runtime prompt packet.
- Recover Codex JSON-RPC app-server state when stdin/stdout/child state becomes inconsistent, and avoid unattended approval stalls by setting the repo runtime approval policy to `never`.
- Allow repo backlog polling to recover from a failed poll workflow by reopening the specific `failed -> scanning` transition through the guarded validation context.

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --workspace -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `git diff --check origin/main...HEAD`

## Review

Pre-landing review completed locally against `origin/main`. No blocking findings found.
