### PR TITLE
perf(runtime): paginate workflow runtime tree

### DIFF
--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -237,6 +237,10 @@ fn summarize_runtime_tree(tree: &Value) -> RuntimeTreeSummary {
         summary.jobs = tree["summary"]["total_runtime_jobs"].as_u64().unwrap_or(0) as usize;
         summary.command_statuses = count_map_from_value(&tree["summary"]["command_statuses"]);
         summary.job_statuses = count_map_from_value(&tree["summary"]["runtime_job_statuses"]);
+        summary.activity_outcomes = count_map_from_value(&tree["summary"]["activity_outcomes"]);
+        summary.jobs_without_activity_envelope = tree["summary"]["jobs_without_activity_envelope"]
+            .as_u64()
+            .unwrap_or(0) as usize;
     }
     if let Some(workflows) = tree["workflows"].as_array() {
         for workflow in workflows {
@@ -265,10 +269,12 @@ fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary, inclu
                             job["status"].as_str().unwrap_or("unknown"),
                         );
                     }
-                    if let Some(outcome) = job["activity_result_envelope"]["outcome"].as_str() {
-                        increment(&mut summary.activity_outcomes, outcome);
-                    } else {
-                        summary.jobs_without_activity_envelope += 1;
+                    if include_counts {
+                        if let Some(outcome) = job["activity_result_envelope"]["outcome"].as_str() {
+                            increment(&mut summary.activity_outcomes, outcome);
+                        } else {
+                            summary.jobs_without_activity_envelope += 1;
+                        }
                     }
                 }
             }
