### PR TITLE
Fix dashboard runtime metrics

### DIFF
--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -8,12 +8,13 @@
 //! CPU/RAM) are returned as `null` so the UI degrades gracefully.
 
 use crate::http::AppState;
+use crate::task_runner::{SchedulerAuthorityState, TaskSummary};
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Duration, Timelike, Utc};
 use harness_core::types::{Decision, Event, EventFilters};
 use harness_observe::quality::QualityGrader;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Rolling window for the overview page. Matches the `24h` segment pill in
@@ -41,8 +42,9 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
 
     // ---- global task queue counts (reuse existing services) ----
     let tq = &state.concurrency.task_queue;
-    let running = tq.running_count();
-    let queued = tq.queued_count();
+    let active_counts = active_task_overview_counts(&state).await;
+    let running = active_counts.running;
+    let queued = active_counts.queued;
     let max_concurrent = tq.global_limit();
 
     let dashboard_counts = state.task_svc.count_for_dashboard().await;
@@ -80,7 +82,11 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     let mut throughput_series: Vec<Value> = Vec::with_capacity(project_list.len());
     for p in &project_list {
         let key = p.root.to_string_lossy().into_owned();
-        let qs = tq.project_stats(&key);
+        let active_project_counts = active_counts
+            .by_project
+            .get(&key)
+            .copied()
+            .unwrap_or_default();
         let counts = dashboard_counts.by_project.get(&key);
         let done = counts.map_or(0, |c| c.done);
         let failed = counts.map_or(0, |c| c.failed);
@@ -91,8 +97,8 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
         projects_json.push(json!({
             "id": p.id,
             "root": p.root,
-            "running": qs.running,
-            "queued": qs.queued,
+            "running": active_project_counts.running,
+            "queued": active_project_counts.queued,
             "done": done,
             "failed": failed,
             "merged_24h": merged_window,
@@ -226,7 +232,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
             "now": now.to_rfc3339(),
         },
         "kpi": {
-            "active_tasks": (running as u64) + (queued as u64),
+            "active_tasks": active_counts.total,
             "merged_24h": merged_24h,
             "avg_review_score": avg_review_score,
             "grade": grade_letter,
@@ -274,6 +280,145 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
 /// filter and [`build_hour_axis`] so the two views align.
 fn window_start(now: DateTime<Utc>) -> DateTime<Utc> {
     hour_top(now) - Duration::hours((THROUGHPUT_BUCKETS as i64) - 1)
+}
+
+#[derive(Debug, Default)]
+struct ActiveTaskOverviewCounts {
+    total: u64,
+    running: u64,
+    queued: u64,
+    by_project: HashMap<String, ActiveProjectCounts>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ActiveProjectCounts {
+    running: u64,
+    queued: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveTaskBucket {
+    Running,
+    Queued,
+}
+
+impl ActiveTaskOverviewCounts {
+    fn add(&mut self, project: Option<&str>, bucket: ActiveTaskBucket) {
+        self.total += 1;
+        let project_counts = project.map(|project| self.by_project.entry(project.to_string()));
+        match bucket {
+            ActiveTaskBucket::Running => {
+                self.running += 1;
+                if let Some(entry) = project_counts {
+                    entry.or_default().running += 1;
+                }
+            }
+            ActiveTaskBucket::Queued => {
+                self.queued += 1;
+                if let Some(entry) = project_counts {
+                    entry.or_default().queued += 1;
+                }
+            }
+        }
+    }
+}
+
+async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCounts {
+    let mut counts = ActiveTaskOverviewCounts::default();
+    let mut listed_task_ids = HashSet::new();
+    let mut loaded_legacy_tasks = false;
+
+    match state.core.tasks.list_all_summaries_with_terminal().await {
+        Ok(summaries) => {
+            loaded_legacy_tasks = true;
+            for summary in summaries {
+                listed_task_ids.insert(summary.id.as_str().to_string());
+                add_active_summary(&mut counts, &summary);
+            }
+        }
+        Err(error) => {
+            tracing::warn!("overview: failed to list task summaries for active counts: {error}");
+        }
+    }
+
+    if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+        for definition_id in [
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+        ] {
+            match store
+                .list_instances_by_definition(definition_id, None, None)
+                .await
+            {
+                Ok(workflows) => {
+                    for workflow in workflows {
+                        let Some(task_id) =
+                            crate::workflow_runtime_submission::runtime_issue_task_handle(
+                                &workflow,
+                            )
+                        else {
+                            continue;
+                        };
+                        if !listed_task_ids.insert(task_id.as_str().to_string()) {
+                            continue;
+                        }
+                        add_active_runtime_workflow(&mut counts, &workflow);
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        definition_id,
+                        "overview: failed to list runtime workflows for active counts: {error}"
+                    );
+                }
+            }
+        }
+    }
+
+    if !loaded_legacy_tasks {
+        for _ in 0..state.concurrency.task_queue.running_count() {
+            counts.add(None, ActiveTaskBucket::Running);
+        }
+        for _ in 0..state.concurrency.task_queue.queued_count() {
+            counts.add(None, ActiveTaskBucket::Queued);
+        }
+    }
+
+    counts
+}
+
+fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSummary) {
+    if summary.status.is_terminal() {
+        return;
+    }
+    let bucket = if summary.scheduler.authority_state == SchedulerAuthorityState::Running {
+        ActiveTaskBucket::Running
+    } else {
+        ActiveTaskBucket::Queued
+    };
+    counts.add(summary.project.as_deref(), bucket);
+}
+
+fn add_active_runtime_workflow(
+    counts: &mut ActiveTaskOverviewCounts,
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+) {
+    let Some(bucket) = runtime_workflow_active_bucket(&workflow.state) else {
+        return;
+    };
+    let project = workflow
+        .data
+        .get("project_id")
+        .and_then(serde_json::Value::as_str);
+    counts.add(project, bucket);
+}
+
+fn runtime_workflow_active_bucket(state: &str) -> Option<ActiveTaskBucket> {
+    match state {
+        "done" | "passed" | "failed" | "cancelled" => None,
+        "implementing" | "replanning" | "addressing_feedback" => Some(ActiveTaskBucket::Running),
+        _ => Some(ActiveTaskBucket::Queued),
+    }
 }
 
 /// Top of the current hour (i.e. `HH:00:00Z`). Falls back to `now` on the
@@ -491,6 +636,51 @@ mod tests {
         assert_eq!(v["drafts_pending"], 3u64);
         assert_eq!(v["drafts_auto_adopted"], 2u64);
         assert_eq!(v["skills_invoked_in_window"], 7u64);
+    }
+
+    #[test]
+    fn runtime_workflow_active_counts_match_dashboard_buckets() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let running = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-1",
+        }));
+        let waiting = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "ready_to_merge",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:2"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-2",
+        }));
+        let terminal = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "done",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:3"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-3",
+        }));
+
+        add_active_runtime_workflow(&mut counts, &running);
+        add_active_runtime_workflow(&mut counts, &waiting);
+        add_active_runtime_workflow(&mut counts, &terminal);
+
+        assert_eq!(counts.total, 2);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.queued, 1);
+        assert_eq!(counts.by_project["/repo"].running, 1);
+        assert_eq!(counts.by_project["/repo"].queued, 1);
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -329,7 +329,7 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
     let mut loaded_legacy_tasks = false;
     let mut counted_runtime_active_workflows = false;
 
