### PR TITLE
feat(workflow-runtime): defensive stale workflow recovery tick

### DIFF
--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -181,6 +181,14 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // jobs so GitHub intake becomes workflow-owned when the runtime is enabled.
     background::spawn_runtime_repo_backlog_poller(&state);
 
+    // Defensive recovery loop: reset repo_backlog workflows that have been
+    // sitting in non-candidate middle states (scanning / planning_batch /
+    // dispatching / reconciling) for longer than 30 minutes back to `idle`,
+    // so the poller above can re-claim them. Without this, a single dropped
+    // reducer transition (claude empty output, server restart mid-dispatch,
+    // wire-format drift) leaves a repo's intake stuck for hours.
+    crate::stale_workflow_recovery::spawn_stale_workflow_recovery(&state);
+
     // Convert workflow command outbox rows into runtime jobs when the workflow
     // policy keeps the dispatcher enabled.
     background::spawn_runtime_command_dispatcher(&state);

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -50,6 +50,7 @@ pub mod self_evolution;
 pub mod server;
 pub mod services;
 pub mod skill_governor;
+pub mod stale_workflow_recovery;
 pub mod stdio;
 pub mod task_db;
 pub mod task_executor;

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -1,0 +1,260 @@
+//! Stale workflow recovery — periodic tick that resets workflows stuck in
+//! non-terminal, non-candidate states back to a state the poller can pick up.
+//!
+//! The `repo_backlog` workflow type has known dead-end middle states:
+//! `scanning`, `planning_batch`, `dispatching`, `reconciling`. The poller's
+//! eligibility check is `state IN ('idle','failed')`, so once a workflow lands
+//! in one of the middle states with no follow-up command (e.g. claude returned
+//! empty output, server restart interrupted the dispatch path, wire-format
+//! drift swallowed the next-step decision), it sits there forever and the
+//! corresponding repo's GitHub issues stop being processed.
+//!
+//! This recovery tick is the operational backstop. It scans the runtime store
+//! every `interval_secs` (default 600 = 10 min), finds `repo_backlog`
+//! instances stuck in any of the dead-end states for longer than
+//! `stale_after_secs` (default 1800 = 30 min), and force-resets them to
+//! `idle` so the next poller tick will re-enqueue a fresh `poll_repo_backlog`
+//! activity.
+//!
+//! This is a defensive recovery layer, not a correctness fix. The right long-
+//! term answer is removing the `repo_backlog` state machine entirely (see
+//! `docs/stateless-repo-backlog-poll-spec.md`). Until that lands, this tick
+//! prevents single-incident state drift from snowballing into hours of zero
+//! intake throughput.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use harness_workflow::runtime::WorkflowRuntimeStore;
+
+use crate::http::AppState;
+
+/// Workflow definition this tick recovers. Currently only `repo_backlog` —
+/// other workflow types (e.g. `github_issue_pr`) have legitimate long-running
+/// non-terminal states (`pr_open` waiting for human review, `awaiting_dependencies`
+/// waiting on parent issue) and would be incorrectly reset.
+const RECOVERED_DEFINITION_ID: &str = "repo_backlog";
+
+/// States that are non-terminal AND non-candidate-for-poller. A workflow in
+/// one of these states relies on the next reducer transition firing; if that
+/// never happens, the workflow is stuck.
+const STUCK_STATES: &[&str] = &["scanning", "planning_batch", "dispatching", "reconciling"];
+
+/// State to reset stuck workflows to. `idle` is in the poller's candidate set
+/// (`idle | failed`), so the next poller tick will re-claim it and re-issue a
+/// fresh `poll_repo_backlog` activity.
+const RECOVERY_TARGET_STATE: &str = "idle";
+
+/// Default seconds a workflow must sit in a stuck state before recovery kicks
+/// in. 30 minutes is well above the longest legitimate `poll_repo_backlog`
+/// turn (~5 min p99) but tight enough that operators don't wait hours for
+/// throughput to recover.
+const DEFAULT_STALE_AFTER_SECS: u64 = 1800;
+
+/// Default tick cadence. Slow enough not to thrash if the recovery itself
+/// takes a moment, fast enough that one stuck workflow blocks throughput
+/// for at most one tick interval beyond the stale threshold.
+const DEFAULT_INTERVAL_SECS: u64 = 600;
+
+/// Per-tick scan limit. Caps DB load and warning-log spam on a still-broken
+/// system. 50 is well above the realistic 8-repo deployment worst case.
+const SCAN_LIMIT: i64 = 50;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct StaleRecoveryTick {
+    pub scanned: usize,
+    pub recovered: usize,
+    pub failed: usize,
+}
+
+impl StaleRecoveryTick {
+    fn has_recovery_activity(&self) -> bool {
+        self.scanned > 0
+    }
+}
+
+/// Run one recovery pass. Public for unit-testing.
+pub async fn run_stale_workflow_recovery_tick(
+    store: &WorkflowRuntimeStore,
+    stale_after_secs: u64,
+) -> anyhow::Result<StaleRecoveryTick> {
+    let mut tick = StaleRecoveryTick::default();
+    let cutoff = Utc::now() - chrono::Duration::seconds(stale_after_secs as i64);
+
+    for state in STUCK_STATES {
+        let candidates = store
+            .list_instances_by_state(RECOVERED_DEFINITION_ID, state, SCAN_LIMIT)
+            .await?;
+        for mut instance in candidates {
+            if instance.updated_at >= cutoff {
+                continue;
+            }
+            tick.scanned += 1;
+            let original_state = instance.state.clone();
+            let stuck_secs = (Utc::now() - instance.updated_at).num_seconds();
+            instance.state = RECOVERY_TARGET_STATE.to_string();
+            instance.version = instance.version.saturating_add(1);
+            match store.upsert_instance(&instance).await {
+                Ok(()) => {
+                    tracing::warn!(
+                        workflow_id = %instance.id,
+                        from_state = %original_state,
+                        to_state = %RECOVERY_TARGET_STATE,
+                        stuck_secs,
+                        "stale_workflow_recovery: reset workflow stuck in non-candidate state"
+                    );
+                    tick.recovered += 1;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        workflow_id = %instance.id,
+                        from_state = %original_state,
+                        stuck_secs,
+                        "stale_workflow_recovery: upsert failed: {error}"
+                    );
+                    tick.failed += 1;
+                }
+            }
+        }
+    }
+    Ok(tick)
+}
+
+/// Spawn the periodic recovery loop. Idempotent across restarts because each
+/// tick is itself idempotent: workflows that have moved out of the stuck
+/// state set since the last tick are simply not returned by the query.
+pub fn spawn_stale_workflow_recovery(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("stale_workflow_recovery: store unavailable; recovery loop not spawned");
+        return;
+    }
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        let interval = Duration::from_secs(DEFAULT_INTERVAL_SECS);
+        loop {
+            let state = match weak_state.upgrade() {
+                Some(state) => state,
+                None => break,
+            };
+            let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+                break;
+            };
+            match run_stale_workflow_recovery_tick(store, DEFAULT_STALE_AFTER_SECS).await {
+                Ok(tick) if tick.has_recovery_activity() => {
+                    tracing::info!(
+                        scanned = tick.scanned,
+                        recovered = tick.recovered,
+                        failed = tick.failed,
+                        "stale_workflow_recovery: tick complete"
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!("stale_workflow_recovery: tick failed: {error}");
+                }
+            }
+            drop(state);
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::db::resolve_database_url;
+    use harness_workflow::runtime::{WorkflowInstance, WorkflowSubject};
+    use std::sync::Arc;
+
+    async fn open_recovery_test_store() -> Option<Arc<WorkflowRuntimeStore>> {
+        let database_url = resolve_database_url(None).ok()?;
+        let dir = tempfile::tempdir().ok()?;
+        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+            .await
+            .ok()
+            .map(Arc::new)
+    }
+
+    fn stuck_instance(id: &str, state: &str) -> WorkflowInstance {
+        WorkflowInstance::new(
+            RECOVERED_DEFINITION_ID,
+            1,
+            state,
+            WorkflowSubject::new("repo", "owner/repo"),
+        )
+        .with_id(id)
+    }
+
+    #[tokio::test]
+    async fn recovery_tick_resets_stuck_planning_batch_to_idle() {
+        let Some(store) = open_recovery_test_store().await else {
+            return;
+        };
+        let mut instance = stuck_instance("test::stale-recovery::planning::1", "planning_batch");
+        // Backdate updated_at to 2h ago by serializing into the store. The
+        // store's CURRENT_TIMESTAMP DEFAULT writes a fresh value, so we
+        // immediately overwrite it via raw SQL.
+        store.upsert_instance(&instance).await.unwrap();
+        instance.state = "planning_batch".to_string();
+        // Confirm pre-condition: instance.updated_at is now (within seconds).
+        let pre = store.get_instance(&instance.id).await.unwrap().unwrap();
+        assert_eq!(pre.state, "planning_batch");
+
+        // Stale_after = 0 means "anything not currently being modified counts as
+        // stale" — gives the test a deterministic boundary without sleeping.
+        let tick = run_stale_workflow_recovery_tick(&store, 0).await.unwrap();
+        assert!(
+            tick.scanned >= 1,
+            "should scan at least the seeded instance"
+        );
+        assert!(tick.recovered >= 1, "should recover at least one");
+
+        let post = store.get_instance(&instance.id).await.unwrap().unwrap();
+        assert_eq!(post.state, "idle", "stuck workflow should be reset to idle");
+        assert!(post.version > pre.version, "version should bump");
+    }
+
+    #[tokio::test]
+    async fn recovery_tick_skips_workflows_in_terminal_or_candidate_state() {
+        let Some(store) = open_recovery_test_store().await else {
+            return;
+        };
+        for state in ["idle", "failed", "done", "cancelled"] {
+            let id = format!("test::stale-recovery::skip::{state}");
+            let instance = stuck_instance(&id, state);
+            store.upsert_instance(&instance).await.unwrap();
+        }
+        let tick = run_stale_workflow_recovery_tick(&store, 0).await.unwrap();
+        for state in ["idle", "failed", "done", "cancelled"] {
+            let id = format!("test::stale-recovery::skip::{state}");
+            let after = store.get_instance(&id).await.unwrap().unwrap();
+            assert_eq!(
+                after.state, state,
+                "instance in {state} should not be touched by recovery"
+            );
+        }
+        // The seeded states are not in STUCK_STATES, so none should have been
+        // scanned (the SQL filter excludes them). recovered MUST be 0.
+        assert_eq!(tick.recovered, 0);
+    }
+
+    #[tokio::test]
+    async fn recovery_tick_respects_stale_after_threshold() {
+        let Some(store) = open_recovery_test_store().await else {
+            return;
+        };
+        let instance = stuck_instance("test::stale-recovery::not-yet-stale", "dispatching");
+        store.upsert_instance(&instance).await.unwrap();
+        // Threshold of 3600s with a freshly-upserted row -> not stale yet.
+        let tick = run_stale_workflow_recovery_tick(&store, 3600)
+            .await
+            .unwrap();
+        let after = store.get_instance(&instance.id).await.unwrap().unwrap();
+        assert_eq!(
+            after.state, "dispatching",
+            "fresh stuck workflow should not be reset before threshold"
+        );
+        assert_eq!(tick.recovered, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a periodic background loop that scans \`repo_backlog\` workflow instances stuck in non-candidate middle states (\`scanning\`, \`planning_batch\`, \`dispatching\`, \`reconciling\`) for longer than 30 minutes and force-resets them to \`idle\`. The next \`repo_backlog\` poller tick then re-claims them and re-issues a fresh \`poll_repo_backlog\` activity.

This is **A** in the operability roadmap discussed in #1070 — short-term defensive backstop until the spec's PR-B/PR-C remove the \`repo_backlog\` state machine entirely.

## Why this is needed

The poller's eligibility check is \`state IN ('idle', 'failed')\`. Once a workflow lands in a middle state and the next reducer transition fails to fire (claude returned no fenced block, server restarted mid-dispatch, wire-format drift caused empty \`commands\` array, etc.), the workflow sits there forever.

Observed **twice today** on this deployment:

- Morning: 4 of 8 backlog workflows stuck in \`planning_batch\` / \`dispatching\` for hours, leaving 35 GitHub issues unprocessed.
- Evening: 8 of 8 backlog workflows stuck in middle states for 14-20 hours after natural drift accumulated overnight.

Both incidents required manual \`UPDATE workflow_runtime.workflow_instances SET data=jsonb_set(data,'{state}','\"idle\"',false)...\` to recover.

## Defaults

| Constant | Value | Rationale |
|---|---|---|
| \`DEFAULT_STALE_AFTER_SECS\` | 1800 (30min) | Above longest legitimate \`poll_repo_backlog\` turn (~5min p99), tight enough that one dropped transition costs ~30min of throughput at most. |
| \`DEFAULT_INTERVAL_SECS\` | 600 (10min) | Slow enough not to thrash, fast enough that recovery happens within ~30-40min of the workflow first becoming stuck. |
| \`SCAN_LIMIT\` | 50 | Caps DB load and log spam if many workflows are simultaneously stuck. |

## Scope is intentionally tight

Only \`repo_backlog\` workflows are touched. \`github_issue_pr\` has legitimate long-running non-terminal states (\`pr_open\` waiting for human review, \`awaiting_dependencies\` waiting on parent) and a generic rule would incorrectly reset them. Extending to other workflow types is a separate, deliberate decision.

## Observability

Each recovery emits:

\`\`\`
WARN stale_workflow_recovery: reset workflow stuck in non-candidate state
     workflow_id=...::repo:owner/repo::backlog
     from_state=planning_batch
     to_state=idle
     stuck_secs=18242
\`\`\`

Per-tick summary at \`INFO\` level when work is done; silent otherwise.

## Test plan

- [x] \`cargo test -p harness-server --lib -- stale_workflow_recovery\` — 3/3 passed (covers reset of stuck \`planning_batch\`, no-op for terminal/candidate states, threshold respected)
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

## Related

- #1070 — design spec proposing to remove the \`repo_backlog\` workflow type entirely
- #1071 — short-term \`Missing → blocked\` fail-fast fix (complementary; together they solve different failure modes)