### PR TITLE
feat(tasks): paginate task list queries

### DIFF
--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -1,18 +1,18 @@
 use axum::{
-    extract::{Path, State},
+    extract::{rejection::QueryRejection, Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use super::state::AppState;
 use crate::task_runner::{
     SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskState,
-    TaskStatus, TaskSummary, TaskWorkflowSummary,
+    TaskStatus, TaskSummary, TaskSummaryFilter, TaskWorkflowSummary,
 };
 use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
@@ -46,8 +46,112 @@ struct RuntimeTaskResponse {
     workflow: Option<TaskWorkflowSummary>,
 }
 
-pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
-    match state.core.tasks.list_all_summaries_with_terminal().await {
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawTaskListParams {
+    status: Option<String>,
+    scheduler_state: Option<String>,
+    active: Option<bool>,
+    kind: Option<String>,
+    source: Option<String>,
+    repo: Option<String>,
+    project_id: Option<String>,
+    limit: Option<u32>,
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TaskListQuery {
+    filter: TaskSummaryFilter,
+    limit: usize,
+    cursor: Option<TaskListCursor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TaskListCursor {
+    created_at: String,
+    id: String,
+}
+
+#[derive(Serialize)]
+struct TaskListResponse {
+    data: Vec<TaskSummary>,
+    page: TaskListPage,
+    counts: TaskListCounts,
+}
+
+#[derive(Serialize)]
+struct TaskListPage {
+    limit: usize,
+    has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_cursor: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TaskListCounts {
+    total: usize,
+    running: usize,
+    failed: usize,
+    by_status: BTreeMap<String, usize>,
+    by_scheduler_state: BTreeMap<String, usize>,
+}
+
+const DEFAULT_TASK_LIST_LIMIT: u32 = 50;
+const MAX_TASK_LIST_LIMIT: u32 = 500;
+
+#[derive(Debug)]
+struct TaskListQueryError {
+    error: &'static str,
+    message: String,
+    hint: Option<&'static str>,
+}
+
+impl IntoResponse for TaskListQueryError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": self.error,
+                "message": self.message,
+                "hint": self.hint,
+                "allowed": {
+                    "status": allowed_task_statuses(),
+                    "scheduler_state": allowed_scheduler_states(),
+                    "kind": ["issue", "pr", "prompt", "review", "planner"],
+                }
+            })),
+        )
+            .into_response()
+    }
+}
+
+pub(crate) async fn list_tasks(
+    State(state): State<Arc<AppState>>,
+    query: Result<Query<RawTaskListParams>, QueryRejection>,
+) -> Response {
+    let raw_query = match query {
+        Ok(Query(query)) => query,
+        Err(error) => {
+            return task_list_bad_request(
+                "invalid_query",
+                format!("Invalid /tasks query parameters: {error}"),
+                None,
+            )
+            .into_response();
+        }
+    };
+    let query = match TaskListQuery::from_raw(raw_query) {
+        Ok(query) => query,
+        Err(error) => return error.into_response(),
+    };
+
+    match state
+        .core
+        .tasks
+        .list_summaries_filtered_with_terminal(&query.filter)
+        .await
+    {
         Ok(mut summaries) => {
             if let Some(workflow_store) = state.core.issue_workflow_store.as_ref() {
                 // Bulk-fetch all workflows once to avoid O(N) sequential DB round trips.
@@ -102,10 +206,16 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
                     };
                 }
             }
-            if let Err(e) = append_runtime_submission_summaries(&state, &mut summaries).await {
+            if let Err(e) =
+                append_runtime_submission_summaries(&state, &mut summaries, &query.filter).await
+            {
                 tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
             }
-            Json(summaries).into_response()
+            summaries.retain(|summary| query.filter.matches_summary(summary));
+            sort_task_summaries(&mut summaries);
+            let counts = task_list_counts(&summaries);
+            let (data, page) = paginate_task_summaries(&summaries, &query);
+            Json(TaskListResponse { data, page, counts }).into_response()
         }
         Err(e) => {
             tracing::error!("list_tasks: database error: {e}");
@@ -118,9 +228,269 @@ pub(crate) async fn list_tasks(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
+impl TaskListQuery {
+    fn from_raw(raw: RawTaskListParams) -> Result<Self, TaskListQueryError> {
+        let statuses = parse_task_statuses(raw.status.as_deref())?;
+        let scheduler_states = parse_scheduler_states(raw.scheduler_state.as_deref())?;
+        let active = raw.active.unwrap_or(false);
+        if active && statuses.iter().any(TaskStatus::is_terminal) {
+            return Err(task_list_bad_request(
+                "invalid_filter",
+                "`active=true` cannot be combined with terminal task statuses.",
+                Some("Remove active=true or query terminal statuses without the active filter."),
+            ));
+        }
+        let limit = raw.limit.unwrap_or(DEFAULT_TASK_LIST_LIMIT);
+        if !(1..=MAX_TASK_LIST_LIMIT).contains(&limit) {
+            return Err(task_list_bad_request(
+                "invalid_limit",
+                format!("limit must be between 1 and {MAX_TASK_LIST_LIMIT}."),
+                None,
+            ));
+        }
+        Ok(Self {
+            filter: TaskSummaryFilter {
+                statuses,
+                scheduler_states,
+                kinds: parse_task_kinds(raw.kind.as_deref())?,
+                source: normalize_optional_query_value(raw.source),
+                repo: normalize_optional_query_value(raw.repo),
+                project: normalize_optional_query_value(raw.project_id),
+                active,
+            },
+            limit: limit as usize,
+            cursor: raw
+                .cursor
+                .as_deref()
+                .map(parse_task_list_cursor)
+                .transpose()?,
+        })
+    }
+}
+
+fn parse_task_statuses(raw: Option<&str>) -> Result<Vec<TaskStatus>, TaskListQueryError> {
+    parse_csv(raw)
+        .into_iter()
+        .map(|value| {
+            value.parse::<TaskStatus>().map_err(|_| {
+                let hint = if value == "running" {
+                    Some("Use scheduler_state=running instead of status=running.")
+                } else {
+                    None
+                };
+                task_list_bad_request(
+                    "invalid_status",
+                    format!("Unknown task status `{value}`."),
+                    hint,
+                )
+            })
+        })
+        .collect()
+}
+
+fn parse_scheduler_states(
+    raw: Option<&str>,
+) -> Result<Vec<SchedulerAuthorityState>, TaskListQueryError> {
+    parse_csv(raw)
+        .into_iter()
+        .map(|value| {
+            value.parse::<SchedulerAuthorityState>().map_err(|_| {
+                task_list_bad_request(
+                    "invalid_scheduler_state",
+                    format!("Unknown scheduler_state `{value}`."),
+                    None,
+                )
+            })
+        })
+        .collect()
+}
+
+fn parse_task_kinds(raw: Option<&str>) -> Result<Vec<TaskKind>, TaskListQueryError> {
+    parse_csv(raw)
+        .into_iter()
+        .map(|value| match value.as_str() {
+            "issue" => Ok(TaskKind::Issue),
+            "pr" => Ok(TaskKind::Pr),
+            "prompt" => Ok(TaskKind::Prompt),
+            "review" => Ok(TaskKind::Review),
+            "planner" => Ok(TaskKind::Planner),
+            _ => Err(task_list_bad_request(
+                "invalid_kind",
+                format!("Unknown task kind `{value}`."),
+                None,
+            )),
+        })
+        .collect()
+}
+
+fn parse_csv(raw: Option<&str>) -> Vec<String> {
+    raw.unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn normalize_optional_query_value(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn parse_task_list_cursor(raw: &str) -> Result<TaskListCursor, TaskListQueryError> {
+    let Some((created_at, id)) = raw.split_once('|') else {
+        return Err(task_list_bad_request(
+            "invalid_cursor",
+            "cursor must be the opaque value returned by the previous /tasks response.",
+            None,
+        ));
+    };
+    if id.trim().is_empty() {
+        return Err(task_list_bad_request(
+            "invalid_cursor",
+            "cursor task id is empty.",
+            None,
+        ));
+    }
+    Ok(TaskListCursor {
+        created_at: created_at.to_string(),
+        id: id.to_string(),
+    })
+}
+
+fn task_list_bad_request(
+    error: &'static str,
+    message: impl Into<String>,
+    hint: Option<&'static str>,
+) -> TaskListQueryError {
+    TaskListQueryError {
+        error,
+        message: message.into(),
+        hint,
+    }
+}
+
+fn allowed_task_statuses() -> Vec<&'static str> {
+    vec![
+        "pending",
+        "awaiting_deps",
+        "triaging",
+        "planning",
+        "implementing",
+        "review_generating",
+        "review_waiting",
+        "planner_generating",
+        "planner_waiting",
+        "agent_review",
+        "waiting",
+        "reviewing",
+        "done",
+        "failed",
+        "cancelled",
+    ]
+}
+
+fn allowed_scheduler_states() -> Vec<&'static str> {
+    vec![
+        "queued",
+        "awaiting_dependencies",
+        "running",
+        "retry_backoff",
+        "leased",
+        "recovering",
+        "done",
+        "failed",
+        "cancelled",
+    ]
+}
+
+fn sort_task_summaries(summaries: &mut [TaskSummary]) {
+    summaries.sort_by(|left, right| {
+        task_summary_sort_key(right)
+            .cmp(&task_summary_sort_key(left))
+            .then_with(|| right.id.as_str().cmp(left.id.as_str()))
+    });
+}
+
+fn task_summary_sort_key(summary: &TaskSummary) -> (&str, &str) {
+    (
+        summary.created_at.as_deref().unwrap_or(""),
+        summary.id.as_str(),
+    )
+}
+
+fn task_list_counts(summaries: &[TaskSummary]) -> TaskListCounts {
+    let mut by_status = BTreeMap::new();
+    let mut by_scheduler_state = BTreeMap::new();
+    for summary in summaries {
+        *by_status
+            .entry(summary.status.as_ref().to_string())
+            .or_insert(0) += 1;
+        *by_scheduler_state
+            .entry(summary.scheduler.authority_state.as_ref().to_string())
+            .or_insert(0) += 1;
+    }
+    TaskListCounts {
+        total: summaries.len(),
+        running: *by_scheduler_state.get("running").unwrap_or(&0),
+        failed: *by_status.get("failed").unwrap_or(&0),
+        by_status,
+        by_scheduler_state,
+    }
+}
+
+fn paginate_task_summaries(
+    summaries: &[TaskSummary],
+    query: &TaskListQuery,
+) -> (Vec<TaskSummary>, TaskListPage) {
+    let mut page = summaries
+        .iter()
+        .filter(|summary| {
+            query
+                .cursor
+                .as_ref()
+                .is_none_or(|cursor| task_is_after_cursor(summary, cursor))
+        })
+        .take(query.limit + 1)
+        .cloned()
+        .collect::<Vec<_>>();
+    let has_more = page.len() > query.limit;
+    if has_more {
+        page.truncate(query.limit);
+    }
+    let next_cursor = has_more
+        .then(|| page.last().map(task_list_cursor_for_summary))
+        .flatten();
+    (
+        page,
+        TaskListPage {
+            limit: query.limit,
+            has_more,
+            next_cursor,
+        },
+    )
+}
+
+fn task_is_after_cursor(summary: &TaskSummary, cursor: &TaskListCursor) -> bool {
+    let (created_at, id) = task_summary_sort_key(summary);
+    created_at < cursor.created_at.as_str()
+        || (created_at == cursor.created_at.as_str() && id < cursor.id.as_str())
+}
+
+fn task_list_cursor_for_summary(summary: &TaskSummary) -> String {
+    format!(
+        "{}|{}",
+        summary.created_at.as_deref().unwrap_or(""),
+        summary.id.as_str()
+    )
+}
+
 async fn append_runtime_submission_summaries(
     state: &AppState,
     summaries: &mut Vec<TaskSummary>,
+    filter: &TaskSummaryFilter,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(());
@@ -130,6 +500,7 @@ async fn append_runtime_submission_summaries(
         summaries,
         harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
         TaskKind::Issue,
+        filter,
     )
     .await?;
     append_runtime_definition_summaries(
@@ -137,6 +508,7 @@ async fn append_runtime_submission_summaries(
         summaries,
         harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
         TaskKind::Prompt,
+        filter,
     )
     .await
 }
@@ -146,9 +518,10 @@ async fn append_runtime_definition_summaries(
     summaries: &mut Vec<TaskSummary>,
     definition_id: &str,
     task_kind: TaskKind,
+    filter: &TaskSummaryFilter,
 ) -> anyhow::Result<()> {
     let workflows = store
-        .list_instances_by_definition(definition_id, None, None)
+        .list_instances_by_definition(definition_id, filter.project.as_deref(), None)
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()
@@ -163,7 +536,10 @@ async fn append_runtime_definition_summaries(
         if !listed_ids.insert(task_id.as_str().to_string()) {
             continue;
         }
-        summaries.push(runtime_workflow_task_summary(workflow, task_id, task_kind));
+        let summary = runtime_workflow_task_summary(workflow, task_id, task_kind);
+        if filter.matches_summary(&summary) {
+            summaries.push(summary);
+        }
     }
     Ok(())
 }
@@ -174,7 +550,7 @@ fn runtime_workflow_task_summary(
     task_kind: TaskKind,
 ) -> TaskSummary {
     let status = runtime_workflow_state_to_task_status(&workflow.state);
-    let scheduler = runtime_workflow_scheduler_state(&status);
+    let scheduler = runtime_workflow_scheduler_state(&workflow.state, &status);
     let issue = workflow
         .data
         .get("issue_number")
@@ -240,22 +616,39 @@ fn runtime_workflow_state_to_task_phase(state: &str) -> TaskPhase {
     }
 }
 
-fn runtime_workflow_scheduler_state(status: &TaskStatus) -> TaskSchedulerState {
-    match status {
-        TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
-        TaskStatus::Pending => TaskSchedulerState::queued(),
-        TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => {
-            let mut scheduler = TaskSchedulerState::queued();
-            scheduler.mark_terminal(status);
-            scheduler
-        }
-        _ => TaskSchedulerState {
+fn runtime_workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSchedulerState {
+    match state {
+        "awaiting_dependencies" => TaskSchedulerState::awaiting_dependencies(),
+        "scheduled" | "discovered" => TaskSchedulerState::queued(),
+        "implementing" | "replanning" | "addressing_feedback" => TaskSchedulerState {
             authority_state: SchedulerAuthorityState::Running,
             owner: None,
             run_generation: 0,
             recovery_generation: 0,
             lease_expires_at: None,
         },
+        "done" | "passed" | "failed" | "cancelled" => {
+            let mut scheduler = TaskSchedulerState::queued();
+            scheduler.mark_terminal(status);
+            scheduler
+        }
+        "pr_open" | "awaiting_feedback" | "ready_to_merge" | "blocked" => {
+            TaskSchedulerState::queued()
+        }
+        _ if matches!(status, TaskStatus::AwaitingDeps) => {
+            TaskSchedulerState::awaiting_dependencies()
+        }
+        _ if matches!(status, TaskStatus::Pending) => TaskSchedulerState::queued(),
+        _ if matches!(
+            status,
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+        ) =>
+        {
+            let mut scheduler = TaskSchedulerState::queued();
+            scheduler.mark_terminal(status);
+            scheduler
+        }
+        _ => TaskSchedulerState::queued(),
     }
 }
 

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -6,13 +6,14 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use super::state::AppState;
 use crate::task_runner::{
     SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskState,
-    TaskStatus, TaskSummary, TaskSummaryFilter, TaskWorkflowSummary,
+    TaskStatus, TaskSummary, TaskSummaryFilter, TaskSummaryPageCursor, TaskWorkflowSummary,
 };
 use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
@@ -69,7 +70,7 @@ struct TaskListQuery {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TaskListCursor {
-    created_at: String,
+    created_at: chrono::DateTime<chrono::Utc>,
     id: String,
 }
 
@@ -146,10 +147,19 @@ pub(crate) async fn list_tasks(
         Err(error) => return error.into_response(),
     };
 
+    let task_store_cursor = query
+        .cursor
+        .as_ref()
+        .map(TaskListCursor::as_task_summary_cursor);
+
     match state
         .core
         .tasks
-        .list_summaries_filtered_with_terminal(&query.filter)
+        .list_summaries_filtered_page_with_terminal(
+            &query.filter,
+            task_store_cursor.as_ref(),
+            query.limit + 1,
+        )
         .await
     {
         Ok(mut summaries) => {
@@ -206,12 +216,16 @@ pub(crate) async fn list_tasks(
                     };
                 }
             }
-            if let Err(e) =
-                append_runtime_submission_summaries(&state, &mut summaries, &query.filter).await
+            if let Err(e) = append_runtime_submission_summaries(
+                &state,
+                &mut summaries,
+                &query.filter,
+                query.limit + 1,
+            )
+            .await
             {
                 tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
             }
-            summaries.retain(|summary| query.filter.matches_summary(summary));
             sort_task_summaries(&mut summaries);
             let counts = task_list_counts(&summaries);
             let (data, page) = paginate_task_summaries(&summaries, &query);
@@ -355,9 +369,26 @@ fn parse_task_list_cursor(raw: &str) -> Result<TaskListCursor, TaskListQueryErro
         ));
     }
     Ok(TaskListCursor {
-        created_at: created_at.to_string(),
+        created_at: chrono::DateTime::parse_from_rfc3339(created_at)
+            .map_err(|_| {
+                task_list_bad_request(
+                    "invalid_cursor",
+                    "cursor created_at is not a valid RFC3339 timestamp.",
+                    None,
+                )
+            })?
+            .with_timezone(&chrono::Utc),
         id: id.to_string(),
     })
+}
+
+impl TaskListCursor {
+    fn as_task_summary_cursor(&self) -> TaskSummaryPageCursor {
+        TaskSummaryPageCursor {
+            created_at: self.created_at,
+            id: self.id.clone(),
+        }
+    }
 }
 
 fn task_list_bad_request(
@@ -407,18 +438,18 @@ fn allowed_scheduler_states() -> Vec<&'static str> {
 }
 
 fn sort_task_summaries(summaries: &mut [TaskSummary]) {
-    summaries.sort_by(|left, right| {
-        task_summary_sort_key(right)
-            .cmp(&task_summary_sort_key(left))
-            .then_with(|| right.id.as_str().cmp(left.id.as_str()))
-    });
+    summaries.sort_by(compare_task_summaries_desc);
 }
 
-fn task_summary_sort_key(summary: &TaskSummary) -> (&str, &str) {
-    (
-        summary.created_at.as_deref().unwrap_or(""),
-        summary.id.as_str(),
-    )
+fn compare_task_summaries_desc(left: &TaskSummary, right: &TaskSummary) -> Ordering {
+    match (left.created_at.as_deref(), right.created_at.as_deref()) {
+        (Some(left_created), Some(right_created)) => right_created
+            .cmp(left_created)
+            .then_with(|| right.id.as_str().cmp(left.id.as_str())),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => right.id.as_str().cmp(left.id.as_str()),
+    }
 }
 
 fn task_list_counts(summaries: &[TaskSummary]) -> TaskListCounts {
@@ -461,7 +492,7 @@ fn paginate_task_summaries(
         page.truncate(query.limit);
     }
     let next_cursor = has_more
-        .then(|| page.last().map(task_list_cursor_for_summary))
+        .then(|| page.last().and_then(task_list_cursor_for_summary))
         .flatten();
     (
         page,
@@ -474,23 +505,28 @@ fn paginate_task_summaries(
 }
 
 fn task_is_after_cursor(summary: &TaskSummary, cursor: &TaskListCursor) -> bool {
-    let (created_at, id) = task_summary_sort_key(summary);
-    created_at < cursor.created_at.as_str()
-        || (created_at == cursor.created_at.as_str() && id < cursor.id.as_str())
+    let Some(created_at) = summary
+        .created_at
+        .as_deref()
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+    else {
+        return false;
+    };
+    created_at < cursor.created_at
+        || (created_at == cursor.created_at && summary.id.as_str() < cursor.id.as_str())
 }
 
-fn task_list_cursor_for_summary(summary: &TaskSummary) -> String {
-    format!(
-        "{}|{}",
-        summary.created_at.as_deref().unwrap_or(""),
-        summary.id.as_str()
-    )
+fn task_list_cursor_for_summary(summary: &TaskSummary) -> Option<String> {
+    let created_at = summary.created_at.as_deref()?;
+    Some(format!("{}|{}", created_at, summary.id.as_str()))
 }
 
 async fn append_runtime_submission_summaries(
     state: &AppState,
     summaries: &mut Vec<TaskSummary>,
     filter: &TaskSummaryFilter,
+    limit: usize,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(());
@@ -501,6 +537,7 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
         TaskKind::Issue,
         filter,
+        limit,
     )
     .await?;
     append_runtime_definition_summaries(
@@ -509,6 +546,7 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
         TaskKind::Prompt,
         filter,
+        limit,
     )
     .await
 }
@@ -519,9 +557,14 @@ async fn append_runtime_definition_summaries(
     definition_id: &str,
     task_kind: TaskKind,
     filter: &TaskSummaryFilter,
+    limit: usize,
 ) -> anyhow::Result<()> {
     let workflows = store
-        .list_instances_by_definition(definition_id, filter.project.as_deref(), None)
+        .list_instances_by_definition(
+            definition_id,
+            filter.project.as_deref(),
+            Some(i64::try_from(limit.max(1)).unwrap_or(i64::MAX)),
+        )
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -216,13 +216,8 @@ pub(crate) async fn list_tasks(
                     };
                 }
             }
-            if let Err(e) = append_runtime_submission_summaries(
-                &state,
-                &mut summaries,
-                &query.filter,
-                query.limit + 1,
-            )
-            .await
+            if let Err(e) =
+                append_runtime_submission_summaries(&state, &mut summaries, &query.filter).await
             {
                 tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
             }
@@ -526,7 +521,6 @@ async fn append_runtime_submission_summaries(
     state: &AppState,
     summaries: &mut Vec<TaskSummary>,
     filter: &TaskSummaryFilter,
-    limit: usize,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(());
@@ -537,7 +531,6 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
         TaskKind::Issue,
         filter,
-        limit,
     )
     .await?;
     append_runtime_definition_summaries(
@@ -546,7 +539,6 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
         TaskKind::Prompt,
         filter,
-        limit,
     )
     .await
 }
@@ -557,14 +549,12 @@ async fn append_runtime_definition_summaries(
     definition_id: &str,
     task_kind: TaskKind,
     filter: &TaskSummaryFilter,
-    limit: usize,
 ) -> anyhow::Result<()> {
+    if !filter.kinds.is_empty() && !filter.kinds.contains(&task_kind) {
+        return Ok(());
+    }
     let workflows = store
-        .list_instances_by_definition(
-            definition_id,
-            filter.project.as_deref(),
-            Some(i64::try_from(limit.max(1)).unwrap_or(i64::MAX)),
-        )
+        .list_instances_by_definition(definition_id, filter.project.as_deref(), None)
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -4,6 +4,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::cmp::Ordering;
@@ -216,14 +217,20 @@ pub(crate) async fn list_tasks(
                     };
                 }
             }
-            if let Err(e) =
-                append_runtime_submission_summaries(&state, &mut summaries, &query.filter).await
+            if let Err(e) = append_runtime_submission_summaries(
+                &state,
+                &mut summaries,
+                &query.filter,
+                task_store_cursor.as_ref(),
+                query.limit + 1,
+            )
+            .await
             {
                 tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
             }
             sort_task_summaries(&mut summaries);
-            let counts = task_list_counts(&summaries);
             let (data, page) = paginate_task_summaries(&summaries, &query);
+            let counts = task_list_counts(&data);
             Json(TaskListResponse { data, page, counts }).into_response()
         }
         Err(e) => {
@@ -437,14 +444,25 @@ fn sort_task_summaries(summaries: &mut [TaskSummary]) {
 }
 
 fn compare_task_summaries_desc(left: &TaskSummary, right: &TaskSummary) -> Ordering {
-    match (left.created_at.as_deref(), right.created_at.as_deref()) {
+    match (
+        task_summary_created_at(left),
+        task_summary_created_at(right),
+    ) {
         (Some(left_created), Some(right_created)) => right_created
-            .cmp(left_created)
+            .cmp(&left_created)
             .then_with(|| right.id.as_str().cmp(left.id.as_str())),
         (Some(_), None) => Ordering::Less,
         (None, Some(_)) => Ordering::Greater,
         (None, None) => right.id.as_str().cmp(left.id.as_str()),
     }
+}
+
+fn task_summary_created_at(summary: &TaskSummary) -> Option<DateTime<Utc>> {
+    summary
+        .created_at
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
 }
 
 fn task_list_counts(summaries: &[TaskSummary]) -> TaskListCounts {
@@ -500,12 +518,7 @@ fn paginate_task_summaries(
 }
 
 fn task_is_after_cursor(summary: &TaskSummary, cursor: &TaskListCursor) -> bool {
-    let Some(created_at) = summary
-        .created_at
-        .as_deref()
-        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
-        .map(|value| value.with_timezone(&chrono::Utc))
-    else {
+    let Some(created_at) = task_summary_created_at(summary) else {
         return false;
     };
     created_at < cursor.created_at
@@ -521,6 +534,8 @@ async fn append_runtime_submission_summaries(
     state: &AppState,
     summaries: &mut Vec<TaskSummary>,
     filter: &TaskSummaryFilter,
+    cursor: Option<&TaskSummaryPageCursor>,
+    limit: usize,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(());
@@ -531,6 +546,8 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
         TaskKind::Issue,
         filter,
+        cursor,
+        limit,
     )
     .await?;
     append_runtime_definition_summaries(
@@ -539,6 +556,8 @@ async fn append_runtime_submission_summaries(
         harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
         TaskKind::Prompt,
         filter,
+        cursor,
+        limit,
     )
     .await
 }
@@ -549,12 +568,20 @@ async fn append_runtime_definition_summaries(
     definition_id: &str,
     task_kind: TaskKind,
     filter: &TaskSummaryFilter,
+    cursor: Option<&TaskSummaryPageCursor>,
+    limit: usize,
 ) -> anyhow::Result<()> {
     if !filter.kinds.is_empty() && !filter.kinds.contains(&task_kind) {
         return Ok(());
     }
     let workflows = store
-        .list_instances_by_definition(definition_id, filter.project.as_deref(), None)
+        .list_instances_by_definition_page(
+            definition_id,
+            filter.project.as_deref(),
+            cursor.map(|cursor| cursor.created_at),
+            cursor.map(|cursor| cursor.id.as_str()),
+            i64::try_from(limit.max(1)).unwrap_or(i64::MAX),
+        )
         .await?;
     let mut listed_ids: HashSet<String> = summaries
         .iter()
@@ -668,20 +695,16 @@ fn runtime_workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSch
         "pr_open" | "awaiting_feedback" | "ready_to_merge" | "blocked" => {
             TaskSchedulerState::queued()
         }
-        _ if matches!(status, TaskStatus::AwaitingDeps) => {
-            TaskSchedulerState::awaiting_dependencies()
-        }
-        _ if matches!(status, TaskStatus::Pending) => TaskSchedulerState::queued(),
-        _ if matches!(
-            status,
-            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
-        ) =>
-        {
-            let mut scheduler = TaskSchedulerState::queued();
-            scheduler.mark_terminal(status);
-            scheduler
-        }
-        _ => TaskSchedulerState::queued(),
+        _ => match status {
+            TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
+            TaskStatus::Pending => TaskSchedulerState::queued(),
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => {
+                let mut scheduler = TaskSchedulerState::queued();
+                scheduler.mark_terminal(status);
+                scheduler
+            }
+            _ => TaskSchedulerState::queued(),
+        },
     }
 }
 

--- a/crates/harness-server/src/http/task_query_routes_tests.rs
+++ b/crates/harness-server/src/http/task_query_routes_tests.rs
@@ -218,3 +218,37 @@ fn paginate_task_summaries_returns_next_cursor_and_resumes_after_it() {
     assert!(!second_metadata.has_more);
     assert_eq!(second_metadata.next_cursor, None);
 }
+
+#[test]
+fn task_list_counts_use_returned_page_only() {
+    let summaries = vec![
+        summary_with_created_at("task-c", "2026-05-20T03:00:00Z"),
+        summary_with_created_at("task-b", "2026-05-20T02:00:00Z"),
+        summary_with_created_at("task-a", "2026-05-20T01:00:00Z"),
+    ];
+    let query = TaskListQuery {
+        filter: TaskSummaryFilter::default(),
+        limit: 2,
+        cursor: None,
+    };
+
+    let (page, metadata) = paginate_task_summaries(&summaries, &query);
+    let counts = task_list_counts(&page);
+
+    assert!(metadata.has_more);
+    assert_eq!(page.len(), 2);
+    assert_eq!(counts.total, 2);
+}
+
+#[test]
+fn sort_task_summaries_compares_rfc3339_instants() {
+    let mut summaries = vec![
+        summary_with_created_at("older-whole-second", "2026-05-20T01:00:00Z"),
+        summary_with_created_at("newer-fractional", "2026-05-20T01:00:00.100Z"),
+    ];
+
+    sort_task_summaries(&mut summaries);
+
+    assert_eq!(summaries[0].id.as_str(), "newer-fractional");
+    assert_eq!(summaries[1].id.as_str(), "older-whole-second");
+}

--- a/crates/harness-server/src/http/task_query_routes_tests.rs
+++ b/crates/harness-server/src/http/task_query_routes_tests.rs
@@ -5,6 +5,12 @@ fn task_with_id(id: &str) -> TaskState {
     TaskState::new(harness_core::types::TaskId(id.to_string()))
 }
 
+fn summary_with_created_at(id: &str, created_at: &str) -> TaskSummary {
+    let mut task = task_with_id(id);
+    task.created_at = Some(created_at.to_string());
+    task.summary()
+}
+
 #[test]
 fn proof_for_done_task_with_lgtm_is_passed_and_approved() {
     let mut task = task_with_id("done-lgtm");
@@ -140,4 +146,75 @@ fn proof_counts_agent_review_issues_as_changes_requested() {
     assert_eq!(proof.review_outcome, ReviewOutcome::ChangesRequested);
     assert_eq!(proof.ci_status, CiStatus::Unknown);
     assert_eq!(proof.review_rounds, 1);
+}
+
+#[test]
+fn runtime_workflow_scheduler_state_only_marks_executing_states_running() {
+    let blocked = runtime_workflow_scheduler_state("blocked", &TaskStatus::Waiting);
+    assert_eq!(blocked.authority_state, SchedulerAuthorityState::Queued);
+
+    let awaiting_feedback =
+        runtime_workflow_scheduler_state("awaiting_feedback", &TaskStatus::Waiting);
+    assert_eq!(
+        awaiting_feedback.authority_state,
+        SchedulerAuthorityState::Queued
+    );
+
+    let implementing = runtime_workflow_scheduler_state("implementing", &TaskStatus::Implementing);
+    assert_eq!(
+        implementing.authority_state,
+        SchedulerAuthorityState::Running
+    );
+}
+
+#[test]
+fn paginate_task_summaries_returns_next_cursor_and_resumes_after_it() {
+    let mut summaries = vec![
+        summary_with_created_at("task-a", "2026-05-20T01:00:00Z"),
+        summary_with_created_at("task-c", "2026-05-20T03:00:00Z"),
+        summary_with_created_at("task-b", "2026-05-20T02:00:00Z"),
+    ];
+    sort_task_summaries(&mut summaries);
+    let first_query = TaskListQuery {
+        filter: TaskSummaryFilter::default(),
+        limit: 2,
+        cursor: None,
+    };
+
+    let (first_page, first_metadata) = paginate_task_summaries(&summaries, &first_query);
+
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|summary| summary.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-c", "task-b"]
+    );
+    assert!(first_metadata.has_more);
+    assert_eq!(
+        first_metadata.next_cursor.as_deref(),
+        Some("2026-05-20T02:00:00Z|task-b")
+    );
+
+    let second_query = TaskListQuery {
+        filter: TaskSummaryFilter::default(),
+        limit: 2,
+        cursor: first_metadata
+            .next_cursor
+            .as_deref()
+            .map(parse_task_list_cursor)
+            .transpose()
+            .expect("cursor should parse"),
+    };
+    let (second_page, second_metadata) = paginate_task_summaries(&summaries, &second_query);
+
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|summary| summary.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-a"]
+    );
+    assert!(!second_metadata.has_more);
+    assert_eq!(second_metadata.next_cursor, None);
 }

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -3706,7 +3706,7 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
         .await?;
     assert_eq!(list_response.status(), StatusCode::OK);
     let listed = response_json(list_response).await?;
-    let tasks = listed.as_array().expect("tasks should be an array");
+    let tasks = listed["data"].as_array().expect("tasks should be an array");
     let runtime_task = tasks
         .iter()
         .find(|task| task["id"] == task_id)
@@ -3999,7 +3999,7 @@ async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> 
         .await?;
     assert_eq!(list_response.status(), StatusCode::OK);
     let listed = response_json(list_response).await?;
-    let tasks = listed.as_array().expect("tasks should be an array");
+    let tasks = listed["data"].as_array().expect("tasks should be an array");
     let runtime_task = tasks
         .iter()
         .find(|task| task["id"] == task_id)
@@ -5028,13 +5028,101 @@ async fn list_tasks_exposes_task_kind_and_non_implementation_statuses() -> anyho
     assert_eq!(response.status(), StatusCode::OK);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
     let tasks: serde_json::Value = serde_json::from_slice(&body)?;
-    let tasks = tasks.as_array().expect("tasks array");
+    let tasks = tasks["data"].as_array().expect("tasks array");
     assert!(tasks
         .iter()
         .any(|task| { task["task_kind"] == "review" && task["status"] == "review_waiting" }));
     assert!(tasks
         .iter()
         .any(|task| { task["task_kind"] == "planner" && task["status"] == "planner_generating" }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_tasks_rejects_running_as_task_status() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks?status=running")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "invalid_status");
+    assert_eq!(
+        body["hint"],
+        "Use scheduler_state=running instead of status=running."
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_tasks_rejects_invalid_limit() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks?limit=0")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "invalid_limit");
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_tasks_filters_by_scheduler_state_and_returns_envelope() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .with_state(state.clone());
+
+    let mut running_task = task_runner::TaskState::new(task_runner::TaskId::new());
+    running_task.status = task_runner::TaskStatus::Implementing;
+    running_task.scheduler.claim_scheduler("test-scheduler");
+    let running_task_id = running_task.id.0.clone();
+
+    let mut queued_task = task_runner::TaskState::new(task_runner::TaskId::new());
+    queued_task.status = task_runner::TaskStatus::Pending;
+    queued_task.scheduler = task_runner::TaskSchedulerState::queued();
+
+    state.core.tasks.insert(&running_task).await;
+    state.core.tasks.insert(&queued_task).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks?scheduler_state=running&limit=1")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    let tasks = body["data"].as_array().expect("tasks array");
+
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0]["id"], running_task_id);
+    assert_eq!(tasks[0]["scheduler"]["authority_state"], "running");
+    assert_eq!(body["page"]["limit"], 1);
+    assert_eq!(body["counts"]["total"], 1);
+    assert_eq!(body["counts"]["running"], 1);
     Ok(())
 }
 
@@ -5182,7 +5270,7 @@ async fn list_tasks_enriches_workflows_for_issue_and_pr_tasks() -> anyhow::Resul
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
     let tasks: serde_json::Value = serde_json::from_slice(&body)?;
-    let tasks = tasks.as_array().expect("tasks array");
+    let tasks = tasks["data"].as_array().expect("tasks array");
 
     let issue_json = tasks
         .iter()
@@ -5297,7 +5385,8 @@ async fn list_tasks_exposes_workflow_fallback_metadata() -> anyhow::Result<()> {
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
     let tasks: serde_json::Value = serde_json::from_slice(&body)?;
     let task = tasks
-        .as_array()
+        .get("data")
+        .and_then(serde_json::Value::as_array)
         .and_then(|tasks| tasks.first())
         .expect("task row");
     assert_eq!(task["workflow"]["state"], "ready_to_merge");

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -4023,6 +4023,97 @@ async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> 
 }
 
 #[tokio::test]
+async fn list_tasks_paginates_past_runtime_only_second_page() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = Router::new()
+        .route("/tasks", get(list_tasks).post(task_routes::create_task))
+        .with_state(state);
+
+    let mut created_ids = Vec::new();
+    for index in 0..3 {
+        let body = serde_json::json!({
+            "project": project_root.display().to_string(),
+            "prompt": format!("runtime prompt page {index}"),
+            "source": "dashboard",
+            "external_id": format!("manual:prompt:page:{index}")
+        });
+        let create_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))?,
+            )
+            .await?;
+        assert_eq!(create_response.status(), StatusCode::ACCEPTED);
+        let created = response_json(create_response).await?;
+        created_ids.push(
+            created["task_id"]
+                .as_str()
+                .expect("runtime submission should return a task handle")
+                .to_string(),
+        );
+    }
+
+    let mut cursor: Option<String> = None;
+    let mut listed_ids = Vec::new();
+    for page_index in 0..3 {
+        let uri = match cursor.as_deref() {
+            Some(cursor) => format!(
+                "/tasks?limit=1&cursor={}",
+                cursor
+                    .replace('+', "%2B")
+                    .replace(':', "%3A")
+                    .replace('|', "%7C")
+            ),
+            None => "/tasks?limit=1".to_string(),
+        };
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await?;
+        let tasks = body["data"].as_array().expect("tasks should be an array");
+        assert_eq!(tasks.len(), 1, "page {page_index} should contain one task");
+        listed_ids.push(
+            tasks[0]["id"]
+                .as_str()
+                .expect("task id should be present")
+                .to_string(),
+        );
+        cursor = body["page"]["next_cursor"].as_str().map(str::to_string);
+        if page_index < 2 {
+            assert!(
+                body["page"]["has_more"].as_bool().unwrap_or(false),
+                "page {page_index} should expose another runtime-only page"
+            );
+            assert!(cursor.is_some(), "page {page_index} should return a cursor");
+        }
+    }
+
+    created_ids.sort();
+    listed_ids.sort();
+    assert_eq!(listed_ids, created_ids);
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_task_with_blocked_issue_returns_runtime_state() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -17,6 +17,7 @@ use harness_core::db::Migration;
 /// v20 – add system_input column for restart-safe system prompt bundles.
 /// v21 – add workspace lifecycle ownership and failure classification columns.
 /// v22 – add scheduler_state column as the single authoritative ownership/recovery contract.
+/// v23 – add indexes for server-side task list filters.
 pub(super) static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -161,5 +162,17 @@ pub(super) static TASK_MIGRATIONS: &[Migration] = &[
         description: "add scheduler_state column for unified task ownership and recovery",
         sql: "ALTER TABLE tasks ADD COLUMN scheduler_state TEXT NOT NULL DEFAULT \
               '{\"authority_state\":\"queued\",\"run_generation\":0,\"recovery_generation\":0}'",
+    },
+    Migration {
+        version: 23,
+        description: "add indexes for task list filters",
+        sql: "CREATE INDEX IF NOT EXISTS idx_tasks_scheduler_state_created \
+              ON tasks((scheduler_state::jsonb ->> 'authority_state'), created_at DESC); \
+              CREATE INDEX IF NOT EXISTS idx_tasks_repo_created \
+              ON tasks(repo, created_at DESC); \
+              CREATE INDEX IF NOT EXISTS idx_tasks_source_created \
+              ON tasks(source, created_at DESC); \
+              CREATE INDEX IF NOT EXISTS idx_tasks_kind_created \
+              ON tasks(task_kind, created_at DESC)",
     },
 ];

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -1,4 +1,4 @@
-use crate::task_runner::{TaskState, TaskStatus, TaskSummaryFilter};
+use crate::task_runner::{TaskState, TaskStatus, TaskSummaryFilter, TaskSummaryPageCursor};
 use chrono::{DateTime, Utc};
 use sqlx::{Postgres, QueryBuilder};
 use std::collections::HashMap;
@@ -416,6 +416,51 @@ impl TaskDb {
         Ok(summaries)
     }
 
+    pub async fn list_summaries_filtered_page(
+        &self,
+        filter: &TaskSummaryFilter,
+        cursor: Option<&TaskSummaryPageCursor>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
+             created_at, repo, depends_on, project, workspace_path, workspace_owner, \
+             run_generation, phase, description, scheduler_state FROM tasks",
+        );
+        let mut has_where = push_task_summary_filter(&mut query, filter);
+        if let Some(cursor) = cursor {
+            push_where_prefix(&mut query, &mut has_where);
+            query.push("(created_at < ");
+            query.push_bind(cursor.created_at);
+            query.push(" OR (created_at = ");
+            query.push_bind(cursor.created_at);
+            query.push(" AND id < ");
+            query.push_bind(cursor.id.as_str());
+            query.push("))");
+        }
+        query.push(" ORDER BY created_at DESC, id DESC LIMIT ");
+        query.push_bind(i64::try_from(limit.max(1)).unwrap_or(i64::MAX));
+
+        let rows = query
+            .build_query_as::<TaskSummaryRow>()
+            .fetch_all(&self.pool)
+            .await?;
+        let mut summaries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id = row.id.clone();
+            match TaskSummaryRow::try_into_summary(row) {
+                Ok(summary) => summaries.push(summary),
+                Err(error) => {
+                    tracing::warn!(
+                        task_id = %id,
+                        "skipping malformed task row in list_summaries_filtered_page: {error}"
+                    );
+                }
+            }
+        }
+        Ok(summaries)
+    }
+
     /// Return `(task_id, first_token_latency_ms)` pairs for the 500 most-recently
     /// completed terminal tasks. Latency extracted via jsonb correlated subquery.
     pub async fn list_terminal_first_token_latencies_ms(
@@ -731,7 +776,7 @@ fn decode_task_summary_rows(
 fn push_task_summary_filter<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     filter: &'a TaskSummaryFilter,
-) {
+) -> bool {
     let mut has_where = false;
 
     if !filter.statuses.is_empty() {
@@ -791,6 +836,8 @@ fn push_task_summary_filter<'a>(
         query.push("project = ");
         query.push_bind(project.to_string());
     }
+
+    has_where
 }
 
 fn push_where_prefix(query: &mut QueryBuilder<'_, Postgres>, has_where: &mut bool) {

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -1,5 +1,6 @@
-use crate::task_runner::{TaskState, TaskStatus};
+use crate::task_runner::{TaskState, TaskStatus, TaskSummaryFilter};
 use chrono::{DateTime, Utc};
+use sqlx::{Postgres, QueryBuilder};
 use std::collections::HashMap;
 
 use super::types::{
@@ -382,6 +383,39 @@ impl TaskDb {
         Ok(decode_task_summary_rows(rows, "list_active_summaries"))
     }
 
+    pub async fn list_summaries_filtered(
+        &self,
+        filter: &TaskSummaryFilter,
+    ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
+             created_at, repo, depends_on, project, workspace_path, workspace_owner, \
+             run_generation, phase, description, scheduler_state FROM tasks",
+        );
+        push_task_summary_filter(&mut query, filter);
+        query.push(" ORDER BY created_at DESC, id DESC");
+
+        let rows = query
+            .build_query_as::<TaskSummaryRow>()
+            .fetch_all(&self.pool)
+            .await?;
+        let mut summaries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id = row.id.clone();
+            match TaskSummaryRow::try_into_summary(row) {
+                Ok(summary) if filter.matches_summary(&summary) => summaries.push(summary),
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        task_id = %id,
+                        "skipping malformed task row in list_summaries_filtered: {error}"
+                    );
+                }
+            }
+        }
+        Ok(summaries)
+    }
+
     /// Return `(task_id, first_token_latency_ms)` pairs for the 500 most-recently
     /// completed terminal tasks. Latency extracted via jsonb correlated subquery.
     pub async fn list_terminal_first_token_latencies_ms(
@@ -692,6 +726,80 @@ fn decode_task_summary_rows(
         }
     }
     summaries
