### PR TITLE
Route open PR feedback through runtime prompts

### DIFF
--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -2006,6 +2006,110 @@ async fn runtime_job_worker_starts_child_workflow_without_agent_turn() -> anyhow
 }
 
 #[tokio::test]
+async fn runtime_job_worker_starts_prompt_child_workflow_for_open_pr_feedback() -> anyhow::Result<()>
+{
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-pr-feedback-prompt");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+        1,
+        "dispatching",
+        harness_workflow::runtime::WorkflowSubject::new("repo", "owner/repo"),
+    )
+    .with_id("repo-backlog-pr-feedback")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "repo-backlog:owner/repo:pr:1120:feedback",
+        serde_json::json!({
+            "definition_id": "prompt_task",
+            "subject_key": "pr:1120:feedback",
+            "repo": "owner/repo",
+            "pr_number": 1120,
+            "source": "github_pr_feedback",
+            "external_id": "pr-feedback:owner/repo:1120",
+            "task_id": "repo-backlog:owner/repo:pr:1120:feedback",
+            "prompt": "Handle unresolved review feedback for PR https://github.com/owner/repo/pull/1120.",
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    let activity = command.runtime_activity_key().to_string();
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": activity,
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    assert_eq!(tick.failed, 0);
+    let task_id = harness_core::types::TaskId::from_str("repo-backlog:owner/repo:pr:1120:feedback");
+    let child_id = crate::workflow_runtime_submission::prompt_workflow_id(
+        &project_id,
+        Some("pr-feedback:owner/repo:1120"),
+        &task_id,
+    );
+    let child = store
+        .get_instance(&child_id)
+        .await?
+        .expect("prompt child workflow should be created");
+    assert_eq!(child.definition_id, "prompt_task");
+    assert_eq!(
+        child.parent_workflow_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(child.data["source"], "github_pr_feedback");
+    assert_eq!(child.data["external_id"], "pr-feedback:owner/repo:1120");
+    let completed = store
+        .get_runtime_job(&runtime_job.id)
+        .await?
+        .expect("runtime job should exist");
+    let output: harness_workflow::runtime::ActivityResult = serde_json::from_value(
+        completed
+            .output
+            .expect("activity result should be recorded"),
+    )?;
+    assert_eq!(output.activity, "start_child_workflow");
+    assert!(output
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "child_submission"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -81,8 +81,15 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
     match (workflow_definition, activity) {
         (REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_signals(vec!["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"])
-                .with_explicit_noop_signals(vec!["NoOpenIssueFound"])
+                .with_accepted_signals(vec![
+                    "IssueDiscovered",
+                    "IssueSkipped",
+                    "NoOpenIssueFound",
+                    "OpenPrFeedbackDiscovered",
+                    "OpenPrFeedbackSkipped",
+                    "NoOpenPrFeedbackFound",
+                ])
+                .with_explicit_noop_signals(vec!["NoOpenIssueFound", "NoOpenPrFeedbackFound"])
                 .requires("at_least_one_accepted_signal")
         }
         (REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY) => {

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -214,12 +214,15 @@ async fn execute_start_prompt_task_child_workflow(
     )
     .await?;
 
+    let mut child = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("prompt task child workflow was not persisted"))?;
+
     if let Some(parent) = parent {
-        if let Some(mut child) = store.get_instance(&submission.workflow_id).await? {
-            if child.parent_workflow_id.is_none() {
-                child.parent_workflow_id = Some(parent.id.clone());
-                store.upsert_instance(&child).await?;
-            }
+        if child.parent_workflow_id.is_none() {
+            child.parent_workflow_id = Some(parent.id.clone());
+            store.upsert_instance(&child).await?;
         }
     }
 
@@ -237,11 +240,6 @@ async fn execute_start_prompt_task_child_workflow(
             }),
         )
         .await?;
-
-    let child = store
-        .get_instance(&submission.workflow_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("prompt task child workflow was not persisted"))?;
 
     Ok(ActivityResult::succeeded(
         activity_name(job),

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -3,7 +3,8 @@ use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
     build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
     DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob, WorkflowDecisionRecord,
-    WorkflowDefinition, WorkflowInstance, WorkflowSubject, PR_FEEDBACK_DEFINITION_ID,
+    WorkflowDefinition, WorkflowInstance, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
+    PR_FEEDBACK_DEFINITION_ID,
 };
 use serde_json::{json, Value};
 use std::path::Path;
@@ -33,6 +34,10 @@ pub(super) async fn execute_start_child_workflow(
     let subject_key = required_string(command, "subject_key")?;
     if definition_id == PR_FEEDBACK_DEFINITION_ID {
         return execute_start_pr_feedback_child_workflow(state, job, parent, command, subject_key)
+            .await;
+    }
+    if definition_id == PROMPT_TASK_DEFINITION_ID {
+        return execute_start_prompt_task_child_workflow(state, job, parent, command, subject_key)
             .await;
     }
     if definition_id != "github_issue_pr" {
@@ -160,6 +165,107 @@ pub(super) async fn execute_start_child_workflow(
         ));
     }
     Ok(result)
+}
+
+async fn execute_start_prompt_task_child_workflow(
+    state: &Arc<AppState>,
+    job: &RuntimeJob,
+    parent: Option<&WorkflowInstance>,
+    command: &Value,
+    subject_key: &str,
+) -> anyhow::Result<ActivityResult> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        anyhow::bail!("workflow runtime store is unavailable");
+    };
+    let project_id = parent
+        .and_then(|workflow| workflow.data.get("project_id"))
+        .and_then(Value::as_str)
+        .or_else(|| job.input.get("project_id").and_then(Value::as_str))
+        .ok_or_else(|| anyhow::anyhow!("prompt task child workflow project_id is missing"))?;
+    let prompt = required_string(command, "prompt")?;
+    let repo = command.get("repo").and_then(Value::as_str).or_else(|| {
+        parent
+            .and_then(|workflow| workflow.data.get("repo"))
+            .and_then(Value::as_str)
+    });
+    let task_id = optional_string(command, "task_id").unwrap_or_else(|| {
+        format!(
+            "repo-backlog:{}:{}",
+            repo.unwrap_or("<none>"),
+            subject_key.replace(':', "-")
+        )
+    });
+    let task_id = TaskId::from_str(&task_id);
+    let source = optional_string(command, "source").unwrap_or_else(|| "runtime_child".to_string());
+    let external_id =
+        optional_string(command, "external_id").unwrap_or_else(|| subject_key.to_string());
+    let submission = crate::workflow_runtime_submission::record_prompt_submission(
+        store,
+        crate::workflow_runtime_submission::PromptSubmissionRuntimeContext {
+            project_root: Path::new(project_id),
+            task_id: &task_id,
+            prompt,
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some(source.as_str()),
+            external_id: Some(external_id.as_str()),
+        },
+    )
+    .await?;
+
+    if let Some(parent) = parent {
+        if let Some(mut child) = store.get_instance(&submission.workflow_id).await? {
+            if child.parent_workflow_id.is_none() {
+                child.parent_workflow_id = Some(parent.id.clone());
+                store.upsert_instance(&child).await?;
+            }
+        }
+    }
+
+    store
+        .append_event(
+            &submission.workflow_id,
+            "ChildWorkflowStarted",
+            "workflow_runtime_worker",
+            json!({
+                "parent_workflow_id": parent.map(|workflow| workflow.id.as_str()),
+                "runtime_job_id": job.id.as_str(),
+                "command_id": job.command_id.as_str(),
+                "definition_id": PROMPT_TASK_DEFINITION_ID,
+                "subject_key": subject_key,
+            }),
+        )
+        .await?;
+
+    let child = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("prompt task child workflow was not persisted"))?;
+
+    Ok(ActivityResult::succeeded(
+        activity_name(job),
+        format!("Prompt task child workflow `{}` started.", child.id),
+    )
+    .with_artifact(ActivityArtifact::new(
+        "child_workflow",
+        json!({
+            "workflow_id": child.id,
+            "definition_id": child.definition_id,
+            "state": child.state,
+            "subject_key": child.subject.subject_key,
+        }),
+    ))
+    .with_artifact(ActivityArtifact::new(
+        "child_submission",
+        json!({
+            "workflow_id": submission.workflow_id,
+            "accepted": submission.accepted,
+            "decision_id": submission.decision_id,
+            "command_ids": submission.command_ids,
+            "rejection_reason": submission.rejection_reason,
+        }),
+    )))
 }
 
 async fn execute_start_pr_feedback_child_workflow(

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -327,11 +327,11 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         }),
         ("repo_backlog", "poll_repo_backlog") => json!({
             "on_succeeded": {
-                "reducer_next_state": "planning_batch_when_IssueDiscovered_signals_exist_else_idle",
-                "accepted_signals": ["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
+                "reducer_next_state": "planning_batch_when_IssueDiscovered_signals_exist; dispatching_when_only_OpenPrFeedbackDiscovered_signals_exist; otherwise idle",
+                "accepted_signals": ["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound", "OpenPrFeedbackDiscovered", "OpenPrFeedbackSkipped", "NoOpenPrFeedbackFound"],
                 "success_requires": "At least one accepted signal. Empty signals are invalid even when status is succeeded.",
                 "empty_success_allowed": false,
-                "required_summary": "Describe the GitHub issue query, existing workflow checks, and new issue workflow candidates."
+                "required_summary": "Describe the GitHub issue query, open PR feedback query, existing workflow checks, new issue workflow candidates, and standalone PR feedback candidates."
             },
             "structured_decision": {
                 "optional": true,
@@ -476,13 +476,16 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             }
         }),
         ("repo_backlog", "poll_repo_backlog") => json!({
-            "must_include": ["repo and label queried", "open issues inspected", "existing workflow checks", "new issue workflow candidates", "next workflow action"],
+            "must_include": ["repo and label queried", "open issues inspected", "open PR feedback inspected", "existing workflow checks", "new issue workflow candidates", "open PR feedback candidates", "next workflow action"],
             "must_not_include": ["repository code changes", "workflow table mutations", "server-side GitHub polling changes"],
-            "success_rule": "A succeeded result MUST emit IssueDiscovered, IssueSkipped, or NoOpenIssueFound. Do not return succeeded with empty signals.",
+            "success_rule": "A succeeded result MUST emit at least one accepted issue or open PR feedback signal. Do not return succeeded with empty signals.",
             "signals": {
                 "IssueDiscovered": "Use for each open GitHub issue that should be considered by the runtime sprint planner. Include issue_number, issue_url, repo, title, and labels when available.",
                 "IssueSkipped": "Use for open GitHub issues that already have a workflow, are PRs, or should not be started. Include issue_number and reason. When an issue already has a workflow, include workflow_state.",
-                "NoOpenIssueFound": "Use when the repo/label query found no candidate issues."
+                "NoOpenIssueFound": "Use when the repo/label query found no candidate issues.",
+                "OpenPrFeedbackDiscovered": "Use for each open PR with unresolved actionable review feedback and no active bound workflow. Include pr_number, pr_url, repo, title, feedback_count, and summary.",
+                "OpenPrFeedbackSkipped": "Use for open PRs intentionally skipped because they are already covered, have no actionable feedback, are draft/closed, or are otherwise not candidates. Include pr_number and reason.",
+                "NoOpenPrFeedbackFound": "Use when the open PR review query found no standalone PR feedback candidates."
             },
             "artifacts": {
                 "workflow_decision": {
@@ -697,7 +700,11 @@ mod tests {
         );
         assert_eq!(
             schema["agent_summary_contract"]["success_rule"],
-            "A succeeded result MUST emit IssueDiscovered, IssueSkipped, or NoOpenIssueFound. Do not return succeeded with empty signals."
+            "A succeeded result MUST emit at least one accepted issue or open PR feedback signal. Do not return succeeded with empty signals."
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["signals"]["OpenPrFeedbackDiscovered"],
+            "Use for each open PR with unresolved actionable review feedback and no active bound workflow. Include pr_number, pr_url, repo, title, feedback_count, and summary."
         );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -324,16 +324,47 @@ fn repo_backlog_poll_decision_from_activity_result(
     let parent_repo = optional_data_string(instance, "repo");
     let discovered =
         issue_candidates_from_signals(result, "IssueDiscovered", parent_repo.as_deref());
+    let pr_feedback = pr_feedback_candidates_from_signals(
+        result,
+        "OpenPrFeedbackDiscovered",
+        parent_repo.as_deref(),
+    );
     let known_dependencies =
         known_dependency_candidates_from_skipped_signals(result, parent_repo.as_deref());
 
-    if discovered.is_empty() {
+    if discovered.is_empty() && pr_feedback.is_empty() {
         return None;
+    }
+
+    if discovered.is_empty() {
+        let mut decision = WorkflowDecision::new(
+            &instance.id,
+            &instance.state,
+            "start_open_pr_feedback_tasks_from_scan",
+            "dispatching",
+            format!(
+                "repo backlog scan discovered {} open PR(s) with actionable review feedback",
+                pr_feedback.len()
+            ),
+        )
+        .with_evidence(runtime_completion_evidence(event, result));
+
+        for candidate in pr_feedback {
+            decision = decision
+                .with_command(candidate.start_prompt_task_command(event))
+                .with_evidence(candidate.github_pr_evidence());
+        }
+
+        return Some(decision.high_confidence());
     }
 
     let issue_payloads = discovered
         .iter()
         .map(RepoBacklogIssueCandidate::to_command_value)
+        .collect::<Vec<_>>();
+    let pr_feedback_payloads = pr_feedback
+        .iter()
+        .map(RepoBacklogPrFeedbackCandidate::to_command_value)
         .collect::<Vec<_>>();
     let known_dependency_payloads = known_dependencies
         .iter()
@@ -356,6 +387,7 @@ fn repo_backlog_poll_decision_from_activity_result(
             "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
             "repo": parent_repo,
             "issues": issue_payloads,
+            "open_pr_feedback": pr_feedback_payloads,
             "known_dependencies": known_dependency_payloads,
         }),
     ))
@@ -363,6 +395,9 @@ fn repo_backlog_poll_decision_from_activity_result(
 
     for candidate in discovered {
         decision = decision.with_evidence(candidate.github_issue_evidence());
+    }
+    for candidate in pr_feedback {
+        decision = decision.with_evidence(candidate.github_pr_evidence());
     }
 
     Some(decision.high_confidence())
@@ -390,19 +425,34 @@ fn repo_backlog_sprint_plan_decision_from_activity_result(
         sprint_plan_selected_issues(result, event, parent_repo.as_deref()),
         &sprint_plan_known_dependency_inputs(event, parent_repo.as_deref()),
     );
-    if selected.is_empty() {
+    let pr_feedback = sprint_plan_pr_feedback_inputs(event, parent_repo.as_deref());
+    if selected.is_empty() && pr_feedback.is_empty() {
         return None;
     }
 
-    let mut decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        "start_issue_workflows_from_sprint_plan",
-        "dispatching",
+    let decision_name = if pr_feedback.is_empty() {
+        "start_issue_workflows_from_sprint_plan"
+    } else {
+        "start_repo_backlog_workflows_from_sprint_plan"
+    };
+    let reason = if pr_feedback.is_empty() {
         format!(
             "runtime sprint planner selected {} issue workflow(s) for dispatch",
             selected.len()
-        ),
+        )
+    } else {
+        format!(
+            "runtime sprint planner selected {} issue workflow(s) and {} open PR feedback task(s) for dispatch",
+            selected.len(),
+            pr_feedback.len()
+        )
+    };
+    let mut decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        decision_name,
+        "dispatching",
+        reason,
     )
     .with_evidence(runtime_completion_evidence(event, result));
 
@@ -429,6 +479,11 @@ fn repo_backlog_sprint_plan_decision_from_activity_result(
             ))
             .with_evidence(candidate.github_issue_evidence());
     }
+    for candidate in pr_feedback {
+        decision = decision
+            .with_command(candidate.start_prompt_task_command(event))
+            .with_evidence(candidate.github_pr_evidence());
+    }
 
     Some(decision.high_confidence())
 }
@@ -441,6 +496,120 @@ struct RepoBacklogIssueCandidate {
     title: Option<String>,
     labels: Vec<String>,
     depends_on: Vec<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoBacklogPrFeedbackCandidate {
+    pr_number: u64,
+    repo: Option<String>,
+    pr_url: Option<String>,
+    title: Option<String>,
+    feedback_count: Option<u64>,
+    summary: Option<String>,
+}
+
+impl RepoBacklogPrFeedbackCandidate {
+    fn from_value(value: &Value, parent_repo: Option<&str>) -> Option<Self> {
+        let pr_number = value
+            .get("pr_number")
+            .or_else(|| value.get("pull_request"))
+            .or_else(|| value.get("pr"))
+            .and_then(json_value_u64)?;
+        let repo = value
+            .get("repo")
+            .and_then(non_empty_json_string)
+            .or_else(|| parent_repo.map(ToOwned::to_owned));
+        let pr_url = value
+            .get("pr_url")
+            .or_else(|| value.get("pull_request_url"))
+            .and_then(non_empty_json_string);
+        let title = value.get("title").and_then(non_empty_json_string);
+        let feedback_count = value
+            .get("feedback_count")
+            .or_else(|| value.get("review_thread_count"))
+            .or_else(|| value.get("thread_count"))
+            .and_then(json_value_u64);
+        let summary = value
+            .get("summary")
+            .or_else(|| value.get("reason"))
+            .and_then(non_empty_json_string);
+        Some(Self {
+            pr_number,
+            repo,
+            pr_url,
+            title,
+            feedback_count,
+            summary,
+        })
+    }
+
+    fn start_prompt_task_command(&self, event: &WorkflowEvent) -> WorkflowCommand {
+        let repo_key = self.repo.as_deref().unwrap_or("<none>");
+        let external_id = format!("pr-feedback:{repo_key}:{}", self.pr_number);
+        WorkflowCommand::new(
+            WorkflowCommandType::StartChildWorkflow,
+            format!("repo-backlog:{repo_key}:pr:{}:feedback", self.pr_number),
+            json!({
+                "definition_id": PROMPT_TASK_DEFINITION_ID,
+                "subject_key": format!("pr:{}:feedback", self.pr_number),
+                "repo": self.repo,
+                "pr_number": self.pr_number,
+                "pr_url": self.pr_url,
+                "title": self.title,
+                "feedback_count": self.feedback_count,
+                "source": "github_pr_feedback",
+                "external_id": external_id,
+                "task_id": format!("repo-backlog:{repo_key}:pr:{}:feedback", self.pr_number),
+                "prompt": self.prompt(),
+                "source_event_id": event.id,
+            }),
+        )
+    }
+
+    fn to_command_value(&self) -> Value {
+        json!({
+            "pr_number": self.pr_number,
+            "repo": self.repo,
+            "pr_url": self.pr_url,
+            "title": self.title,
+            "feedback_count": self.feedback_count,
+            "summary": self.summary,
+        })
+    }
+
+    fn prompt(&self) -> String {
+        let repo = self.repo.as_deref().unwrap_or("<unknown repo>");
+        let pr_ref = self
+            .pr_url
+            .as_deref()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("{repo}#{}", self.pr_number));
+        let title = self.title.as_deref().unwrap_or("<unknown title>");
+        let feedback_count = self
+            .feedback_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let summary = self.summary.as_deref().unwrap_or("No summary provided.");
+        format!(
+            "Handle unresolved review feedback for PR {pr_ref}.\n\n\
+Repository: {repo}\n\
+PR number: {}\n\
+PR title: {title}\n\
+Unresolved/actionable feedback count: {feedback_count}\n\
+Discovery summary: {summary}\n\n\
+Inspect the PR review threads, CI state, and mergeability. Address valid requested changes on the PR branch, run the relevant validation commands, push the branch, and reply to or resolve addressed review threads when possible. Do not make unrelated changes.",
+            self.pr_number
+        )
+    }
+
+    fn github_pr_evidence(&self) -> WorkflowEvidence {
+        let repo = self.repo.as_deref().unwrap_or("<none>");
+        let url = self.pr_url.as_deref().unwrap_or("<unknown>");
+        WorkflowEvidence::new(
+            "github_pr_feedback",
+            format!("repo={repo} pr={} url={url}", self.pr_number),
+        )
+    }
 }
 
 impl RepoBacklogIssueCandidate {
@@ -557,6 +726,21 @@ fn issue_candidates_from_signals(
         .collect()
 }
 
+fn pr_feedback_candidates_from_signals(
+    result: &ActivityResult,
+    signal_type: &str,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogPrFeedbackCandidate> {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == signal_type)
+        .filter_map(|signal| {
+            RepoBacklogPrFeedbackCandidate::from_value(&signal.signal, parent_repo)
+        })
+        .collect()
+}
+
 fn known_dependency_candidates_from_skipped_signals(
     result: &ActivityResult,
     parent_repo: Option<&str>,
@@ -624,6 +808,28 @@ fn sprint_plan_known_dependency_inputs(
                         .iter()
                         .filter_map(|value| {
                             RepoBacklogIssueCandidate::from_value(value, parent_repo)
+                        })
+                        .collect()
+                })
+        })
+        .unwrap_or_default()
+}
+
+fn sprint_plan_pr_feedback_inputs(
+    event: &WorkflowEvent,
+    parent_repo: Option<&str>,
+) -> Vec<RepoBacklogPrFeedbackCandidate> {
+    event_workflow_command(event)
+        .and_then(|command| {
+            command
+                .command
+                .get("open_pr_feedback")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|value| {
+                            RepoBacklogPrFeedbackCandidate::from_value(value, parent_repo)
                         })
                         .collect()
                 })
