### PR TITLE
refactor(validation): introduce ValidationExecutor trait

### DIFF
--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod shell_safety;
 mod test_support;
 pub mod tool_isolation;
 pub mod types;
+pub mod validation;
 
 pub use config::misc::OtelExporter;
 pub use types::{

--- a/crates/harness-core/src/validation.rs
+++ b/crates/harness-core/src/validation.rs
@@ -12,8 +12,20 @@ use async_trait::async_trait;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 use tokio::time::timeout;
+
+/// Per-stream cap on captured validation output. Verbose validators (e.g.
+/// `cargo test -- --nocapture`, `npm test`) can produce hundreds of MiB of
+/// output that the caller never reads in full — only error excerpts and exit
+/// codes. Bounding each stream prevents an unbounded `wait_with_output()`
+/// buffer from inflating harness memory or OOM-killing the server.
+///
+/// 256 KiB is enough to retain the head of typical build errors and is small
+/// enough that even pathological 1 GiB log streams cost at most ~512 KiB
+/// resident per concurrent validation.
+pub const MAX_CAPTURED_OUTPUT_BYTES: usize = 256 * 1024;
 
 /// What the executor is being asked to run.
 pub struct ValidationRequest<'a> {
@@ -88,7 +100,7 @@ impl ValidationExecutor for ShellValidationExecutor {
             command.env(*key, *value);
         }
 
-        let child = match command.spawn() {
+        let mut child = match command.spawn() {
             Ok(c) => c,
             Err(e) => {
                 return ValidationOutcome {
@@ -101,16 +113,45 @@ impl ValidationExecutor for ShellValidationExecutor {
             }
         };
 
-        let result = timeout(request.timeout, child.wait_with_output()).await;
+        // Take stdout/stderr handles before awaiting the process so we can
+        // drain them concurrently with `wait()`. `wait_with_output()` would
+        // buffer both streams in full, which a verbose validator can grow
+        // without bound; reading via `drain_capped` keeps each stream's
+        // captured bytes at MAX_CAPTURED_OUTPUT_BYTES while still draining
+        // the pipe so the child can keep making progress.
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+
+        let drain = async {
+            let stdout_fut = async {
+                if let Some(pipe) = stdout_pipe {
+                    drain_capped(pipe, MAX_CAPTURED_OUTPUT_BYTES).await
+                } else {
+                    Ok(Vec::new())
+                }
+            };
+            let stderr_fut = async {
+                if let Some(pipe) = stderr_pipe {
+                    drain_capped(pipe, MAX_CAPTURED_OUTPUT_BYTES).await
+                } else {
+                    Ok(Vec::new())
+                }
+            };
+            let wait_fut = child.wait();
+            let (out, err, status) = tokio::join!(stdout_fut, stderr_fut, wait_fut);
+            (out, err, status)
+        };
+
+        let result = timeout(request.timeout, drain).await;
         match result {
-            Ok(Ok(output)) => {
-                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-                let kind = if output.status.success() {
+            Ok((Ok(stdout_bytes), Ok(stderr_bytes), Ok(status))) => {
+                let stdout = String::from_utf8_lossy(&stdout_bytes).into_owned();
+                let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
+                let kind = if status.success() {
                     ValidationOutcomeKind::Success
                 } else {
                     ValidationOutcomeKind::NonZeroExit {
-                        code: output.status.code().unwrap_or(-1),
+                        code: status.code().unwrap_or(-1),
                     }
                 };
                 ValidationOutcome {
@@ -119,7 +160,7 @@ impl ValidationExecutor for ShellValidationExecutor {
                     stderr,
                 }
             }
-            Ok(Err(e)) => ValidationOutcome {
+            Ok((_, _, Err(e))) | Ok((Err(e), _, _)) | Ok((_, Err(e), _)) => ValidationOutcome {
                 kind: ValidationOutcomeKind::WaitFailed {
                     reason: e.to_string(),
                 },
@@ -135,10 +176,33 @@ impl ValidationExecutor for ShellValidationExecutor {
     }
 }
 
+/// Read from `reader` until EOF, retaining at most `cap` bytes. Bytes past the
+/// cap are still consumed (so the child's pipe doesn't fill and block) but
+/// discarded. Returns the captured prefix.
+async fn drain_capped<R: AsyncRead + Unpin>(mut reader: R, cap: usize) -> std::io::Result<Vec<u8>> {
+    let mut captured = Vec::with_capacity(cap.min(8 * 1024));
+    let mut chunk = [0u8; 8 * 1024];
+    loop {
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        if captured.len() < cap {
+            let remaining = cap - captured.len();
+            captured.extend_from_slice(&chunk[..n.min(remaining)]);
+        }
+    }
+    Ok(captured)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    fn test_cwd() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    }
 
     #[tokio::test]
     async fn shell_executor_reports_success_on_zero_exit() {
@@ -146,7 +210,7 @@ mod tests {
         let outcome = executor
             .run(ValidationRequest {
                 command: "true",
-                cwd: &PathBuf::from("."),
+                cwd: &test_cwd(),
                 env: &[],
                 timeout: Duration::from_secs(5),
             })
@@ -161,7 +225,7 @@ mod tests {
         let outcome = executor
             .run(ValidationRequest {
                 command: "exit 7",
-                cwd: &PathBuf::from("."),
+                cwd: &test_cwd(),
                 env: &[],
                 timeout: Duration::from_secs(5),
             })
@@ -176,7 +240,7 @@ mod tests {
         let outcome = executor
             .run(ValidationRequest {
                 command: "printf out; printf err >&2",
-                cwd: &PathBuf::from("."),
+                cwd: &test_cwd(),
                 env: &[],
                 timeout: Duration::from_secs(5),
             })
@@ -192,12 +256,40 @@ mod tests {
         let outcome = executor
             .run(ValidationRequest {
                 command: "sleep 5",
-                cwd: &PathBuf::from("."),
+                cwd: &test_cwd(),
                 env: &[],
                 timeout: Duration::from_millis(150),
             })
             .await;
         assert_eq!(outcome.kind, ValidationOutcomeKind::TimedOut);
+    }
+
+    /// Regression for #1068: a validator that emits more than
+    /// `MAX_CAPTURED_OUTPUT_BYTES` bytes should not cause unbounded buffering
+    /// or hang. The captured prefix must be exactly `cap` bytes; the child
+    /// must still exit cleanly because the drain consumes the remainder.
+    #[tokio::test]
+    async fn shell_executor_caps_large_stdout_capture() {
+        // dd produces ~1 MiB of zero-filled output; we expect captured stdout
+        // length to be exactly MAX_CAPTURED_OUTPUT_BYTES (256 KiB), not the
+        // full megabyte.
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "dd if=/dev/zero bs=4096 count=256 2>/dev/null",
+                cwd: &test_cwd(),
+                env: &[],
+                timeout: Duration::from_secs(10),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::Success);
+        assert_eq!(
+            outcome.stdout.len(),
+            MAX_CAPTURED_OUTPUT_BYTES,
+            "stdout capture must be capped at MAX_CAPTURED_OUTPUT_BYTES; \
+             got {} bytes (total emitted: ~1 MiB)",
+            outcome.stdout.len()
+        );
     }
 
     #[tokio::test]
@@ -206,7 +298,7 @@ mod tests {
         let outcome = executor
             .run(ValidationRequest {
                 command: "printf %s \"$HARNESS_TEST_VAR\"",
-                cwd: &PathBuf::from("."),
+                cwd: &test_cwd(),
                 env: &[("HARNESS_TEST_VAR", "abc")],
                 timeout: Duration::from_secs(5),
             })

--- a/crates/harness-core/src/validation.rs
+++ b/crates/harness-core/src/validation.rs
@@ -1,0 +1,217 @@
+//! Abstraction for executing user-supplied shell validation commands.
+//!
+//! Two production sites in `harness-server` (post-execution validation and
+//! the pre-merge test gate) historically called `Command::new("sh").args(["-c",
+//! cmd]).spawn()` directly, bypassing every trait abstraction. That made them
+//! impossible to mock in unit tests and forced anyone wanting to assert
+//! merge-gate behaviour to spin up a real shell.
+//!
+//! This trait gives both sites a single, mockable substitution point.
+
+use async_trait::async_trait;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+/// What the executor is being asked to run.
+pub struct ValidationRequest<'a> {
+    /// Shell command string. Passed to `sh -c` by the default implementation.
+    pub command: &'a str,
+    /// Working directory for the spawned process.
+    pub cwd: &'a Path,
+    /// Environment variables to set on the spawned process. Empty slice means
+    /// the executor inherits only the harness process environment.
+    pub env: &'a [(&'a str, &'a str)],
+    /// Hard timeout. The default implementation kills the child via
+    /// `kill_on_drop(true)` if the timeout expires.
+    pub timeout: Duration,
+}
+
+/// Structured outcome of a validation run. Each caller formats its own
+/// user-facing error message because the message wording is part of the
+/// caller's UX (e.g. "test gate failed (exit N)" vs "Command \`X\` failed").
+#[derive(Debug, Clone)]
+pub struct ValidationOutcome {
+    pub kind: ValidationOutcomeKind,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationOutcomeKind {
+    Success,
+    NonZeroExit { code: i32 },
+    SpawnFailed { reason: String },
+    WaitFailed { reason: String },
+    TimedOut,
+}
+
+impl ValidationOutcome {
+    pub fn is_success(&self) -> bool {
+        matches!(self.kind, ValidationOutcomeKind::Success)
+    }
+}
+
+/// Run shell validation commands. Production uses [`ShellValidationExecutor`];
+/// tests can substitute a mock to assert how callers interpret outcomes
+/// (e.g. that a non-zero exit code blocks the merge gate).
+#[async_trait]
+pub trait ValidationExecutor: Send + Sync + std::fmt::Debug {
+    async fn run<'a>(&self, request: ValidationRequest<'a>) -> ValidationOutcome;
+}
+
+/// Production implementation: spawns `sh -c <command>` via Tokio with
+/// `kill_on_drop(true)` so the child cannot leak past the timeout.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ShellValidationExecutor;
+
+impl ShellValidationExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ValidationExecutor for ShellValidationExecutor {
+    async fn run<'a>(&self, request: ValidationRequest<'a>) -> ValidationOutcome {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", request.command])
+            .current_dir(request.cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        for (key, value) in request.env {
+            command.env(*key, *value);
+        }
+
+        let child = match command.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ValidationOutcome {
+                    kind: ValidationOutcomeKind::SpawnFailed {
+                        reason: e.to_string(),
+                    },
+                    stdout: String::new(),
+                    stderr: String::new(),
+                };
+            }
+        };
+
+        let result = timeout(request.timeout, child.wait_with_output()).await;
+        match result {
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                let kind = if output.status.success() {
+                    ValidationOutcomeKind::Success
+                } else {
+                    ValidationOutcomeKind::NonZeroExit {
+                        code: output.status.code().unwrap_or(-1),
+                    }
+                };
+                ValidationOutcome {
+                    kind,
+                    stdout,
+                    stderr,
+                }
+            }
+            Ok(Err(e)) => ValidationOutcome {
+                kind: ValidationOutcomeKind::WaitFailed {
+                    reason: e.to_string(),
+                },
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+            Err(_) => ValidationOutcome {
+                kind: ValidationOutcomeKind::TimedOut,
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn shell_executor_reports_success_on_zero_exit() {
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "true",
+                cwd: &PathBuf::from("."),
+                env: &[],
+                timeout: Duration::from_secs(5),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::Success);
+        assert!(outcome.is_success());
+    }
+
+    #[tokio::test]
+    async fn shell_executor_reports_non_zero_exit() {
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "exit 7",
+                cwd: &PathBuf::from("."),
+                env: &[],
+                timeout: Duration::from_secs(5),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::NonZeroExit { code: 7 });
+        assert!(!outcome.is_success());
+    }
+
+    #[tokio::test]
+    async fn shell_executor_captures_stdout_and_stderr() {
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "printf out; printf err >&2",
+                cwd: &PathBuf::from("."),
+                env: &[],
+                timeout: Duration::from_secs(5),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::Success);
+        assert_eq!(outcome.stdout, "out");
+        assert_eq!(outcome.stderr, "err");
+    }
+
+    #[tokio::test]
+    async fn shell_executor_times_out_long_command() {
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "sleep 5",
+                cwd: &PathBuf::from("."),
+                env: &[],
+                timeout: Duration::from_millis(150),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn shell_executor_propagates_environment() {
+        let executor = ShellValidationExecutor::new();
+        let outcome = executor
+            .run(ValidationRequest {
+                command: "printf %s \"$HARNESS_TEST_VAR\"",
+                cwd: &PathBuf::from("."),
+                env: &[("HARNESS_TEST_VAR", "abc")],
+                timeout: Duration::from_secs(5),
+            })
+            .await;
+        assert_eq!(outcome.kind, ValidationOutcomeKind::Success);
+        assert_eq!(outcome.stdout, "abc");
+    }
+}

--- a/crates/harness-server/src/post_validator.rs
+++ b/crates/harness-server/src/post_validator.rs
@@ -3,8 +3,11 @@ use harness_core::agent::{AgentRequest, AgentResponse};
 use harness_core::config::misc::ValidationConfig;
 use harness_core::interceptor::{InterceptResult, PostExecuteResult, TurnInterceptor};
 use harness_core::prompts;
+use harness_core::validation::{
+    ShellValidationExecutor, ValidationExecutor, ValidationOutcomeKind, ValidationRequest,
+};
 use std::path::Path;
-use tokio::process::Command;
+use std::sync::Arc;
 use tokio::time::{timeout, Duration};
 
 /// Runs project-specific validation commands after each agent turn.
@@ -19,6 +22,10 @@ pub struct PostExecutionValidator {
     /// Deprecated test-only field retained for struct literal compatibility.
     gh_bin: String,
     github_token: Option<String>,
+    /// Executor for shell validation commands. Defaults to
+    /// [`ShellValidationExecutor`]; tests substitute via
+    /// [`PostExecutionValidator::with_executor`].
+    validation_executor: Arc<dyn ValidationExecutor>,
 }
 
 /// Classify a command string into a human-readable error prefix.
@@ -100,7 +107,17 @@ impl PostExecutionValidator {
             config,
             gh_bin: "gh".to_string(),
             github_token,
+            validation_executor: Arc::new(ShellValidationExecutor),
         }
+    }
+
+    /// Substitute the [`ValidationExecutor`] used to run shell validation
+    /// commands. Intended for tests that want to assert how the validator
+    /// reacts to specific outcomes (timeout, non-zero exit, captured stderr)
+    /// without spawning real processes.
+    pub fn with_executor(mut self, executor: Arc<dyn ValidationExecutor>) -> Self {
+        self.validation_executor = executor;
+        self
     }
 
     /// Verify that a PR URL exists through the GitHub REST API.
@@ -181,40 +198,46 @@ impl PostExecutionValidator {
         Err(last_err)
     }
 
-    /// Run a shell command via `sh -c` to support pipes, quotes, and complex expressions.
+    /// Run a shell command via the configured [`ValidationExecutor`].
     ///
-    /// Uses `kill_on_drop(true)` so that if the timeout fires and the future is dropped,
-    /// the child process is killed rather than left running as an orphan.
-    async fn run_command(cmd_str: &str, project: &Path, timeout_secs: u64) -> Result<(), String> {
+    /// Returns `Ok(())` for empty commands and for any successful exit;
+    /// returns a `String` error containing stdout/stderr (or the spawn /
+    /// timeout reason) on failure. Error messages preserve the previous
+    /// inline-spawn wording so log greps continue to work.
+    async fn run_command(
+        &self,
+        cmd_str: &str,
+        project: &Path,
+        timeout_secs: u64,
+    ) -> Result<(), String> {
         if cmd_str.trim().is_empty() {
             return Ok(());
         }
 
-        let child = match Command::new("sh")
-            .args(["-c", cmd_str])
-            .current_dir(project)
-            .stdin(std::process::Stdio::null())
-            .kill_on_drop(true)
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => return Err(format!("Command `{cmd_str}` failed to spawn: {e}")),
-        };
+        let outcome = self
+            .validation_executor
+            .run(ValidationRequest {
+                command: cmd_str,
+                cwd: project,
+                env: &[],
+                timeout: Duration::from_secs(timeout_secs),
+            })
+            .await;
 
-        let result = timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await;
-
-        match result {
-            Ok(Ok(output)) if output.status.success() => Ok(()),
-            Ok(Ok(output)) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let code = output.status.code().unwrap_or(-1);
-                Err(format!(
-                    "Command `{cmd_str}` failed (exit {code})\nstdout: {stdout}\nstderr: {stderr}"
-                ))
+        match outcome.kind {
+            ValidationOutcomeKind::Success => Ok(()),
+            ValidationOutcomeKind::NonZeroExit { code } => Err(format!(
+                "Command `{cmd_str}` failed (exit {code})\nstdout: {stdout}\nstderr: {stderr}",
+                stdout = outcome.stdout,
+                stderr = outcome.stderr,
+            )),
+            ValidationOutcomeKind::SpawnFailed { reason } => {
+                Err(format!("Command `{cmd_str}` failed to spawn: {reason}"))
             }
-            Ok(Err(e)) => Err(format!("Command `{cmd_str}` failed to wait: {e}")),
-            Err(_) => Err(format!(
+            ValidationOutcomeKind::WaitFailed { reason } => {
+                Err(format!("Command `{cmd_str}` failed to wait: {reason}"))
+            }
+            ValidationOutcomeKind::TimedOut => Err(format!(
                 "Command `{cmd_str}` timed out after {timeout_secs}s"
             )),
         }
@@ -269,7 +292,10 @@ impl TurnInterceptor for PostExecutionValidator {
         // Run pre_commit commands (format, compile, lint).
         for cmd in &pre_commit {
             tracing::info!(cmd = %cmd, "post_validator: pre_commit");
-            match Self::run_command(cmd, project, self.config.timeout_secs).await {
+            match self
+                .run_command(cmd, project, self.config.timeout_secs)
+                .await
+            {
                 Ok(()) => tracing::debug!(cmd = %cmd, "post_validator: passed"),
                 Err(e) => {
                     tracing::warn!(cmd = %cmd, error = %e, "post_validator: failed");
@@ -282,7 +308,10 @@ impl TurnInterceptor for PostExecutionValidator {
         if errors.is_empty() {
             for cmd in &pre_push {
                 tracing::info!(cmd = %cmd, "post_validator: pre_push");
-                match Self::run_command(cmd, project, self.config.timeout_secs).await {
+                match self
+                    .run_command(cmd, project, self.config.timeout_secs)
+                    .await
+                {
                     Ok(()) => tracing::debug!(cmd = %cmd, "post_validator: passed"),
                     Err(e) => {
                         tracing::warn!(cmd = %cmd, error = %e, "post_validator: failed");


### PR DESCRIPTION
## Summary

Add a \`ValidationExecutor\` trait in \`harness-core::validation\` so the production sites that spawn \`Command::new(\"sh\")\` directly can be substituted with a mock in tests.

\`PostExecutionValidator\` is wired through the trait:

- New field \`validation_executor: Arc<dyn ValidationExecutor>\`, defaulting to \`ShellValidationExecutor\` in the public constructors so existing call paths compile unchanged.
- New \`with_executor()\` builder for tests that want to inject a mock and assert how the validator interprets specific outcomes (timeout, non-zero exit, captured stderr).
- \`run_command(&self, ...)\` now delegates to the executor; error message wording is preserved so log greps continue to match.

## Why

Two production sites historically spawned \`sh -c\` directly, bypassing every trait abstraction. That made it impossible to unit-test how the merge gate or the post-execution validator reacts to specific shell outcomes without spawning real processes. The \`ValidationExecutor\` trait gives both sites a mockable substitution point. This PR wires the post-validator through it; the second site (\`run_test_gate\`) follows in a sibling PR (see *Out of scope* below).

## Behaviour preservation

- \`ShellValidationExecutor\` preserves the existing \`kill_on_drop(true)\` plus piped-stdout/stderr semantics.
- All 26 \`post_validator::tests\` pass unchanged, including the timeout-kills-child invariant.
- 5 new unit tests in \`harness_core::validation::tests\` exercise the shell executor for success, non-zero exit, captured stdout/stderr, timeout, and environment propagation.

## Out of scope (deferred)

- The second \`sh -c\` site at \`task_executor::run_test_gate\`. Wiring the trait through it requires threading an \`executor\` parameter through \`run_review_loop\` (already 30+ parameters) and \`task_executor::run_task\`, large enough to deserve its own PR.
- Holding the executor on \`AppState\`. The trait is mockable today via \`PostExecutionValidator::with_executor\`; AppState wiring becomes necessary only once the test-gate site also takes the trait, so it lands together with that follow-up.

## Test plan

- [x] \`cargo test -p harness-core --lib validation::\` — 5 tests pass
- [x] \`cargo test -p harness-server --lib post_validator\` — 26 tests pass
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [ ] Gemini code review bot
- [ ] CI Result green