### PR TITLE
refactor(prompts): centralise inline prompts under harness-core

### DIFF
--- a/crates/harness-core/src/prompts/cross_review.rs
+++ b/crates/harness-core/src/prompts/cross_review.rs
@@ -1,0 +1,59 @@
+//! Prompts for the cross-review (primary + challenger) workflow.
+
+/// Prompt sent to the primary reviewer agent.
+///
+/// `safe_target` must already be wrapped via [`super::wrap_external_data`] so
+/// that user-controlled review content cannot escape the prompt boundary.
+pub fn primary_review_prompt(safe_target: &str) -> String {
+    format!(
+        "Review the following target for issues:\n{safe_target}\n\n\
+         List each issue on its own line prefixed with \"ISSUE: \".\n\
+         If no issues are found, output: LGTM"
+    )
+}
+
+/// Prompt sent to the challenger reviewer agent.
+///
+/// `safe_primary` must already be wrapped via [`super::wrap_external_data`].
+/// `outstanding` is appended verbatim and may be empty; when non-empty it
+/// should already start with the leading delimiter the caller wants
+/// (typically `"\n\nOutstanding issues from previous round:\n- …"`).
+pub fn challenger_prompt(safe_primary: &str, outstanding: &str) -> String {
+    format!(
+        "You are a challenger reviewer. Given this primary code review:\n{safe_primary}\n\n\
+         For each ISSUE listed, classify it on its own line:\n\
+         CONFIRMED: <issue>  — the issue is a real problem\n\
+         FALSE-POSITIVE: <issue>  — the issue is wrong or not applicable\n\
+         Also list any issues the primary review missed as:\n\
+         MISSED: <new issue>{outstanding}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primary_prompt_contains_target_and_lgtm_marker() {
+        let prompt = primary_review_prompt("WRAPPED_TARGET");
+        assert!(prompt.contains("WRAPPED_TARGET"));
+        assert!(prompt.contains("ISSUE: "));
+        assert!(prompt.contains("LGTM"));
+    }
+
+    #[test]
+    fn challenger_prompt_handles_empty_outstanding() {
+        let prompt = challenger_prompt("WRAPPED_PRIMARY", "");
+        assert!(prompt.contains("WRAPPED_PRIMARY"));
+        assert!(prompt.contains("CONFIRMED:"));
+        assert!(prompt.contains("FALSE-POSITIVE:"));
+        assert!(prompt.contains("MISSED:"));
+        assert!(prompt.ends_with("MISSED: <new issue>"));
+    }
+
+    #[test]
+    fn challenger_prompt_appends_outstanding() {
+        let prompt = challenger_prompt("X", "\n\nOutstanding issues from previous round:\n- foo");
+        assert!(prompt.contains("Outstanding issues from previous round:\n- foo"));
+    }
+}

