### PR TITLE
fix(runtime): release closed blocked issue dependencies

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,10 +1,11 @@
 use crate::task_runner::{TaskId, TaskStatus, TaskStore};
 use harness_workflow::runtime::{
-    build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
-    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
-    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowDecisionRecord,
-    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
-    PROMPT_TASK_DEFINITION_ID,
+    activity_result_has_closed_issue_evidence, build_issue_submission_decision,
+    build_prompt_submission_decision, value_has_closed_issue_evidence, ActivityResult,
+    DecisionValidator, IssueSubmissionDecisionInput, PromptSubmissionDecisionInput,
+    ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance,
+    WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID, RUNTIME_JOB_COMPLETED_EVENT,
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -162,12 +163,58 @@ pub(crate) async fn resolve_issue_dependency_status(
     let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
         return Ok(RuntimeDependencyStatus::Waiting);
     };
+    runtime_dependency_status_from_instance(store, &instance).await
+}
+
+async fn runtime_dependency_status_from_instance(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<RuntimeDependencyStatus> {
     Ok(match instance.state.as_str() {
         "done" => RuntimeDependencyStatus::Done,
         "failed" => RuntimeDependencyStatus::Failed,
         "cancelled" => RuntimeDependencyStatus::Cancelled,
+        "blocked" if blocked_issue_dependency_is_satisfied(store, instance).await? => {
+            RuntimeDependencyStatus::Done
+        }
         _ => RuntimeDependencyStatus::Waiting,
     })
+}
+
+async fn blocked_issue_dependency_is_satisfied(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<bool> {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID || instance.state != "blocked" {
+        return Ok(false);
+    }
+    if instance_data_has_closed_issue_evidence(&instance.data) {
+        return Ok(true);
+    }
+    let events = store.events_for(&instance.id).await?;
+    Ok(events
+        .iter()
+        .rev()
+        .any(runtime_event_has_closed_issue_evidence))
+}
+
+fn instance_data_has_closed_issue_evidence(data: &serde_json::Value) -> bool {
+    ["closed_issue_evidence", "issue_state"]
+        .iter()
+        .filter_map(|field| data.get(field))
+        .any(value_has_closed_issue_evidence)
+}
+
+fn runtime_event_has_closed_issue_evidence(event: &WorkflowEvent) -> bool {
+    if event.event_type != RUNTIME_JOB_COMPLETED_EVENT {
+        return false;
+    }
+    event
+        .event
+        .get("activity_result")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<ActivityResult>(value).ok())
+        .is_some_and(|result| activity_result_has_closed_issue_evidence(&result))
 }
 
 pub(crate) async fn release_ready_issue_dependencies(

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,11 +1,11 @@
 use crate::task_runner::{TaskId, TaskStatus, TaskStore};
 use harness_workflow::runtime::{
-    activity_result_has_closed_issue_evidence, build_issue_submission_decision,
-    build_prompt_submission_decision, value_has_closed_issue_evidence, ActivityResult,
-    DecisionValidator, IssueSubmissionDecisionInput, PromptSubmissionDecisionInput,
-    ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance,
-    WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID, RUNTIME_JOB_COMPLETED_EVENT,
+    activity_result_value_has_closed_issue_evidence, build_issue_submission_decision,
+    build_prompt_submission_decision, value_has_closed_issue_evidence, DecisionValidator,
+    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
+    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowDefinition, WorkflowEvent, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    PROMPT_TASK_DEFINITION_ID, RUNTIME_JOB_COMPLETED_EVENT,
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -191,11 +191,11 @@ async fn blocked_issue_dependency_is_satisfied(
     if instance_data_has_closed_issue_evidence(&instance.data) {
         return Ok(true);
     }
-    let events = store.events_for(&instance.id).await?;
-    Ok(events
-        .iter()
-        .rev()
-        .any(runtime_event_has_closed_issue_evidence))
+    Ok(store
+        .latest_event_for_type(&instance.id, RUNTIME_JOB_COMPLETED_EVENT)
+        .await?
+        .as_ref()
+        .is_some_and(runtime_event_has_closed_issue_evidence))
 }
 
 fn instance_data_has_closed_issue_evidence(data: &serde_json::Value) -> bool {
@@ -212,9 +212,7 @@ fn runtime_event_has_closed_issue_evidence(event: &WorkflowEvent) -> bool {
     event
         .event
         .get("activity_result")
-        .cloned()
-        .and_then(|value| serde_json::from_value::<ActivityResult>(value).ok())
-        .is_some_and(|result| activity_result_has_closed_issue_evidence(&result))
+        .is_some_and(activity_result_value_has_closed_issue_evidence)
 }
 
 pub(crate) async fn release_ready_issue_dependencies(

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -1011,6 +1011,83 @@ async fn issue_submission_keeps_blocked_runtime_dependency_without_closed_eviden
 }
 
 #[tokio::test]
+async fn issue_submission_releases_blocked_runtime_dependency_with_persisted_closed_evidence(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let labels = vec!["bug".to_string()];
+    let dep_id = TaskId::from_str("runtime-blocked-persisted-closed-evidence");
+    let dep_result = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 86,
+            task_id: &dep_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let mut dep_workflow = store
+        .get_instance(&dep_result.workflow_id)
+        .await?
+        .expect("dependency workflow should exist");
+    dep_workflow.state = "blocked".to_string();
+    dep_workflow.data["closed_issue_evidence"] = serde_json::json!({
+        "source": "IssueClosed",
+        "issue_number": 86,
+        "state": "closed",
+        "issue_url": "https://github.com/owner/repo/issues/86",
+        "closed": true,
+    });
+    store.upsert_instance(&dep_workflow).await?;
+
+    let task_id = TaskId::from_str("runtime-dependent-on-persisted-closed-evidence");
+    let blocked = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 87,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: std::slice::from_ref(&dep_id),
+            dependencies_blocked: true,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+
+    let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+    assert_eq!(released.released, 1);
+    assert_eq!(released.waiting, 0);
+    assert_eq!(released.failed, 0);
+    let workflow = store
+        .get_instance(&blocked.workflow_id)
+        .await?
+        .expect("dependent workflow should remain persisted");
+    assert_eq!(workflow.state, "implementing");
+    assert_eq!(store.commands_for(&blocked.workflow_id).await?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn issue_submission_releases_blocked_runtime_dependency_with_closed_issue_evidence(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 use harness_core::db::resolve_database_url;
+use harness_workflow::runtime::{
+    ActivityResult, ActivitySignal, ActivityStatus, RUNTIME_JOB_COMPLETED_EVENT,
+};
 
 async fn open_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
     let database_url = resolve_database_url(None)?;
@@ -934,6 +937,169 @@ async fn issue_submission_releases_dependency_on_completed_runtime_handle() -> a
 
     let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
     assert_eq!(released.released, 1);
+    let workflow = store
+        .get_instance(&blocked.workflow_id)
+        .await?
+        .expect("dependent workflow should remain persisted");
+    assert_eq!(workflow.state, "implementing");
+    assert_eq!(store.commands_for(&blocked.workflow_id).await?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn issue_submission_keeps_blocked_runtime_dependency_without_closed_evidence_waiting(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let labels = vec!["bug".to_string()];
+    let dep_id = TaskId::from_str("runtime-blocked-no-evidence");
+    let dep_result = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 82,
+            task_id: &dep_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let mut dep_workflow = store
+        .get_instance(&dep_result.workflow_id)
+        .await?
+        .expect("dependency workflow should exist");
+    dep_workflow.state = "blocked".to_string();
+    store.upsert_instance(&dep_workflow).await?;
+
+    let task_id = TaskId::from_str("runtime-dependent-on-blocked-no-evidence");
+    record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 83,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: std::slice::from_ref(&dep_id),
+            dependencies_blocked: true,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+
+    let waiting = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+    assert_eq!(waiting.waiting, 1);
+    assert_eq!(waiting.released, 0);
+    assert_eq!(waiting.failed, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn issue_submission_releases_blocked_runtime_dependency_with_closed_issue_evidence(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let labels = vec!["bug".to_string()];
+    let dep_id = TaskId::from_str("runtime-blocked-closed-evidence");
+    let dep_result = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 84,
+            task_id: &dep_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let mut dep_workflow = store
+        .get_instance(&dep_result.workflow_id)
+        .await?
+        .expect("dependency workflow should exist");
+    dep_workflow.state = "blocked".to_string();
+    store.upsert_instance(&dep_workflow).await?;
+    let activity_result = ActivityResult {
+        activity: "implement_issue".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Issue was already resolved upstream.".to_string(),
+        artifacts: Vec::new(),
+        signals: vec![ActivitySignal::new(
+            "IssueAlreadyResolved",
+            serde_json::json!({
+                "issue_number": 84,
+                "state": "closed",
+                "issue_url": "https://github.com/owner/repo/issues/84",
+            }),
+        )],
+        validation: Vec::new(),
+        error: Some("No PR is needed because the upstream issue is closed.".to_string()),
+        error_kind: None,
+    };
+    store
+        .append_event(
+            &dep_result.workflow_id,
+            RUNTIME_JOB_COMPLETED_EVENT,
+            "runtime-1",
+            serde_json::json!({
+                "command_id": "command-1",
+                "runtime_job_id": "job-1",
+                "activity_result": activity_result,
+            }),
+        )
+        .await?;
+
+    let task_id = TaskId::from_str("runtime-dependent-on-blocked-closed-evidence");
+    let blocked = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 85,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: std::slice::from_ref(&dep_id),
+            dependencies_blocked: true,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+
+    let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+    assert_eq!(released.released, 1);
+    assert_eq!(released.waiting, 0);
+    assert_eq!(released.failed, 0);
     let workflow = store
         .get_instance(&blocked.workflow_id)
         .await?

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -53,9 +53,10 @@ pub use quality_gate::{
     QUALITY_PASSED_SIGNAL,
 };
 pub use reducer::{
-    activity_result_has_closed_issue_evidence, reduce_runtime_job_completed,
-    value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL,
-    ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT, RUNTIME_JOB_COMPLETED_EVENT,
+    activity_result_has_closed_issue_evidence, activity_result_value_has_closed_issue_evidence,
+    reduce_runtime_job_completed, value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID,
+    ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT,
+    RUNTIME_JOB_COMPLETED_EVENT,
 };
 pub use repo_backlog::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -53,7 +53,8 @@ pub use quality_gate::{
     QUALITY_PASSED_SIGNAL,
 };
 pub use reducer::{
-    reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL,
+    activity_result_has_closed_issue_evidence, reduce_runtime_job_completed,
+    value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL,
     ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT, RUNTIME_JOB_COMPLETED_EVENT,
 };
 pub use repo_backlog::{

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -21,6 +21,14 @@ pub const ISSUE_CLOSED_SIGNAL: &str = "IssueClosed";
 pub const ISSUE_ALREADY_RESOLVED_SIGNAL: &str = "IssueAlreadyResolved";
 pub const ISSUE_STATE_ARTIFACT: &str = "issue_state";
 
+pub fn activity_result_has_closed_issue_evidence(result: &ActivityResult) -> bool {
+    closed_issue_evidence_from_activity_result(result).is_some()
+}
+
+pub fn value_has_closed_issue_evidence(value: &Value) -> bool {
+    closed_issue_evidence_from_value(value, ISSUE_STATE_ARTIFACT).is_some()
+}
+
 pub fn reduce_runtime_job_completed(
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
@@ -36,7 +44,8 @@ pub fn reduce_runtime_job_completed(
 
     let decision = match result.status {
         ActivityStatus::Succeeded => reduce_success(instance, event, &result),
-        ActivityStatus::Blocked => Some(runtime_blocked_decision(instance, event, &result)),
+        ActivityStatus::Blocked => issue_implementation_closed_decision(instance, event, &result)
+            .or_else(|| Some(runtime_blocked_decision(instance, event, &result))),
         ActivityStatus::Failed => Some(
             retry_failed_activity_decision(instance, event, &result)
                 .unwrap_or_else(|| runtime_failed_decision(instance, event, &result)),

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -25,6 +25,10 @@ pub fn activity_result_has_closed_issue_evidence(result: &ActivityResult) -> boo
     closed_issue_evidence_from_activity_result(result).is_some()
 }
 
+pub fn activity_result_value_has_closed_issue_evidence(value: &Value) -> bool {
+    closed_issue_evidence_from_activity_result_value(value).is_some()
+}
+
 pub fn value_has_closed_issue_evidence(value: &Value) -> bool {
     closed_issue_evidence_from_value(value, ISSUE_STATE_ARTIFACT).is_some()
 }
@@ -44,7 +48,7 @@ pub fn reduce_runtime_job_completed(
 
     let decision = match result.status {
         ActivityStatus::Succeeded => reduce_success(instance, event, &result),
-        ActivityStatus::Blocked => issue_implementation_closed_decision(instance, event, &result)
+        ActivityStatus::Blocked => github_issue_closed_decision(instance, event, &result)
             .or_else(|| Some(runtime_blocked_decision(instance, event, &result))),
         ActivityStatus::Failed => Some(
             retry_failed_activity_decision(instance, event, &result)
@@ -73,7 +77,7 @@ fn reduce_success(
         return Some(decision);
     }
 
-    if let Some(decision) = issue_implementation_closed_decision(instance, event, result) {
+    if let Some(decision) = github_issue_closed_decision(instance, event, result) {
         return Some(decision);
     }
 
@@ -254,33 +258,29 @@ fn issue_implementation_missing_result_decision(
     )
 }
 
-fn issue_implementation_closed_decision(
+fn github_issue_closed_decision(
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
-    if (
-        instance.definition_id.as_str(),
-        instance.state.as_str(),
-        result.activity.as_str(),
-    ) != (
-        GITHUB_ISSUE_PR_DEFINITION_ID,
-        "implementing",
-        "implement_issue",
-    ) {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID
+        || !github_issue_state_can_finish_closed(instance.state.as_str())
+    {
         return None;
     }
 
     let closed_issue = closed_issue_evidence_from_activity_result(result)?;
-    let reason =
-        "implement_issue reported structured evidence that the GitHub issue is already closed";
+    let reason = format!(
+        "{} reported structured evidence that the GitHub issue is already closed",
+        result.activity
+    );
     Some(
         WorkflowDecision::new(
             &instance.id,
             &instance.state,
             "finish_closed_issue",
             "done",
-            reason,
+            &reason,
         )
         .with_command(WorkflowCommand::new(
             WorkflowCommandType::MarkDone,
@@ -295,6 +295,13 @@ fn issue_implementation_closed_decision(
         .with_evidence(WorkflowEvidence::new("closed_issue", closed_issue.summary))
         .with_evidence(runtime_completion_evidence(event, result))
         .high_confidence(),
+    )
+}
+
+fn github_issue_state_can_finish_closed(state: &str) -> bool {
+    matches!(
+        state,
+        "implementing" | "pr_open" | "awaiting_feedback" | "addressing_feedback" | "ready_to_merge"
     )
 }
 
@@ -1320,6 +1327,42 @@ fn closed_issue_evidence_from_activity_result(
                     } else {
                         None
                     }
+                })
+        })
+}
+
+fn closed_issue_evidence_from_activity_result_value(value: &Value) -> Option<ClosedIssueEvidence> {
+    value
+        .get("signals")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find_map(|signal| {
+            let signal_type = signal.get("signal_type").and_then(non_empty_json_string)?;
+            match signal_type.as_str() {
+                ISSUE_CLOSED_SIGNAL | ISSUE_ALREADY_RESOLVED_SIGNAL => signal
+                    .get("signal")
+                    .and_then(|payload| closed_issue_evidence_from_value(payload, &signal_type)),
+                _ => None,
+            }
+        })
+        .or_else(|| {
+            value
+                .get("artifacts")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter(|artifact| {
+                    artifact.get("artifact_type").and_then(Value::as_str)
+                        == Some(ISSUE_STATE_ARTIFACT)
+                })
+                .find_map(|artifact| {
+                    artifact
+                        .get("artifact")
+                        .filter(|payload| issue_state_is_closed(payload))
+                        .and_then(|payload| {
+                            closed_issue_evidence_from_value(payload, ISSUE_STATE_ARTIFACT)
+                        })
                 })
         })
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -190,6 +190,12 @@ static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_runtime_jobs_command_created
               ON runtime_jobs (command_id, created_at DESC, id DESC)",
     },
+    Migration {
+        version: 9,
+        description: "index workflow events by type",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_events_workflow_type_sequence
+              ON workflow_events (workflow_id, event_type, sequence DESC)",
+    },
 ];
 
 pub struct WorkflowRuntimeStore {
@@ -788,6 +794,26 @@ impl WorkflowRuntimeStore {
         rows.into_iter()
             .map(|(data,)| Ok(serde_json::from_str(&data)?))
             .collect()
+    }
+
+    pub async fn latest_event_for_type(
+        &self,
+        workflow_id: &str,
+        event_type: &str,
+    ) -> anyhow::Result<Option<WorkflowEvent>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_events
+             WHERE workflow_id = $1
+               AND event_type = $2
+             ORDER BY sequence DESC
+             LIMIT 1",
+        )
+        .bind(workflow_id)
+        .bind(event_type)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .transpose()
     }
 
     pub async fn events_for_workflows(
@@ -2135,9 +2161,17 @@ fn apply_inline_command_side_effect(
     instance: &mut WorkflowInstance,
     command: &WorkflowCommand,
 ) -> anyhow::Result<()> {
-    if command.command_type != WorkflowCommandType::BindPr {
-        return Ok(());
+    match command.command_type {
+        WorkflowCommandType::BindPr => apply_bind_pr_side_effect(instance, command),
+        WorkflowCommandType::MarkDone => apply_mark_done_side_effect(instance, command),
+        _ => Ok(()),
     }
+}
+
+fn apply_bind_pr_side_effect(
+    instance: &mut WorkflowInstance,
+    command: &WorkflowCommand,
+) -> anyhow::Result<()> {
     let pr_number = command
         .command
         .get("pr_number")
@@ -2158,6 +2192,24 @@ fn apply_inline_command_side_effect(
         .context("workflow instance data is not an object")?;
     data.insert("pr_number".to_string(), json!(pr_number));
     data.insert("pr_url".to_string(), json!(pr_url));
+    Ok(())
+}
+
+fn apply_mark_done_side_effect(
+    instance: &mut WorkflowInstance,
+    command: &WorkflowCommand,
+) -> anyhow::Result<()> {
+    let Some(closed_issue_evidence) = command.command.get("closed_issue_evidence").cloned() else {
+        return Ok(());
+    };
+    if !instance.data.is_object() {
+        instance.data = json!({});
+    }
+    let data = instance
+        .data
+        .as_object_mut()
+        .context("workflow instance data is not an object")?;
+    data.insert("closed_issue_evidence".to_string(), closed_issue_evidence);
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -821,6 +821,61 @@ fn runtime_completion_reducer_finishes_closed_issue_signal_without_pr() {
 }
 
 #[test]
+fn runtime_completion_reducer_finishes_blocked_closed_issue_signal_without_pr() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult {
+        activity: "implement_issue".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Issue was already resolved upstream before implementation.".to_string(),
+        artifacts: Vec::new(),
+        signals: vec![ActivitySignal::new(
+            "IssueAlreadyResolved",
+            json!({
+                "issue_number": 123,
+                "state": "resolved",
+                "issue_url": "https://github.com/owner/repo/issues/123"
+            }),
+        )],
+        validation: Vec::new(),
+        error: Some("No implementation PR is needed for an already resolved issue.".to_string()),
+        error_kind: None,
+    };
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("blocked closed issue signal should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkDone
+    );
+    assert!(decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "closed_issue"));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("blocked closed issue completion should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_uses_issue_state_artifact_as_closed_issue_evidence() {
     let instance = issue_instance("implementing");
     let result =

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -876,6 +876,61 @@ fn runtime_completion_reducer_finishes_blocked_closed_issue_signal_without_pr() 
 }
 
 #[test]
+fn runtime_completion_reducer_finishes_feedback_closed_issue_signal_without_pr() {
+    let instance = issue_instance("addressing_feedback");
+    let result = ActivityResult {
+        activity: "address_pr_feedback".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Issue was closed while addressing PR feedback.".to_string(),
+        artifacts: Vec::new(),
+        signals: vec![ActivitySignal::new(
+            "IssueClosed",
+            json!({
+                "issue_number": 123,
+                "state": "closed",
+                "issue_url": "https://github.com/owner/repo/issues/123"
+            }),
+        )],
+        validation: Vec::new(),
+        error: Some("No further feedback work is needed because the issue is closed.".to_string()),
+        error_kind: None,
+    };
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("closed issue signal from feedback work should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkDone
+    );
+    assert_eq!(
+        decision.commands[0].command["activity"],
+        "address_pr_feedback"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("feedback closed issue completion should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_uses_issue_state_artifact_as_closed_issue_evidence() {
     let instance = issue_instance("implementing");
     let result =
@@ -4367,6 +4422,10 @@ async fn runtime_worker_finishes_closed_issue_success_without_pr() -> anyhow::Re
     assert_eq!(reloaded.state, "done");
     assert_eq!(reloaded.data["project_id"], "/project-a");
     assert_eq!(reloaded.data["issue_number"], 125);
+    assert_eq!(
+        reloaded.data["closed_issue_evidence"]["issue_url"],
+        "https://github.com/owner/repo/issues/125"
+    );
 
     let commands = store.commands_for(&workflow.id).await?;
     assert_eq!(commands[0].id, command_id);

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -363,9 +363,17 @@ fn apply_inline_command_side_effect(
     instance: &mut WorkflowInstance,
     command: &WorkflowCommand,
 ) -> anyhow::Result<()> {
-    if command.command_type != WorkflowCommandType::BindPr {
-        return Ok(());
+    match command.command_type {
+        WorkflowCommandType::BindPr => apply_bind_pr_side_effect(instance, command),
+        WorkflowCommandType::MarkDone => apply_mark_done_side_effect(instance, command),
+        _ => Ok(()),
     }
+}
+
+fn apply_bind_pr_side_effect(
+    instance: &mut WorkflowInstance,
+    command: &WorkflowCommand,
+) -> anyhow::Result<()> {
     let pr_number = command
         .command
         .get("pr_number")
@@ -386,6 +394,24 @@ fn apply_inline_command_side_effect(
         .context("workflow instance data is not an object")?;
     data.insert("pr_number".to_string(), json!(pr_number));
     data.insert("pr_url".to_string(), json!(pr_url));
+    Ok(())
+}
+
+fn apply_mark_done_side_effect(
+    instance: &mut WorkflowInstance,
+    command: &WorkflowCommand,
+) -> anyhow::Result<()> {
+    let Some(closed_issue_evidence) = command.command.get("closed_issue_evidence").cloned() else {
+        return Ok(());
+    };
+    if !instance.data.is_object() {
+        instance.data = json!({});
+    }
+    let data = instance
+        .data
+        .as_object_mut()
+        .context("workflow instance data is not an object")?;
+    data.insert("closed_issue_evidence".to_string(), closed_issue_evidence);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- finish issue workflows when a blocked implement_issue result still carries structured closed/resolved issue evidence
- reuse the workflow evidence parser for dependency resolution so historical blocked workflows only unblock dependents when their recorded runtime event/data has closed issue evidence
- add regression tests for blocked dependencies with and without closed issue evidence

Fixes #1118.

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo check
- cargo test -p harness-workflow runtime_completion_reducer -- --nocapture
- cargo test -p harness-server workflow_runtime_submission::tests -- --nocapture
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets