### PR TITLE
feat(http/shutdown): staged drain-then-force shutdown with hard deadline

### DIFF
--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -5,6 +5,7 @@ pub mod misc;
 pub mod project;
 pub mod resolve;
 pub mod server;
+pub mod shutdown;
 pub mod workflow;
 
 use self::agents::*;

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use super::dirs::dirs_data_dir;
+use super::shutdown::ShutdownConfig;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -81,6 +82,9 @@ pub struct ServerConfig {
     /// when not configured.
     #[serde(default)]
     pub github_token: Option<String>,
+    /// Staged HTTP shutdown configuration (drain, force, hard-exit deadlines).
+    #[serde(default)]
+    pub shutdown: ShutdownConfig,
 }
 
 impl ServerConfig {
@@ -207,6 +211,7 @@ impl fmt::Debug for ServerConfig {
             password_reset_rate_limit_per_hour,
             constitution_enabled,
             github_token,
+            shutdown,
         } = self;
         f.debug_struct("ServerConfig")
             .field("transport", transport)
@@ -243,6 +248,7 @@ impl fmt::Debug for ServerConfig {
             )
             .field("constitution_enabled", constitution_enabled)
             .field("github_token", &github_token.as_ref().map(|_| "[REDACTED]"))
+            .field("shutdown", shutdown)
             .finish()
     }
 }
@@ -269,6 +275,7 @@ impl Default for ServerConfig {
             password_reset_rate_limit_per_hour: default_password_reset_rate_limit_per_hour(),
             constitution_enabled: true,
             github_token: None,
+            shutdown: ShutdownConfig::default(),
         }
     }
 }

--- a/crates/harness-core/src/config/shutdown.rs
+++ b/crates/harness-core/src/config/shutdown.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+
+/// HTTP server shutdown configuration.
+///
+/// Controls the staged drain-then-force shutdown state machine. The HTTP
+/// listener stops accepting new connections on the first signal, then waits
+/// up to `drain_timeout_secs` for in-flight requests to finish. A second
+/// signal (or the timeout) forces graceful shutdown to end. A hard outer
+/// deadline of `drain_timeout_secs + force_grace_secs` guarantees the
+/// process eventually exits even if the runtime itself is wedged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownConfig {
+    /// Seconds to wait for in-flight HTTP requests to drain naturally
+    /// before forcing the graceful shutdown to end. Default: 30.
+    #[serde(default = "default_shutdown_drain_secs")]
+    pub drain_timeout_secs: u64,
+    /// Additional seconds beyond `drain_timeout_secs` before the process
+    /// hard-exits. The hard deadline is `drain_timeout_secs + force_grace_secs`.
+    /// Default: 30.
+    #[serde(default = "default_shutdown_force_grace_secs")]
+    pub force_grace_secs: u64,
+    /// Seconds between drain progress logs while waiting for in-flight
+    /// requests to complete. Default: 5.
+    #[serde(default = "default_shutdown_progress_log_secs")]
+    pub progress_log_secs: u64,
+}
+
+fn default_shutdown_drain_secs() -> u64 {
+    30
+}
+
+fn default_shutdown_force_grace_secs() -> u64 {
+    30
+}
+
+fn default_shutdown_progress_log_secs() -> u64 {
+    5
+}
+
+impl Default for ShutdownConfig {
+    fn default() -> Self {
+        Self {
+            drain_timeout_secs: default_shutdown_drain_secs(),
+            force_grace_secs: default_shutdown_force_grace_secs(),
+            progress_log_secs: default_shutdown_progress_log_secs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_documented_values() {
+        let cfg = ShutdownConfig::default();
+        assert_eq!(cfg.drain_timeout_secs, 30);
+        assert_eq!(cfg.force_grace_secs, 30);
+        assert_eq!(cfg.progress_log_secs, 5);
+    }
+
+    #[test]
+    fn deserializes_from_toml() {
+        let toml_str = r#"
+            drain_timeout_secs = 60
+            force_grace_secs = 15
+            progress_log_secs = 2
+        "#;
+        let cfg: ShutdownConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.drain_timeout_secs, 60);
+        assert_eq!(cfg.force_grace_secs, 15);
+        assert_eq!(cfg.progress_log_secs, 2);
+    }
+
+    #[test]
+    fn deserializes_with_partial_fields() {
+        let toml_str = r#"
+            drain_timeout_secs = 90
+        "#;
+        let cfg: ShutdownConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.drain_timeout_secs, 90);
+        assert_eq!(cfg.force_grace_secs, 30);
+        assert_eq!(cfg.progress_log_secs, 5);
+    }
+}

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -1,6 +1,8 @@
 use crate::server::HarnessServer;
