### PR TITLE
feat(observe): proof-of-work summary endpoint for completed tasks

### DIFF
--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod interceptor;
 pub mod lang_detect;
 pub mod prompts;
+pub mod proof_of_work;
 pub mod shell_safety;
 #[cfg(test)]
 mod test_support;

--- a/crates/harness-core/src/proof_of_work.rs
+++ b/crates/harness-core/src/proof_of_work.rs
@@ -1,0 +1,134 @@
+//! Machine-readable "proof of work" summary for a completed task.
+//!
+//! Issue #876: operators currently reconstruct completion evidence from raw
+//! logs, PR state, and event history. The structures here package the same
+//! evidence into a single response so callers can consume it without crossing
+//! storage boundaries.
+//!
+//! These types are pure data — derivation lives in `harness-server` because
+//! it requires knowledge of `TaskState`. Keeping the wire format here lets
+//! API consumers depend only on `harness-core`.
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome of the project's CI/test gate for the completed task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiStatus {
+    /// Local validation passed and the reviewer approved.
+    Passed,
+    /// The task ended in a failure, or a review round reported a
+    /// quota / billing / upstream / timeout failure.
+    Failed,
+    /// No conclusive signal — for example, a cancelled task or one where
+    /// the review loop never produced a terminal verdict.
+    Unknown,
+}
+
+/// Reviewer-side verdict aggregated across all review rounds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewOutcome {
+    /// The last review round was `lgtm`, or an agent-review round was
+    /// explicitly `approved`.
+    Approved,
+    /// At least one review round requested changes and no later round
+    /// approved the PR.
+    ChangesRequested,
+    /// No review round ran for this task.
+    Skipped,
+}
+
+/// Free-form quality signal surfaced alongside the structured proof.
+///
+/// Kept open-ended so additional dimensions (complexity score, lint summary,
+/// coverage delta) can be attached without a schema change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QualitySignal {
+    pub name: String,
+    pub value: String,
+}
+
+/// Single-payload proof-of-work summary for a completed task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProofOfWork {
+    pub task_id: String,
+    /// Task status at the time the proof was generated. Snake-case to match
+    /// the on-the-wire representation of `TaskStatus` (e.g. `done`, `failed`).
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    pub ci_status: CiStatus,
+    pub review_outcome: ReviewOutcome,
+    /// Total number of review rounds the task went through. `0` when the
+    /// task completed without entering the review phase.
+    pub review_rounds: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quality_signals: Vec<QualitySignal>,
+}
+
+impl ProofOfWork {
+    pub fn with_quality_signals(mut self, signals: Vec<QualitySignal>) -> Self {
+        self.quality_signals = signals;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_serde_roundtrip() {
+        let proof = ProofOfWork {
+            task_id: "task-1".into(),
+            status: "done".into(),
+            pr_url: Some("https://github.com/owner/repo/pull/42".into()),
+            ci_status: CiStatus::Passed,
+            review_outcome: ReviewOutcome::Approved,
+            review_rounds: 3,
+            quality_signals: vec![QualitySignal {
+                name: "turns".into(),
+                value: "3".into(),
+            }],
+        };
+        let json = serde_json::to_string(&proof).unwrap();
+        let decoded: ProofOfWork = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, proof);
+    }
+
+    #[test]
+    fn empty_quality_signals_skipped_in_json() {
+        let proof = ProofOfWork {
+            task_id: "task-2".into(),
+            status: "failed".into(),
+            pr_url: None,
+            ci_status: CiStatus::Failed,
+            review_outcome: ReviewOutcome::Skipped,
+            review_rounds: 0,
+            quality_signals: Vec::new(),
+        };
+        let json = serde_json::to_string(&proof).unwrap();
+        assert!(!json.contains("quality_signals"));
+        assert!(!json.contains("pr_url"));
+    }
+
+    #[test]
+    fn with_quality_signals_replaces_vector() {
+        let signal = QualitySignal {
+            name: "complexity".into(),
+            value: "low".into(),
+        };
+        let proof = ProofOfWork {
+            task_id: "task-3".into(),
+            status: "done".into(),
+            pr_url: None,
+            ci_status: CiStatus::Unknown,
+            review_outcome: ReviewOutcome::Skipped,
+            review_rounds: 0,
+            quality_signals: Vec::new(),
+        }
+        .with_quality_signals(vec![signal.clone()]);
+        assert_eq!(proof.quality_signals, vec![signal]);
+    }
+}

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 
 use super::{
     auth, get_issue_workflow_by_issue, get_issue_workflow_by_pr, get_project_workflow_by_project,
-    get_task, get_task_artifacts, get_task_prompts, get_workflow_runtime_tree, github_webhook,
-    handle_rpc, health_check, ingest_signal, intake_status, list_tasks, password_reset,
-    project_queue_stats, state::AppState, stream_task_sse, task_mutation_routes, task_routes,
+    get_task, get_task_artifacts, get_task_prompts, get_task_proof, get_workflow_runtime_tree,
+    github_webhook, handle_rpc, health_check, ingest_signal, intake_status, list_tasks,
+    password_reset, project_queue_stats, state::AppState, stream_task_sse, task_mutation_routes,
+    task_routes,
 };
 
 pub(super) fn build_router(state: Arc<AppState>) -> Router {
@@ -34,6 +35,7 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
         .route("/tasks/{id}/merge", post(task_mutation_routes::merge_task))
         .route("/tasks/{id}/artifacts", get(get_task_artifacts))
         .route("/tasks/{id}/prompts", get(get_task_prompts))
+        .route("/tasks/{id}/proof", get(get_task_proof))
         .route("/tasks/{id}/stream", get(stream_task_sse))
         .route(
             "/projects",

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -48,7 +48,9 @@ pub(crate) use misc_routes::{
     intake_status, password_reset, project_queue_stats,
 };
 pub(crate) use sse_routes::stream_task_sse;
-pub(crate) use task_query_routes::{get_task, get_task_artifacts, get_task_prompts, list_tasks};
+pub(crate) use task_query_routes::{
+    get_task, get_task_artifacts, get_task_prompts, get_task_proof, list_tasks,
+};
 
 /// Resolve the reviewer agent for independent agent review.
 ///

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -11,9 +11,10 @@ use std::sync::Arc;
 
 use super::state::AppState;
 use crate::task_runner::{
-    SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskStatus,
-    TaskSummary, TaskWorkflowSummary,
+    SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskState,
+    TaskStatus, TaskSummary, TaskWorkflowSummary,
 };
+use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
 /// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
 /// that requires a separate workflow-store lookup (not persisted on `TaskState` itself).
@@ -454,6 +455,118 @@ pub(crate) async fn get_task_artifacts(
     }
 }
 
+/// Derive a [`ProofOfWork`] summary from a [`TaskState`].
+///
+/// Uses only `TaskState` fields already populated by the review loop, so the
+/// derivation is a pure function and stays cheap to call from HTTP handlers.
+///
+/// CI status policy:
+/// - `Passed` requires both terminal `Done` status and an approving review,
+///   because the LGTM gate is what runs the project's test command.
+/// - `Failed` covers explicit `Failed` status and review rounds that recorded
+///   a `quota_exhausted` / `billing_failed` / `upstream_failure` / `timeout`
+///   result.
+/// - Everything else (cancelled, no review evidence) reports `Unknown`.
+pub(crate) fn proof_from_state(task: &TaskState) -> ProofOfWork {
+    let mut review_rounds: u32 = 0;
+    let mut last_review_result: Option<&str> = None;
+    let mut saw_review_failure = false;
+
+    for round in &task.rounds {
+        if !matches!(round.action.as_str(), "review" | "agent_review") {
+            continue;
+        }
+        review_rounds = review_rounds.saturating_add(1);
+        last_review_result = Some(round.result.as_str());
+        if matches!(
+            round.result.as_str(),
+            "quota_exhausted" | "billing_failed" | "upstream_failure" | "timeout" | "failed"
+        ) {
+            saw_review_failure = true;
+        }
+    }
+
+    let review_outcome = match last_review_result {
+        Some("lgtm") | Some("approved") => ReviewOutcome::Approved,
+        Some("needs_fix") | Some("fixed") => ReviewOutcome::ChangesRequested,
+        Some(result) if result.ends_with(" issues") => ReviewOutcome::ChangesRequested,
+        Some(_) => ReviewOutcome::Skipped,
+        None => ReviewOutcome::Skipped,
+    };
+
+    let ci_status =
+        if matches!(task.status, TaskStatus::Done) && review_outcome == ReviewOutcome::Approved {
+            CiStatus::Passed
+        } else if matches!(task.status, TaskStatus::Failed) || saw_review_failure {
+            CiStatus::Failed
+        } else {
+            CiStatus::Unknown
+        };
+
+    let mut signals = Vec::new();
+    signals.push(QualitySignal {
+        name: "turns".to_string(),
+        value: task.turn.to_string(),
+    });
+    if let Some(error) = task.error.as_deref().filter(|s| !s.is_empty()) {
+        signals.push(QualitySignal {
+            name: "error".to_string(),
+            value: error.to_string(),
+        });
+    }
+
+    ProofOfWork {
+        task_id: task.id.0.clone(),
+        status: task.status.as_ref().to_string(),
+        pr_url: task.pr_url.clone(),
+        ci_status,
+        review_outcome,
+        review_rounds,
+        quality_signals: signals,
+    }
+}
+
+/// GET /tasks/{id}/proof — machine-readable proof-of-work summary for a
+/// completed task.
+///
+/// Returns 404 for unknown task IDs, 422 while the task is still in flight,
+/// and 200 with a JSON [`ProofOfWork`] for terminal tasks (Done / Failed /
+/// Cancelled). See `harness-core::proof_of_work` for the wire format.
+pub(crate) async fn get_task_proof(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(Some(task)) => {
+            if !task.status.is_terminal() {
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(json!({
+                        "error": "task is not in a terminal state",
+                        "status": task.status.as_ref(),
+                    })),
+                )
+                    .into_response();
+            }
+            Json(proof_from_state(&task)).into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "task not found"})),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("get_task_proof: database error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
 pub(crate) async fn get_task_prompts(
     State(state): State<Arc<AppState>>,
@@ -490,3 +603,7 @@ pub(crate) async fn get_task_prompts(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "task_query_routes_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/http/task_query_routes_tests.rs
+++ b/crates/harness-server/src/http/task_query_routes_tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::task_runner::{RoundResult, TaskState};
+
+fn task_with_id(id: &str) -> TaskState {
+    TaskState::new(harness_core::types::TaskId(id.to_string()))
+}
+
+#[test]
+fn proof_for_done_task_with_lgtm_is_passed_and_approved() {
+    let mut task = task_with_id("done-lgtm");
+    task.status = TaskStatus::Done;
+    task.turn = 3;
+    task.pr_url = Some("https://github.com/owner/repo/pull/7".to_string());
+    task.rounds
+        .push(RoundResult::new(1, "implement", "ok", None, None, None));
+    task.rounds
+        .push(RoundResult::new(2, "review", "needs_fix", None, None, None));
+    task.rounds
+        .push(RoundResult::new(3, "review", "lgtm", None, None, None));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.task_id, "done-lgtm");
+    assert_eq!(proof.status, "done");
+    assert_eq!(
+        proof.pr_url.as_deref(),
+        Some("https://github.com/owner/repo/pull/7")
+    );
+    assert_eq!(proof.ci_status, CiStatus::Passed);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Approved);
+    assert_eq!(proof.review_rounds, 2);
+    assert!(proof
+        .quality_signals
+        .iter()
+        .any(|q| q.name == "turns" && q.value == "3"));
+}
+
+#[test]
+fn proof_for_failed_task_records_failed_ci() {
+    let mut task = task_with_id("failed");
+    task.status = TaskStatus::Failed;
+    task.error = Some("agent crashed".to_string());
+    task.rounds.push(RoundResult::new(
+        1,
+        "review",
+        "quota_exhausted",
+        None,
+        None,
+        None,
+    ));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.status, "failed");
+    assert_eq!(proof.ci_status, CiStatus::Failed);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Skipped);
+    assert_eq!(proof.review_rounds, 1);
+    assert!(proof
+        .quality_signals
+        .iter()
+        .any(|q| q.name == "error" && q.value == "agent crashed"));
+}
+
+#[test]
+fn proof_for_done_without_review_is_unknown_and_skipped() {
+    let mut task = task_with_id("done-no-review");
+    task.status = TaskStatus::Done;
+    task.rounds
+        .push(RoundResult::new(1, "implement", "ok", None, None, None));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.ci_status, CiStatus::Unknown);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Skipped);
+    assert_eq!(proof.review_rounds, 0);
+}
+
+#[test]
+fn proof_marks_changes_requested_when_last_review_is_needs_fix() {
+    let mut task = task_with_id("changes-requested");
+    task.status = TaskStatus::Done;
+    task.rounds
+        .push(RoundResult::new(1, "review", "lgtm", None, None, None));
+    task.rounds
+        .push(RoundResult::new(2, "review", "needs_fix", None, None, None));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.review_outcome, ReviewOutcome::ChangesRequested);
+    assert_eq!(proof.ci_status, CiStatus::Unknown);
+}
+
+#[test]
+fn proof_does_not_treat_fallback_ready_to_merge_as_passed_ci() {
+    let mut task = task_with_id("ready-to-merge");
+    task.status = TaskStatus::Done;
+    task.rounds.push(RoundResult::new(
+        1,
+        "review",
+        "ready_to_merge",
+        None,
+        None,
+        None,
+    ));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Skipped);
+    assert_eq!(proof.ci_status, CiStatus::Unknown);
+}
+
+#[test]
+fn proof_counts_agent_review_approval_as_review_evidence() {
+    let mut task = task_with_id("agent-review-approved");
+    task.status = TaskStatus::Done;
+    task.rounds.push(RoundResult::new(
+        1,
+        "agent_review",
+        "approved",
+        None,
+        None,
+        None,
+    ));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Approved);
+    assert_eq!(proof.ci_status, CiStatus::Passed);
+    assert_eq!(proof.review_rounds, 1);
+}
+
+#[test]
+fn proof_counts_agent_review_issues_as_changes_requested() {
+    let mut task = task_with_id("agent-review-issues");
+    task.status = TaskStatus::Done;
+    task.rounds.push(RoundResult::new(
+        1,
+        "agent_review",
+        "2 issues",
+        None,
+        None,
+        None,
+    ));
+
+    let proof = proof_from_state(&task);
+    assert_eq!(proof.review_outcome, ReviewOutcome::ChangesRequested);
+    assert_eq!(proof.ci_status, CiStatus::Unknown);
+    assert_eq!(proof.review_rounds, 1);
+}