@@ -409,7 +415,12 @@ mod tests {
                 "runtime_job_statuses": {
                     "failed": 4,
                     "succeeded": 38
-                }
+                },
+                "activity_outcomes": {
+                    "accepted": 36,
+                    "repaired_structured_output": 2
+                },
+                "jobs_without_activity_envelope": 4
             },
             "workflows": [{
                 "commands": [{
@@ -434,6 +445,8 @@ mod tests {
         assert_eq!(summary.command_statuses["pending"], 2);
         assert_eq!(summary.job_statuses["failed"], 4);
         assert_eq!(summary.job_statuses["succeeded"], 38);
-        assert_eq!(summary.activity_outcomes["accepted"], 1);
+        assert_eq!(summary.activity_outcomes["accepted"], 36);
+        assert_eq!(summary.activity_outcomes["repaired_structured_output"], 2);
+        assert_eq!(summary.jobs_without_activity_envelope, 4);
     }
 }

--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -231,29 +231,40 @@ fn summarize_runtime_tree(tree: &Value) -> RuntimeTreeSummary {
         workflows: tree["total_workflows"].as_u64().unwrap_or(0) as usize,
         ..Default::default()
     };
+    let has_server_summary = tree["summary"].is_object();
+    if has_server_summary {
+        summary.commands = tree["summary"]["total_commands"].as_u64().unwrap_or(0) as usize;
+        summary.jobs = tree["summary"]["total_runtime_jobs"].as_u64().unwrap_or(0) as usize;
+        summary.command_statuses = count_map_from_value(&tree["summary"]["command_statuses"]);
+        summary.job_statuses = count_map_from_value(&tree["summary"]["runtime_job_statuses"]);
+    }
     if let Some(workflows) = tree["workflows"].as_array() {
         for workflow in workflows {
-            summarize_workflow_node(workflow, &mut summary);
+            summarize_workflow_node(workflow, &mut summary, !has_server_summary);
         }
     }
     summary
 }
 
-fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary) {
+fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary, include_counts: bool) {
     if let Some(commands) = node["commands"].as_array() {
         for command in commands {
-            summary.commands += 1;
-            increment(
-                &mut summary.command_statuses,
-                command["status"].as_str().unwrap_or("unknown"),
-            );
+            if include_counts {
+                summary.commands += 1;
+                increment(
+                    &mut summary.command_statuses,
+                    command["status"].as_str().unwrap_or("unknown"),
+                );
+            }
             if let Some(jobs) = command["runtime_jobs"].as_array() {
                 for job in jobs {
-                    summary.jobs += 1;
-                    increment(
-                        &mut summary.job_statuses,
-                        job["status"].as_str().unwrap_or("unknown"),
-                    );
+                    if include_counts {
+                        summary.jobs += 1;
+                        increment(
+                            &mut summary.job_statuses,
+                            job["status"].as_str().unwrap_or("unknown"),
+                        );
+                    }
                     if let Some(outcome) = job["activity_result_envelope"]["outcome"].as_str() {
                         increment(&mut summary.activity_outcomes, outcome);
                     } else {
@@ -265,13 +276,27 @@ fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary) {
     }
     if let Some(children) = node["children"].as_array() {
         for child in children {
-            summarize_workflow_node(child, summary);
+            summarize_workflow_node(child, summary, include_counts);
         }
     }
 }
 
 fn increment(map: &mut BTreeMap<String, usize>, key: &str) {
     *map.entry(key.to_string()).or_insert(0) += 1;
+}
+
+fn count_map_from_value(value: &Value) -> BTreeMap<String, usize> {
+    value
+        .as_object()
+        .map(|object| {
+            object
+                .iter()
+                .filter_map(|(key, value)| {
+                    value.as_u64().map(|count| (key.clone(), count as usize))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn number_or_zero(value: &Value) -> u64 {
@@ -368,5 +393,47 @@ mod tests {
         assert_eq!(summary.job_statuses["pending"], 1);
         assert_eq!(summary.activity_outcomes["accepted"], 1);
         assert_eq!(summary.jobs_without_activity_envelope, 1);
+    }
+
+    #[test]
+    fn summarize_runtime_tree_prefers_server_totals_when_present() {
+        let tree = json!({
+            "total_workflows": 2,
+            "summary": {
+                "total_commands": 7,
+                "total_runtime_jobs": 42,
+                "command_statuses": {
+                    "completed": 5,
+                    "pending": 2
+                },
+                "runtime_job_statuses": {
+                    "failed": 4,
+                    "succeeded": 38
+                }
+            },
+            "workflows": [{
+                "commands": [{
+                    "status": "completed",
+                    "runtime_jobs": [{
+                        "status": "succeeded",
+                        "activity_result_envelope": {
+                            "outcome": "accepted"
+                        }
+                    }]
+                }],
+                "children": []
+            }]
+        });
+
+        let summary = summarize_runtime_tree(&tree);
+
+        assert_eq!(summary.workflows, 2);
+        assert_eq!(summary.commands, 7);
+        assert_eq!(summary.jobs, 42);
+        assert_eq!(summary.command_statuses["completed"], 5);
+        assert_eq!(summary.command_statuses["pending"], 2);
+        assert_eq!(summary.job_statuses["failed"], 4);
+        assert_eq!(summary.job_statuses["succeeded"], 38);
+        assert_eq!(summary.activity_outcomes["accepted"], 1);
     }
 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -453,17 +453,15 @@ async fn build_workflow_runtime_tree(
             })
             .collect();
         summary.total_commands += commands.len();
-        let runtime_job_count = commands
-            .iter()
-            .map(|command| {
-                summary
-                    .command_statuses
-                    .entry(command.status.clone())
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-                command.runtime_job_count
-            })
-            .sum();
+        let mut runtime_job_count = 0;
+        for command in &commands {
+            summary
+                .command_statuses
+                .entry(command.status.clone())
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            runtime_job_count += command.runtime_job_count;
+        }
         summary.total_runtime_jobs += runtime_job_count;
         by_id.insert(
             workflow_id,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -368,7 +368,14 @@ pub(crate) async fn get_workflow_runtime_tree(
         .list_instances_page(query.project_id.as_deref(), limit, offset)
         .await
     {
-        Ok(page) => match build_workflow_runtime_tree(store, page, job_limit as usize).await {
+        Ok(page) => match build_workflow_runtime_tree(
+            store,
+            page,
+            query.project_id.as_deref(),
+            job_limit as usize,
+        )
+        .await
+        {
             Ok(response) => (StatusCode::OK, Json(response)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -387,6 +394,7 @@ pub(crate) async fn get_workflow_runtime_tree(
 async fn build_workflow_runtime_tree(
     store: &harness_workflow::runtime::WorkflowRuntimeStore,
     page: harness_workflow::runtime::store::WorkflowInstancePage,
+    project_id: Option<&str>,
     job_limit: usize,
 ) -> anyhow::Result<WorkflowRuntimeTreeResponse> {
     let instances = page.instances;
@@ -402,10 +410,6 @@ async fn build_workflow_runtime_tree(
         .flat_map(|commands| commands.iter().map(|command| command.id.clone()))
         .collect();
     let runtime_job_counts_by_command = store.runtime_job_counts_for_commands(&command_ids).await?;
-    let runtime_job_statuses = store
-        .runtime_job_status_counts_for_commands(&command_ids)
-        .await?;
-    let all_runtime_jobs_by_command = store.runtime_jobs_for_commands(&command_ids).await?;
     let mut runtime_jobs_by_command = store
         .runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
         .await?;
@@ -417,11 +421,21 @@ async fn build_workflow_runtime_tree(
 
     let mut by_id = BTreeMap::new();
     let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    let mut summary = WorkflowRuntimeTreeSummary {
-        runtime_job_statuses,
-        ..Default::default()
+    let aggregate_summary = store
+        .runtime_summary_counts_for_instances(
+            project_id,
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+        )
+        .await?;
+    let summary = WorkflowRuntimeTreeSummary {
+        total_commands: aggregate_summary.total_commands,
+        total_runtime_jobs: aggregate_summary.total_runtime_jobs,
+        command_statuses: aggregate_summary.command_statuses,
+        runtime_job_statuses: aggregate_summary.runtime_job_statuses,
+        activity_outcomes: aggregate_summary.activity_outcomes,
+        jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
     };
-    apply_runtime_activity_summary(&mut summary, &all_runtime_jobs_by_command);
     for instance in instances {
         let workflow_id = instance.id.clone();
         if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
@@ -456,17 +470,10 @@ async fn build_workflow_runtime_tree(
                 WorkflowRuntimeCommandNode::new(command, runtime_job_count, runtime_jobs)
             })
             .collect();
-        summary.total_commands += commands.len();
         let mut runtime_job_count = 0;
         for command in &commands {
-            summary
-                .command_statuses
-                .entry(command.status.clone())
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
             runtime_job_count += command.runtime_job_count;
         }
-        summary.total_runtime_jobs += runtime_job_count;
         by_id.insert(
             workflow_id,
             WorkflowRuntimeTreeNode {
@@ -519,6 +526,7 @@ async fn build_workflow_runtime_tree(
     })
 }
 
+#[cfg(test)]
 fn apply_runtime_activity_summary(
     summary: &mut WorkflowRuntimeTreeSummary,
     jobs_by_command: &BTreeMap<String, Vec<RuntimeJob>>,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -253,6 +253,8 @@ struct WorkflowRuntimeTreeSummary {
     pub total_runtime_jobs: usize,
     pub command_statuses: BTreeMap<String, usize>,
     pub runtime_job_statuses: BTreeMap<String, usize>,
+    pub activity_outcomes: BTreeMap<String, usize>,
+    pub jobs_without_activity_envelope: usize,
 }
 
 pub(crate) async fn get_issue_workflow_by_issue(
@@ -403,6 +405,7 @@ async fn build_workflow_runtime_tree(
     let runtime_job_statuses = store
         .runtime_job_status_counts_for_commands(&command_ids)
         .await?;
+    let all_runtime_jobs_by_command = store.runtime_jobs_for_commands(&command_ids).await?;
     let mut runtime_jobs_by_command = store
         .runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
         .await?;
@@ -418,6 +421,7 @@ async fn build_workflow_runtime_tree(
         runtime_job_statuses,
         ..Default::default()
     };
+    apply_runtime_activity_summary(&mut summary, &all_runtime_jobs_by_command);
     for instance in instances {
         let workflow_id = instance.id.clone();
         if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
@@ -513,6 +517,28 @@ async fn build_workflow_runtime_tree(
         summary,
         workflows,
     })
+}
+
+fn apply_runtime_activity_summary(
+    summary: &mut WorkflowRuntimeTreeSummary,
+    jobs_by_command: &BTreeMap<String, Vec<RuntimeJob>>,
+) {
+    for job in jobs_by_command.values().flatten() {
+        if let Some(outcome) = activity_result_envelope_from_job(job).and_then(|envelope| {
+            envelope
+                .get("outcome")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }) {
+            summary
+                .activity_outcomes
+                .entry(outcome)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+        } else {
+            summary.jobs_without_activity_envelope += 1;
+        }
+    }
 }
 
 fn prompt_packet_digest_from_events(events: &[RuntimeEvent]) -> Option<String> {
@@ -627,6 +653,45 @@ mod runtime_tree_tests {
             }),
         )]);
         assert!(activity_result_envelope_from_job(&job).is_none());
+    }
+
+    #[test]
+    fn runtime_activity_summary_counts_all_loaded_jobs() {
+        let accepted = ActivityArtifact::new(
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            json!({
+                "schema": ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+                "outcome": "accepted",
+            }),
+        );
+        let repaired = ActivityArtifact::new(
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            json!({
+                "schema": ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+                "outcome": "repaired_structured_output",
+            }),
+        );
+        let mut jobs_by_command = BTreeMap::new();
+        jobs_by_command.insert(
+            "command-1".to_string(),
+            vec![
+                runtime_job_with_artifacts(vec![accepted]),
+                runtime_job_with_artifacts(vec![repaired]),
+                RuntimeJob::pending(
+                    "command-1",
+                    RuntimeKind::CodexJsonrpc,
+                    "codex-high",
+                    json!({}),
+                ),
+            ],
+        );
+        let mut summary = WorkflowRuntimeTreeSummary::default();
+
+        apply_runtime_activity_summary(&mut summary, &jobs_by_command);
+
+        assert_eq!(summary.activity_outcomes["accepted"], 1);
+        assert_eq!(summary.activity_outcomes["repaired_structured_output"], 1);
+        assert_eq!(summary.jobs_without_activity_envelope, 1);
     }
 }
 

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -20,6 +20,10 @@ use harness_workflow::runtime::{
 
 const ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE: &str = "activity_result_envelope";
 const ACTIVITY_RESULT_ENVELOPE_SCHEMA: &str = "harness.runtime.activity_result_envelope.v1";
+const WORKFLOW_RUNTIME_TREE_DEFAULT_LIMIT: i64 = 100;
+const WORKFLOW_RUNTIME_TREE_MAX_LIMIT: i64 = 500;
+const WORKFLOW_RUNTIME_TREE_DEFAULT_JOB_LIMIT: i64 = 5;
+const WORKFLOW_RUNTIME_TREE_MAX_JOB_LIMIT: i64 = 50;
 
 fn startup_error_code(error: Option<&str>) -> Option<&'static str> {
     let error = error?;
@@ -133,6 +137,8 @@ pub(crate) struct ProjectWorkflowByProjectQuery {
 pub(crate) struct WorkflowRuntimeTreeQuery {
     pub project_id: Option<String>,
     pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub job_limit: Option<i64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -142,19 +148,25 @@ struct WorkflowRuntimeCommandNode {
     pub decision_id: Option<String>,
     pub status: String,
     pub command: WorkflowCommand,
+    pub runtime_job_count: usize,
     pub runtime_jobs: Vec<WorkflowRuntimeJobNode>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl WorkflowRuntimeCommandNode {
-    fn new(record: WorkflowCommandRecord, runtime_jobs: Vec<WorkflowRuntimeJobNode>) -> Self {
+    fn new(
+        record: WorkflowCommandRecord,
+        runtime_job_count: usize,
+        runtime_jobs: Vec<WorkflowRuntimeJobNode>,
+    ) -> Self {
         Self {
             id: record.id,
             workflow_id: record.workflow_id,
             decision_id: record.decision_id,
             status: record.status,
             command: record.command,
+            runtime_job_count,
             runtime_jobs,
             created_at: record.created_at,
             updated_at: record.updated_at,
@@ -190,6 +202,7 @@ impl WorkflowRuntimeJobNode {
 #[derive(Debug, Clone, serde::Serialize)]
 struct WorkflowRuntimeTreeNode {
     pub workflow: WorkflowInstance,
+    pub runtime_job_count: usize,
     pub events: Vec<WorkflowEvent>,
     pub decisions: Vec<WorkflowDecisionRecord>,
     pub commands: Vec<WorkflowRuntimeCommandNode>,
@@ -200,6 +213,46 @@ struct WorkflowRuntimeTreeNode {
 struct WorkflowRuntimeTreeResponse {
     pub workflows: Vec<WorkflowRuntimeTreeNode>,
     pub total_workflows: usize,
+    pub pagination: WorkflowRuntimeTreePagination,
+    pub summary: WorkflowRuntimeTreeSummary,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct WorkflowRuntimeTreePagination {
+    pub limit: usize,
+    pub offset: usize,
+    pub returned: usize,
+    pub total: usize,
+    pub has_more: bool,
+    pub next_offset: Option<usize>,
+    pub job_limit: usize,
+}
+
+impl WorkflowRuntimeTreePagination {
+    fn new(limit: i64, offset: i64, returned: usize, total: i64, job_limit: usize) -> Self {
+        let limit = limit.max(1) as usize;
+        let offset = offset.max(0) as usize;
+        let total = total.max(0) as usize;
+        let next_offset = offset.saturating_add(returned);
+        let has_more = next_offset < total;
+        Self {
+            limit,
+            offset,
+            returned,
+            total,
+            has_more,
+            next_offset: has_more.then_some(next_offset),
+            job_limit,
+        }
+    }
+}
+
+#[derive(Debug, Default, serde::Serialize)]
+struct WorkflowRuntimeTreeSummary {
+    pub total_commands: usize,
+    pub total_runtime_jobs: usize,
+    pub command_statuses: BTreeMap<String, usize>,
+    pub runtime_job_statuses: BTreeMap<String, usize>,
 }
 
 pub(crate) async fn get_issue_workflow_by_issue(
@@ -300,12 +353,20 @@ pub(crate) async fn get_workflow_runtime_tree(
         )
             .into_response();
     };
-    let limit = query.limit.unwrap_or(100).clamp(1, 500);
+    let limit = query
+        .limit
+        .unwrap_or(WORKFLOW_RUNTIME_TREE_DEFAULT_LIMIT)
+        .clamp(1, WORKFLOW_RUNTIME_TREE_MAX_LIMIT);
+    let offset = query.offset.unwrap_or(0).max(0);
+    let job_limit = query
+        .job_limit
+        .unwrap_or(WORKFLOW_RUNTIME_TREE_DEFAULT_JOB_LIMIT)
+        .clamp(0, WORKFLOW_RUNTIME_TREE_MAX_JOB_LIMIT);
     match store
-        .list_instances(query.project_id.as_deref(), limit)
+        .list_instances_page(query.project_id.as_deref(), limit, offset)
         .await
     {
-        Ok(instances) => match build_workflow_runtime_tree(store, instances).await {
+        Ok(page) => match build_workflow_runtime_tree(store, page, job_limit as usize).await {
             Ok(response) => (StatusCode::OK, Json(response)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -323,8 +384,10 @@ pub(crate) async fn get_workflow_runtime_tree(
 
 async fn build_workflow_runtime_tree(
     store: &harness_workflow::runtime::WorkflowRuntimeStore,
-    instances: Vec<WorkflowInstance>,
+    page: harness_workflow::runtime::store::WorkflowInstancePage,
+    job_limit: usize,
 ) -> anyhow::Result<WorkflowRuntimeTreeResponse> {
+    let instances = page.instances;
     let workflow_ids: Vec<String> = instances
         .iter()
         .map(|instance| instance.id.clone())
@@ -336,7 +399,13 @@ async fn build_workflow_runtime_tree(
         .values()
         .flat_map(|commands| commands.iter().map(|command| command.id.clone()))
         .collect();
-    let mut runtime_jobs_by_command = store.runtime_jobs_for_commands(&command_ids).await?;
+    let runtime_job_counts_by_command = store.runtime_job_counts_for_commands(&command_ids).await?;
+    let runtime_job_statuses = store
+        .runtime_job_status_counts_for_commands(&command_ids)
+        .await?;
+    let mut runtime_jobs_by_command = store
+        .runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
+        .await?;
     let runtime_job_ids: Vec<String> = runtime_jobs_by_command
         .values()
         .flat_map(|jobs| jobs.iter().map(|job| job.id.clone()))
@@ -345,6 +414,10 @@ async fn build_workflow_runtime_tree(
 
     let mut by_id = BTreeMap::new();
     let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut summary = WorkflowRuntimeTreeSummary {
+        runtime_job_statuses,
+        ..Default::default()
+    };
     for instance in instances {
         let workflow_id = instance.id.clone();
         if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
@@ -357,11 +430,15 @@ async fn build_workflow_runtime_tree(
         let decisions = decisions_by_workflow
             .remove(&workflow_id)
             .unwrap_or_default();
-        let commands = commands_by_workflow
+        let commands: Vec<WorkflowRuntimeCommandNode> = commands_by_workflow
             .remove(&workflow_id)
             .unwrap_or_default()
             .into_iter()
             .map(|command| {
+                let runtime_job_count = runtime_job_counts_by_command
+                    .get(&command.id)
+                    .copied()
+                    .unwrap_or_default();
                 let runtime_jobs = runtime_jobs_by_command
                     .remove(&command.id)
                     .unwrap_or_default()
@@ -372,13 +449,27 @@ async fn build_workflow_runtime_tree(
                         WorkflowRuntimeJobNode::new(job, runtime_events)
                     })
                     .collect();
-                WorkflowRuntimeCommandNode::new(command, runtime_jobs)
+                WorkflowRuntimeCommandNode::new(command, runtime_job_count, runtime_jobs)
             })
             .collect();
+        summary.total_commands += commands.len();
+        let runtime_job_count = commands
+            .iter()
+            .map(|command| {
+                summary
+                    .command_statuses
+                    .entry(command.status.clone())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                command.runtime_job_count
+            })
+            .sum();
+        summary.total_runtime_jobs += runtime_job_count;
         by_id.insert(
             workflow_id,
             WorkflowRuntimeTreeNode {
                 workflow: instance,
+                runtime_job_count,
                 events,
                 decisions,
                 commands,
@@ -413,7 +504,15 @@ async fn build_workflow_runtime_tree(
     }
 
     Ok(WorkflowRuntimeTreeResponse {
-        total_workflows: by_id.len(),
+        total_workflows: page.total.max(0) as usize,
+        pagination: WorkflowRuntimeTreePagination::new(
+            page.limit,
+            page.offset,
+            by_id.len(),
+            page.total,
+            job_limit,
+        ),
+        summary,
         workflows,
     })
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1140,9 +1140,15 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await?;
     assert_eq!(body["total_workflows"], 2);
+    assert_eq!(body["pagination"]["limit"], 100);
+    assert_eq!(body["pagination"]["offset"], 0);
+    assert_eq!(body["pagination"]["returned"], 2);
+    assert_eq!(body["summary"]["total_commands"], 1);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 1);
     assert_eq!(body["workflows"][0]["workflow"]["id"], "repo-backlog");
     let child_node = &body["workflows"][0]["children"][0];
     assert_eq!(child_node["workflow"]["id"], "issue-123");
+    assert_eq!(child_node["runtime_job_count"], 1);
     assert_eq!(
         child_node["decisions"][0]["rejection_reason"],
         "replan limit exhausted"
@@ -1184,6 +1190,72 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
         child_node["commands"][0]["runtime_jobs"][0]["activity_result_envelope"]["final_result"]
             ["status"],
         "succeeded"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_runtime_tree_endpoint_limits_runtime_jobs_per_command() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "replanning",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:456"),
+    )
+    .with_id("issue-456")
+    .with_data(serde_json::json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 456,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("replan_issue", "replan-456");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    for index in 0..7 {
+        store
+            .enqueue_runtime_job(
+                &command_id,
+                harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                "codex-high",
+                serde_json::json!({ "index": index }),
+            )
+            .await?;
+    }
+
+    let response = workflow_runtime_app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/tree?project_id=%2Fproject-a&job_limit=2")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    let node = &body["workflows"][0];
+    let command_node = &node["commands"][0];
+    assert_eq!(body["summary"]["total_commands"], 1);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 7);
+    assert_eq!(body["pagination"]["job_limit"], 2);
+    assert_eq!(node["runtime_job_count"], 7);
+    assert_eq!(command_node["runtime_job_count"], 7);
+    assert_eq!(
+        command_node["runtime_jobs"]
+            .as_array()
+            .expect("runtime_jobs should be an array")
+            .len(),
+        2
     );
     Ok(())
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1195,6 +1195,84 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
 }
 
 #[tokio::test]
+async fn workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_paginated(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    for (id, project_id, issue_number) in [
+        ("issue-101", "/project-a", 101),
+        ("issue-102", "/project-a", 102),
+        ("issue-201", "/project-b", 201),
+    ] {
+        let workflow = harness_workflow::runtime::WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "replanning",
+            harness_workflow::runtime::WorkflowSubject::new(
+                "issue",
+                format!("issue:{issue_number}"),
+            ),
+        )
+        .with_id(id)
+        .with_data(serde_json::json!({
+            "project_id": project_id,
+            "repo": "owner/repo",
+            "issue_number": issue_number,
+        }));
+        store.upsert_instance(&workflow).await?;
+        let command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+            "replan_issue",
+            format!("replan-{issue_number}"),
+        );
+        let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+        store
+            .enqueue_runtime_job(
+                &command_id,
+                harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                "codex-high",
+                serde_json::json!({ "workflow_id": workflow.id }),
+            )
+            .await?;
+    }
+
+    let response = workflow_runtime_app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/tree?project_id=%2Fproject-a&limit=1")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["total_workflows"], 2);
+    assert_eq!(body["pagination"]["returned"], 1);
+    assert_eq!(body["pagination"]["total"], 2);
+    assert_eq!(body["pagination"]["has_more"], true);
+    assert_eq!(
+        body["workflows"]
+            .as_array()
+            .expect("workflows should be an array")
+            .len(),
+        1
+    );
+    assert_eq!(body["summary"]["total_commands"], 2);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 2);
+    assert_eq!(body["summary"]["command_statuses"]["pending"], 2);
+    assert_eq!(body["summary"]["runtime_job_statuses"]["pending"], 2);
+    assert_eq!(body["summary"]["jobs_without_activity_envelope"], 2);
+    Ok(())
+}
+
+#[tokio::test]
 async fn workflow_runtime_tree_endpoint_limits_runtime_jobs_per_command() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -203,6 +203,16 @@ pub struct WorkflowInstancePage {
     pub offset: i64,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WorkflowRuntimeSummaryCounts {
+    pub total_commands: usize,
+    pub total_runtime_jobs: usize,
+    pub command_statuses: BTreeMap<String, usize>,
+    pub runtime_job_statuses: BTreeMap<String, usize>,
+    pub activity_outcomes: BTreeMap<String, usize>,
+    pub jobs_without_activity_envelope: usize,
+}
+
 pub struct WorkflowDecisionTransition<'a> {
     pub expected_state: &'a str,
     pub event_type: &'a str,
@@ -1833,6 +1843,98 @@ impl WorkflowRuntimeStore {
             .into_iter()
             .map(|(status, count)| (status, count.max(0) as usize))
             .collect())
+    }
+
+    pub async fn runtime_summary_counts_for_instances(
+        &self,
+        project_id: Option<&str>,
+        activity_envelope_artifact_type: &str,
+        activity_envelope_schema: &str,
+    ) -> anyhow::Result<WorkflowRuntimeSummaryCounts> {
+        let command_status_rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT command.status, COUNT(*)
+             FROM workflow_commands command
+             JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+             WHERE ($1::text IS NULL OR workflow.data->'data'->>'project_id' = $1)
+             GROUP BY command.status
+             ORDER BY command.status ASC",
+        )
+        .bind(project_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let command_statuses: BTreeMap<String, usize> = command_status_rows
+            .into_iter()
+            .map(|(status, count)| (status, count.max(0) as usize))
+            .collect();
+        let total_commands = command_statuses.values().sum();
+
+        let runtime_job_status_rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT job.status, COUNT(*)
+             FROM runtime_jobs job
+             JOIN workflow_commands command ON command.id = job.command_id
+             JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+             WHERE ($1::text IS NULL OR workflow.data->'data'->>'project_id' = $1)
+             GROUP BY job.status
+             ORDER BY job.status ASC",
+        )
+        .bind(project_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let runtime_job_statuses: BTreeMap<String, usize> = runtime_job_status_rows
+            .into_iter()
+            .map(|(status, count)| (status, count.max(0) as usize))
+            .collect();
+        let total_runtime_jobs = runtime_job_statuses.values().sum();
+
+        let activity_outcome_rows: Vec<(Option<String>, i64)> = sqlx::query_as(
+            "SELECT envelope.payload->>'outcome' AS outcome, COUNT(*)
+             FROM runtime_jobs job
+             JOIN workflow_commands command ON command.id = job.command_id
+             JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+             LEFT JOIN LATERAL (
+                 SELECT artifact.value->'artifact' AS payload
+                 FROM jsonb_array_elements(
+                     CASE
+                         WHEN jsonb_typeof(job.data->'output'->'artifacts') = 'array'
+                         THEN job.data->'output'->'artifacts'
+                         ELSE '[]'::jsonb
+                     END
+                 ) WITH ORDINALITY AS artifact(value, ordinal)
+                 WHERE artifact.value->>'artifact_type' = $2
+                   AND artifact.value->'artifact'->>'schema' = $3
+                 ORDER BY artifact.ordinal DESC
+                 LIMIT 1
+             ) envelope ON true
+             WHERE ($1::text IS NULL OR workflow.data->'data'->>'project_id' = $1)
+             GROUP BY envelope.payload->>'outcome'
+             ORDER BY envelope.payload->>'outcome' ASC NULLS FIRST",
+        )
+        .bind(project_id)
+        .bind(activity_envelope_artifact_type)
+        .bind(activity_envelope_schema)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut activity_outcomes = BTreeMap::new();
+        let mut jobs_without_activity_envelope = 0;
+        for (outcome, count) in activity_outcome_rows {
+            match outcome {
+                Some(outcome) => {
+                    activity_outcomes.insert(outcome, count.max(0) as usize);
+                }
+                None => {
+                    jobs_without_activity_envelope = count.max(0) as usize;
+                }
+            }
+        }
+
+        Ok(WorkflowRuntimeSummaryCounts {
+            total_commands,
+            total_runtime_jobs,
+            command_statuses,
+            runtime_job_statuses,
+            activity_outcomes,
+            jobs_without_activity_envelope,
+        })
     }
 
     pub async fn runtime_jobs_for_commands_limited(

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -184,10 +184,23 @@ static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
               )
               WHERE data->'data'->>'pr_number' IS NOT NULL",
     },
+    Migration {
+        version: 8,
+        description: "index runtime job command pagination",
+        sql: "CREATE INDEX IF NOT EXISTS idx_runtime_jobs_command_created
+              ON runtime_jobs (command_id, created_at DESC, id DESC)",
+    },
 ];
 
 pub struct WorkflowRuntimeStore {
     pool: PgPool,
+}
+
+pub struct WorkflowInstancePage {
+    pub instances: Vec<WorkflowInstance>,
+    pub total: i64,
+    pub limit: i64,
+    pub offset: i64,
 }
 
 pub struct WorkflowDecisionTransition<'a> {
@@ -586,20 +599,47 @@ impl WorkflowRuntimeStore {
         project_id: Option<&str>,
         limit: i64,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let page = self.list_instances_page(project_id, limit, 0).await?;
+        Ok(page.instances)
+    }
+
+    pub async fn list_instances_page(
+        &self,
+        project_id: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<WorkflowInstancePage> {
         let limit = limit.clamp(1, 500);
+        let offset = offset.max(0);
+        let (total,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)
+             FROM workflow_instances
+             WHERE ($1::text IS NULL OR data->'data'->>'project_id' = $1)",
+        )
+        .bind(project_id)
+        .fetch_one(&self.pool)
+        .await?;
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT data::text FROM workflow_instances
              WHERE ($1::text IS NULL OR data->'data'->>'project_id' = $1)
              ORDER BY updated_at DESC
-             LIMIT $2",
+             LIMIT $2 OFFSET $3",
         )
         .bind(project_id)
         .bind(limit)
+        .bind(offset)
         .fetch_all(&self.pool)
         .await?;
-        rows.into_iter()
+        let instances = rows
+            .into_iter()
             .map(|(data,)| Ok(serde_json::from_str(&data)?))
-            .collect()
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(WorkflowInstancePage {
+            instances,
+            total,
+            limit,
+            offset,
+        })
     }
 
     pub async fn list_instances_by_definition(
@@ -1738,6 +1778,86 @@ impl WorkflowRuntimeStore {
              ORDER BY command_id ASC, created_at ASC",
         )
         .bind(command_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut by_command = BTreeMap::new();
+        for (command_id, data) in rows {
+            by_command
+                .entry(command_id)
+                .or_insert_with(Vec::new)
+                .push(serde_json::from_str(&data)?);
+        }
+        Ok(by_command)
+    }
+
+    pub async fn runtime_job_counts_for_commands(
+        &self,
+        command_ids: &[String],
+    ) -> anyhow::Result<BTreeMap<String, usize>> {
+        if command_ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT command_id, COUNT(*)
+             FROM runtime_jobs
+             WHERE command_id = ANY($1::text[])
+             GROUP BY command_id",
+        )
+        .bind(command_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(command_id, count)| (command_id, count.max(0) as usize))
+            .collect())
+    }
+
+    pub async fn runtime_job_status_counts_for_commands(
+        &self,
+        command_ids: &[String],
+    ) -> anyhow::Result<BTreeMap<String, usize>> {
+        if command_ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT status, COUNT(*)
+             FROM runtime_jobs
+             WHERE command_id = ANY($1::text[])
+             GROUP BY status
+             ORDER BY status ASC",
+        )
+        .bind(command_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(status, count)| (status, count.max(0) as usize))
+            .collect())
+    }
+
+    pub async fn runtime_jobs_for_commands_limited(
+        &self,
+        command_ids: &[String],
+        per_command_limit: i64,
+    ) -> anyhow::Result<BTreeMap<String, Vec<RuntimeJob>>> {
+        if command_ids.is_empty() || per_command_limit <= 0 {
+            return Ok(BTreeMap::new());
+        }
+        let per_command_limit = per_command_limit.clamp(1, 50);
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT job.command_id, job.data
+             FROM unnest($1::text[]) AS selected(command_id)
+             JOIN LATERAL (
+                 SELECT command_id, data::text AS data, created_at, id
+                 FROM runtime_jobs
+                 WHERE command_id = selected.command_id
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT $2
+             ) AS job ON true
+             ORDER BY job.command_id ASC, job.created_at ASC, job.id ASC",
+        )
+        .bind(command_ids)
+        .bind(per_command_limit)
         .fetch_all(&self.pool)
         .await?;
         let mut by_command = BTreeMap::new();

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -622,7 +622,7 @@ impl WorkflowRuntimeStore {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT data::text FROM workflow_instances
              WHERE ($1::text IS NULL OR data->'data'->>'project_id' = $1)
-             ORDER BY updated_at DESC
+             ORDER BY updated_at DESC, id DESC
              LIMIT $2 OFFSET $3",
         )
         .bind(project_id)

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -260,6 +260,21 @@ describe("<Active>", () => {
     mockUseWorkflowRuntimeTree.mockReturnValue({
       data: {
         total_workflows: 2,
+        pagination: {
+          limit: 100,
+          offset: 0,
+          returned: 2,
+          total: 2,
+          has_more: false,
+          next_offset: null,
+          job_limit: 5,
+        },
+        summary: {
+          total_commands: 1,
+          total_runtime_jobs: 7,
+          command_statuses: { pending: 1 },
+          runtime_job_statuses: { failed: 3, running: 4 },
+        },
         workflows: [
           {
             workflow: {
@@ -327,6 +342,7 @@ describe("<Active>", () => {
                       dedupe_key: "issue-123-replan-2",
                       command: { activity: "replan_issue" },
                     },
+                    runtime_job_count: 7,
                     runtime_jobs: [
                       {
                         id: "job-1",
@@ -376,12 +392,14 @@ describe("<Active>", () => {
     wrap(<Active projectFilter="harness" />);
 
     expect(screen.getByText("Workflow Runtime")).toBeInTheDocument();
+    expect(screen.getByText("2/2 workflows")).toBeInTheDocument();
     expect(screen.getByText("repo_backlog - owner/repo")).toBeInTheDocument();
     expect(screen.getByText("github_issue_pr - issue:123")).toBeInTheDocument();
     expect(screen.getByText("activity: replan_issue")).toBeInTheDocument();
+    expect(screen.getByText("7 jobs")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "2 jobs - running - event ActivityStarted - prompt abcdef012345",
+        "2/7 jobs - running - event ActivityStarted - prompt abcdef012345",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("rejected: replan limit exhausted")).toBeInTheDocument();

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -126,11 +126,16 @@ function latestRuntimeJob(command: WorkflowRuntimeCommandNode): WorkflowRuntimeJ
 
 function runtimeJobLabel(command: WorkflowRuntimeCommandNode): string {
   const job = latestRuntimeJob(command);
-  if (!job) return `${command.runtime_jobs.length} jobs`;
+  const totalJobs = command.runtime_job_count ?? command.runtime_jobs.length;
+  const jobCountLabel =
+    totalJobs === command.runtime_jobs.length
+      ? `${totalJobs} jobs`
+      : `${command.runtime_jobs.length}/${totalJobs} jobs`;
+  if (!job) return jobCountLabel;
   const notBefore = job.not_before ? ` - not before ${job.not_before}` : "";
   const latestEvent = job.latest_runtime_event_type ? ` - event ${job.latest_runtime_event_type}` : "";
   const promptDigest = job.prompt_packet_digest ? ` - prompt ${job.prompt_packet_digest.slice(0, 12)}` : "";
-  return `${command.runtime_jobs.length} jobs - ${job.status}${notBefore}${latestEvent}${promptDigest}`;
+  return `${jobCountLabel} - ${job.status}${notBefore}${latestEvent}${promptDigest}`;
 }
 
 function runtimeMergeWorkflowId(workflow?: WorkflowSummary | null): string | null {
@@ -164,6 +169,23 @@ function workflowRuntimeCounts(nodes: WorkflowRuntimeTreeNode[]) {
   };
   for (const node of nodes) visit(node);
   return { workflows, commands, jobs, rejected };
+}
+
+function workflowRuntimePanelCounts(payload?: WorkflowRuntimeTreePayload) {
+  const counts = workflowRuntimeCounts(payload?.workflows ?? []);
+  return {
+    ...counts,
+    workflows: payload?.total_workflows ?? counts.workflows,
+    commands: payload?.summary?.total_commands ?? counts.commands,
+    jobs: payload?.summary?.total_runtime_jobs ?? counts.jobs,
+  };
+}
+
+function workflowRuntimeWorkflowLabel(payload: WorkflowRuntimeTreePayload | undefined, fallback: number) {
+  if (payload?.pagination) {
+    return `${payload.pagination.returned}/${payload.pagination.total}`;
+  }
+  return `${payload?.total_workflows ?? fallback}`;
 }
 
 function WorkflowRuntimeNode({
@@ -273,7 +295,7 @@ function WorkflowRuntimePanel({
   cancellingWorkflowIds?: Set<string>;
 }) {
   const workflows = payload?.workflows ?? [];
-  const counts = workflowRuntimeCounts(workflows);
+  const counts = workflowRuntimePanelCounts(payload);
   const empty = workflows.length === 0;
   return (
     <section className="border border-line bg-bg-1">
@@ -283,7 +305,7 @@ function WorkflowRuntimePanel({
             Workflow Runtime
           </div>
           <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] text-ink-3">
-            <span>{payload?.total_workflows ?? counts.workflows} workflows</span>
+            <span>{workflowRuntimeWorkflowLabel(payload, counts.workflows)} workflows</span>
             <span>{counts.commands} commands</span>
             <span>{counts.jobs} jobs</span>
             <span>{counts.rejected} rejected</span>

--- a/web/src/types/workflow_runtime.ts
+++ b/web/src/types/workflow_runtime.ts
@@ -1,10 +1,26 @@
 export interface WorkflowRuntimeTreePayload {
   workflows: WorkflowRuntimeTreeNode[];
   total_workflows: number;
+  pagination?: {
+    limit: number;
+    offset: number;
+    returned: number;
+    total: number;
+    has_more: boolean;
+    next_offset?: number | null;
+    job_limit: number;
+  };
+  summary?: {
+    total_commands: number;
+    total_runtime_jobs: number;
+    command_statuses: Record<string, number>;
+    runtime_job_statuses: Record<string, number>;
+  };
 }
 
 export interface WorkflowRuntimeTreeNode {
   workflow: WorkflowRuntimeInstance;
+  runtime_job_count?: number;
   events: WorkflowRuntimeEvent[];
   decisions: WorkflowRuntimeDecisionRecord[];
   commands: WorkflowRuntimeCommandNode[];
@@ -61,6 +77,7 @@ export interface WorkflowRuntimeCommandNode {
     dedupe_key: string;
     command: Record<string, unknown>;
   };
+  runtime_job_count?: number;
   runtime_jobs: WorkflowRuntimeJob[];
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- Add paginated workflow-runtime tree loading with `limit`, `offset`, and per-command `job_limit` query support.
- Add runtime job count/status summaries so dashboards and CLI status keep accurate totals while returning bounded job details.
- Add an index for command-scoped runtime job pagination and update the dashboard runtime panel to show returned/total workflow and job counts.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p harness-server workflow_runtime_tree_endpoint -- --nocapture`
- `cargo test -p harness-cli commands::status::tests -- --nocapture`
- `RUSTFLAGS=\"-Dwarnings\" cargo check --workspace --all-targets`
- `cargo test --workspace -- --test-threads=1`
- `bun run typecheck`
- `bun run test -- src/routes/dashboard/Active.test.tsx`
- `git diff --check`