-    match state.core.tasks.list_all_summaries_with_terminal().await {
+    match state.core.tasks.list_active_summaries().await {
         Ok(summaries) => {
             loaded_legacy_tasks = true;
             for summary in summaries {
@@ -349,16 +349,12 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
             harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
         ] {
             match store
-                .list_instances_by_definition(definition_id, None, None)
+                .list_nonterminal_instances_by_definition(definition_id, None, None)
                 .await
             {
                 Ok(workflows) => {
                     for workflow in workflows {
-                        let Some(task_id) =
-                            crate::workflow_runtime_submission::runtime_issue_task_handle(
-                                &workflow,
-                            )
-                        else {
+                        let Some(task_id) = runtime_workflow_dedupe_task_handle(&workflow) else {
                             continue;
                         };
                         if active_legacy_task_ids.contains(task_id.as_str()) {
@@ -424,6 +420,33 @@ fn runtime_workflow_active_bucket(state: &str) -> Option<ActiveTaskBucket> {
         "implementing" | "replanning" | "addressing_feedback" => Some(ActiveTaskBucket::Running),
         _ => Some(ActiveTaskBucket::Queued),
     }
+}
+
+fn runtime_workflow_dedupe_task_handle(
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+) -> Option<String> {
+    workflow
+        .data
+        .get("task_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|task_id| !task_id.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            workflow
+                .data
+                .get("task_ids")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|task_ids| {
+                    task_ids.iter().rev().find_map(|task_id| {
+                        task_id
+                            .as_str()
+                            .map(str::trim)
+                            .filter(|task_id| !task_id.is_empty())
+                            .map(ToOwned::to_owned)
+                    })
+                })
+        })
 }
 
 /// Top of the current hour (i.e. `HH:00:00Z`). Falls back to `now` on the
@@ -713,7 +736,7 @@ mod tests {
             "project_id": "/repo",
             "task_id": "runtime-task-1",
         }));
-        let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&runtime)
+        let task_id = runtime_workflow_dedupe_task_handle(&runtime)
             .expect("runtime workflow should expose a task handle");
         if !active_legacy_task_ids.contains(task_id.as_str()) {
             add_active_runtime_workflow(&mut counts, &runtime);
@@ -749,8 +772,46 @@ mod tests {
             "project_id": "/repo",
             "task_id": "runtime-task-1",
         }));
-        let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&runtime)
+        let task_id = runtime_workflow_dedupe_task_handle(&runtime)
             .expect("runtime workflow should expose a task handle");
+        if !active_legacy_task_ids.contains(task_id.as_str()) {
+            add_active_runtime_workflow(&mut counts, &runtime);
+        }
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.by_project["/repo"].running, 1);
+    }
+
+    #[test]
+    fn active_legacy_summary_suppresses_runtime_workflow_by_current_task_id() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let mut active_legacy_task_ids = HashSet::new();
+        let mut active_legacy = crate::task_runner::TaskState::new(harness_core::types::TaskId(
+            "current-runtime-task".to_string(),
+        ))
+        .summary();
+        active_legacy.status = crate::task_runner::TaskStatus::Implementing;
+        active_legacy.scheduler.authority_state = SchedulerAuthorityState::Running;
+        active_legacy.project = Some("/repo".to_string());
+        if add_active_summary(&mut counts, &active_legacy) {
+            active_legacy_task_ids.insert(active_legacy.id.as_str().to_string());
+        }
+
+        let runtime = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "current-runtime-task",
+            "task_ids": ["historical-runtime-task", "current-runtime-task"],
+        }));
+        let task_id = runtime_workflow_dedupe_task_handle(&runtime)
+            .expect("runtime workflow should expose a task handle");
+        assert_eq!(task_id, "current-runtime-task");
         if !active_legacy_task_ids.contains(task_id.as_str()) {
             add_active_runtime_workflow(&mut counts, &runtime);
         }

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -354,10 +354,10 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
             {
                 Ok(workflows) => {
                     for workflow in workflows {
-                        let Some(task_id) = runtime_workflow_dedupe_task_handle(&workflow) else {
-                            continue;
-                        };
-                        if active_legacy_task_ids.contains(task_id.as_str()) {
+                        if runtime_workflow_matches_active_legacy_task(
+                            &workflow,
+                            &active_legacy_task_ids,
+                        ) {
                             continue;
                         }
                         counted_runtime_active_workflows |=
@@ -418,9 +418,19 @@ fn add_active_runtime_workflow(
 fn runtime_workflow_active_bucket(state: &str) -> Option<ActiveTaskBucket> {
     match state {
         "done" | "passed" | "failed" | "cancelled" => None,
-        "implementing" | "replanning" | "addressing_feedback" => Some(ActiveTaskBucket::Running),
+        "planning" | "implementing" | "replanning" | "addressing_feedback" => {
+            Some(ActiveTaskBucket::Running)
+        }
         _ => Some(ActiveTaskBucket::Queued),
     }
+}
+
+fn runtime_workflow_matches_active_legacy_task(
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+    active_legacy_task_ids: &HashSet<String>,
+) -> bool {
+    runtime_workflow_dedupe_task_handle(workflow)
+        .is_some_and(|task_id| active_legacy_task_ids.contains(task_id.as_str()))
 }
 
 fn runtime_workflow_dedupe_task_handle(
@@ -710,6 +720,56 @@ mod tests {
         assert_eq!(counts.queued, 1);
         assert_eq!(counts.by_project["/repo"].running, 1);
         assert_eq!(counts.by_project["/repo"].queued, 1);
+    }
+
+    #[test]
+    fn planning_runtime_workflow_counts_as_running_work() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let planning = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "planning",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-1",
+        }));
+
+        assert!(add_active_runtime_workflow(&mut counts, &planning));
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.queued, 0);
+        assert_eq!(counts.by_project["/repo"].running, 1);
+    }
+
+    #[test]
+    fn runtime_workflow_without_task_handle_still_counts_active_work() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let active_legacy_task_ids = HashSet::from(["legacy-task".to_string()]);
+        let runtime = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+        }));
+
+        assert!(runtime_workflow_dedupe_task_handle(&runtime).is_none());
+        assert!(!runtime_workflow_matches_active_legacy_task(
+            &runtime,
+            &active_legacy_task_ids,
+        ));
+        if !runtime_workflow_matches_active_legacy_task(&runtime, &active_legacy_task_ids) {
+            add_active_runtime_workflow(&mut counts, &runtime);
+        }
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.by_project["/repo"].running, 1);
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -390,10 +390,11 @@ fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSumma
     if summary.status.is_terminal() {
         return false;
     }
