### PR TITLE
fix(review): require PR head proof after local fixes

### DIFF
--- a/crates/harness-core/src/prompts/review.rs
+++ b/crates/harness-core/src/prompts/review.rs
@@ -201,7 +201,10 @@ pub fn agent_review_fix_prompt(
         "The independent reviewer found the following issues in PR {pr_url} \
          (agent review round {round}):\n\n{safe_issue_list}\n\n\
          Fix each issue, run {validation_cmd}, then commit and push.\n\
-         On the last line of your output, print PR_URL=<PR URL>"
+         At the end of your output, print these exact sentinel lines separately:\n\
+         PR_URL=<PR URL>\n\
+         PUSHED_COMMIT=true|false\n\
+         Use PUSHED_COMMIT=false only when no file changes were needed."
     )
 }
 
@@ -230,7 +233,10 @@ pub fn agent_review_intervention_prompt(
          instead of repeating the same fix strategy.\n\n\
          Issues that remain unresolved:\n\n{safe_issue_list}\n\n\
          Fix each issue, run {validation_cmd}, then commit and push.\n\
-         On the last line of your output, print PR_URL=<PR URL>"
+         At the end of your output, print these exact sentinel lines separately:\n\
+         PR_URL=<PR URL>\n\
+         PUSHED_COMMIT=true|false\n\
+         Use PUSHED_COMMIT=false only when no file changes were needed."
     )
 }
 
@@ -620,6 +626,8 @@ mod tests {
         assert!(p.contains("Missing error handling"));
         assert!(p.contains("Unbounded loop"));
         assert!(p.contains("PR_URL="));
+        assert!(p.contains("PUSHED_COMMIT=true|false"));
+        assert!(p.contains("sentinel lines separately"));
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -17,6 +17,10 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
+#[path = "agent_review_workspace_snapshot.rs"]
+mod workspace_snapshot;
+use workspace_snapshot::WorkspaceSnapshot;
+
 /// Compute Jaccard word-similarity between two strings.
 ///
 /// Tokenizes each string into a set of non-empty words (split on non-alphanumeric chars),
@@ -142,8 +146,8 @@ pub(crate) async fn run_agent_review(
     let max_rounds = review_config.max_rounds;
     // (normalized_issues, consecutive_count): tracks how many consecutive rounds produced identical issues.
     let mut impasse_tracker: Option<(Vec<String>, u32)> = None;
-    // Whether the last action in this loop pushed a new commit (fix or intervention).
-    let mut pushed_commit = false;
+    // Whether any local-review fix must be proven by an advanced PR head.
+    let mut fix_requires_pr_head_advance = false;
     let mut approved_review = false;
     let mut approved_review_head: Option<Result<String, String>> = None;
     let mut last_issues: Vec<String> = Vec::new();
@@ -428,7 +432,7 @@ pub(crate) async fn run_agent_review(
                 Some(review_detail),
             )
             .await?;
-            return Ok((false, pushed_commit, approved_review_head));
+            return Ok((false, fix_requires_pr_head_advance, approved_review_head));
         }
 
         // Detect impasse: track how many consecutive rounds produced identical issues.
@@ -481,7 +485,24 @@ pub(crate) async fn run_agent_review(
             break;
         }
 
-        // Implementor fixes the issues
+        // Implementor fixes the issues. The snapshot proves whether a no-op fix
+        // really left the local workspace unchanged.
+        let snapshot_before_fix = match WorkspaceSnapshot::capture(project) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                fail_agent_review(
+                    store,
+                    events,
+                    task_id,
+                    agent_round,
+                    pr_url,
+                    format!("Agent review fix preflight failed: {error}"),
+                    None,
+                )
+                .await?;
+                return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+            }
+        };
         let fix_prompt_built_at = Utc::now();
         let fix_req = AgentRequest {
             prompt: {
@@ -526,6 +547,41 @@ pub(crate) async fn run_agent_review(
         match fix_resp {
             Ok(Ok(success)) => {
                 let r = success.response;
+                let pushed_marker = match prompts::parse_pushed_commit(&r.output) {
+                    Ok(Some(value)) => value,
+                    Ok(None) => {
+                        let error = format!(
+                            "Agent review fix round {agent_round} did not report PUSHED_COMMIT=true|false."
+                        );
+                        fail_agent_review(
+                            store,
+                            events,
+                            task_id,
+                            agent_round,
+                            pr_url,
+                            error,
+                            Some(r.output.clone()),
+                        )
+                        .await?;
+                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                    }
+                    Err(error) => {
+                        let error = format!(
+                            "Agent review fix round {agent_round} reported invalid PUSHED_COMMIT marker: {error}"
+                        );
+                        fail_agent_review(
+                            store,
+                            events,
+                            task_id,
+                            agent_round,
+                            pr_url,
+                            error,
+                            Some(r.output.clone()),
+                        )
+                        .await?;
+                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                    }
+                };
                 if let Some(val_err) = run_post_execute(interceptors, &fix_req, &r).await {
                     tracing::warn!(
                         agent_round,
@@ -533,12 +589,49 @@ pub(crate) async fn run_agent_review(
                         "post-execute validation failed in agent review fix; continuing"
                     );
                 }
+                let workspace_changed = match snapshot_before_fix.changed_since(project) {
+                    Ok(changed) => changed,
+                    Err(error) => {
+                        fail_agent_review(
+                            store,
+                            events,
+                            task_id,
+                            agent_round,
+                            pr_url,
+                            format!("Agent review fix verification failed: {error}"),
+                            Some(r.output.clone()),
+                        )
+                        .await?;
+                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                    }
+                };
+                if workspace_changed && !pushed_marker {
+                    let error = format!(
+                        "Agent review fix round {agent_round} changed the workspace but reported PUSHED_COMMIT=false."
+                    );
+                    fail_agent_review(
+                        store,
+                        events,
+                        task_id,
+                        agent_round,
+                        pr_url,
+                        error,
+                        Some(r.output.clone()),
+                    )
+                    .await?;
+                    return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                }
+                if workspace_changed || pushed_marker {
+                    fix_requires_pr_head_advance = true;
+                }
                 mutate_and_persist(store, task_id, |s| {
                     s.rounds.push(RoundResult::new(
                         0,
                         "agent_review_fix",
                         "fixed",
-                        None,
+                        Some(format!(
+                            "PUSHED_COMMIT={pushed_marker}; WORKSPACE_CHANGED={workspace_changed}"
+                        )),
                         Some(success.telemetry.clone()),
                         None,
                     ));
@@ -589,11 +682,10 @@ pub(crate) async fn run_agent_review(
                 return Err(anyhow::anyhow!("{msg}"));
             }
         }
-        pushed_commit = true;
     }
 
     if approved_review {
-        return Ok((true, pushed_commit, approved_review_head));
+        return Ok((true, fix_requires_pr_head_advance, approved_review_head));
     }
 
     let detail = if last_issues.is_empty() {
@@ -610,5 +702,5 @@ pub(crate) async fn run_agent_review(
         format!("Agent review exhausted {max_rounds} rounds without approval.")
     };
     fail_agent_review(store, events, task_id, max_rounds, pr_url, error, detail).await?;
-    Ok((false, pushed_commit, approved_review_head))
+    Ok((false, fix_requires_pr_head_advance, approved_review_head))
 }

--- a/crates/harness-server/src/task_executor/agent_review_tests.rs
+++ b/crates/harness-server/src/task_executor/agent_review_tests.rs
@@ -2,9 +2,12 @@ use super::agent_review::{jaccard_word_similarity, normalize_issues, run_agent_r
 use crate::task_runner::{TaskId, TaskState, TaskStatus, TaskStore};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
 use harness_core::config::agents::SandboxMode;
-use harness_core::types::{Capability, TokenUsage};
+use harness_core::interceptor::{InterceptResult, PostExecuteResult, TurnInterceptor};
+use harness_core::types::{Capability, ExecutionPhase, TokenUsage};
 use harness_observe::event_store::EventStore;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Duration;
 
@@ -74,6 +77,85 @@ impl CodeAgent for SequenceAgent {
         let _ = tx.send(StreamItem::MessageDelta { text: output }).await;
         let _ = tx.send(StreamItem::Done).await;
         Ok(())
+    }
+}
+
+struct MutatingAgent {
+    name: &'static str,
+    response: &'static str,
+    path: PathBuf,
+}
+
+#[async_trait::async_trait]
+impl CodeAgent for MutatingAgent {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        Vec::new()
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        std::fs::write(&self.path, "changed").map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(error.to_string())
+        })?;
+        Ok(AgentResponse {
+            output: self.response.to_string(),
+            stderr: String::new(),
+            items: Vec::new(),
+            token_usage: TokenUsage::default(),
+            model: self.name.to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        std::fs::write(&self.path, "changed").map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(error.to_string())
+        })?;
+        let _ = tx
+            .send(StreamItem::MessageDelta {
+                text: self.response.to_string(),
+            })
+            .await;
+        let _ = tx.send(StreamItem::Done).await;
+        Ok(())
+    }
+}
+
+struct CacheWritingPostInterceptor {
+    path: PathBuf,
+    execution_only: bool,
+}
+
+#[async_trait::async_trait]
+impl TurnInterceptor for CacheWritingPostInterceptor {
+    fn name(&self) -> &str {
+        "cache_writing_post"
+    }
+
+    async fn pre_execute(&self, _req: &AgentRequest) -> InterceptResult {
+        InterceptResult::pass()
+    }
+
+    async fn post_execute(&self, req: &AgentRequest, _resp: &AgentResponse) -> PostExecuteResult {
+        if self.execution_only && req.execution_phase != Some(ExecutionPhase::Execution) {
+            return PostExecuteResult::pass();
+        }
+        if let Some(parent) = self.path.parent() {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                return PostExecuteResult::fail(error.to_string());
+            }
+        }
+        match std::fs::write(&self.path, "cache") {
+            Ok(()) => PostExecuteResult::pass(),
+            Err(error) => PostExecuteResult::fail(error.to_string()),
+        }
     }
 }
 
@@ -260,7 +342,13 @@ async fn final_impasse_round_does_not_push_unreviewed_fix() -> anyhow::Result<()
         max_rounds: 3,
         ..harness_core::config::agents::AgentReviewConfig::default()
     };
-    let implementor = SequenceAgent::new("implementor", vec!["fixed once", "fixed twice"]);
+    let implementor = SequenceAgent::new(
+        "implementor",
+        vec![
+            "fixed once\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=true",
+            "fixed twice\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=true",
+        ],
+    );
     let reviewer = SequenceAgent::new(
         "reviewer",
         vec![
@@ -312,6 +400,236 @@ async fn final_impasse_round_does_not_push_unreviewed_fix() -> anyhow::Result<()
             .as_deref()
             .unwrap_or_default()
             .contains("exhausted 3 rounds without approval"),
+        "unexpected error: {:?}",
+        state.error
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn changed_fix_round_requires_pr_head_advance() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let project = dir.path().join("project");
+    std::fs::create_dir(&project)?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store.insert(&TaskState::new(task_id.clone())).await;
+    let events = EventStore::new(dir.path()).await?;
+    let skills = RwLock::new(harness_skills::store::SkillStore::new());
+    let config = harness_core::config::agents::AgentReviewConfig {
+        enabled: true,
+        max_rounds: 2,
+        ..harness_core::config::agents::AgentReviewConfig::default()
+    };
+    let implementor = MutatingAgent {
+        name: "implementor",
+        response: "fixed\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=true",
+        path: project.join("changed.txt"),
+    };
+    let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
+    let mut turns_used = 0;
+
+    let (approved, requires_head_advance, _) = run_agent_review(
+        &store,
+        &task_id,
+        &implementor,
+        &reviewer,
+        &config,
+        &[],
+        &project,
+        &[],
+        Duration::from_secs(5),
+        "https://github.com/owner/repo/pull/1",
+        "standard",
+        &events,
+        &skills,
+        &HashMap::new(),
+        None,
+        None,
+        &mut turns_used,
+    )
+    .await?;
+
+    assert!(approved);
+    assert!(
+        requires_head_advance,
+        "changed local fix must require a new reviewed PR head"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn changed_fix_round_rejects_false_noop_marker() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let project = dir.path().join("project");
+    std::fs::create_dir(&project)?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store.insert(&TaskState::new(task_id.clone())).await;
+    let events = EventStore::new(dir.path()).await?;
+    let skills = RwLock::new(harness_skills::store::SkillStore::new());
+    let config = harness_core::config::agents::AgentReviewConfig {
+        enabled: true,
+        max_rounds: 2,
+        ..harness_core::config::agents::AgentReviewConfig::default()
+    };
+    let implementor = MutatingAgent {
+        name: "implementor",
+        response: "fixed\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=false",
+        path: project.join("changed.txt"),
+    };
+    let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
+    let mut turns_used = 0;
+
+    let (approved, requires_head_advance, _) = run_agent_review(
+        &store,
+        &task_id,
+        &implementor,
+        &reviewer,
+        &config,
+        &[],
+        &project,
+        &[],
+        Duration::from_secs(5),
+        "https://github.com/owner/repo/pull/1",
+        "standard",
+        &events,
+        &skills,
+        &HashMap::new(),
+        None,
+        None,
+        &mut turns_used,
+    )
+    .await?;
+
+    let state = store.get(&task_id).expect("task state should be present");
+    assert!(!approved);
+    assert!(!requires_head_advance);
+    assert_eq!(state.status, TaskStatus::Failed);
+    assert!(
+        state
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("changed the workspace but reported PUSHED_COMMIT=false"),
+        "unexpected error: {:?}",
+        state.error
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn noop_fix_round_ignores_validation_cache_artifacts() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let project = dir.path().join("project");
+    std::fs::create_dir(&project)?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store.insert(&TaskState::new(task_id.clone())).await;
+    let events = EventStore::new(dir.path()).await?;
+    let skills = RwLock::new(harness_skills::store::SkillStore::new());
+    let config = harness_core::config::agents::AgentReviewConfig {
+        enabled: true,
+        max_rounds: 2,
+        ..harness_core::config::agents::AgentReviewConfig::default()
+    };
+    let implementor = SequenceAgent::new(
+        "implementor",
+        vec!["no source changes\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=false"],
+    );
+    let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
+    let interceptors: Vec<Arc<dyn TurnInterceptor>> = vec![Arc::new(CacheWritingPostInterceptor {
+        path: project.join(".pytest_cache").join("nodeids"),
+        execution_only: true,
+    })];
+    let mut turns_used = 0;
+
+    let (approved, requires_head_advance, _) = run_agent_review(
+        &store,
+        &task_id,
+        &implementor,
+        &reviewer,
+        &config,
+        &[],
+        &project,
+        &interceptors,
+        Duration::from_secs(5),
+        "https://github.com/owner/repo/pull/1",
+        "standard",
+        &events,
+        &skills,
+        &HashMap::new(),
+        None,
+        None,
+        &mut turns_used,
+    )
+    .await?;
+
+    assert!(approved);
+    assert!(
+        !requires_head_advance,
+        "post-execute cache artifacts must not force PR-head advancement for no-op fixes"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn noop_fix_round_rejects_validation_source_artifacts() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let project = dir.path().join("project");
+    std::fs::create_dir(&project)?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store.insert(&TaskState::new(task_id.clone())).await;
+    let events = EventStore::new(dir.path()).await?;
+    let skills = RwLock::new(harness_skills::store::SkillStore::new());
+    let config = harness_core::config::agents::AgentReviewConfig {
+        enabled: true,
+        max_rounds: 2,
+        ..harness_core::config::agents::AgentReviewConfig::default()
+    };
+    let implementor = SequenceAgent::new(
+        "implementor",
+        vec!["no source changes\nPR_URL=https://github.com/owner/repo/pull/1\nPUSHED_COMMIT=false"],
+    );
+    let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
+    let interceptors: Vec<Arc<dyn TurnInterceptor>> = vec![Arc::new(CacheWritingPostInterceptor {
+        path: project.join("src").join("formatted.rs"),
+        execution_only: true,
+    })];
+    let mut turns_used = 0;
+
+    let (approved, requires_head_advance, _) = run_agent_review(
+        &store,
+        &task_id,
+        &implementor,
+        &reviewer,
+        &config,
+        &[],
+        &project,
+        &interceptors,
+        Duration::from_secs(5),
+        "https://github.com/owner/repo/pull/1",
+        "standard",
+        &events,
+        &skills,
+        &HashMap::new(),
+        None,
+        None,
+        &mut turns_used,
+    )
+    .await?;
+
+    let state = store.get(&task_id).expect("task state should be present");
+    assert!(!approved);
+    assert!(!requires_head_advance);
+    assert_eq!(state.status, TaskStatus::Failed);
+    assert!(
+        state
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("changed the workspace but reported PUSHED_COMMIT=false"),
         "unexpected error: {:?}",
         state.error
     );

--- a/crates/harness-server/src/task_executor/agent_review_workspace_snapshot.rs
+++ b/crates/harness-server/src/task_executor/agent_review_workspace_snapshot.rs
@@ -1,0 +1,272 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::fs;
+use std::hash::Hasher;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct WorkspaceSnapshot {
+    files: BTreeMap<PathBuf, EntryFingerprint>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum EntryFingerprint {
+    File(FileFingerprint),
+    Symlink { target: PathBuf },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct FileFingerprint {
+    len: u64,
+    hash: u64,
+    mode: u32,
+}
+
+impl WorkspaceSnapshot {
+    pub(super) fn capture(root: &Path) -> Result<Self, String> {
+        let mut files = BTreeMap::new();
+        collect_snapshot_files(root, root, &mut files)?;
+        Ok(Self { files })
+    }
+
+    pub(super) fn changed_since(&self, root: &Path) -> Result<bool, String> {
+        Ok(*self != Self::capture(root)?)
+    }
+}
+
+fn collect_snapshot_files(
+    root: &Path,
+    dir: &Path,
+    files: &mut BTreeMap<PathBuf, EntryFingerprint>,
+) -> Result<(), String> {
+    let entries = fs::read_dir(dir).map_err(|error| {
+        format!(
+            "failed to read workspace directory {}: {error}",
+            dir.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read workspace entry in {}: {error}",
+                dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| {
+            format!("failed to stat workspace entry {}: {error}", path.display())
+        })?;
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        if file_type.is_dir() {
+            if should_skip_snapshot_dir(&name) {
+                continue;
+            }
+            collect_snapshot_files(root, &path, files)?;
+            continue;
+        }
+        if should_skip_snapshot_file(&name) {
+            continue;
+        }
+        let relative = relative_snapshot_path(root, &path)?;
+        if file_type.is_symlink() {
+            files.insert(relative, fingerprint_symlink(&path)?);
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        files.insert(relative, fingerprint_file(&path)?);
+    }
+    Ok(())
+}
+
+fn should_skip_snapshot_dir(name: &str) -> bool {
+    const SKIPPED_DIRS: &[&str] = &[
+        ".git",
+        "target",
+        "node_modules",
+        ".next",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".tox",
+        ".nox",
+        ".cache",
+        ".parcel-cache",
+        ".turbo",
+        ".svelte-kit",
+        ".vite",
+        ".gradle",
+        "coverage",
+        "__pycache__",
+        ".venv",
+        "venv",
+    ];
+    SKIPPED_DIRS.contains(&name)
+}
+
+fn should_skip_snapshot_file(name: &str) -> bool {
+    name == ".DS_Store"
+        || name == "tasks.db"
+        || name.starts_with("tasks.db-")
+        || name == "events.db"
+        || name.starts_with("events.db-")
+}
+
+fn relative_snapshot_path(root: &Path, path: &Path) -> Result<PathBuf, String> {
+    path.strip_prefix(root)
+        .map(Path::to_path_buf)
+        .map_err(|error| format!("failed to normalize {}: {error}", path.display()))
+}
+
+fn fingerprint_file(path: &Path) -> Result<EntryFingerprint, String> {
+    let mode = fingerprint_mode(path)?;
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("failed to open {}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to stat {}: {error}", path.display()))?;
+    let mut hasher = DefaultHasher::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let bytes_read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.write(&buffer[..bytes_read]);
+    }
+    Ok(EntryFingerprint::File(FileFingerprint {
+        len: metadata.len(),
+        hash: hasher.finish(),
+        mode,
+    }))
+}
+
+fn fingerprint_symlink(path: &Path) -> Result<EntryFingerprint, String> {
+    fs::read_link(path)
+        .map(|target| EntryFingerprint::Symlink { target })
+        .map_err(|error| format!("failed to read symlink {}: {error}", path.display()))
+}
+
+#[cfg(unix)]
+fn fingerprint_mode(path: &Path) -> Result<u32, String> {
+    use std::os::unix::fs::MetadataExt;
+
+    fs::metadata(path)
+        .map(|metadata| metadata.mode())
+        .map_err(|error| format!("failed to stat {}: {error}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn fingerprint_mode(path: &Path) -> Result<u32, String> {
+    fs::metadata(path)
+        .map(|metadata| u32::from(metadata.permissions().readonly()))
+        .map_err(|error| format!("failed to stat {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkspaceSnapshot;
+
+    #[test]
+    fn changed_since_detects_tracked_output_directory_changes() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let dist_file = dir.path().join("dist").join("bundle.js");
+        let build_file = dir.path().join("build").join("artifact.txt");
+        std::fs::create_dir_all(dist_file.parent().expect("dist parent"))?;
+        std::fs::create_dir_all(build_file.parent().expect("build parent"))?;
+        std::fs::write(&dist_file, "old")?;
+        std::fs::write(&build_file, "old")?;
+
+        let snapshot = WorkspaceSnapshot::capture(dir.path()).map_err(anyhow::Error::msg)?;
+        std::fs::write(&dist_file, "new")?;
+        assert!(snapshot
+            .changed_since(dir.path())
+            .map_err(anyhow::Error::msg)?);
+
+        let snapshot = WorkspaceSnapshot::capture(dir.path()).map_err(anyhow::Error::msg)?;
+        std::fs::write(&build_file, "new")?;
+        assert!(snapshot
+            .changed_since(dir.path())
+            .map_err(anyhow::Error::msg)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn changed_since_ignores_large_cache_directories() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cache_files = [
+            dir.path().join("target").join("debug").join("artifact"),
+            dir.path().join(".pytest_cache").join("nodeids"),
+            dir.path().join(".mypy_cache").join("module.meta.json"),
+        ];
+        for cache_file in &cache_files {
+            std::fs::create_dir_all(cache_file.parent().expect("cache parent"))?;
+            std::fs::write(cache_file, "old")?;
+        }
+
+        let snapshot = WorkspaceSnapshot::capture(dir.path()).map_err(anyhow::Error::msg)?;
+        for cache_file in &cache_files {
+            std::fs::write(cache_file, "new")?;
+        }
+        assert!(!snapshot
+            .changed_since(dir.path())
+            .map_err(anyhow::Error::msg)?);
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn changed_since_detects_executable_bit_changes() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir()?;
+        let script = dir.path().join("script.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n")?;
+
+        let mut permissions = std::fs::metadata(&script)?.permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&script, permissions)?;
+
+        let snapshot = WorkspaceSnapshot::capture(dir.path()).map_err(anyhow::Error::msg)?;
+
+        let mut permissions = std::fs::metadata(&script)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions)?;
+
+        assert!(snapshot
+            .changed_since(dir.path())
+            .map_err(anyhow::Error::msg)?);
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn changed_since_detects_symlink_target_changes() -> anyhow::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("target-a.txt"), "a")?;
+        std::fs::write(dir.path().join("target-b.txt"), "b")?;
+        let link = dir.path().join("current.txt");
+        symlink("target-a.txt", &link)?;
+
+        let snapshot = WorkspaceSnapshot::capture(dir.path()).map_err(anyhow::Error::msg)?;
+
+        std::fs::remove_file(&link)?;
+        symlink("target-b.txt", &link)?;
+
+        assert!(snapshot
+            .changed_since(dir.path())
+            .map_err(anyhow::Error::msg)?);
+
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/task_executor/local_review_completion.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion.rs
@@ -68,7 +68,7 @@ pub(crate) enum LocalReviewPrHead<'a> {
         before_review_error: Option<&'a str>,
         approved_review_sha: Option<&'a str>,
         approved_review_error: Option<&'a str>,
-        local_fix_attempted: bool,
+        local_fix_requires_pr_head_advance: bool,
     },
     #[cfg(test)]
     Verified,
@@ -87,7 +87,7 @@ impl LocalReviewPrHead<'_> {
                 before_review_error,
                 approved_review_sha,
                 approved_review_error,
-                local_fix_attempted,
+                local_fix_requires_pr_head_advance,
                 ..
             } => {
                 if let Some(error) = before_review_error {
@@ -106,7 +106,14 @@ impl LocalReviewPrHead<'_> {
                 let approved_review_sha = approved_review_sha.ok_or_else(|| {
                     "GitHub PR head approval SHA is missing after local review".to_string()
                 })?;
-                if !*local_fix_attempted && approved_review_sha != before_review_sha {
+                if *local_fix_requires_pr_head_advance && approved_review_sha == before_review_sha {
+                    return Err(format!(
+                        "GitHub PR head did not advance after local review fix for \
+                         {repo_slug}#{pr_num}; before {before_review_sha}, approved {approved_review_sha}"
+                    ));
+                }
+                if !*local_fix_requires_pr_head_advance && approved_review_sha != before_review_sha
+                {
                     return Err(format!(
                         "GitHub PR head changed during local review without a local fix for \
                          {repo_slug}#{pr_num}; before {before_review_sha}, approved {approved_review_sha}"
@@ -694,10 +701,31 @@ mod tests {
             before_review_error: None,
             approved_review_sha: Some("same-sha"),
             approved_review_error: None,
-            local_fix_attempted: true,
+            local_fix_requires_pr_head_advance: false,
         };
 
         assert!(gate.verify_local_fix(77).await.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pr_head_gate_requires_advance_after_changed_local_fix() -> anyhow::Result<()> {
+        let gate = LocalReviewPrHead::GitHub {
+            repo_slug: "owner/repo",
+            github_token: None,
+            before_review_sha: Some("same-sha"),
+            before_review_error: None,
+            approved_review_sha: Some("same-sha"),
+            approved_review_error: None,
+            local_fix_requires_pr_head_advance: true,
+        };
+
+        let error = gate
+            .verify_local_fix(77)
+            .await
+            .expect_err("unchanged head should fail after a changed local fix");
+        assert!(error.contains("did not advance after local review fix"));
 
         Ok(())
     }

--- a/crates/harness-server/src/task_executor/local_review_completion_tests.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion_tests.rs
@@ -433,7 +433,7 @@ async fn hosted_bot_disabled_blocks_pr_head_change_during_no_fix_review() -> any
                 before_review_error: None,
                 approved_review_sha: Some("new-sha"),
                 approved_review_error: None,
-                local_fix_attempted: false,
+                local_fix_requires_pr_head_advance: false,
             },
             pr_state: LocalReviewPrState::Open,
         }),

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -702,32 +702,33 @@ pub(crate) async fn run_task(
                     pr_num,
                     github_token: server_config.server.github_token.as_deref(),
                 });
-            let (review_ok, pushed, approved_review_head) = agent_review::run_agent_review(
-                store,
-                task_id,
-                agent,
-                reviewer,
-                review_config,
-                &context_items,
-                &project,
-                &interceptors,
-                turn_timeout,
-                pr_url.as_deref().unwrap_or(""),
-                project_config.review_type.as_str(),
-                &events,
-                &skills,
-                &cargo_env,
-                effective_max_turns,
-                review_head_probe,
-                &mut turns_used,
-            )
-            .await?;
+            let (review_ok, fix_requires_pr_head_advance, approved_review_head) =
+                agent_review::run_agent_review(
+                    store,
+                    task_id,
+                    agent,
+                    reviewer,
+                    review_config,
+                    &context_items,
+                    &project,
+                    &interceptors,
+                    turn_timeout,
+                    pr_url.as_deref().unwrap_or(""),
+                    project_config.review_type.as_str(),
+                    &events,
+                    &skills,
+                    &cargo_env,
+                    effective_max_turns,
+                    review_head_probe,
+                    &mut turns_used,
+                )
+                .await?;
             *turns_used_acc = turns_used;
             if !review_ok {
                 return Ok(());
             }
             local_review_approved = true;
-            agent_pushed_commit = pushed;
+            agent_pushed_commit = fix_requires_pr_head_advance;
             if !review_config.review_bot_auto_trigger {
                 local_review_head_approved = approved_review_head;
             }
@@ -735,7 +736,7 @@ pub(crate) async fn run_task(
             tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
         }
     }
-    let local_review_fix_attempted = agent_pushed_commit;
+    let local_fix_requires_pr_head_advance = agent_pushed_commit;
     agent_pushed_commit |= implementation_pushed_commit;
 
     let wait_secs = resolved.review_wait_secs.unwrap_or(req.wait_secs);
@@ -786,10 +787,7 @@ pub(crate) async fn run_task(
                     before_review_error,
                     approved_review_sha,
                     approved_review_error,
-                    // A successful fix round may be a no-op, so do not require
-                    // the PR head to advance. It only permits a reviewed head
-                    // change; the final gate still locks that approved head.
-                    local_fix_attempted: local_review_fix_attempted,
+                    local_fix_requires_pr_head_advance,
                 },
                 pr_state: LocalReviewPrState::GitHub {
                     repo_slug: &repo_slug_for_review,

--- a/docs/local-codex-review-provider-spec.md
+++ b/docs/local-codex-review-provider-spec.md
@@ -521,9 +521,10 @@ Gate rules:
 7. Missing or pending advisory reports produce `advisory_pending` only when `external_required =
    true`; otherwise the gate can still return `approved` with pending advisory status attached to the
    report.
-8. Merge readiness requires local review pass, PR-head advancement after any local review fix,
-   unchanged reviewed PR head after CI polling, CI green, and an open PR. A PR that was already
-   merged externally after local approval completes the task instead of reopening review.
+8. Merge readiness requires local review pass, PR-head advancement after any local review fix that
+   changed the workspace or reported a pushed commit, unchanged reviewed PR head after CI polling,
+   CI green, and an open PR. A PR that was already merged externally after local approval completes
+   the task instead of reopening review.
 9. If no required providers are configured, Harness must log a warning and fall back to the legacy
    behavior for one release cycle.
 
@@ -786,8 +787,9 @@ Partial implementation shipped first:
 - `harness pr review` uses configured bot command and reviewer names instead of
   hardcoded Gemini strings.
 - Hosted-bot-disabled completion requires local review approval, local
-  validation, PR-head advancement after local review fixes, unchanged reviewed PR head after CI
-  polling, green GitHub PR checks, and an open PR before recording `ReadyToMerge`;
+  validation, PR-head advancement after local review fixes that changed the workspace or reported a
+  pushed commit, unchanged reviewed PR head after CI polling, green GitHub PR checks, and an open PR
+  before recording `ReadyToMerge`;
   PRs that merged externally after local approval are marked done instead of failed;
   pending checks are polled up to the configured review wait budget instead of
   failing immediately;

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -350,7 +350,7 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 | `enabled` | `true` | Enable independent agent review after PR creation. |
 | `reviewer_agent` | `"codex"` | Agent used for review. It may match the implementor when configured explicitly; Harness runs it as a separate review turn. |
 | `max_rounds` | `3` | Maximum review-fix cycles |
-| `review_bot_auto_trigger` | `false` | Post and wait for a hosted review bot command. When omitted with `enabled = false`, Harness keeps the hosted-bot path; when disabled, local completion requires local review approval, validation, PR-head advancement after local review fixes, unchanged reviewed PR head after CI polling, green GitHub PR checks, an open PR or already merged PR, and a configured GitHub token. |
+| `review_bot_auto_trigger` | `false` | Post and wait for a hosted review bot command. When omitted with `enabled = false`, Harness keeps the hosted-bot path; when disabled, local completion requires local review approval, validation, PR-head advancement after local review fixes that changed the workspace or reported a pushed commit, unchanged reviewed PR head after CI polling, green GitHub PR checks, an open PR or already merged PR, and a configured GitHub token. |
 
 ### `[review]`
 


### PR DESCRIPTION
## Summary
- require local review fix rounds to report PUSHED_COMMIT=true|false
- snapshot the workspace around local review fixes so no-op fixes are only accepted when files did not change
- require the GitHub PR head to advance after a local review fix changed files or reported a pushed commit

## Tests
- cargo fmt --all
- git diff --check
- cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets
- cargo test --package harness-server changed_fix_round -- --nocapture
- cargo test