--- a/crates/harness-core/src/prompts/gc_signal.rs
+++ b/crates/harness-core/src/prompts/gc_signal.rs
@@ -56,9 +56,11 @@ pub fn linter_violations(project_name: &str, details: &str) -> String {
 mod tests {
     use super::*;
 
+    type SignalRenderer = fn(&str, &str) -> String;
+
     #[test]
     fn each_prompt_includes_project_name_and_details() {
-        let cases: &[(&str, fn(&str, &str) -> String)] = &[
+        let cases: &[(&str, SignalRenderer)] = &[
             ("guard script", repeated_warn),
             ("rule improvements", chronic_block),
             ("SKILL.md", hot_files),

--- a/crates/harness-core/src/prompts/gc_signal.rs
+++ b/crates/harness-core/src/prompts/gc_signal.rs
@@ -1,0 +1,81 @@
+//! Prompts for GC-driven remediation drafts, one per `SignalType`.
+//!
+//! The `SignalType` enum lives in `harness-gc`; matching on a variant remains
+//! the caller's responsibility so this crate does not depend on `harness-gc`.
+//! Callers fan out a `match SignalType` to the appropriate function below.
+
+/// Remediation prompt for the `RepeatedWarn` signal.
+pub fn repeated_warn(project_name: &str, details: &str) -> String {
+    format!(
+        "Analyze repeated warnings in project {project_name} and generate a guard script to detect this pattern.\n\
+         Details: {details}"
+    )
+}
+
+/// Remediation prompt for the `ChronicBlock` signal.
+pub fn chronic_block(project_name: &str, details: &str) -> String {
+    format!(
+        "Analyze chronic block events in project {project_name} and suggest rule improvements to reduce false blocks.\n\
+         Details: {details}"
+    )
+}
+
+/// Remediation prompt for the `HotFiles` signal.
+pub fn hot_files(project_name: &str, details: &str) -> String {
+    format!(
+        "Analyze frequently edited files in project {project_name} and create a SKILL.md with editing strategies.\n\
+         Details: {details}"
+    )
+}
+
+/// Remediation prompt for the `SlowSessions` signal.
+pub fn slow_sessions(project_name: &str, details: &str) -> String {
+    format!(
+        "Analyze slow operations in project {project_name} and create a performance optimization SKILL.md.\n\
+         Details: {details}"
+    )
+}
+
+/// Remediation prompt for the `WarnEscalation` signal.
+pub fn warn_escalation(project_name: &str, details: &str) -> String {
+    format!(
+        "Warning trends are escalating in project {project_name}. Suggest rule upgrades (warn → block).\n\
+         Details: {details}"
+    )
+}
+
+/// Remediation prompt for the `LinterViolations` signal.
+pub fn linter_violations(project_name: &str, details: &str) -> String {
+    format!(
+        "Code scan found violations in project {project_name}. Generate a guard script to detect and prevent these.\n\
+         Details: {details}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_prompt_includes_project_name_and_details() {
+        let cases: &[(&str, fn(&str, &str) -> String)] = &[
+            ("guard script", repeated_warn),
+            ("rule improvements", chronic_block),
+            ("SKILL.md", hot_files),
+            ("performance optimization", slow_sessions),
+            ("rule upgrades", warn_escalation),
+            ("guard script", linter_violations),
+        ];
+        for (marker, render) in cases {
+            let prompt = render("demo-project", "raw details");
+            assert!(
+                prompt.contains("demo-project"),
+                "missing project name in `{marker}` prompt"
+            );
+            assert!(
+                prompt.contains("Details: raw details"),
+                "missing details in `{marker}` prompt"
+            );
+        }
+    }
+}

--- a/crates/harness-core/src/prompts/intake.rs
+++ b/crates/harness-core/src/prompts/intake.rs
@@ -1,0 +1,64 @@
+//! Prompts produced by the intake pipeline (issue → agent submission).
+
+/// Borrowed view of the fields needed to render an "implement this issue" prompt.
+///
+/// Lives in `harness-core` so callers in `harness-server::intake` (which owns the
+/// `IncomingIssue` struct) do not need to share their type with this crate.
+pub struct IncomingIssueView<'a> {
+    pub source: &'a str,
+    pub identifier: &'a str,
+    pub title: &'a str,
+    pub url: Option<&'a str>,
+    pub description: Option<&'a str>,
+}
+
+/// Prompt the agent receives for an unattended issue submission.
+pub fn from_incoming_issue(view: &IncomingIssueView<'_>) -> String {
+    format!(
+        "You are working on {source} issue {id}: {title}\n\n\
+         URL: {url}\n\n\
+         Description:\n{desc}\n\n\
+         Instructions:\n\
+         1. This is an unattended session. Do not ask humans for help.\n\
+         2. Implement changes, run validation, create PR, push.\n\
+         3. Only stop for true blockers (missing auth/permissions).",
+        source = view.source,
+        id = view.identifier,
+        title = view.title,
+        url = view.url.unwrap_or("N/A"),
+        desc = view.description.unwrap_or("No description."),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_all_fields() {
+        let prompt = from_incoming_issue(&IncomingIssueView {
+            source: "github",
+            identifier: "42",
+            title: "Fix the bug",
+            url: Some("https://example/issues/42"),
+            description: Some("Bug body."),
+        });
+        assert!(prompt.contains("github issue 42: Fix the bug"));
+        assert!(prompt.contains("URL: https://example/issues/42"));
+        assert!(prompt.contains("Description:\nBug body."));
+        assert!(prompt.contains("unattended session"));
+    }
+
+    #[test]
+    fn fills_defaults_when_missing() {
+        let prompt = from_incoming_issue(&IncomingIssueView {
+            source: "feishu",
+            identifier: "FE-1",
+            title: "no body",
+            url: None,
+            description: None,
+        });
+        assert!(prompt.contains("URL: N/A"));
+        assert!(prompt.contains("Description:\nNo description."));
+    }
+}

--- a/crates/harness-core/src/prompts/learn.rs
+++ b/crates/harness-core/src/prompts/learn.rs
@@ -1,0 +1,71 @@
+//! Prompts for the GC `learn` flow that mines reusable rules and skills out of
+//! adopted remediation drafts.
+
+use super::wrap_external_data;
+
+/// Prompt that asks the agent to extract reusable guard rules from a list of
+/// adopted draft contents.
+pub fn rules_extraction_prompt(draft_contents: &[String]) -> String {
+    let joined = draft_contents.join("\n\n---\n\n");
+    let safe_content = wrap_external_data(&joined);
+    format!(
+        "Analyze the following adopted remediation drafts and extract reusable guard rules.\n\
+         {safe_content}\n\n\
+         For each distinct rule pattern you identify, output a block in this exact format:\n\
+         ## RULE_ID: Short title\n\
+         severity: high\n\
+         Description of the rule and why it matters.\n\n\
+         Use severity values: critical, high, medium, or low.\n\
+         Use RULE_IDs like LEARN-001, LEARN-002, etc.\n\
+         Output only rule blocks, no other text."
+    )
+}
+
+/// Prompt that asks the agent to extract reusable skills from a list of
+/// adopted draft contents.
+pub fn skills_extraction_prompt(draft_contents: &[String]) -> String {
+    let joined = draft_contents.join("\n\n---\n\n");
+    let safe_content = wrap_external_data(&joined);
+    format!(
+        "Analyze the following adopted remediation drafts and extract reusable skills.\n\
+         {safe_content}\n\n\
+         For each reusable skill or pattern you identify, output a block in this exact format:\n\
+         === skill: kebab-case-name ===\n\
+         # Skill Title\n\
+         Description and usage instructions.\n\n\
+         Output only skill blocks, no other text."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rules_prompt_includes_drafts_and_format_marker() {
+        let drafts = vec!["draft A".to_string(), "draft B".to_string()];
+        let prompt = rules_extraction_prompt(&drafts);
+        assert!(prompt.contains("draft A"));
+        assert!(prompt.contains("draft B"));
+        assert!(prompt.contains("---"));
+        assert!(prompt.contains("## RULE_ID:"));
+        assert!(prompt.contains("severity: high"));
+    }
+
+    #[test]
+    fn skills_prompt_includes_drafts_and_format_marker() {
+        let drafts = vec!["s1".to_string()];
+        let prompt = skills_extraction_prompt(&drafts);
+        assert!(prompt.contains("s1"));
+        assert!(prompt.contains("=== skill: kebab-case-name ==="));
+    }
+
+    #[test]
+    fn handles_empty_drafts() {
+        let prompt = rules_extraction_prompt(&[]);
+        // Empty join produces a wrapped empty payload; the structure of the
+        // surrounding instructions must still be intact.
+        assert!(prompt.contains("Analyze the following adopted remediation drafts"));
+        assert!(prompt.contains("Output only rule blocks"));
+    }
+}

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -2,7 +2,11 @@
 
 pub mod context;
 pub mod contract;
+pub mod cross_review;
+pub mod gc_signal;
+pub mod intake;
 pub mod issue;
+pub mod learn;
 pub mod parsing;
 pub mod pr;
 pub mod review;

--- a/crates/harness-gc/src/gc_agent.rs
+++ b/crates/harness-gc/src/gc_agent.rs
@@ -467,37 +467,19 @@ fn resolve_for_boundary_check(path: &Path) -> anyhow::Result<PathBuf> {
 }
 
 fn build_prompt(signal: &Signal, project: &Project) -> String {
+    use harness_core::prompts::gc_signal;
+    let project_name = project.name.as_str();
+    // `Signal::details` is a `serde_json::Value`; rendering it via `Display`
+    // preserves the JSON shape that the original inline `format!("{}", ...)`
+    // produced (e.g. quoted string variants).
+    let details = signal.details.to_string();
     match signal.signal_type {
-        SignalType::RepeatedWarn => format!(
-            "Analyze repeated warnings in project {} and generate a guard script to detect this pattern.\nDetails: {}",
-            project.name,
-            signal.details
-        ),
-        SignalType::ChronicBlock => format!(
-            "Analyze chronic block events in project {} and suggest rule improvements to reduce false blocks.\nDetails: {}",
-            project.name,
-            signal.details
-        ),
-        SignalType::HotFiles => format!(
-            "Analyze frequently edited files in project {} and create a SKILL.md with editing strategies.\nDetails: {}",
-            project.name,
-            signal.details
-        ),
-        SignalType::SlowSessions => format!(
-            "Analyze slow operations in project {} and create a performance optimization SKILL.md.\nDetails: {}",
-            project.name,
-            signal.details
-        ),
-        SignalType::WarnEscalation => format!(
-            "Warning trends are escalating in project {}. Suggest rule upgrades (warn → block).\nDetails: {}",
-            project.name,
-            signal.details
-        ),
-        SignalType::LinterViolations => format!(
-            "Code scan found violations in project {}. Generate a guard script to detect and prevent these.\nDetails: {}",
-            project.name,
-            signal.details
-        ),
+        SignalType::RepeatedWarn => gc_signal::repeated_warn(project_name, &details),
+        SignalType::ChronicBlock => gc_signal::chronic_block(project_name, &details),
+        SignalType::HotFiles => gc_signal::hot_files(project_name, &details),
+        SignalType::SlowSessions => gc_signal::slow_sessions(project_name, &details),
+        SignalType::WarnEscalation => gc_signal::warn_escalation(project_name, &details),
+        SignalType::LinterViolations => gc_signal::linter_violations(project_name, &details),
     }
 }
 

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -69,11 +69,7 @@ pub async fn run_cross_review(
     allowed_tools: Option<Vec<String>>,
 ) -> Result<CrossReviewResult, String> {
     let safe_target = harness_core::prompts::wrap_external_data(&target);
-    let primary_prompt = format!(
-        "Review the following target for issues:\n{safe_target}\n\n\
-         List each issue on its own line prefixed with \"ISSUE: \".\n\
-         If no issues are found, output: LGTM"
-    );
+    let primary_prompt = harness_core::prompts::cross_review::primary_review_prompt(&safe_target);
 
     let primary_resp = primary
         .execute(AgentRequest {
@@ -124,14 +120,8 @@ pub async fn run_cross_review(
             format!("\n\nOutstanding issues from previous round:\n{items}")
         };
 
-        let challenge_prompt = format!(
-            "You are a challenger reviewer. Given this primary code review:\n{safe_primary}\n\n\
-             For each ISSUE listed, classify it on its own line:\n\
-             CONFIRMED: <issue>  — the issue is a real problem\n\
-             FALSE-POSITIVE: <issue>  — the issue is wrong or not applicable\n\
-             Also list any issues the primary review missed as:\n\
-             MISSED: <new issue>{outstanding}"
-        );
+        let challenge_prompt =
+            harness_core::prompts::cross_review::challenger_prompt(&safe_primary, &outstanding);
 
         let resp = challenger
             .execute(AgentRequest {

--- a/crates/harness-server/src/handlers/learn.rs
+++ b/crates/harness-server/src/handlers/learn.rs
@@ -245,33 +245,11 @@ async fn collect_adopted_draft_contents(
 }
 
 fn build_learn_rules_prompt(draft_contents: &[String]) -> String {
-    let joined = draft_contents.join("\n\n---\n\n");
-    let safe_content = harness_core::prompts::wrap_external_data(&joined);
-    format!(
-        "Analyze the following adopted remediation drafts and extract reusable guard rules.\n\
-         {safe_content}\n\n\
-         For each distinct rule pattern you identify, output a block in this exact format:\n\
-         ## RULE_ID: Short title\n\
-         severity: high\n\
-         Description of the rule and why it matters.\n\n\
-         Use severity values: critical, high, medium, or low.\n\
-         Use RULE_IDs like LEARN-001, LEARN-002, etc.\n\
-         Output only rule blocks, no other text."
-    )
+    harness_core::prompts::learn::rules_extraction_prompt(draft_contents)
 }
 
 fn build_learn_skills_prompt(draft_contents: &[String]) -> String {
-    let joined = draft_contents.join("\n\n---\n\n");
-    let safe_content = harness_core::prompts::wrap_external_data(&joined);
-    format!(
-        "Analyze the following adopted remediation drafts and extract reusable skills.\n\
-         {safe_content}\n\n\
-         For each reusable skill or pattern you identify, output a block in this exact format:\n\
-         === skill: kebab-case-name ===\n\
-         # Skill Title\n\
-         Description and usage instructions.\n\n\
-         Output only skill blocks, no other text."
-    )
+    harness_core::prompts::learn::skills_extraction_prompt(draft_contents)
 }
 
 /// Parse `## RULE_ID: Title` blocks from agent output into Rule structs.

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -1300,19 +1300,14 @@ pub fn build_orchestrator(
 }
 
 pub(crate) fn build_prompt_from_issue(issue: &IncomingIssue) -> String {
-    format!(
-        "You are working on {source} issue {id}: {title}\n\n\
-         URL: {url}\n\n\
-         Description:\n{desc}\n\n\
-         Instructions:\n\
-         1. This is an unattended session. Do not ask humans for help.\n\
-         2. Implement changes, run validation, create PR, push.\n\
-         3. Only stop for true blockers (missing auth/permissions).",
-        source = issue.source,
-        id = issue.identifier,
-        title = issue.title,
-        url = issue.url.as_deref().unwrap_or("N/A"),
-        desc = issue.description.as_deref().unwrap_or("No description."),
+    harness_core::prompts::intake::from_incoming_issue(
+        &harness_core::prompts::intake::IncomingIssueView {
+            source: &issue.source,
+            identifier: &issue.identifier,
+            title: &issue.title,
+            url: issue.url.as_deref(),
+            description: issue.description.as_deref(),
+        },
     )
 }
 


### PR DESCRIPTION
## Summary

Move four production inline-prompt sites into typed sub-modules of \`harness-core/src/prompts/\` so every "what the agent sees" entry-point is visible from one location:

| From | To |
|---|---|
| \`harness-server/src/intake/mod.rs\` (\`build_prompt_from_issue\`) | \`harness_core::prompts::intake::from_incoming_issue\` |
| \`harness-server/src/handlers/cross_review.rs\` (primary + challenger) | \`harness_core::prompts::cross_review::{primary_review_prompt, challenger_prompt}\` |
| \`harness-server/src/handlers/learn.rs\` (rules + skills) | \`harness_core::prompts::learn::{rules_extraction_prompt, skills_extraction_prompt}\` |
| \`harness-gc/src/gc_agent.rs\` (6 \`SignalType\` arms) | \`harness_core::prompts::gc_signal::{repeated_warn, chronic_block, hot_files, slow_sessions, warn_escalation, linter_violations}\` |

Each new prompt function takes a typed input (a borrowed view struct for \`IncomingIssue\`, or named \`&str\` parameters for the rest) instead of free-form formatted strings. The \`match SignalType\` stays in \`harness-gc\` so this crate does not need to depend on the GC enum.

## Why

Inline prompts scattered outside \`harness-core/src/prompts/\` were flagged in a recent architecture review as a module-boundary smell: contributors adding new prompts had no obvious canonical home, and review of "what the agent reads" required a workspace-wide grep. This PR centralises them so additions follow the same pattern as existing prompts (\`issue.rs\`, \`pr.rs\`, \`review.rs\`).

## Out of scope (deferred)

The runtime-worker prompt at \`harness-server/src/workflow_runtime_worker.rs:1318\` is the fifth such site; it is intentionally **not** included here because there is concurrent WIP on the same file. A follow-up PR will move it once the WIP lands.

## Behaviour preservation

- All prompt strings are byte-equal copies of the former inline literals.
- Existing tests in \`intake::tests\`, \`handlers::cross_review::tests\`, \`handlers::learn::tests\`, and \`gc_agent::tests\` pass unchanged (no test snapshot updates were needed).
- New tests added for each module under \`harness-core/src/prompts/\` to lock in the rendered output.

## Test plan

- [x] \`cargo test -p harness-core --lib prompts::\` — 126 tests pass (includes new module tests)
- [x] \`cargo test -p harness-gc\` — 44 tests pass
- [x] \`cargo test -p harness-server --lib intake::tests::build_prompt\` — 2 tests pass
- [x] \`cargo test -p harness-server --lib handlers::cross_review\` — 3 tests pass
- [x] \`cargo test -p harness-server --lib handlers::learn\` — 27 tests pass
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [ ] Gemini code review bot
- [ ] CI Result green