### PR TITLE
feat(skills): add rebase-pr playbook skill

### DIFF
--- a/crates/harness-skills/src/builtin.rs
+++ b/crates/harness-skills/src/builtin.rs
@@ -1,0 +1,26 @@
+//! Static registry of builtin skill markdown files.
+//!
+//! Skills listed here are bundled into the binary via `include_str!` and loaded
+//! by `SkillStore::load_builtin`.  Adding a new builtin skill is a one-line
+//! change in [`BUILTIN_SKILLS`] plus a markdown file under `skills/`.
+
+/// Builtin skill registry: `(name, content)` pairs.
+///
+/// `name` is the on-disk filename without the `.md` suffix and is also used as
+/// the skill's stable identifier.  `content` is the entire markdown body.
+pub(crate) const BUILTIN_SKILLS: &[(&str, &str)] = &[
+    ("interview", include_str!("../../../skills/interview.md")),
+    ("exec-plan", include_str!("../../../skills/exec-plan.md")),
+    ("preflight", include_str!("../../../skills/preflight.md")),
+    ("check", include_str!("../../../skills/check.md")),
+    ("build-fix", include_str!("../../../skills/build-fix.md")),
+    ("review", include_str!("../../../skills/review.md")),
+    (
+        "cross-review",
+        include_str!("../../../skills/cross-review.md"),
+    ),
+    ("learn", include_str!("../../../skills/learn.md")),
+    ("gc", include_str!("../../../skills/gc.md")),
+    ("stats", include_str!("../../../skills/stats.md")),
+    ("rebase-pr", include_str!("../../../skills/rebase-pr.md")),
+];

--- a/crates/harness-skills/src/lib.rs
+++ b/crates/harness-skills/src/lib.rs
@@ -1,2 +1,3 @@
+pub(crate) mod builtin;
 pub mod freshness;
 pub mod store;

