### PR TITLE
Fix runtime worker capacity under long turns

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -417,7 +417,7 @@ fn default_runtime_worker_interval_secs() -> u64 {
 }
 
 fn default_runtime_worker_concurrency() -> u32 {
-    1
+    10
 }
 
 fn default_runtime_worker_lease_ttl_secs() -> u64 {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -46,7 +46,7 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert!(cfg.runtime_dispatch.workflow_activity_profiles.is_empty());
     assert!(cfg.runtime_worker.enabled);
     assert_eq!(cfg.runtime_worker.interval_secs, 5);
-    assert_eq!(cfg.runtime_worker.concurrency, 1);
+    assert_eq!(cfg.runtime_worker.concurrency, 10);
     assert_eq!(cfg.runtime_worker.lease_ttl_secs, 3900);
     assert!(cfg.runtime_retry_policy.is_empty());
     assert!(cfg.issue_workflow.auto_replan_on_plan_issue);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
@@ -1468,11 +1469,13 @@ fn runtime_worker_lease_ttl(
 fn runtime_worker_loop_policy(
     policy: harness_core::config::workflow::RuntimeWorkerPolicy,
 ) -> harness_core::config::workflow::RuntimeWorkerPolicy {
-    if policy.enabled {
+    let mut policy = if policy.enabled {
         policy
     } else {
         harness_core::config::workflow::RuntimeWorkerPolicy::default()
-    }
+    };
+    policy.concurrency = policy.concurrency.max(1);
+    policy
 }
 
 fn log_runtime_worker_tick_result(
@@ -1514,23 +1517,65 @@ fn runtime_worker_open_slots(active_workers: usize, configured_concurrency: u32)
     (configured_concurrency as usize).saturating_sub(active_workers)
 }
 
+fn runtime_worker_has_external_state_owner(
+    observed_state_strong_count: usize,
+    active_worker_state_clones: usize,
+) -> bool {
+    observed_state_strong_count > active_worker_state_clones.saturating_add(1)
+}
+
+struct RuntimeWorkerStateLease {
+    state: Option<Arc<AppState>>,
+    active_worker_state_clones: Arc<AtomicUsize>,
+}
+
+impl RuntimeWorkerStateLease {
+    fn new(state: Arc<AppState>, active_worker_state_clones: Arc<AtomicUsize>) -> Self {
+        active_worker_state_clones.fetch_add(1, Ordering::AcqRel);
+        Self {
+            state: Some(state),
+            active_worker_state_clones,
+        }
+    }
+
+    fn state(&self) -> &Arc<AppState> {
+        self.state
+            .as_ref()
+            .expect("runtime worker state lease must hold app state")
+    }
+}
+
+impl Drop for RuntimeWorkerStateLease {
+    fn drop(&mut self) {
+        drop(self.state.take());
+        self.active_worker_state_clones
+            .fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 fn spawn_runtime_worker_ticks(
     workers: &mut tokio::task::JoinSet<
         anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
     >,
     state: &Arc<AppState>,
+    active_worker_state_clones: &Arc<AtomicUsize>,
     concurrency: u32,
     lease_ttl: chrono::Duration,
     next_worker_id: &mut u64,
 ) {
     let open_slots = runtime_worker_open_slots(workers.len(), concurrency);
     for _ in 0..open_slots {
-        let state = state.clone();
+        let state_lease =
+            RuntimeWorkerStateLease::new(state.clone(), active_worker_state_clones.clone());
         let owner = format!("server-runtime-worker-{next_worker_id}");
         *next_worker_id = next_worker_id.saturating_add(1);
         workers.spawn(async move {
-            crate::workflow_runtime_worker::run_runtime_job_worker_tick(&state, owner, lease_ttl)
-                .await
+            crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+                state_lease.state(),
+                owner,
+                lease_ttl,
+            )
+            .await
         });
     }
 }
@@ -1545,6 +1590,7 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
     let mut shutdown_rx = state.notifications.ws_shutdown_tx.subscribe();
     tokio::spawn(async move {
         let mut workers = tokio::task::JoinSet::new();
+        let active_worker_state_clones = Arc::new(AtomicUsize::new(0));
         let mut next_worker_id = 0;
         loop {
             let state = match weak_state.upgrade() {
@@ -1559,9 +1605,23 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
             let lease_ttl = runtime_worker_lease_ttl(&policy);
             drain_finished_runtime_worker_ticks(&mut workers);
+            let worker_state_clones = active_worker_state_clones.load(Ordering::Acquire);
+            if !runtime_worker_has_external_state_owner(
+                Arc::strong_count(&state),
+                worker_state_clones,
+            ) {
+                tracing::info!(
+                    active_workers = workers.len(),
+                    worker_state_clones,
+                    "workflow runtime job worker supervisor stopping: app state owner dropped"
+                );
+                workers.abort_all();
+                break;
+            }
             spawn_runtime_worker_ticks(
                 &mut workers,
                 &state,
+                &active_worker_state_clones,
                 policy.concurrency,
                 lease_ttl,
                 &mut next_worker_id,
@@ -2844,11 +2904,32 @@ mod tests {
     }
 
     #[test]
+    fn runtime_worker_loop_policy_clamps_zero_concurrency() {
+        let policy = harness_core::config::workflow::RuntimeWorkerPolicy {
+            enabled: true,
+            concurrency: 0,
+            ..Default::default()
+        };
+
+        let effective = runtime_worker_loop_policy(policy);
+
+        assert_eq!(effective.concurrency, 1);
+    }
+
+    #[test]
     fn runtime_worker_open_slots_preserves_capacity_when_one_worker_hangs() {
         assert_eq!(runtime_worker_open_slots(1, 6), 5);
         assert_eq!(runtime_worker_open_slots(6, 6), 0);
         assert_eq!(runtime_worker_open_slots(0, 0), 0);
         assert_eq!(runtime_worker_open_slots(1, 10), 9);
+    }
+
+    #[test]
+    fn runtime_worker_state_owner_gate_ignores_worker_clones() {
+        assert!(runtime_worker_has_external_state_owner(2, 0));
+        assert!(runtime_worker_has_external_state_owner(4, 2));
+        assert!(!runtime_worker_has_external_state_owner(1, 0));
+        assert!(!runtime_worker_has_external_state_owner(3, 2));
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1511,7 +1511,7 @@ fn drain_finished_runtime_worker_ticks(
 }
 
 fn runtime_worker_open_slots(active_workers: usize, configured_concurrency: u32) -> usize {
-    (configured_concurrency.max(1) as usize).saturating_sub(active_workers)
+    (configured_concurrency as usize).saturating_sub(active_workers)
 }
 
 fn spawn_runtime_worker_ticks(
@@ -1542,6 +1542,7 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
     }
 
     let weak_state = Arc::downgrade(state);
+    let mut shutdown_rx = state.notifications.ws_shutdown_tx.subscribe();
     tokio::spawn(async move {
         let mut workers = tokio::task::JoinSet::new();
         let mut next_worker_id = 0;
@@ -1565,7 +1566,27 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
                 lease_ttl,
                 &mut next_worker_id,
             );
-            tokio::time::sleep(interval).await;
+            drop(state);
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                shutdown_result = shutdown_rx.recv() => {
+                    match shutdown_result {
+                        Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            tracing::info!("workflow runtime job worker supervisor stopping for shutdown");
+                            workers.abort_all();
+                            break;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            tracing::warn!(
+                                skipped,
+                                "workflow runtime job worker supervisor lagged shutdown signal"
+                            );
+                            workers.abort_all();
+                            break;
+                        }
+                    }
+                }
+            }
         }
     });
 }
@@ -2826,7 +2847,7 @@ mod tests {
     fn runtime_worker_open_slots_preserves_capacity_when_one_worker_hangs() {
         assert_eq!(runtime_worker_open_slots(1, 6), 5);
         assert_eq!(runtime_worker_open_slots(6, 6), 0);
-        assert_eq!(runtime_worker_open_slots(0, 0), 1);
+        assert_eq!(runtime_worker_open_slots(0, 0), 0);
         assert_eq!(runtime_worker_open_slots(1, 10), 9);
     }
 

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1475,6 +1475,66 @@ fn runtime_worker_loop_policy(
     }
 }
 
+fn log_runtime_worker_tick_result(
+    result: Result<
+        anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
+        tokio::task::JoinError,
+    >,
+) {
+    match result {
+        Ok(Ok(tick)) if tick.touched_anything() => {
+            tracing::info!(
+                succeeded = tick.succeeded,
+                failed = tick.failed,
+                cancelled = tick.cancelled,
+                "workflow runtime job worker tick complete"
+            );
+        }
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            tracing::warn!("workflow runtime job worker tick failed: {e}");
+        }
+        Err(e) => {
+            tracing::warn!("workflow runtime job worker task panicked: {e}");
+        }
+    }
+}
+
+fn drain_finished_runtime_worker_ticks(
+    workers: &mut tokio::task::JoinSet<
+        anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
+    >,
+) {
+    while let Some(result) = workers.try_join_next() {
+        log_runtime_worker_tick_result(result);
+    }
+}
+
+fn runtime_worker_open_slots(active_workers: usize, configured_concurrency: u32) -> usize {
+    (configured_concurrency.max(1) as usize).saturating_sub(active_workers)
+}
+
+fn spawn_runtime_worker_ticks(
+    workers: &mut tokio::task::JoinSet<
+        anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
+    >,
+    state: &Arc<AppState>,
+    concurrency: u32,
+    lease_ttl: chrono::Duration,
+    next_worker_id: &mut u64,
+) {
+    let open_slots = runtime_worker_open_slots(workers.len(), concurrency);
+    for _ in 0..open_slots {
+        let state = state.clone();
+        let owner = format!("server-runtime-worker-{next_worker_id}");
+        *next_worker_id = next_worker_id.saturating_add(1);
+        workers.spawn(async move {
+            crate::workflow_runtime_worker::run_runtime_job_worker_tick(&state, owner, lease_ttl)
+                .await
+        });
+    }
+}
+
 pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
     if state.core.workflow_runtime_store.is_none() {
         tracing::debug!("workflow runtime job workers disabled: store unavailable");
@@ -1483,6 +1543,8 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
 
     let weak_state = Arc::downgrade(state);
     tokio::spawn(async move {
+        let mut workers = tokio::task::JoinSet::new();
+        let mut next_worker_id = 0;
         loop {
             let state = match weak_state.upgrade() {
                 Some(state) => state,
@@ -1494,38 +1556,15 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
             );
             let policy = runtime_worker_loop_policy(workflow_cfg.runtime_worker);
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
-            let concurrency = policy.concurrency.max(1);
             let lease_ttl = runtime_worker_lease_ttl(&policy);
-            let mut handles = Vec::with_capacity(concurrency as usize);
-            for worker_idx in 0..concurrency {
-                let state = state.clone();
-                let owner = format!("server-runtime-worker-{worker_idx}");
-                handles.push(tokio::spawn(async move {
-                    crate::workflow_runtime_worker::run_runtime_job_worker_tick(
-                        &state, owner, lease_ttl,
-                    )
-                    .await
-                }));
-            }
-            for handle in handles {
-                match handle.await {
-                    Ok(Ok(tick)) if tick.touched_anything() => {
-                        tracing::info!(
-                            succeeded = tick.succeeded,
-                            failed = tick.failed,
-                            cancelled = tick.cancelled,
-                            "workflow runtime job worker tick complete"
-                        );
-                    }
-                    Ok(Ok(_)) => {}
-                    Ok(Err(e)) => {
-                        tracing::warn!("workflow runtime job worker tick failed: {e}");
-                    }
-                    Err(e) => {
-                        tracing::warn!("workflow runtime job worker task panicked: {e}");
-                    }
-                }
-            }
+            drain_finished_runtime_worker_ticks(&mut workers);
+            spawn_runtime_worker_ticks(
+                &mut workers,
+                &state,
+                policy.concurrency,
+                lease_ttl,
+                &mut next_worker_id,
+            );
             tokio::time::sleep(interval).await;
         }
     });
@@ -2779,8 +2818,48 @@ mod tests {
         let effective = runtime_worker_loop_policy(policy);
 
         assert!(effective.enabled);
-        assert_eq!(effective.concurrency, 1);
+        assert_eq!(effective.concurrency, 10);
         assert_eq!(effective.interval_secs, 5);
+    }
+
+    #[test]
+    fn runtime_worker_open_slots_preserves_capacity_when_one_worker_hangs() {
+        assert_eq!(runtime_worker_open_slots(1, 6), 5);
+        assert_eq!(runtime_worker_open_slots(6, 6), 0);
+        assert_eq!(runtime_worker_open_slots(0, 0), 1);
+        assert_eq!(runtime_worker_open_slots(1, 10), 9);
+    }
+
+    #[tokio::test]
+    async fn drain_finished_runtime_worker_ticks_does_not_wait_for_hanging_worker() {
+        let mut workers = tokio::task::JoinSet::new();
+        workers.spawn(async {
+            std::future::pending::<
+                anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
+            >()
+            .await
+        });
+        workers.spawn(async {
+            Ok(crate::workflow_runtime_worker::RuntimeJobWorkerTick {
+                succeeded: 1,
+                ..Default::default()
+            })
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                drain_finished_runtime_worker_ticks(&mut workers);
+                if workers.len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("finished worker should be drained without waiting for hung worker");
+
+        workers.abort_all();
+        while workers.join_next().await.is_some() {}
     }
 
     // ARCH-GH-EXEMPT test double: mirrors the logic of fetch_pr_state_by_url in

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -294,6 +294,7 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
 
     let serve_result = serve_future.await;
     tracing::info!("server shutting down");
+    ws_shutdown_tx.send(()).ok();
     state.observability.events.shutdown().await;
     force_watcher.abort();
     serve_result?;

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -70,7 +70,7 @@ pub(crate) async fn run_runtime_job_worker_tick(
         });
     };
     let worker = RuntimeWorker::new(store.as_ref(), owner).with_lease_ttl(lease_ttl);
-    let executor = ServerRuntimeJobExecutor::new(state.clone());
+    let executor = ServerRuntimeJobExecutor::new(state);
     let completed = worker.run_once(&executor).await?;
     if let Some(job) = completed.as_ref() {
         if let Err(error) = notify_runtime_submission_terminal(state, job).await {

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -27,16 +27,16 @@ use super::runtime_profile::{
 };
 use super::workspace::{finish_runtime_workspace, prepare_runtime_workspace};
 
-const DEFAULT_RUNTIME_TURN_TIMEOUT_SECS: u64 = 900;
+const DEFAULT_RUNTIME_TURN_TIMEOUT_SECS: u64 = 3600;
 const DEFAULT_PR_FEEDBACK_INSPECT_TIMEOUT_SECS: u64 = 3600;
 const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 600;
 
-pub(super) struct ServerRuntimeJobExecutor {
-    state: Arc<AppState>,
+pub(super) struct ServerRuntimeJobExecutor<'a> {
+    state: &'a Arc<AppState>,
 }
 
-impl ServerRuntimeJobExecutor {
-    pub(super) fn new(state: Arc<AppState>) -> Self {
+impl<'a> ServerRuntimeJobExecutor<'a> {
+    pub(super) fn new(state: &'a Arc<AppState>) -> Self {
         Self { state }
     }
 
@@ -77,7 +77,7 @@ impl ServerRuntimeJobExecutor {
         }
 
         let runtime_workspace = prepare_runtime_workspace(
-            &self.state,
+            self.state,
             &job,
             workflow.as_ref(),
             &source_project_root,
@@ -110,7 +110,7 @@ impl ServerRuntimeJobExecutor {
                 prompt.clone(),
                 AgentId::from_str(agent_name),
             )?;
-            persist_created_thread(&self.state, &thread_id).await;
+            persist_created_thread(self.state, &thread_id).await;
 
             crate::task_executor::turn_lifecycle::run_turn_lifecycle_with_options(
                 self.state.core.server.clone(),
@@ -150,7 +150,7 @@ impl ServerRuntimeJobExecutor {
             ))
         }
         .await;
-        let finish_result = finish_runtime_workspace(&self.state, &runtime_workspace).await;
+        let finish_result = finish_runtime_workspace(self.state, &runtime_workspace).await;
         match (activity_result, finish_result) {
             (Ok(mut result), Err(error)) => {
                 tracing::warn!(
@@ -196,13 +196,13 @@ impl ServerRuntimeJobExecutor {
     ) -> anyhow::Result<Option<ActivityResult>> {
         match activity_name(job).as_str() {
             "start_child_workflow" => Ok(Some(
-                execute_start_child_workflow(&self.state, job, parent).await?,
+                execute_start_child_workflow(self.state, job, parent).await?,
             )),
             "mark_bound_issue_done" => Ok(Some(
-                execute_mark_bound_issue_done(&self.state, job, parent).await?,
+                execute_mark_bound_issue_done(self.state, job, parent).await?,
             )),
             "recover_issue_workflow" => Ok(Some(
-                execute_recover_issue_workflow(&self.state, job, parent).await?,
+                execute_recover_issue_workflow(self.state, job, parent).await?,
             )),
             _ => Ok(None),
         }
@@ -254,7 +254,7 @@ impl ServerRuntimeJobExecutor {
 }
 
 #[async_trait]
-impl RuntimeJobExecutor for ServerRuntimeJobExecutor {
+impl RuntimeJobExecutor for ServerRuntimeJobExecutor<'_> {
     fn consumes_runtime_turn(&self, job: &RuntimeJob) -> bool {
         !is_builtin_lifecycle_activity(job)
     }
@@ -443,7 +443,7 @@ mod tests {
         );
         assert_eq!(
             runtime_timeout_fallback(&config, None, &runtime_job("implement_issue")),
-            Some(900)
+            Some(3600)
         );
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -1,9 +1,11 @@
 use crate::http::AppState;
 use crate::task_executor::turn_lifecycle::TurnLifecycleOptions;
 use async_trait::async_trait;
+use harness_core::config::workflow::{RuntimeDispatchProfileOverride, WorkflowConfig};
 use harness_core::types::{AgentId, ThreadId};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, RuntimeJob, RuntimeJobExecutor, WorkflowInstance,
+    ActivityArtifact, ActivityResult, RuntimeJob, RuntimeJobExecutor, RuntimeProfile,
+    WorkflowInstance,
 };
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -24,6 +26,10 @@ use super::runtime_profile::{
     runtime_profile_sandbox_mode,
 };
 use super::workspace::{finish_runtime_workspace, prepare_runtime_workspace};
+
+const DEFAULT_RUNTIME_TURN_TIMEOUT_SECS: u64 = 900;
+const DEFAULT_PR_FEEDBACK_INSPECT_TIMEOUT_SECS: u64 = 3600;
+const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 600;
 
 pub(super) struct ServerRuntimeJobExecutor {
     state: Arc<AppState>,
@@ -57,7 +63,12 @@ impl ServerRuntimeJobExecutor {
             anyhow::bail!("runtime agent `{agent_name}` is not registered");
         }
 
-        let runtime_profile = runtime_profile_for_job(&job)?;
+        let runtime_profile = runtime_profile_with_timeout_fallback(
+            runtime_profile_for_job(&job)?,
+            &workflow_document.config,
+            workflow.as_ref(),
+            &job,
+        );
         let sandbox_mode = runtime_profile_sandbox_mode(&runtime_profile)?;
         let approval_policy = runtime_profile_approval_policy(&runtime_profile, job.runtime_kind)?;
         let prompt_task_request = prompt_task_request_for_job(&job)?;
@@ -270,5 +281,169 @@ async fn persist_created_thread(state: &AppState, thread_id: &ThreadId) {
     };
     if let Err(error) = db.insert(&thread).await {
         tracing::warn!(thread_id = %thread_id, "failed to persist runtime worker thread: {error}");
+    }
+}
+
+fn runtime_profile_with_timeout_fallback(
+    mut profile: RuntimeProfile,
+    workflow_config: &WorkflowConfig,
+    workflow: Option<&WorkflowInstance>,
+    job: &RuntimeJob,
+) -> RuntimeProfile {
+    if profile.timeout_secs.is_none() {
+        profile.timeout_secs = runtime_timeout_fallback(workflow_config, workflow, job);
+    }
+    profile
+}
+
+fn runtime_timeout_fallback(
+    workflow_config: &WorkflowConfig,
+    workflow: Option<&WorkflowInstance>,
+    job: &RuntimeJob,
+) -> Option<u64> {
+    let runtime_dispatch = &workflow_config.runtime_dispatch;
+    let workflow_definition_id = workflow.map(|workflow| workflow.definition_id.as_str());
+    let activity = activity_name(job);
+
+    workflow_definition_id
+        .and_then(|definition_id| {
+            runtime_dispatch
+                .workflow_activity_profiles
+                .get(definition_id)
+                .and_then(|profiles| profiles.get(&activity))
+        })
+        .and_then(profile_timeout)
+        .or_else(|| {
+            runtime_dispatch
+                .activity_profiles
+                .get(&activity)
+                .and_then(profile_timeout)
+        })
+        .or_else(|| {
+            workflow_definition_id.and_then(|definition_id| {
+                runtime_dispatch
+                    .workflow_profiles
+                    .get(definition_id)
+                    .and_then(profile_timeout)
+            })
+        })
+        .or(runtime_dispatch.timeout_secs)
+        .or_else(|| default_runtime_timeout(&activity))
+}
+
+fn profile_timeout(profile: &RuntimeDispatchProfileOverride) -> Option<u64> {
+    profile.timeout_secs
+}
+
+fn default_runtime_timeout(activity: &str) -> Option<u64> {
+    Some(match activity {
+        "inspect_pr_feedback" => DEFAULT_PR_FEEDBACK_INSPECT_TIMEOUT_SECS,
+        "poll_repo_backlog" => DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS,
+        _ => DEFAULT_RUNTIME_TURN_TIMEOUT_SECS,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::{RuntimeKind, WorkflowSubject};
+    use serde_json::json;
+
+    fn runtime_job(activity: &str) -> RuntimeJob {
+        RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": activity }),
+        )
+    }
+
+    fn workflow(definition_id: &str) -> WorkflowInstance {
+        WorkflowInstance::new(
+            definition_id,
+            1,
+            "running",
+            WorkflowSubject::new("issue", "issue-1"),
+        )
+    }
+
+    #[test]
+    fn runtime_timeout_fallback_prefers_workflow_activity_profile() {
+        let mut config = WorkflowConfig::default();
+        config.runtime_dispatch.timeout_secs = Some(900);
+        config.runtime_dispatch.activity_profiles.insert(
+            "inspect_pr_feedback".to_string(),
+            RuntimeDispatchProfileOverride {
+                timeout_secs: Some(1800),
+                ..RuntimeDispatchProfileOverride::default()
+            },
+        );
+        config.runtime_dispatch.workflow_profiles.insert(
+            "pr_feedback".to_string(),
+            RuntimeDispatchProfileOverride {
+                timeout_secs: Some(240),
+                ..RuntimeDispatchProfileOverride::default()
+            },
+        );
+        config
+            .runtime_dispatch
+            .workflow_activity_profiles
+            .entry("pr_feedback".to_string())
+            .or_default()
+            .insert(
+                "inspect_pr_feedback".to_string(),
+                RuntimeDispatchProfileOverride {
+                    timeout_secs: Some(120),
+                    ..RuntimeDispatchProfileOverride::default()
+                },
+            );
+
+        assert_eq!(
+            runtime_timeout_fallback(
+                &config,
+                Some(&workflow("pr_feedback")),
+                &runtime_job("inspect_pr_feedback"),
+            ),
+            Some(120)
+        );
+    }
+
+    #[test]
+    fn runtime_profile_with_timeout_fallback_preserves_embedded_timeout() {
+        let mut config = WorkflowConfig::default();
+        config.runtime_dispatch.timeout_secs = Some(900);
+        let mut profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        profile.timeout_secs = Some(42);
+
+        let profile = runtime_profile_with_timeout_fallback(
+            profile,
+            &config,
+            Some(&workflow("pr_feedback")),
+            &runtime_job("inspect_pr_feedback"),
+        );
+
+        assert_eq!(profile.timeout_secs, Some(42));
+    }
+
+    #[test]
+    fn runtime_timeout_fallback_has_global_activity_defaults() {
+        let config = WorkflowConfig::default();
+
+        assert_eq!(
+            runtime_timeout_fallback(
+                &config,
+                Some(&workflow("pr_feedback")),
+                &runtime_job("inspect_pr_feedback")
+            ),
+            Some(3600)
+        );
+        assert_eq!(
+            runtime_timeout_fallback(&config, None, &runtime_job("poll_repo_backlog")),
+            Some(600)
+        );
+        assert_eq!(
+            runtime_timeout_fallback(&config, None, &runtime_job("implement_issue")),
+            Some(900)
+        );
     }
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1362,7 +1362,6 @@ impl WorkflowRuntimeStore {
         .bind(runtime_job_id)
         .execute(&mut *tx)
         .await?;
-
         let command_row: Option<WorkflowCommandRecordRow> = sqlx::query_as(
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
                     dispatch_lease_expires_at, data::text, created_at, updated_at
@@ -1534,6 +1533,50 @@ impl WorkflowRuntimeStore {
             workflow_event: Some(event),
             decision: decision_record,
         }))
+    }
+
+    pub async fn extend_runtime_job_lease_if_owned(
+        &self,
+        runtime_job_id: &str,
+        owner: &str,
+        current_lease_expires_at: DateTime<Utc>,
+        next_lease_expires_at: DateTime<Utc>,
+    ) -> anyhow::Result<Option<RuntimeJob>> {
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1 FOR UPDATE")
+                .bind(runtime_job_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((data,)) = row else {
+            anyhow::bail!("runtime job not found: {runtime_job_id}");
+        };
+        let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        let is_current_lease = job.status == RuntimeJobStatus::Running
+            && job.lease.as_ref().is_some_and(|lease| {
+                lease.owner == owner && lease.expires_at == current_lease_expires_at
+            });
+        if !is_current_lease {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        job.claim(owner, next_lease_expires_at);
+        let updated = to_jsonb_string(&job)?;
+        let status = enum_str(&job.status)?;
+        sqlx::query(
+            "UPDATE runtime_jobs
+             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $4",
+        )
+        .bind(&status)
+        .bind(job.not_before)
+        .bind(&updated)
+        .bind(runtime_job_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(Some(job))
     }
 
     pub async fn get_runtime_job(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -30,7 +30,7 @@ use harness_core::db::resolve_database_url;
 use serde_json::json;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 
 fn issue_instance(state: &str) -> WorkflowInstance {
@@ -2958,6 +2958,31 @@ impl RuntimeJobExecutor for CountingRuntimeExecutor {
     }
 }
 
+struct BlockingRuntimeExecutor {
+    result: ActivityResult,
+    calls: Arc<AtomicUsize>,
+    started: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    finish: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+}
+
+#[async_trait]
+impl RuntimeJobExecutor for BlockingRuntimeExecutor {
+    async fn execute(&self, _job: RuntimeJob) -> ActivityResult {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(started) = self.started.lock().unwrap().take() {
+            let _ = started.send(());
+        }
+        let finish = self
+            .finish
+            .lock()
+            .unwrap()
+            .take()
+            .expect("blocking executor should only run once");
+        let _ = finish.await;
+        self.result.clone()
+    }
+}
+
 #[test]
 fn accepts_replan_decision_from_plan_issue() {
     let instance = leased_issue_instance("implementing");
@@ -3645,6 +3670,64 @@ async fn runtime_store_does_not_reclaim_unexpired_running_job() -> anyhow::Resul
         .claim_next_runtime_job("runtime-2", Utc::now() + Duration::minutes(10))
         .await?
         .is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_renews_running_job_lease_until_completion() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store =
+        Arc::new(WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?);
+    let job = store
+        .enqueue_runtime_job(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "check" }),
+        )
+        .await?;
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+    let blocking_calls = Arc::new(AtomicUsize::new(0));
+    let blocking_executor = BlockingRuntimeExecutor {
+        result: ActivityResult::succeeded("check", "Validation passed."),
+        calls: blocking_calls.clone(),
+        started: Mutex::new(Some(started_tx)),
+        finish: Mutex::new(Some(finish_rx)),
+    };
+    let worker_store = store.clone();
+    let worker_handle = tokio::spawn(async move {
+        let worker = RuntimeWorker::new(worker_store.as_ref(), "runtime-1")
+            .with_lease_ttl(Duration::seconds(2));
+        worker.run_once(&blocking_executor).await
+    });
+
+    started_rx.await?;
+    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+
+    let second_calls = Arc::new(AtomicUsize::new(0));
+    let second_executor = CountingRuntimeExecutor {
+        result: ActivityResult::succeeded("check", "Second worker should not run."),
+        calls: second_calls.clone(),
+    };
+    let second_worker =
+        RuntimeWorker::new(store.as_ref(), "runtime-2").with_lease_ttl(Duration::seconds(2));
+    let second_claim = second_worker.run_once(&second_executor).await?;
+    let _ = finish_tx.send(());
+    let completed = worker_handle
+        .await??
+        .expect("first worker should complete the runtime job");
+
+    assert!(second_claim.is_none());
+    assert_eq!(second_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(blocking_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(completed.id, job.id);
+    assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
+    assert!(completed.lease.is_none());
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use serde_json::{json, Value};
+use std::time::Duration as StdDuration;
 
 const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
 
@@ -45,7 +46,7 @@ impl<'a> RuntimeWorker<'a> {
         &self,
         executor: &(dyn RuntimeJobExecutor + Send + Sync),
     ) -> anyhow::Result<Option<RuntimeJob>> {
-        let lease_expires_at = Utc::now() + self.lease_ttl;
+        let mut lease_expires_at = Utc::now() + self.lease_ttl;
         let Some(job) = self
             .store
             .claim_next_runtime_job(&self.owner, lease_expires_at)
@@ -83,7 +84,11 @@ impl<'a> RuntimeWorker<'a> {
                         )
                         .await?;
                 }
-                executor.execute(job.clone()).await
+                let execution = self
+                    .execute_with_lease_renewal(&job, executor, lease_expires_at)
+                    .await?;
+                lease_expires_at = execution.lease_expires_at;
+                execution.result
             }
         };
         self.store
@@ -115,6 +120,59 @@ impl<'a> RuntimeWorker<'a> {
                 .await?;
         }
         Ok(Some(completion.runtime_job))
+    }
+
+    async fn execute_with_lease_renewal(
+        &self,
+        job: &RuntimeJob,
+        executor: &(dyn RuntimeJobExecutor + Send + Sync),
+        initial_lease_expires_at: chrono::DateTime<Utc>,
+    ) -> anyhow::Result<RuntimeJobExecution> {
+        let mut lease_expires_at = initial_lease_expires_at;
+        let renewal_interval = runtime_lease_renewal_interval(self.lease_ttl);
+        let activity = runtime_job_activity_name(job);
+        let execution = executor.execute(job.clone());
+        tokio::pin!(execution);
+
+        loop {
+            let renewal_sleep = tokio::time::sleep(renewal_interval);
+            tokio::pin!(renewal_sleep);
+
+            tokio::select! {
+                result = &mut execution => {
+                    return Ok(RuntimeJobExecution {
+                        result,
+                        lease_expires_at,
+                    });
+                }
+                _ = &mut renewal_sleep => {
+                    let next_lease_expires_at = Utc::now() + self.lease_ttl;
+                    let Some(updated) = self.store
+                        .extend_runtime_job_lease_if_owned(
+                            &job.id,
+                            &self.owner,
+                            lease_expires_at,
+                            next_lease_expires_at,
+                        )
+                        .await?
+                    else {
+                        return Ok(RuntimeJobExecution {
+                            result: ActivityResult::failed(
+                                activity,
+                                "Runtime job lease was lost before the agent completed.",
+                                "Another runtime worker reclaimed the job after this worker's lease expired.",
+                            ),
+                            lease_expires_at,
+                        });
+                    };
+                    lease_expires_at = updated
+                        .lease
+                        .as_ref()
+                        .map(|lease| lease.expires_at)
+                        .unwrap_or(next_lease_expires_at);
+                }
+            }
+        }
     }
 
     async fn propagate_pr_feedback_child_completion(
@@ -245,6 +303,24 @@ impl<'a> RuntimeWorker<'a> {
             max_turns,
         )))
     }
+}
+
+struct RuntimeJobExecution {
+    result: ActivityResult,
+    lease_expires_at: chrono::DateTime<Utc>,
+}
+
+fn runtime_lease_renewal_interval(lease_ttl: Duration) -> StdDuration {
+    let lease_ttl_secs = lease_ttl.num_seconds().max(1) as u64;
+    StdDuration::from_secs((lease_ttl_secs / 2).clamp(1, 30))
+}
+
+fn runtime_job_activity_name(job: &RuntimeJob) -> String {
+    job.input
+        .get("activity")
+        .and_then(Value::as_str)
+        .unwrap_or("runtime_job")
+        .to_string()
 }
 
 fn runtime_event_result_succeeded(event: &super::model::WorkflowEvent) -> bool {


### PR DESCRIPTION
## Summary
- raise the default workflow runtime worker concurrency from 1 to 10
- keep runtime worker ticks in a bounded JoinSet so long-running turns do not block future worker capacity
- apply workflow/activity timeout fallbacks for runtime jobs, including 60 minutes for PR feedback inspection

## Verification
- cargo fmt --all
- cargo check
- cargo test -p harness-core workflow_config -- --nocapture
- cargo test -p harness-server runtime_worker -- --nocapture
- cargo test -p harness-server runtime_timeout -- --nocapture
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets
- cargo test --workspace -- --test-threads=1