### PR TITLE
Harden workflow runtime contracts and status diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "harness-skills",
  "harness-workflow",
  "libc",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ subtle = "2"
 
 # HTTP client (for Anthropic API)
 reqwest = { version = "0.12", features = ["json", "stream"] }
+url = "2"
 
 # System info (memory pressure monitoring)
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 anyhow = { workspace = true }
+reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
+url = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::fmt::writer::MakeWriter;
 mod exec;
 mod reconcile;
 mod serve;
+mod status;
 
 const RUNTIME_LOG_PREFIX: &str = "harness-serve-";
 const RUNTIME_LOG_SUFFIX: &str = ".log";
@@ -124,6 +125,22 @@ pub enum Command {
 
     /// Display the current version
     Version,
+
+    /// Show live server health, queue, and workflow runtime status
+    Status {
+        /// Server base URL. Defaults to server.http_addr from config.
+        #[arg(long)]
+        url: Option<String>,
+        /// Filter runtime workflow tree to one project_id.
+        #[arg(long)]
+        project_id: Option<String>,
+        /// Maximum workflow rows requested from the runtime tree endpoint.
+        #[arg(long, default_value_t = 20)]
+        runtime_limit: i64,
+        /// Print raw combined JSON instead of a compact text summary.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Reconcile harness task state against GitHub PR/issue state
     Reconcile {
@@ -834,6 +851,15 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             }
         }
 
+        Command::Status {
+            url,
+            project_id,
+            runtime_limit,
+            json,
+        } => {
+            status::run(&config, url, project_id, runtime_limit, json).await?;
+        }
+
         Command::Reconcile { dry_run, project } => {
             reconcile::run(dry_run, project, &config).await?;
         }
@@ -1091,6 +1117,36 @@ mod tests {
                 assert_eq!(port, Some(8080));
             }
             _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_status_with_filters() {
+        let cli = Cli::try_parse_from([
+            "harness",
+            "status",
+            "--url",
+            "127.0.0.1:9800",
+            "--project-id",
+            "/project-a",
+            "--runtime-limit",
+            "5",
+            "--json",
+        ])
+        .expect("status with filters should parse");
+        match cli.command {
+            Command::Status {
+                url,
+                project_id,
+                runtime_limit,
+                json,
+            } => {
+                assert_eq!(url.as_deref(), Some("127.0.0.1:9800"));
+                assert_eq!(project_id.as_deref(), Some("/project-a"));
+                assert_eq!(runtime_limit, 5);
+                assert!(json);
+            }
+            _ => panic!("expected Status command"),
         }
     }
 

--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -4,6 +4,7 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::time::Duration;
+use url::form_urlencoded;
 
 const REQUEST_TIMEOUT_SECS: u64 = 5;
 
@@ -135,27 +136,12 @@ async fn get_json(
 }
 
 fn runtime_tree_path(project_id: Option<&str>, limit: i64) -> String {
-    let mut query = vec![format!("limit={}", limit.max(1))];
+    let mut query = form_urlencoded::Serializer::new(String::new());
+    query.append_pair("limit", &limit.max(1).to_string());
     if let Some(project_id) = project_id.filter(|value| !value.is_empty()) {
-        query.push(format!(
-            "project_id={}",
-            percent_encode_query_value(project_id)
-        ));
+        query.append_pair("project_id", project_id);
     }
-    format!("/api/workflows/runtime/tree?{}", query.join("&"))
-}
-
-fn percent_encode_query_value(value: &str) -> String {
-    let mut out = String::new();
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
-                out.push(byte as char);
-            }
-            other => out.push_str(&format!("%{other:02X}")),
-        }
-    }
-    out
+    format!("/api/workflows/runtime/tree?{}", query.finish())
 }
 
 fn print_summary(combined: &Value) {
@@ -310,10 +296,10 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
-    fn percent_encode_query_value_encodes_path_like_project_id() {
+    fn runtime_tree_path_encodes_path_like_project_id() {
         assert_eq!(
-            percent_encode_query_value("/Users/apple/repo name"),
-            "%2FUsers%2Fapple%2Frepo%20name"
+            runtime_tree_path(Some("/Users/apple/repo name"), 20),
+            "/api/workflows/runtime/tree?limit=20&project_id=%2FUsers%2Fapple%2Frepo+name"
         );
     }
 

--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -1,0 +1,386 @@
+use anyhow::Context;
+use harness_core::config::HarnessConfig;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RuntimeTreeSummary {
+    workflows: usize,
+    commands: usize,
+    command_statuses: BTreeMap<String, usize>,
+    jobs: usize,
+    job_statuses: BTreeMap<String, usize>,
+    activity_outcomes: BTreeMap<String, usize>,
+    jobs_without_activity_envelope: usize,
+}
+
+pub async fn run(
+    config: &HarnessConfig,
+    url: Option<String>,
+    project_id: Option<String>,
+    runtime_limit: i64,
+    raw_json: bool,
+) -> anyhow::Result<()> {
+    let base_url = server_base_url(config, url)?;
+    let token = resolve_api_token(config);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .no_proxy()
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let runtime_path = runtime_tree_path(project_id.as_deref(), runtime_limit);
+    let health = get_json(&client, &base_url, "/health", token.as_deref()).await?;
+    let queue = get_json(
+        &client,
+        &base_url,
+        "/projects/queue-stats",
+        token.as_deref(),
+    )
+    .await?;
+    let operator = get_json(
+        &client,
+        &base_url,
+        "/api/operator-snapshot",
+        token.as_deref(),
+    )
+    .await?;
+    let runtime_tree = get_json(&client, &base_url, &runtime_path, token.as_deref()).await?;
+
+    let combined = json!({
+        "server_url": base_url,
+        "health": health,
+        "queue": queue,
+        "operator_snapshot": operator,
+        "runtime_tree": runtime_tree,
+    });
+
+    if raw_json {
+        println!("{}", serde_json::to_string_pretty(&combined)?);
+    } else {
+        print_summary(&combined);
+    }
+    Ok(())
+}
+
+fn resolve_api_token(config: &HarnessConfig) -> Option<String> {
+    config
+        .server
+        .api_token
+        .as_deref()
+        .filter(|token| !token.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            std::env::var("HARNESS_API_TOKEN")
+                .ok()
+                .filter(|token| !token.is_empty())
+        })
+}
+
+fn server_base_url(config: &HarnessConfig, override_url: Option<String>) -> anyhow::Result<String> {
+    if let Some(url) = override_url {
+        let trimmed = url.trim().trim_end_matches('/');
+        if trimmed.is_empty() {
+            anyhow::bail!("--url must not be empty");
+        }
+        if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+            return Ok(trimmed.to_string());
+        }
+        return Ok(format!("http://{trimmed}"));
+    }
+
+    let addr = config.server.http_addr;
+    let host = match addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1".to_string(),
+        IpAddr::V4(ip) => ip.to_string(),
+        IpAddr::V6(ip) if ip.is_unspecified() => "[::1]".to_string(),
+        IpAddr::V6(ip) => format!("[{ip}]"),
+    };
+    Ok(format!("http://{}:{}", host, addr.port()))
+}
+
+async fn get_json(
+    client: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+    token: Option<&str>,
+) -> anyhow::Result<Value> {
+    let url = format!("{base_url}{path}");
+    let mut request = client.get(&url);
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("failed to connect to harness server at {url}"))?;
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        anyhow::bail!(
+            "server rejected {path} with 401; set server.api_token in config or HARNESS_API_TOKEN"
+        );
+    }
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status} for {path}: {body}");
+    }
+    response
+        .json::<Value>()
+        .await
+        .with_context(|| format!("server returned invalid JSON for {path}"))
+}
+
+fn runtime_tree_path(project_id: Option<&str>, limit: i64) -> String {
+    let mut query = vec![format!("limit={}", limit.max(1))];
+    if let Some(project_id) = project_id.filter(|value| !value.is_empty()) {
+        query.push(format!(
+            "project_id={}",
+            percent_encode_query_value(project_id)
+        ));
+    }
+    format!("/api/workflows/runtime/tree?{}", query.join("&"))
+}
+
+fn percent_encode_query_value(value: &str) -> String {
+    let mut out = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char);
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+fn print_summary(combined: &Value) {
+    let health = &combined["health"];
+    let queue = &combined["queue"];
+    let operator = &combined["operator_snapshot"];
+    let runtime = &combined["runtime_tree"];
+    let runtime_summary = summarize_runtime_tree(runtime);
+
+    println!(
+        "Harness status: {}",
+        health["status"].as_str().unwrap_or("unknown")
+    );
+    println!(
+        "Server: {}",
+        combined["server_url"].as_str().unwrap_or("unknown")
+    );
+    println!("Tasks: {}", number_or_zero(&health["tasks"]));
+    println!(
+        "Queue: running {}/{} queued {}",
+        number_or_zero(&queue["global"]["running"]),
+        number_or_zero(&queue["global"]["limit"]),
+        number_or_zero(&queue["global"]["queued"])
+    );
+
+    let degraded = health["persistence"]["degraded_subsystems"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|items| !items.is_empty());
+    if let Some(degraded) = degraded {
+        println!("Degraded subsystems: {degraded}");
+    }
+
+    let last_tick = &operator["retry"]["last_tick"];
+    if last_tick.is_object() {
+        println!(
+            "Retry tick: checked {} stuck {} retried {} skipped {} at {}",
+            number_or_zero(&last_tick["checked"]),
+            number_or_zero(&last_tick["stuck"]),
+            number_or_zero(&last_tick["retried"]),
+            number_or_zero(&last_tick["skipped"]),
+            last_tick["at"].as_str().unwrap_or("unknown")
+        );
+    } else {
+        println!("Retry tick: none");
+    }
+    println!(
+        "Stalled tasks: {}",
+        operator["retry"]["stalled_tasks"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or(0)
+    );
+    println!(
+        "Recent failures: {}",
+        operator["recent_failures"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or(0)
+    );
+    println!(
+        "Runtime workflows: {} workflows, {} commands, {} jobs",
+        runtime_summary.workflows, runtime_summary.commands, runtime_summary.jobs
+    );
+    print_count_map("Command statuses", &runtime_summary.command_statuses);
+    print_count_map("Runtime job statuses", &runtime_summary.job_statuses);
+    print_count_map(
+        "Activity result outcomes",
+        &runtime_summary.activity_outcomes,
+    );
+    if runtime_summary.jobs_without_activity_envelope > 0 {
+        println!(
+            "Jobs without activity result envelope: {}",
+            runtime_summary.jobs_without_activity_envelope
+        );
+    }
+}
+
+fn summarize_runtime_tree(tree: &Value) -> RuntimeTreeSummary {
+    let mut summary = RuntimeTreeSummary {
+        workflows: tree["total_workflows"].as_u64().unwrap_or(0) as usize,
+        ..Default::default()
+    };
+    if let Some(workflows) = tree["workflows"].as_array() {
+        for workflow in workflows {
+            summarize_workflow_node(workflow, &mut summary);
+        }
+    }
+    summary
+}
+
+fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary) {
+    if let Some(commands) = node["commands"].as_array() {
+        for command in commands {
+            summary.commands += 1;
+            increment(
+                &mut summary.command_statuses,
+                command["status"].as_str().unwrap_or("unknown"),
+            );
+            if let Some(jobs) = command["runtime_jobs"].as_array() {
+                for job in jobs {
+                    summary.jobs += 1;
+                    increment(
+                        &mut summary.job_statuses,
+                        job["status"].as_str().unwrap_or("unknown"),
+                    );
+                    if let Some(outcome) = job["activity_result_envelope"]["outcome"].as_str() {
+                        increment(&mut summary.activity_outcomes, outcome);
+                    } else {
+                        summary.jobs_without_activity_envelope += 1;
+                    }
+                }
+            }
+        }
+    }
+    if let Some(children) = node["children"].as_array() {
+        for child in children {
+            summarize_workflow_node(child, summary);
+        }
+    }
+}
+
+fn increment(map: &mut BTreeMap<String, usize>, key: &str) {
+    *map.entry(key.to_string()).or_insert(0) += 1;
+}
+
+fn number_or_zero(value: &Value) -> u64 {
+    value.as_u64().unwrap_or(0)
+}
+
+fn print_count_map(label: &str, counts: &BTreeMap<String, usize>) {
+    if counts.is_empty() {
+        return;
+    }
+    let rendered = counts
+        .iter()
+        .map(|(key, count)| format!("{key}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("{label}: {rendered}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn percent_encode_query_value_encodes_path_like_project_id() {
+        assert_eq!(
+            percent_encode_query_value("/Users/apple/repo name"),
+            "%2FUsers%2Fapple%2Frepo%20name"
+        );
+    }
+
+    #[test]
+    fn runtime_tree_path_clamps_limit_and_encodes_project_id() {
+        assert_eq!(
+            runtime_tree_path(Some("/project-a"), 0),
+            "/api/workflows/runtime/tree?limit=1&project_id=%2Fproject-a"
+        );
+    }
+
+    #[test]
+    fn server_base_url_uses_loopback_for_unspecified_config_addr() {
+        let mut config = HarnessConfig::default();
+        config.server.http_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 9800));
+
+        let url = server_base_url(&config, None).expect("url should resolve");
+
+        assert_eq!(url, "http://127.0.0.1:9800");
+    }
+
+    #[test]
+    fn server_base_url_accepts_host_port_override() {
+        let config = HarnessConfig::default();
+
+        let url = server_base_url(&config, Some("127.0.0.1:9900/".to_string()))
+            .expect("url should resolve");
+
+        assert_eq!(url, "http://127.0.0.1:9900");
+    }
+
+    #[test]
+    fn summarize_runtime_tree_counts_nested_jobs_and_activity_outcomes() {
+        let tree = json!({
+            "total_workflows": 2,
+            "workflows": [{
+                "commands": [{
+                    "status": "completed",
+                    "runtime_jobs": [{
+                        "status": "succeeded",
+                        "activity_result_envelope": {
+                            "outcome": "accepted"
+                        }
+                    }]
+                }],
+                "children": [{
+                    "commands": [{
+                        "status": "pending",
+                        "runtime_jobs": [{
+                            "status": "pending"
+                        }]
+                    }],
+                    "children": []
+                }]
+            }]
+        });
+
+        let summary = summarize_runtime_tree(&tree);
+
+        assert_eq!(summary.workflows, 2);
+        assert_eq!(summary.commands, 2);
+        assert_eq!(summary.jobs, 2);
+        assert_eq!(summary.command_statuses["completed"], 1);
+        assert_eq!(summary.command_statuses["pending"], 1);
+        assert_eq!(summary.job_statuses["succeeded"], 1);
+        assert_eq!(summary.job_statuses["pending"], 1);
+        assert_eq!(summary.activity_outcomes["accepted"], 1);
+        assert_eq!(summary.jobs_without_activity_envelope, 1);
+    }
+}

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -18,6 +18,9 @@ use harness_workflow::runtime::{
     WorkflowEvent, WorkflowInstance,
 };
 
+const ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE: &str = "activity_result_envelope";
+const ACTIVITY_RESULT_ENVELOPE_SCHEMA: &str = "harness.runtime.activity_result_envelope.v1";
+
 fn startup_error_code(error: Option<&str>) -> Option<&'static str> {
     let error = error?;
     let lower = error.to_ascii_lowercase();
@@ -166,17 +169,20 @@ struct WorkflowRuntimeJobNode {
     pub runtime_event_count: usize,
     pub latest_runtime_event_type: Option<String>,
     pub prompt_packet_digest: Option<String>,
+    pub activity_result_envelope: Option<Value>,
 }
 
 impl WorkflowRuntimeJobNode {
     fn new(job: RuntimeJob, runtime_events: Vec<RuntimeEvent>) -> Self {
         let latest_runtime_event_type = runtime_events.last().map(|event| event.event_type.clone());
         let prompt_packet_digest = prompt_packet_digest_from_events(&runtime_events);
+        let activity_result_envelope = activity_result_envelope_from_job(&job);
         Self {
             job,
             runtime_event_count: runtime_events.len(),
             latest_runtime_event_type,
             prompt_packet_digest,
+            activity_result_envelope,
         }
     }
 }
@@ -425,6 +431,22 @@ fn prompt_packet_digest_from_events(events: &[RuntimeEvent]) -> Option<String> {
     })
 }
 