@@ -821,15 +1027,33 @@ fn repo_backlog_invalid_success_decision(
                     "repo backlog poll emitted IssueDiscovered signals, but none contained a valid issue_number",
                 ));
             }
+            let pr_feedback_count = signal_count(result, "OpenPrFeedbackDiscovered");
+            let valid_pr_feedback_count =
+                pr_feedback_candidates_from_signals(result, "OpenPrFeedbackDiscovered", None).len();
+            if pr_feedback_count > 0 && valid_pr_feedback_count == 0 {
+                return Some(invalid_agent_output_blocked_decision(
+                    instance,
+                    event,
+                    result,
+                    "repo backlog poll emitted OpenPrFeedbackDiscovered signals, but none contained a valid pr_number",
+                ));
+            }
             if !has_any_signal(
                 result,
-                &["IssueDiscovered", "IssueSkipped", "NoOpenIssueFound"],
+                &[
+                    "IssueDiscovered",
+                    "IssueSkipped",
+                    "NoOpenIssueFound",
+                    "OpenPrFeedbackDiscovered",
+                    "OpenPrFeedbackSkipped",
+                    "NoOpenPrFeedbackFound",
+                ],
             ) {
                 return Some(invalid_agent_output_blocked_decision(
                     instance,
                     event,
                     result,
-                    "repo backlog poll succeeded without IssueDiscovered, IssueSkipped, or NoOpenIssueFound signals",
+                    "repo backlog poll succeeded without issue or open PR feedback signals",
                 ));
             }
             if structured_decision.is_some() {

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -84,6 +84,12 @@ fn reduce_success(
     }
 
     if let Some(decision) =
+        repo_backlog_invalid_success_decision(instance, event, result, structured_decision.as_ref())
+    {
+        return Some(decision);
+    }
+
+    if let Some(decision) =
         repo_backlog_sprint_plan_decision_from_activity_result(instance, event, result)
     {
         return Some(decision);
@@ -91,12 +97,6 @@ fn reduce_success(
 
     if repo_backlog_child_dispatch_still_active(instance, event) {
         return None;
-    }
-
-    if let Some(decision) =
-        repo_backlog_invalid_success_decision(instance, event, result, structured_decision.as_ref())
-    {
-        return Some(decision);
     }
 
     if let Some(decision) = structured_decision.as_ref() {

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -78,13 +78,13 @@ fn reduce_success(
         return Some(decision);
     }
 
-    if let Some(decision) = repo_backlog_poll_decision_from_activity_result(instance, event, result)
+    if let Some(decision) =
+        repo_backlog_invalid_success_decision(instance, event, result, structured_decision.as_ref())
     {
         return Some(decision);
     }
 
-    if let Some(decision) =
-        repo_backlog_invalid_success_decision(instance, event, result, structured_decision.as_ref())
+    if let Some(decision) = repo_backlog_poll_decision_from_activity_result(instance, event, result)
     {
         return Some(decision);
     }
@@ -1083,7 +1083,8 @@ fn repo_backlog_invalid_success_decision(
             if !has_any_signal(
                 result,
                 &["SprintTaskSelected", "IssueSkipped", "NoSprintTaskSelected"],
-            ) && !has_valid_noop_sprint_plan_artifact
+            ) && sprint_plan_task_count == 0
+                && !has_valid_noop_sprint_plan_artifact
             {
                 return Some(invalid_agent_output_blocked_decision(
                     instance,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -2383,6 +2383,66 @@ fn runtime_completion_reducer_dispatches_sprint_plan_with_pr_feedback_candidates
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_pr_feedback_dispatch_without_valid_sprint_plan_output() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [],
+            "open_pr_feedback": [{
+                "pr_number": 1120,
+                "pr_url": "https://github.com/owner/repo/pull/1120",
+                "title": "feat(tasks): paginate task list queries",
+                "feedback_count": 3,
+                "summary": "Review threads request DB-level pagination."
+            }],
+            "known_dependencies": []
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Completed without emitting a valid sprint plan.",
+    );
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("invalid sprint plan output should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .reason
+        .contains("repo sprint plan succeeded without"));
+    assert!(!decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::StartChildWorkflow));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("invalid sprint plan output block should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_uses_scan_candidates_for_sprint_plan_artifact() {
     let instance = repo_backlog_instance("planning_batch").with_data(json!({
         "repo": "owner/repo"

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -2106,6 +2106,136 @@ fn runtime_completion_reducer_dispatches_repo_backlog_issue_signals() {
 }
 
 #[test]
+fn runtime_completion_reducer_dispatches_standalone_pr_feedback_signals() {
+    let instance = repo_backlog_instance("scanning").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Found one open PR with unresolved review feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "OpenPrFeedbackDiscovered",
+        json!({
+            "pr_number": 1120,
+            "pr_url": "https://github.com/owner/repo/pull/1120",
+            "title": "feat(tasks): paginate task list queries",
+            "feedback_count": 3,
+            "summary": "Review threads request DB-level pagination."
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("repo backlog scan signal should start a PR feedback prompt task");
+
+    assert_eq!(decision.decision, "start_open_pr_feedback_tasks_from_scan");
+    assert_eq!(decision.next_state, "dispatching");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(decision.commands[0].command["definition_id"], "prompt_task");
+    assert_eq!(decision.commands[0].command["pr_number"], 1120);
+    assert_eq!(decision.commands[0].command["source"], "github_pr_feedback");
+    assert!(decision.commands[0].command["prompt"]
+        .as_str()
+        .expect("prompt should be present")
+        .contains("Handle unresolved review feedback"));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("standalone PR feedback dispatch should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_preserves_pr_feedback_when_scan_also_discovers_issues() {
+    let instance = repo_backlog_instance("scanning").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Found one issue and one open PR with unresolved review feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueDiscovered",
+        json!({
+            "issue_number": 42,
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "labels": ["harness"]
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "OpenPrFeedbackDiscovered",
+        json!({
+            "pr_number": 1120,
+            "pr_url": "https://github.com/owner/repo/pull/1120",
+            "title": "feat(tasks): paginate task list queries",
+            "feedback_count": 3,
+            "summary": "Review threads request DB-level pagination."
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("repo backlog scan should keep PR feedback candidates for sprint dispatch");
+
+    assert_eq!(decision.decision, "plan_repo_sprint_from_scan");
+    assert_eq!(decision.next_state, "planning_batch");
+    assert_eq!(
+        decision.commands[0].command["open_pr_feedback"][0]["pr_number"],
+        1120
+    );
+    assert_eq!(
+        decision.commands[0].command["open_pr_feedback"][0]["summary"],
+        "Review threads request DB-level pagination."
+    );
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("repo backlog scan planning should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_dispatches_repo_backlog_sprint_plan() {
     let instance = repo_backlog_instance("planning_batch").with_data(json!({
         "repo": "owner/repo"
@@ -2170,6 +2300,86 @@ fn runtime_completion_reducer_dispatches_repo_backlog_sprint_plan() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("repo backlog sprint dispatch should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_dispatches_sprint_plan_with_pr_feedback_candidates() {
+    let instance = repo_backlog_instance("planning_batch").with_data(json!({
+        "repo": "owner/repo"
+    }));
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        "repo-backlog:owner/repo:plan",
+        json!({
+            "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+            "issues": [{
+                "issue_number": 42,
+                "issue_url": "https://github.com/owner/repo/issues/42",
+                "labels": ["harness"]
+            }],
+            "open_pr_feedback": [{
+                "pr_number": 1120,
+                "pr_url": "https://github.com/owner/repo/pull/1120",
+                "title": "feat(tasks): paginate task list queries",
+                "feedback_count": 3,
+                "summary": "Review threads request DB-level pagination."
+            }],
+            "known_dependencies": []
+        }),
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+        "Selected one issue for sprint dispatch.",
+    )
+    .with_signal(ActivitySignal::new(
+        "SprintTaskSelected",
+        json!({
+            "issue_number": 42,
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "labels": ["harness"],
+            "depends_on": []
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("sprint plan should dispatch issue and PR feedback workflows");
+
+    assert_eq!(
+        decision.decision,
+        "start_repo_backlog_workflows_from_sprint_plan"
+    );
+    assert_eq!(decision.next_state, "dispatching");
+    assert_eq!(decision.commands.len(), 2);
+    assert_eq!(
+        decision.commands[0].command["definition_id"],
+        "github_issue_pr"
+    );
+    assert_eq!(decision.commands[1].command["definition_id"], "prompt_task");
+    assert_eq!(decision.commands[1].command["pr_number"], 1120);
+    assert!(decision.commands[1].command["prompt"]
+        .as_str()
+        .expect("prompt should be present")
+        .contains("Handle unresolved review feedback"));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("mixed repo backlog dispatch should validate");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -3027,6 +3027,66 @@ fn runtime_completion_reducer_blocks_repo_backlog_scan_with_invalid_issue_signal
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_invalid_issue_signal_before_pr_feedback_dispatch() {
+    let instance = repo_backlog_instance("scanning");
+    let command = WorkflowCommand::enqueue_activity(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "repo-backlog:owner/repo:poll",
+    );
+    let result = ActivityResult::succeeded(
+        REPO_BACKLOG_POLL_ACTIVITY,
+        "Found a malformed issue candidate and one PR with feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueDiscovered",
+        json!({
+            "issue_url": "https://github.com/owner/repo/issues/42",
+            "title": "Missing issue number"
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "OpenPrFeedbackDiscovered",
+        json!({
+            "pr_number": 1123,
+            "pr_url": "https://github.com/owner/repo/pull/1123",
+            "title": "Route open PR feedback through runtime prompts",
+            "feedback_count": 1
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("invalid issue signal should block before PR feedback dispatch");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("valid issue_number"));
+    assert!(!decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::StartChildWorkflow));
+    DecisionValidator::repo_backlog()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("invalid mixed scan signal block decision should validate");
+}
+
+#[test]
 fn repo_backlog_requires_plan_activity_when_entering_planning_batch() {
     let instance = repo_backlog_instance("scanning");
     let decision = WorkflowDecision::new(


### PR DESCRIPTION
## Summary
- extend repo backlog poll contracts so runtime agents report standalone open PR feedback candidates
- route `OpenPrFeedbackDiscovered` signals into prompt_task child workflows instead of server-side GitHub polling
- preserve PR feedback candidates when the same scan also discovers issues, then dispatch them after sprint planning

## Testing
- cargo fmt --all -- --check
- cargo test -p harness-workflow pr_feedback -- --nocapture
- cargo test -p harness-workflow
- cargo test -p harness-server runtime_job_worker_starts_prompt_child_workflow_for_open_pr_feedback -- --nocapture
- cargo test -p harness-server
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets