### PR TITLE
fix(workflow): harden runtime state transitions

### DIFF
--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Duration, Utc};
 use harness_workflow::issue_lifecycle::IssueWorkflowStore;
 use harness_workflow::runtime::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,
@@ -11,8 +10,6 @@ use harness_workflow::runtime::{
 };
 use serde_json::json;
 use std::path::Path;
-
-const REPO_BACKLOG_FAILED_RETRY_BACKOFF: Duration = Duration::minutes(15);
 
 pub(crate) struct OpenIssueRuntimeContext<'a> {
     pub project_root: &'a Path,
@@ -70,18 +67,11 @@ pub(crate) async fn request_repo_backlog_poll(
             workflow_id: instance.id,
         });
     }
-    if instance.state == "failed" && repo_backlog_failed_retry_backoff_active(&commands, Utc::now())
-    {
-        return Ok(RepoBacklogPollRequestOutcome::NotCandidate {
-            workflow_id: instance.id,
-            state: instance.state,
-        });
-    }
     persist_repo_backlog_poll_request(store, instance, &ctx).await
 }
 
 fn repo_backlog_poll_candidate_state(state: &str) -> bool {
-    matches!(state, "idle" | "failed")
+    state == "idle"
 }
 
 pub(crate) async fn record_open_issue_without_workflow(
@@ -420,21 +410,6 @@ fn has_active_repo_backlog_poll_command(commands: &[WorkflowCommandRecord]) -> b
     })
 }
 
-fn repo_backlog_failed_retry_backoff_active(
-    commands: &[WorkflowCommandRecord],
-    now: DateTime<Utc>,
-) -> bool {
-    let Some(latest) = commands
-        .iter()
-        .filter(|record| is_repo_backlog_poll_command(record))
-        .max_by_key(|record| record.updated_at)
-    else {
-        return false;
-    };
-    latest.status == "failed"
-        && now.signed_duration_since(latest.updated_at) < REPO_BACKLOG_FAILED_RETRY_BACKOFF
-}
-
 fn is_repo_backlog_poll_command(record: &WorkflowCommandRecord) -> bool {
     record.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
 }
@@ -478,6 +453,7 @@ fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_jso
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{DateTime, Utc};
     use harness_core::db::resolve_database_url;
     use harness_workflow::issue_lifecycle::IssueLifecycleState;
     use harness_workflow::runtime::WorkflowCommand;
@@ -616,28 +592,6 @@ mod tests {
         assert_eq!(retry_instance.state, "failed");
         assert_eq!(store.commands_for(&workflow_id).await?.len(), 1);
         Ok(())
-    }
-
-    #[test]
-    fn repo_backlog_failed_retry_backoff_expires() {
-        let now = Utc::now();
-        let recent_failed = repo_backlog_poll_command_record(
-            "failed",
-            now - REPO_BACKLOG_FAILED_RETRY_BACKOFF + Duration::seconds(1),
-        );
-        assert!(repo_backlog_failed_retry_backoff_active(
-            &[recent_failed],
-            now
-        ));
-
-        let stale_failed = repo_backlog_poll_command_record(
-            "failed",
-            now - REPO_BACKLOG_FAILED_RETRY_BACKOFF - Duration::seconds(1),
-        );
-        assert!(!repo_backlog_failed_retry_backoff_active(
-            &[stale_failed],
-            now
-        ));
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -51,6 +51,7 @@ pub(super) fn activity_result_from_turn(
                     "activity result block invalid: {error}"
                 );
                 ActivityResult::failed(activity, "Structured activity result was invalid.", error)
+                    .with_error_kind(ActivityErrorKind::Configuration)
             }
         },
         TurnStatus::Cancelled => ActivityResult::cancelled(activity, summary),
@@ -359,6 +360,7 @@ Final result:
             result.error.as_deref(),
             Some("activity result block reported activity `replan_issue`, expected `implement_issue`")
         );
+        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
         assert!(!result
             .artifacts
             .iter()
@@ -416,6 +418,7 @@ Final result:
             .error
             .as_deref()
             .is_some_and(|error| error.starts_with("activity result block is invalid JSON:")));