+fn activity_result_envelope_from_job(job: &RuntimeJob) -> Option<Value> {
+    let artifacts = job.output.as_ref()?.get("artifacts")?.as_array()?;
+    artifacts.iter().rev().find_map(|artifact| {
+        if artifact.get("artifact_type").and_then(Value::as_str)
+            != Some(ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE)
+        {
+            return None;
+        }
+        let payload = artifact.get("artifact")?;
+        if payload.get("schema").and_then(Value::as_str) != Some(ACTIVITY_RESULT_ENVELOPE_SCHEMA) {
+            return None;
+        }
+        Some(payload.clone())
+    })
+}
+
 fn attach_workflow_children(
     workflow_id: &str,
     by_id: &BTreeMap<String, WorkflowRuntimeTreeNode>,
@@ -443,6 +465,72 @@ fn attach_workflow_children(
         .collect();
     path.remove(workflow_id);
     Some(node)
+}
+
+#[cfg(test)]
+mod runtime_tree_tests {
+    use super::*;
+    use harness_workflow::runtime::{ActivityArtifact, ActivityResult, RuntimeJob, RuntimeKind};
+    use serde_json::json;
+
+    fn runtime_job_with_artifacts(artifacts: Vec<ActivityArtifact>) -> RuntimeJob {
+        let result = artifacts.into_iter().fold(
+            ActivityResult::succeeded("replan_issue", "Runtime job completed."),
+            ActivityResult::with_artifact,
+        );
+        let mut job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-high",
+            json!({}),
+        );
+        job.output = Some(serde_json::to_value(result).expect("activity result should serialize"));
+        job
+    }
+
+    #[test]
+    fn activity_result_envelope_from_job_returns_latest_valid_envelope() {
+        let older = ActivityArtifact::new(
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            json!({
+                "schema": ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+                "outcome": "accepted",
+            }),
+        );
+        let newer = ActivityArtifact::new(
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            json!({
+                "schema": ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+                "outcome": "repaired_structured_output",
+            }),
+        );
+        let job = runtime_job_with_artifacts(vec![older, newer]);
+
+        let envelope =
+            activity_result_envelope_from_job(&job).expect("valid envelope should be exposed");
+
+        assert_eq!(envelope["outcome"], "repaired_structured_output");
+    }
+
+    #[test]
+    fn activity_result_envelope_from_job_ignores_missing_or_invalid_envelope() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-high",
+            json!({}),
+        );
+        assert!(activity_result_envelope_from_job(&job).is_none());
+
+        let job = runtime_job_with_artifacts(vec![ActivityArtifact::new(
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            json!({
+                "schema": "harness.runtime.activity_result_envelope.v0",
+                "outcome": "accepted",
+            }),
+        )]);
+        assert!(activity_result_envelope_from_job(&job).is_none());
+    }
 }
 
 pub(crate) async fn handle_rpc(

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1066,7 +1066,7 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
     let command_id = store
         .enqueue_command(&child.id, Some(&rejected.id), &command)
         .await?;
-    let not_before = chrono::Utc::now() + chrono::Duration::minutes(5);
+    let not_before = chrono::Utc::now() - chrono::Duration::minutes(5);
     let runtime_job = store
         .enqueue_runtime_job_with_not_before(
             &command_id,
@@ -1093,6 +1093,42 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
             serde_json::json!({ "status": "succeeded" }),
         )
         .await?;
+    let lease_owner = "workflow-runtime-tree-test";
+    let lease_expires_at = chrono::Utc::now() + chrono::Duration::minutes(5);
+    let claimed = store
+        .claim_next_runtime_job(lease_owner, lease_expires_at)
+        .await?
+        .expect("runtime job should be claimable");
+    assert_eq!(claimed.id, runtime_job.id);
+    let activity_result = harness_workflow::runtime::ActivityResult::succeeded(
+        "replan_issue",
+        "Runtime job completed.",
+    )
+    .with_artifact(harness_workflow::runtime::ActivityArtifact::new(
+        "activity_result_envelope",
+        serde_json::json!({
+            "schema": "harness.runtime.activity_result_envelope.v1",
+            "extraction_strategy": "json_fence_repair",
+            "outcome": "repaired_structured_output",
+            "raw_status": "completed",
+            "extracted_activity": "replan_issue",
+            "extraction_error": null,
+            "final_result": {
+                "activity": "replan_issue",
+                "status": "succeeded",
+                "error_kind": null,
+            }
+        }),
+    ));
+    store
+        .complete_runtime_job_if_owned(
+            &runtime_job.id,
+            lease_owner,
+            lease_expires_at,
+            &activity_result,
+        )
+        .await?
+        .expect("runtime job should complete with the current lease");
 
     let response = workflow_runtime_app(state)
         .oneshot(
@@ -1134,6 +1170,20 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
     assert_eq!(
         child_node["commands"][0]["runtime_jobs"][0]["prompt_packet_digest"],
         prompt_packet_digest
+    );
+    assert_eq!(
+        child_node["commands"][0]["runtime_jobs"][0]["activity_result_envelope"]["outcome"],
+        "repaired_structured_output"
+    );
+    assert_eq!(
+        child_node["commands"][0]["runtime_jobs"][0]["activity_result_envelope"]
+            ["extraction_strategy"],
+        "json_fence_repair"
+    );
+    assert_eq!(
+        child_node["commands"][0]["runtime_jobs"][0]["activity_result_envelope"]["final_result"]
+            ["status"],
+        "succeeded"
     );
     Ok(())
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -9,6 +9,8 @@ use harness_workflow::runtime::{
 use serde_json::json;
 use std::path::Path;
 
+const PR_FEEDBACK_FAILED_CHILD_SUPPRESSION_SECS: i64 = 24 * 60 * 60;
+
 pub(crate) struct PrDetectedRuntimeContext<'a> {
     pub project_root: &'a Path,
     pub repo: Option<&'a str>,
@@ -504,9 +506,31 @@ async fn has_active_pr_feedback_command(
         {
             return Ok(true);
         }
+        if matches!(instance.state.as_str(), "failed" | "blocked")
+            && has_recent_failed_child_pr_feedback_command(store, &instance.id).await?
+        {
+            return Ok(true);
+        }
     }
 
     Ok(false)
+}
+
+async fn has_recent_failed_child_pr_feedback_command(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
+    let cutoff =
+        chrono::Utc::now() - chrono::Duration::seconds(PR_FEEDBACK_FAILED_CHILD_SUPPRESSION_SECS);
+    Ok(store
+        .commands_for(workflow_id)
+        .await?
+        .into_iter()
+        .any(|record| {
+            matches!(record.status.as_str(), "failed" | "blocked")
+                && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
+                && record.updated_at >= cutoff
+        }))
 }
 
 async fn has_active_child_pr_feedback_command(
@@ -869,6 +893,83 @@ mod tests {
         assert!(
             has_active_pr_feedback_command(&store, &workflow_id).await?,
             "an inspecting child with a pending command should still suppress duplicate sweeps"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_pr_feedback_child_suppresses_duplicate_feedback_sweep() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            123,
+        );
+        upsert_github_issue_pr_definition(&store).await?;
+        let parent = issue_instance(
+            workflow_id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "awaiting_feedback",
+        )
+        .with_data(json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 123,
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "task-1",
+        }));
+        store.upsert_instance(&parent).await?;
+        let child = WorkflowInstance::new(
+            PR_FEEDBACK_DEFINITION_ID,
+            1,
+            "failed",
+            WorkflowSubject::new("pr", "pr:77"),
+        )
+        .with_id("pr-feedback-child-failed")
+        .with_parent(workflow_id.clone());
+        store.upsert_instance(&child).await?;
+        let child_command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+            PR_FEEDBACK_INSPECT_ACTIVITY,
+            "inspect-pr-feedback-77",
+        );
+        let child_command_id = store
+            .enqueue_command(&child.id, None, &child_command)
+            .await?;
+        store
+            .mark_command_status(&child_command_id, "failed")
+            .await?;
+
+        assert!(
+            has_active_pr_feedback_command(&store, &workflow_id).await?,
+            "a recently failed inspection child should suppress duplicate sweeps"
+        );
+
+        let outcome = request_pr_feedback_sweep(&store, &workflow_id).await?;
+        assert_eq!(
+            outcome,
+            PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                workflow_id: workflow_id.clone(),
+                task_id: "task-1".to_string(),
+            }
+        );
+        assert!(
+            store.commands_for(&workflow_id).await?.is_empty(),
+            "the parent workflow must not enqueue another PR feedback child while the failed child is cooling down"
         );
         Ok(())
     }

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -1,3 +1,4 @@
+mod activity_contract;
 mod activity_result;
 mod child_workflow;
 mod data_helpers;

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -1,0 +1,157 @@
+use harness_workflow::runtime::{
+    GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct ActivityContract {
+    pub schema: &'static str,
+    pub workflow_definition: String,
+    pub activity: String,
+    pub accepted_signals: Vec<&'static str>,
+    pub accepted_artifacts: Vec<&'static str>,
+    pub explicit_noop_signals: Vec<&'static str>,
+    pub required_artifacts: Vec<&'static str>,
+    pub empty_success_allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success_requires: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub child_outcome_contract: Option<&'static str>,
+}
+
+impl ActivityContract {
+    fn new(workflow_definition: &str, activity: &str) -> Self {
+        Self {
+            schema: "harness.runtime.activity_contract.v1",
+            workflow_definition: workflow_definition.to_string(),
+            activity: activity.to_string(),
+            accepted_signals: Vec::new(),
+            accepted_artifacts: Vec::new(),
+            explicit_noop_signals: Vec::new(),
+            required_artifacts: Vec::new(),
+            empty_success_allowed: true,
+            success_requires: None,
+            child_outcome_contract: None,
+        }
+    }
+
+    fn with_accepted_signals(mut self, signals: Vec<&'static str>) -> Self {
+        self.accepted_signals = signals;
+        self
+    }
+
+    fn with_accepted_artifacts(mut self, artifacts: Vec<&'static str>) -> Self {
+        self.accepted_artifacts = artifacts;
+        self
+    }
+
+    fn with_explicit_noop_signals(mut self, signals: Vec<&'static str>) -> Self {
+        self.explicit_noop_signals = signals;
+        self
+    }
+
+    fn with_required_artifacts(mut self, artifacts: Vec<&'static str>) -> Self {
+        self.required_artifacts = artifacts;
+        self
+    }
+
+    fn requires(mut self, requirement: &'static str) -> Self {
+        self.empty_success_allowed = false;
+        self.success_requires = Some(requirement);
+        self
+    }
+
+    fn with_child_outcome(mut self, contract: &'static str) -> Self {
+        self.child_outcome_contract = Some(contract);
+        self
+    }
+
+    pub(super) fn to_prompt_value(&self) -> Value {
+        json!(self)
+    }
+}
+
+pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> ActivityContract {
+    match (workflow_definition, activity) {
+        (REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY) => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_signals(vec!["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"])
+                .with_explicit_noop_signals(vec!["NoOpenIssueFound"])
+                .requires("at_least_one_accepted_signal")
+        }
+        (REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY) => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_signals(vec![
+                    "SprintTaskSelected",
+                    "IssueSkipped",
+                    "NoSprintTaskSelected",
+                ])
+                .with_accepted_artifacts(vec!["sprint_plan"])
+                .with_explicit_noop_signals(vec!["NoSprintTaskSelected"])
+                .requires("at_least_one_accepted_signal_or_artifact")
+        }
+        (PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => {
+            pr_feedback_contract(workflow_definition, activity)
+                .with_child_outcome("pr_feedback_outcome")
+        }
+        (GITHUB_ISSUE_PR_DEFINITION_ID, "sweep_pr_feedback")
+        | (GITHUB_ISSUE_PR_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => {
+            pr_feedback_contract(workflow_definition, activity)
+        }
+        (GITHUB_ISSUE_PR_DEFINITION_ID, "implement_issue") => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_artifacts(vec!["pull_request", "workflow_decision"])
+        }
+        (GITHUB_ISSUE_PR_DEFINITION_ID, "replan_issue") => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_artifacts(vec!["workflow_decision"])
+        }
+        (GITHUB_ISSUE_PR_DEFINITION_ID, "address_pr_feedback") => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_artifacts(vec!["workflow_decision"])
+        }
+        (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_artifacts(vec!["validation_report"])
+        }
+        (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_accepted_signals(vec![
+                    QUALITY_PASSED_SIGNAL,
+                    QUALITY_FAILED_SIGNAL,
+                    QUALITY_BLOCKED_SIGNAL,
+                ])
+                .requires("quality_gate_status_signal")
+        }
+        (REPO_BACKLOG_DEFINITION_ID, "start_child_workflow") => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_required_artifacts(vec!["child_workflow"])
+                .requires("child_workflow_artifact")
+        }
+        (REPO_BACKLOG_DEFINITION_ID, "mark_bound_issue_done")
+        | (REPO_BACKLOG_DEFINITION_ID, "recover_issue_workflow") => {
+            ActivityContract::new(workflow_definition, activity)
+                .with_required_artifacts(vec!["child_workflow"])
+                .requires("child_workflow_artifact")
+        }
+        _ => ActivityContract::new(workflow_definition, activity),
+    }
+}
+
+fn pr_feedback_contract(workflow_definition: &str, activity: &str) -> ActivityContract {
+    ActivityContract::new(workflow_definition, activity)
+        .with_accepted_signals(vec![
+            "FeedbackFound",
+            "NoFeedbackFound",
+            "PrReadyToMerge",
+            "ChangesRequested",
+            "ChecksFailed",
+        ])
+        .with_explicit_noop_signals(vec!["NoFeedbackFound"])
+        .requires("at_least_one_feedback_outcome_signal")
+}

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -47,6 +47,15 @@ pub(super) fn activity_result_from_turn(
                 );
             }
         }