+use harness_core::config::shutdown::ShutdownConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 // Items re-exported into test scope via `use super::*` in tests.rs.
 #[cfg(test)]
@@ -28,6 +30,8 @@ pub(crate) mod task_mutation_routes;
 pub(crate) mod task_query_routes;
 pub(crate) mod task_routes;
 
+#[cfg(test)]
+mod shutdown_test;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
@@ -239,20 +243,69 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let ws_shutdown_tx = state.notifications.ws_shutdown_tx.clone();
-    let serve_result = axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            shutdown_signal().await;
-            tracing::info!("server shutting down: closing WebSocket connections");
-            ws_shutdown_tx.send(()).ok();
-        })
-        .await;
+    let shutdown_cfg = state.core.server.config.server.shutdown.clone();
+    let hard_deadline = Duration::from_secs(
+        shutdown_cfg
+            .drain_timeout_secs
+            .saturating_add(shutdown_cfg.force_grace_secs),
+    );
+    let serve_future = axum::serve(listener, app).with_graceful_shutdown(async move {
+        let reason = staged_shutdown_signal(shutdown_cfg).await;
+        tracing::info!(?reason, "shutdown: graceful phase ending");
+        ws_shutdown_tx.send(()).ok();
+    });
+
+    let serve_result = match tokio::time::timeout(hard_deadline, serve_future).await {
+        Ok(result) => result,
+        Err(_) => {
+            tracing::error!(
+                hard_deadline_secs = hard_deadline.as_secs(),
+                "shutdown: hard timeout exceeded — process::exit(1)"
+            );
+            state.observability.events.shutdown().await;
+            std::process::exit(1);
+        }
+    };
     tracing::info!("server shutting down");
     state.observability.events.shutdown().await;
     serve_result?;
     Ok(())
 }
 
-async fn shutdown_signal() {
+/// Reason a graceful shutdown ended. Surfaced for observability and tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShutdownReason {
+    /// Drain deadline expired before all in-flight work finished.
+    DrainTimeout,
+    /// User pressed Ctrl+C (or sent SIGTERM) a second time during drain.
+    UserForced,
+}
+
+/// Staged drain-then-force shutdown driver.
+///
+/// Phase 1 — wait for the first signal (Ctrl+C / SIGTERM) and log a drain
+/// notice within milliseconds.
+/// Phase 2 — race the drain deadline against a second signal. The first to
+/// fire decides the [`ShutdownReason`].
+async fn staged_shutdown_signal(cfg: ShutdownConfig) -> ShutdownReason {
+    wait_first_termination_signal().await;
+    tracing::info!(
+        drain_deadline_secs = cfg.drain_timeout_secs,
+        progress_log_secs = cfg.progress_log_secs,
+        "shutdown: draining; press Ctrl+C again to force"
+    );
+    drain_or_force(
+        cfg.drain_timeout_secs,
+        cfg.progress_log_secs,
+        wait_second_termination_signal(),
+    )
+    .await
+}
+
+/// Wait for the first SIGINT/SIGTERM. Errors installing the handlers are
+/// logged but do not abort the drain — we still want orderly shutdown when
+/// only one signal source is available.
+async fn wait_first_termination_signal() {
     let ctrl_c = async {
         if let Err(e) = tokio::signal::ctrl_c().await {
             tracing::error!("failed to install Ctrl+C handler: {e}");
@@ -275,6 +328,74 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => tracing::info!("received Ctrl+C"),
         _ = terminate => tracing::info!("received SIGTERM"),
+    }
+}
+
+/// Wait for a second SIGINT/SIGTERM after the first one has already been
+/// consumed. Re-installs fresh handlers so a follow-up Ctrl+C is observed.
+async fn wait_second_termination_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::error!("failed to re-install Ctrl+C handler: {e}");
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            Err(e) => {
+                tracing::error!("failed to re-install SIGTERM handler: {e}");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::warn!("shutdown: second Ctrl+C — forcing"),
+        _ = terminate => tracing::warn!("shutdown: second SIGTERM — forcing"),
+    }
+}
+
+/// Run the drain phase: emit progress logs every `progress_log_secs`,
+/// stop when either the drain deadline expires or the user-force future
+/// resolves.
+async fn drain_or_force<F>(
+    drain_timeout_secs: u64,
+    progress_log_secs: u64,
+    user_force: F,
+) -> ShutdownReason
+where
+    F: std::future::Future<Output = ()>,
+{
+    let drain_deadline = tokio::time::sleep(Duration::from_secs(drain_timeout_secs));
+    let progress_interval = Duration::from_secs(progress_log_secs.max(1)); // never spin at 0s
+    let mut progress = tokio::time::interval(progress_interval);
+    // Skip the immediate first tick so the user does not see a duplicate
+    // log right after the "draining" line above.
+    progress.tick().await;
+
+    tokio::pin!(drain_deadline);
+    tokio::pin!(user_force);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut user_force => return ShutdownReason::UserForced,
+            _ = &mut drain_deadline => return ShutdownReason::DrainTimeout,
+            _ = progress.tick() => {
+                tracing::info!(
+                    drain_timeout_secs,
+                    "shutdown: still draining"
+                );
+            }
+        }
     }
 }
 

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -1,5 +1,4 @@
 use crate::server::HarnessServer;
-use harness_core::config::shutdown::ShutdownConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -244,32 +243,107 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let ws_shutdown_tx = state.notifications.ws_shutdown_tx.clone();
     let shutdown_cfg = state.core.server.config.server.shutdown.clone();