+}
+
+fn push_task_summary_filter<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    filter: &'a TaskSummaryFilter,
+) {
+    let mut has_where = false;
+
+    if !filter.statuses.is_empty() {
+        push_where_prefix(query, &mut has_where);
+        query.push("status IN (");
+        let mut separated = query.separated(", ");
+        for status in &filter.statuses {
+            separated.push_bind(status.as_ref());
+        }
+        separated.push_unseparated(")");
+    }
+
+    if filter.active {
+        push_where_prefix(query, &mut has_where);
+        query.push("status NOT IN (");
+        let mut separated = query.separated(", ");
+        for status in TaskStatus::terminal_statuses() {
+            separated.push_bind(*status);
+        }
+        separated.push_unseparated(")");
+    }
+
+    if !filter.scheduler_states.is_empty() {
+        push_where_prefix(query, &mut has_where);
+        query.push("(scheduler_state::jsonb ->> 'authority_state') IN (");
+        let mut separated = query.separated(", ");
+        for state in &filter.scheduler_states {
+            separated.push_bind(state.as_ref());
+        }
+        separated.push_unseparated(")");
+    }
+
+    if !filter.kinds.is_empty() {
+        push_where_prefix(query, &mut has_where);
+        query.push("task_kind IN (");
+        let mut separated = query.separated(", ");
+        for kind in &filter.kinds {
+            separated.push_bind(kind.as_ref());
+        }
+        separated.push_unseparated(")");
+    }
+
+    if let Some(source) = filter.source.as_deref() {
+        push_where_prefix(query, &mut has_where);
+        query.push("source = ");
+        query.push_bind(source.to_string());
+    }
+
+    if let Some(repo) = filter.repo.as_deref() {
+        push_where_prefix(query, &mut has_where);
+        query.push("repo = ");
+        query.push_bind(repo.to_string());
+    }
+
+    if let Some(project) = filter.project.as_deref() {
+        push_where_prefix(query, &mut has_where);
+        query.push("project = ");
+        query.push_bind(project.to_string());
+    }
+}
+
+fn push_where_prefix(query: &mut QueryBuilder<'_, Postgres>, has_where: &mut bool) {
+    if *has_where {
+        query.push(" AND ");
+    } else {
+        query.push(" WHERE ");
+        *has_where = true;
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -403,8 +403,7 @@ impl TaskDb {
         for row in rows {
             let id = row.id.clone();
             match TaskSummaryRow::try_into_summary(row) {
-                Ok(summary) if filter.matches_summary(&summary) => summaries.push(summary),
-                Ok(_) => {}
+                Ok(summary) => summaries.push(summary),
                 Err(error) => {
                     tracing::warn!(
                         task_id = %id,

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -27,7 +27,9 @@ pub use state::{
     RecentFailureTask, RoundResult, SchedulerAuthorityState, SchedulerOwner, SchedulerOwnerKind,
     TaskSchedulerState, TaskState, TaskSummary, TaskWorkflowSummary,
 };
-pub use store::{mutate_and_persist, update_status, TaskStore, TaskSummaryFilter};
+pub use store::{
+    mutate_and_persist, update_status, TaskStore, TaskSummaryFilter, TaskSummaryPageCursor,
+};
 pub use types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};
 
 impl TaskStore {

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -27,7 +27,7 @@ pub use state::{
     RecentFailureTask, RoundResult, SchedulerAuthorityState, SchedulerOwner, SchedulerOwnerKind,
     TaskSchedulerState, TaskState, TaskSummary, TaskWorkflowSummary,
 };
-pub use store::{mutate_and_persist, update_status, TaskStore};
+pub use store::{mutate_and_persist, update_status, TaskStore, TaskSummaryFilter};
 pub use types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};
 
 impl TaskStore {

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -73,6 +73,47 @@ pub enum SchedulerAuthorityState {
     Cancelled,
 }
 
+impl SchedulerAuthorityState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::AwaitingDependencies => "awaiting_dependencies",
+            Self::Running => "running",
+            Self::RetryBackoff => "retry_backoff",
+            Self::Leased => "leased",
+            Self::Recovering => "recovering",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl std::str::FromStr for SchedulerAuthorityState {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "awaiting_dependencies" => Ok(Self::AwaitingDependencies),
+            "running" => Ok(Self::Running),
+            "retry_backoff" => Ok(Self::RetryBackoff),
+            "leased" => Ok(Self::Leased),
+            "recovering" => Ok(Self::Recovering),
+            "done" => Ok(Self::Done),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => anyhow::bail!("unknown scheduler state `{value}`"),
+        }
+    }
+}
+
+impl AsRef<str> for SchedulerAuthorityState {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskSchedulerState {
     #[serde(default)]

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 use tokio::sync::{broadcast, Mutex, RwLock};
 
 use super::metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
-use super::state::{SchedulerOwnerKind, TaskState, TaskSummary};
-use super::types::{TaskId, TaskStatus};
+use super::state::{SchedulerAuthorityState, SchedulerOwnerKind, TaskState, TaskSummary};
+use super::types::{TaskId, TaskKind, TaskStatus};
 use super::CompletionCallback;
 
 /// Broadcast channel capacity for per-task stream events.
@@ -48,6 +48,60 @@ pub struct TaskStore {
     /// Append-only JSONL event log for crash recovery. `None` if the file
     /// could not be opened (best-effort; server still starts without it).
     pub(crate) event_log: Option<Arc<crate::event_replay::TaskEventLog>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TaskSummaryFilter {
+    pub statuses: Vec<TaskStatus>,
+    pub scheduler_states: Vec<SchedulerAuthorityState>,
+    pub kinds: Vec<TaskKind>,
+    pub source: Option<String>,
+    pub repo: Option<String>,
+    pub project: Option<String>,
+    pub active: bool,
+}
+
+impl TaskSummaryFilter {
+    pub fn matches_summary(&self, summary: &TaskSummary) -> bool {
+        if !self.statuses.is_empty() && !self.statuses.contains(&summary.status) {
+            return false;
+        }
+        if self.active && summary.status.is_terminal() {
+            return false;
+        }
+        if !self.scheduler_states.is_empty()
+            && !self
+                .scheduler_states
+                .contains(&summary.scheduler.authority_state)
+        {
+            return false;
+        }
+        if !self.kinds.is_empty() && !self.kinds.contains(&summary.task_kind) {
+            return false;
+        }
+        if self
+            .source
+            .as_deref()
+            .is_some_and(|source| summary.source.as_deref() != Some(source))
+        {
+            return false;
+        }
+        if self
+            .repo
+            .as_deref()
+            .is_some_and(|repo| summary.repo.as_deref() != Some(repo))
+        {
+            return false;
+        }
+        if self
+            .project
+            .as_deref()
+            .is_some_and(|project| summary.project.as_deref() != Some(project))
+        {
+            return false;
+        }
+        true
+    }
 }
 
 impl TaskStore {
@@ -368,6 +422,28 @@ impl TaskStore {
                 by_id.remove(&summary.id);
             } else {
                 by_id.insert(entry.key().clone(), summary);
+            }
+        }
+        Ok(by_id.into_values().collect())
+    }
+
+    pub async fn list_summaries_filtered_with_terminal(
+        &self,
+        filter: &TaskSummaryFilter,
+    ) -> anyhow::Result<Vec<TaskSummary>> {
+        let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
+            .db
+            .list_summaries_filtered(filter)
+            .await?
+            .into_iter()
+            .map(|summary| (summary.id.clone(), summary))
+            .collect();
+        for entry in self.cache.iter() {
+            let summary = entry.value().summary();
+            if filter.matches_summary(&summary) {
+                by_id.insert(entry.key().clone(), summary);
+            } else {
+                by_id.remove(entry.key());
             }
         }
         Ok(by_id.into_values().collect())

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1,5 +1,5 @@
 use crate::task_db::TaskDb;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use futures::StreamExt;
 use harness_core::agent::StreamItem;
@@ -61,6 +61,12 @@ pub struct TaskSummaryFilter {
     pub active: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskSummaryPageCursor {
+    pub created_at: DateTime<Utc>,
+    pub id: String,
+}
+
 impl TaskSummaryFilter {
     pub fn matches_summary(&self, summary: &TaskSummary) -> bool {
         if !self.statuses.is_empty() && !self.statuses.contains(&summary.status) {
@@ -102,6 +108,19 @@ impl TaskSummaryFilter {
         }
         true
     }
+}
+
+fn task_summary_is_after_cursor(summary: &TaskSummary, cursor: &TaskSummaryPageCursor) -> bool {
+    let Some(created_at) = summary
+        .created_at
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+    else {
+        return false;
+    };
+    created_at < cursor.created_at
+        || (created_at == cursor.created_at && summary.id.as_str() < cursor.id.as_str())
 }
 
 impl TaskStore {
@@ -441,6 +460,33 @@ impl TaskStore {
         for entry in self.cache.iter() {
             let summary = entry.value().summary();
             if filter.matches_summary(&summary) {
+                by_id.insert(entry.key().clone(), summary);
+            } else {
+                by_id.remove(entry.key());
+            }
+        }
+        Ok(by_id.into_values().collect())
+    }
+
+    pub async fn list_summaries_filtered_page_with_terminal(
+        &self,
+        filter: &TaskSummaryFilter,
+        cursor: Option<&TaskSummaryPageCursor>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<TaskSummary>> {
+        let db_limit = limit.saturating_add(self.cache.len()).saturating_add(1);
+        let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
+            .db
+            .list_summaries_filtered_page(filter, cursor, db_limit)
+            .await?
+            .into_iter()
+            .map(|summary| (summary.id.clone(), summary))
+            .collect();
+        for entry in self.cache.iter() {
+            let summary = entry.value().summary();
+            if filter.matches_summary(&summary)
+                && cursor.is_none_or(|cursor| task_summary_is_after_cursor(&summary, cursor))
+            {
                 by_id.insert(entry.key().clone(), summary);
             } else {
                 by_id.remove(entry.key());

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -626,6 +626,43 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn list_instances_by_definition_page(
+        &self,
+        definition_id: &str,
+        project_id: Option<&str>,
+        cursor_created_at: Option<DateTime<Utc>>,
+        cursor_id: Option<&str>,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let limit = limit.max(1);
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE definition_id = $1
+               AND ($2::text IS NULL OR data->'data'->>'project_id' = $2)
+               AND (
+                   $3::timestamptz IS NULL
+                   OR (data->>'created_at')::timestamptz < $3
+                   OR (
+                       (data->>'created_at')::timestamptz = $3
+                       AND COALESCE(data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) < COALESCE($4::text, '')
+                   )
+               )
+             ORDER BY (data->>'created_at')::timestamptz DESC,
+                      COALESCE(data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) DESC
+             LIMIT $5",
+        )
+        .bind(definition_id)
+        .bind(project_id)
+        .bind(cursor_created_at)
+        .bind(cursor_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
     pub async fn list_nonterminal_instances_by_definition(
         &self,
         definition_id: &str,

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -142,6 +142,30 @@ The design is intentional:
 | Load rules for an agent to respect | `rule/load` (JSON-RPC) |
 | Record an event from within an agent | `event/log` (JSON-RPC) |
 
+## HTTP task list
+
+`GET /tasks` returns a paginated envelope, not a raw array:
+
+```json
+{
+  "data": [],
+  "page": { "limit": 50, "has_more": false, "next_cursor": null },
+  "counts": {
+    "total": 0,
+    "running": 0,
+    "failed": 0,
+    "by_status": {},
+    "by_scheduler_state": {}
+  }
+}
+```
+
+Supported query parameters are `status`, `scheduler_state`, `active`, `kind`,
+`source`, `repo`, `project_id`, `limit`, and `cursor`. `status` is the task
+lifecycle status; `scheduler_state` is the ownership/execution state. For
+example, currently executing work is queried with
+`/tasks?scheduler_state=running`, not `status=running`.
+
 ## Error codes
 
 All JSON-RPC errors follow [JSON-RPC 2.0](https://www.jsonrpc.org/specification).

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -40,6 +40,13 @@ function makeFullTask(overrides: Partial<FullTask> = {}): FullTask {
     subtask_ids: [],
     project: null,
     workflow: null,
+    scheduler: {
+      authority_state: "running",
+      owner: null,
+      run_generation: 1,
+      recovery_generation: 0,
+      lease_expires_at: null,
+    },
     rounds: [],
     system_input: null,
     request_settings: null,

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -24,10 +24,21 @@ type TaskStub = {
 
 function mockFetch(tasks: TaskStub[]) {
   const overview = { projects: [], runtimes: [], kpi: { active_tasks: 0 } };
+  const taskList = {
+    data: tasks,
+    page: { limit: 200, has_more: false, next_cursor: null },
+    counts: {
+      total: tasks.length,
+      running: tasks.length,
+      failed: 0,
+      by_status: {},
+      by_scheduler_state: {},
+    },
+  };
   global.fetch = vi.fn().mockImplementation((url: string) => {
     const body = url.includes("/api/overview")
       ? JSON.stringify(overview)
-      : JSON.stringify(tasks);
+      : JSON.stringify(taskList);
     return Promise.resolve(new Response(body, { status: 200 }));
   }) as unknown as typeof fetch;
 }
@@ -130,10 +141,21 @@ describe("stream URL construction", () => {
 // ── useTasks ─────────────────────────────────────────────────────────────────
 
 describe("useTasks", () => {
-  it("fetches the task list from /tasks without an /api prefix", async () => {
+  it("fetches the active task list envelope from /tasks without an /api prefix", async () => {
     const task = { id: "t1", status: "implementing", turn: 1, project: null };
+    const taskList = {
+      data: [task],
+      page: { limit: 200, has_more: false, next_cursor: null },
+      counts: {
+        total: 1,
+        running: 1,
+        failed: 0,
+        by_status: { implementing: 1 },
+        by_scheduler_state: {},
+      },
+    };
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify([task]), { status: 200 }),
+      new Response(JSON.stringify(taskList), { status: 200 }),
     );
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -141,12 +163,12 @@ describe("useTasks", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "/tasks",
+      "/tasks?active=true&limit=200",
       expect.objectContaining({
         headers: expect.objectContaining({ Accept: "application/json" }),
       }),
     );
-    expect(result.current.data).toMatchObject([{ id: "t1", status: "implementing" }]);
+    expect(result.current.data?.data).toMatchObject([{ id: "t1", status: "implementing" }]);
   });
 });
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -7,7 +7,7 @@ import type {
   OperatorSnapshotPayload,
   OverviewPayload,
   StreamItem,
-  Task,
+  TaskListResponse,
   WorkflowRuntimeTreePayload,
 } from "@/types";
 
@@ -33,12 +33,34 @@ export function useOperatorSnapshot() {
   });
 }
 
-export function useTasks() {
-  return useQuery<Task[], Error>({
-    queryKey: ["tasks"],
+export interface TaskListParams {
+  status?: string;
+  scheduler_state?: string;
+  active?: boolean;
+  kind?: string;
+  source?: string;
+  repo?: string;
+  project_id?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+function taskListPath(params: TaskListParams): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+  const suffix = query.toString();
+  return suffix ? `/tasks?${suffix}` : "/tasks";
+}
+
+export function useTasks(params: TaskListParams = { active: true, limit: 200 }) {
+  return useQuery<TaskListResponse, Error>({
+    queryKey: ["tasks", params],
     // Task list/detail/stream routes are exposed at `/tasks`; only aggregate
     // dashboard endpoints are mounted under `/api/*`.
-    queryFn: ({ signal }) => apiJson<Task[]>("/tasks", { signal }),
+    queryFn: ({ signal }) => apiJson<TaskListResponse>(taskListPath(params), { signal }),
   });
 }
 
@@ -183,14 +205,14 @@ export async function registerProject(req: {
 }
 
 export function useWorktrees(): { cards: WorktreeCard[]; isLoading: boolean; error: Error | null } {
-  const tasks = useTasks();
+  const tasks = useTasks({ active: true, limit: 200 });
   const overview = useOverview();
 
   const isLoading = tasks.isLoading || overview.isLoading;
   const error = tasks.error ?? overview.error ?? null;
 
   const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
-  const runningTasks = (tasks.data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
+  const runningTasks = (tasks.data?.data ?? []).filter((t) => !TERMINAL_STATUSES.has(t.status));
 
   const cards: WorktreeCard[] = runningTasks.map((task) => {
     const project = (overview.data?.projects ?? []).find(

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -60,6 +60,27 @@ function makeTask(id: string, project: string | null, status = "running", task_k
     subtask_ids: [],
     project,
     workflow: null,
+    scheduler: {
+      authority_state: "running",
+      owner: null,
+      run_generation: 1,
+      recovery_generation: 0,
+      lease_expires_at: null,
+    },
+  };
+}
+
+function taskList(data: Task[]) {
+  return {
+    data,
+    page: { limit: 200, has_more: false, next_cursor: null },
+    counts: {
+      total: data.length,
+      running: data.filter((task) => task.scheduler.authority_state === "running").length,
+      failed: data.filter((task) => task.status === "failed").length,
+      by_status: {},
+      by_scheduler_state: {},
+    },
   };
 }
 
@@ -100,7 +121,7 @@ describe("<Active>", () => {
   });
 
   it("filters to matching project when projectFilter is set", () => {
-    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList(tasks), isLoading: false, isError: false });
     wrap(<Active projectFilter="harness" />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
@@ -109,7 +130,7 @@ describe("<Active>", () => {
   });
 
   it("shows all non-terminal tasks when no projectFilter", () => {
-    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList(tasks), isLoading: false, isError: false });
     wrap(<Active />);
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t2")).toBeInTheDocument();
@@ -118,7 +139,7 @@ describe("<Active>", () => {
   });
 
   it("shows empty columns when projectFilter matches no tasks", () => {
-    mockUseTasks.mockReturnValue({ data: tasks, isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList(tasks), isLoading: false, isError: false });
     wrap(<Active projectFilter="nonexistent" />);
     expect(screen.queryByText("t1")).not.toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
@@ -135,7 +156,11 @@ describe("<Active>", () => {
       ...makeTask("feedback-task", "harness", "pending"),
       workflow: { state: "addressing_feedback", pr_number: 124 },
     };
-    mockUseTasks.mockReturnValue({ data: [ready, feedback], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({
+      data: taskList([ready, feedback]),
+      isLoading: false,
+      isError: false,
+    });
     wrap(<Active projectFilter="harness" />);
 
     expect(screen.getByText("wf Ready To Merge")).toBeInTheDocument();
@@ -156,7 +181,7 @@ describe("<Active>", () => {
         review_fallback: { tier: "c", trigger: "silence", active_bot: "codex", activated_at: "2026-04-30T00:00:00Z" },
       },
     };
-    mockUseTasks.mockReturnValue({ data: [ready], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([ready]), isLoading: false, isError: false });
 
     wrap(<Active projectFilter="harness" />);
 
@@ -184,7 +209,7 @@ describe("<Active>", () => {
         pr_number: 124,
       },
     };
-    mockUseTasks.mockReturnValue({ data: [ready], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([ready]), isLoading: false, isError: false });
 
     wrap(<Active projectFilter="harness" />);
     fireEvent.click(screen.getByRole("button", { name: "Merge" }));
@@ -200,11 +225,11 @@ describe("<Active>", () => {
 
   it("groups planner and review lifecycle statuses outside implementing", () => {
     mockUseTasks.mockReturnValue({
-      data: [
+      data: taskList([
         makeTask("planner-task", "harness", "planner_waiting", "planner"),
         makeTask("review-task", "harness", "review_generating", "review"),
         makeTask("impl-task", "harness", "triaging", "issue"),
-      ],
+      ]),
       isLoading: false,
       isError: false,
     });
@@ -217,7 +242,7 @@ describe("<Active>", () => {
   });
 
   it("renders workflow runtime tree with jobs and rejected decisions", () => {
-    mockUseTasks.mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([]), isLoading: false, isError: false });
     mockUseWorkflowRuntimeTree.mockReturnValue({
       data: {
         total_workflows: 2,
@@ -349,7 +374,7 @@ describe("<Active>", () => {
   });
 
   it("cancels a non-terminal runtime issue workflow from the runtime panel", async () => {
-    mockUseTasks.mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([]), isLoading: false, isError: false });
     mockUseWorkflowRuntimeTree.mockReturnValue({
       data: {
         total_workflows: 1,
@@ -394,7 +419,7 @@ describe("<Active>", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const qc = makeQueryClient();
     const invalidateQueries = vi.spyOn(qc, "invalidateQueries");
-    mockUseTasks.mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([]), isLoading: false, isError: false });
     mockUseWorkflowRuntimeTree.mockReturnValue({
       data: {
         total_workflows: 1,
@@ -444,7 +469,11 @@ describe("<Active>", () => {
   });
 
   it("clicking a standard task card opens the slide-over with that task's id", () => {
-    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({
+      data: taskList([makeTask("t1", "proj")]),
+      isLoading: false,
+      isError: false,
+    });
     wrap(<Active />);
     fireEvent.click(screen.getByText("t1"));
     expect(screen.getByTestId("task-slideover")).toHaveAttribute("data-task-id", "t1");
@@ -452,14 +481,18 @@ describe("<Active>", () => {
 
   it("clicking a prompt task card opens the shared slide-over", () => {
     const promptTask = makeTask("prompt-task", "proj", "planning", "prompt");
-    mockUseTasks.mockReturnValue({ data: [promptTask], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([promptTask]), isLoading: false, isError: false });
     wrap(<Active />);
     fireEvent.click(screen.getByText("prompt-task"));
     expect(screen.getByTestId("task-slideover")).toHaveAttribute("data-task-id", "prompt-task");
   });
 
   it("calling onClose from the slide-over hides it", () => {
-    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({
+      data: taskList([makeTask("t1", "proj")]),
+      isLoading: false,
+      isError: false,
+    });
     wrap(<Active />);
     fireEvent.click(screen.getByText("t1"));
     expect(screen.getByTestId("task-slideover")).toBeInTheDocument();
@@ -468,7 +501,11 @@ describe("<Active>", () => {
   });
 
   it("clicking the scrim overlay closes the slide-over", () => {
-    mockUseTasks.mockReturnValue({ data: [makeTask("t1", "proj")], isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({
+      data: taskList([makeTask("t1", "proj")]),
+      isLoading: false,
+      isError: false,
+    });
     wrap(<Active />);
     fireEvent.click(screen.getByText("t1"));
     expect(screen.getByTestId("task-slideover")).toBeInTheDocument();

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -120,9 +120,18 @@ describe("<Active>", () => {
     });
   });
 
-  it("filters to matching project when projectFilter is set", () => {
-    mockUseTasks.mockReturnValue({ data: taskList(tasks), isLoading: false, isError: false });
+  it("requests project-scoped active tasks when projectFilter is set", () => {
+    mockUseTasks.mockReturnValue({
+      data: taskList([tasks[0], tasks[2]]),
+      isLoading: false,
+      isError: false,
+    });
     wrap(<Active projectFilter="harness" />);
+    expect(mockUseTasks).toHaveBeenCalledWith({
+      active: true,
+      limit: 200,
+      project_id: "harness",
+    });
     expect(screen.getByText("t1")).toBeInTheDocument();
     expect(screen.getByText("t3")).toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
@@ -139,8 +148,13 @@ describe("<Active>", () => {
   });
 
   it("shows empty columns when projectFilter matches no tasks", () => {
-    mockUseTasks.mockReturnValue({ data: taskList(tasks), isLoading: false, isError: false });
+    mockUseTasks.mockReturnValue({ data: taskList([]), isLoading: false, isError: false });
     wrap(<Active projectFilter="nonexistent" />);
+    expect(mockUseTasks).toHaveBeenCalledWith({
+      active: true,
+      limit: 200,
+      project_id: "nonexistent",
+    });
     expect(screen.queryByText("t1")).not.toBeInTheDocument();
     expect(screen.queryByText("t2")).not.toBeInTheDocument();
     const dashes = screen.getAllByText("—");

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -410,7 +410,6 @@ export function Active({ projectFilter }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [merging, setMerging] = useState<Set<string>>(new Set());
   const [cancellingWorkflows, setCancellingWorkflows] = useState<Set<string>>(new Set());
-  const { data, isLoading, isError } = useTasks({ active: true, limit: 200 });
   const { data: dashboard } = useDashboard();
   const queryClient = useQueryClient();
 
@@ -472,11 +471,14 @@ export function Active({ projectFilter }: Props) {
   const resolvedRoot = projectFilter
     ? (dashboard?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
     : null;
+  const { data, isLoading, isError } = useTasks({
+    active: true,
+    limit: 200,
+    project_id: resolvedRoot ?? undefined,
+  });
   const workflowRuntime = useWorkflowRuntimeTree(resolvedRoot);
 
-  const active = (data?.data ?? [])
-    .filter(shouldShowTask)
-    .filter((t) => !resolvedRoot || t.project === resolvedRoot);
+  const active = (data?.data ?? []).filter(shouldShowTask);
   const grouped: Record<string, Task[]> = {};
   for (const c of COLUMNS) grouped[c.key] = [];
   const other: Task[] = [];

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -410,7 +410,7 @@ export function Active({ projectFilter }: Props) {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [merging, setMerging] = useState<Set<string>>(new Set());
   const [cancellingWorkflows, setCancellingWorkflows] = useState<Set<string>>(new Set());
-  const { data, isLoading, isError } = useTasks();
+  const { data, isLoading, isError } = useTasks({ active: true, limit: 200 });
   const { data: dashboard } = useDashboard();
   const queryClient = useQueryClient();
 
@@ -474,7 +474,7 @@ export function Active({ projectFilter }: Props) {
     : null;
   const workflowRuntime = useWorkflowRuntimeTree(resolvedRoot);
 
-  const active = (data ?? [])
+  const active = (data?.data ?? [])
     .filter(shouldShowTask)
     .filter((t) => !resolvedRoot || t.project === resolvedRoot);
   const grouped: Record<string, Task[]> = {};

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -39,7 +39,7 @@ export function History({ projectFilter }: Props) {
       <div className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">
         done {totalDone} · failed {totalFailed} · filter {filter} · query {query || "(none)"}
         <div className="mt-3 text-ink-4 text-[11px]">
-          Task list endpoint is /tasks; cursor-based pagination TBD in a separate PR.
+          Task list endpoint is /tasks with server-side filters and cursor pagination.
         </div>
       </div>
     </div>

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -21,6 +21,40 @@ export interface Task {
   subtask_ids: string[];
   project: string | null;
   workflow?: WorkflowSummary | null;
+  scheduler: TaskSchedulerState;
+}
+
+export interface TaskSchedulerOwner {
+  kind: string;
+  id: string;
+}
+
+export interface TaskSchedulerState {
+  authority_state: string;
+  owner?: TaskSchedulerOwner | null;
+  run_generation: number;
+  recovery_generation: number;
+  lease_expires_at?: string | null;
+}
+
+export interface TaskListPage {
+  limit: number;
+  has_more: boolean;
+  next_cursor?: string | null;
+}
+
+export interface TaskListCounts {
+  total: number;
+  running: number;
+  failed: number;
+  by_status: Record<string, number>;
+  by_scheduler_state: Record<string, number>;
+}
+
+export interface TaskListResponse {
+  data: Task[];
+  page: TaskListPage;
+  counts: TaskListCounts;
 }
 
 export interface TaskArtifact {


### PR DESCRIPTION
## Summary
- add server-side /tasks filtering for status, scheduler_state, kind, source, repo, project_id, active, limit, and cursor
- return a task list envelope with page metadata and status/scheduler counts
- update dashboard queries and tests to consume the envelope and default to active task pagination

## Verification
- cargo fmt --all -- --check
- cargo check
- cargo test -p harness-server list_tasks -- --nocapture
- cargo test -p harness-server task_query_routes -- --nocapture
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test --workspace -- --test-threads=1
- bun run typecheck
- bun run test -- src/lib/queries.test.ts src/routes/dashboard/Active.test.tsx src/components/TaskDetailSlideover.test.tsx
- git diff --check