+        ActivityResultEnvelopeOutcome::RepairedStructuredOutput => {
+            tracing::info!(
+                runtime_job_id = %job.id,
+                activity = %activity,
+                agent = %agent_name,
+                extraction_strategy = ?envelope.extraction_strategy,
+                "activity result recovered from compatible structured output"
+            );
+        }
         ActivityResultEnvelopeOutcome::TurnFailed => {
             if let Some(error) = envelope.extraction_error.as_deref() {
                 tracing::warn!(
@@ -88,6 +97,7 @@ pub(super) fn activity_result_from_turn(
 #[serde(rename_all = "snake_case")]
 enum ActivityResultExtractionStrategy {
     FencedActivityResult,
+    JsonFenceRepair,
     NotAttempted,
 }
 
@@ -95,6 +105,7 @@ enum ActivityResultExtractionStrategy {
 #[serde(rename_all = "snake_case")]
 enum ActivityResultEnvelopeOutcome {
     Accepted,
+    RepairedStructuredOutput,
     MissingStructuredOutput,
     InvalidStructuredOutput,
     TurnCancelled,
@@ -120,6 +131,21 @@ impl ActivityResultEnvelope {
         Self {
             extraction_strategy,
             outcome: ActivityResultEnvelopeOutcome::Accepted,
+            raw_status,
+            extracted_activity: Some(result.activity.clone()),
+            extraction_error: None,
+            final_result: result,
+        }
+    }
+
+    fn repaired(
+        raw_status: TurnStatus,
+        extraction_strategy: ActivityResultExtractionStrategy,
+        result: ActivityResult,
+    ) -> Self {
+        Self {
+            extraction_strategy,
+            outcome: ActivityResultEnvelopeOutcome::RepairedStructuredOutput,
             raw_status,
             extracted_activity: Some(result.activity.clone()),
             extraction_error: None,
@@ -228,6 +254,13 @@ fn activity_result_envelope_from_turn(
                 ActivityResultExtractionStrategy::FencedActivityResult,
                 result,
             ),
+            StructuredActivityResult::RepairedJsonFence(result) => {
+                ActivityResultEnvelope::repaired(
+                    *status,
+                    ActivityResultExtractionStrategy::JsonFenceRepair,
+                    result,
+                )
+            }
             StructuredActivityResult::Missing => ActivityResultEnvelope::missing_structured_output(
                 *status,
                 activity.to_string(),
@@ -261,6 +294,7 @@ fn turn_error_is_timeout(error: &str) -> bool {
 enum StructuredActivityResult {
     Missing,
     Parsed(ActivityResult),
+    RepairedJsonFence(ActivityResult),
     Invalid {
         error: String,
         extracted_activity: Option<String>,
@@ -268,26 +302,69 @@ enum StructuredActivityResult {
 }
 
 fn structured_activity_result(items: &[Item], expected_activity: &str) -> StructuredActivityResult {
-    let Some(block) = latest_activity_result_block(items) else {
-        return StructuredActivityResult::Missing;
-    };
+    if let Some(block) = latest_activity_result_block(items) {
+        return parse_activity_result_block(block, expected_activity);
+    }
 
+    latest_json_activity_result_repair(items, expected_activity)
+        .unwrap_or(StructuredActivityResult::Missing)
+}
+
+fn parse_activity_result_block(block: &str, expected_activity: &str) -> StructuredActivityResult {
+    match parse_activity_result_json(block, expected_activity) {
+        Ok(result) => StructuredActivityResult::Parsed(result),
+        Err(error) => StructuredActivityResult::Invalid {
+            error: error.error,
+            extracted_activity: error.extracted_activity,
+        },
+    }
+}
+
+fn parse_activity_result_json(
+    block: &str,
+    expected_activity: &str,
+) -> Result<ActivityResult, StructuredActivityResultError> {
     match serde_json::from_str::<ActivityResult>(block) {
-        Ok(result) if result.activity == expected_activity => {
-            StructuredActivityResult::Parsed(result)
-        }
-        Ok(result) => StructuredActivityResult::Invalid {
+        Ok(result) if result.activity == expected_activity => Ok(result),
+        Ok(result) => Err(StructuredActivityResultError {
             error: format!(
                 "activity result block reported activity `{}`, expected `{expected_activity}`",
                 result.activity
             ),
             extracted_activity: Some(result.activity),
-        },
-        Err(error) => StructuredActivityResult::Invalid {
+        }),
+        Err(error) => Err(StructuredActivityResultError {
             error: format!("activity result block is invalid JSON: {error}"),
             extracted_activity: None,
-        },
+        }),
     }
+}
+
+struct StructuredActivityResultError {
+    error: String,
+    extracted_activity: Option<String>,
+}
+
+fn latest_json_activity_result_repair(
+    items: &[Item],
+    expected_activity: &str,
+) -> Option<StructuredActivityResult> {
+    items.iter().rev().find_map(|item| match item {
+        Item::AgentReasoning { content } => {
+            let block = extract_fenced_block(content, "json")?;
+            match parse_activity_result_json(block, expected_activity) {
+                Ok(result) => Some(StructuredActivityResult::RepairedJsonFence(result)),
+                Err(error) if error.extracted_activity.is_some() => {
+                    Some(StructuredActivityResult::Invalid {
+                        error: error.error,
+                        extracted_activity: error.extracted_activity,
+                    })
+                }
+                Err(_) => None,
+            }
+        }
+        _ => None,
+    })
 }
 
 fn latest_activity_result_block(items: &[Item]) -> Option<&str> {
@@ -497,6 +574,93 @@ Final result:
             .signals
             .iter()
             .any(|signal| signal.signal_type == "RuntimeTurnCompleted"));
+    }
+
+    #[test]
+    fn activity_result_from_turn_repairs_generic_json_activity_result_block() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue"
+            }),
+        );
+        let items = vec![Item::AgentReasoning {
+            content: r#"Work completed.
+
+```json
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed from generic JSON.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":88,"pr_url":"https://github.com/owner/repo/pull/88"}}]}
+```"#
+                .to_string(),
+        }];
+
+        let result = activity_result_from_turn(
+            &job,
+            &TurnStatus::Completed,
+            &items,
+            &ThreadId::from_str("thread-1"),
+            &TurnId::from_str("turn-1"),
+            "codex",
+            Path::new("/project"),
+            "digest-1",
+        );
+
+        assert_eq!(result.activity, "implement_issue");
+        assert_eq!(result.status, ActivityStatus::Succeeded);
+        assert_eq!(
+            result.summary,
+            "Implementation completed from generic JSON."
+        );
+        let pr_artifact = result
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_type == "pull_request")
+            .expect("repaired pull request artifact should be preserved");
+        assert_eq!(pr_artifact.artifact["pr_number"], 88);
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "repaired_structured_output");
+        assert_eq!(envelope["extraction_strategy"], "json_fence_repair");
+        assert_eq!(envelope["extracted_activity"], "implement_issue");
+        assert!(envelope["extraction_error"].is_null());
+    }
+
+    #[test]
+    fn activity_result_from_turn_does_not_repair_ambiguous_json_block() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue"
+            }),
+        );
+        let items = vec![Item::AgentReasoning {
+            content: r#"Work completed.
+
+```json
+{"summary":"Done, but this is not an ActivityResult."}
+```"#
+                .to_string(),
+        }];
+
+        let result = activity_result_from_turn(
+            &job,
+            &TurnStatus::Completed,
+            &items,
+            &ThreadId::from_str("thread-1"),
+            &TurnId::from_str("turn-1"),
+            "codex",
+            Path::new("/project"),
+            "digest-1",
+        );
+
+        assert_eq!(result.activity, "implement_issue");
+        assert_eq!(result.status, ActivityStatus::Failed);
+        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "missing_structured_output");
+        assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -2,6 +2,7 @@ use harness_core::types::{Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
     ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, RuntimeJob,
 };
+use serde::Serialize;
 use serde_json::json;
 use std::path::Path;
 
@@ -25,54 +26,45 @@ pub(super) fn activity_result_from_turn(
         TurnStatus::Failed => "Agent turn failed.".to_string(),
         TurnStatus::Running => "Agent turn is still running after lifecycle returned.".to_string(),
     });