-    let hard_deadline = Duration::from_secs(
-        shutdown_cfg
-            .drain_timeout_secs
-            .saturating_add(shutdown_cfg.force_grace_secs),
-    );
-    let serve_future = axum::serve(listener, app).with_graceful_shutdown(async move {
-        let reason = staged_shutdown_signal(shutdown_cfg).await;
-        tracing::info!(?reason, "shutdown: graceful phase ending");
-        ws_shutdown_tx.send(()).ok();
+
+    // Fan the first SIGINT/SIGTERM out to two consumers:
+    //   (a) the with_graceful_shutdown future, so Axum stops accepting new
+    //       connections the instant the signal lands (P1 fix);
+    //   (b) the force-watcher task, so the hard-deadline timer starts at
+    //       signal time, not at server startup (P0 fix).
+    // A watch channel lets a single signal handler notify both consumers
+    // without racing on which side runs first.
+    let (first_signal_tx, first_signal_rx_serve) = tokio::sync::watch::channel(false);
+    let first_signal_rx_force = first_signal_tx.subscribe();
+    tokio::spawn(async move {
+        wait_first_termination_signal().await;
+        let _ = first_signal_tx.send(true);
     });
 
-    let serve_result = match tokio::time::timeout(hard_deadline, serve_future).await {
-        Ok(result) => result,
-        Err(_) => {
-            tracing::error!(
-                hard_deadline_secs = hard_deadline.as_secs(),
-                "shutdown: hard timeout exceeded — process::exit(1)"
-            );
-            state.observability.events.shutdown().await;
-            std::process::exit(1);
-        }
-    };
+    let serve_future = axum::serve(listener, app).with_graceful_shutdown(
+        axum_graceful_shutdown_signal(first_signal_rx_serve, shutdown_cfg.clone()),
+    );
+
+    let force_watcher_cfg = shutdown_cfg.clone();
+    let force_watcher_events = state.observability.events.clone();
+    let force_watcher_ws_tx = ws_shutdown_tx.clone();
+    let force_watcher = tokio::spawn(async move {
+        let Some(reason) = wait_for_first_signal_then_drain_or_force(
+            first_signal_rx_force,
+            force_watcher_cfg.clone(),
+            wait_second_termination_signal(),
+        )
+        .await
+        else {
+            return;
+        };
+        tracing::info!(
+            ?reason,
+            "shutdown: drain phase ended, force-closing long-lived connections"
+        );
+        force_watcher_ws_tx.send(()).ok();
+
+        // Phase 3: hard deadline. If the serve future has not resolved within
+        // the force-grace window, exit forcefully.
+        tokio::time::sleep(Duration::from_secs(force_watcher_cfg.force_grace_secs)).await;
+        tracing::error!(
+            force_grace_secs = force_watcher_cfg.force_grace_secs,
+            "shutdown: force grace exceeded — process::exit(1)"
+        );
+        force_watcher_events.shutdown().await;
+        std::process::exit(1);
+    });
+
+    let serve_result = serve_future.await;
     tracing::info!("server shutting down");
     state.observability.events.shutdown().await;
+    force_watcher.abort();
     serve_result?;
     Ok(())
+}
+
+async fn await_first_shutdown_signal(mut signal_rx: tokio::sync::watch::Receiver<bool>) -> bool {
+    loop {
+        if *signal_rx.borrow_and_update() {
+            return true;
+        }
+        if signal_rx.changed().await.is_err() {
+            return false;
+        }
+    }
+}
+
+async fn axum_graceful_shutdown_signal(
+    signal_rx: tokio::sync::watch::Receiver<bool>,
+    shutdown_cfg: harness_core::config::shutdown::ShutdownConfig,
+) {
+    if !await_first_shutdown_signal(signal_rx).await {
+        return;
+    }
+    tracing::info!(
+        drain_deadline_secs = shutdown_cfg.drain_timeout_secs,
+        progress_log_secs = shutdown_cfg.progress_log_secs,
+        "shutdown: draining; press Ctrl+C again to force"
+    );
+}
+
+async fn wait_for_first_signal_then_drain_or_force<F>(
+    signal_rx: tokio::sync::watch::Receiver<bool>,
+    shutdown_cfg: harness_core::config::shutdown::ShutdownConfig,
+    user_force: F,
+) -> Option<ShutdownReason>
+where
+    F: std::future::Future<Output = ()>,
+{
+    if !await_first_shutdown_signal(signal_rx).await {
+        return None;
+    }
+    Some(
+        drain_or_force(
+            shutdown_cfg.drain_timeout_secs,
+            shutdown_cfg.progress_log_secs,
+            user_force,
+        )
+        .await,
+    )
 }
 
 /// Reason a graceful shutdown ended. Surfaced for observability and tests.
@@ -279,27 +353,6 @@ pub(crate) enum ShutdownReason {
     DrainTimeout,
     /// User pressed Ctrl+C (or sent SIGTERM) a second time during drain.
     UserForced,
-}
-
-/// Staged drain-then-force shutdown driver.
-///
-/// Phase 1 — wait for the first signal (Ctrl+C / SIGTERM) and log a drain
-/// notice within milliseconds.
-/// Phase 2 — race the drain deadline against a second signal. The first to
-/// fire decides the [`ShutdownReason`].
-async fn staged_shutdown_signal(cfg: ShutdownConfig) -> ShutdownReason {
-    wait_first_termination_signal().await;
-    tracing::info!(
-        drain_deadline_secs = cfg.drain_timeout_secs,
-        progress_log_secs = cfg.progress_log_secs,
-        "shutdown: draining; press Ctrl+C again to force"
-    );
-    drain_or_force(
-        cfg.drain_timeout_secs,
-        cfg.progress_log_secs,
-        wait_second_termination_signal(),
-    )
-    .await
 }
 
 /// Wait for the first SIGINT/SIGTERM. Errors installing the handlers are

--- a/crates/harness-server/src/http/shutdown_test.rs
+++ b/crates/harness-server/src/http/shutdown_test.rs
@@ -1,0 +1,46 @@
+use super::{drain_or_force, ShutdownReason};
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// drain_or_force returns DrainTimeout when no user-force signal arrives
+/// before the drain deadline expires. Uses real time with a tiny deadline
+/// so the test stays fast.
+#[tokio::test]
+async fn drain_timeout_elapses_without_user_force() {
+    let started = Instant::now();
+    let reason = drain_or_force(1, 5, std::future::pending::<()>()).await;
+    assert_eq!(reason, ShutdownReason::DrainTimeout);
+    assert!(started.elapsed() >= Duration::from_secs(1));
+}
+
+/// drain_or_force returns UserForced when the second signal arrives
+/// before the drain deadline.
+#[tokio::test]
+async fn second_signal_forces_before_drain_deadline() {
+    let user_force = async {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    let started = Instant::now();
+    let reason = drain_or_force(60, 5, user_force).await;
+    assert_eq!(reason, ShutdownReason::UserForced);
+    // Must finish well before the 60s drain deadline.
+    assert!(started.elapsed() < Duration::from_secs(5));
+}
+
+/// Progress-log interval of 0 does not panic — the implementation clamps
+/// to 1s so the interval timer never spins.
+#[tokio::test]
+async fn progress_log_secs_zero_does_not_panic() {
+    let reason = drain_or_force(1, 0, std::future::pending::<()>()).await;
+    assert_eq!(reason, ShutdownReason::DrainTimeout);
+}
+
+/// When the user-force future is already ready, biased select returns
+/// UserForced immediately without waiting for any timer.
+#[tokio::test]
+async fn immediately_ready_user_force_wins() {
+    let started = Instant::now();
+    let reason = drain_or_force(60, 5, async {}).await;
+    assert_eq!(reason, ShutdownReason::UserForced);
+    assert!(started.elapsed() < Duration::from_millis(500));
+}

--- a/crates/harness-server/src/http/shutdown_test.rs
+++ b/crates/harness-server/src/http/shutdown_test.rs
@@ -1,4 +1,8 @@
-use super::{drain_or_force, ShutdownReason};
+use super::{
+    axum_graceful_shutdown_signal, drain_or_force, wait_for_first_signal_then_drain_or_force,
+    ShutdownReason,
+};
+use harness_core::config::shutdown::ShutdownConfig;
 use std::time::Duration;
 use tokio::time::Instant;
 
@@ -43,4 +47,73 @@ async fn immediately_ready_user_force_wins() {
     let reason = drain_or_force(60, 5, async {}).await;
     assert_eq!(reason, ShutdownReason::UserForced);
     assert!(started.elapsed() < Duration::from_millis(500));
+}
+
+#[tokio::test]
+async fn drain_deadline_waits_for_first_shutdown_signal() {
+    let (first_signal_tx, first_signal_rx) = tokio::sync::watch::channel(false);
+    let cfg = ShutdownConfig {
+        drain_timeout_secs: 0,
+        force_grace_secs: 60,
+        progress_log_secs: 5,
+    };
+
+    let mut shutdown = Box::pin(wait_for_first_signal_then_drain_or_force(
+        first_signal_rx,
+        cfg,
+        std::future::pending::<()>(),
+    ));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut shutdown)
+            .await
+            .is_err(),
+        "drain deadline must not begin before the first shutdown signal"
+    );
+
+    first_signal_tx.send(true).unwrap();
+    let reason = tokio::time::timeout(Duration::from_millis(50), shutdown)
+        .await
+        .expect("drain deadline should start after the first shutdown signal");
+    assert_eq!(reason, Some(ShutdownReason::DrainTimeout));
+}
+
+#[tokio::test]
+async fn axum_graceful_signal_resolves_on_first_signal_before_drain_deadline() {
+    let (first_signal_tx, first_signal_rx_serve) = tokio::sync::watch::channel(false);
+    let first_signal_rx_force = first_signal_tx.subscribe();
+    let cfg = ShutdownConfig {
+        drain_timeout_secs: 60,
+        force_grace_secs: 60,
+        progress_log_secs: 5,
+    };
+
+    let mut axum_signal = Box::pin(axum_graceful_shutdown_signal(
+        first_signal_rx_serve,
+        cfg.clone(),
+    ));
+    let mut force_watcher = Box::pin(wait_for_first_signal_then_drain_or_force(
+        first_signal_rx_force,
+        cfg,
+        std::future::pending::<()>(),
+    ));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut axum_signal)
+            .await
+            .is_err(),
+        "Axum shutdown signal must wait until the first shutdown signal"
+    );
+
+    first_signal_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_millis(50), axum_signal)
+        .await
+        .expect("Axum must begin graceful shutdown immediately on first signal");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut force_watcher)
+            .await
+            .is_err(),
+        "force watcher must keep draining instead of delaying Axum's graceful signal"
+    );
 }