--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 
 pub use crate::freshness::FreshnessClass;
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillGovernanceStatus {
@@ -548,22 +551,7 @@ impl SkillStore {
     }
 
     pub fn load_builtin(&mut self) {
-        let builtins = [
-            ("interview", include_str!("../../../skills/interview.md")),
-            ("exec-plan", include_str!("../../../skills/exec-plan.md")),
-            ("preflight", include_str!("../../../skills/preflight.md")),
-            ("check", include_str!("../../../skills/check.md")),
-            ("build-fix", include_str!("../../../skills/build-fix.md")),
-            ("review", include_str!("../../../skills/review.md")),
-            (
-                "cross-review",
-                include_str!("../../../skills/cross-review.md"),
-            ),
-            ("learn", include_str!("../../../skills/learn.md")),
-            ("gc", include_str!("../../../skills/gc.md")),
-            ("stats", include_str!("../../../skills/stats.md")),
-        ];
-        for (name, content) in builtins {
+        for &(name, content) in crate::builtin::BUILTIN_SKILLS {
             if self.get_by_name(name).is_none() {
                 let usage = if let Some(dir) = &self.persist_dir {
                     self.skill_dirs.insert(name.to_string(), dir.clone());
@@ -751,7 +739,3 @@ fn location_priority(loc: SkillLocation) -> u8 {
         SkillLocation::System => 1,
     }
 }
-
-#[cfg(test)]
-#[path = "store_tests.rs"]
-mod tests;

--- a/crates/harness-skills/src/store/tests.rs
+++ b/crates/harness-skills/src/store/tests.rs
@@ -689,3 +689,66 @@ fn rebase_pr_playbook_covers_cherry_pick_fallback() {
         "playbook must include a cherry-pick-onto-fresh-main fallback"
     );
 }
+
+/// Regression for #1078: the skill must prescribe terminal tokens that the
+/// server's `parse_pr_review_prep_outcome` parser actually accepts. The parser
+/// rejects bare `REBASE_CONFLICT` (without the mandatory `paths=...` suffix)
+/// and any other `REBASE_*` token. If the skill prescribes
+/// `REBASE_VERIFY_FAILED` or bare `REBASE_CONFLICT`, an agent following the
+/// playbook produces output the server discards as malformed, losing the
+/// structured report.
+#[test]
+fn rebase_pr_terminal_tokens_match_parser_contract() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.as_str();
+
+    // The three accepted tokens must all be documented.
+    assert!(
+        body.contains("REBASE_PUSHED"),
+        "skill must document REBASE_PUSHED — the parser-accepted success token"
+    );
+    assert!(
+        body.contains("REBASE_SKIPPED"),
+        "skill must document REBASE_SKIPPED — the parser-accepted no-op token"
+    );
+    assert!(
+        body.contains("REBASE_CONFLICT paths="),
+        "skill must prescribe REBASE_CONFLICT with the mandatory paths= suffix; \
+         the parser rejects bare REBASE_CONFLICT and the report is lost"
+    );
+
+    // Tokens the parser rejects must not appear as prescribed terminal tokens.
+    // (Substring match is a deliberate over-approximation — even a stray
+    // mention can mislead an agent following the playbook.)
+    assert!(
+        !body.contains("REBASE_VERIFY_FAILED"),
+        "skill must not prescribe REBASE_VERIFY_FAILED — the parser rejects \
+         it, so the structured report is discarded; verify-failed should be \
+         emitted as REBASE_CONFLICT paths=... with classification=verify_failed \
+        in the structured report"
+    );
+}
+
+/// Regression for #1078: direct PR review-prep prompts provide their own
+/// isolated worktree path, usually `/tmp/harness-pr-{pr}`. The skill must not
+/// contradict that caller contract by sending the agent to a different
+/// hard-coded path.
+#[test]
+fn rebase_pr_worktree_path_uses_caller_provided_contract() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.as_str();
+
+    assert!(
+        body.contains("caller-provided isolated worktree"),
+        "skill must tell agents to use the worktree path supplied by the caller"
+    );
+    assert!(
+        body.contains("/tmp/harness-pr-{pr}"),
+        "skill should document the direct PR review-prep worktree shape"
+    );
+    assert!(
+        !body.contains("/tmp/harness-rebase"),
+        "skill must not hard-code a second worktree path that conflicts with \
+         the PR review-prep prompt"
+    );
+}

--- a/crates/harness-skills/src/store/tests.rs
+++ b/crates/harness-skills/src/store/tests.rs
@@ -1,0 +1,691 @@
+use super::*;
+
+fn make_skill(name: &str, location: SkillLocation) -> Skill {
+    Skill {
+        id: SkillId::new(),
+        name: name.to_string(),
+        description: "desc".to_string(),
+        content: "content".to_string(),
+        trigger_patterns: Vec::new(),
+        version: "1.0.0".to_string(),
+        author: "test".to_string(),
+        location,
+        content_hash: compute_content_hash("content"),
+        usage_count: 0,
+        last_used: None,
+        quality_score: default_quality_score(),
+        scored_samples: 0,
+        governance_status: SkillGovernanceStatus::Active,
+        canary_ratio: default_canary_ratio(),
+        last_scored: None,
+    }
+}
+
+#[test]
+fn deduplicate_keeps_higher_priority() {
+    let mut store = SkillStore::new();
+    store
+        .skills
+        .push(make_skill("deploy", SkillLocation::System));
+    store.skills.push(make_skill("deploy", SkillLocation::Repo));
+    store.deduplicate();
+    assert_eq!(store.list().len(), 1);
+    assert_eq!(store.list()[0].location, SkillLocation::Repo);
+}
+
+#[test]
+fn deduplicate_removes_lower_priority_duplicate() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill("lint", SkillLocation::User));
+    store.skills.push(make_skill("lint", SkillLocation::Admin));
+    store.deduplicate();
+    assert_eq!(store.list().len(), 1);
+    assert_eq!(store.list()[0].location, SkillLocation::User);
+}
+
+#[test]
+fn deduplicate_keeps_unique_skills() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill("alpha", SkillLocation::Repo));
+    store.skills.push(make_skill("beta", SkillLocation::User));
+    store.deduplicate();
+    assert_eq!(store.list().len(), 2);
+}
+
+#[test]
+fn create_adds_skill_to_store() {
+    let mut store = SkillStore::new();
+    store.create(
+        "my-skill".to_string(),
+        "# My Skill\nDoes stuff.".to_string(),
+    );
+    assert_eq!(store.list().len(), 1);
+    assert_eq!(store.list()[0].name, "my-skill");
+}
+
+#[test]
+fn delete_removes_skill() {
+    let mut store = SkillStore::new();
+    store.create("removable".to_string(), "content".to_string());
+    let id = store.list()[0].id.clone();
+    assert!(store.delete(&id));
+    assert!(store.list().is_empty());
+}
+
+#[test]
+fn create_persists_file_to_disk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let persist_path = dir.path().to_path_buf();
+    let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+    store.create(
+        "my-skill".to_string(),
+        "# My Skill\nDoes stuff.".to_string(),
+    );
+    let file = persist_path.join("my-skill.md");
+    assert!(file.exists(), "skill file should be written to disk");
+    let contents = std::fs::read_to_string(&file).expect("read file");
+    assert!(contents.contains("Does stuff."));
+}
+
+#[test]
+fn delete_removes_file_from_disk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let persist_path = dir.path().to_path_buf();
+    let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+    store.create("removable".to_string(), "content".to_string());
+    let file = persist_path.join("removable.md");
+    assert!(file.exists(), "file should exist after create");
+    let id = store.list()[0].id.clone();
+    assert!(store.delete(&id));
+    assert!(!file.exists(), "file should be removed after delete");
+}
+
+#[test]
+fn search_finds_by_name() {
+    let mut store = SkillStore::new();
+    store.create("rust-lint".to_string(), "# Lint tool".to_string());
+    store.create("python-format".to_string(), "# Format tool".to_string());
+    let results = store.search("rust");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "rust-lint");
+}
+
+#[test]
+fn load_builtin_adds_all_registered_skills() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    assert_eq!(store.list().len(), crate::builtin::BUILTIN_SKILLS.len());
+}
+
+#[test]
+fn load_builtin_all_system_location() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    for skill in store.list() {
+        assert_eq!(
+            skill.location,
+            SkillLocation::System,
+            "builtin skill '{}' should have System location",
+            skill.name
+        );
+    }
+}
+
+#[test]
+fn load_builtin_user_skill_overrides_builtin() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill("review", SkillLocation::User));
+    store.load_builtin();
+    assert_eq!(store.list().len(), crate::builtin::BUILTIN_SKILLS.len());
+    let Some(review) = store.get_by_name("review") else {
+        panic!("review skill must exist");
+    };
+    assert_eq!(review.location, SkillLocation::User);
+}
+
+#[test]
+fn load_builtin_idempotent() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    store.load_builtin();
+    assert_eq!(
+        store.list().len(),
+        crate::builtin::BUILTIN_SKILLS.len(),
+        "calling load_builtin twice must not duplicate skills"
+    );
+}
+
+#[test]
+fn load_builtin_restores_sidecar_governance_from_persist_dir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let persist_path = dir.path().to_path_buf();
+    let sidecar_path = persist_path.join("review.usage.json");
+    let sidecar = SkillUsage {
+        usage_count: 7,
+        last_used: Some(Utc::now()),
+        quality_score: 0.2,
+        scored_samples: 40,
+        governance_status: SkillGovernanceStatus::Retired,
+        canary_ratio: 0.0,
+        last_scored: Some(Utc::now()),
+    };
+    std::fs::write(
+        &sidecar_path,
+        serde_json::to_string(&sidecar).expect("serialize sidecar"),
+    )
+    .expect("write sidecar");
+
+    let mut store = SkillStore::new().with_persist_dir(persist_path);
+    store.load_builtin();
+    let review = store
+        .get_by_name("review")
+        .expect("builtin review skill should exist");
+    assert_eq!(review.usage_count, 7);
+    assert_eq!(review.governance_status, SkillGovernanceStatus::Retired);
+    assert_eq!(review.scored_samples, 40);
+}
+
+#[test]
+fn get_by_name_returns_correct_skill() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    let Some(skill) = store.get_by_name("interview") else {
+        panic!("interview skill must exist");
+    };
+    assert_eq!(skill.name, "interview");
+    assert_eq!(skill.location, SkillLocation::System);
+}
+
+#[test]
+fn get_by_name_returns_none_for_missing() {
+    let store = SkillStore::new();
+    assert!(store.get_by_name("nonexistent").is_none());
+}
+
+#[test]
+fn load_builtin_skills_have_trigger_patterns() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    for skill in store.list() {
+        assert!(
+            !skill.trigger_patterns.is_empty(),
+            "builtin skill '{}' should have trigger patterns parsed from content",
+            skill.name
+        );
+    }
+}
+
+#[test]
+fn create_parses_trigger_patterns_from_content() {
+    let mut store = SkillStore::new();
+    store.create(
+        "my-skill".to_string(),
+        "# My Skill\n<!-- trigger-patterns: my keyword, another pattern -->\nContent.".to_string(),
+    );
+    assert_eq!(
+        store.list()[0].trigger_patterns,
+        vec!["my keyword", "another pattern"]
+    );
+}
+
+#[test]
+fn match_prompt_returns_matching_skills() {
+    let mut store = SkillStore::new();
+    store.skills.push(Skill {
+        id: SkillId::new(),
+        name: "review".to_string(),
+        description: "review code".to_string(),
+        content: String::new(),
+        trigger_patterns: vec!["code review".to_string(), "review pr".to_string()],
+        version: "1.0.0".to_string(),
+        author: "system".to_string(),
+        location: SkillLocation::System,
+        content_hash: compute_content_hash(""),
+        usage_count: 0,
+        last_used: None,
+        quality_score: default_quality_score(),
+        scored_samples: 0,
+        governance_status: SkillGovernanceStatus::Active,
+        canary_ratio: default_canary_ratio(),
+        last_scored: None,
+    });
+    let matches = store.match_prompt("please do a code review of this PR");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].name, "review");
+}
+
+#[test]
+fn match_prompt_is_case_insensitive() {
+    let mut store = SkillStore::new();
+    store.skills.push(Skill {
+        id: SkillId::new(),
+        name: "build-fix".to_string(),
+        description: "fix builds".to_string(),
+        content: String::new(),
+        trigger_patterns: vec!["build error".to_string()],
+        version: "1.0.0".to_string(),
+        author: "system".to_string(),
+        location: SkillLocation::System,
+        content_hash: compute_content_hash(""),
+        usage_count: 0,
+        last_used: None,
+        quality_score: default_quality_score(),
+        scored_samples: 0,
+        governance_status: SkillGovernanceStatus::Active,
+        canary_ratio: default_canary_ratio(),
+        last_scored: None,
+    });
+    let matches = store.match_prompt("I have a BUILD ERROR in my project");
+    assert_eq!(matches.len(), 1);
+}
+
+#[test]
+fn match_prompt_skips_skills_without_patterns() {
+    let mut store = SkillStore::new();
+    store
+        .skills
+        .push(make_skill("no-patterns", SkillLocation::System));
+    let matches = store.match_prompt("any prompt with no-patterns keywords");
+    assert!(
+        matches.is_empty(),
+        "skills without patterns should not be returned"
+    );
+}
+
+#[test]
+fn match_prompt_returns_empty_when_no_match() {
+    let mut store = SkillStore::new();
+    store.skills.push(Skill {
+        id: SkillId::new(),
+        name: "review".to_string(),
+        description: "review code".to_string(),
+        content: String::new(),
+        trigger_patterns: vec!["code review".to_string()],
+        version: "1.0.0".to_string(),
+        author: "system".to_string(),
+        location: SkillLocation::System,
+        content_hash: compute_content_hash(""),
+        usage_count: 0,
+        last_used: None,
+        quality_score: default_quality_score(),
+        scored_samples: 0,
+        governance_status: SkillGovernanceStatus::Active,
+        canary_ratio: default_canary_ratio(),
+        last_scored: None,
+    });
+    let matches = store.match_prompt("implement feature X");
+    assert!(matches.is_empty());
+}
+
+#[test]
+fn parse_version_from_frontmatter_returns_version_field() {
+    let content = "---\nversion: 2.3.4\n---\n# Title\n";
+    assert_eq!(parse_version_from_frontmatter(content), "2.3.4");
+}
+
+#[test]
+fn parse_version_from_frontmatter_defaults_when_absent() {
+    let content = "# Title\nNo frontmatter here.";
+    assert_eq!(parse_version_from_frontmatter(content), "1.0.0");
+}
+
+#[test]
+fn parse_version_from_frontmatter_defaults_when_field_missing() {
+    let content = "---\nauthor: alice\n---\n# Title\n";
+    assert_eq!(parse_version_from_frontmatter(content), "1.0.0");
+}
+
+#[test]
+fn parse_version_from_frontmatter_ignores_trailing_whitespace() {
+    let content = "---\nversion:  1.2.3  \n---\n";
+    assert_eq!(parse_version_from_frontmatter(content), "1.2.3");
+}
+
+#[test]
+fn increment_patch_bumps_last_component() {
+    assert_eq!(increment_patch("1.0.0"), "1.0.1");
+    assert_eq!(increment_patch("2.5.9"), "2.5.10");
+}
+
+#[test]
+fn increment_patch_does_not_touch_major_or_minor() {
+    assert_eq!(increment_patch("3.7.2"), "3.7.3");
+}
+
+#[test]
+fn update_increments_patch_when_content_changes() {
+    let mut store = SkillStore::new();
+    store.create("skill-a".to_string(), "original content".to_string());
+    let id = store.list()[0].id.clone();
+    assert_eq!(store.list()[0].version, "1.0.0");
+    store.update(&id, "changed content".to_string());
+    assert_eq!(store.list()[0].version, "1.0.1");
+}
+
+#[test]
+fn update_does_not_increment_when_content_unchanged() {
+    let mut store = SkillStore::new();
+    store.create("skill-b".to_string(), "same content".to_string());
+    let id = store.list()[0].id.clone();
+    store.update(&id, "same content".to_string());
+    assert_eq!(store.list()[0].version, "1.0.0");
+}
+
+#[test]
+fn update_returns_none_for_unknown_id() {
+    let mut store = SkillStore::new();
+    let unknown = SkillId::new();
+    assert!(store.update(&unknown, "content".to_string()).is_none());
+}
+
+#[test]
+fn create_parses_version_from_frontmatter() {
+    let mut store = SkillStore::new();
+    store.create(
+        "versioned".to_string(),
+        "---\nversion: 3.1.4\n---\n# Title\n".to_string(),
+    );
+    assert_eq!(store.list()[0].version, "3.1.4");
+}
+
+#[test]
+fn create_defaults_version_when_no_frontmatter() {
+    let mut store = SkillStore::new();
+    store.create(
+        "plain".to_string(),
+        "# Plain skill\nNo frontmatter.".to_string(),
+    );
+    assert_eq!(store.list()[0].version, "1.0.0");
+}
+
+#[test]
+fn record_use_increments_counter() {
+    let mut store = SkillStore::new();
+    let skill = make_skill("deploy", SkillLocation::System);
+    let id = skill.id.clone();
+    store.skills.push(skill);
+    store.record_use(&id);
+    store.record_use(&id);
+    let s = store.get(&id).unwrap();
+    assert_eq!(s.usage_count, 2);
+    assert!(s.last_used.is_some());
+}
+
+#[test]
+fn record_use_unknown_id_is_noop() {
+    let mut store = SkillStore::new();
+    store
+        .skills
+        .push(make_skill("deploy", SkillLocation::System));
+    let unknown = SkillId::new();
+    store.record_use(&unknown);
+    assert_eq!(store.list()[0].usage_count, 0);
+}
+
+#[test]
+fn record_use_persists_sidecar() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut store = SkillStore::new();
+    let skill = make_skill("deploy", SkillLocation::User);
+    let id = skill.id.clone();
+    store.skills.push(skill);
+    store
+        .skill_dirs
+        .insert("deploy".to_string(), tmp.path().to_path_buf());
+    store.record_use(&id);
+    let sidecar = tmp.path().join("deploy.usage.json");
+    assert!(sidecar.exists(), "sidecar file should be created");
+    let data: SkillUsage =
+        serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    assert_eq!(data.usage_count, 1);
+    assert!(data.last_used.is_some());
+    assert_eq!(data.governance_status, SkillGovernanceStatus::Active);
+    assert!(data.quality_score > 0.0);
+}
+
+#[test]
+fn load_usage_sidecar_returns_defaults_when_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let usage = load_usage_sidecar(tmp.path(), "nonexistent");
+    assert_eq!(usage.usage_count, 0);
+    assert!(usage.last_used.is_none());
+    assert_eq!(usage.governance_status, SkillGovernanceStatus::Active);
+    assert_eq!(usage.canary_ratio, 1.0);
+}
+
+#[test]
+fn load_usage_sidecar_restores_persisted_values() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sidecar = tmp.path().join("myskill.usage.json");
+    let stored = SkillUsage {
+        usage_count: 42,
+        last_used: Some(chrono::Utc::now()),
+        ..Default::default()
+    };
+    std::fs::write(&sidecar, serde_json::to_string(&stored).unwrap()).unwrap();
+    let loaded = load_usage_sidecar(tmp.path(), "myskill");
+    assert_eq!(loaded.usage_count, 42);
+    assert!(loaded.last_used.is_some());
+}
+
+#[test]
+fn governance_update_can_quarantine_skill() {
+    let mut store = SkillStore::new();
+    store.create(
+        "review-skill".to_string(),
+        "# review\n<!-- trigger-patterns: review -->".to_string(),
+    );
+    let id = store.list()[0].id.clone();
+
+    let update = store
+        .apply_governance_outcome(
+            &id,
+            SkillGovernanceInput {
+                success: 0,
+                fail: 20,
+                unknown: 0,
+            },
+        )
+        .expect("governance update should exist");
+    assert_eq!(update.current_status, SkillGovernanceStatus::Quarantine);
+    assert_eq!(update.canary_ratio, 0.1);
+    assert!(update.quality_score < 0.45);
+}
+
+#[test]
+fn governance_update_ignores_unknown_only_samples() {
+    let mut store = SkillStore::new();
+    store.create(
+        "unknown-skill".to_string(),
+        "# unknown\n<!-- trigger-patterns: unknown -->".to_string(),
+    );
+    let id = store.list()[0].id.clone();
+
+    let update = store.apply_governance_outcome(
+        &id,
+        SkillGovernanceInput {
+            success: 0,
+            fail: 0,
+            unknown: 12,
+        },
+    );
+    assert!(
+        update.is_none(),
+        "unknown-only samples should not change score"
+    );
+
+    let skill = store.get(&id).expect("skill should exist");
+    assert_eq!(skill.scored_samples, 0);
+    assert_eq!(skill.quality_score, default_quality_score());
+}
+
+#[test]
+fn retired_skill_is_not_auto_injected() {
+    let mut store = SkillStore::new();
+    store.skills.push(Skill {
+        id: SkillId::new(),
+        name: "retired-review".to_string(),
+        description: "review code".to_string(),
+        content: String::new(),
+        trigger_patterns: vec!["code review".to_string()],
+        version: "1.0.0".to_string(),
+        author: "system".to_string(),
+        location: SkillLocation::System,
+        content_hash: compute_content_hash(""),
+        usage_count: 0,
+        last_used: None,
+        quality_score: 0.2,
+        scored_samples: 100,
+        governance_status: SkillGovernanceStatus::Retired,
+        canary_ratio: 0.0,
+        last_scored: Some(Utc::now()),
+    });
+    let matches = store.match_prompt("please do a code review of this PR");
+    assert!(matches.is_empty(), "retired skill should not auto-inject");
+}
+
+#[test]
+fn discover_reloads_persisted_skills_across_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let persist_path = dir.path().to_path_buf();
+
+    // First "session": create and persist a skill to disk.
+    let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+    store.create(
+        "custom-workflow".to_string(),
+        "# Custom Workflow\nDoes custom things.".to_string(),
+    );
+    assert!(
+        persist_path.join("custom-workflow.md").exists(),
+        "skill file must be written to disk before restart"
+    );
+
+    // Simulate server restart: new store, same persist_dir.
+    let mut restarted = SkillStore::new().with_persist_dir(persist_path.clone());
+    restarted.load_builtin();
+    restarted
+        .discover()
+        .expect("discover must not fail on restart");
+
+    assert!(
+        restarted.get_by_name("custom-workflow").is_some(),
+        "persisted skill must survive simulated server restart"
+    );
+}
+
+#[test]
+fn persisted_skill_shadowing_builtin_survives_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let persist_path = dir.path().to_path_buf();
+
+    // First "session": create a user skill whose name matches a builtin.
+    let user_content = "# review\nMy custom review skill.".to_string();
+    let mut store = SkillStore::new().with_persist_dir(persist_path.clone());
+    store.create("review".to_string(), user_content.clone());
+    assert!(
+        persist_path.join("review.md").exists(),
+        "skill file must be written to disk before restart"
+    );
+
+    // Simulate server restart: load builtins first (as http.rs does),
+    // then discover persisted skills.
+    let mut restarted = SkillStore::new().with_persist_dir(persist_path.clone());
+    restarted.load_builtin();
+    restarted
+        .discover()
+        .expect("discover must not fail on restart");
+
+    // The user's override must win over the same-named builtin.
+    let skill = restarted
+        .get_by_name("review")
+        .expect("shadowed builtin must survive restart");
+    assert_eq!(
+        skill.location,
+        SkillLocation::User,
+        "persisted skill must have User location, not System"
+    );
+    assert_eq!(
+        skill.content, user_content,
+        "persisted skill content must be the user version, not the builtin"
+    );
+}
+
+// ── rebase-pr skill: playbook coverage ────────────────────────────────────────
+//
+// The rebase-pr skill is a markdown playbook for the agent. The acceptance
+// criteria from issue #985 require unit tests covering: stray-skip,
+// duplicate-skip, HEAD-supersedes, and escalation. These tests verify the
+// loaded skill content names each strategy explicitly so future edits cannot
+// silently drop one of the four classification arms.
+
+fn rebase_pr_skill() -> Skill {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    store
+        .get_by_name("rebase-pr")
+        .cloned()
+        .expect("rebase-pr builtin must be registered")
+}
+
+#[test]
+fn rebase_pr_skill_is_registered_and_triggers_on_rebase_prompt() {
+    let mut store = SkillStore::new();
+    store.load_builtin();
+    let matches =
+        store.match_prompt("PR #42 is conflicting; run git rebase origin/main and push the result");
+    assert!(
+        matches.iter().any(|s| s.name == "rebase-pr"),
+        "rebase-pr skill must auto-inject on a rebase-themed prompt"
+    );
+}
+
+#[test]
+fn rebase_pr_playbook_covers_stray_skip() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.to_lowercase();
+    assert!(
+        body.contains("stray commit") && body.contains("git rebase --skip"),
+        "playbook must cover the stray-skip arm with the --skip command"
+    );
+}
+
+#[test]
+fn rebase_pr_playbook_covers_duplicate_skip() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.to_lowercase();
+    assert!(
+        body.contains("duplicate commit") && body.contains("git rebase --skip"),
+        "playbook must cover the duplicate-skip arm with the --skip command"
+    );
+}
+
+#[test]
+fn rebase_pr_playbook_covers_head_supersedes() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.to_lowercase();
+    assert!(
+        body.contains("head supersedes") && body.contains("--ours"),
+        "playbook must cover the HEAD-supersedes arm and instruct keeping our side"
+    );
+}
+
+#[test]
+fn rebase_pr_playbook_covers_escalation_with_structured_report() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.to_lowercase();
+    assert!(
+        body.contains("semantic_conflict") && body.contains("conflicting_files"),
+        "escalation arm must emit a structured report, not the bare \
+         'manual resolution required' string"
+    );
+}
+
+#[test]
+fn rebase_pr_playbook_covers_cherry_pick_fallback() {
+    let skill = rebase_pr_skill();
+    let body = skill.content.to_lowercase();
+    assert!(
+        body.contains("cherry-pick") && body.contains("origin/$base"),
+        "playbook must include a cherry-pick-onto-fresh-main fallback"
+    );
+}

