### PR TITLE
docs(agents): clarify runtime terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,20 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 - ZERO `Command::new("gh")` or `Command::new("git")` calls inside harness crates — all GitHub/git interaction must be in agent prompts only
 - When user says "fix issue X" or "handle PR Y", ALWAYS delegate to harness server (`POST /tasks`) instead of implementing directly
 
+## Glossary
+
+These names overlap in everyday speech but mean different things in code. Use them precisely in commit messages, PR descriptions, and code comments.
+
+| Term | Meaning | Location |
+|---|---|---|
+| **workflow runtime** | Orchestration layer that decides what should happen next; event-sourced state machine with a command outbox. | `crates/harness-workflow/src/runtime/` |
+| **agent runtime** (a.k.a. `CodeAgent` / `AgentAdapter`) | Agent abstraction; receives an `AgentRequest` and returns a stream or response. | `crates/harness-core/src/agent.rs`, `crates/harness-agents/src/` |
+| **`RuntimeKind`** | Label the workflow layer attaches to an agent type (`CodexExec` / `CodexJsonrpc` / `ClaudeCode` / `AnthropicApi` / `RemoteHost`). | `crates/harness-workflow/src/runtime/model.rs` |
+| **task** | Legacy execution unit; submissions are being migrated to flow through the workflow runtime instead. | `crates/harness-server/src/task_runner/` |
+| **runtime host** | Process instance that executes runtime jobs; can register remotely via `/api/runtime-hosts`. | `crates/harness-server/src/runtime_hosts.rs` |
+
+There is no type literally named `AgentRuntime` in the codebase. The phrase is used informally to mean "the agent runtime layer" (i.e. `CodeAgent` and `AgentAdapter` impls). Prefer the precise names above when writing code.
+
 ## Worktree Usage
 
 - NEVER use `isolation: "worktree"` for tasks that depend on unpushed local commits — worktrees check out from remote, missing local changes


### PR DESCRIPTION
## Summary

Add a Glossary section to AGENTS.md that distinguishes terms which are easy to confuse in everyday speech but mean different things in code:

- **workflow runtime** — orchestration layer (`crates/harness-workflow/src/runtime/`)
- **agent runtime** — `CodeAgent` / `AgentAdapter` trait (`crates/harness-core/src/agent.rs`)
- **`RuntimeKind`** — workflow-side label for an agent type
- **task** — legacy execution unit being migrated through the workflow runtime
- **runtime host** — process instance that executes runtime jobs

Also notes that there is no type literally named `AgentRuntime`; the phrase is used informally for the agent runtime layer.

## Why

Vocabulary drift was flagged during a recent architecture review. The terms "AgentRuntime" / "workflow runtime" / "runtime host" / "task" overlap in casual conversation; collapsing them to one shared definition table reduces churn in PR descriptions and code comments.

## Scope

Documentation only. No code change. No behaviour change.

## Test plan

- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [ ] Gemini code review bot
- [ ] CI Result green