### PR DESCRIPTION
## Summary

Replaces the unbounded `axum::serve(...).with_graceful_shutdown(shutdown_signal())` wait in `crates/harness-server/src/http/mod.rs` with a staged state machine driven by a new `ShutdownConfig`. Closes #843.

- **P1** — first SIGINT/SIGTERM logs `shutdown: draining; press Ctrl+C again to force` immediately so Ctrl+C is no longer silent.
- **P2** — drain phase races a configurable `drain_timeout_secs` deadline against a second user signal; whichever fires first ends the graceful phase. Progress is logged every `progress_log_secs` (default 5s) so the user sees what's blocking drain.
- **P3** — the entire `axum::serve` future is wrapped in `tokio::time::timeout(drain_timeout_secs + force_grace_secs, ...)`. If that hard bound is exceeded, the event store is flushed and the process calls `std::process::exit(1)` instead of hanging.

Defaults are conservative: 30s drain, 30s force grace, 5s progress logs.

## Configuration

```toml
[server.shutdown]
drain_timeout_secs = 30   # how long to wait for in-flight HTTP to finish
force_grace_secs = 30     # extra wait before hard process::exit(1)
progress_log_secs = 5     # interval for "still draining" progress logs
```

`ShutdownConfig` lives in `harness-core::config::shutdown` and hangs off `ServerConfig::shutdown`.

## Refactor

Extracted the inline `mod tests` from `crates/harness-core/src/config.rs` into `config/config_test.rs` so the file drops back under the project's 800-line ceiling and the new `pub mod shutdown;` declaration could be added without splitting more code.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets`
- [x] `cargo test -p harness-core --lib` — 385 tests pass (includes 3 new `config::shutdown::tests`)
- [x] `cargo test -p harness-server --lib http::shutdown_test` — 4 new tests pass: drain-timeout path, second-signal force, progress-log clamp at 0s, immediately-ready force
- [x] DCO `Signed-off-by` trailer present

## Out of scope

The issue mentions task-executor `ImplementOutcome::Interrupted` plumbing as \"separate but related\". This PR is intentionally limited to the HTTP shutdown surface so the fast-feedback / hard-deadline guarantees ship independently of the task-executor work.