-    let result = match status {
-        TurnStatus::Completed => match structured_activity_result(items, &activity) {
-            StructuredActivityResult::Parsed(result) => result,
-            StructuredActivityResult::Missing => {
-                tracing::warn!(
-                    runtime_job_id = %job.id,
-                    activity = %activity,
-                    agent = %agent_name,
-                    "activity completed without harness-activity-result fenced block; \
-                     marking failed to prevent silent state-machine no-progress loops"
-                );
-                ActivityResult::failed(
-                    activity,
-                    summary,
-                    "agent emitted no harness-activity-result fenced JSON block",
-                )
-                .with_error_kind(ActivityErrorKind::Configuration)
-            }
-            StructuredActivityResult::Invalid(error) => {
+    let envelope = activity_result_envelope_from_turn(status, items, &activity, summary);
+    match envelope.outcome {
+        ActivityResultEnvelopeOutcome::MissingStructuredOutput => {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                activity = %activity,
+                agent = %agent_name,
+                "activity completed without harness-activity-result fenced block; \
+                 marking failed to prevent silent state-machine no-progress loops"
+            );
+        }
+        ActivityResultEnvelopeOutcome::InvalidStructuredOutput => {
+            if let Some(error) = envelope.extraction_error.as_deref() {
                 tracing::warn!(
                     runtime_job_id = %job.id,
                     activity = %activity,
                     agent = %agent_name,
                     "activity result block invalid: {error}"
                 );
-                ActivityResult::failed(activity, "Structured activity result was invalid.", error)
-                    .with_error_kind(ActivityErrorKind::Configuration)
             }
-        },
-        TurnStatus::Cancelled => ActivityResult::cancelled(activity, summary),
-        TurnStatus::Failed | TurnStatus::Running => {
-            let error = last_error(items).unwrap_or_else(|| "agent turn failed".to_string());
-            tracing::warn!(
-                runtime_job_id = %job.id,
-                activity = %activity,
-                agent = %agent_name,
-                turn_status = ?status,
-                items = items.len(),
-                "runtime turn failed: {error}"
-            );
-            let mut result = ActivityResult::failed(activity, summary, error.clone());
-            if turn_error_is_timeout(&error) {
-                result = result.with_error_kind(ActivityErrorKind::Timeout);
-            }
-            result
         }
-    };
+        ActivityResultEnvelopeOutcome::TurnFailed => {
+            if let Some(error) = envelope.extraction_error.as_deref() {
+                tracing::warn!(
+                    runtime_job_id = %job.id,
+                    activity = %activity,
+                    agent = %agent_name,
+                    turn_status = ?status,
+                    items = items.len(),
+                    "runtime turn failed: {error}"
+                );
+            }
+        }
+        ActivityResultEnvelopeOutcome::Accepted | ActivityResultEnvelopeOutcome::TurnCancelled => {}
+    }
+    let envelope_artifact = envelope.to_artifact();
+    let result = envelope.into_final_result();
     result
+        .with_artifact(envelope_artifact)
         .with_artifact(workflow_prompt_artifact(prompt_packet_digest))
         .with_artifact(ActivityArtifact::new(
             "runtime_turn",
@@ -92,6 +84,175 @@ pub(super) fn activity_result_from_turn(
         ))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ActivityResultExtractionStrategy {
+    FencedActivityResult,
+    NotAttempted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ActivityResultEnvelopeOutcome {
+    Accepted,
+    MissingStructuredOutput,
+    InvalidStructuredOutput,
+    TurnCancelled,
+    TurnFailed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ActivityResultEnvelope {
+    extraction_strategy: ActivityResultExtractionStrategy,
+    outcome: ActivityResultEnvelopeOutcome,
+    raw_status: TurnStatus,
+    extracted_activity: Option<String>,
+    extraction_error: Option<String>,
+    final_result: ActivityResult,
+}
+
+impl ActivityResultEnvelope {
+    fn accepted(
+        raw_status: TurnStatus,
+        extraction_strategy: ActivityResultExtractionStrategy,
+        result: ActivityResult,
+    ) -> Self {
+        Self {
+            extraction_strategy,
+            outcome: ActivityResultEnvelopeOutcome::Accepted,
+            raw_status,
+            extracted_activity: Some(result.activity.clone()),
+            extraction_error: None,
+            final_result: result,
+        }
+    }
+
+    fn missing_structured_output(
+        raw_status: TurnStatus,
+        activity: String,
+        summary: String,
+    ) -> Self {
+        let error = "agent emitted no harness-activity-result fenced JSON block".to_string();
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
+            outcome: ActivityResultEnvelopeOutcome::MissingStructuredOutput,
+            raw_status,
+            extracted_activity: None,
+            extraction_error: Some(error.clone()),
+            final_result: ActivityResult::failed(activity, summary, error)
+                .with_error_kind(ActivityErrorKind::Configuration),
+        }
+    }
+
+    fn invalid_structured_output(
+        raw_status: TurnStatus,
+        activity: String,
+        error: String,
+        extracted_activity: Option<String>,
+    ) -> Self {
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
+            outcome: ActivityResultEnvelopeOutcome::InvalidStructuredOutput,
+            raw_status,
+            extracted_activity,
+            extraction_error: Some(error.clone()),
+            final_result: ActivityResult::failed(
+                activity,
+                "Structured activity result was invalid.",
+                error,
+            )
+            .with_error_kind(ActivityErrorKind::Configuration),
+        }
+    }
+
+    fn cancelled(raw_status: TurnStatus, activity: String, summary: String) -> Self {
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::NotAttempted,
+            outcome: ActivityResultEnvelopeOutcome::TurnCancelled,
+            raw_status,
+            extracted_activity: None,
+            extraction_error: None,
+            final_result: ActivityResult::cancelled(activity, summary),
+        }
+    }
+
+    fn failed(raw_status: TurnStatus, activity: String, summary: String, error: String) -> Self {
+        let mut result = ActivityResult::failed(activity, summary, error.clone());
+        if turn_error_is_timeout(&error) {
+            result = result.with_error_kind(ActivityErrorKind::Timeout);
+        }
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::NotAttempted,
+            outcome: ActivityResultEnvelopeOutcome::TurnFailed,
+            raw_status,
+            extracted_activity: None,
+            extraction_error: Some(error),
+            final_result: result,
+        }
+    }
+
+    fn to_artifact(&self) -> ActivityArtifact {
+        ActivityArtifact::new(
+            "activity_result_envelope",
+            json!({
+                "schema": "harness.runtime.activity_result_envelope.v1",
+                "extraction_strategy": self.extraction_strategy,
+                "outcome": self.outcome,
+                "raw_status": self.raw_status,
+                "extracted_activity": self.extracted_activity,
+                "extraction_error": self.extraction_error,
+                "final_result": {
+                    "activity": self.final_result.activity,
+                    "status": self.final_result.status,
+                    "error_kind": self.final_result.error_kind,
+                }
+            }),
+        )
+    }
+
+    fn into_final_result(self) -> ActivityResult {
+        self.final_result
+    }
+}
+
+fn activity_result_envelope_from_turn(
+    status: &TurnStatus,
+    items: &[Item],
+    activity: &str,
+    summary: String,
+) -> ActivityResultEnvelope {
+    match status {
+        TurnStatus::Completed => match structured_activity_result(items, activity) {
+            StructuredActivityResult::Parsed(result) => ActivityResultEnvelope::accepted(
+                *status,
+                ActivityResultExtractionStrategy::FencedActivityResult,
+                result,
+            ),
+            StructuredActivityResult::Missing => ActivityResultEnvelope::missing_structured_output(
+                *status,
+                activity.to_string(),
+                summary,
+            ),
+            StructuredActivityResult::Invalid {
+                error,
+                extracted_activity,
+            } => ActivityResultEnvelope::invalid_structured_output(
+                *status,
+                activity.to_string(),
+                error,
+                extracted_activity,
+            ),
+        },
+        TurnStatus::Cancelled => {
+            ActivityResultEnvelope::cancelled(*status, activity.to_string(), summary)
+        }
+        TurnStatus::Failed | TurnStatus::Running => {
+            let error = last_error(items).unwrap_or_else(|| "agent turn failed".to_string());
+            ActivityResultEnvelope::failed(*status, activity.to_string(), summary, error)
+        }
+    }
+}
+
 fn turn_error_is_timeout(error: &str) -> bool {
     let normalized = error.to_ascii_lowercase();
     normalized.contains("timed out") || normalized.contains("timeout reached")
@@ -100,7 +261,10 @@ fn turn_error_is_timeout(error: &str) -> bool {
 enum StructuredActivityResult {
     Missing,
     Parsed(ActivityResult),
-    Invalid(String),
+    Invalid {
+        error: String,
+        extracted_activity: Option<String>,
+    },
 }
 
 fn structured_activity_result(items: &[Item], expected_activity: &str) -> StructuredActivityResult {
@@ -112,13 +276,17 @@ fn structured_activity_result(items: &[Item], expected_activity: &str) -> Struct
         Ok(result) if result.activity == expected_activity => {
             StructuredActivityResult::Parsed(result)
         }
-        Ok(result) => StructuredActivityResult::Invalid(format!(
-            "activity result block reported activity `{}`, expected `{expected_activity}`",
-            result.activity
-        )),
-        Err(error) => StructuredActivityResult::Invalid(format!(
-            "activity result block is invalid JSON: {error}"
-        )),
+        Ok(result) => StructuredActivityResult::Invalid {
+            error: format!(
+                "activity result block reported activity `{}`, expected `{expected_activity}`",
+                result.activity
+            ),
+            extracted_activity: Some(result.activity),
+        },
+        Err(error) => StructuredActivityResult::Invalid {
+            error: format!("activity result block is invalid JSON: {error}"),
+            extracted_activity: None,
+        },
     }
 }
 
@@ -253,6 +421,10 @@ mod tests {
                 .is_some_and(|e| e.contains("harness-activity-result")),
             "error message MUST mention the missing block so operators can diagnose"
         );
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "missing_structured_output");
+        assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+        assert_eq!(envelope["raw_status"], "completed");
     }
 
     #[test]