### PR DESCRIPTION
## Summary

Closes #876.

Adds a machine-readable proof-of-work summary so operators can retrieve completion evidence without reconstructing it from raw logs, PR state, and event history.

- `harness-core::proof_of_work` — pure data types (`ProofOfWork`, `CiStatus`, `ReviewOutcome`, `QualitySignal`).
- `harness-server::http::task_query_routes::proof_from_state` — derives the summary from `TaskState.rounds` already populated by the review loop.
- `GET /tasks/{id}/proof` HTTP endpoint:
  - 404 — unknown task ID
  - 422 — task is not in a terminal state
  - 200 — JSON `ProofOfWork` for Done / Failed / Cancelled tasks

## What/Why

Issue #876: Harness already enforces review/test gates, but operator-facing completion evidence is fragmented. The new endpoint packages PR URL, CI status (passed/failed/unknown), reviewer outcome (approved/changes_requested/skipped), review round count, and quality signals into one JSON response.

Replaces closed PR #880 (which had unresolvable merge conflicts) with a fresh implementation against current `main`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p harness-core proof_of_work` — 3 unit tests pass
- [x] `cargo test -p harness-server --lib http::task_query_routes` — 5 unit tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

## AI Role

Core logic is AI-generated. Risk: low — derives from existing `TaskState` fields, no new persistence.

## Review Focus

- `proof_from_state` CI-status policy: `Passed` requires both terminal `Done` and an approving review round (because the LGTM gate runs the project's test command).
- 422 vs 404 choice for non-terminal tasks (current: 422 Unprocessable Entity).
- Whether `quality_signals` should grow beyond `turns` / `error` in this first pass (kept minimal per issue's "first pass" non-goal).