--- a/skills/rebase-pr.md
+++ b/skills/rebase-pr.md
@@ -1,0 +1,155 @@
+# Use when: rebasing a PR branch onto main and the rebase produces conflicts. Triggers on: rebase origin/main, rebase the PR, rebase --continue, rebase --skip, rebase conflict, conflicting and rebase, manual resolution required, rebase the conflicting
+
+<!-- trigger-patterns: rebase origin/main, rebase the PR, rebase --continue, rebase --skip, rebase conflict, conflicting and rebase, manual resolution required, rebase the conflicting -->
+
+## Trigger
+Use when a `git rebase` against the base branch surfaces one or more conflicts that the default "abort and bail" path would otherwise drop as `manual resolution required`.
+
+## Input
+- PR number, head branch, and base branch (resolved via `gh pr view`).
+- Path to an isolated worktree, e.g. `/tmp/harness-rebase-<pr>`.
+- Read access to the GitHub repo (for divergence stats and commit fingerprints).
+
+## Procedure
+
+### 1. Pre-flight
+Before starting the rebase, gather the data the conflict triage relies on:
+
+- Count divergent commits ahead of base:
+  `git log --oneline origin/$BASE..HEAD`
+- List overlapping files with base:
+  `git diff --name-only origin/$BASE...HEAD`
+- Fingerprint each commit on the branch with `(commit_message_hash, diff_size_bytes, touched_paths)`. Store the list — duplicate-skip and stray-skip both consult it.
+- Note the PR / issue scope (title, labels) to detect commits whose messages are off-theme (stray candidates).
+
+### 2. First pass
+Run the rebase and capture the first conflict point if any:
+
+```
+git rebase "origin/$BASE"
+```
+
+If clean: skip to step 5 (Verify).
+If conflicting: capture the conflict report:
+
+- Conflicting files: `git diff --name-only --diff-filter=U`
+- For each conflicting file capture the conflicting hunks (lines between `<<<<<<<` and `>>>>>>>`).
+- Identify the offending commit being replayed: `git rev-parse REBASE_HEAD` and `git log -1 --format=%H%n%s%n%b REBASE_HEAD`.
+
+### 3. Triage each conflict
+
+For each conflict, classify and act in order:
+
+#### a. HEAD identical to incoming → auto-resolve
+Both sides produced byte-identical content for the conflicting region. Take either side and continue.
+
+```
+git checkout --theirs <path>   # or --ours, both produce the same bytes
+git add <path>
+git rebase --continue
+```
+
+#### b. HEAD supersedes (HEAD has the strictly newer revision of the same lines)
+HEAD already includes a later iteration of the same change (e.g., the PR has a post-Gemini-fix commit that rewrote the same lines the replayed commit is touching). Keep HEAD's version verbatim.
+
+```
+git checkout --ours <path>
+git add <path>
+git rebase --continue
+```
+
+Document the decision: which HEAD commit supersedes which incoming commit.
+
+#### c. Stray commit → `git rebase --skip`
+The replayed commit is unrelated to the PR/issue scope (mismatched message theme, clearly an audit-findings or unrelated cleanup commit dropped in by a previous flaky run, no association with the PR title or labels).
+
+```
+git rebase --skip
+```
+
+Record the dropped commit SHA + subject so the final report can list it.
+
+#### d. Duplicate commit → `git rebase --skip`
+Compare the offending commit's fingerprint against commits already applied on HEAD (or already present in `origin/$BASE`). High overlap = duplicate. Heuristics:
+
+- Identical commit message hash, OR
+- Diff size and touched paths overlap > 80% with an already-applied commit, OR
+- `git cherry origin/$BASE HEAD` reports the commit as `-` (already in upstream).
+
+```
+git rebase --skip
+```
+
+Record the dropped commit SHA + which already-applied commit it duplicates.
+
+#### e. Otherwise → escalate with structured report
+If none of (a)-(d) apply, the conflict is a genuine semantic conflict. Do NOT force a side. Abort cleanly and emit a structured report:
+
+```
+git rebase --abort
+```
+
+Emit a JSON-shaped report on stdout:
+
+```
+{
+  "classification": "semantic_conflict",
+  "pr": <pr_number>,
+  "base": "<base_branch>",
+  "head": "<head_branch>",
+  "conflicting_files": ["<path>", ...],
+  "conflicting_hunks": [
+    {"path": "<path>", "ours_lines": "Lstart-Lend", "theirs_lines": "Lstart-Lend", "summary": "<one-line>"}
+  ],
+  "offending_commits": [{"sha": "<hex>", "subject": "<msg>"}]
+}
+```
+
+End the agent run with that report — do NOT print the bare `manual resolution required` string. Future automation needs the file + hunk list to plan a next step.
+
+### 4. Fallback: cherry-pick onto fresh main
+If step 3 escalated *and* the orchestrator has explicitly enabled the cherry-pick fallback (label, config flag, or follow-up task), attempt a clean rebuild:
+
+1. Reset the PR worktree to `origin/$BASE`:
+   `git checkout -B "$BRANCH" "origin/$BASE"`
+2. Walk the original commit list filtered through the duplicate-skip and stray-skip fingerprints from step 1, keeping only the "clean" commits.
+3. `git cherry-pick <sha>` each remaining commit in order. If any cherry-pick conflicts:
+   - Re-run the same triage rules from step 3 (HEAD-identical / HEAD-supersedes / stray / duplicate / escalate).
+   - On semantic conflict, `git cherry-pick --abort` and emit the same structured report (extend with `"phase": "cherry_pick_fallback"`).
+4. If every clean commit cherry-picks successfully, treat the result as the rebased branch and continue at step 5.
+
+### 5. Verify
+Before pushing, run the repo-appropriate build sanity check:
+
+- Rust workspace: `cargo check --workspace --all-targets`
+- TypeScript: `npx tsc --noEmit`
+- Go: `go build ./...`
+- Python: `python -m compileall <package>` or `pytest --collect-only` for syntax/import sanity.
+
+If verification fails, do NOT push. Emit a structured report with `"classification": "verify_failed"` and the build error excerpt.
+
+### 6. Push
+Force-push only with lease safety:
+
+```
+git push --force-with-lease "$HEAD_REPO_URL" HEAD:"$BRANCH"
+```
+
+Report the new commit count (`git log --oneline origin/$BASE..HEAD | wc -l`) and the new base SHA (`git rev-parse origin/$BASE`).
+
+## Output Format
+End the run with one terminal token on its own line:
+
+- `REBASE_PUSHED` — rebase or cherry-pick fallback succeeded, verify passed, force-push completed.
+- `REBASE_SKIPPED` — branch was already up to date with base; nothing to do.
+- `REBASE_CONFLICT` — escalation report emitted; manual review required.
+- `REBASE_VERIFY_FAILED` — rebase resolved but build/test sanity check failed; report attached.
+
+When emitting `REBASE_CONFLICT` or `REBASE_VERIFY_FAILED`, the *previous* lines of output MUST contain the structured report described above so the orchestrator can plan a next step without re-running the rebase.
+
+## Constraints
+- Never run `git checkout` or `git stash` in the main repository working tree — use `/tmp/harness-rebase-<pr>` worktree only.
+- Never push without `--force-with-lease`.
+- Never silently drop a commit. Every `--skip` decision must be logged with the dropped SHA, subject, and the rule (stray vs duplicate) that classified it.
+- Never claim success without running step 5 verification in this session.
+- If three consecutive triage attempts fail to make progress (no `--continue` and no `--skip` was applicable), stop and escalate per step 3e — this enforces the W-02 back-off.

--- a/skills/rebase-pr.md
+++ b/skills/rebase-pr.md
@@ -7,7 +7,9 @@ Use when a `git rebase` against the base branch surfaces one or more conflicts t
 
 ## Input
 - PR number, head branch, and base branch (resolved via `gh pr view`).
-- Path to an isolated worktree, e.g. `/tmp/harness-rebase-<pr>`.
+- Path to the isolated worktree provided by the caller. Direct `pr:N`
+  review-prep prompts usually use `/tmp/harness-pr-{pr}`; standalone rebase
+  tasks may provide a different path. Use the provided path verbatim.
 - Read access to the GitHub repo (for divergence stats and commit fingerprints).
 
 ## Procedure
@@ -138,17 +140,46 @@ git push --force-with-lease "$HEAD_REPO_URL" HEAD:"$BRANCH"
 Report the new commit count (`git log --oneline origin/$BASE..HEAD | wc -l`) and the new base SHA (`git rev-parse origin/$BASE`).
 
 ## Output Format
-End the run with one terminal token on its own line:
 
-- `REBASE_PUSHED` — rebase or cherry-pick fallback succeeded, verify passed, force-push completed.
+This skill targets the implement-turn pre-PR review-prep contract that
+`harness_core::prompts::parse_pr_review_prep_outcome` consumes. The parser
+accepts exactly three terminal tokens; any other token starting with
+`REBASE_` (including a bare `REBASE_CONFLICT` without `paths=...`) is
+rejected and the run is treated as malformed, losing the structured report
+you wrote above. Emit one — and only one — of these tokens on its own
+final line:
+
+- `REBASE_PUSHED` — rebase or cherry-pick fallback succeeded, verify passed,
+  force-push completed.
 - `REBASE_SKIPPED` — branch was already up to date with base; nothing to do.
