### PR TITLE
Harden workflow runtime under Codex defaults

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -31,14 +31,12 @@ runtime_dispatch:
   enabled: true
   interval_secs: 30
   batch_limit: 25
-  runtime_kind: claude_code
-  runtime_profile: claude-default
   approval_policy: never
 runtime_worker:
   enabled: true
   interval_secs: 5
-  concurrency: 1
-  lease_ttl_secs: 900
+  concurrency: 6
+  lease_ttl_secs: 3900
 runtime_retry_policy:
   activity_retries: {}
 storage:

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -25,10 +25,15 @@ database_url = "postgres://harness:harness@localhost:5432/harness"
 data_dir = "/home/yourname/.local/share/harness"
 project_root = "."
 
+[concurrency]
+# High-reasoning agent runs can stay silent for several minutes while thinking.
+# Increase this when using gpt-5.5/xhigh for background workflow runtime jobs.
+# stall_timeout_secs = 3600
+
 [agents]
-default_agent = "auto"
+default_agent = "codex"
 # Optional: preferred routing order for complex/critical tasks.
-# complexity_preferred_agents = ["codex", "claude"]
+complexity_preferred_agents = ["codex"]
 sandbox_mode = "danger-full-access"
 
 [agents.claude]
@@ -37,6 +42,8 @@ default_model = "sonnet"
 
 [agents.codex]
 cli_path = "codex"
+default_model = "gpt-5.5"
+reasoning_effort = "xhigh"
 
 [agents.anthropic_api]
 base_url = "https://api.anthropic.com"
@@ -93,7 +100,7 @@ enabled = false
 # [intake.github]
 # enabled = true
 # poll_interval_secs = 300
-# planner_agent = "claude"
+# planner_agent = "codex"
 # sprint_timeout_secs = 10800
 # retry_backoff_base_secs = 15
 # retry_backoff_max_secs = 120

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -158,6 +158,22 @@ pub(crate) fn parse_codex_item(item: &Value) -> Option<Item> {
     }
 }
 