@@ -317,6 +489,10 @@ Final result:
             .expect("runtime turn artifact should be appended");
         assert_eq!(turn_artifact.artifact["thread_id"], "thread-1");
         assert_eq!(turn_artifact.artifact["turn_id"], "turn-1");
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "accepted");
+        assert_eq!(envelope["extracted_activity"], "implement_issue");
+        assert_eq!(envelope["final_result"]["status"], "succeeded");
         assert!(result
             .signals
             .iter()
@@ -365,6 +541,9 @@ Final result:
             .artifacts
             .iter()
             .any(|artifact| artifact.artifact_type == "pull_request"));
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "invalid_structured_output");
+        assert_eq!(envelope["extracted_activity"], "replan_issue");
         assert!(result
             .artifacts
             .iter()
@@ -423,6 +602,9 @@ Final result:
             .artifacts
             .iter()
             .any(|artifact| artifact.artifact_type == "pull_request"));
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "invalid_structured_output");
+        assert!(envelope["extracted_activity"].is_null());
         assert!(result
             .artifacts
             .iter()
@@ -466,5 +648,17 @@ Final result:
             result.error.as_deref(),
             Some("Agent turn timed out after 30s")
         );
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "turn_failed");
+        assert_eq!(envelope["extraction_strategy"], "not_attempted");
+    }
+
+    fn envelope_artifact(result: &ActivityResult) -> &serde_json::Value {
+        &result
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_type == "activity_result_envelope")
+            .expect("activity result envelope artifact should be appended")
+            .artifact
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
+use super::activity_contract::activity_contract;
 use super::data_helpers::activity_name;
 
 pub(super) fn build_runtime_prompt_packet(
@@ -138,6 +139,7 @@ pub(super) fn activity_result_schema(
     let workflow_definition = workflow
         .map(|workflow| workflow.definition_id.as_str())
         .unwrap_or("unknown");
+    let activity_contract = activity_contract(workflow_definition, &activity);
     let transition_contract = activity_transition_contract(workflow_definition, &activity);
     let summary_contract = agent_summary_contract(workflow_definition, &activity);
     let decision_contract = workflow_decision_contract(workflow);
@@ -145,6 +147,7 @@ pub(super) fn activity_result_schema(
         "schema": "harness.runtime.activity_result.v1",
         "activity": activity,
         "workflow_definition": workflow_definition,
+        "activity_contract": activity_contract.to_prompt_value(),
         "result_type": "ActivityResult",
         "required_fields": ["activity", "status", "summary"],
         "optional_fields": ["artifacts", "signals", "validation", "error", "error_kind"],
@@ -582,6 +585,14 @@ mod tests {
             schema["agent_summary_contract"]["must_include"][0],
             "validation commands"
         );
+        assert_eq!(
+            schema["activity_contract"]["accepted_signals"][0],
+            QUALITY_PASSED_SIGNAL
+        );
+        assert_eq!(
+            schema["activity_contract"]["success_requires"],
+            "quality_gate_status_signal"
+        );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()
             .expect("allowed transitions should be an array")
@@ -617,6 +628,14 @@ mod tests {
         assert_eq!(
             schema["transition_contract"]["on_succeeded"]["empty_success_allowed"],
             false
+        );
+        assert_eq!(
+            schema["activity_contract"]["success_requires"],
+            "at_least_one_accepted_signal"
+        );
+        assert_eq!(
+            schema["activity_contract"]["explicit_noop_signals"][0],
+            "NoOpenIssueFound"
         );
         assert_eq!(
             schema["agent_summary_contract"]["signals"]["IssueDiscovered"],
@@ -667,6 +686,14 @@ mod tests {
             "sprint_plan"
         );
         assert_eq!(
+            schema["activity_contract"]["success_requires"],
+            "at_least_one_accepted_signal_or_artifact"
+        );
+        assert_eq!(
+            schema["activity_contract"]["accepted_artifacts"][0],
+            "sprint_plan"
+        );
+        assert_eq!(
             schema["agent_summary_contract"]["signals"]["SprintTaskSelected"],
             "Use once for each issue selected for execution. Include issue_number, issue_url, repo, labels, and depends_on as issue numbers."
         );
@@ -709,6 +736,10 @@ mod tests {
         assert_eq!(
             schema["transition_contract"]["on_succeeded"]["parent_propagation"],
             "The same activity result is propagated to the parent github_issue_pr workflow."
+        );
+        assert_eq!(
+            schema["activity_contract"]["child_outcome_contract"],
+            "pr_feedback_outcome"
         );
         assert_eq!(
             schema["agent_summary_contract"]["signals"]["PrReadyToMerge"],

--- a/docs/prompt-workflow-contract-long-term-design.md
+++ b/docs/prompt-workflow-contract-long-term-design.md
@@ -1,0 +1,532 @@
+# Prompt Workflow Contract Long-Term Design
+
+Status: Draft
+Date: 2026-05-13
+
+Related documents:
+
+- `docs/workflow-runtime-decoupling-plan.md`
+- `docs/workflow-runtime-hardening-design.md`
+- `docs/local-codex-review-provider-spec.md`
+- `docs/codex-app-server-reference.md`
+
+## Goal
+
+Make Harness reliable for long-running autonomous work by turning prompts from best-effort
+instructions into versioned workflow contracts.
+
+The long-term design keeps the current workflow runtime direction: the server owns state,
+agents propose facts and decisions, and reducers validate every state transition. The missing
+piece is a durable contract boundary around prompts and agent output:
+
+```text
+Project workflow definition
+  -> PromptSpec compiler
+  -> RuntimePromptPacket
+  -> AgentAdapter
+  -> ActivityResultEnvelope
+  -> Output repair and validation
+  -> Reducer decision
+  -> Workflow event and command outbox
+```
+
+The system should tolerate normal agent variability without silently burning quota, losing parent
+workflow progress, or requiring operators to discover contract drift only after an overnight run.
+
+## Problem Statement
+
+Harness currently has the right high-level architecture, but the prompt boundary is still too soft.
+A runtime agent can complete a turn successfully while failing the workflow contract. For example,
+the agent may return ordinary prose, place JSON in the wrong block, omit required signals, emit a
+valid-looking but semantically empty result, or produce a child workflow decision that is stripped
+before the parent can consume it.
+
+These are not ordinary model quality issues. They are contract failures between the agent runtime
+and the workflow runtime. Contract failures must be classified, repaired when safe, suppressed when
+repetition cannot help, and surfaced through health/status tooling.
+
+## Design Principles
+
+1. **Workflow state is server-owned.** Agents never mutate workflow state directly. They only return
+   candidate facts, artifacts, validation results, and decisions.
+2. **Prompt text is compiled, not hand-assembled.** Workflow definitions and activity contracts
+   compile into prompt packets, schemas, examples, and reducer expectations from one source of
+   truth.
+3. **Structured output is mandatory but adapter-specific.** Use native structured output or tool
+   result channels where available. Keep fenced JSON as compatibility, not the only contract.
+4. **Semantic empty success is invalid.** A successful activity must emit the signals or artifacts
+   required by its activity contract, or an explicit no-op signal that proves no work exists.
+5. **Every completed turn resolves.** A completed agent turn must become exactly one of:
+   `accepted`, `repaired`, `blocked`, `retry_scheduled`, or `terminal_failed`.
+6. **Repair is bounded and observable.** Repair can normalize formatting or classify an otherwise
+   useful result, but it cannot invent domain facts.
+7. **Parent and child workflows exchange typed outcomes.** Child completion must propagate a
+   normalized outcome envelope. Parents should not depend on duplicated ad hoc signal strings.
+8. **Operators need first-class health signals.** Status endpoints must show stalled workflows,
+   invalid output, repair attempts, suppressions, retry cooldowns, and capacity pressure.
+9. **Repo owners can change workflow policy safely.** Project-owned workflow files should be
+   validated before dispatch and hot-reloaded without server restart.
+10. **Backward compatibility is explicit.** Existing built-in workflow definitions continue to work
+    while project workflow files and structured adapter output roll out incrementally.
+
+## Lessons From Symphony
+
+Symphony has a simpler workflow model, but several design choices are worth adopting:
+
+| Area | Symphony approach | Harness long-term adoption |
+|---|---|---|
+| Workflow ownership | Repo-owned `WORKFLOW.md` contains config and prompt policy. | Add project workflow definitions that compile into typed Harness contracts. |
+| Template validation | Unknown template variables fail before dispatch. | Validate workflow prompt templates during project load and reload. |
+| State split | Orchestrator state is separate from tracker state. | Keep workflow runtime state separate from GitHub/issue tracker state. |
+| Multi-turn loop | After each turn, re-check external state and continue until done or max turns. | Keep runtime turn budgets and make continuation decisions explicit workflow commands. |
+| Retry/backoff | Turn failures use bounded backoff. | Keep retry policy, but add contract-failure suppression and repair counters. |
+| Tool protocol | Dynamic tools have schemas and normalized result envelopes. | Normalize all provider/adapter outputs through `ActivityResultEnvelope`. |
+
+Symphony does not fully solve machine-verified final business output. Its final response policy is
+still mostly prompt-driven. Harness should take the stronger path: keep the typed workflow runtime,
+but make prompt and output contracts hard enough for unattended operation.
+
+## Target Architecture
+
+```text
+Source adapter
+  -> WorkflowEvent
+  -> WorkflowController
+  -> WorkflowDefinitionRegistry
+  -> ActivityContract
+  -> PromptSpecCompiler
+  -> RuntimePromptPacket
+  -> RuntimeJob
+  -> AgentAdapter
+  -> RawAgentTurn
+  -> ActivityResultExtractor
+  -> ActivityResultRepair
+  -> ActivityResultValidator
+  -> Reducer
+  -> WorkflowDecision
+  -> WorkflowCommand outbox
+```
+
+### WorkflowDefinitionRegistry
+
+The registry owns workflow definitions from two sources:
+
+- built-in definitions compiled into Harness
+- project workflow definition files loaded from configured project paths
+
+Recommended project file lookup order:
+
+1. explicit `projects.<name>.workflow_file`
+2. `.harness/WORKFLOW.md`
+3. `WORKFLOW.md`
+4. built-in workflow defaults
+
+The registry returns a validated `WorkflowDefinitionBundle`:
+
+```text
+WorkflowDefinitionBundle
+  workflow_id
+  version
+  states
+  terminal_states
+  activities
+  transition_rules
+  command_rules
+  retry_policy
+  prompt_templates
+  status_mapping
+  provider_policy
+```
+
+Invalid project definitions are configuration failures and must block dispatch. They should not
+silently fall back to defaults unless the project explicitly enables fallback.
+
+### ActivityContract
+
+Each runtime activity must have a typed contract:
+
+```text
+ActivityContract
+  workflow_id
+  activity
+  expected_current_states
+  allowed_next_states
+  required_signals
+  optional_signals
+  required_artifacts
+  optional_artifacts
+  explicit_noop_signals
+  validation_commands
+  child_outcome_contract
+  retry_policy
+  repair_policy
+  examples
+```
+
+This contract is the single source for:
+
+- prompt packet instructions
+- JSON schema generation
+- reducer semantic guards
+- test fixtures
+- status/diagnostic rendering
+
+The existing drift where prompt text describes fields that do not match `ActivityResult` must be
+eliminated. Prompt-visible schema must be generated from the same Rust contract used by validation.
+
+### PromptSpecCompiler
+
+The compiler converts a workflow definition and runtime job context into a `RuntimePromptPacket`.
+
+Inputs:
+
+- workflow instance snapshot
+- activity contract
+- runtime profile
+- project workflow template
+- source event context
+- available commands and transition rules
+- previous attempts and repair history
+
+Outputs:
+
+- prompt packet JSON
+- human-readable prompt body
+- strict output schema
+- activity-specific examples
+- digest and provenance metadata
+
+The packet should be versioned and recorded before execution. Any prompt packet change should be
+traceable through its digest and compiler version.
+
+### RuntimePromptPacket
+
+The packet should include:
+
+```text
+schema = "harness.runtime.prompt_packet.v2"
+workflow_id
+workflow_instance_id
+activity
+contract_version
+current_state
+allowed_transitions
+required_commands
+required_signals
+required_artifacts
+explicit_noop_signals
+output_schema
+repair_policy
+project_instructions
+activity_prompt
+examples
+```
+
+Prompt text should be short and repetitive by design. The agent should see the same output contract
+near the start and again at the end. The final section should be mechanically generated from the
+contract, not manually written per activity.
+
+### AgentAdapter
+
+Adapters should expose capability metadata:
+
+```text
+AgentAdapterCapabilities
+  supports_structured_output
+  supports_tool_result_output
+  supports_jsonrpc_turn_events
+  supports_continuation
+  supports_review_mode
+  supports_reasoning_effort
+  supports_timeout
+  supports_sandbox_policy
+```
+
+Output strategy order:
+
+1. Native structured output or tool result channel.
+2. App-server JSON-RPC event result when available.
+3. Final fenced `harness-activity-result` JSON block.
+4. Legacy compatibility parser that can identify a likely JSON object and pass it to repair.
+
+The runtime should record which strategy produced the result. Fenced JSON should remain supported,
+but it should not be the only successful path.
+
+### ActivityResultEnvelope
+
+Raw agent output should first become an envelope:
+
+```text
+ActivityResultEnvelope
+  extraction_strategy
+  raw_turn_id
+  raw_status
+  extracted_result
+  extraction_errors
+  repair_attempts
+  validation_errors
+  final_result
+```
+
+This separates three facts that are currently easy to confuse:
+
+- the agent process completed
+- Harness extracted a candidate result
+- the candidate result passed the activity contract
+
+The reducer should only receive `final_result` after validation, or a typed invalid-output result
+when validation cannot succeed.
+
+### ActivityResultRepair
+
+Repair is allowed only when it preserves facts already present in the raw turn. It may:
+
+- move JSON from a generic block into the expected envelope
+- normalize field names from a known compatibility alias
+- convert clear native review text into a normalized review report
+- classify a missing final block as `InvalidAgentOutput`
+- extract validation command results already present in the transcript
+
+Repair must not:
+
+- invent issue numbers, PR numbers, mergeability, approvals, or CI state
+- convert ambiguous prose into success
+- fabricate validation commands that were not run
+- create a parent transition when child outcome evidence is missing
+
+Repair outcomes:
+
+| Repair outcome | Meaning |
+|---|---|
+| `repaired` | A valid result was recovered from raw output. |
+| `blocked_invalid_output` | The turn completed, but no safe result can be produced. |
+| `retry_invalid_output` | The output failed due to a retryable adapter or provider problem. |
+| `terminal_invalid_output` | The same prompt/adapter contract repeatedly failed and is suppressed. |
+
+### Reducer Invariants
+
+Reducers must enforce these invariants:
+
+1. A valid structured `workflow_decision` wins only after transition and command validation.
+2. Activity-specific reducers may derive decisions from typed signals and artifacts.
+3. Invalid structured decisions become blocked decisions with operator attention.
+4. Empty success is blocked unless an explicit no-op signal is valid for that activity.
+5. Child workflow completion propagates a typed child outcome envelope to the parent.
+6. Parent workflows consume child outcomes directly, not stripped artifacts plus duplicated signals.
+7. Terminal states are never ordinary scheduler candidates.
+8. Repeated invalid-output failures trigger cooldown or suppression, not unbounded polling.
+
+## Project Workflow File
+
+The project workflow file should be Markdown with YAML front matter:
+
+```markdown
+---
+schema: harness.project_workflow.v1
+workflow_id: github_issue_pr
+max_turns: 12
+max_concurrent_workflows: 4
+retry:
+  max_attempts: 3
+  max_backoff_secs: 1800
+providers:
+  implementor: codex_exec
+  reviewer: codex_cli_review
+status_mapping:
+  backlog: ["Backlog", "Todo"]
+  active: ["In Progress", "Rework"]
+  review: ["Human Review"]
+  done: ["Done"]
+---
+
+## Activity: implement_issue
+
+Project-specific implementation policy.
+
+## Activity: inspect_pr_feedback
+
+Project-specific review feedback policy.
+```
+
+The front matter controls validated runtime settings. The Markdown body controls project policy and
+activity-specific instructions. The compiler should reject unknown required keys and unknown
+template variables.
+
+## Workflow-Specific Contracts
+
+### `repo_backlog`
+
+Required outcomes:
+
+- `IssueDiscovered`
+- `IssueSkipped`
+- `NoOpenIssueFound`
+
+`plan_repo_sprint` must produce one of:
+
+- `SprintTaskSelected`
+- `IssueSkipped`
+- `NoSprintTaskSelected`
+- valid `sprint_plan` artifact with selected tasks or explicit no-op evidence
+
+Invalid empty success must block and suppress repeated sweeps for a bounded cooldown.
+
+### `github_issue_pr`
+
+Required outcomes depend on state:
+
+- implementation states must bind a PR artifact, produce a blocked decision, or produce validation
+  evidence for no-code/no-PR completion when the workflow allows it
+- PR feedback states must consume `pr_feedback` child outcomes
+- ready-to-merge states must require local review and CI evidence according to review policy
+
+The workflow should not rely on direct GitHub/git calls inside Rust. GitHub and git inspection
+remain agent/runtime responsibilities expressed through prompts and normalized results.
+
+### `pr_feedback`
+
+The child workflow should return a typed `PrFeedbackOutcome`:
+
+```text
+PrFeedbackOutcome
+  status = feedback_found | no_feedback_found | changes_requested | checks_failed | ready_to_merge | blocked
+  comments
+  check_runs
+  review_state
+  mergeability
+  evidence
+```
+
+The parent should consume this outcome directly. The child should not lose valid decision artifacts
+before parent propagation.
+
+### `prompt_task`
+
+Prompt-only tasks should return:
+
+- implementation summary
+- changed files when applicable
+- validation results
+- blockers or explicit no-op evidence
+
+The task should not be marked done solely because the agent process completed.
+
+### `quality_gate`
+
+Quality gate activities should return:
+
+- gate name
+- commands run
+- pass/fail state
+- findings
+- blocking severity
+- suggested next activity when blocked
+
+## Status And Health Model
+
+Harness needs a first-class status surface for operators and for self-healing logic.
+
+Minimum status categories:
+
+| Category | Examples |
+|---|---|
+| Runtime health | running jobs, queued jobs, stalled streams, timeout counts |
+| Contract health | missing result blocks, invalid schemas, repair successes, repair failures |
+| Workflow health | blocked workflows, terminal failures, retry cooldowns, child workflows awaiting parent propagation |
+| Capacity health | domain limits, project limits, pool wait, queue age |
+| Provider health | Codex CLI availability, app-server availability, review provider status |
+| Suppression health | suppressed sweeps, suppression reason, next allowed attempt |
+
+Recommended endpoints:
+
+- `GET /health`: lightweight liveness and dependency state
+- `GET /status`: operator summary across projects and domains
+- `GET /api/workflow-runtime/diagnostics`: detailed contract and reducer diagnostics
+- `GET /api/workflow-runtime/instances/:id/trace`: prompt packet, extraction envelope, reducer decision, commands
+
+## Testing Strategy
+
+Every activity contract should generate or reference fixtures.
+
+Required test groups:
+
+| Test group | Expectation |
+|---|---|
+| Prompt compilation | Unknown template variables fail before dispatch. |
+| Schema drift | Generated prompt schema matches `ActivityResult` and activity contracts. |
+| Extraction | Native structured output, fenced JSON, generic JSON, and missing output are classified correctly. |
+| Repair | Safe formatting repair succeeds; ambiguous prose blocks. |
+| Reducer invariants | Empty success, invalid decision, missing commands, and terminal candidates are rejected. |
+| Parent/child propagation | Child outcomes advance or block parents deterministically. |
+| Suppression | Repeated invalid-output failures do not enqueue unbounded sweeps. |
+| Status API | Diagnostics expose stuck workflows and contract failure counts. |
+| End-to-end simulation | Repo backlog, issue PR, PR feedback, prompt task, and quality gate run through synthetic turns. |
+
+## Migration Plan
+
+### Phase 1: Contract Inventory
+
+- Define `ActivityContract` for every existing runtime activity.
+- Generate prompt-visible schemas from runtime types.
+- Remove manually duplicated schema fragments that can drift.
+- Add fixture tests for all current activity output examples.
+
+### Phase 2: Extraction Envelope
+
+- Introduce `ActivityResultEnvelope`.
+- Record extraction strategy and validation errors.
+- Keep existing fenced JSON parser as one extraction strategy.
+- Add compatibility parsing for native structured output and generic JSON blocks.
+
+### Phase 3: Repair And Suppression
+
+- Add bounded repair for formatting-only failures.
+- Add invalid-output cooldowns by workflow/activity/project.
+- Surface repair and suppression metrics in runtime events.
+
+### Phase 4: Parent/Child Outcome Model
+
+- Add typed child outcome artifacts for `pr_feedback`.
+- Stop relying on stripped decisions plus duplicated signals.
+- Make parent consumption deterministic and tested.
+
+### Phase 5: Project Workflow Definitions
+
+- Add project workflow file loader and validator.
+- Support `.harness/WORKFLOW.md` and explicit configured workflow files.
+- Compile project policy into prompt packets.
+- Hot-reload changed workflow definitions after validation.
+
+### Phase 6: Status And Diagnostics
+
+- Add `/status` and workflow runtime diagnostics.
+- Include contract failures, queue pressure, suppression state, and stuck workflow detection.
+- Add dashboard rendering after the API shape is stable.
+
+### Phase 7: Adapter Capability Upgrade
+
+- Add adapter capability probes.
+- Prefer native structured output or tool result channels.
+- Keep fenced JSON compatibility until all supported adapters have better output channels.
+
+## Acceptance Criteria
+
+The long-term design is complete when:
+
+1. No runtime activity relies on manually duplicated prompt schema.
+2. Every runtime activity has an `ActivityContract`.
+3. Every completed agent turn resolves to accepted, repaired, blocked, retry scheduled, or terminal
+   failed.
+4. Missing or malformed output cannot cause unbounded polling or quota burn.
+5. Parent workflows consume typed child outcomes.
+6. Project workflow definitions can be validated before dispatch and reloaded safely.
+7. Operators can answer "what is stuck and why" from `/status` without inspecting database tables.
+8. End-to-end tests cover repo backlog, issue PR, PR feedback, prompt task, and quality gate flows.
+
+## Non-Goals
+
+- Do not make agents deterministic.
+- Do not move product judgment into Rust reducers.
+- Do not call `git` or `gh` directly from Harness crates.
+- Do not require every project to adopt project workflow files on day one.
+- Do not remove existing built-in workflow definitions during the migration.


### PR DESCRIPTION
## Summary
- Suppress failed PR feedback sweep storms by marking unrecoverable sweep rows before requeueing.
- Add a workflow prompt contract foundation, including prompt packets and activity result envelopes.
- Normalize generic JSON activity results and expose extraction diagnostics through the runtime tree API.
- Add `harness status` for live server health, queue, retry, runtime tree, and activity result diagnostics.
- Document the long-term workflow contract design in `docs/prompt-workflow-contract-long-term-design.md`.

## Test Coverage
All new code paths have focused unit coverage for runtime diagnostics, activity result parsing, and CLI status summarization.

## Pre-Landing Review
No separate pre-landing review findings are open in this PR creation pass.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt eval suite was run; prompt contract changes are covered by Rust tests and the long-term design document.

## Plan Completion
No plan file detected.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check`
- [x] `cargo test -p harness-server activity_result_envelope_from_job`
- [x] `cargo test -p harness-server workflow_runtime_tree_endpoint_returns_nested_runtime_details`
- [x] `cargo test -p harness-cli status`
- [x] `cargo test`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