-- `REBASE_CONFLICT` — escalation report emitted; manual review required.
-- `REBASE_VERIFY_FAILED` — rebase resolved but build/test sanity check failed; report attached.
+- `REBASE_CONFLICT paths=path1,path2` — manual handling required. The
+  `paths=` suffix is mandatory; list every file that holds an unresolved
+  conflict or that the verification step flagged. The previous lines of
+  output MUST contain the structured report described above so downstream
+  automation can plan a next step without re-running the rebase.
 
-When emitting `REBASE_CONFLICT` or `REBASE_VERIFY_FAILED`, the *previous* lines of output MUST contain the structured report described above so the orchestrator can plan a next step without re-running the rebase.
+### Verification failures
+
+A failed step-5 build/test check is also reported as
+`REBASE_CONFLICT paths=...` (with the files modified during the rebase, or
+the files implicated by the failing tests). The accompanying structured
+report sets `"classification": "verify_failed"` so the orchestrator can
+distinguish a verify-failed escalation from a true textual conflict; the
+terminal token stays inside the parser-accepted set so the report is
+preserved instead of being discarded as malformed output.
+
+### Out of scope: resumed conflict-gate prompts
+
+If you are resolving the resumed conflict gate (the prompt that asks "is
+this PR clean to merge?"), use that gate's own contract — `CLEAN_PR`,
+`REBASE_PUSHED`, or `MANUAL_RESOLUTION_REQUIRED` — emitted by
+`task_executor::conflict_resolver::parse_conflict_check_output`. Do not
+mix the two contracts in one run.
 
 ## Constraints
-- Never run `git checkout` or `git stash` in the main repository working tree — use `/tmp/harness-rebase-<pr>` worktree only.
+- Never run `git checkout` or `git stash` in the main repository working tree.
+  Use the caller-provided isolated worktree only, and do not switch to or create
+  a different hard-coded path.
 - Never push without `--force-with-lease`.
 - Never silently drop a commit. Every `--skip` decision must be logged with the dropped SHA, subject, and the rule (stray vs duplicate) that classified it.
 - Never claim success without running step 5 verification in this session.


### PR DESCRIPTION
## Summary

Closes #985.

Adds a dedicated `rebase-pr` builtin skill that encodes a triage playbook so harness PR-rebase tasks no longer give up at the first conflict with the bare `manual resolution required` string.

The skill covers four conflict classes plus a fallback:

- **Stray commit** (off-theme to PR/issue scope) -> `git rebase --skip`
- **Duplicate commit** (high fingerprint overlap with HEAD or already in upstream) -> `git rebase --skip`
- **HEAD identical / HEAD strictly supersedes** incoming -> auto-resolve via `--ours`
- **Otherwise (semantic conflict)** -> abort with a structured JSON report listing `conflicting_files`, `conflicting_hunks`, and `offending_commits` so the orchestrator can plan a next step without re-running the rebase
- **Cherry-pick-onto-fresh-main fallback** for cases that escalate but where a clean rebuild is feasible

The skill auto-injects whenever the agent prompt mentions rebase-themed phrases (`rebase origin/main`, `rebase --continue`, `rebase --skip`, `manual resolution required`, etc.), so the existing PR-task pipeline picks it up without plumbing changes.

To register the new builtin while staying under the 800-line file ceiling, the builtin registry is extracted into `crates/harness-skills/src/builtin.rs` and the test module moves to a sibling `crates/harness-skills/src/store/tests.rs` file. Production behavior is unchanged.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p harness-skills`
- [x] `cargo test -p harness-skills` — 60 tests pass, including the new coverage:
    - `rebase_pr_skill_is_registered_and_triggers_on_rebase_prompt`
    - `rebase_pr_playbook_covers_stray_skip`
    - `rebase_pr_playbook_covers_duplicate_skip`
    - `rebase_pr_playbook_covers_head_supersedes`
    - `rebase_pr_playbook_covers_escalation_with_structured_report`
    - `rebase_pr_playbook_covers_cherry_pick_fallback`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`