+pub(crate) fn parse_codex_error_item_message(item: &Value) -> Option<String> {
+    if json_str_field(item, &["type"])? != "error" {
+        return None;
+    }
+
+    Some(
+        json_str_field(item, &["message"])
+            .or_else(|| {
+                item.get("error")
+                    .and_then(|error| json_str_field(error, &["message"]))
+            })
+            .unwrap_or("unknown error")
+            .to_string(),
+    )
+}
+
 pub(crate) fn parse_codex_token_usage(usage: &Value) -> Option<TokenUsage> {
     let input_tokens = usage
         .get("input_tokens")
@@ -210,6 +226,9 @@ fn parse_codex_exec_event_line(line: &str) -> Option<ParsedCodexExecEvent> {
             .or(Some(ParsedCodexExecEvent::Ignore)),
         "item.started" | "item.completed" => {
             let item_value = value.get("item")?;
+            if let Some(message) = parse_codex_error_item_message(item_value) {
+                return Some(ParsedCodexExecEvent::Error { message });
+            }
             let item_id = json_str_field(item_value, &["id"])?.to_string();
             let item = parse_codex_item(item_value)?;
             if event_type == "item.started" {

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -1,4 +1,4 @@
-use crate::codex::{parse_codex_item, parse_codex_token_usage};
+use crate::codex::{parse_codex_error_item_message, parse_codex_item, parse_codex_token_usage};
 use crate::streaming::capture_agent_stderr_diagnostics;
 use async_trait::async_trait;
 use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
@@ -565,8 +565,17 @@ fn parse_app_server_agent_event(
             .unwrap_or(ParsedCodexMessage::Ignore),
         "item/completed" => params
             .get("item")
-            .and_then(parse_codex_item)
-            .map(|item| ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload { item }))
+            .map(|item| {
+                if let Some(message) = parse_codex_error_item_message(item) {
+                    ParsedCodexMessage::Event(AgentEvent::Error { message })
+                } else {
+                    parse_codex_item(item)
+                        .map(|item| {
+                            ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload { item })
+                        })
+                        .unwrap_or(ParsedCodexMessage::Ignore)
+                }
+            })
             .unwrap_or(ParsedCodexMessage::Ignore),
         "thread/tokenUsage/updated" => params
             .get("tokenUsage")
@@ -732,6 +741,18 @@ mod tests {
                 item: Item::AgentReasoning {
                     content: "done".into()
                 }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_item_completed_error_notification() {
+        let line = r#"{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-2","type":"error","message":"bad config"}}}"#;
+        let message = parse_codex_message(line).unwrap();
+        assert_eq!(
+            message,
+            ParsedCodexMessage::Event(AgentEvent::Error {
+                message: "bad config".into()
             })
         );
     }

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -158,6 +158,27 @@ fn parse_exec_warning_and_error() {
 }
 
 #[test]
+fn parse_exec_item_completed_error() {
+    let line =
+        r#"{"type":"item.completed","item":{"id":"item_0","type":"error","message":"bad config"}}"#;
+    let event = parse_codex_exec_event_line(line).expect("event should parse");
+
+    assert!(matches!(
+        event,
+        ParsedCodexExecEvent::Error { ref message } if message == "bad config"
+    ));
+}
+
+#[test]
+fn parse_exec_output_surfaces_item_completed_error() {
+    let stdout =
+        r#"{"type":"item.completed","item":{"id":"item_0","type":"error","message":"bad config"}}"#;
+    let parsed = parse_codex_exec_output(stdout).expect("stdout should parse");
+
+    assert_eq!(parsed.structured_error.as_deref(), Some("bad config"));
+}
+
+#[test]
 fn parse_exec_turn_completed_usage() {
     let line = r#"{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":4,"output_tokens":3,"reasoning_output_tokens":2}}"#;
     let event = parse_codex_exec_event_line(line).expect("event should parse");

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -115,7 +115,7 @@ pub struct ConcurrencyConfig {
     /// Maximum number of tasks waiting for a slot. Excess tasks are rejected. Default: 32.
     #[serde(default = "default_max_queue_size")]
     pub max_queue_size: usize,
-    /// Seconds of silence from the agent stream before declaring a stall. Default: 300.
+    /// Seconds of silence from the agent stream before declaring a stall. Default: 3600.
     #[serde(default = "default_stall_timeout_secs")]
     pub stall_timeout_secs: u64,
     /// Per-project concurrency limits.
@@ -167,7 +167,7 @@ fn default_max_queue_size() -> usize {
 }
 
 fn default_stall_timeout_secs() -> u64 {
-    300
+    3600
 }
 
 fn default_loop_jaccard_threshold() -> f64 {

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -119,10 +119,10 @@ pub struct RuntimeDispatchPolicy {
     pub interval_secs: u64,
     #[serde(default = "default_runtime_dispatch_batch_limit")]
     pub batch_limit: u32,
-    #[serde(default = "default_runtime_dispatch_kind")]
-    pub runtime_kind: String,
-    #[serde(default = "default_runtime_dispatch_profile")]
-    pub runtime_profile: String,
+    #[serde(default)]
+    pub runtime_kind: Option<String>,
+    #[serde(default)]
+    pub runtime_profile: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
@@ -279,8 +279,8 @@ impl Default for RuntimeDispatchPolicy {
             enabled: true,
             interval_secs: default_runtime_dispatch_interval_secs(),
             batch_limit: default_runtime_dispatch_batch_limit(),
-            runtime_kind: default_runtime_dispatch_kind(),
-            runtime_profile: default_runtime_dispatch_profile(),
+            runtime_kind: None,
+            runtime_profile: None,
             model: None,
             reasoning_effort: None,
             sandbox: None,
@@ -412,14 +412,6 @@ fn default_runtime_dispatch_batch_limit() -> u32 {
     25
 }
 
-fn default_runtime_dispatch_kind() -> String {
-    "claude_code".to_string()
-}
-
-fn default_runtime_dispatch_profile() -> String {
-    "claude-default".to_string()
-}
-
 fn default_runtime_worker_interval_secs() -> u64 {
     5
 }
@@ -429,7 +421,7 @@ fn default_runtime_worker_concurrency() -> u32 {
 }
 
 fn default_runtime_worker_lease_ttl_secs() -> u64 {
-    900
+    3900
 }
 
 fn default_workflow_schema_namespace() -> String {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -33,8 +33,8 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert!(cfg.runtime_dispatch.enabled);
     assert_eq!(cfg.runtime_dispatch.interval_secs, 30);
     assert_eq!(cfg.runtime_dispatch.batch_limit, 25);
-    assert_eq!(cfg.runtime_dispatch.runtime_kind, "claude_code");
-    assert_eq!(cfg.runtime_dispatch.runtime_profile, "claude-default");
+    assert_eq!(cfg.runtime_dispatch.runtime_kind, None);
+    assert_eq!(cfg.runtime_dispatch.runtime_profile, None);
     assert_eq!(cfg.runtime_dispatch.model, None);
     assert_eq!(cfg.runtime_dispatch.reasoning_effort, None);
     assert_eq!(cfg.runtime_dispatch.sandbox, None);
@@ -47,7 +47,7 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert!(cfg.runtime_worker.enabled);
     assert_eq!(cfg.runtime_worker.interval_secs, 5);
     assert_eq!(cfg.runtime_worker.concurrency, 1);
-    assert_eq!(cfg.runtime_worker.lease_ttl_secs, 900);
+    assert_eq!(cfg.runtime_worker.lease_ttl_secs, 3900);
     assert!(cfg.runtime_retry_policy.is_empty());
     assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
     assert_eq!(cfg.storage.schema_namespace, "workflow");
@@ -104,10 +104,10 @@ runtime_dispatch:
   enabled: true
   interval_secs: 5
   batch_limit: 7
-  runtime_kind: claude_code
-  runtime_profile: claude-default
-  model: claude-sonnet-4-6
-  reasoning_effort: medium
+  runtime_kind: codex_jsonrpc
+  runtime_profile: codex-gpt-5.5-xhigh
+  model: gpt-5.5
+  reasoning_effort: xhigh
   sandbox: workspace-write
   approval_policy: on-request
   max_turns: 4
@@ -201,15 +201,18 @@ Body
     assert!(cfg.runtime_dispatch.enabled);
     assert_eq!(cfg.runtime_dispatch.interval_secs, 5);
     assert_eq!(cfg.runtime_dispatch.batch_limit, 7);
-    assert_eq!(cfg.runtime_dispatch.runtime_kind, "claude_code");
-    assert_eq!(cfg.runtime_dispatch.runtime_profile, "claude-default");
     assert_eq!(
-        cfg.runtime_dispatch.model.as_deref(),
-        Some("claude-sonnet-4-6")
+        cfg.runtime_dispatch.runtime_kind.as_deref(),
+        Some("codex_jsonrpc")
     );
     assert_eq!(
+        cfg.runtime_dispatch.runtime_profile.as_deref(),
+        Some("codex-gpt-5.5-xhigh")
+    );
+    assert_eq!(cfg.runtime_dispatch.model.as_deref(), Some("gpt-5.5"));
+    assert_eq!(
         cfg.runtime_dispatch.reasoning_effort.as_deref(),
-        Some("medium")
+        Some("xhigh")
     );
     assert_eq!(
         cfg.runtime_dispatch.sandbox.as_deref(),

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::task_runner;
+use anyhow::Context;
 use harness_workflow::issue_lifecycle::{
     is_feedback_claim_placeholder, IssueLifecycleState, IssueWorkflowInstance,
 };
@@ -553,8 +554,13 @@ async fn dispatch_runtime_command_with_project_policy(
             .await;
     }
 
-    let Some(profile_selector) =
-        runtime_dispatch_profile_selector_for_command(state, store, &command).await?
+    let Some(profile_selector) = runtime_dispatch_profile_selector_for_command(
+        state,
+        store,
+        &command,
+        &fallback_profile_selector,
+    )
+    .await?
     else {
         let command_id = command.id.clone();
         store.mark_command_status(&command_id, "skipped").await?;
@@ -573,6 +579,7 @@ async fn runtime_dispatch_profile_selector_for_command(
     state: &Arc<AppState>,
     store: &WorkflowRuntimeStore,
     command: &WorkflowCommandRecord,
+    fallback_profile_selector: &RuntimeProfileSelector,
 ) -> anyhow::Result<Option<RuntimeProfileSelector>> {
     let project_root =
         runtime_command_project_root(store, command, &state.core.project_root).await?;
@@ -591,10 +598,25 @@ async fn runtime_dispatch_profile_selector_for_command(
         );
         return Ok(None);
     }
-    persist_runtime_profile_manifest(store, &project_root, &workflow_cfg.runtime_dispatch).await?;
-    Ok(Some(runtime_dispatch_profile_selector(
+    let inherited_profile = runtime_default_profile_for_project(
+        state,
+        &project_root,
+        Some(fallback_profile_selector.select(None, None)),
+    )
+    .await?;
+    persist_runtime_profile_manifest(
+        store,
+        &project_root,
+        &state.core.server.config,
         &workflow_cfg.runtime_dispatch,
-    )))
+        &inherited_profile,
+    )
+    .await?;
+    Ok(Some(runtime_dispatch_profile_selector(
+        &state.core.server.config,
+        &workflow_cfg.runtime_dispatch,
+        &inherited_profile,
+    )?))
 }
 
 async fn runtime_command_project_root(
@@ -957,26 +979,157 @@ fn runtime_kind_from_config(value: &str) -> Option<RuntimeKind> {
     }
 }
 
-fn runtime_dispatch_profile(
-    policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
+fn runtime_profile_from_kind(
+    config: &harness_core::config::HarnessConfig,
+    kind: RuntimeKind,
 ) -> RuntimeProfile {
-    let kind = runtime_kind_from_config(&policy.runtime_kind).unwrap_or_else(|| {
+    match kind {
+        RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc => {
+            let mut profile = RuntimeProfile::new("codex-default", kind);
+            profile.model = Some(config.agents.codex.default_model.clone());
+            profile.reasoning_effort = Some(config.agents.codex.reasoning_effort.clone());
+            profile
+        }
+        RuntimeKind::ClaudeCode => {
+            let mut profile = RuntimeProfile::new("claude-default", kind);
+            profile.model = Some(config.agents.claude.default_model.clone());
+            profile
+        }
+        RuntimeKind::AnthropicApi => {
+            let mut profile = RuntimeProfile::new("anthropic-api-default", kind);
+            profile.model = Some(config.agents.anthropic_api.default_model.clone());
+            profile
+        }
+        RuntimeKind::RemoteHost => RuntimeProfile::new("remote-host-default", kind),
+    }
+}
+
+fn runtime_profile_from_agent(
+    config: &harness_core::config::HarnessConfig,
+    agent_name: &str,
+) -> Option<RuntimeProfile> {
+    match agent_name {
+        "codex" => Some(runtime_profile_from_kind(config, RuntimeKind::CodexJsonrpc)),
+        "claude" => Some(runtime_profile_from_kind(config, RuntimeKind::ClaudeCode)),
+        "anthropic-api" => Some(runtime_profile_from_kind(config, RuntimeKind::AnthropicApi)),
+        _ => None,
+    }
+}
+
+async fn runtime_default_agent_name_for_project(
+    state: &Arc<AppState>,
+    project_root: &Path,
+) -> anyhow::Result<Option<String>> {
+    let project_cfg = harness_core::config::project::load_project_config(project_root)
+        .with_context(|| {
+            format!(
+                "failed to load project config at {}",
+                project_root.display()
+            )
+        })?;
+    if let Some(agent_name) = project_cfg
+        .agent
+        .as_ref()
+        .and_then(|agent| agent.default.as_deref())
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && !name.eq_ignore_ascii_case("auto"))
+    {
+        return Ok(Some(agent_name.to_string()));
+    }
+
+    if let Some(registry) = state.core.project_registry.as_deref() {
+        let canonical_root = project_root
+            .canonicalize()
+            .unwrap_or_else(|_| project_root.to_path_buf());
+        if let Some(project) = registry.get_by_root(&canonical_root).await? {
+            if let Some(agent_name) = project
+                .default_agent
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty() && !name.eq_ignore_ascii_case("auto"))
+            {
+                return Ok(Some(agent_name.to_string()));
+            }
+        }
+    }
+
+    Ok(state
+        .core
+        .server
+        .agent_registry
+        .resolved_default_agent_name()
+        .map(str::to_string))
+}
+
+async fn runtime_default_profile_for_project(
+    state: &Arc<AppState>,
+    project_root: &Path,
+    fallback_profile: Option<&RuntimeProfile>,
+) -> anyhow::Result<RuntimeProfile> {
+    let agent_name = runtime_default_agent_name_for_project(state, project_root).await?;
+    if let Some(agent_name) = agent_name.as_deref() {
+        if let Some(profile) = runtime_profile_from_agent(&state.core.server.config, agent_name) {
+            return Ok(profile);
+        }
         tracing::warn!(
-            runtime_kind = policy.runtime_kind,
-            "workflow runtime command dispatcher: unknown runtime_kind, falling back to codex_jsonrpc"
+            agent = agent_name,
+            project_root = %project_root.display(),
+            "workflow runtime cannot derive a runtime profile from the project default agent; falling back to dispatcher profile"
         );
-        RuntimeKind::CodexJsonrpc
-    });
-    let mut profile = RuntimeProfile::new(policy.runtime_profile.clone(), kind);
-    profile.model = policy.model.clone();
-    profile.reasoning_effort = policy.reasoning_effort.clone();
-    profile.sandbox = policy.sandbox.clone();
+    }
+
+    fallback_profile.cloned().ok_or_else(|| {
+        anyhow::anyhow!(
+            "workflow runtime cannot derive a runtime profile for {}; set runtime_dispatch.runtime_kind or configure a supported default agent",
+            project_root.display()
+        )
+    })
+}
+
+fn runtime_dispatch_profile(
+    config: &harness_core::config::HarnessConfig,
+    policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
+    inherited_profile: &RuntimeProfile,
+) -> anyhow::Result<RuntimeProfile> {
+    let base_profile = match policy.runtime_kind.as_deref() {
+        Some(value) => match runtime_kind_from_config(value) {
+            Some(kind) => runtime_profile_from_kind(config, kind),
+            None => {
+                tracing::warn!(
+                    runtime_kind = value,
+                    "workflow runtime command dispatcher: unknown runtime_kind, inheriting the configured default runtime profile"
+                );
+                inherited_profile.clone()
+            }
+        },
+        None => inherited_profile.clone(),
+    };
+    let kind = base_profile.kind;
+    let profile_name = policy
+        .runtime_profile
+        .clone()
+        .unwrap_or_else(|| base_profile.name.clone());
+    let mut profile = RuntimeProfile::new(profile_name, kind);
+    profile.model = policy.model.clone().or_else(|| base_profile.model.clone());
+    profile.reasoning_effort = policy
+        .reasoning_effort
+        .clone()
+        .or_else(|| base_profile.reasoning_effort.clone());
+    profile.sandbox = policy
+        .sandbox
+        .clone()
+        .or_else(|| base_profile.sandbox.clone());
     profile.approval_policy = runtime_kind_supports_approval_policy(kind)
-        .then(|| policy.approval_policy.clone())
+        .then(|| {
+            policy
+                .approval_policy
+                .clone()
+                .or_else(|| base_profile.approval_policy.clone())
+        })
         .flatten();
-    profile.max_turns = policy.max_turns;
-    profile.timeout_secs = policy.timeout_secs;
-    profile
+    profile.max_turns = policy.max_turns.or(base_profile.max_turns);
+    profile.timeout_secs = policy.timeout_secs.or(base_profile.timeout_secs);
+    Ok(profile)
 }
 
 #[derive(Clone)]
@@ -989,9 +1142,11 @@ struct ResolvedRuntimeDispatchProfiles {
 }
 
 fn resolve_runtime_dispatch_profiles(
+    config: &harness_core::config::HarnessConfig,
     policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
-) -> ResolvedRuntimeDispatchProfiles {
-    let default_profile = runtime_dispatch_profile(policy);
+    inherited_profile: &RuntimeProfile,
+) -> anyhow::Result<ResolvedRuntimeDispatchProfiles> {
+    let default_profile = runtime_dispatch_profile(config, policy, inherited_profile)?;
     let workflow_profiles = policy
         .workflow_profiles
         .iter()
@@ -1026,18 +1181,20 @@ fn resolve_runtime_dispatch_profiles(
                 .insert(activity.clone(), profile);
         }
     }
-    ResolvedRuntimeDispatchProfiles {
+    Ok(ResolvedRuntimeDispatchProfiles {
         default_profile,
         workflow_profiles,
         activity_profiles,
         workflow_activity_profiles,
-    }
+    })
 }
 
 fn runtime_dispatch_profile_selector(
+    config: &harness_core::config::HarnessConfig,
     policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
-) -> RuntimeProfileSelector {
-    let resolved = resolve_runtime_dispatch_profiles(policy);
+    inherited_profile: &RuntimeProfile,
+) -> anyhow::Result<RuntimeProfileSelector> {
+    let resolved = resolve_runtime_dispatch_profiles(config, policy, inherited_profile)?;
     let default_profile = resolved.default_profile;
     let mut selector = RuntimeProfileSelector::new(default_profile);
     for (definition_id, profile) in &resolved.workflow_profiles {
@@ -1055,23 +1212,28 @@ fn runtime_dispatch_profile_selector(
             );
         }
     }
-    selector
+    Ok(selector)
 }
 
 async fn persist_runtime_profile_manifest(
     store: &WorkflowRuntimeStore,
     project_root: &Path,
+    config: &harness_core::config::HarnessConfig,
     policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
+    inherited_profile: &RuntimeProfile,
 ) -> anyhow::Result<()> {
-    let definition = runtime_profile_manifest_definition(project_root, policy)?;
+    let definition =
+        runtime_profile_manifest_definition(project_root, config, policy, inherited_profile)?;
     store.upsert_definition(&definition).await
 }
 
 pub(super) fn runtime_profile_manifest_definition(
     project_root: &Path,
+    config: &harness_core::config::HarnessConfig,
     policy: &harness_core::config::workflow::RuntimeDispatchPolicy,
+    inherited_profile: &RuntimeProfile,
 ) -> anyhow::Result<WorkflowDefinition> {
-    let resolved = resolve_runtime_dispatch_profiles(policy);
+    let resolved = resolve_runtime_dispatch_profiles(config, policy, inherited_profile)?;
     let metadata = serde_json::json!({
         "artifact_type": "runtime_profile_manifest",
         "project_root": project_root.to_string_lossy(),
@@ -1177,7 +1339,36 @@ pub(super) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
             );
             let policy = workflow_cfg.runtime_dispatch;
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
-            let profile_selector = runtime_dispatch_profile_selector(&policy);
+            let inherited_profile = match runtime_default_profile_for_project(
+                &state,
+                &state.core.project_root,
+                None,
+            )
+            .await
+            {
+                Ok(profile) => profile,
+                Err(error) => {
+                    tracing::warn!(
+                            "workflow runtime command dispatcher could not resolve default runtime profile: {error}"
+                        );
+                    tokio::time::sleep(interval).await;
+                    continue;
+                }
+            };
+            let profile_selector = match runtime_dispatch_profile_selector(
+                &state.core.server.config,
+                &policy,
+                &inherited_profile,
+            ) {
+                Ok(selector) => selector,
+                Err(error) => {
+                    tracing::warn!(
+                        "workflow runtime command dispatcher could not build runtime profile selector: {error}"
+                    );
+                    tokio::time::sleep(interval).await;
+                    continue;
+                }
+            };
             match run_runtime_command_dispatch_tick(
                 &state,
                 profile_selector,
@@ -2247,10 +2438,52 @@ mod tests {
     const RECONCILE_GH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
     #[test]
+    fn runtime_dispatch_profile_selector_inherits_configured_agent_profile_when_unset() {
+        let mut config = harness_core::config::HarnessConfig::default();
+        config.agents.codex.default_model = "gpt-5.5".to_string();
+        config.agents.codex.reasoning_effort = "xhigh".to_string();
+        let inherited_profile = runtime_profile_from_agent(&config, "codex").unwrap();
+        let policy = harness_core::config::workflow::RuntimeDispatchPolicy {
+            approval_policy: Some("never".to_string()),
+            ..Default::default()
+        };
+
+        let selector =
+            runtime_dispatch_profile_selector(&config, &policy, &inherited_profile).unwrap();
+        let profile = selector.select_for_workflow(Some("github_issue_pr"));
+        assert_eq!(profile.kind, RuntimeKind::CodexJsonrpc);
+        assert_eq!(profile.name, "codex-default");
+        assert_eq!(profile.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(profile.reasoning_effort.as_deref(), Some("xhigh"));
+        assert_eq!(profile.approval_policy.as_deref(), Some("never"));
+    }
+
+    #[test]
+    fn runtime_dispatch_profile_explicit_kind_uses_matching_provider_config() {
+        let mut config = harness_core::config::HarnessConfig::default();
+        config.agents.codex.default_model = "gpt-5.5".to_string();
+        config.agents.codex.reasoning_effort = "xhigh".to_string();
+        config.agents.claude.default_model = "sonnet-explicit".to_string();
+        let inherited_profile = runtime_profile_from_agent(&config, "codex").unwrap();
+        let policy = harness_core::config::workflow::RuntimeDispatchPolicy {
+            runtime_kind: Some("claude_code".to_string()),
+            ..Default::default()
+        };
+
+        let profile = runtime_dispatch_profile(&config, &policy, &inherited_profile).unwrap();
+        assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
+        assert_eq!(profile.name, "claude-default");
+        assert_eq!(profile.model.as_deref(), Some("sonnet-explicit"));
+        assert_eq!(profile.reasoning_effort, None);
+    }
+
+    #[test]
     fn runtime_dispatch_profile_selector_applies_workflow_overrides() {
+        let config = harness_core::config::HarnessConfig::default();
+        let inherited_profile = RuntimeProfile::new("inherited-default", RuntimeKind::CodexJsonrpc);
         let mut policy = harness_core::config::workflow::RuntimeDispatchPolicy {
-            runtime_kind: "claude_code".to_string(),
-            runtime_profile: "claude-default".to_string(),
+            runtime_kind: Some("claude_code".to_string()),
+            runtime_profile: Some("claude-default".to_string()),
             model: Some("claude-sonnet-4-6".to_string()),
             timeout_secs: Some(600),
             ..Default::default()
@@ -2295,7 +2528,8 @@ mod tests {
             )]),
         );
 
-        let selector = runtime_dispatch_profile_selector(&policy);
+        let selector =
+            runtime_dispatch_profile_selector(&config, &policy, &inherited_profile).unwrap();
         let issue_profile = selector.select_for_workflow(Some("github_issue_pr"));
         assert_eq!(issue_profile.kind, RuntimeKind::CodexExec);
         assert_eq!(issue_profile.name, "codex-high");
@@ -2325,9 +2559,11 @@ mod tests {
 
     #[test]
     fn runtime_profile_manifest_definition_records_resolved_profiles() -> anyhow::Result<()> {
+        let config = harness_core::config::HarnessConfig::default();
+        let inherited_profile = RuntimeProfile::new("inherited-default", RuntimeKind::CodexJsonrpc);
         let mut policy = harness_core::config::workflow::RuntimeDispatchPolicy {
-            runtime_kind: "codex_jsonrpc".to_string(),
-            runtime_profile: "codex-default".to_string(),
+            runtime_kind: Some("codex_jsonrpc".to_string()),
+            runtime_profile: Some("codex-default".to_string()),
             model: Some("gpt-default".to_string()),
             timeout_secs: Some(600),
             ..Default::default()
@@ -2346,7 +2582,12 @@ mod tests {
         );
 
         let project_root = std::path::Path::new("/tmp/harness-runtime-profile-project");
-        let definition = runtime_profile_manifest_definition(project_root, &policy)?;
+        let definition = runtime_profile_manifest_definition(
+            project_root,
+            &config,
+            &policy,
+            &inherited_profile,
+        )?;
 
         assert!(definition.id.starts_with("runtime_profiles:"));
         assert_eq!(definition.name, "Runtime Profile Manifest");
@@ -2378,9 +2619,11 @@ mod tests {
 
     #[test]
     fn runtime_dispatch_profile_selector_drops_codex_approval_for_non_codex_override() {
+        let config = harness_core::config::HarnessConfig::default();
+        let inherited_profile = RuntimeProfile::new("inherited-default", RuntimeKind::CodexJsonrpc);
         let mut policy = harness_core::config::workflow::RuntimeDispatchPolicy {
-            runtime_kind: "codex_jsonrpc".to_string(),
-            runtime_profile: "codex-default".to_string(),
+            runtime_kind: Some("codex_jsonrpc".to_string()),
+            runtime_profile: Some("codex-default".to_string()),
             approval_policy: Some("on-request".to_string()),
             ..Default::default()
         };
@@ -2401,7 +2644,8 @@ mod tests {
             },
         );
 
-        let selector = runtime_dispatch_profile_selector(&policy);
+        let selector =
+            runtime_dispatch_profile_selector(&config, &policy, &inherited_profile).unwrap();
         let claude_profile = selector.select_for_workflow(Some("claude_review"));
         assert_eq!(claude_profile.kind, RuntimeKind::ClaudeCode);
         assert_eq!(claude_profile.name, "claude-review");
@@ -2415,14 +2659,16 @@ mod tests {
 
     #[test]
     fn runtime_dispatch_profile_drops_codex_approval_for_non_codex_default() {
+        let config = harness_core::config::HarnessConfig::default();
+        let inherited_profile = RuntimeProfile::new("inherited-default", RuntimeKind::CodexJsonrpc);
         let policy = harness_core::config::workflow::RuntimeDispatchPolicy {
-            runtime_kind: "claude_code".to_string(),
-            runtime_profile: "claude-default".to_string(),
+            runtime_kind: Some("claude_code".to_string()),
+            runtime_profile: Some("claude-default".to_string()),
             approval_policy: Some("on-request".to_string()),
             ..Default::default()
         };
 
-        let profile = runtime_dispatch_profile(&policy);
+        let profile = runtime_dispatch_profile(&config, &policy, &inherited_profile).unwrap();
         assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
         assert_eq!(profile.name, "claude-default");
         assert_eq!(profile.approval_policy, None);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1020,13 +1020,18 @@ async fn runtime_default_agent_name_for_project(
     state: &Arc<AppState>,
     project_root: &Path,
 ) -> anyhow::Result<Option<String>> {
-    let project_cfg = harness_core::config::project::load_project_config(project_root)
-        .with_context(|| {
-            format!(
-                "failed to load project config at {}",
-                project_root.display()
-            )
-        })?;
+    let project_root_for_config = project_root.to_path_buf();
+    let project_cfg = tokio::task::spawn_blocking(move || {
+        harness_core::config::project::load_project_config(&project_root_for_config)
+    })
+    .await
+    .context("failed to join project config load task")?
+    .with_context(|| {
+        format!(
+            "failed to load project config at {}",
+            project_root.display()
+        )
+    })?;
     if let Some(agent_name) = project_cfg
         .agent
         .as_ref()
@@ -1038,8 +1043,8 @@ async fn runtime_default_agent_name_for_project(
     }
 
     if let Some(registry) = state.core.project_registry.as_deref() {
-        let canonical_root = project_root
-            .canonicalize()
+        let canonical_root = tokio::fs::canonicalize(project_root)
+            .await
             .unwrap_or_else(|_| project_root.to_path_buf());
         if let Some(project) = registry.get_by_root(&canonical_root).await? {
             if let Some(agent_name) = project
@@ -1153,7 +1158,7 @@ fn resolve_runtime_dispatch_profiles(
         .map(|(definition_id, override_policy)| {
             (
                 definition_id.clone(),
-                apply_runtime_dispatch_profile_override(&default_profile, override_policy),
+                apply_runtime_dispatch_profile_override(config, &default_profile, override_policy),
             )
         })
         .collect::<std::collections::BTreeMap<_, _>>();
@@ -1163,7 +1168,7 @@ fn resolve_runtime_dispatch_profiles(
         .map(|(activity, override_policy)| {
             (
                 activity.clone(),
-                apply_runtime_dispatch_profile_override(&default_profile, override_policy),
+                apply_runtime_dispatch_profile_override(config, &default_profile, override_policy),
             )
         })
         .collect::<std::collections::BTreeMap<_, _>>();
@@ -1174,7 +1179,8 @@ fn resolve_runtime_dispatch_profiles(
                 .get(activity)
                 .or_else(|| workflow_profiles.get(definition_id))
                 .unwrap_or(&default_profile);
-            let profile = apply_runtime_dispatch_profile_override(base_profile, override_policy);
+            let profile =
+                apply_runtime_dispatch_profile_override(config, base_profile, override_policy);
             workflow_activity_profiles
                 .entry(definition_id.clone())
                 .or_insert_with(std::collections::BTreeMap::new)
@@ -1267,33 +1273,42 @@ pub(super) fn runtime_profile_manifest_definition(
 }
 
 fn apply_runtime_dispatch_profile_override(
+    config: &harness_core::config::HarnessConfig,
     default_profile: &RuntimeProfile,
     override_policy: &harness_core::config::workflow::RuntimeDispatchProfileOverride,
 ) -> RuntimeProfile {
-    let kind = override_policy
+    let runtime_kind_profile = override_policy
         .runtime_kind
         .as_deref()
         .and_then(runtime_kind_from_config)
-        .unwrap_or(default_profile.kind);
+        .map(|kind| {
+            if kind == default_profile.kind {
+                default_profile.clone()
+            } else {
+                runtime_profile_from_kind(config, kind)
+            }
+        })
+        .unwrap_or_else(|| default_profile.clone());
+    let kind = runtime_kind_profile.kind;
     let profile_name = override_policy
         .runtime_profile
         .clone()
-        .unwrap_or_else(|| default_profile.name.clone());
+        .unwrap_or_else(|| runtime_kind_profile.name.clone());
     let mut profile = RuntimeProfile::new(profile_name, kind);
     profile.model = override_policy
         .model
         .clone()
-        .or_else(|| default_profile.model.clone());
+        .or_else(|| runtime_kind_profile.model.clone());
     profile.reasoning_effort = override_policy
         .reasoning_effort
         .clone()
-        .or_else(|| default_profile.reasoning_effort.clone());
+        .or_else(|| runtime_kind_profile.reasoning_effort.clone());
     profile.sandbox = override_policy
         .sandbox
         .clone()
         .or_else(|| default_profile.sandbox.clone());
     profile.approval_policy =
-        runtime_dispatch_approval_policy(default_profile, override_policy, kind);
+        runtime_dispatch_approval_policy(&runtime_kind_profile, override_policy, kind);
     profile.max_turns = override_policy.max_turns.or(default_profile.max_turns);
     profile.timeout_secs = override_policy
         .timeout_secs
@@ -2475,6 +2490,36 @@ mod tests {
         assert_eq!(profile.name, "claude-default");
         assert_eq!(profile.model.as_deref(), Some("sonnet-explicit"));
         assert_eq!(profile.reasoning_effort, None);
+    }
+
+    #[test]
+    fn runtime_dispatch_profile_override_kind_uses_matching_provider_config() {
+        let mut config = harness_core::config::HarnessConfig::default();
+        config.agents.codex.default_model = "gpt-5.5".to_string();
+        config.agents.codex.reasoning_effort = "xhigh".to_string();
+        config.agents.claude.default_model = "sonnet-override".to_string();
+        let inherited_profile = runtime_profile_from_agent(&config, "codex").unwrap();
+        let mut policy = harness_core::config::workflow::RuntimeDispatchPolicy {
+            runtime_kind: Some("codex_jsonrpc".to_string()),
+            timeout_secs: Some(3600),
+            ..Default::default()
+        };
+        policy.workflow_profiles.insert(
+            "claude_review".to_string(),
+            harness_core::config::workflow::RuntimeDispatchProfileOverride {
+                runtime_kind: Some("claude_code".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let selector =
+            runtime_dispatch_profile_selector(&config, &policy, &inherited_profile).unwrap();
+        let profile = selector.select_for_workflow(Some("claude_review"));
+        assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
+        assert_eq!(profile.name, "claude-default");
+        assert_eq!(profile.model.as_deref(), Some("sonnet-override"));
+        assert_eq!(profile.reasoning_effort, None);
+        assert_eq!(profile.timeout_secs, Some(3600));
     }
 
     #[test]

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -22,17 +22,6 @@ pub(crate) async fn enqueue_task(
     state.execution_svc.enqueue(req).await
 }
 
-pub(crate) async fn enqueue_task_in_domain(
-    state: &Arc<AppState>,
-    req: task_runner::CreateTaskRequest,
-    queue_domain: QueueDomain,
-) -> Result<task_runner::TaskId, EnqueueTaskError> {
-    state
-        .execution_svc
-        .enqueue_in_domain(req, queue_domain)
-        .await
-}
-
 pub(crate) async fn enqueue_task_background(
     state: Arc<AppState>,
     req: task_runner::CreateTaskRequest,

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1191,9 +1191,15 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
     assert_eq!(jobs.len(), 1);
     assert_eq!(jobs[0].runtime_profile, "codex-high");
     let workflow_cfg = harness_core::config::workflow::load_workflow_config(&project_root)?;
+    let inherited_profile = harness_workflow::runtime::RuntimeProfile::new(
+        "codex-high",
+        harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+    );
     let expected_profile_manifest = super::background::runtime_profile_manifest_definition(
         &project_root,
+        &state.core.server.config,
         &workflow_cfg.runtime_dispatch,
+        &inherited_profile,
     )?;
     let persisted_profile_manifest = store
         .get_definition(

--- a/crates/harness-server/src/periodic_reviewer.rs
+++ b/crates/harness-server/src/periodic_reviewer.rs
@@ -858,10 +858,14 @@ async fn run_review_tick(
         ..CreateTaskRequest::default()
     };
 
-    let primary_review_id =
-        task_routes::enqueue_task_in_domain(state, review_req, task_routes::QueueDomain::Review)
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to enqueue periodic review: {e}"))?;
+    let primary_review_id = task_routes::enqueue_task_background_in_domain(
+        state.clone(),
+        review_req,
+        None,
+        task_routes::QueueDomain::Review,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to enqueue periodic review: {e}"))?;
     tracing::info!(
         task_id = %primary_review_id,
         agent = %review_agent,
@@ -961,9 +965,10 @@ async fn run_review_tick(
                 }),
                 ..CreateTaskRequest::default()
             };
-            match task_routes::enqueue_task_in_domain(
-                &state_for_synthesis,
+            match task_routes::enqueue_task_background_in_domain(
+                state_for_synthesis.clone(),
                 req,
+                None,
                 task_routes::QueueDomain::Review,
             )
             .await
@@ -1046,9 +1051,10 @@ async fn run_review_tick(
                     }),
                     ..CreateTaskRequest::default()
                 };
-                match task_routes::enqueue_task_in_domain(
-                    &state_for_synthesis,
+                match task_routes::enqueue_task_background_in_domain(
+                    state_for_synthesis.clone(),
                     synth_req,
+                    None,
                     task_routes::QueueDomain::Review,
                 )
                 .await

--- a/crates/harness-server/src/task_queue_tests.rs
+++ b/crates/harness-server/src/task_queue_tests.rs
@@ -6,7 +6,7 @@ fn config(max_concurrent: usize, max_queue: usize) -> ConcurrencyConfig {
     ConcurrencyConfig {
         max_concurrent_tasks: max_concurrent,
         max_queue_size: max_queue,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project: Default::default(),
         ..ConcurrencyConfig::default()
     }
@@ -122,7 +122,7 @@ async fn per_project_limit_enforced() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 4,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -153,7 +153,7 @@ async fn project_cannot_starve_another() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 2,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -191,7 +191,7 @@ async fn project_stats_reflect_running_and_queued() {
     let cfg2 = ConcurrencyConfig {
         max_concurrent_tasks: 4,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -317,7 +317,7 @@ async fn cancelled_project_wait_does_not_leak_queued_count() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 4,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -355,7 +355,7 @@ async fn cancelled_global_wait_releases_project_permit() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 1,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -404,7 +404,7 @@ async fn project_permit_not_leaked_on_mid_send_cancellation() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 4,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };
@@ -444,7 +444,7 @@ async fn global_permit_not_leaked_on_mid_send_cancellation() {
     let cfg = ConcurrencyConfig {
         max_concurrent_tasks: 1,
         max_queue_size: 16,
-        stall_timeout_secs: 300,
+        stall_timeout_secs: 3600,
         per_project,
         ..ConcurrencyConfig::default()
     };

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -52,7 +52,7 @@ pub struct CreateTaskRequest {
     /// Maximum backoff cap in milliseconds for validation retries. Default: 300 000 ms (5 min).
     #[serde(default = "default_retry_max_backoff_ms")]
     pub retry_max_backoff_ms: u64,
-    /// Seconds of silence from the agent stream before declaring a stall; defaults to 300.
+    /// Seconds of silence from the agent stream before declaring a stall; defaults to 3600.
     /// Overrides the global `concurrency.stall_timeout_secs` for this task.
     #[serde(default = "default_stall_timeout")]
     pub stall_timeout_secs: u64,
@@ -403,7 +403,7 @@ pub(super) fn default_turn_timeout() -> u64 {
 }
 
 pub(super) fn default_stall_timeout() -> u64 {
-    300
+    3600
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/task_runner/spawn_tests.rs
+++ b/crates/harness-server/src/task_runner/spawn_tests.rs
@@ -943,11 +943,11 @@ fn transient_error_detection() {
     assert!(is_transient_error("HTTP 429 Too Many Requests"));
     assert!(is_transient_error("502 Bad Gateway"));
     assert!(is_transient_error(
-        "Agent stream stalled: no output for 300s"
+        "Agent stream stalled: no output for 3600s"
     ));
     assert!(is_transient_error("connection reset by peer"));
     assert!(is_transient_error(
-        "stream idle timeout after 300s: zombie connection terminated"
+        "stream idle timeout after 3600s: zombie connection terminated"
     ));
     assert!(is_transient_error(
         "claude exited with exit status: 1: stderr=[] stdout_tail=[You've hit your limit · resets 3pm (Asia/Shanghai)\n]"

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -1,14 +1,18 @@
+use chrono::{DateTime, Duration, Utc};
 use harness_workflow::issue_lifecycle::IssueWorkflowStore;
 use harness_workflow::runtime::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,
     build_repo_backlog_poll_decision, build_stale_active_workflow_decision,
     repo_backlog_workflow_id, DecisionValidator, MergedPrDecisionInput, OpenIssueDecisionInput,
-    RepoBacklogPollDecisionInput, StaleWorkflowDecisionInput, ValidationContext, WorkflowDecision,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore,
-    WorkflowSubject, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    RepoBacklogPollDecisionInput, StaleWorkflowDecisionInput, ValidationContext,
+    WorkflowCommandRecord, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject, REPO_BACKLOG_DEFINITION_ID,
+    REPO_BACKLOG_POLL_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
+
+const REPO_BACKLOG_FAILED_RETRY_BACKOFF: Duration = Duration::minutes(15);
 
 pub(crate) struct OpenIssueRuntimeContext<'a> {
     pub project_root: &'a Path,
@@ -60,16 +64,24 @@ pub(crate) async fn request_repo_backlog_poll(
             state: instance.state,
         });
     }
-    if has_active_repo_backlog_poll_command(store, &instance.id).await? {
+    let commands = store.commands_for(&instance.id).await?;
+    if has_active_repo_backlog_poll_command(&commands) {
         return Ok(RepoBacklogPollRequestOutcome::ActiveCommandExists {
             workflow_id: instance.id,
+        });
+    }
+    if instance.state == "failed" && repo_backlog_failed_retry_backoff_active(&commands, Utc::now())
+    {
+        return Ok(RepoBacklogPollRequestOutcome::NotCandidate {
+            workflow_id: instance.id,
+            state: instance.state,
         });
     }
     persist_repo_backlog_poll_request(store, instance, &ctx).await
 }
 
 fn repo_backlog_poll_candidate_state(state: &str) -> bool {
-    matches!(state, "idle")
+    matches!(state, "idle" | "failed")
 }
 
 pub(crate) async fn record_open_issue_without_workflow(
@@ -399,18 +411,32 @@ fn repo_backlog_validation_context(
     ValidationContext::new("workflow-policy", chrono::Utc::now())
 }
 
-async fn has_active_repo_backlog_poll_command(
-    store: &WorkflowRuntimeStore,
-    workflow_id: &str,
-) -> anyhow::Result<bool> {
-    Ok(store
-        .commands_for(workflow_id)
-        .await?
-        .into_iter()
-        .any(|record| {
-            matches!(record.status.as_str(), "pending" | "dispatched")
-                && record.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
-        }))
+fn has_active_repo_backlog_poll_command(commands: &[WorkflowCommandRecord]) -> bool {
+    commands.iter().any(|record| {
+        matches!(
+            record.status.as_str(),
+            "pending" | "dispatching" | "dispatched"
+        ) && is_repo_backlog_poll_command(record)
+    })
+}
+
+fn repo_backlog_failed_retry_backoff_active(
+    commands: &[WorkflowCommandRecord],
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(latest) = commands
+        .iter()
+        .filter(|record| is_repo_backlog_poll_command(record))
+        .max_by_key(|record| record.updated_at)
+    else {
+        return false;
+    };
+    latest.status == "failed"
+        && now.signed_duration_since(latest.updated_at) < REPO_BACKLOG_FAILED_RETRY_BACKOFF
+}
+
+fn is_repo_backlog_poll_command(record: &WorkflowCommandRecord) -> bool {
+    record.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
 }
 
 async fn upsert_repo_backlog_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -454,6 +480,7 @@ mod tests {
     use super::*;
     use harness_core::db::resolve_database_url;
     use harness_workflow::issue_lifecycle::IssueLifecycleState;
+    use harness_workflow::runtime::WorkflowCommand;
 
     async fn open_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
         let database_url = resolve_database_url(None)?;
@@ -589,6 +616,52 @@ mod tests {
         assert_eq!(retry_instance.state, "failed");
         assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
         Ok(())
+    }
+
+    #[test]
+    fn repo_backlog_failed_retry_backoff_expires() {
+        let now = Utc::now();
+        let recent_failed = repo_backlog_poll_command_record(
+            "failed",
+            now - REPO_BACKLOG_FAILED_RETRY_BACKOFF + Duration::seconds(1),
+        );
+        assert!(repo_backlog_failed_retry_backoff_active(
+            &[recent_failed],
+            now
+        ));
+
+        let stale_failed = repo_backlog_poll_command_record(
+            "failed",
+            now - REPO_BACKLOG_FAILED_RETRY_BACKOFF - Duration::seconds(1),
+        );
+        assert!(!repo_backlog_failed_retry_backoff_active(
+            &[stale_failed],
+            now
+        ));
+    }
+
+    #[test]
+    fn repo_backlog_poll_active_command_includes_dispatching() {
+        let command = repo_backlog_poll_command_record("dispatching", Utc::now());
+
+        assert!(has_active_repo_backlog_poll_command(&[command]));
+    }
+
+    fn repo_backlog_poll_command_record(
+        status: impl Into<String>,
+        updated_at: DateTime<Utc>,
+    ) -> WorkflowCommandRecord {
+        WorkflowCommandRecord {
+            id: "command-1".to_string(),
+            workflow_id: "repo-backlog".to_string(),
+            decision_id: None,
+            status: status.into(),
+            dispatch_owner: None,
+            dispatch_lease_expires_at: None,
+            command: WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "dedupe"),
+            created_at: updated_at,
+            updated_at,
+        }
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -69,7 +69,7 @@ pub(crate) async fn request_repo_backlog_poll(
 }
 
 fn repo_backlog_poll_candidate_state(state: &str) -> bool {
-    matches!(state, "idle" | "failed")
+    matches!(state, "idle")
 }
 
 pub(crate) async fn record_open_issue_without_workflow(
@@ -393,17 +393,10 @@ async fn apply_decision_with_outcome(
 }
 
 fn repo_backlog_validation_context(
-    instance: &WorkflowInstance,
-    decision: &WorkflowDecision,
+    _instance: &WorkflowInstance,
+    _decision: &WorkflowDecision,
 ) -> ValidationContext {
-    let context = ValidationContext::new("workflow-policy", chrono::Utc::now());
-    if instance.state == "failed"
-        && decision.decision == "poll_repo_backlog"
-        && decision.next_state == "scanning"
-    {
-        return context.allow_terminal_reopen();
-    }
-    context
+    ValidationContext::new("workflow-policy", chrono::Utc::now())
 }
 
 async fn has_active_repo_backlog_poll_command(
@@ -584,16 +577,17 @@ mod tests {
         .await?;
         assert_eq!(
             retry,
-            RepoBacklogPollRequestOutcome::Requested {
-                workflow_id: workflow_id.clone()
+            RepoBacklogPollRequestOutcome::NotCandidate {
+                workflow_id: workflow_id.clone(),
+                state: "failed".to_string()
             }
         );
         let retry_instance = store
             .get_instance(&workflow_id)
             .await?
             .expect("repo backlog workflow instance should still be persisted");
-        assert_eq!(retry_instance.state, "scanning");
-        assert_eq!(store.commands_for(&workflow_id).await?.len(), 2);
+        assert_eq!(retry_instance.state, "failed");
+        assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
         Ok(())
     }
 

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -394,13 +394,14 @@ impl WorkspaceManager {
 
         let git_ops_guard = self.git_ops.lock().await;
         let mut decision = WorkspaceAcquireDecision::CreatedFresh;
-        let workspace_registered = if workspace_path.exists() {
-            true
+        let workspace_path_exists = workspace_path.exists();
+        let missing_path_registered_worktree = if workspace_path_exists {
+            false
         } else {
             is_registered_worktree(source_repo, &workspace_path).await
         };
 
-        if workspace_path.exists() || workspace_registered {
+        if workspace_path_exists || missing_path_registered_worktree {
             let owner_record = read_owner_record(&workspace_path);
             if owner_record.as_ref().is_some_and(|record| {
                 owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
@@ -451,7 +452,13 @@ impl WorkspaceManager {
                 });
             }
 
-            if let Err(err) = cleanup_workspace_path(source_repo, &workspace_path).await {
+            if let Err(err) = cleanup_workspace_path_with_registration(
+                source_repo,
+                &workspace_path,
+                missing_path_registered_worktree.then_some(true),
+            )
+            .await
+            {
                 self.remove_active_workspace(task_id);
                 return Err(WorkspaceLifecycleError::ReconcileFailed {
                     workspace_path: workspace_path.clone(),
@@ -1050,7 +1057,7 @@ impl WorkspaceManager {
             }
         };
 
-        let _git_ops = self.git_ops.lock().await;
+        let mut orphan_paths = Vec::new();
         for entry in read_dir.flatten() {
             let path = entry.path();
             if !path.is_dir() {
@@ -1086,6 +1093,17 @@ impl WorkspaceManager {
             if self.active.iter().any(|e| e.workspace_path == path) {
                 continue;
             }
+            orphan_paths.push(path);
+        }
+
+        for path in orphan_paths {
+            if self.active.iter().any(|e| e.workspace_path == path) {
+                continue;
+            }
+            let _git_ops = self.git_ops.lock().await;
+            if self.active.iter().any(|e| e.workspace_path == path) {
+                continue;
+            }
             tracing::info!(
                 "cleanup_orphan_worktrees: removing orphan worktree {:?}",
                 path
@@ -1096,6 +1114,7 @@ impl WorkspaceManager {
         }
 
         // Prune stale worktree metadata so git no longer tracks removed directories.
+        let _git_ops = self.git_ops.lock().await;
         if let Err(e) = git_command()
             .args(["-C", &source_repo.to_string_lossy(), "worktree", "prune"])
             .output()
@@ -1349,7 +1368,18 @@ async fn remove_worktree(source_repo: &Path, workspace_path: &Path) -> anyhow::R
 }
 
 async fn cleanup_workspace_path(source_repo: &Path, workspace_path: &Path) -> anyhow::Result<()> {
-    let worktree_registered = is_registered_worktree(source_repo, workspace_path).await;
+    cleanup_workspace_path_with_registration(source_repo, workspace_path, None).await
+}
+
+async fn cleanup_workspace_path_with_registration(
+    source_repo: &Path,
+    workspace_path: &Path,
+    known_worktree_registered: Option<bool>,
+) -> anyhow::Result<()> {
+    let worktree_registered = match known_worktree_registered {
+        Some(registered) => registered,
+        None => is_registered_worktree(source_repo, workspace_path).await,
+    };
     if worktree_registered {
         match remove_worktree(source_repo, workspace_path).await {
             Ok(()) => {}

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -211,6 +211,7 @@ pub struct WorkspaceManager {
     pub(crate) active: DashMap<TaskId, ActiveWorkspace>,
     pub(crate) active_paths: DashMap<PathBuf, TaskId>,
     pub(crate) owner_session: String,
+    git_ops: tokio::sync::Mutex<()>,
 }
 
 impl WorkspaceManager {
@@ -224,6 +225,7 @@ impl WorkspaceManager {
             active: DashMap::new(),
             active_paths: DashMap::new(),
             owner_session: SessionId::new().to_string(),
+            git_ops: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -241,6 +243,15 @@ impl WorkspaceManager {
         let (_, active) = self.active.remove(task_id)?;
         self.release_active_path(task_id, &active.workspace_path);
         Some(active)
+    }
+
+    async fn cleanup_workspace_path_locked(
+        &self,
+        source_repo: &Path,
+        workspace_path: &Path,
+    ) -> anyhow::Result<()> {
+        let _git_ops = self.git_ops.lock().await;
+        cleanup_workspace_path(source_repo, workspace_path).await
     }
 
     /// Create a git worktree for the given task under `config.root/<sanitized_task_id>`.
@@ -381,9 +392,15 @@ impl WorkspaceManager {
             }
         }
 
+        let git_ops_guard = self.git_ops.lock().await;
         let mut decision = WorkspaceAcquireDecision::CreatedFresh;
+        let workspace_registered = if workspace_path.exists() {
+            true
+        } else {
+            is_registered_worktree(source_repo, &workspace_path).await
+        };
 
-        if workspace_path.exists() {
+        if workspace_path.exists() || workspace_registered {
             let owner_record = read_owner_record(&workspace_path);
             if owner_record.as_ref().is_some_and(|record| {
                 owner_record_matches_workspace(record, task_id, &workspace_key, run_generation)
@@ -607,6 +624,7 @@ impl WorkspaceManager {
                 message: format!("failed to persist workspace owner record: {err}"),
             });
         }
+        drop(git_ops_guard);
 
         // Run after_create_hook if set. Fatal on failure: cleanup partial worktree.
         let after_create_hook = options
@@ -629,13 +647,15 @@ impl WorkspaceManager {
             };
 
             if let Some(err_msg) = hook_error {
-                self.remove_active_workspace(task_id);
-                if let Err(cleanup_err) = cleanup_workspace_path(source_repo, &workspace_path).await
+                if let Err(cleanup_err) = self
+                    .cleanup_workspace_path_locked(source_repo, &workspace_path)
+                    .await
                 {
                     tracing::warn!(
                         "failed to cleanup partial worktree after hook failure: {cleanup_err}"
                     );
                 }
+                self.remove_active_workspace(task_id);
                 return Err(WorkspaceLifecycleError::CreateFailed {
                     workspace_path,
                     workspace_owner: Some(owner_session),
@@ -677,7 +697,10 @@ impl WorkspaceManager {
             }
         }
 
-        if let Err(e) = cleanup_workspace_path(&entry.source_repo, &entry.workspace_path).await {
+        if let Err(e) = self
+            .cleanup_workspace_path_locked(&entry.source_repo, &entry.workspace_path)
+            .await
+        {
             tracing::warn!(
                 "git worktree remove failed for {:?}: {e}",
                 entry.workspace_path
@@ -728,7 +751,8 @@ impl WorkspaceManager {
             );
             return Ok(());
         }
-        cleanup_workspace_path(source_repo, &target).await
+        self.cleanup_workspace_path_locked(source_repo, &target)
+            .await
     }
 
     /// Return the workspace path for the given task if it is active.
@@ -836,7 +860,10 @@ impl WorkspaceManager {
                     .as_ref()
                     .and_then(owner_record_external_id)
                     .is_some();
-                match cleanup_workspace_path(&cleanup_repo, &path).await {
+                match self
+                    .cleanup_workspace_path_locked(&cleanup_repo, &path)
+                    .await
+                {
                     Ok(()) => {
                         if is_new_key {
                             summary.migrated += 1;
@@ -871,7 +898,10 @@ impl WorkspaceManager {
                 continue;
             }
 
-            match cleanup_workspace_path(&cleanup_repo, path).await {
+            match self
+                .cleanup_workspace_path_locked(&cleanup_repo, path)
+                .await
+            {
                 Ok(()) => {
                     summary.removed += 1;
                 }
@@ -975,7 +1005,7 @@ impl WorkspaceManager {
             );
 
             if should_remove {
-                match cleanup_workspace_path(source_repo, &path).await {
+                match self.cleanup_workspace_path_locked(source_repo, &path).await {
                     Ok(()) => summary.removed += 1,
                     Err(e) => tracing::warn!(
                         "reconcile_disk_workspaces: cleanup failed for {path:?}: {e}"
@@ -1020,6 +1050,7 @@ impl WorkspaceManager {
             }
         };
 
+        let _git_ops = self.git_ops.lock().await;
         for entry in read_dir.flatten() {
             let path = entry.path();
             if !path.is_dir() {

--- a/crates/harness-server/src/workspace_tests.rs
+++ b/crates/harness-server/src/workspace_tests.rs
@@ -773,6 +773,43 @@ async fn create_workspace_reconciles_stale_directory() {
 }
 
 #[tokio::test]
+async fn create_workspace_reconciles_missing_registered_worktree() {
+    let source = tempfile::tempdir().expect("tempdir");
+    init_git_repo(source.path());
+    let branch = current_branch(source.path());
+
+    let workspaces = tempfile::tempdir().expect("tempdir");
+    let config = WorkspaceConfig {
+        root: workspaces.path().to_path_buf(),
+        ..Default::default()
+    };
+    let task_id = harness_core::types::TaskId("missing-registered-task".to_string());
+    let first_mgr = WorkspaceManager::new(config.clone()).expect("first manager");
+    let first = first_mgr
+        .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
+        .await
+        .expect("create initial workspace");
+    std::fs::remove_dir_all(&first.workspace_path).expect("remove worktree directory");
+    assert!(
+        is_registered_worktree(source.path(), &first.workspace_path).await,
+        "removed workspace path should still be registered in git metadata"
+    );
+
+    let second_mgr = WorkspaceManager::new(config).expect("second manager");
+    let recreated = second_mgr
+        .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
+        .await
+        .expect("missing registered worktree should be pruned and recreated");
+
+    assert_eq!(recreated.decision, WorkspaceAcquireDecision::RecreatedStale);
+    assert!(recreated.workspace_path.exists());
+    assert!(
+        is_registered_worktree(source.path(), &recreated.workspace_path).await,
+        "recreated workspace should be registered as a live worktree"
+    );
+}
+
+#[tokio::test]
 async fn create_workspace_blocks_live_foreign_owner() {
     let source = tempfile::tempdir().expect("tempdir");
     init_git_repo(source.path());


### PR DESCRIPTION
## Summary
- clean up missing-but-registered worktrees before creating new runtime workspaces
- stop repo backlog failed workflows from being reopened by the periodic poller
- surface Codex item-completed error messages instead of JSON parse noise
- inherit workflow runtime profiles from the configured default agent, with Codex/gpt-5.5/xhigh examples
- route periodic reviews through the review background queue domain

## Validation
- cargo fmt --all
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test -p harness-agents
- cargo test -p harness-core workflow_config -- --nocapture
- cargo test -p harness-server workspace::tests -- --nocapture
- cargo test -p harness-server workflow_runtime_repo_backlog::tests -- --nocapture
- cargo test -p harness-server runtime_dispatch_profile -- --nocapture
- cargo build --release --bin harness

## Notes
- cargo test -p harness-server previously reached 1163 passed / 1 Postgres pool timeout; the failed test passed when rerun directly, matching known local DB pool contention behavior.