+        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
         assert!(!result
             .artifacts
             .iter()

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -105,7 +105,7 @@ pub(super) fn build_runtime_job_prompt(
          - Use the prompt packet activity_result_schema to shape your final summary.\n\
          - When returning structured activity output, put a JSON object in a final fenced `harness-activity-result` block matching activity_result_schema.\n\
          - The structured result activity field must match this runtime job activity exactly.\n\
-         - Return a concise final summary with changed files, validation commands, and remaining blockers.\n\n\
+         - Return a concise final summary appropriate to the activity. Include changed files and validation commands only when repository code changes were requested; for discovery and planning activities, report inspected inputs, emitted signals, and remaining blockers.\n\n\
          Project root: {project_root}\n\
          Runtime job id: {job_id}\n\
          Runtime profile: {runtime_profile}\n\
@@ -325,11 +325,13 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "planning_batch_when_IssueDiscovered_signals_exist_else_idle",
                 "accepted_signals": ["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
+                "success_requires": "At least one accepted signal. Empty signals are invalid even when status is succeeded.",
+                "empty_success_allowed": false,
                 "required_summary": "Describe the GitHub issue query, existing workflow checks, and new issue workflow candidates."
             },
             "structured_decision": {
                 "optional": true,
-                "description": "A workflow_decision artifact may propose a plan_repo_sprint activity command, but IssueDiscovered signals are sufficient."
+                "description": "Prefer signals. Only emit workflow_decision when you can include every required command; a transition to planning_batch without an enqueue_activity command is invalid."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -340,11 +342,14 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "dispatching_when_SprintTaskSelected_signals_exist_else_idle",
                 "accepted_signals": ["SprintTaskSelected", "IssueSkipped", "NoSprintTaskSelected"],
+                "accepted_artifacts": ["sprint_plan"],
+                "success_requires": "At least one accepted signal or a sprint_plan artifact. Empty signals and no sprint_plan artifact are invalid even when status is succeeded.",
+                "empty_success_allowed": false,
                 "required_summary": "Describe dependency planning, skipped issues, and selected issue workflow dispatch order."
             },
             "structured_decision": {
                 "optional": true,
-                "description": "A workflow_decision artifact may propose start_child_workflow commands, but SprintTaskSelected signals are sufficient."
+                "description": "Prefer signals. Only emit workflow_decision when you can include every required command; a transition to dispatching without start_child_workflow commands is invalid."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -458,6 +463,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
         ("repo_backlog", "poll_repo_backlog") => json!({
             "must_include": ["repo and label queried", "open issues inspected", "existing workflow checks", "new issue workflow candidates", "next workflow action"],
             "must_not_include": ["repository code changes", "workflow table mutations", "server-side GitHub polling changes"],
+            "success_rule": "A succeeded result MUST emit IssueDiscovered, IssueSkipped, or NoOpenIssueFound. Do not return succeeded with empty signals.",
             "signals": {
                 "IssueDiscovered": "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available.",
                 "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason. When an issue already has a workflow, include workflow_state.",
@@ -473,6 +479,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
         ("repo_backlog", "plan_repo_sprint") => json!({
             "must_include": ["issues considered", "dependency reasoning", "selected tasks", "skipped issues", "next workflow action"],
             "must_not_include": ["repository code changes", "workflow table mutations", "server-side task queue changes"],
+            "success_rule": "A succeeded result MUST emit SprintTaskSelected, IssueSkipped, NoSprintTaskSelected, or a sprint_plan artifact. Do not return succeeded with empty signals and no sprint_plan artifact.",
             "signals": {
                 "SprintTaskSelected": "Use once for each issue selected for execution. Include issue_number, issue_url, repo, labels, and depends_on as issue numbers.",
                 "IssueSkipped": "Use for discovered issues intentionally skipped by planning. Include issue_number and reason.",
@@ -608,8 +615,16 @@ mod tests {
             "IssueDiscovered"
         );
         assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["empty_success_allowed"],
+            false
+        );
+        assert_eq!(
             schema["agent_summary_contract"]["signals"]["IssueDiscovered"],
             "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available."
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["success_rule"],
+            "A succeeded result MUST emit IssueDiscovered, IssueSkipped, or NoOpenIssueFound. Do not return succeeded with empty signals."
         );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()
@@ -644,8 +659,20 @@ mod tests {
             "SprintTaskSelected"
         );
         assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["empty_success_allowed"],
+            false
+        );
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["accepted_artifacts"][0],
+            "sprint_plan"
+        );
+        assert_eq!(
             schema["agent_summary_contract"]["signals"]["SprintTaskSelected"],
             "Use once for each issue selected for execution. Include issue_number, issue_url, repo, labels, and depends_on as issue numbers."
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["success_rule"],
+            "A succeeded result MUST emit SprintTaskSelected, IssueSkipped, NoSprintTaskSelected, or a sprint_plan artifact. Do not return succeeded with empty signals and no sprint_plan artifact."
         );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()

--- a/crates/harness-server/src/workflow_runtime_worker_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker_tests.rs
@@ -543,6 +543,10 @@ fn activity_result_from_turn_fails_mismatched_structured_activity() {
         result.error.as_deref(),
         Some("activity result block reported activity `replan_issue`, expected `implement_issue`")
     );
+    assert_eq!(
+        result.error_kind,
+        Some(harness_workflow::runtime::ActivityErrorKind::Configuration)
+    );
     assert!(!result
         .artifacts
         .iter()
@@ -603,6 +607,10 @@ Final result:
         .error
         .as_deref()
         .is_some_and(|error| error.starts_with("activity result block is invalid JSON:")));
+    assert_eq!(
+        result.error_kind,
+        Some(harness_workflow::runtime::ActivityErrorKind::Configuration)
+    );
     assert!(!result
         .artifacts
         .iter()

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -86,8 +86,24 @@ fn reduce_success(
         return None;
     }
 
-    if let Some(decision) = structured_decision {
+    if let Some(decision) =
+        repo_backlog_invalid_success_decision(instance, event, result, structured_decision.as_ref())
+    {
         return Some(decision);
+    }
+
+    if let Some(decision) = structured_decision.as_ref() {
+        let reason = format!(
+            "runtime activity `{}` emitted workflow_decision `{}` for workflow `{}` in state `{}`, but the decision to `{}` did not validate and no domain fallback was available",
+            result.activity,
+            decision.decision,
+            instance.definition_id,
+            instance.state,
+            decision.next_state
+        );
+        return Some(invalid_agent_output_blocked_decision(
+            instance, event, result, &reason,
+        ));
     }
 
     let (next_state, decision, reason) = match (
@@ -667,6 +683,147 @@ fn structured_decision_validates(
         .is_ok()
 }
 
+fn repo_backlog_invalid_success_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    structured_decision: Option<&WorkflowDecision>,
+) -> Option<WorkflowDecision> {
+    match (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) {
+        (REPO_BACKLOG_DEFINITION_ID, "scanning", REPO_BACKLOG_POLL_ACTIVITY) => {
+            let issue_discovered_count = signal_count(result, "IssueDiscovered");
+            let valid_issue_discovered_count =
+                issue_candidates_from_signals(result, "IssueDiscovered", None).len();
+            if issue_discovered_count > 0 && valid_issue_discovered_count == 0 {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo backlog poll emitted IssueDiscovered signals, but none contained a valid issue_number",
+                ));
+            }
+            if !has_any_signal(
+                result,
+                &["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
+            ) {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo backlog poll succeeded without IssueDiscovered, IssueSkipped, or NoOpenIssueFound signals",
+                ));
+            }
+            if structured_decision.is_some() {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo backlog poll emitted a workflow_decision artifact that did not validate and no valid domain fallback was available",
+                ));
+            }
+            None
+        }
+        (REPO_BACKLOG_DEFINITION_ID, "planning_batch", REPO_BACKLOG_SPRINT_PLAN_ACTIVITY) => {
+            let sprint_task_selected_count = signal_count(result, "SprintTaskSelected");
+            let sprint_plan_task_count = sprint_plan_task_count(result);
+            let has_sprint_plan_artifact = result
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.artifact_type == "sprint_plan");
+            if (sprint_task_selected_count > 0 || sprint_plan_task_count > 0)
+                && sprint_plan_selected_issues(result, event, None).is_empty()
+            {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo sprint plan emitted selected task output, but no selected issue had a valid issue_number",
+                ));
+            }
+            if !has_any_signal(
+                result,
+                &["SprintTaskSelected", "IssueSkipped", "NoSprintTaskSelected"],
+            ) && !has_sprint_plan_artifact
+            {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo sprint plan succeeded without SprintTaskSelected, IssueSkipped, or NoSprintTaskSelected signals",
+                ));
+            }
+            if structured_decision.is_some() {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo sprint plan emitted a workflow_decision artifact that did not validate and no valid domain fallback was available",
+                ));
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn invalid_agent_output_blocked_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    reason: &str,
+) -> WorkflowDecision {
+    WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "block_invalid_agent_output",
+        "blocked",
+        reason,
+    )
+    .with_command(WorkflowCommand::mark_blocked(
+        reason,
+        format!("runtime-completion:{}:invalid-output:block", event.id),
+    ))
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::RequestOperatorAttention,
+        format!("runtime-completion:{}:invalid-output:operator", event.id),
+        json!({
+            "reason": reason,
+            "activity": result.activity,
+            "runtime_job_id": event_field_string(event, "runtime_job_id"),
+        }),
+    ))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .high_confidence()
+}
+
+fn signal_count(result: &ActivityResult, signal_type: &str) -> usize {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == signal_type)
+        .count()
+}
+
+fn has_any_signal(result: &ActivityResult, signal_types: &[&str]) -> bool {
+    result
+        .signals
+        .iter()
+        .any(|signal| signal_types.contains(&signal.signal_type.as_str()))
+}
+
+fn sprint_plan_task_count(result: &ActivityResult) -> usize {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "sprint_plan")
+        .map(|artifact| array_items(&artifact.artifact, "tasks").len())
+        .sum()
+}
+
 fn repo_backlog_child_dispatch_still_active(
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
@@ -1209,7 +1366,7 @@ fn supports_same_state_activity_retry(definition_id: &str, state: &str) -> bool 
             "implementing" | "awaiting_feedback" | "addressing_feedback"
         ) | (
             REPO_BACKLOG_DEFINITION_ID,
-            "dispatching" | "reconciling" | "planning_batch"
+            "scanning" | "dispatching" | "reconciling" | "planning_batch"
         ) | (PR_FEEDBACK_DEFINITION_ID, "inspecting")
             | (PROMPT_TASK_DEFINITION_ID, "implementing")
             | (QUALITY_GATE_DEFINITION_ID, "checking")

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -730,10 +730,7 @@ fn repo_backlog_invalid_success_decision(
         (REPO_BACKLOG_DEFINITION_ID, "planning_batch", REPO_BACKLOG_SPRINT_PLAN_ACTIVITY) => {
             let sprint_task_selected_count = signal_count(result, "SprintTaskSelected");
             let sprint_plan_task_count = sprint_plan_task_count(result);
-            let has_sprint_plan_artifact = result
-                .artifacts
-                .iter()
-                .any(|artifact| artifact.artifact_type == "sprint_plan");
+            let has_valid_noop_sprint_plan_artifact = has_valid_noop_sprint_plan_artifact(result);
             if (sprint_task_selected_count > 0 || sprint_plan_task_count > 0)
                 && sprint_plan_selected_issues(result, event, None).is_empty()
             {
@@ -747,13 +744,13 @@ fn repo_backlog_invalid_success_decision(
             if !has_any_signal(
                 result,
                 &["SprintTaskSelected", "IssueSkipped", "NoSprintTaskSelected"],
-            ) && !has_sprint_plan_artifact
+            ) && !has_valid_noop_sprint_plan_artifact
             {
                 return Some(invalid_agent_output_blocked_decision(
                     instance,
                     event,
                     result,
-                    "repo sprint plan succeeded without SprintTaskSelected, IssueSkipped, or NoSprintTaskSelected signals",
+                    "repo sprint plan succeeded without SprintTaskSelected, IssueSkipped, NoSprintTaskSelected, or a valid no-op sprint_plan artifact",
                 ));
             }
             if structured_decision.is_some() {
@@ -822,6 +819,59 @@ fn sprint_plan_task_count(result: &ActivityResult) -> usize {
         .filter(|artifact| artifact.artifact_type == "sprint_plan")
         .map(|artifact| array_items(&artifact.artifact, "tasks").len())
         .sum()
+}
+
+fn has_valid_noop_sprint_plan_artifact(result: &ActivityResult) -> bool {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "sprint_plan")
+        .any(|artifact| valid_noop_sprint_plan_artifact(&artifact.artifact))
+}
+
+fn valid_noop_sprint_plan_artifact(value: &Value) -> bool {
+    let Some(tasks) = value.get("tasks").and_then(Value::as_array) else {
+        return false;
+    };
+    tasks.is_empty() && (has_valid_skip_evidence(value) || has_explicit_noop_evidence(value))
+}
+
+fn has_valid_skip_evidence(value: &Value) -> bool {
+    value
+        .get("skip")
+        .or_else(|| value.get("skipped"))
+        .and_then(Value::as_array)
+        .is_some_and(|items| items.iter().any(valid_sprint_plan_skip_evidence))
+}
+
+fn valid_sprint_plan_skip_evidence(value: &Value) -> bool {
+    let has_issue = value
+        .get("issue")
+        .or_else(|| value.get("issue_number"))
+        .and_then(json_value_u64)
+        .is_some_and(|issue_number| issue_number > 0);
+    let has_reason = value
+        .get("reason")
+        .or_else(|| value.get("note"))
+        .and_then(non_empty_json_string)
+        .is_some();
+    has_issue && has_reason
+}
+
+fn has_explicit_noop_evidence(value: &Value) -> bool {
+    let has_noop_flag = value
+        .get("no_task_selected")
+        .or_else(|| value.get("no_tasks_selected"))
+        .or_else(|| value.get("no_sprint_task_selected"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let has_reason = value
+        .get("reason")
+        .or_else(|| value.get("summary"))
+        .or_else(|| value.get("note"))
+        .and_then(non_empty_json_string)
+        .is_some();
+    has_noop_flag && has_reason
 }
 
 fn repo_backlog_child_dispatch_still_active(

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1259,37 +1259,6 @@ impl WorkflowRuntimeStore {
         Ok(by_job)
     }
 
-    pub async fn complete_runtime_job(
-        &self,
-        runtime_job_id: &str,
-        result: &ActivityResult,
-    ) -> anyhow::Result<RuntimeJob> {
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1")
-                .bind(runtime_job_id)
-                .fetch_optional(&self.pool)
-                .await?;
-        let Some((data,)) = row else {
-            anyhow::bail!("runtime job not found: {runtime_job_id}");
-        };
-        let mut job: RuntimeJob = serde_json::from_str(&data)?;
-        job.complete(result)?;
-        let updated = to_jsonb_string(&job)?;
-        let status = enum_str(&job.status)?;
-        sqlx::query(
-            "UPDATE runtime_jobs
-             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
-             WHERE id = $4",
-        )
-        .bind(&status)
-        .bind(job.not_before)
-        .bind(&updated)
-        .bind(runtime_job_id)
-        .execute(&self.pool)
-        .await?;
-        Ok(job)
-    }
-
     pub async fn complete_runtime_job_if_owned(
         &self,
         runtime_job_id: &str,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1290,6 +1290,51 @@ impl WorkflowRuntimeStore {
         Ok(job)
     }
 
+    pub async fn complete_runtime_job_if_owned(
+        &self,
+        runtime_job_id: &str,
+        owner: &str,
+        lease_expires_at: DateTime<Utc>,
+        result: &ActivityResult,
+    ) -> anyhow::Result<Option<RuntimeJob>> {
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1 FOR UPDATE")
+                .bind(runtime_job_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((data,)) = row else {
+            anyhow::bail!("runtime job not found: {runtime_job_id}");
+        };
+        let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        let is_current_lease = job.status == RuntimeJobStatus::Running
+            && job
+                .lease
+                .as_ref()
+                .is_some_and(|lease| lease.owner == owner && lease.expires_at == lease_expires_at);
+        if !is_current_lease {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        job.complete(result)?;
+        let updated = to_jsonb_string(&job)?;
+        let status = enum_str(&job.status)?;
+        sqlx::query(
+            "UPDATE runtime_jobs
+             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $4",
+        )
+        .bind(&status)
+        .bind(job.not_before)
+        .bind(&updated)
+        .bind(runtime_job_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(Some(job))
+    }
+
     pub async fn get_runtime_job(
         &self,
         runtime_job_id: &str,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -2383,6 +2383,53 @@ fn runtime_completion_reducer_idles_repo_backlog_after_empty_sprint_plan_artifac
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_sprint_plan_artifact_without_noop_evidence() {
+    let cases = [
+        ("missing tasks", json!({})),
+        ("empty tasks without evidence", json!({ "tasks": [] })),
+    ];
+
+    for (case_name, artifact) in cases {
+        let instance = repo_backlog_instance("planning_batch");
+        let command = WorkflowCommand::enqueue_activity(
+            REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "repo-backlog:owner/repo:plan",
+        );
+        let result = ActivityResult::succeeded(
+            REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "No sprint tasks were selected.",
+        )
+        .with_artifact(ActivityArtifact::new("sprint_plan", artifact));
+        let event = WorkflowEvent::new(
+            &instance.id,
+            1,
+            super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+            "runtime-1",
+        )
+        .with_payload(json!({
+            "command_id": "command-1",
+            "command": command,
+            "runtime_job_id": "job-1",
+            "activity_result": result,
+        }));
+
+        let decision = reduce_runtime_job_completed(&instance, &event)
+            .expect("event should parse")
+            .unwrap_or_else(|| panic!("{case_name} should block invalid sprint plan output"));
+
+        assert_eq!(decision.decision, "block_invalid_agent_output");
+        assert_eq!(decision.next_state, "blocked");
+        DecisionValidator::repo_backlog()
+            .validate(
+                &instance,
+                &decision,
+                &ValidationContext::new("runtime-1", Utc::now()),
+            )
+            .expect("invalid sprint plan artifact should reduce to a valid blocked decision");
+    }
+}
+
+#[test]
 fn runtime_completion_reducer_idles_repo_backlog_after_empty_scan() {
     let instance = repo_backlog_instance("scanning");
     let command = WorkflowCommand::enqueue_activity(
@@ -4226,7 +4273,15 @@ async fn durable_store_persists_workflow_runtime_bus_contract() -> anyhow::Resul
 
     let result = ActivityResult::succeeded("replan_issue", "Replan completed.")
         .with_signal(ActivitySignal::new("ReplanCompleted", json!({})));
-    let completed = store.complete_runtime_job(&claimed.id, &result).await?;
+    let lease_expires_at = claimed
+        .lease
+        .as_ref()
+        .expect("lease should exist")
+        .expires_at;
+    let completed = store
+        .complete_runtime_job_if_owned(&claimed.id, "runtime-1", lease_expires_at, &result)
+        .await?
+        .expect("current owner completion should be accepted");
     assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
     assert_eq!(
         store

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1113,7 +1113,7 @@ fn runtime_completion_reducer_prefers_blocking_pr_feedback_over_ready_signal() {
 }
 
 #[test]
-fn runtime_completion_reducer_returns_invalid_structured_workflow_decision_for_audit() {
+fn runtime_completion_reducer_blocks_invalid_structured_workflow_decision() {
     let instance = issue_instance("pr_open");
     let proposed_decision = WorkflowDecision::new(
         &instance.id,
@@ -1148,16 +1148,25 @@ fn runtime_completion_reducer_returns_invalid_structured_workflow_decision_for_a
 
     let decision = reduce_runtime_job_completed(&instance, &event)
         .expect("event should parse")
-        .expect("invalid structured workflow decision should still be returned");
+        .expect("invalid structured workflow decision should be blocked");
 
-    let error = DecisionValidator::github_issue_pr()
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| { command.command_type == WorkflowCommandType::RequestOperatorAttention }));
+    DecisionValidator::github_issue_pr()
         .validate(
             &instance,
             &decision,
             &ValidationContext::new("runtime-1", Utc::now()),
         )
-        .expect_err("validator should reject stale observed state");
-    assert_eq!(error.kind, WorkflowDecisionRejectionKind::StateMismatch);
+        .expect("invalid structured workflow decision should reduce to a valid blocked decision");
 }
 
 #[test]
@@ -1215,6 +1224,58 @@ fn runtime_completion_reducer_retries_failed_activity_when_policy_allows() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("retry decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_retries_repo_backlog_scan_failure_when_policy_allows() {
+    let instance = repo_backlog_instance("scanning").with_data(json!({
+        "runtime_retry_policy": {
+            "max_failed_activity_retries": 1
+        }
+    }));
+    let command = WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "repo-poll-1");
+    let result = ActivityResult::failed(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Repo backlog scan failed.",
+        "repo backlog poll agent returned an external dependency error",
+    )
+    .with_error_kind(ActivityErrorKind::ExternalDependency);
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("failed repo backlog scan should produce a retry decision");
+
+    assert_eq!(decision.decision, "retry_failed_runtime_activity");
+    assert_eq!(decision.next_state, "scanning");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::EnqueueActivity
+    );
+    assert_eq!(
+        decision.commands[0].command["activity"],
+        REPO_BACKLOG_POLL_ACTIVITY
+    );
+    assert_eq!(decision.commands[0].command["retry_attempt"], 1);
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog scan retry decision should validate");
 }
 
 #[test]
@@ -2272,6 +2333,56 @@ fn runtime_completion_reducer_idles_repo_backlog_after_empty_sprint_plan() {
 }
 
 #[test]
+fn runtime_completion_reducer_idles_repo_backlog_after_empty_sprint_plan_artifact() {
+    let instance = repo_backlog_instance("planning_batch");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "repo-backlog:owner/repo:plan",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "All candidate issues were skipped.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "sprint_plan",
+        json!({
+            "tasks": [],
+            "skip": [{
+                "issue": 42,
+                "reason": "already handled by an active workflow"
+            }]
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("empty sprint plan artifact should idle workflow");
+
+    assert_eq!(decision.decision, "finish_repo_sprint_plan");
+    assert_eq!(decision.next_state, "idle");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog empty sprint artifact completion should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_idles_repo_backlog_after_empty_scan() {
     let instance = repo_backlog_instance("scanning");
     let command = WorkflowCommand::enqueue_activity(
@@ -2313,6 +2424,150 @@ fn runtime_completion_reducer_idles_repo_backlog_after_empty_scan() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("repo backlog scan idle completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_repo_backlog_scan_with_empty_success() {
+    let instance = repo_backlog_instance("scanning");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Scan completed but did not report structured signals.",
+    );
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("empty repo backlog success should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkBlocked
+    );
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("invalid output block decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_repo_backlog_scan_with_invalid_issue_signal() {
+    let instance = repo_backlog_instance("scanning");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Found one issue, but emitted malformed payload.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueDiscovered",
+        json!({
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "title": "Missing issue number"
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("invalid issue signal should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("valid issue_number"));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("invalid issue signal block decision should validate");
+}
+
+#[test]
+fn repo_backlog_requires_plan_activity_when_entering_planning_batch() {
+    let instance = repo_backlog_instance("scanning");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "scanning",
+        "agent_reported_planning_batch",
+        "planning_batch",
+        "The agent reported a planning state without enqueueing the planner.",
+    )
+    .with_command(WorkflowCommand::wait(
+        "planner command omitted",
+        "repo-backlog:planner-omitted",
+    ));
+
+    let err = DecisionValidator::repo_backlog()
+        .validate(&instance, &decision, &validation_context())
+        .expect_err("planning_batch transition should require EnqueueActivity");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::RequiredCommandMissing
+    );
+}
+
+#[test]
+fn repo_backlog_requires_child_start_when_entering_dispatching() {
+    let instance = repo_backlog_instance("planning_batch");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "planning_batch",
+        "agent_reported_dispatching",
+        "dispatching",
+        "The agent reported dispatching without start_child_workflow commands.",
+    )
+    .with_command(WorkflowCommand::wait(
+        "child workflow command omitted",
+        "repo-backlog:dispatch-omitted",
+    ));
+
+    let err = DecisionValidator::repo_backlog()
+        .validate(&instance, &decision, &validation_context())
+        .expect_err("dispatching transition should require StartChildWorkflow");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::RequiredCommandMissing
+    );
 }
 
 #[test]
@@ -3065,17 +3320,65 @@ async fn runtime_store_reclaims_expired_running_job() -> anyhow::Result<()> {
             .owner,
         "runtime-1"
     );
+    let first_lease_expires_at = first_claim
+        .lease
+        .as_ref()
+        .expect("lease should exist")
+        .expires_at;
 
     let reclaimed = store
-        .claim_next_runtime_job("runtime-2", Utc::now() + Duration::minutes(5))
+        .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
         .await?
         .expect("expired running job should be reclaimable");
     assert_eq!(reclaimed.id, job.id);
     assert_eq!(reclaimed.status, RuntimeJobStatus::Running);
     assert_eq!(
         reclaimed.lease.as_ref().expect("lease should exist").owner,
-        "runtime-2"
+        "runtime-1"
     );
+    let reclaimed_lease_expires_at = reclaimed
+        .lease
+        .as_ref()
+        .expect("lease should exist")
+        .expires_at;
+    assert_ne!(first_lease_expires_at, reclaimed_lease_expires_at);
+
+    let stale_result = ActivityResult::succeeded("check", "Stale worker completed.");
+    assert!(
+        store
+            .complete_runtime_job_if_owned(
+                &first_claim.id,
+                "runtime-1",
+                first_lease_expires_at,
+                &stale_result
+            )
+            .await?
+            .is_none(),
+        "stale lease completion should be ignored even when owner name is reused"
+    );
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .expect("runtime job should still exist");
+    assert_eq!(persisted.status, RuntimeJobStatus::Running);
+    assert_eq!(
+        persisted.lease.as_ref().expect("lease should exist").owner,
+        "runtime-1"
+    );
+    assert!(persisted.output.is_none());
+
+    let current_result = ActivityResult::succeeded("check", "Current worker completed.");
+    let completed = store
+        .complete_runtime_job_if_owned(
+            &reclaimed.id,
+            "runtime-1",
+            reclaimed_lease_expires_at,
+            &current_result,
+        )
+        .await?
+        .expect("current owner completion should be accepted");
+    assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
+    assert!(completed.lease.is_none());
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -225,7 +225,6 @@ impl TransitionAllowlist {
                 [StartChildWorkflow, EnqueueActivity, Wait],
             )
             .allow("idle", "scanning", [EnqueueActivity, Wait])
-            .allow("failed", "scanning", [EnqueueActivity, Wait])
             .allow("scanning", "scanning", [EnqueueActivity, Wait])
             .allow("scanning", "planning_batch", [EnqueueActivity, Wait])
             .allow("planning_batch", "planning_batch", [EnqueueActivity, Wait])
@@ -646,6 +645,9 @@ fn required_command_for_transition(
 ) -> Option<WorkflowCommandType> {
     match (from_state, to_state) {
         (from_state, "pr_open") if from_state != "pr_open" => Some(WorkflowCommandType::BindPr),
+        ("idle", "scanning") => Some(WorkflowCommandType::EnqueueActivity),
+        ("scanning", "planning_batch") => Some(WorkflowCommandType::EnqueueActivity),
+        ("planning_batch", "dispatching") => Some(WorkflowCommandType::StartChildWorkflow),
         (_, "done") => Some(WorkflowCommandType::MarkDone),
         (_, "blocked") => Some(WorkflowCommandType::MarkBlocked),
         (_, "failed") => Some(WorkflowCommandType::MarkFailed),

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -93,7 +93,18 @@ impl<'a> RuntimeWorker<'a> {
                 serde_json::to_value(&result)?,
             )
             .await?;
-        let completed = self.store.complete_runtime_job(&job.id, &result).await?;
+        let Some(completed) = self
+            .store
+            .complete_runtime_job_if_owned(&job.id, &self.owner, lease_expires_at, &result)
+            .await?
+        else {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                owner = %self.owner,
+                "runtime job completion ignored because the worker no longer owns the lease"
+            );
+            return Ok(None);
+        };
         self.record_workflow_completion(&completed, &result).await?;
         Ok(Some(completed))
     }

--- a/docs/workflow-runtime-hardening-design.md
+++ b/docs/workflow-runtime-hardening-design.md
@@ -1,0 +1,115 @@
+# Workflow Runtime Hardening Design
+
+## Goal
+
+The workflow runtime must remain correct when agent output is incomplete, stale, malformed, or semantically wrong. Agents are allowed to propose facts and decisions; the workflow runtime owns persisted state transitions, command creation, leases, retry policy, and operator escalation.
+
+This design covers every workflow definition currently wired through the runtime reducer and validator:
+
+| Workflow | Definition ID | Runtime activities | Primary completion contract |
+|---|---|---|---|
+| GitHub issue PR | `github_issue_pr` | implementation, feedback, replan, merge/recovery activities | Bind PR artifacts, feedback signals, or validated workflow decisions |
+| Repo backlog | `repo_backlog` | `poll_repo_backlog`, `plan_repo_sprint`, child dispatch/reconciliation activities | Issue/sprint signals with valid issue numbers, or explicit no-op signals |
+| PR feedback child | `pr_feedback` | `inspect_pr_feedback` | Feedback outcome signals |
+| Prompt task | `prompt_task` | `implement_prompt_task` | Successful implementation result and `MarkDone` command |
+| Quality gate | `quality_gate` | quality check activity | Successful check result or blocked/failed result |
+
+## Core Invariants
+
+1. **The server owns state.** Agent output is candidate input. A persisted workflow state changes only after a `WorkflowDecision` validates against the workflow instance, transition allowlist, required command rules, lease context, and terminal-state policy.
+2. **Every completed agent turn must return structured output.** A completed turn without a `harness-activity-result` fenced JSON block is a configuration failure. A malformed or mismatched structured block is also a configuration failure. Configuration failures are not retryable by default because repeating the same prompt/adapter contract is expected to fail again.
+3. **Structured `workflow_decision` artifacts are never trusted blindly.** A valid structured decision wins. An invalid structured decision is converted into a deterministic `blocked` decision with `MarkBlocked` and `RequestOperatorAttention` unless a workflow-specific reducer can derive a valid fallback from structured signals or artifacts.
+4. **Semantic empty success is not success.** Discovery and planning activities must emit either actionable signals or explicit empty/no-op signals. For example, `poll_repo_backlog` must emit `IssueDiscovered`, `IssueSkipped`, or `NoOpenIssueFound`; `plan_repo_sprint` must emit `SprintTaskSelected`, `IssueSkipped`, `NoSprintTaskSelected`, or a valid sprint plan artifact.
+5. **Transitions that require work must create commands.** The validator enforces required command types for workflow transitions such as repo backlog scan, sprint planning, and child workflow dispatch. A state move without the command that makes the next state progress is rejected.
+6. **Terminal states are not ordinary scheduler candidates.** Normal sweepers must not reopen `failed`, `done`, or `cancelled` workflows. Recovery from a terminal state requires an explicit recovery path and validation context.
+7. **Runtime job completion is lease-owned.** A worker may complete a runtime job only while it still owns the exact running job lease. Late output from an expired lease is ignored and cannot overwrite a reclaimed job, even when the next worker reuses the same owner name.
+
+## Agent Output Boundary
+
+The only stable boundary between an agent runtime and the workflow runtime is `ActivityResult`.
+
+Valid successful activity results should use:
+
+- `status: "succeeded"` only when the activity emitted all required domain signals/artifacts.
+- Domain signals for observed facts, such as `IssueDiscovered`, `NoOpenIssueFound`, `FeedbackFound`, or `PrReadyToMerge`.
+- Domain artifacts for durable objects, such as `pull_request`, `sprint_plan`, or `workflow_decision`.
+
+Invalid output is classified as follows:
+
+| Output problem | Runtime status | Error kind | Reducer behavior |
+|---|---|---|---|
+| Missing fenced result block | `failed` | `configuration` | Fail activity; no retry by default |
+| Malformed fenced JSON | `failed` | `configuration` | Fail activity; no retry by default |
+| Fenced result activity does not match expected activity | `failed` | `configuration` | Fail activity; no retry by default |
+| Valid JSON but invalid workflow decision | `succeeded` input, reduced to `blocked` workflow decision | n/a | Mark workflow blocked and request operator attention |
+| Discovery/planning success with no required signals | `succeeded` input, reduced to `blocked` workflow decision | n/a | Mark workflow blocked and request operator attention |
+| Timeout or external dependency failure | `failed` | `timeout` / `external_dependency` | Retry only when workflow state and retry policy allow it |
+
+## Reducer Policy
+
+Reducer order is intentionally conservative:
+
+1. Parse any structured `workflow_decision`.
+2. If it validates, accept it.
+3. Try workflow-specific domain reducers that derive decisions from stable signals and artifacts.
+4. Apply workflow-specific semantic guards, such as repo backlog empty-success blocking.
+5. If an invalid structured decision remains, convert it to `blocked`.
+6. Apply narrow legacy success fallbacks for known activities.
+7. Return no decision when the runtime cannot safely infer progress.
+
+This preserves useful agent autonomy while preventing invalid proposals from being recorded as silent no-progress loops.
+
+## Retry And Recovery
+
+Retry is only for failures where repetition can plausibly succeed:
+
+- Retryable error kinds: `retryable`, `timeout`, `external_dependency`, `unknown`, or no error kind.
+- Non-retryable error kinds: `fatal` and `configuration`.
+- Retry must be enabled by `runtime_retry_policy`.
+- Same-state retry is allowed only for workflow states where re-enqueueing the same activity is safe.
+
+Repo backlog scan now participates in same-state retry while it is actively `scanning`. A repo backlog workflow in `failed` is not a poll candidate; terminal recovery must be explicit.
+
+## Lease Ownership
+
+Runtime workers can reclaim expired running jobs. After reclaim, the old worker may still return output. The store now provides an owner-checked completion path:
+
+1. Load the runtime job under row lock.
+2. Verify `status == running`.
+3. Verify `lease.owner == current worker`.
+4. Verify `lease.expires_at == claimed lease expires_at`.
+5. Complete the job only when all checks pass.
+6. Return `None` for stale leases without mutating job output or command/workflow state.
+
+The worker uses this owner-checked completion path before recording workflow completion.
+
+## Observability
+
+Blocked decisions include:
+
+- The activity name.
+- The runtime job ID when available.
+- The reason the output could not safely advance the workflow.
+- A `MarkBlocked` command for persisted workflow state.
+- A `RequestOperatorAttention` command for operator-facing remediation.
+
+The intended operator response is to inspect the prompt packet, activity result, runtime job events, and workflow state, then either fix the prompt/adapter/configuration or run an explicit recovery action.
+
+## Verification Matrix
+
+Required checks for this hardening layer:
+
+| Area | Test expectation |
+|---|---|
+| Invalid structured decision | Reducer emits valid `blocked` decision instead of returning invalid agent proposal |
+| Repo backlog empty success | Poll and sprint activities block when required signals/artifacts are missing |
+| Repo backlog invalid issue signals | Poll/sprint activities block when selected/discovered issues have no valid `issue_number` |
+| Required transition commands | Repo backlog scan/planning/dispatch transitions require the command that makes progress possible |
+| Retry policy | Same-state retry works for allowed states, including repo backlog `scanning` |
+| Terminal boundary | Repo backlog `failed` is not an ordinary poll candidate |
+| Activity result parsing | Missing/malformed/mismatched structured results become configuration failures |
+| Runtime job lease ownership | Stale worker completion is ignored after another worker reclaims the job |
+
+## Non-Goals
+
+This design does not make agents deterministic. It makes unstable output observable and bounded. It also does not start the harness server from inside a Codex session; server startup remains an operator action from a standalone terminal.


### PR DESCRIPTION
## Summary
- Block invalid runtime workflow decisions with operator-visible blocked decisions.
- Reject empty repo backlog successes while allowing explicit no-op sprint plans.
- Guard runtime job completion with exact lease ownership.
- Document workflow runtime hardening invariants for all workflow families.

## Review
- Ran `codex review --base origin/main` before the final fix; it found a P2 where empty `sprint_plan` artifacts would be blocked.
- Fixed that finding by only treating sprint plans with selected tasks as dispatch candidates, and added regression coverage.
- Ran `codex review --base origin/main` again after the fix; no actionable diff-introduced correctness issues were found.

## Tests
- `cargo fmt --all`
- `cargo check`
- `cargo test --package harness-workflow --lib`
- `cargo test --package harness-server activity_result_from_turn --lib`
- `cargo test --package harness-server repo_backlog --lib`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`