### PR TITLE
test(workspace): synchronize CwdGuard via cwd_lock

### DIFF
--- a/crates/harness-server/src/workspace_tests.rs
+++ b/crates/harness-server/src/workspace_tests.rs
@@ -20,6 +20,11 @@ fn async_env_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
+fn async_cwd_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 struct ScopedEnvVar {
     key: String,
     original: Option<String>,
@@ -1181,19 +1186,26 @@ async fn reconcile_startup_continues_after_workspace_cleanup_failure() {
     );
 }
 
-struct CwdGuard(PathBuf);
+struct CwdGuard {
+    original: PathBuf,
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+}
 
 impl CwdGuard {
-    fn switch_to(path: &Path) -> anyhow::Result<Self> {
+    async fn switch_to(path: &Path) -> anyhow::Result<Self> {
+        let guard = async_cwd_lock().lock().await;
         let original = std::env::current_dir()?;
         std::env::set_current_dir(path)?;
-        Ok(Self(original))
+        Ok(Self {
+            original,
+            _guard: guard,
+        })
     }
 }
 
 impl Drop for CwdGuard {
     fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.0);
+        let _ = std::env::set_current_dir(&self.original);
     }
 }
 
@@ -1202,7 +1214,9 @@ async fn is_registered_worktree_matches_relative_workspace_paths() {
     let _guard = async_env_lock().lock().await;
 
     let sandbox = tempfile::tempdir().expect("tempdir");
-    let _cwd_guard = CwdGuard::switch_to(sandbox.path()).expect("switch cwd");
+    let _cwd_guard = CwdGuard::switch_to(sandbox.path())
+        .await
+        .expect("switch cwd");
 
     let source = sandbox.path().join("source");
     std::fs::create_dir_all(&source).expect("create source");


### PR DESCRIPTION
## Summary

`CwdGuard` in `workspace_tests.rs` mutates global process state via `std::env::set_current_dir` but did not hold a synchronization lock, while the analogous `ScopedEnvVar` already serialized env mutations through `env_lock`. Gemini flagged this on PR #1084 as a parallel-test flake risk.

This adds `cwd_lock()` and has `CwdGuard` hold the `MutexGuard` for its lifetime, matching the `ScopedEnvVar` pattern exactly. The lock is released on drop alongside the cwd restore.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p harness-server --tests`
- [x] `cargo test -p harness-server --lib workspace` — 54/54 pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Closes #1085