-    let bucket = if summary.scheduler.authority_state == SchedulerAuthorityState::Running {
-        ActiveTaskBucket::Running
-    } else {
-        ActiveTaskBucket::Queued
+    let bucket = match summary.scheduler.authority_state {
+        SchedulerAuthorityState::Running | SchedulerAuthorityState::Leased => {
+            ActiveTaskBucket::Running
+        }
+        _ => ActiveTaskBucket::Queued,
     };
     counts.add(summary.project.as_deref(), bucket);
     true
@@ -781,6 +782,26 @@ mod tests {
         assert_eq!(counts.total, 1);
         assert_eq!(counts.running, 1);
         assert_eq!(counts.by_project["/repo"].running, 1);
+    }
+
+    #[test]
+    fn leased_legacy_summary_counts_as_running_work() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let mut leased = crate::task_runner::TaskState::new(harness_core::types::TaskId(
+            "leased-runtime-task".to_string(),
+        ))
+        .summary();
+        leased.status = crate::task_runner::TaskStatus::Implementing;
+        leased.scheduler.authority_state = SchedulerAuthorityState::Leased;
+        leased.project = Some("/repo".to_string());
+
+        assert!(add_active_summary(&mut counts, &leased));
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.queued, 0);
+        assert_eq!(counts.by_project["/repo"].running, 1);
+        assert_eq!(counts.by_project["/repo"].queued, 0);
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -325,7 +325,7 @@ impl ActiveTaskOverviewCounts {
 
 async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCounts {
     let mut counts = ActiveTaskOverviewCounts::default();
-    let mut listed_task_ids = HashSet::new();
+    let mut active_legacy_task_ids = HashSet::new();
     let mut loaded_legacy_tasks = false;
     let mut counted_runtime_active_workflows = false;
 
@@ -333,8 +333,9 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
         Ok(summaries) => {
             loaded_legacy_tasks = true;
             for summary in summaries {
-                listed_task_ids.insert(summary.id.as_str().to_string());
-                add_active_summary(&mut counts, &summary);
+                if add_active_summary(&mut counts, &summary) {
+                    active_legacy_task_ids.insert(summary.id.as_str().to_string());
+                }
             }
         }
         Err(error) => {
@@ -360,7 +361,7 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
                         else {
                             continue;
                         };
-                        if !listed_task_ids.insert(task_id.as_str().to_string()) {
+                        if active_legacy_task_ids.contains(task_id.as_str()) {
                             continue;
                         }
                         counted_runtime_active_workflows |=
@@ -389,9 +390,9 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
     counts
 }
 
-fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSummary) {
+fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSummary) -> bool {
     if summary.status.is_terminal() {
-        return;
+        return false;
     }
     let bucket = if summary.scheduler.authority_state == SchedulerAuthorityState::Running {
         ActiveTaskBucket::Running
@@ -399,6 +400,7 @@ fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSumma
         ActiveTaskBucket::Queued
     };
     counts.add(summary.project.as_deref(), bucket);
+    true
 }
 
 fn add_active_runtime_workflow(
@@ -684,6 +686,78 @@ mod tests {
         assert_eq!(counts.queued, 1);
         assert_eq!(counts.by_project["/repo"].running, 1);
         assert_eq!(counts.by_project["/repo"].queued, 1);
+    }
+
+    #[test]
+    fn terminal_legacy_summary_does_not_suppress_active_runtime_workflow() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let mut active_legacy_task_ids = HashSet::new();
+        let mut terminal_legacy = crate::task_runner::TaskState::new(harness_core::types::TaskId(
+            "runtime-task-1".to_string(),
+        ))
+        .summary();
+        terminal_legacy.status = crate::task_runner::TaskStatus::Failed;
+        terminal_legacy.scheduler.authority_state = SchedulerAuthorityState::Failed;
+        terminal_legacy.project = Some("/repo".to_string());
+        if add_active_summary(&mut counts, &terminal_legacy) {
+            active_legacy_task_ids.insert(terminal_legacy.id.as_str().to_string());
+        }
+
+        let runtime = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-task-1",
+        }));
+        let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&runtime)
+            .expect("runtime workflow should expose a task handle");
+        if !active_legacy_task_ids.contains(task_id.as_str()) {
+            add_active_runtime_workflow(&mut counts, &runtime);
+        }
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.by_project["/repo"].running, 1);
+    }
+
+    #[test]
+    fn active_legacy_summary_still_suppresses_matching_runtime_workflow() {
+        let mut counts = ActiveTaskOverviewCounts::default();
+        let mut active_legacy_task_ids = HashSet::new();
+        let mut active_legacy = crate::task_runner::TaskState::new(harness_core::types::TaskId(
+            "runtime-task-1".to_string(),
+        ))
+        .summary();
+        active_legacy.status = crate::task_runner::TaskStatus::Implementing;
+        active_legacy.scheduler.authority_state = SchedulerAuthorityState::Running;
+        active_legacy.project = Some("/repo".to_string());
+        if add_active_summary(&mut counts, &active_legacy) {
+            active_legacy_task_ids.insert(active_legacy.id.as_str().to_string());
+        }
+
+        let runtime = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(serde_json::json!({
+            "project_id": "/repo",
+            "task_id": "runtime-task-1",
+        }));
+        let task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&runtime)
+            .expect("runtime workflow should expose a task handle");
+        if !active_legacy_task_ids.contains(task_id.as_str()) {
+            add_active_runtime_workflow(&mut counts, &runtime);
+        }
+
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.by_project["/repo"].running, 1);
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -327,6 +327,7 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
     let mut counts = ActiveTaskOverviewCounts::default();
     let mut listed_task_ids = HashSet::new();
     let mut loaded_legacy_tasks = false;
