### PR TITLE
fix(runtime): enforce quality gate success contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,6 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 
 - RS-03 exempt: `fn main()` scope, `Mutex::lock().unwrap()`, `RwLock::{read,write}().unwrap()`
 - RS-13: only flag functions returning `()` or `Result<()>` — typed returns are transformers, not action functions
-- U-16 exempt: `**/prompts.rs` → 1200-line limit, `**/dispatch.rs` → 1000-line limit, `**/services/execution.rs` → 2600-line limit, `**/task_runner/spawn.rs` → 2700-line limit, `**/task_runner/store.rs` → 2200-line limit, `**/harness-workflow/src/runtime/store.rs` → 2300-line limit, `**/harness-workflow/src/runtime/tests.rs` → 6000-line limit (legacy oversized files; pending split)
+- U-16 exempt: `**/prompts.rs` → 1200-line limit, `**/dispatch.rs` → 1000-line limit, `**/services/execution.rs` → 2600-line limit, `**/task_runner/spawn.rs` → 2700-line limit, `**/task_runner/store.rs` → 2200-line limit, `**/harness-workflow/src/runtime/store.rs` → 2300-line limit, `**/harness-workflow/src/runtime/tests.rs` → 6500-line limit (legacy oversized files; pending split)
 - L1 exempt: new files matching `src/**/{mod,lib,main}.rs` (standard Rust module files)
 - gh/git guard: CLAUDE.md rule is semantic (agent prompts only); bash guard should not double-block `cargo test` subprocesses

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -140,7 +140,8 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
                     QUALITY_FAILED_SIGNAL,
                     QUALITY_BLOCKED_SIGNAL,
                 ])
-                .requires("quality_gate_status_signal")
+                .with_accepted_artifacts(vec!["validation_report"])
+                .requires("quality_gate_status_signal_and_validation_evidence")
         }
         (REPO_BACKLOG_DEFINITION_ID, "start_child_workflow") => {
             ActivityContract::new(workflow_definition, activity)

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -648,7 +648,7 @@ mod tests {
         );
         assert_eq!(
             schema["activity_contract"]["success_requires"],
-            "quality_gate_status_signal"
+            "quality_gate_status_signal_and_validation_evidence"
         );
         assert!(schema["workflow_decision_contract"]["allowed_transitions"]
             .as_array()

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -7,7 +7,10 @@ use super::pr_feedback::{
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use super::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
-use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
+use super::quality_gate::{
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
+};
 use super::repo_backlog::{
     REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
@@ -105,6 +108,10 @@ fn reduce_success(
     if let Some(decision) =
         repo_backlog_sprint_plan_decision_from_activity_result(instance, event, result)
     {
+        return Some(decision);
+    }
+
+    if let Some(decision) = quality_gate_success_decision(instance, event, result) {
         return Some(decision);
     }
 
@@ -1151,6 +1158,66 @@ fn invalid_agent_output_blocked_decision(
     ))
     .with_evidence(runtime_completion_evidence(event, result))
     .high_confidence()
+}
+
+fn quality_gate_success_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        QUALITY_GATE_DEFINITION_ID,
+        "checking",
+        QUALITY_GATE_ACTIVITY,
+    ) {
+        return None;
+    }
+
+    let passed = signal_count(result, QUALITY_PASSED_SIGNAL);
+    let failed = signal_count(result, QUALITY_FAILED_SIGNAL);
+    let blocked = signal_count(result, QUALITY_BLOCKED_SIGNAL);
+    if passed == 1 && failed == 0 && blocked == 0 && quality_gate_has_validation_evidence(result) {
+        return Some(
+            WorkflowDecision::new(
+                &instance.id,
+                &instance.state,
+                "quality_passed",
+                "passed",
+                "quality gate activity completed successfully with passing evidence",
+            )
+            .with_evidence(runtime_completion_evidence(event, result))
+            .high_confidence(),
+        );
+    }
+
+    let status_count = passed + failed + blocked;
+    let reason = if status_count == 0 {
+        "run_quality_gate succeeded without a quality status signal"
+    } else if passed == 0 {
+        "run_quality_gate succeeded without a QualityPassed signal"
+    } else if passed > 1 || failed > 0 || blocked > 0 {
+        "run_quality_gate succeeded with ambiguous quality status signals"
+    } else {
+        "run_quality_gate succeeded without validation evidence"
+    };
+    Some(invalid_agent_output_blocked_decision(
+        instance, event, result, reason,
+    ))
+}
+
+fn quality_gate_has_validation_evidence(result: &ActivityResult) -> bool {
+    result
+        .validation
+        .iter()
+        .any(|record| !record.command.trim().is_empty())
+        || result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_type == "validation_report")
 }
 
 fn signal_count(result: &ActivityResult, signal_type: &str) -> usize {

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -76,6 +76,31 @@ fn reduce_success(
         return Some(decision);
     }
 
+    if quality_gate_activity_matches(instance, result) {
+        if let Some(decision) = structured_decision.as_ref() {
+            let reason = if let Some(contract_reason) = quality_gate_success_contract_error(result)
+            {
+                format!(
+                    "runtime activity `{}` emitted workflow_decision `{}` for workflow `{}` in state `{}`, but {contract_reason}",
+                    result.activity, decision.decision, instance.definition_id, instance.state
+                )
+            } else {
+                format!(
+                    "runtime activity `{}` emitted workflow_decision `{}` for workflow `{}` in state `{}`, but the decision to `{}` did not validate",
+                    result.activity,
+                    decision.decision,
+                    instance.definition_id,
+                    instance.state,
+                    decision.next_state
+                )
+            };
+            return Some(invalid_agent_output_blocked_decision(
+                instance, event, result, &reason,
+            ));
+        }
+        return quality_gate_success_decision(instance, event, result);
+    }
+
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
         return Some(decision);
     }
@@ -108,10 +133,6 @@ fn reduce_success(
     if let Some(decision) =
         repo_backlog_sprint_plan_decision_from_activity_result(instance, event, result)
     {
-        return Some(decision);
-    }
-
-    if let Some(decision) = quality_gate_success_decision(instance, event, result) {
         return Some(decision);
     }
 
@@ -1010,6 +1031,12 @@ fn structured_decision_validates(
     {
         return false;
     }
+    if quality_gate_activity_matches(instance, result)
+        && decision.next_state == "passed"
+        && quality_gate_success_contract_error(result).is_some()
+    {
+        return false;
+    }
 
     let validator = match instance.definition_id.as_str() {
         GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
@@ -1165,22 +1192,11 @@ fn quality_gate_success_decision(
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
-    if (
-        instance.definition_id.as_str(),
-        instance.state.as_str(),
-        result.activity.as_str(),
-    ) != (
-        QUALITY_GATE_DEFINITION_ID,
-        "checking",
-        QUALITY_GATE_ACTIVITY,
-    ) {
+    if !quality_gate_activity_matches(instance, result) {
         return None;
     }
 
-    let passed = signal_count(result, QUALITY_PASSED_SIGNAL);
-    let failed = signal_count(result, QUALITY_FAILED_SIGNAL);
-    let blocked = signal_count(result, QUALITY_BLOCKED_SIGNAL);
-    if passed == 1 && failed == 0 && blocked == 0 && quality_gate_has_validation_evidence(result) {
+    if quality_gate_success_contract_error(result).is_none() {
         return Some(
             WorkflowDecision::new(
                 &instance.id,
@@ -1194,19 +1210,40 @@ fn quality_gate_success_decision(
         );
     }
 
-    let status_count = passed + failed + blocked;
-    let reason = if status_count == 0 {
-        "run_quality_gate succeeded without a quality status signal"
-    } else if passed == 0 {
-        "run_quality_gate succeeded without a QualityPassed signal"
-    } else if passed > 1 || failed > 0 || blocked > 0 {
-        "run_quality_gate succeeded with ambiguous quality status signals"
-    } else {
-        "run_quality_gate succeeded without validation evidence"
-    };
+    let reason = quality_gate_success_contract_error(result)?;
     Some(invalid_agent_output_blocked_decision(
         instance, event, result, reason,
     ))
+}
+
+fn quality_gate_activity_matches(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
+    (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) == (
+        QUALITY_GATE_DEFINITION_ID,
+        "checking",
+        QUALITY_GATE_ACTIVITY,
+    )
+}
+
+fn quality_gate_success_contract_error(result: &ActivityResult) -> Option<&'static str> {
+    let passed = signal_count(result, QUALITY_PASSED_SIGNAL);
+    let failed = signal_count(result, QUALITY_FAILED_SIGNAL);
+    let blocked = signal_count(result, QUALITY_BLOCKED_SIGNAL);
+    let status_count = passed + failed + blocked;
+    if status_count == 0 {
+        Some("run_quality_gate succeeded without a quality status signal")
+    } else if passed == 0 {
+        Some("run_quality_gate succeeded without a QualityPassed signal")
+    } else if passed > 1 || failed > 0 || blocked > 0 {
+        Some("run_quality_gate succeeded with ambiguous quality status signals")
+    } else if !quality_gate_has_validation_evidence(result) {
+        Some("run_quality_gate succeeded without validation evidence")
+    } else {
+        None
+    }
 }
 
 fn quality_gate_has_validation_evidence(result: &ActivityResult) -> bool {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -3441,6 +3441,91 @@ fn runtime_completion_reducer_blocks_quality_gate_success_with_conflicting_statu
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_quality_gate_structured_pass_without_contract_evidence() {
+    let instance = quality_gate_instance("checking");
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "checking",
+        "quality_passed",
+        "passed",
+        "The agent claimed the quality gate passed.",
+    )
+    .with_evidence(WorkflowEvidence::new("quality_gate", "claimed pass"));
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_artifact(ActivityArtifact::new(
+            "workflow_decision",
+            serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quality gate structured pass without contract evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("without a quality status signal"));
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_quality_gate_invalid_structured_decision_with_contract_evidence(
+) {
+    let instance = quality_gate_instance("checking");
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "pending",
+        "quality_passed",
+        "passed",
+        "The agent observed a stale quality gate state.",
+    );
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ))
+        .with_validation(ValidationRecord::new("cargo test", "passed"))
+        .with_artifact(ActivityArtifact::new(
+            "workflow_decision",
+            serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("invalid quality gate workflow_decision should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("did not validate"));
+}
+
+#[test]
 fn runtime_completion_reducer_retries_quality_gate_transient_failure() {
     let instance = quality_gate_instance("checking").with_data(json!({
         "runtime_retry_policy": {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -22,7 +22,8 @@ use super::{
     RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowDecisionTransition,
     WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
     PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID,
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID,
     REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
@@ -3284,6 +3285,12 @@ fn runtime_completion_reducer_passes_quality_gate_after_success() {
     let instance = quality_gate_instance("checking");
     let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
     let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ))
         .with_validation(ValidationRecord::new("cargo check", "passed"))
         .with_validation(ValidationRecord::new("cargo test", "passed"));
     let event = WorkflowEvent::new(
@@ -3313,6 +3320,124 @@ fn runtime_completion_reducer_passes_quality_gate_after_success() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("quality gate pass transition should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_quality_gate_success_without_status_signal() {
+    let instance = quality_gate_instance("checking");
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_validation(ValidationRecord::new("cargo check", "passed"));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quality gate missing status signal should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkBlocked
+    );
+    assert!(decision.reason.contains("without a quality status signal"));
+    DecisionValidator::quality_gate()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("quality gate invalid output should validate as blocked");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_quality_gate_success_without_validation_evidence() {
+    let instance = quality_gate_instance("checking");
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quality gate missing validation evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("without validation evidence"));
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_quality_gate_success_with_conflicting_status_signals() {
+    let instance = quality_gate_instance("checking");
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation was inconsistent.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ))
+        .with_signal(ActivitySignal::new(
+            QUALITY_FAILED_SIGNAL,
+            json!({
+                "validation": "failed"
+            }),
+        ))
+        .with_signal(ActivitySignal::new(
+            QUALITY_BLOCKED_SIGNAL,
+            json!({
+                "blocker": "manual review needed"
+            }),
+        ))
+        .with_validation(ValidationRecord::new("cargo test", "passed"));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quality gate conflicting status signals should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("ambiguous quality status signals"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- require successful quality gate activity results to include exactly one QualityPassed signal
- require validation evidence through validation records or a validation_report artifact before moving quality gates to passed
- update the prompt packet contract and reducer tests for missing, conflicting, and evidence-free quality gate output

Closes #1117.

## Validation
- cargo fmt --all
- cargo test -p harness-workflow runtime_completion_reducer_passes_quality_gate_after_success -- --nocapture
- cargo test -p harness-workflow runtime_completion_reducer_blocks_quality_gate_success -- --nocapture
- cargo test -p harness-server activity_result_schema_describes_quality_gate_contract -- --nocapture
- cargo check
- cargo test -p harness-workflow runtime_completion_reducer -- --nocapture
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets