### PR TITLE
test(services/execution): keep TempDir alive in make_event_store_noop

### DIFF
--- a/crates/harness-server/src/services/execution_tests.rs
+++ b/crates/harness-server/src/services/execution_tests.rs
@@ -1084,9 +1084,9 @@ async fn enqueue_background_issue_submission_accepts_completed_runtime_dependenc
 // ── helpers ──────────────────────────────────────────────────────────────
 
 async fn make_event_store_noop() -> Arc<harness_observe::event_store::EventStore> {
-    let dir = tempfile::tempdir().unwrap();
+    let path = tempfile::tempdir().unwrap().keep();
     Arc::new(
-        harness_observe::event_store::EventStore::new(dir.path())
+        harness_observe::event_store::EventStore::new(&path)
             .await
             .unwrap(),
     )


### PR DESCRIPTION
## Summary

Fixes the TempDir lifetime bug Gemini flagged on #1086. `tempfile::tempdir()` returns a `TempDir` whose `Drop` removes the directory, so the previous helper let the directory be reaped while the `EventStore` was still in use.

Switch to `TempDir::keep()` (the non-deprecated successor of `into_path()`) so the path is leaked for the test process lifetime — matches the pattern already used elsewhere where per-process leakage is acceptable.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --tests`
- [x] `cargo test -p harness-server --lib services::execution` — 27 passed

Closes #1087