+    let mut counted_runtime_active_workflows = false;
 
     match state.core.tasks.list_all_summaries_with_terminal().await {
         Ok(summaries) => {
@@ -362,7 +363,8 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
                         if !listed_task_ids.insert(task_id.as_str().to_string()) {
                             continue;
                         }
-                        add_active_runtime_workflow(&mut counts, &workflow);
+                        counted_runtime_active_workflows |=
+                            add_active_runtime_workflow(&mut counts, &workflow);
                     }
                 }
                 Err(error) => {
@@ -375,7 +377,7 @@ async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCoun
         }
     }
 
-    if !loaded_legacy_tasks {
+    if !loaded_legacy_tasks && !counted_runtime_active_workflows {
         for _ in 0..state.concurrency.task_queue.running_count() {
             counts.add(None, ActiveTaskBucket::Running);
         }
@@ -402,15 +404,16 @@ fn add_active_summary(counts: &mut ActiveTaskOverviewCounts, summary: &TaskSumma
 fn add_active_runtime_workflow(
     counts: &mut ActiveTaskOverviewCounts,
     workflow: &harness_workflow::runtime::WorkflowInstance,
-) {
+) -> bool {
     let Some(bucket) = runtime_workflow_active_bucket(&workflow.state) else {
-        return;
+        return false;
     };
     let project = workflow
         .data
         .get("project_id")
         .and_then(serde_json::Value::as_str);
     counts.add(project, bucket);
+    true
 }
 
 fn runtime_workflow_active_bucket(state: &str) -> Option<ActiveTaskBucket> {

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -458,10 +458,24 @@ fn parse_timestamp(ts: &str) -> Result<ParsedUsageTimestamp, String> {
     let occurred_at = DateTime::parse_from_rfc3339(ts)
         .map_err(|err| format!("invalid timestamp '{ts}': {err}"))?
         .with_timezone(&Utc);
+    let (day, hour) = if ts.ends_with('Z') || ts.ends_with("+00:00") {
+        let day = ts
+            .get(..10)
+            .ok_or_else(|| format!("invalid timestamp '{ts}': missing date component"))?;
+        let hour = ts
+            .get(11..13)
+            .ok_or_else(|| format!("invalid timestamp '{ts}': missing hour component"))?;
+        (day.to_string(), format!("{day} {hour}:00"))
+    } else {
+        (
+            occurred_at.format("%Y-%m-%d").to_string(),
+            occurred_at.format("%Y-%m-%d %H:00").to_string(),
+        )
+    };
     Ok(ParsedUsageTimestamp {
         occurred_at,
-        day: occurred_at.format("%Y-%m-%d").to_string(),
-        hour: occurred_at.format("%Y-%m-%d %H:00").to_string(),
+        day,
+        hour,
     })
 }
 
@@ -592,6 +606,13 @@ mod tests {
     fn parse_timestamp_rejects_invalid_input() {
         assert!(parse_timestamp("invalid").is_err());
         assert!(parse_timestamp("2026-03-26 03:05:56Z").is_err());
+    }
+
+    #[test]
+    fn parse_timestamp_preserves_utc_bucket_for_offset_input() {
+        let parsed = parse_timestamp("2026-03-26T23:05:56-02:00").unwrap();
+        assert_eq!(parsed.day, "2026-03-27");
+        assert_eq!(parsed.hour, "2026-03-27 01:00");
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/token_usage.rs
+++ b/crates/harness-server/src/handlers/token_usage.rs
@@ -1,4 +1,5 @@
 use axum::{extract::State, http::StatusCode, Json};
+use chrono::{DateTime, Duration, Utc};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -6,6 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::http::AppState;
+
+const DEFAULT_TOKEN_USAGE_WINDOW_HOURS: i64 = 24;
 
 #[derive(Debug, Default, Clone, Serialize)]
 struct UsageBucket {
@@ -31,6 +34,43 @@ struct ParsedUsageRecord {
     cache_read: u64,
     cache_create: u64,
     model: String,
+    occurred_at: DateTime<Utc>,
+    day: String,
+    hour: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TokenUsageWindow {
+    hours: i64,
+    since: DateTime<Utc>,
+    now: DateTime<Utc>,
+}
+
+impl TokenUsageWindow {
+    fn last_hours(now: DateTime<Utc>, hours: i64) -> Self {
+        Self {
+            hours,
+            since: now - Duration::hours(hours),
+            now,
+        }
+    }
+
+    fn contains(&self, ts: DateTime<Utc>) -> bool {
+        ts >= self.since && ts <= self.now
+    }
+
+    fn to_json(self) -> Value {
+        serde_json::json!({
+            "hours": self.hours,
+            "since": self.since.to_rfc3339(),
+            "now": self.now.to_rfc3339(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParsedUsageTimestamp {
+    occurred_at: DateTime<Utc>,
     day: String,
     hour: String,
 }
@@ -50,6 +90,7 @@ fn home_dir() -> Result<PathBuf, String> {
 /// This endpoint is intentionally strict: malformed source data returns an
 /// explicit error response instead of silently producing partial/empty metrics.
 pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Value>) {
+    let window = TokenUsageWindow::last_hours(Utc::now(), DEFAULT_TOKEN_USAGE_WINDOW_HOURS);
     let home = match home_dir() {
         Ok(path) => path,
         Err(err) => return error_response(err),
@@ -90,7 +131,7 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
                 "token_usage: session projects directory not found; \
                  returning empty metrics (expected with --no-session-persistence)"
             );
-            return missing_dir_response();
+            return missing_dir_response(window);
         }
         Err(e) => {
             return error_response(format!(
@@ -104,9 +145,13 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
         Ok(files) => files,
         Err(err) => return error_response(err),
     };
+    let files = match filter_session_files_for_window(files, window) {
+        Ok(files) => files,
+        Err(err) => return error_response(err),
+    };
 
     if files.is_empty() {
-        return empty_usage_response();
+        return empty_usage_response(window);
     }
 
     let mut by_day: BTreeMap<String, UsageBucket> = BTreeMap::new();
@@ -160,6 +205,9 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
                 Ok(None) => continue,
                 Err(err) => return error_response(err),
             };
+            if !window.contains(parsed.occurred_at) {
+                continue;
+            }
 
             let total_ctx = parsed.input + parsed.cache_read + parsed.cache_create;
 
@@ -251,6 +299,7 @@ pub async fn token_usage(State(state): State<Arc<AppState>>) -> (StatusCode, Jso
     let total_context = totals.input_tokens + totals.cache_read_tokens + totals.cache_create_tokens;
 
     let body = serde_json::json!({
+        "window": window.to_json(),
         "by_day": by_day,
         "by_hour": by_hour,
         "model_trend": model_trend,
@@ -281,8 +330,9 @@ fn error_response(message: String) -> (StatusCode, Json<Value>) {
 /// so callers and monitoring can distinguish "directory absent" (potentially a
 /// misconfiguration) from "directory present but no sessions yet" (expected
 /// in --no-session-persistence environments).
-fn missing_dir_response() -> (StatusCode, Json<Value>) {
+fn missing_dir_response(window: TokenUsageWindow) -> (StatusCode, Json<Value>) {
     let body = serde_json::json!({
+        "window": window.to_json(),
         "by_day": {},
         "by_hour": {},
         "model_trend": {},
@@ -304,8 +354,9 @@ fn missing_dir_response() -> (StatusCode, Json<Value>) {
 /// This is the correct response when `--no-session-persistence` is active:
 /// agents do not write JSONL files, so an absent or empty projects directory
 /// is expected, not an error.
-fn empty_usage_response() -> (StatusCode, Json<Value>) {
+fn empty_usage_response(window: TokenUsageWindow) -> (StatusCode, Json<Value>) {
     let body = serde_json::json!({
+        "window": window.to_json(),
         "by_day": {},
         "by_hour": {},
         "model_trend": {},
@@ -335,7 +386,7 @@ fn parse_usage_record(entry: &Value, ctx: &str) -> Result<Option<ParsedUsageReco
 
     let model = required_str_at_pointer(entry, "/message/model", ctx)?.to_string();
     let ts = required_str_field(entry, "timestamp", ctx)?;
-    let (day, hour) = parse_timestamp(ts).map_err(|err| format!("{ctx}: {err}"))?;
+    let timestamp = parse_timestamp(ts).map_err(|err| format!("{ctx}: {err}"))?;
 
     Ok(Some(ParsedUsageRecord {
         input,
@@ -343,8 +394,9 @@ fn parse_usage_record(entry: &Value, ctx: &str) -> Result<Option<ParsedUsageReco
         cache_read,
         cache_create,
         model,
-        day,
-        hour,
+        occurred_at: timestamp.occurred_at,
+        day: timestamp.day,
+        hour: timestamp.hour,
     }))
 }
 
@@ -399,19 +451,18 @@ fn estimate_cost(usage: &UsageBucket) -> f64 {
 }
 
 /// Parse an ISO-8601 timestamp into (YYYY-MM-DD, YYYY-MM-DD HH:00).
-fn parse_timestamp(ts: &str) -> Result<(String, String), String> {
-    if ts.len() < 13 {
-        return Err(format!("invalid timestamp '{ts}': too short"));
-    }
+fn parse_timestamp(ts: &str) -> Result<ParsedUsageTimestamp, String> {
     if ts.as_bytes().get(10) != Some(&b'T') {
         return Err(format!("invalid timestamp '{ts}': missing 'T' separator"));
     }
-    let day = &ts[..10];
-    let hour = &ts[11..13];
-    if !hour.chars().all(|c| c.is_ascii_digit()) {
-        return Err(format!("invalid timestamp '{ts}': hour is not numeric"));
-    }
-    Ok((day.to_string(), format!("{day} {hour}:00")))
+    let occurred_at = DateTime::parse_from_rfc3339(ts)
+        .map_err(|err| format!("invalid timestamp '{ts}': {err}"))?
+        .with_timezone(&Utc);
+    Ok(ParsedUsageTimestamp {
+        occurred_at,
+        day: occurred_at.format("%Y-%m-%d").to_string(),
+        hour: occurred_at.format("%Y-%m-%d %H:00").to_string(),
+    })
 }
 
 fn collect_session_files(claude_projects_dir: &Path) -> Result<Vec<PathBuf>, String> {
@@ -455,6 +506,32 @@ fn collect_session_files(claude_projects_dir: &Path) -> Result<Vec<PathBuf>, Str
     }
 
     Ok(files)
+}
+
+fn filter_session_files_for_window(
+    files: Vec<PathBuf>,
+    window: TokenUsageWindow,
+) -> Result<Vec<PathBuf>, String> {
+    let mut filtered = Vec::new();
+    for file in files {
+        if file_may_have_window_records(&file, window)? {
+            filtered.push(file);
+        }
+    }
+    Ok(filtered)
+}
+
+fn file_may_have_window_records(path: &Path, window: TokenUsageWindow) -> Result<bool, String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|err| format!("failed to stat token usage file {}: {err}", path.display()))?;
+    let modified = metadata.modified().map_err(|err| {
+        format!(
+            "failed to read token usage file mtime {}: {err}",
+            path.display()
+        )
+    })?;
+    let modified_at: DateTime<Utc> = modified.into();
+    Ok(modified_at >= window.since)
 }
 
 fn collect_jsonl_in_dir(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
@@ -557,5 +634,46 @@ mod tests {
         assert_eq!(parsed.cache_create, 10);
         assert_eq!(parsed.day, "2026-03-26");
         assert_eq!(parsed.hour, "2026-03-26 03:00");
+    }
+
+    #[test]
+    fn usage_window_keeps_only_recent_records() {
+        let now = DateTime::parse_from_rfc3339("2026-05-20T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let window = TokenUsageWindow::last_hours(now, 24);
+        let recent = parse_usage_record(
+            &serde_json::json!({
+                "timestamp": "2026-05-20T09:59:00Z",
+                "message": {
+                    "model": "claude-sonnet",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 20
+                    }
+                }
+            }),
+            "recent:1",
+        )
+        .unwrap()
+        .unwrap();
+        let old = parse_usage_record(
+            &serde_json::json!({
+                "timestamp": "2026-05-18T09:59:00Z",
+                "message": {
+                    "model": "claude-sonnet",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 20
+                    }
+                }
+            }),
+            "old:1",
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(window.contains(recent.occurred_at));
+        assert!(!window.contains(old.occurred_at));
     }
 }

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -362,17 +362,24 @@ impl TaskDb {
         )
         .fetch_all(&self.pool)
         .await?;
-        let mut summaries = Vec::with_capacity(rows.len());
-        for row in rows {
-            let id = row.id.clone();
-            match TaskSummaryRow::try_into_summary(row) {
-                Ok(summary) => summaries.push(summary),
-                Err(e) => {
-                    tracing::warn!(task_id = %id, "skipping malformed task row in list_summaries: {e}");
-                }
-            }
-        }
-        Ok(summaries)
+        Ok(decode_task_summary_rows(rows, "list_summaries"))
+    }
+
+    /// Return active tasks as lightweight summaries, skipping terminal history and `rounds`.
+    pub async fn list_active_summaries(
+        &self,
+    ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        let rows = sqlx::query_as::<_, TaskSummaryRow>(
+            "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
+             created_at, repo, depends_on, project, workspace_path, workspace_owner, \
+             run_generation, phase, description, scheduler_state \
+             FROM tasks \
+             WHERE status NOT IN ('done', 'failed', 'cancelled') \
+             ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(decode_task_summary_rows(rows, "list_active_summaries"))
     }
 
     /// Return `(task_id, first_token_latency_ms)` pairs for the 500 most-recently
@@ -668,6 +675,23 @@ impl TaskDb {
             .await?;
         Ok(())
     }
+}
+
+fn decode_task_summary_rows(
+    rows: Vec<TaskSummaryRow>,
+    context: &str,
+) -> Vec<crate::task_runner::TaskSummary> {
+    let mut summaries = Vec::with_capacity(rows.len());
+    for row in rows {
+        let id = row.id.clone();
+        match TaskSummaryRow::try_into_summary(row) {
+            Ok(summary) => summaries.push(summary),
+            Err(e) => {
+                tracing::warn!(task_id = %id, "{context}: skipping malformed task row: {e}");
+            }
+        }
+    }
+    summaries
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -350,6 +350,29 @@ impl TaskStore {
         Ok(by_id.into_values().collect())
     }
 
+    /// Return active tasks as lightweight [`TaskSummary`] values.
+    ///
+    /// Fetches only non-terminal summary rows from the DB, then applies live cache
+    /// overrides so recently terminal tasks are removed and in-flight state wins.
+    pub async fn list_active_summaries(&self) -> anyhow::Result<Vec<TaskSummary>> {
+        let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
+            .db
+            .list_active_summaries()
+            .await?
+            .into_iter()
+            .map(|s| (s.id.clone(), s))
+            .collect();
+        for entry in self.cache.iter() {
+            let summary = entry.value().summary();
+            if summary.status.is_terminal() {
+                by_id.remove(&summary.id);
+            } else {
+                by_id.insert(entry.key().clone(), summary);
+            }
+        }
+        Ok(by_id.into_values().collect())
+    }
+
     /// Return `(TaskId, TaskStatus)` pairs for all tasks without deserializing `rounds`.
     ///
     /// Hot-path callers (skill governance, token usage attribution) that only need
@@ -1509,6 +1532,42 @@ mod tests {
                 pr_url: "https://github.com/acme/myrepo/pull/42".to_string(),
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn list_active_summaries_filters_terminal_history_and_cache_overrides(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+        let active_id = harness_core::types::TaskId("active".to_string());
+        let active = TaskState::new(active_id.clone());
+        store.insert(&active).await;
+
+        let terminal_id = harness_core::types::TaskId("terminal".to_string());
+        let mut terminal = TaskState::new(terminal_id.clone());
+        terminal.status = TaskStatus::Done;
+        store.insert(&terminal).await;
+
+        let stale_db_id = harness_core::types::TaskId("stale-db-active".to_string());
+        let stale_db_active = TaskState::new(stale_db_id.clone());
+        store.insert(&stale_db_active).await;
+        let mut terminal_cache = stale_db_active;
+        terminal_cache.status = TaskStatus::Failed;
+        terminal_cache.reconcile_scheduler_with_status();
+        store.cache.insert(stale_db_id.clone(), terminal_cache);
+
+        let ids: std::collections::HashSet<_> = store
+            .list_active_summaries()
+            .await?
+            .into_iter()
+            .map(|summary| summary.id)
+            .collect();
+
+        assert!(ids.contains(&active_id));
+        assert!(!ids.contains(&terminal_id));
+        assert!(!ids.contains(&stale_db_id));
+        Ok(())
     }
 
     fn pending_task(id: &str) -> TaskState {

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -626,6 +626,31 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn list_nonterminal_instances_by_definition(
+        &self,
+        definition_id: &str,
+        project_id: Option<&str>,
+        limit: Option<i64>,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let limit = limit.map(|value| value.clamp(1, 500));
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE definition_id = $1
+               AND state NOT IN ('done', 'passed', 'failed', 'cancelled')
+               AND ($2::text IS NULL OR data->'data'->>'project_id' = $2)
+             ORDER BY updated_at DESC
+             LIMIT COALESCE($3, 2147483647)",
+        )
+        .bind(definition_id)
+        .bind(project_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
     pub async fn append_event(
         &self,
         workflow_id: &str,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -20,9 +20,10 @@ use super::{
     QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogPollDecisionInput,
     RepoBacklogWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
     RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowRuntimeStore,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -5114,6 +5115,46 @@ async fn durable_store_lists_workflow_runtime_tree_inputs() -> anyhow::Result<()
     assert_eq!(jobs[0].id, job.id);
     assert_eq!(jobs[0].status, RuntimeJobStatus::Pending);
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn durable_store_lists_nonterminal_instances_by_definition() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let active = project_issue_instance("/project-a", 123, "implementing");
+    let queued = project_issue_instance("/project-a", 124, "ready_to_merge");
+    let terminal = project_issue_instance("/project-a", 125, "done");
+    let other_definition = repo_backlog_instance("dispatching").with_data(json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+    }));
+    let other_project = project_issue_instance("/project-b", 126, "implementing");
+    store.upsert_instance(&active).await?;
+    store.upsert_instance(&queued).await?;
+    store.upsert_instance(&terminal).await?;
+    store.upsert_instance(&other_definition).await?;
+    store.upsert_instance(&other_project).await?;
+
+    let listed = store
+        .list_nonterminal_instances_by_definition(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            Some("/project-a"),
+            None,
+        )
+        .await?;
+    let ids: std::collections::HashSet<_> =
+        listed.into_iter().map(|instance| instance.id).collect();
+
+    assert!(ids.contains(&active.id));
+    assert!(ids.contains(&queued.id));
+    assert!(!ids.contains(&terminal.id));
+    assert!(!ids.contains(&other_definition.id));
+    assert!(!ids.contains(&other_project.id));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- count active overview tasks from persisted task summaries and workflow runtime submissions instead of the in-memory task queue only
- dedupe runtime submissions by task handle and bucket workflow states into running or queued dashboard counts
- limit token usage aggregation to the last 24 hours and expose the response window

## Verification
- cargo fmt --all -- --check
- cargo test -p harness-server handlers::overview -- --nocapture
- cargo test -p harness-server handlers::token_usage -- --nocapture
- cargo check -p harness-server
- cargo test -p harness-server
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets