### PR TITLE
refactor(task-kind): centralise per-kind metadata on TaskKind

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -138,13 +138,7 @@ fn task_allows_prompt_orphan_recovery(task: &task_runner::TaskState) -> bool {
 }
 
 fn orphan_recovery_failure_reason(task: &task_runner::TaskState) -> &'static str {
-    match task.task_kind {
-        task_runner::TaskKind::Issue => "orphaned issue task: issue number not persisted",
-        task_runner::TaskKind::Pr => "orphaned PR task: PR number not persisted",
-        task_runner::TaskKind::Prompt => "orphaned prompt-only task: prompt not persisted",
-        task_runner::TaskKind::Review => "orphaned review task: prompt not persisted",
-        task_runner::TaskKind::Planner => "orphaned planner task: prompt not persisted",
-    }
+    task.task_kind.orphan_recovery_failure_reason()
 }
 
 pub(super) fn recovery_queue_domain(task_kind: task_runner::TaskKind) -> task_routes::QueueDomain {

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -178,11 +178,7 @@ fn runtime_workflow_task_summary(
         .data
         .get("issue_number")
         .and_then(|value| value.as_u64());
-    let external_id = match task_kind {
-        TaskKind::Issue => issue.map(|issue_number| format!("issue:{issue_number}")),
-        TaskKind::Prompt => runtime_string_field(&workflow.data, "external_id"),
-        _ => None,
-    };
+    let external_id = runtime_external_id(task_kind, &workflow.data, issue);
     let description = match task_kind {
         TaskKind::Issue => Some(
             issue
@@ -268,6 +264,22 @@ fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String>
         .map(ToOwned::to_owned)
 }
 
+/// Render the `external_id` shown for a runtime-backed task in dashboard
+/// responses. Pulled out of two identical match blocks in
+/// [`runtime_workflow_task_summary`] and [`runtime_task_response_by_handle`]
+/// so that adding a new `TaskKind` variant only edits one place.
+fn runtime_external_id(
+    task_kind: TaskKind,
+    workflow_data: &serde_json::Value,
+    issue: Option<u64>,
+) -> Option<String> {
+    match task_kind {
+        TaskKind::Issue => issue.map(|issue_number| format!("issue:{issue_number}")),
+        TaskKind::Prompt => runtime_string_field(workflow_data, "external_id"),
+        TaskKind::Pr | TaskKind::Review | TaskKind::Planner => None,
+    }
+}
+
 fn runtime_task_id_array(
     data: &serde_json::Value,
     field: &str,
@@ -343,11 +355,7 @@ async fn runtime_task_response_by_handle(
     }) else {
         return Ok(None);
     };
-    let external_id = match task_kind {
-        TaskKind::Issue => issue.map(|issue_number| format!("issue:{issue_number}")),
-        TaskKind::Prompt => runtime_string_field(&workflow.data, "external_id"),
-        _ => None,
-    };
+    let external_id = runtime_external_id(task_kind, &workflow.data, issue);
     Ok(Some(RuntimeTaskResponse {
         id: task_id.as_str().to_string(),
         task_id: task_id.as_str().to_string(),

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -281,11 +281,7 @@ pub(super) fn summarize_request_description(req: &CreateTaskRequest) -> Option<S
         return Some(format!("PR #{n}"));
     }
     if req.prompt.is_some() {
-        return Some(match task_kind {
-            TaskKind::Review => "periodic review".to_string(),
-            TaskKind::Planner => "sprint planner".to_string(),
-            TaskKind::Issue | TaskKind::Pr | TaskKind::Prompt => "prompt task".to_string(),
-        });
+        return task_kind.prompt_task_label().map(str::to_string);
     }
     None
 }

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -88,6 +88,33 @@ impl TaskKind {
         }
     }
 
+    /// Stable, user-facing reason string emitted when a task of this kind is
+    /// found with no persisted external identifier during orphan recovery.
+    /// Centralised here so that adding a new variant forces an explicit
+    /// orphan-reason decision in one place rather than ten.
+    pub fn orphan_recovery_failure_reason(&self) -> &'static str {
+        match self {
+            Self::Issue => "orphaned issue task: issue number not persisted",
+            Self::Pr => "orphaned PR task: PR number not persisted",
+            Self::Prompt => "orphaned prompt-only task: prompt not persisted",
+            Self::Review => "orphaned review task: prompt not persisted",
+            Self::Planner => "orphaned planner task: prompt not persisted",
+        }
+    }
+
+    /// Short human-readable label used as the persisted task description when
+    /// the request carries a prompt but no structured issue / PR identifier.
+    /// `None` for kinds that never receive a freeform prompt-only submission;
+    /// today every kind does, but the option leaves room for future variants
+    /// that should reject prompt-only intake.
+    pub fn prompt_task_label(&self) -> Option<&'static str> {
+        Some(match self {
+            Self::Review => "periodic review",
+            Self::Planner => "sprint planner",
+            Self::Issue | Self::Pr | Self::Prompt => "prompt task",
+        })
+    }
+
     pub fn requires_pr_url(&self) -> bool {
         matches!(self, Self::Issue | Self::Pr)
     }


### PR DESCRIPTION
## Summary

Consolidate the genuinely-repeated \`match task_kind\` blocks in \`harness-server\` into either inherent methods on \`TaskKind\` or file-local helpers:

- \`TaskKind::orphan_recovery_failure_reason()\` replaces the per-kind failure-reason mapping in \`http::background::orphan_recovery_failure_reason\` (which is now a one-line delegate kept for symmetry with the existing call sites).
- \`TaskKind::prompt_task_label()\` replaces the per-kind label match in \`task_runner::request\`. Returns \`Option<&'static str>\` so a future variant can opt out of prompt-only intake instead of being silently coerced to \`\"prompt task\"\`.
- New file-local helper \`runtime_external_id\` in \`http::task_query_routes\` deduplicates two byte-identical \`match task_kind\` blocks.

## Why — and a scope correction

The architecture review flagged this as the highest-leverage refactor (~10 production sites). A closer audit found the situation milder than reported:

- Most \`match task_kind\` sites are unique per-call decisions, not duplicated logic — extracting each into a method would just add indirection.
- \`recovery_queue_domain\` was already a separate free function; nothing to centralise there.
- The few sites that are actually duplicated (\`external_id\`) or that benefit from being expressed as inherent methods (\`orphan_recovery_failure_reason\`, \`prompt_task_label\`) are addressed by this PR.

The result is a smaller refactor than originally planned, but the cases it covers are the ones that actually pay back when adding a new \`TaskKind\` variant.

## Out of scope (intentional)

- The \`match task_kind\` block at \`workflow_runtime_worker.rs:153\` lives on a file with concurrent WIP; deferred to PR-5b once that work lands.
- One-line \`matches!(task_kind, ...)\` patterns in \`task_runner::spawn\` and \`task_executor::helpers\`. Wrapping each in a method costs more readability than it saves.
- The \`description\` mapping in \`task_query_routes::runtime_workflow_task_summary\` mixes workflow-specific data with TaskKind branching; not pure enough to belong on the enum.

## Behaviour preservation

- Per-kind strings are byte-equal copies of the previous inline literals.
- 70 \`task_runner\` tests pass unchanged.

## Test plan

- [x] \`cargo test -p harness-server --lib task_runner\` — 70 tests pass
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [ ] Gemini code review bot
- [ ] CI Result green

> Note: an unrelated test \`http::background::tests::runtime_worker_loop_policy_keeps_polling_when_server_root_disables_worker\` is currently failing in this working tree, but the failure also reproduces on \`origin/main\` with this PR\\'s changes stashed. Not caused by this PR.