### PR TITLE
Harden Codex app-server turn adapters

### DIFF
--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -11,6 +11,7 @@ use tokio::process::ChildStdout;
 use tokio::sync::{mpsc, Mutex};
 
 type StdoutLines = Lines<BufReader<ChildStdout>>;
+const MAX_PROTOCOL_LINE_PREVIEW: usize = 240;
 
 pub struct CodexAdapter {
     cli_path: PathBuf,
@@ -153,7 +154,12 @@ impl CodexAdapter {
         if line.trim().is_empty() {
             return Ok(Some(ParsedCodexMessage::Ignore));
         }
-        Ok(parse_codex_message(&line))
+        parse_codex_message(&line).map(Some).ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "codex app-server emitted invalid JSON-RPC stdout: {}",
+                protocol_line_preview(&line)
+            ))
+        })
     }
 
     async fn ensure_child(
@@ -325,6 +331,9 @@ impl AgentAdapter for CodexAdapter {
         })?;
         drop(state);
 
+        let mut turn_completed = false;
+        let mut receiver_closed = false;
+        let mut stdout_closed = false;
         while let Some(message) = Self::read_next_message(&mut lines).await? {
             match message {
                 ParsedCodexMessage::TurnStarted { turn_id } => {
@@ -332,6 +341,7 @@ impl AgentAdapter for CodexAdapter {
                     guard.active_turn_id = Some(turn_id);
                     drop(guard);
                     if tx.send(AgentEvent::TurnStarted).await.is_err() {
+                        receiver_closed = true;
                         break;
                     }
                 }
@@ -348,16 +358,35 @@ impl AgentAdapter for CodexAdapter {
                         self.clear_active_turn_id().await;
                     }
                     if tx.send(event).await.is_err() {
+                        receiver_closed = true;
                         break;
                     }
                     if is_terminal {
+                        turn_completed = true;
                         break;
                     }
                 }
             }
         }
+        if !turn_completed && !receiver_closed {
+            stdout_closed = true;
+        }
+
+        if stdout_closed {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "codex app-server stdout closed before turn/completed".into(),
+            ));
+        }
 
         self.state.lock().await.stdout_lines = Some(lines);
+        if receiver_closed {
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "codex event receiver closed before turn/completed".into(),
+            ));
+        }
         Ok(())
     }
 
@@ -422,6 +451,14 @@ impl AgentAdapter for CodexAdapter {
     }
 }
 
+fn protocol_line_preview(line: &str) -> String {
+    let mut preview: String = line.chars().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
+    if line.chars().count() > MAX_PROTOCOL_LINE_PREVIEW {
+        preview.push_str("...");
+    }
+    preview
+}
+
 fn notification_payload(method: &str, params: Value) -> Value {
     json!({
         "method": method,
@@ -442,9 +479,9 @@ fn approval_decision_result(decision: ApprovalDecision) -> Value {
 fn sandbox_mode_value(mode: Option<SandboxMode>) -> Option<String> {
     mode.map(|value| {
         match value {
-            SandboxMode::ReadOnly => "readOnly",
-            SandboxMode::WorkspaceWrite => "workspaceWrite",
-            SandboxMode::DangerFullAccess => "dangerFullAccess",
+            SandboxMode::ReadOnly => "read-only",
+            SandboxMode::WorkspaceWrite => "workspace-write",
+            SandboxMode::DangerFullAccess => "danger-full-access",
         }
         .to_string()
     })
@@ -921,7 +958,7 @@ mod tests {
             json!({
                 "cwd": "/tmp/project",
                 "model": "gpt-runtime",
-                "sandbox": "workspaceWrite",
+                "sandbox": "workspace-write",
                 "approvalPolicy": "on-request",
                 "ephemeral": true,
             })
@@ -952,15 +989,15 @@ mod tests {
     fn sandbox_mode_value_uses_app_server_enum_shape() {
         assert_eq!(
             sandbox_mode_value(Some(SandboxMode::ReadOnly)).as_deref(),
-            Some("readOnly")
+            Some("read-only")
         );
         assert_eq!(
             sandbox_mode_value(Some(SandboxMode::WorkspaceWrite)).as_deref(),
-            Some("workspaceWrite")
+            Some("workspace-write")
         );
         assert_eq!(
             sandbox_mode_value(Some(SandboxMode::DangerFullAccess)).as_deref(),
-            Some("dangerFullAccess")
+            Some("danger-full-access")
         );
         assert_eq!(sandbox_mode_value(None), None);
     }

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -452,8 +452,9 @@ impl AgentAdapter for CodexAdapter {
 }
 
 fn protocol_line_preview(line: &str) -> String {
-    let mut preview: String = line.chars().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
-    if line.chars().count() > MAX_PROTOCOL_LINE_PREVIEW {
+    let mut chars = line.chars();
+    let mut preview: String = chars.by_ref().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
+    if chars.next().is_some() {
         preview.push_str("...");
     }
     preview
@@ -489,12 +490,12 @@ fn sandbox_mode_value(mode: Option<SandboxMode>) -> Option<String> {
 
 fn sandbox_policy_value(mode: Option<SandboxMode>, project_root: &PathBuf) -> Option<Value> {
     mode.map(|value| match value {
-        SandboxMode::ReadOnly => json!({ "type": "readOnly" }),
+        SandboxMode::ReadOnly => json!({ "type": "read-only" }),
         SandboxMode::WorkspaceWrite => json!({
-            "type": "workspaceWrite",
+            "type": "workspace-write",
             "writableRoots": [project_root],
         }),
-        SandboxMode::DangerFullAccess => json!({ "type": "dangerFullAccess" }),
+        SandboxMode::DangerFullAccess => json!({ "type": "danger-full-access" }),
     })
 }
 
@@ -971,7 +972,7 @@ mod tests {
                 "model": "gpt-runtime",
                 "effort": "medium",
                 "sandboxPolicy": {
-                    "type": "workspaceWrite",
+                    "type": "workspace-write",
                     "writableRoots": ["/tmp/project"],
                 },
                 "approvalPolicy": "on-request",
@@ -1000,6 +1001,19 @@ mod tests {
             Some("danger-full-access")
         );
         assert_eq!(sandbox_mode_value(None), None);
+    }
+
+    #[test]
+    fn protocol_line_preview_truncates_without_full_count_scan() {
+        assert_eq!(protocol_line_preview("short"), "short");
+        assert_eq!(
+            protocol_line_preview(&"x".repeat(MAX_PROTOCOL_LINE_PREVIEW)),
+            "x".repeat(MAX_PROTOCOL_LINE_PREVIEW)
+        );
+        assert_eq!(
+            protocol_line_preview(&format!("{}y", "x".repeat(MAX_PROTOCOL_LINE_PREVIEW))),
+            format!("{}...", "x".repeat(MAX_PROTOCOL_LINE_PREVIEW))
+        );
     }
 
     #[tokio::test]

--- a/crates/harness-agents/src/registry.rs
+++ b/crates/harness-agents/src/registry.rs
@@ -32,6 +32,7 @@ impl AdapterExecutionStrategy {
 pub struct AgentDescriptor {
     pub agent: Arc<dyn CodeAgent>,
     pub adapter: Option<Arc<dyn AgentAdapter>>,
+    pub adapter_factory: Option<Arc<dyn Fn() -> Arc<dyn AgentAdapter> + Send + Sync>>,
     pub adapter_strategy: AdapterExecutionStrategy,
 }
 
@@ -67,6 +68,7 @@ impl AgentRegistry {
         // same name (the old split-registry design had this property naturally).
         let existing = self.entries.get(&name);
         let existing_adapter = existing.and_then(|d| d.adapter.clone());
+        let existing_adapter_factory = existing.and_then(|d| d.adapter_factory.clone());
         let existing_strategy = existing.map(|d| d.adapter_strategy).unwrap_or_default();
         if !self.entries.contains_key(&name) {
             self.registration_order.push(name.clone());
@@ -76,6 +78,7 @@ impl AgentRegistry {
             AgentDescriptor {
                 agent,
                 adapter: existing_adapter,
+                adapter_factory: existing_adapter_factory,
                 adapter_strategy: existing_strategy,
             },
         );
@@ -107,11 +110,39 @@ impl AgentRegistry {
         match self.entries.get_mut(name) {
             Some(descriptor) => {
                 descriptor.adapter = Some(adapter);
+                descriptor.adapter_factory = None;
                 descriptor.adapter_strategy = strategy;
                 Ok(())
             }
             None => Err(HarnessError::AgentNotFound(format!(
                 "cannot register adapter: agent '{}' not found",
+                name
+            ))),
+        }
+    }
+
+    /// Attach an adapter factory to an already-registered agent.
+    ///
+    /// Use this for stateful turn-executing adapters that must not share a
+    /// single process or protocol stream across concurrent turns.
+    pub fn register_adapter_factory_with_strategy<F>(
+        &mut self,
+        name: &str,
+        factory: F,
+        strategy: AdapterExecutionStrategy,
+    ) -> harness_core::error::Result<()>
+    where
+        F: Fn() -> Arc<dyn AgentAdapter> + Send + Sync + 'static,
+    {
+        match self.entries.get_mut(name) {
+            Some(descriptor) => {
+                descriptor.adapter = None;
+                descriptor.adapter_factory = Some(Arc::new(factory));
+                descriptor.adapter_strategy = strategy;
+                Ok(())
+            }
+            None => Err(HarnessError::AgentNotFound(format!(
+                "cannot register adapter factory: agent '{}' not found",
                 name
             ))),
         }
@@ -135,7 +166,11 @@ impl AgentRegistry {
     pub fn turn_execution_adapter(&self, name: &str) -> Option<Arc<dyn AgentAdapter>> {
         let descriptor = self.entries.get(name)?;
         if descriptor.adapter_strategy.executes_turns() {
-            descriptor.adapter.clone()
+            descriptor
+                .adapter_factory
+                .as_ref()
+                .map(|factory| factory())
+                .or_else(|| descriptor.adapter.clone())
         } else {
             None
         }
@@ -469,6 +504,31 @@ mod tests {
             Some(AdapterExecutionStrategy::ExecuteTurns)
         );
         assert!(registry.turn_execution_adapter("mock").is_some());
+    }
+
+    #[test]
+    fn adapter_factory_creates_fresh_turn_execution_adapter() {
+        let mut registry = AgentRegistry::new("mock");
+        registry.register("mock", Arc::new(StubAgent { agent_name: "mock" }));
+        let create_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_for_factory = create_count.clone();
+        registry
+            .register_adapter_factory_with_strategy(
+                "mock",
+                move || {
+                    count_for_factory.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Arc::new(StubAdapter {
+                        adapter_name: "mock",
+                    })
+                },
+                AdapterExecutionStrategy::ExecuteTurns,
+            )
+            .unwrap();
+
+        assert!(registry.get_adapter("mock").is_none());
+        assert!(registry.turn_execution_adapter("mock").is_some());
+        assert!(registry.turn_execution_adapter("mock").is_some());
+        assert_eq!(create_count.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/harness-cli/src/commands/serve.rs
+++ b/crates/harness-cli/src/commands/serve.rs
@@ -226,12 +226,15 @@ pub async fn run(
             .with_stream_timeout(serve_config.agents.stream_timeout_secs),
         ),
     );
+    let codex_cli_path = serve_config.agents.codex.cli_path.clone();
     agent_registry
-        .register_adapter_with_strategy(
+        .register_adapter_factory_with_strategy(
             "codex",
-            Arc::new(harness_agents::codex_adapter::CodexAdapter::new(
-                serve_config.agents.codex.cli_path.clone(),
-            )),
+            move || {
+                Arc::new(harness_agents::codex_adapter::CodexAdapter::new(
+                    codex_cli_path.clone(),
+                ))
+            },
             harness_agents::registry::AdapterExecutionStrategy::ExecuteTurns,
         )
         .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -151,8 +151,13 @@ pub(crate) async fn run_turn_lifecycle_with_options(
         }
     }
 
-    // Get the adapter for this agent, if any.
-    let adapter_opt = server.agent_registry.get_adapter(&agent_name);
+    // Prefer the per-turn execution adapter when one exists. Stateful
+    // turn-executing adapters must not be shared across concurrent turns; the
+    // registry may return a fresh adapter instance here.
+    let execution_adapter = server.agent_registry.turn_execution_adapter(&agent_name);
+    let adapter_opt = execution_adapter
+        .clone()
+        .or_else(|| server.agent_registry.get_adapter(&agent_name));
 
     // Register as live adapter (RAII guard for cleanup on turn exit).
     // Adapters may be control-only (Claude: interrupt/steer/approval side
@@ -175,7 +180,6 @@ pub(crate) async fn run_turn_lifecycle_with_options(
     // it owns the full lifecycle. This is the strategy pattern boundary between
     // Codex's App Server adapter and Claude's control-only adapter; avoid
     // branching on agent names here.
-    let execution_adapter = server.agent_registry.turn_execution_adapter(&agent_name);
     let mut execution: std::pin::Pin<
         Box<dyn std::future::Future<Output = harness_core::error::Result<()>> + Send>,
     > = if let Some(adapter_arc) = execution_adapter {


### PR DESCRIPTION
## Summary
- create a fresh Codex app-server adapter for each turn-executing request
- fail loudly when app-server stdout closes before turn completion or the receiver closes early
- align Codex app-server sandbox values with kebab-case enum strings

## Testing
- cargo fmt --all -- --check
- cargo test -p harness-agents
- cargo check -p harness-agents -p harness-cli -p harness-server
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets