### PR TITLE
fix(workflow): commit runtime completion atomically

### DIFF
--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1847,7 +1847,7 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]
             ["signals"]["IssueClosed"],
-        "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include issue_number and state or issue_url."
+        "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include state=closed or state=resolved plus issue_number or issue_url."
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["optional_artifacts"]

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1832,17 +1832,22 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["transition_contract"]
             ["on_succeeded"]["reducer_next_state"],
-        "unchanged_until_pr_detected"
+        "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked"
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]
             ["must_include"][2],
-        "PR URL or blocker"
+        "PR URL, closed issue evidence, or blocker"
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]
             ["artifacts"]["pull_request"]["fields"][1],
         "pr_url"
+    );
+    assert_eq!(
+        prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]
+            ["signals"]["IssueClosed"],
+        "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include issue_number and state or issue_url."
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["optional_artifacts"]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -1,5 +1,6 @@
 use harness_workflow::runtime::{
-    GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL,
+    ISSUE_STATE_ARTIFACT, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
     QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
     QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
@@ -105,7 +106,13 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "implement_issue") => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_artifacts(vec!["pull_request", "workflow_decision"])
+                .with_accepted_signals(vec![ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL])
+                .with_accepted_artifacts(vec![
+                    "pull_request",
+                    ISSUE_STATE_ARTIFACT,
+                    "workflow_decision",
+                ])
+                .requires("pull_request_artifact_or_closed_issue_signal")
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "replan_issue") => {
             ActivityContract::new(workflow_definition, activity)

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -1,6 +1,7 @@
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
     ActivityArtifact, DecisionValidator, RuntimeJob, RuntimeProfile, WorkflowInstance,
+    ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT,
     PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
     PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
     QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
@@ -361,10 +362,13 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         }),
         ("github_issue_pr", "implement_issue") => json!({
             "on_succeeded": {
-                "reducer_next_state": "unchanged_until_pr_detected",
-                "required_summary": "Include changed files, validation commands, and the PR URL when one is created."
+                "reducer_next_state": "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked",
+                "accepted_signals": [ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL],
+                "accepted_artifacts": ["pull_request", ISSUE_STATE_ARTIFACT],
+                "success_requires": "A succeeded implement_issue result MUST include either a pull_request artifact with pr_number/pr_url, or structured closed-issue evidence via IssueClosed/IssueAlreadyResolved signal or issue_state artifact. Empty success is blocked.",
+                "required_summary": "Include changed files, validation commands, and the PR URL or closed issue evidence."
             },
-            "follow_up_event": "PrDetected binds PR metadata and advances the issue workflow."
+            "follow_up_event": "PrDetected can still bind PR metadata, but a runtime result should emit pull_request directly when a PR exists."
         }),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
             "on_succeeded": {
@@ -419,13 +423,21 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
 fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
     match (workflow_definition, activity) {
         ("github_issue_pr", "implement_issue") => json!({
-            "must_include": ["changed files", "validation commands", "PR URL or blocker"],
+            "must_include": ["changed files", "validation commands", "PR URL, closed issue evidence, or blocker"],
             "must_not_include": ["workflow table mutations", "unverified merge claims"],
             "artifacts": {
                 "pull_request": {
                     "required_when": "A PR was created or reused by the activity.",
                     "fields": ["pr_number", "pr_url"]
+                },
+                "issue_state": {
+                    "required_when": "No PR exists because the issue is already closed or resolved.",
+                    "fields": ["issue_number", "state", "issue_url"]
                 }
+            },
+            "signals": {
+                "IssueClosed": "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include issue_number and state or issue_url.",
+                "IssueAlreadyResolved": "Use when the task is already resolved before a PR is created. Include issue_number and state or issue_url."
             }
         }),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
@@ -551,6 +563,48 @@ mod tests {
     use harness_workflow::runtime::{
         RuntimeKind, WorkflowSubject, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
     };
+
+    #[test]
+    fn activity_result_schema_describes_issue_implementation_terminal_evidence_contract() {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue"
+            }),
+        );
+        let workflow = WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:123"),
+        )
+        .with_id("issue-123");
+
+        let schema = activity_result_schema(&job, Some(&workflow));
+
+        assert_eq!(
+            schema["transition_contract"]["on_succeeded"]["reducer_next_state"],
+            "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked"
+        );
+        assert_eq!(
+            schema["activity_contract"]["accepted_signals"][0],
+            ISSUE_CLOSED_SIGNAL
+        );
+        assert_eq!(
+            schema["activity_contract"]["success_requires"],
+            "pull_request_artifact_or_closed_issue_signal"
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["artifacts"]["issue_state"]["fields"][1],
+            "state"
+        );
+        assert_eq!(
+            schema["agent_summary_contract"]["signals"]["IssueAlreadyResolved"],
+            "Use when the task is already resolved before a PR is created. Include issue_number and state or issue_url."
+        );
+    }
 
     #[test]
     fn activity_result_schema_describes_quality_gate_contract() {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -365,7 +365,7 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
                 "reducer_next_state": "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked",
                 "accepted_signals": [ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL],
                 "accepted_artifacts": ["pull_request", ISSUE_STATE_ARTIFACT],
-                "success_requires": "A succeeded implement_issue result MUST include either a pull_request artifact with pr_number/pr_url, or structured closed-issue evidence via IssueClosed/IssueAlreadyResolved signal or issue_state artifact. Empty success is blocked.",
+                "success_requires": "A succeeded implement_issue result MUST include either a pull_request artifact with pr_number/pr_url, or structured closed-issue evidence with explicit closed/resolved state plus issue_number or issue_url. Empty success is blocked.",
                 "required_summary": "Include changed files, validation commands, and the PR URL or closed issue evidence."
             },
             "follow_up_event": "PrDetected can still bind PR metadata, but a runtime result should emit pull_request directly when a PR exists."
@@ -436,8 +436,8 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 }
             },
             "signals": {
-                "IssueClosed": "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include issue_number and state or issue_url.",
-                "IssueAlreadyResolved": "Use when the task is already resolved before a PR is created. Include issue_number and state or issue_url."
+                "IssueClosed": "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include state=closed or state=resolved plus issue_number or issue_url.",
+                "IssueAlreadyResolved": "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url."
             }
         }),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
@@ -602,7 +602,7 @@ mod tests {
         );
         assert_eq!(
             schema["agent_summary_contract"]["signals"]["IssueAlreadyResolved"],
-            "Use when the task is already resolved before a PR is created. Include issue_number and state or issue_url."
+            "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url."
         );
     }
 

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -53,7 +53,8 @@ pub use quality_gate::{
     QUALITY_PASSED_SIGNAL,
 };
 pub use reducer::{
-    reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID, RUNTIME_JOB_COMPLETED_EVENT,
+    reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL,
+    ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT, RUNTIME_JOB_COMPLETED_EVENT,
 };
 pub use repo_backlog::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -1100,7 +1100,7 @@ fn closed_issue_evidence_from_value(value: &Value, source: &str) -> Option<Close
     let state = value.get("state").and_then(non_empty_json_string);
     let closed = issue_state_is_closed(value);
 
-    if issue_number.is_none() && issue_url.is_none() && !closed {
+    if !closed || (issue_number.is_none() && issue_url.is_none()) {
         return None;
     }
 

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -106,6 +106,10 @@ fn reduce_success(
         ));
     }
 
+    if let Some(decision) = issue_implementation_missing_result_decision(instance, event, result) {
+        return Some(decision);
+    }
+
     let (next_state, decision, reason) = match (
         instance.definition_id.as_str(),
         instance.state.as_str(),
@@ -182,6 +186,56 @@ fn reduce_success(
     }
 
     Some(workflow_decision.high_confidence())
+}
+
+fn issue_implementation_missing_result_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        "implementing",
+        "implement_issue",
+    ) {
+        return None;
+    }
+
+    let reason = "implement_issue succeeded without a pull_request artifact, closed-issue evidence, or another validated terminal signal";
+    Some(
+        WorkflowDecision::new(
+            &instance.id,
+            &instance.state,
+            "block_missing_implementation_result",
+            "blocked",
+            reason,
+        )
+        .with_command(WorkflowCommand::mark_blocked(
+            reason,
+            format!(
+                "runtime-completion:{}:missing-implementation:block",
+                event.id
+            ),
+        ))
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::RequestOperatorAttention,
+            format!(
+                "runtime-completion:{}:missing-implementation:operator",
+                event.id
+            ),
+            json!({
+                "reason": reason,
+                "activity": result.activity,
+                "runtime_job_id": event_field_string(event, "runtime_job_id"),
+            }),
+        ))
+        .with_evidence(runtime_completion_evidence(event, result))
+        .high_confidence(),
+    )
 }
 
 fn workflow_decision_from_activity_result(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -17,6 +17,9 @@ use serde_json::{json, Value};
 
 pub const RUNTIME_JOB_COMPLETED_EVENT: &str = "RuntimeJobCompleted";
 pub const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
+pub const ISSUE_CLOSED_SIGNAL: &str = "IssueClosed";
+pub const ISSUE_ALREADY_RESOLVED_SIGNAL: &str = "IssueAlreadyResolved";
+pub const ISSUE_STATE_ARTIFACT: &str = "issue_state";
 
 pub fn reduce_runtime_job_completed(
     instance: &WorkflowInstance,
@@ -51,13 +54,17 @@ fn reduce_success(
     let structured_decision = workflow_decision_from_activity_result(instance, event, result);
     if let Some(decision) = structured_decision
         .as_ref()
-        .filter(|decision| structured_decision_validates(instance, event, decision))
+        .filter(|decision| structured_decision_validates(instance, event, result, decision))
         .cloned()
     {
         return Some(decision);
     }
 
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
+        return Some(decision);
+    }
+
+    if let Some(decision) = issue_implementation_closed_decision(instance, event, result) {
         return Some(decision);
     }
 
@@ -233,6 +240,50 @@ fn issue_implementation_missing_result_decision(
                 "runtime_job_id": event_field_string(event, "runtime_job_id"),
             }),
         ))
+        .with_evidence(runtime_completion_evidence(event, result))
+        .high_confidence(),
+    )
+}
+
+fn issue_implementation_closed_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        "implementing",
+        "implement_issue",
+    ) {
+        return None;
+    }
+
+    let closed_issue = closed_issue_evidence_from_activity_result(result)?;
+    let reason =
+        "implement_issue reported structured evidence that the GitHub issue is already closed";
+    Some(
+        WorkflowDecision::new(
+            &instance.id,
+            &instance.state,
+            "finish_closed_issue",
+            "done",
+            reason,
+        )
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::MarkDone,
+            format!("runtime-completion:{}:closed-issue:done", event.id),
+            json!({
+                "reason": reason,
+                "activity": result.activity,
+                "runtime_job_id": event_field_string(event, "runtime_job_id"),
+                "closed_issue_evidence": closed_issue.payload,
+            }),
+        ))
+        .with_evidence(WorkflowEvidence::new("closed_issue", closed_issue.summary))
         .with_evidence(runtime_completion_evidence(event, result))
         .high_confidence(),
     )
@@ -719,8 +770,18 @@ fn append_missing_u64s(target: &mut Vec<u64>, values: Vec<u64>) {
 fn structured_decision_validates(
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
+    result: &ActivityResult,
     decision: &WorkflowDecision,
 ) -> bool {
+    if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+        && instance.state == "implementing"
+        && result.activity == "implement_issue"
+        && decision.next_state == "done"
+        && closed_issue_evidence_from_activity_result(result).is_none()
+    {
+        return false;
+    }
+
     let validator = match instance.definition_id.as_str() {
         GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
         QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
@@ -994,6 +1055,97 @@ fn pull_request_artifact(result: &ActivityResult) -> Option<(u64, String)> {
                 .to_string();
             Some((pr_number, pr_url))
         })
+}
+
+#[derive(Debug, Clone)]
+struct ClosedIssueEvidence {
+    summary: String,
+    payload: Value,
+}
+
+fn closed_issue_evidence_from_activity_result(
+    result: &ActivityResult,
+) -> Option<ClosedIssueEvidence> {
+    result
+        .signals
+        .iter()
+        .find_map(|signal| match signal.signal_type.as_str() {
+            ISSUE_CLOSED_SIGNAL | ISSUE_ALREADY_RESOLVED_SIGNAL => {
+                closed_issue_evidence_from_value(&signal.signal, &signal.signal_type)
+            }
+            _ => None,
+        })
+        .or_else(|| {
+            result
+                .artifacts
+                .iter()
+                .filter(|artifact| artifact.artifact_type == ISSUE_STATE_ARTIFACT)
+                .find_map(|artifact| {
+                    if issue_state_is_closed(&artifact.artifact) {
+                        closed_issue_evidence_from_value(&artifact.artifact, ISSUE_STATE_ARTIFACT)
+                    } else {
+                        None
+                    }
+                })
+        })
+}
+
+fn closed_issue_evidence_from_value(value: &Value, source: &str) -> Option<ClosedIssueEvidence> {
+    let issue_number = value.get("issue_number").and_then(Value::as_u64);
+    let issue_url = value
+        .get("issue_url")
+        .or_else(|| value.get("html_url"))
+        .or_else(|| value.get("url"))
+        .and_then(non_empty_json_string);
+    let state = value.get("state").and_then(non_empty_json_string);
+    let closed = issue_state_is_closed(value);
+
+    if issue_number.is_none() && issue_url.is_none() && !closed {
+        return None;
+    }
+
+    let mut facts = vec![format!("source={source}")];
+    if let Some(issue_number) = issue_number {
+        facts.push(format!("issue_number={issue_number}"));
+    }
+    if let Some(issue_url) = issue_url.clone() {
+        facts.push(format!("issue_url={issue_url}"));
+    }
+    if let Some(state) = state.clone() {
+        facts.push(format!("state={state}"));
+    }
+    if closed {
+        facts.push("closed=true".to_string());
+    }
+
+    Some(ClosedIssueEvidence {
+        summary: facts.join(" "),
+        payload: json!({
+            "source": source,
+            "issue_number": issue_number,
+            "issue_url": issue_url,
+            "state": state,
+            "closed": closed,
+        }),
+    })
+}
+
+fn issue_state_is_closed(value: &Value) -> bool {
+    value
+        .get("closed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("state")
+            .and_then(Value::as_str)
+            .is_some_and(|state| {
+                state.trim().eq_ignore_ascii_case("closed")
+                    || state.trim().eq_ignore_ascii_case("resolved")
+            })
+        || value
+            .get("is_closed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
 }
 
 fn pr_feedback_sweep_decision_from_activity_result(

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1,16 +1,25 @@
 use super::model::{
-    ActivityResult, RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind, WorkflowCommand,
-    WorkflowCommandRecord, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
-    WorkflowEvent, WorkflowInstance,
+    ActivityResult, ActivityStatus, RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind,
+    WorkflowCommand, WorkflowCommandRecord, WorkflowCommandType, WorkflowDecision,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance,
 };
+use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
+use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
+use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
+use super::reducer::{reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID};
+use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
+use super::validator::{DecisionValidator, ValidationContext};
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use harness_core::db::{Migration, PgStoreContext};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use sqlx::postgres::PgPool;
 use std::collections::BTreeMap;
 use std::path::Path;
 use uuid::Uuid;
+
+const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
 
 static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
     Migration {
@@ -208,6 +217,14 @@ pub enum RuntimeJobEnqueueOutcome {
     Enqueued(RuntimeJob),
     AlreadyExists(RuntimeJob),
     CommandNotPending { status: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeActivityCompletion {
+    pub runtime_job: RuntimeJob,
+    pub command: Option<WorkflowCommandRecord>,
+    pub workflow_event: Option<WorkflowEvent>,
+    pub decision: Option<WorkflowDecisionRecord>,
 }
 
 fn workflow_command_record_from_row(
@@ -1304,6 +1321,221 @@ impl WorkflowRuntimeStore {
         Ok(Some(job))
     }
 
+    pub async fn commit_runtime_activity_completion_if_owned(
+        &self,
+        runtime_job_id: &str,
+        owner: &str,
+        lease_expires_at: DateTime<Utc>,
+        result: &ActivityResult,
+    ) -> anyhow::Result<Option<RuntimeActivityCompletion>> {
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1 FOR UPDATE")
+                .bind(runtime_job_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((data,)) = row else {
+            anyhow::bail!("runtime job not found: {runtime_job_id}");
+        };
+        let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        let is_current_lease = job.status == RuntimeJobStatus::Running
+            && job
+                .lease
+                .as_ref()
+                .is_some_and(|lease| lease.owner == owner && lease.expires_at == lease_expires_at);
+        if !is_current_lease {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        job.complete(result)?;
+        let updated = to_jsonb_string(&job)?;
+        let status = enum_str(&job.status)?;
+        sqlx::query(
+            "UPDATE runtime_jobs
+             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $4",
+        )
+        .bind(&status)
+        .bind(job.not_before)
+        .bind(&updated)
+        .bind(runtime_job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let command_row: Option<WorkflowCommandRecordRow> = sqlx::query_as(
+            "SELECT id, workflow_id, decision_id, status, dispatch_owner,
+                    dispatch_lease_expires_at, data::text, created_at, updated_at
+             FROM workflow_commands
+             WHERE id = $1
+             FOR UPDATE",
+        )
+        .bind(&job.command_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(command_row) = command_row else {
+            tx.commit().await?;
+            return Ok(Some(RuntimeActivityCompletion {
+                runtime_job: job,
+                command: None,
+                workflow_event: None,
+                decision: None,
+            }));
+        };
+        let mut command = workflow_command_record_from_row(command_row)?;
+        let command_status = command_status_for_activity(result.status);
+        sqlx::query(
+            "UPDATE workflow_commands
+             SET status = $1,
+                 dispatch_owner = NULL,
+                 dispatch_lease_expires_at = NULL,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(command_status)
+        .bind(&command.id)
+        .execute(&mut *tx)
+        .await?;
+        command.status = command_status.to_string();
+        command.dispatch_owner = None;
+        command.dispatch_lease_expires_at = None;
+
+        let active_start_child_workflow_commands =
+            if command.command.command_type == WorkflowCommandType::StartChildWorkflow {
+                let command_type = enum_str(&WorkflowCommandType::StartChildWorkflow)?;
+                let (count,): (i64,) = sqlx::query_as(
+                    "SELECT COUNT(*) FROM workflow_commands
+                     WHERE workflow_id = $1
+                       AND id <> $2
+                       AND command_type = $3
+                       AND status IN ('pending', 'dispatched')",
+                )
+                .bind(&command.workflow_id)
+                .bind(&command.id)
+                .bind(&command_type)
+                .fetch_one(&mut *tx)
+                .await?;
+                count as usize
+            } else {
+                0
+            };
+
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(format!("workflow_events:{}", command.workflow_id))
+            .execute(&mut *tx)
+            .await?;
+        let (next_sequence,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
+        )
+        .bind(&command.workflow_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let event = WorkflowEvent::new(
+            &command.workflow_id,
+            next_sequence as u64,
+            "RuntimeJobCompleted",
+            owner,
+        )
+        .with_payload(json!({
+            "command_id": command.id,
+            "command": command.command,
+            "runtime_job_id": job.id,
+            "runtime_job_status": job.status,
+            "active_start_child_workflow_commands": active_start_child_workflow_commands,
+            "activity_result": result,
+        }));
+        let event_data = to_jsonb_string(&event)?;
+        sqlx::query(
+            "INSERT INTO workflow_events
+                (id, workflow_id, sequence, event_type, source, data)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+        )
+        .bind(&event.id)
+        .bind(&event.workflow_id)
+        .bind(event.sequence as i64)
+        .bind(&event.event_type)
+        .bind(&event.source)
+        .bind(&event_data)
+        .execute(&mut *tx)
+        .await?;
+
+        let decision_record = match sqlx::query_as::<_, (String,)>(
+            "SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE",
+        )
+        .bind(&command.workflow_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        {
+            Some((instance_data,)) => {
+                let mut instance: WorkflowInstance = serde_json::from_str(&instance_data)?;
+                match reduce_runtime_job_completed(&instance, &event)? {
+                    Some(decision) => {
+                        let validator = validator_for_definition(&instance.definition_id);
+                        let record = match validator {
+                            Some(validator) => {
+                                match validator.validate(
+                                    &instance,
+                                    &decision,
+                                    &ValidationContext::new(owner, Utc::now()),
+                                ) {
+                                    Ok(()) => WorkflowDecisionRecord::accepted(
+                                        decision.clone(),
+                                        Some(event.id.clone()),
+                                    ),
+                                    Err(error) => WorkflowDecisionRecord::rejected(
+                                        decision,
+                                        Some(event.id.clone()),
+                                        error.to_string(),
+                                    ),
+                                }
+                            }
+                            None => WorkflowDecisionRecord::rejected(
+                                decision,
+                                Some(event.id.clone()),
+                                "unknown workflow definition for runtime completion",
+                            ),
+                        };
+                        insert_decision_record_tx(&mut tx, &record).await?;
+                        if record.accepted {
+                            for followup in &record.decision.commands {
+                                let status = if followup.requires_runtime_job() {
+                                    "pending"
+                                } else {
+                                    COMMAND_STATUS_HANDLED_INLINE
+                                };
+                                insert_workflow_command_tx(
+                                    &mut tx,
+                                    &instance.id,
+                                    Some(&record.id),
+                                    followup,
+                                    status,
+                                )
+                                .await?;
+                                if !followup.requires_runtime_job() {
+                                    apply_inline_command_side_effect(&mut instance, followup)?;
+                                }
+                            }
+                            instance.state = record.decision.next_state.clone();
+                            instance.version = instance.version.saturating_add(1);
+                            upsert_instance_tx(&mut tx, &instance).await?;
+                        }
+                        Some(record)
+                    }
+                    None => None,
+                }
+            }
+            None => None,
+        };
+
+        tx.commit().await?;
+        Ok(Some(RuntimeActivityCompletion {
+            runtime_job: job,
+            command: Some(command),
+            workflow_event: Some(event),
+            decision: decision_record,
+        }))
+    }
+
     pub async fn get_runtime_job(
         &self,
         runtime_job_id: &str,
@@ -1475,4 +1707,149 @@ async fn runtime_job_for_command_tx(
     row.map(|(data,)| serde_json::from_str(&data))
         .transpose()
         .map_err(Into::into)
+}
+
+async fn insert_decision_record_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    record: &WorkflowDecisionRecord,
+) -> anyhow::Result<()> {
+    let data = to_jsonb_string(record)?;
+    sqlx::query(
+        "INSERT INTO workflow_decisions
+            (id, workflow_id, event_id, accepted, data, rejection_reason)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+         ON CONFLICT (id) DO UPDATE SET
+            accepted = EXCLUDED.accepted,
+            data = EXCLUDED.data,
+            rejection_reason = EXCLUDED.rejection_reason",
+    )
+    .bind(&record.id)
+    .bind(&record.workflow_id)
+    .bind(&record.event_id)
+    .bind(record.accepted)
+    .bind(&data)
+    .bind(&record.rejection_reason)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn insert_workflow_command_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    decision_id: Option<&str>,
+    command: &WorkflowCommand,
+    status: &str,
+) -> anyhow::Result<String> {
+    let data = to_jsonb_string(command)?;
+    let command_type = enum_str(&command.command_type)?;
+    let (id,): (String,) = sqlx::query_as(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+         ON CONFLICT (workflow_id, dedupe_key) DO UPDATE SET
+            status = CASE
+                WHEN workflow_commands.status = 'pending' THEN EXCLUDED.status
+                ELSE workflow_commands.status
+            END,
+            updated_at = CASE
+                WHEN workflow_commands.status = 'pending'
+                     AND workflow_commands.status <> EXCLUDED.status
+                THEN CURRENT_TIMESTAMP
+                ELSE workflow_commands.updated_at
+            END
+         RETURNING id",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(workflow_id)
+    .bind(decision_id)
+    .bind(&command_type)
+    .bind(&command.dedupe_key)
+    .bind(status)
+    .bind(&data)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(id)
+}
+
+async fn upsert_instance_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<()> {
+    let data = to_jsonb_string(instance)?;
+    sqlx::query(
+        "INSERT INTO workflow_instances
+            (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         ON CONFLICT (id) DO UPDATE SET
+            definition_id = EXCLUDED.definition_id,
+            state = EXCLUDED.state,
+            subject_type = EXCLUDED.subject_type,
+            subject_key = EXCLUDED.subject_key,
+            parent_workflow_id = EXCLUDED.parent_workflow_id,
+            data = EXCLUDED.data,
+            version = EXCLUDED.version,
+            updated_at = CURRENT_TIMESTAMP",
+    )
+    .bind(&instance.id)
+    .bind(&instance.definition_id)
+    .bind(&instance.state)
+    .bind(&instance.subject.subject_type)
+    .bind(&instance.subject.subject_key)
+    .bind(&instance.parent_workflow_id)
+    .bind(&data)
+    .bind(instance.version as i64)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn apply_inline_command_side_effect(
+    instance: &mut WorkflowInstance,
+    command: &WorkflowCommand,
+) -> anyhow::Result<()> {
+    if command.command_type != WorkflowCommandType::BindPr {
+        return Ok(());
+    }
+    let pr_number = command
+        .command
+        .get("pr_number")
+        .and_then(Value::as_u64)
+        .context("bind_pr command missing pr_number")?;
+    let pr_url = command
+        .command
+        .get("pr_url")
+        .and_then(Value::as_str)
+        .context("bind_pr command missing pr_url")?;
+
+    if !instance.data.is_object() {
+        instance.data = json!({});
+    }
+    let data = instance
+        .data
+        .as_object_mut()
+        .context("workflow instance data is not an object")?;
+    data.insert("pr_number".to_string(), json!(pr_number));
+    data.insert("pr_url".to_string(), json!(pr_url));
+    Ok(())
+}
+
+fn command_status_for_activity(status: ActivityStatus) -> &'static str {
+    match status {
+        ActivityStatus::Succeeded => "completed",
+        ActivityStatus::Failed => "failed",
+        ActivityStatus::Blocked => "blocked",
+        ActivityStatus::Cancelled => "cancelled",
+    }
+}
+
+fn validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
+    match definition_id {
+        GITHUB_ISSUE_PR_DEFINITION_ID => Some(DecisionValidator::github_issue_pr()),
+        QUALITY_GATE_DEFINITION_ID => Some(DecisionValidator::quality_gate()),
+        PR_FEEDBACK_DEFINITION_ID => Some(DecisionValidator::pr_feedback()),
+        PROMPT_TASK_DEFINITION_ID => Some(DecisionValidator::prompt_task()),
+        REPO_BACKLOG_DEFINITION_ID => Some(DecisionValidator::repo_backlog()),
+        _ => None,
+    }
 }

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -766,6 +766,143 @@ fn runtime_completion_reducer_binds_pr_from_structured_pull_request_artifact() {
 }
 
 #[test]
+fn runtime_completion_reducer_finishes_closed_issue_signal_without_pr() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "Issue was already closed before implementation created a PR.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueClosed",
+        json!({
+            "issue_number": 123,
+            "state": "closed",
+            "issue_url": "https://github.com/owner/repo/issues/123"
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("closed issue signal should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkDone
+    );
+    assert_eq!(
+        decision.commands[0].command["closed_issue_evidence"]["state"],
+        "closed"
+    );
+    assert!(decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "closed_issue"));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("closed issue completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_uses_issue_state_artifact_as_closed_issue_evidence() {
+    let instance = issue_instance("implementing");
+    let result =
+        ActivityResult::succeeded("implement_issue", "Issue state confirms no PR is needed.")
+            .with_artifact(ActivityArtifact::new(
+                "issue_state",
+                json!({
+                    "issue_number": 123,
+                    "state": "closed"
+                }),
+            ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("issue_state artifact should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("closed issue artifact completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_structured_done_without_closed_issue_evidence() {
+    let instance = issue_instance("implementing");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "implementing",
+        "finish_closed_issue",
+        "done",
+        "The agent claimed the issue was closed without structured evidence.",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "agent-claimed-done",
+        json!({ "reason": "missing structured issue state" }),
+    ));
+    let result = ActivityResult::succeeded("implement_issue", "Implementation completed.")
+        .with_artifact(ActivityArtifact::new(
+            "workflow_decision",
+            serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing terminal evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+}
+
+#[test]
 fn runtime_completion_reducer_binds_pr_when_structured_workflow_decision_is_invalid() {
     let instance = issue_instance("implementing");
     let proposed_decision = WorkflowDecision::new(
@@ -3669,6 +3806,77 @@ async fn runtime_worker_blocks_implementation_success_without_pr_evidence() -> a
     assert!(decisions.iter().any(|record| {
         record.accepted && record.decision.decision == "block_missing_implementation_result"
     }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_finishes_closed_issue_success_without_pr() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = project_issue_instance("/project-a", 125, "implementing").with_data(json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 125,
+        "task_id": "task-125",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "issue-125-implement");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded(
+            "implement_issue",
+            "Issue was already resolved upstream.",
+        )
+        .with_signal(ActivitySignal::new(
+            "IssueAlreadyResolved",
+            json!({
+                "issue_number": 125,
+                "state": "closed",
+                "issue_url": "https://github.com/owner/repo/issues/125",
+            }),
+        )),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+    assert_eq!(completed.id, job.id);
+    assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
+
+    let reloaded = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(reloaded.state, "done");
+    assert_eq!(reloaded.data["project_id"], "/project-a");
+    assert_eq!(reloaded.data["issue_number"], 125);
+
+    let commands = store.commands_for(&workflow.id).await?;
+    assert_eq!(commands[0].id, command_id);
+    assert_eq!(commands[0].status, "completed");
+    assert!(commands.iter().any(|record| {
+        record.command.command_type == WorkflowCommandType::MarkDone
+            && record.status == "handled_inline"
+    }));
+
+    let decisions = store.decisions_for(&workflow.id).await?;
+    assert!(decisions
+        .iter()
+        .any(|record| record.accepted && record.decision.decision == "finish_closed_issue"));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -635,7 +635,7 @@ fn runtime_completion_reducer_resumes_after_replan() {
 }
 
 #[test]
-fn runtime_completion_reducer_returns_none_for_unmapped_success() {
+fn runtime_completion_reducer_blocks_issue_implementation_success_without_pr() {
     let instance = issue_instance("implementing");
     let result = ActivityResult::succeeded("implement_issue", "Implementation completed.");
     let event = WorkflowEvent::new(
@@ -650,9 +650,27 @@ fn runtime_completion_reducer_returns_none_for_unmapped_success() {
         "activity_result": result,
     }));
 
-    assert!(reduce_runtime_job_completed(&instance, &event)
+    let decision = reduce_runtime_job_completed(&instance, &event)
         .expect("event should parse")
-        .is_none());
+        .expect("implementation success without PR evidence should block");
+
+    assert_eq!(decision.decision, "block_missing_implementation_result");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("blocked implementation decision should validate");
 }
 
 #[test]
@@ -3587,6 +3605,70 @@ async fn runtime_worker_persists_bind_pr_payload_for_pr_open_transition() -> any
         WorkflowCommandType::BindPr
     );
     assert_ne!(commands[1].status, "pending");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_blocks_implementation_success_without_pr_evidence() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = project_issue_instance("/project-a", 124, "implementing").with_data(json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 124,
+        "task_id": "task-124",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "issue-124-implement");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded("implement_issue", "Implementation completed."),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+    assert_eq!(completed.id, job.id);
+    assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
+
+    let reloaded = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(reloaded.state, "blocked");
+    assert_eq!(reloaded.data["project_id"], "/project-a");
+    assert_eq!(reloaded.data["issue_number"], 124);
+
+    let commands = store.commands_for(&workflow.id).await?;
+    assert_eq!(commands[0].id, command_id);
+    assert_eq!(commands[0].status, "completed");
+    assert!(commands.iter().any(|record| {
+        record.command.command_type == WorkflowCommandType::MarkBlocked
+            && record.status == "handled_inline"
+    }));
+    assert!(commands.iter().any(|record| {
+        record.command.command_type == WorkflowCommandType::RequestOperatorAttention
+            && record.status == "handled_inline"
+    }));
+
+    let decisions = store.decisions_for(&workflow.id).await?;
+    assert!(decisions.iter().any(|record| {
+        record.accepted && record.decision.decision == "block_missing_implementation_result"
+    }));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -859,6 +859,40 @@ fn runtime_completion_reducer_uses_issue_state_artifact_as_closed_issue_evidence
 }
 
 #[test]
+fn runtime_completion_reducer_rejects_closed_issue_signal_without_closed_state() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "Issue signal omitted explicit closed evidence.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueClosed",
+        json!({
+            "issue_number": 123,
+            "state": "open"
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("malformed closed issue signal should block");
+
+    assert_eq!(decision.decision, "block_missing_implementation_result");
+    assert_eq!(decision.next_state, "blocked");
+}
+
+#[test]
 fn runtime_completion_reducer_blocks_structured_done_without_closed_issue_evidence() {
     let instance = issue_instance("implementing");
     let proposed_decision = WorkflowDecision::new(

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -151,6 +151,7 @@ impl TransitionAllowlist {
                 "pr_open",
                 [BindPr, EnqueueActivity, StartChildWorkflow, Wait],
             )
+            .allow("implementing", "done", [MarkDone])
             .allow(
                 "scheduled",
                 "pr_open",

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -93,9 +93,14 @@ impl<'a> RuntimeWorker<'a> {
                 serde_json::to_value(&result)?,
             )
             .await?;
-        let Some(completed) = self
+        let Some(completion) = self
             .store
-            .complete_runtime_job_if_owned(&job.id, &self.owner, lease_expires_at, &result)
+            .commit_runtime_activity_completion_if_owned(
+                &job.id,
+                &self.owner,
+                lease_expires_at,
+                &result,
+            )
             .await?
         else {
             tracing::warn!(
@@ -105,65 +110,11 @@ impl<'a> RuntimeWorker<'a> {
             );
             return Ok(None);
         };
-        self.record_workflow_completion(&completed, &result).await?;
-        Ok(Some(completed))
-    }
-
-    async fn record_workflow_completion(
-        &self,
-        job: &RuntimeJob,
-        result: &ActivityResult,
-    ) -> anyhow::Result<()> {
-        let Some(command) = self.store.get_command(&job.command_id).await? else {
-            return Ok(());
-        };
-        self.store
-            .mark_command_status(&command.id, command_status_for_activity(result.status))
-            .await?;
-        let active_start_child_workflow_commands =
-            if command.command.command_type == WorkflowCommandType::StartChildWorkflow {
-                self.active_start_child_workflow_commands(&command.workflow_id)
-                    .await?
-            } else {
-                0
-            };
-        let event = self
-            .store
-            .append_event(
-                &command.workflow_id,
-                "RuntimeJobCompleted",
-                &self.owner,
-                json!({
-                    "command_id": command.id,
-                    "command": command.command,
-                    "runtime_job_id": job.id,
-                    "runtime_job_status": job.status,
-                    "active_start_child_workflow_commands": active_start_child_workflow_commands,
-                    "activity_result": result,
-                }),
-            )
-            .await?;
-        self.apply_runtime_completion_reducer(&command.workflow_id, &event)
-            .await?;
-        self.propagate_pr_feedback_child_completion(&command.workflow_id, &event)
-            .await?;
-        Ok(())
-    }
-
-    async fn active_start_child_workflow_commands(
-        &self,
-        workflow_id: &str,
-    ) -> anyhow::Result<usize> {
-        Ok(self
-            .store
-            .commands_for(workflow_id)
-            .await?
-            .into_iter()
-            .filter(|record| {
-                record.command.command_type == WorkflowCommandType::StartChildWorkflow
-                    && matches!(record.status.as_str(), "pending" | "dispatched")
-            })
-            .count())
+        if let Some(event) = completion.workflow_event.as_ref() {
+            self.propagate_pr_feedback_child_completion(&event.workflow_id, event)
+                .await?;
+        }
+        Ok(Some(completion.runtime_job))
     }
 
     async fn propagate_pr_feedback_child_completion(
@@ -360,15 +311,6 @@ fn apply_inline_command_side_effect(
     data.insert("pr_number".to_string(), json!(pr_number));
     data.insert("pr_url".to_string(), json!(pr_url));
     Ok(())
-}
-
-fn command_status_for_activity(status: ActivityStatus) -> &'static str {
-    match status {
-        ActivityStatus::Succeeded => "completed",
-        ActivityStatus::Failed => "failed",
-        ActivityStatus::Blocked => "blocked",
-        ActivityStatus::Cancelled => "cancelled",
-    }
 }
 
 fn runtime_profile_for_job(job: &RuntimeJob) -> anyhow::Result<Option<RuntimeProfile>> {

--- a/docs/workflow-runtime-v2-state-machine-spec.md
+++ b/docs/workflow-runtime-v2-state-machine-spec.md
@@ -1,0 +1,468 @@
+# Workflow Runtime V2 State Machine Spec
+
+Status: Draft v1
+Date: 2026-05-21
+Compatibility: no backward compatibility with live legacy task orchestration
+Audience: harness maintainers, runtime implementers, and reviewers
+
+## Purpose
+
+Harness currently has enough workflow-runtime pieces to run work, but the
+state machine is not one coherent system yet. The same user-visible work can be
+represented by legacy task rows, workflow instances, command rows, runtime
+jobs, PR feedback children, and UI projections. That split allows a runtime job
+to succeed while the workflow remains active, and it allows one API surface to
+show active work while another reports zero.
+
+V2 makes workflow runtime the only source of orchestration truth. It removes
+live backward compatibility branches and defines the state, persistence,
+recovery, projection, and verification contracts required for routine operation
+to be mechanically provable.
+
+This spec does not claim that agents, GitHub, the network, or local builds can
+never fail. It requires that failures become explicit persisted states with
+operator-visible evidence, and that a completed runtime job cannot silently
+leave an active workflow behind.
+
+## Audit Baseline
+
+The design is based on a ten-lane static audit of the current runtime:
+
+| Lane | Current finding | Evidence anchors |
+|---|---|---|
+| Runtime core | Structured `workflow_decision` artifacts can outrank stronger domain signals. Reducer commit is not atomic. `pr_feedback` child has unreachable `done` transitions. | `crates/harness-workflow/src/runtime/reducer.rs:51`, `crates/harness-workflow/src/runtime/worker.rs:222`, `crates/harness-workflow/src/runtime/validator.rs:291` |
+| Admission | Runtime admission still depends on legacy task and issue workflow checks. Runtime handles can prefer old historical task IDs. Prompt bodies can be process-local only. | `crates/harness-server/src/services/execution.rs:431`, `crates/harness-server/src/workflow_runtime_submission.rs:22`, `crates/harness-server/src/workflow_runtime_submission.rs:323` |
+| Dispatcher and worker | Jobs, commands, events, decisions, and instance state are committed through separate store calls. A terminal job can leave an active workflow if reducer returns no decision. | `crates/harness-workflow/src/runtime/store.rs:1262`, `crates/harness-workflow/src/runtime/worker.rs:202`, `crates/harness-workflow/src/runtime/worker.rs:243` |
+| PR feedback | Review webhooks do not all enter the same feedback sweep path. Empty successful inspection can no-op. Child outcomes are non-terminal. | `crates/harness-server/src/webhook.rs:161`, `crates/harness-workflow/src/runtime/reducer.rs:1009`, `crates/harness-workflow/src/runtime/tests.rs:3737` |
+| Repo backlog | `repo_backlog` is a long-lived state machine for discovery, can block polling, and is already documented as removable. | `docs/stateless-repo-backlog-poll-spec.md:31`, `crates/harness-server/src/workflow_runtime_repo_backlog.rs:73`, `crates/harness-server/src/stale_workflow_recovery.rs:4` |
+| Projections | `/tasks` appends runtime summaries to legacy task summaries, while `/api/overview` still counts legacy `TaskQueue`. | `crates/harness-server/src/http/task_query_routes.rs:49`, `crates/harness-server/src/http/task_query_routes.rs:121`, `crates/harness-server/src/handlers/overview.rs:43` |
+| Persistence | Runtime schema has weak graph constraints, no one-job-per-command database invariant, JSON-only job lease fields, and unbounded instance scans. | `crates/harness-workflow/src/runtime/store.rs:42`, `crates/harness-workflow/src/runtime/store.rs:76`, `crates/harness-workflow/src/runtime/store.rs:588` |
+| Recovery | Runtime reconciliation misses closed issues before PR binding. Stale recovery mutates `repo_backlog` state directly instead of reconciling commands and jobs. | `crates/harness-server/src/reconciliation.rs:177`, `crates/harness-server/src/reconciliation.rs:454`, `crates/harness-server/src/stale_workflow_recovery.rs:85` |
+| Tests | Current DB-backed runtime tests can skip when Postgres is missing. There is no full HTTP submission to dispatcher to worker to reducer to projection E2E. | `crates/harness-server/src/test_helpers.rs:83`, `crates/harness-server/src/http/tests.rs:3320`, `crates/harness-server/src/http/mod.rs:147` |
+| Operations | `/health` does not prove workflow runtime health. Worker concurrency is batch-based. Status defaults can miss old stuck workflows. | `crates/harness-server/src/http/misc_routes.rs:43`, `crates/harness-server/src/http/background.rs:1495`, `crates/harness-cli/src/commands.rs:129` |
+
+## Goals
+
+- Make `workflow_runtime` the only orchestration source for issues, prompts,
+  PR feedback, runtime jobs, status, and dashboard projections.
+- Remove live legacy task compatibility from runtime admission and projection.
+- Delete the long-lived `repo_backlog` workflow. GitHub issue discovery becomes
+  stateless server intake that creates `github_issue_pr` workflows directly.
+- Make runtime completion atomic: job completion, command status, workflow
+  event, decision record, command outbox, inline side effects, and instance
+  state update commit together.
+- Make every known activity reducer domain-owned. Agent decisions are advisory
+  unless the activity is explicitly declared generic.
+- Make semantic empty success impossible for known activities.
+- Make startup and periodic recovery repair or escalate stale runtime state
+  without silently rewriting state.
+- Make `/tasks`, `/api/overview`, dashboard, CLI status, and runtime tree share
+  one runtime projection contract.
+- Make CI prove runtime behavior with non-skipping database and E2E tests.
+
+## Non-Goals
+
+- Preserve compatibility with old live legacy task rows for runtime workflows.
+  Existing rows may be migrated or archived once, but V2 code must not keep live
+  dual-read branches.
+- Keep `repo_backlog` as a workflow definition.
+- Keep `pr_feedback` as a long-lived independent state machine with
+  non-terminal outcome states.
+- Hide unavailable runtime storage behind empty counts or default policies.
+- Start `harness serve` from inside Codex sessions.
+
+## Runtime Ownership
+
+The only long-lived workflow definitions in V2 are:
+
+- `github_issue_pr`: one workflow per tracked GitHub issue or PR-backed issue.
+- `prompt_task`: one workflow per accepted prompt task.
+- `quality_gate`: optional, only when it has independent persisted gate value.
+
+The following are not long-lived workflow state machines in V2:
+
+- GitHub backlog polling. It is stateless intake.
+- PR feedback inspection. It is a parent workflow activity with durable
+  inspection artifacts and command/job records.
+- Dependency analysis. It is an optional batched activity that produces issue
+  creation input, not a per-repo workflow.
+
+`workflow_runtime_store` is mandatory when runtime features are enabled. Server
+startup must fail fast, or the HTTP/API must report runtime unavailable and
+refuse runtime submissions. It must not report zero active work when the runtime
+store failed to open.
+
+## State Model
+
+### Global Rules
+
+- Terminal states are `done`, `failed`, and `cancelled`. `passed` is terminal
+  only for gate workflows.
+- `failed` and `cancelled` are never ordinary scheduler candidates.
+- Reopen-in-place is removed. A retry after terminal state creates a new
+  workflow run or records an explicit recovery workflow with a new run ID.
+- `blocked` is non-terminal but operator-owned. It requires evidence and a
+  `RequestOperatorAttention` command.
+- `running` is not a workflow lifecycle state. It is an execution projection
+  derived only from an unexpired running runtime job lease.
+- A workflow in an active lifecycle state must have one of:
+  - an active command,
+  - an active runtime job,
+  - an external wait condition with a persisted reason and wake rule,
+  - or a recent accepted decision that terminalized or blocked it.
+
+If none of those is true, the workflow is stale and must be repaired or
+escalated by recovery.
+
+### `github_issue_pr`
+
+Allowed states:
+
+- `discovered`
+- `awaiting_dependencies`
+- `scheduled`
+- `implementing`
+- `pr_open`
+- `awaiting_feedback`
+- `addressing_feedback`
+- `ready_to_merge`
+- `blocked`
+- `done`
+- `failed`
+- `cancelled`
+
+Required transitions:
+
+| From | Event or activity | To | Required evidence and commands |
+|---|---|---|---|
+| `discovered` | dependency gate unresolved | `awaiting_dependencies` | persisted dependency set and `Wait` |
+| `discovered`, `awaiting_dependencies`, `scheduled` | ready to implement | `implementing` | `EnqueueActivity(implement_issue)` |
+| `implementing` | implementation produced PR artifact | `pr_open` | `BindPr` with PR number, URL, head SHA when available |
+| `implementing` | issue is externally closed or agent proves already resolved and GitHub confirms closed | `done` | `MarkDone`, GitHub issue state evidence, validation summary |
+| `implementing` | successful agent turn without PR, closure proof, or explicit safe no-op | `blocked` | `MarkBlocked`, `RequestOperatorAttention` |
+| `implementing` | retryable activity failure | `implementing` | retry command with bounded retry policy |
+| `implementing` | non-retryable failure | `blocked` or `failed` | classification evidence |
+| `pr_open`, `awaiting_feedback` | feedback inspection found actionable feedback | `addressing_feedback` | `EnqueueActivity(address_pr_feedback)` and feedback artifact IDs |
+| `pr_open`, `awaiting_feedback` | no actionable feedback but not merge-ready | `awaiting_feedback` | `Wait` with next sweep reason |
+| `pr_open`, `awaiting_feedback`, `addressing_feedback` | no actionable feedback, checks accepted, mergeable or intentionally skipped | `ready_to_merge` | review/check/mergeability evidence |
+| `addressing_feedback` | address activity pushed or replied | `awaiting_feedback` | artifact with pushed head SHA or reply IDs |
+| `addressing_feedback` | successful activity without push, reply, or justified no-op | `blocked` | `MarkBlocked`, `RequestOperatorAttention` |
+| `ready_to_merge` | operator merge approval or external merged PR reconciliation | `done` | `MarkDone`, merge evidence |
+| any non-terminal | explicit operator cancel | `cancelled` | `MarkCancelled` |
+
+The reducer must not leave `implementing` active after `implement_issue`
+succeeds unless another active command or explicit wait was produced in the
+same atomic commit.
+
+### `prompt_task`
+
+Allowed states:
+
+- `submitted`
+- `awaiting_dependencies`
+- `implementing`
+- `blocked`
+- `done`
+- `failed`
+- `cancelled`
+
+Prompt bodies required for execution must be persisted. A process-local cache
+may exist only as an optimization. If a prompt cannot be reconstructed after
+restart, the workflow must enter `blocked` with a configuration error instead
+of staying queued or running.
+
+Prompt idempotency is explicit:
+
+- `external_id` present: idempotent by project and external ID.
+- `external_id` absent: every submission is a new workflow.
+
+### PR Feedback Inspection
+
+V2 removes `pr_feedback` as a long-lived child workflow. Feedback inspection is
+an activity command on the parent `github_issue_pr` workflow.
+
+All review-comment ingress paths must converge on the same parent transition:
+
+- `issue_comment` on a PR
+- `pull_request_review`
+- `pull_request_review_comment`
+- manual `POST /tasks` PR feedback requests
+- periodic sweep
+
+Inspection output must include one explicit outcome:
+
+- `FeedbackFound`
+- `ChangesRequested`
+- `ChecksFailed`
+- `NoFeedbackFound`
+- `PrReadyToMerge`
+
+Empty successful inspection is invalid. The reducer must block with operator
+attention when the activity succeeds without an outcome signal.
+
+Feedback artifacts must persist:
+
+- PR number and URL
+- head SHA inspected
+- unresolved review thread IDs
+- top-level comment IDs considered actionable
+- check suite names and conclusions
+- mergeability state, when available
+- stale or outdated classification
+- body digests for dedupe, not full duplicated comment text unless already
+  stored as part of the existing runtime log
+
+Dedupe keys must include PR number, inspected head SHA, and feedback digest.
+There must be no blanket time-based suppression that hides fresh actionable
+feedback.
+
+### Stateless GitHub Backlog Intake
+
+The `repo_backlog` workflow definition is deleted. Intake directly fetches
+GitHub issues through the configured token and creates `github_issue_pr`
+workflows idempotently.
+
+The existing design in `docs/stateless-repo-backlog-poll-spec.md` is accepted
+as the starting point with these V2 additions:
+
+- Intake counters are part of runtime health: `open_seen`, `skipped_pr`,
+  `skipped_label`, `covered_existing`, `terminal_skipped`, `started_direct`,
+  `dependency_analysis_queued`, and `errors`.
+- `covered_existing` is not running work.
+- `force_execute` label behavior is preserved when creating
+  `github_issue_pr`.
+- Failed or cancelled existing issue workflows are skipped unless an explicit
+  operator retry creates a new run.
+- Old `repo_backlog` rows are removed by migration or archived outside the
+  active runtime schema.
+
+## Reducer Policy
+
+Known activities are server-owned. The reducer order for known activities is:
+
+1. Parse and validate the `ActivityResult` envelope.
+2. Verify the result activity matches the command activity.
+3. Extract required domain signals and artifacts for the activity.
+4. Apply domain precedence. Blocking feedback beats ready-to-merge. GitHub
+   closure evidence beats agent text. Missing required signals is invalid.
+5. Build a server-owned `WorkflowDecision`.
+6. Record any conflicting agent `workflow_decision` artifact as rejected
+   evidence.
+7. Validate the server-owned decision against the state graph.
+8. Commit atomically.
+
+Generic `workflow_decision` artifacts are accepted only for activities whose
+definition explicitly declares `decision_mode = "agent_owned"`. Runtime issue,
+prompt, backlog, and PR feedback activities must not be agent-owned.
+
+The reducer must never perform a silent fallback state transition for a known
+activity without machine-checkable evidence.
+
+## Persistence Contract
+
+Runtime persistence must encode the graph in the database, not only in Rust
+call order.
+
+Required schema changes:
+
+- Add foreign keys where practical:
+  - `workflow_events.workflow_id -> workflow_instances.id`
+  - `workflow_decisions.workflow_id -> workflow_instances.id`
+  - `workflow_commands.workflow_id -> workflow_instances.id`
+  - `workflow_commands.decision_id -> workflow_decisions.id`
+  - `runtime_jobs.command_id -> workflow_commands.id`
+  - `runtime_events.runtime_job_id -> runtime_jobs.id`
+- Add `UNIQUE(runtime_jobs.command_id)` for commands that execute through one
+  runtime job.
+- Promote runtime job lease fields to columns:
+  - `lease_owner`
+  - `lease_expires_at`
+- Index runtime job claiming by `(status, not_before, lease_expires_at,
+  created_at)`.
+- Add first-class runtime projection indexes for:
+  - `definition_id, state, updated_at`
+  - `project_id, repo, issue_number`
+  - `project_id, repo, pr_number`
+  - current task handle only
+- Stop choosing the oldest historical `task_ids` entry as canonical. The
+  current handle is `data.task_id`; historical handles are aliases only.
+- Add real cursor pagination for workflow instance queries. No runtime API or
+  background loop may call unbounded `list_instances_by_definition(None)`.
+
+Required store API changes:
+
+- Replace separate completion calls with one transaction:
+  `commit_runtime_activity_completion`.
+- The transaction must:
+  1. verify current runtime job lease,
+  2. mark the job terminal,
+  3. mark the command terminal,
+  4. append `RuntimeJobCompleted`,
+  5. reduce and validate the decision,
+  6. record accepted or rejected decision,
+  7. enqueue follow-up commands,
+  8. apply inline side effects,
+  9. update workflow instance state and version,
+  10. write projection rows.
+- If any step fails, the transaction rolls back and the job remains eligible
+  for recovery.
+- Public unvalidated runtime job insertion is removed or made test-only.
+
+## Recovery Contract
+
+Recovery must be eventful. It must not mutate workflow state directly without a
+decision record and evidence.
+
+Startup and periodic recovery must detect:
+
+- terminal runtime job with active workflow and no applied reducer decision,
+- terminal command with active workflow and no active successor,
+- dispatched command with no runtime job,
+- pending runtime job with missing command,
+- expired running runtime job lease,
+- active workflow whose required command is missing,
+- closed GitHub issue before PR binding,
+- merged PR,
+- closed unmerged PR,
+- prompt workflow whose persisted prompt body is missing,
+- workflow whose projection row disagrees with stored JSON or events.
+
+Required recovery actions:
+
+- Replay the missing `RuntimeJobCompleted` reduction when enough data exists.
+- Recreate a missing runtime job for a valid dispatched command.
+- Reset an expired running job to pending only through the lease protocol.
+- Mark externally closed issue workflows `done` or `cancelled` with GitHub
+  evidence.
+- Mark merged PR workflows `done` with merge evidence.
+- Block with operator attention when the runtime cannot infer a safe repair.
+- Create a new explicit retry run for terminal workflows instead of reopening
+  the terminal instance.
+
+The old `stale_workflow_recovery` reset-to-idle behavior is removed with
+`repo_backlog`.
+
+## Projection Contract
+
+Runtime projection is a shared module, not a per-route reconstruction.
+
+Required consumers:
+
+- `GET /tasks`
+- `GET /tasks/{id}`
+- `/api/overview`
+- dashboard active and history views
+- `/api/intake`
+- `harness status`
+- runtime tree
+
+The projection must separate lifecycle and execution:
+
+| Projection field | Source |
+|---|---|
+| lifecycle state | `workflow_instances.state` |
+| execution state | active command and runtime job status |
+| running count | unexpired running runtime jobs |
+| queued count | pending runtime jobs plus dispatchable pending commands |
+| blocked count | workflows in `blocked` or failed commands requiring operator action |
+| done/failed/cancelled | terminal workflow states |
+| stale count | recovery detector output |
+
+If runtime projection is unavailable, APIs must return an explicit degraded or
+unavailable response. They must not return zero active work as a fallback.
+
+Legacy task rows may be migrated into archived history, but runtime projection
+must not live-union legacy and runtime rows.
+
+## Operations Contract
+
+`/health` must include runtime state, not only HTTP/store readiness:
+
+- runtime store availability,
+- dispatcher enabled and last successful tick,
+- worker enabled and last successful tick,
+- active worker capacity,
+- pending commands by type,
+- runtime jobs by status,
+- expired running leases,
+- stale active workflows,
+- projection lag,
+- last recovery tick result.
+
+Worker concurrency must be a continuously replenished bounded pool. A long job
+must occupy one worker slot without delaying other finished slots from claiming
+more work.
+
+`WORKFLOW.md` load errors must be consistent:
+
+- startup/runtime loops must fail closed or mark runtime unavailable,
+- HTTP submission must fail with the same configuration error,
+- default-enabled runtime behavior must not silently replace a broken project
+  workflow config.
+
+`harness status` must default to enough runtime visibility for operators, and
+must print when its limit hides older workflows.
+
+## Verification Matrix
+
+CI must run database-backed runtime tests. Tests may skip locally when a
+developer lacks Postgres, but CI must fail if the runtime DB test harness is not
+available.
+
+Required tests:
+
+| Area | Required proof |
+|---|---|
+| Reducer | `implement_issue` success with PR moves to `pr_open`; success with GitHub-closed issue moves to `done`; success without PR or closure blocks. |
+| Reducer | PR feedback blocking signals beat ready signals. Empty feedback success blocks. |
+| Reducer | `address_pr_feedback` success without push, reply, or justified no-op blocks. |
+| Reducer | Terminal workflows cannot reopen in place. |
+| Store | `commit_runtime_activity_completion` is atomic under injected failures after job update, command update, decision record, and command enqueue. |
+| Store | one runtime job per command is enforced by the database. |
+| Store | expired lease reclaim uses indexed columns and stale worker completion is ignored. |
+| Admission | issue, prompt, and PR feedback submissions require runtime store and do not inspect legacy task rows. |
+| Admission | prompt dependency release survives process restart because prompt body is persisted. |
+| Intake | stateless GitHub poll creates workflows idempotently and never creates `repo_backlog` rows. |
+| PR feedback | all webhook types converge on parent feedback inspection. |
+| Recovery | terminal job plus active workflow is replayed or blocked on restart. |
+| Recovery | closed issue without PR binding exits active state. |
+| Projection | `/tasks`, `/api/overview`, dashboard, and status report the same active/running/queued counts from runtime data. |
+| E2E | HTTP submit -> dispatcher -> worker -> reducer -> projection completes for issue and prompt workflows. |
+| E2E | unresolved review comment -> inspect -> address -> rescan -> ready_to_merge. |
+
+## Migration Strategy
+
+This is a breaking runtime migration.
+
+1. Stop the server.
+2. Run schema migrations for runtime V2.
+3. Archive or delete old `repo_backlog` workflow rows, commands, decisions,
+   events, and jobs.
+4. Migrate current runtime issue and prompt handles to the V2 canonical handle
+   format.
+5. Archive legacy task rows that correspond to runtime workflows.
+6. Start server with runtime store mandatory.
+7. Run startup recovery.
+8. Verify projection parity and runtime health before admitting new work.
+
+Old binaries are unsupported after the V2 migration.
+
+## Implementation Order
+
+1. Add failing tests for the known production failure: succeeded runtime job,
+   `github_issue_pr` still `implementing`, no active child process, closed
+   issue or no PR.
+2. Add atomic runtime completion transaction.
+3. Make known activity reducers server-owned and block semantic empty success.
+4. Remove `pr_feedback` child lifecycle and converge all feedback ingress on
+   parent inspection.
+5. Replace `repo_backlog` with stateless GitHub intake.
+6. Persist prompt bodies and fix runtime handle canonicalization.
+7. Build the shared runtime projection module and move `/tasks`,
+   `/api/overview`, dashboard, and status onto it.
+8. Replace direct stale state mutation with eventful recovery.
+9. Add runtime health fields and continuous worker pool semantics.
+10. Remove live legacy task compatibility branches and archive old rows.
+
+Each step must land with focused tests and `cargo check`, `cargo test`, and
+`RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` before PR.

--- a/plan/workflow-runtime-v2-state-machine-plan.md
+++ b/plan/workflow-runtime-v2-state-machine-plan.md
@@ -54,6 +54,9 @@ Completed:
 
 - `implement_issue` success without PR or terminal evidence now has reducer and
   worker coverage and moves the workflow to `blocked`.
+- `implement_issue` success with structured closed-issue evidence now has
+  reducer, worker, and prompt-contract coverage and moves the workflow to
+  `done`.
 
 Validation:
 
@@ -274,3 +277,4 @@ Before the V2 PR can be considered merge-ready:
 | 2026-05-21 | P0.1 partial: `implement_issue` success without PR evidence blocks instead of leaving `implementing`. | `cargo test --package harness-workflow runtime_completion_reducer_blocks_issue_implementation_success_without_pr`; `cargo test --package harness-workflow runtime_worker_blocks_implementation_success_without_pr_evidence` |
 | 2026-05-21 | P0.2: worker runtime completion moved to atomic store commit. | `cargo test --package harness-workflow runtime_completion_reducer`; `cargo test --package harness-workflow runtime_worker` |
 | 2026-05-21 | P0 package verification. | `cargo test --package harness-workflow`; `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` |
+| 2026-05-21 | P0.1 partial: `implement_issue` success with closed issue evidence finishes the workflow. | `cargo test --package harness-workflow runtime_completion_reducer`; `cargo test --package harness-workflow runtime_worker`; `cargo test --package harness-server activity_result_schema_describes_issue_implementation_terminal_evidence_contract`; `cargo test --package harness-server runtime_job_worker_tick_runs_registered_agent_and_completes_job`; `cargo test` |

--- a/plan/workflow-runtime-v2-state-machine-plan.md
+++ b/plan/workflow-runtime-v2-state-machine-plan.md
@@ -57,6 +57,8 @@ Completed:
 - `implement_issue` success with structured closed-issue evidence now has
   reducer, worker, and prompt-contract coverage and moves the workflow to
   `done`.
+- Closed-issue evidence requires explicit closed/resolved state plus issue
+  identity; malformed `IssueClosed` signals with open state still block.
 
 Validation:
 

--- a/plan/workflow-runtime-v2-state-machine-plan.md
+++ b/plan/workflow-runtime-v2-state-machine-plan.md
@@ -1,0 +1,276 @@
+# Workflow Runtime V2 State Machine Plan
+
+Status: draft
+Spec: `docs/workflow-runtime-v2-state-machine-spec.md`
+Compatibility: no backward compatibility with live legacy task orchestration
+
+## Scope
+
+This plan turns the runtime-v2 spec into implementation slices. The immediate
+goal is not another timeout or dashboard patch. The goal is to make the
+workflow runtime's state transitions, command/job graph, recovery, projection,
+and tests one coherent system.
+
+## Baseline
+
+- Current branch: `main`
+- Pre-existing local edits before this plan: `WORKFLOW.md`, `start-server.sh`
+- Current runtime problem class: succeeded terminal runtime jobs can leave
+  active workflow instances, and UI/API projections can disagree about active
+  work.
+- User requirement: no live backward compatibility requirement; prefer a
+  complete long-term design.
+
+## Findings To Fix
+
+| Priority | Finding | Files |
+|---|---|---|
+| P0 | Runtime job completion is not atomic with workflow advancement. | `crates/harness-workflow/src/runtime/worker.rs`, `crates/harness-workflow/src/runtime/store.rs` |
+| P0 | Known activity reducers allow no-op success or agent-owned decisions where server-owned domain evidence is required. | `crates/harness-workflow/src/runtime/reducer.rs`, `crates/harness-workflow/src/runtime/validator.rs` |
+| P0 | Runtime projection is split across legacy task rows, runtime summaries, overview counters, dashboard, and status. | `crates/harness-server/src/http/task_query_routes.rs`, `crates/harness-server/src/handlers/overview.rs`, `crates/harness-cli/src/commands/status.rs` |
+| P1 | PR feedback ingress and child states can strand actionable feedback. | `crates/harness-server/src/webhook.rs`, `crates/harness-server/src/workflow_runtime_pr_feedback.rs`, `crates/harness-workflow/src/runtime/pr_feedback.rs` |
+| P1 | `repo_backlog` is a removable long-lived discovery state machine. | `crates/harness-server/src/workflow_runtime_repo_backlog.rs`, `crates/harness-workflow/src/runtime/repo_backlog.rs`, `crates/harness-server/src/http/background.rs` |
+| P1 | Prompt runtime execution is not restart-safe when prompt bodies are process-local. | `crates/harness-server/src/workflow_runtime_submission.rs`, `crates/harness-server/src/workflow_runtime_worker/data_helpers.rs` |
+| P1 | Recovery mutates state or misses runtime cases instead of replaying or escalating through decisions. | `crates/harness-server/src/reconciliation.rs`, `crates/harness-server/src/stale_workflow_recovery.rs` |
+| P2 | Runtime health and worker concurrency are insufficient for operator proof. | `crates/harness-server/src/http/misc_routes.rs`, `crates/harness-server/src/http/background.rs`, `crates/harness-core/src/config/workflow.rs` |
+
+## Execution Plan
+
+### P0.1 Failing Invariant Tests
+
+Status: in_progress
+
+Add tests that reproduce the production failure class:
+
+- `implement_issue` succeeds with no PR but GitHub issue is closed, and the
+  workflow must become `done`.
+- `implement_issue` succeeds with no PR and no closure proof, and the workflow
+  must become `blocked`.
+- Runtime job terminal state plus active workflow is detected after restart.
+- `/tasks` and `/api/overview` agree on active/running/queued counts for a
+  runtime-only workflow.
+
+Completed:
+
+- `implement_issue` success without PR or terminal evidence now has reducer and
+  worker coverage and moves the workflow to `blocked`.
+
+Validation:
+
+- `cargo test --package harness-workflow runtime_completion`
+- `cargo test --package harness-server runtime_projection`
+
+### P0.2 Atomic Completion Commit
+
+Status: completed
+
+Implement `WorkflowRuntimeStore::commit_runtime_activity_completion` and move
+worker completion to that transaction.
+
+Files:
+
+- `crates/harness-workflow/src/runtime/store.rs`
+- `crates/harness-workflow/src/runtime/worker.rs`
+- `crates/harness-workflow/src/runtime/tests.rs`
+
+Validation:
+
+- worker completion now uses `commit_runtime_activity_completion_if_owned`,
+  which verifies the lease and commits runtime job status, command status,
+  `RuntimeJobCompleted`, reducer decision, follow-up commands, inline side
+  effects, and workflow state together.
+- `cargo test --package harness-workflow runtime_worker`.
+
+### P0.3 Server-Owned Reducers
+
+Status: pending
+
+Make known activities use server-owned reducer decisions. Agent
+`workflow_decision` artifacts become evidence unless the activity explicitly
+declares agent-owned decisions.
+
+Files:
+
+- `crates/harness-workflow/src/runtime/reducer.rs`
+- `crates/harness-workflow/src/runtime/validator.rs`
+- `crates/harness-server/src/workflow_runtime_worker/activity_contract.rs`
+
+Validation:
+
+- semantic empty success blocks for implementation, PR feedback, prompt task,
+  and dependency analysis,
+- blocking PR feedback beats ready-to-merge,
+- terminal reopen denied.
+
+### P0.4 Runtime Projection Module
+
+Status: pending
+
+Create one runtime projection module and route `/tasks`, `/api/overview`,
+dashboard, and CLI status through it.
+
+Files:
+
+- `crates/harness-server/src/runtime_projection.rs`
+- `crates/harness-server/src/http/task_query_routes.rs`
+- `crates/harness-server/src/handlers/overview.rs`
+- `crates/harness-server/src/handlers/dashboard.rs`
+- `crates/harness-cli/src/commands/status.rs`
+
+Validation:
+
+- runtime-only projection tests,
+- cursor pagination tests,
+- degraded runtime-store unavailable tests.
+
+### P1.1 PR Feedback V2
+
+Status: pending
+
+Remove `pr_feedback` as a long-lived state machine. Convert inspection to a
+parent `github_issue_pr` activity and converge all review webhook paths onto
+that activity.
+
+Files:
+
+- `crates/harness-server/src/webhook.rs`
+- `crates/harness-server/src/workflow_runtime_pr_feedback.rs`
+- `crates/harness-workflow/src/runtime/pr_feedback.rs`
+- `crates/harness-workflow/src/runtime/reducer.rs`
+- `crates/harness-server/src/http/tests.rs`
+
+Validation:
+
+- `issue_comment`, `pull_request_review`, and `pull_request_review_comment`
+  all enqueue the same parent inspection path,
+- empty inspection success blocks,
+- unresolved thread IDs are persisted,
+- address feedback and rescan can reach `ready_to_merge`.
+
+### P1.2 Stateless Backlog Intake
+
+Status: pending
+
+Implement `docs/stateless-repo-backlog-poll-spec.md` under V2 constraints and
+delete the `repo_backlog` workflow definition.
+
+Files:
+
+- `crates/harness-server/src/intake/github_backlog_poller.rs`
+- `crates/harness-server/src/http/background.rs`
+- `crates/harness-server/src/workflow_runtime_repo_backlog.rs`
+- `crates/harness-workflow/src/runtime/repo_backlog.rs`
+- `crates/harness-workflow/src/runtime/reducer.rs`
+- `crates/harness-workflow/src/runtime/validator.rs`
+
+Validation:
+
+- idempotent poll test,
+- no `repo_backlog` row creation,
+- force-execute label preserved,
+- second poll starts zero new workflows.
+
+### P1.3 Restart-Safe Prompt Runtime
+
+Status: pending
+
+Persist prompt bodies or durable prompt packets and make dependency release
+restart-safe.
+
+Files:
+
+- `crates/harness-server/src/workflow_runtime_submission.rs`
+- `crates/harness-server/src/workflow_runtime_worker/data_helpers.rs`
+- `crates/harness-workflow/src/runtime/prompt_task.rs`
+
+Validation:
+
+- prompt submitted, server store reopened, dependency released, worker can run,
+- missing persisted prompt body blocks with configuration error.
+
+### P1.4 Eventful Recovery
+
+Status: pending
+
+Replace direct stale state mutation with recovery decisions and replay.
+
+Files:
+
+- `crates/harness-server/src/reconciliation.rs`
+- `crates/harness-server/src/stale_workflow_recovery.rs`
+- `crates/harness-workflow/src/runtime/store.rs`
+
+Validation:
+
+- terminal job plus active workflow recovers,
+- closed issue without PR binding exits active state,
+- merged PR marks workflow done,
+- unsafe repair blocks with operator attention.
+
+### P2.1 Runtime Health And Worker Pool
+
+Status: pending
+
+Make `/health` and `harness status` prove workflow runtime health, and replace
+batch-based worker concurrency with a continuously replenished bounded pool.
+
+Files:
+
+- `crates/harness-server/src/http/misc_routes.rs`
+- `crates/harness-server/src/http/background.rs`
+- `crates/harness-cli/src/commands/status.rs`
+- `crates/harness-core/src/config/workflow.rs`
+
+Validation:
+
+- health reports store, dispatcher, worker, stale, command, and job status,
+- one long job does not prevent free worker slots from claiming more work,
+- status warns when output is limited.
+
+### P2.2 Legacy Removal Migration
+
+Status: pending
+
+Remove live legacy task compatibility from runtime admission and projection.
+Archive or migrate historical rows once.
+
+Files:
+
+- `crates/harness-server/src/services/execution.rs`
+- `crates/harness-server/src/http/task_query_routes.rs`
+- `crates/harness-server/src/task_runner/store.rs`
+- migration files under the runtime store migration sequence
+
+Validation:
+
+- runtime submissions never register legacy task rows,
+- runtime APIs do not live-union legacy rows,
+- old runtime task aliases resolve only through the runtime alias table.
+
+## Stop Conditions
+
+Stop implementation and update this plan if:
+
+- a migration would destroy user data without an archive path,
+- CI cannot provide a non-skipping Postgres runtime test environment,
+- a reducer change needs agent-owned decisions for a known activity,
+- a runtime projection cannot explain why a workflow is counted active.
+
+## Required Final Verification
+
+Before the V2 PR can be considered merge-ready:
+
+- `cargo fmt --all -- --check`
+- `cargo test`
+- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
+- runtime E2E tests with Postgres enabled
+- manual smoke: start server from standalone terminal, submit one prompt and
+  one issue, verify runtime health, projections, and terminal workflow state.
+
+## Execution Log
+
+| Date | Step | Evidence |
+|---|---|---|
+| 2026-05-21 | P0.1 partial: `implement_issue` success without PR evidence blocks instead of leaving `implementing`. | `cargo test --package harness-workflow runtime_completion_reducer_blocks_issue_implementation_success_without_pr`; `cargo test --package harness-workflow runtime_worker_blocks_implementation_success_without_pr_evidence` |
+| 2026-05-21 | P0.2: worker runtime completion moved to atomic store commit. | `cargo test --package harness-workflow runtime_completion_reducer`; `cargo test --package harness-workflow runtime_worker` |
+| 2026-05-21 | P0 package verification. | `cargo test --package harness-workflow`; `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` |


### PR DESCRIPTION
## Summary

- Add a Workflow Runtime V2 state-machine spec and execution plan for the no-backward-compatibility repair path.
- Move runtime worker completion into a single store transaction that commits job status, command status, completion event, reducer decision, follow-up commands, inline side effects, and workflow state together.
- Block `implement_issue` success without a pull request or terminal evidence instead of leaving the workflow active in `implementing`.

## Validation

- `cargo test --package harness-workflow`
- `cargo test --package harness-workflow runtime_completion_reducer`
- `cargo test --package harness-workflow runtime_worker`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo check`
- `git diff --check`

## Notes

`WORKFLOW.md` and `start-server.sh` have local unstaged changes in the checkout, but they are intentionally not included in this PR.