### PR TITLE
fix(runtime): validate inline BindPr payloads

### DIFF
--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -3415,6 +3415,32 @@ fn rejects_pr_open_transition_without_bind_pr_command() {
 }
 
 #[test]
+fn rejects_pr_open_transition_with_invalid_bind_pr_payload() {
+    let instance = issue_instance("implementing");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "implementing",
+        "agent_reported_pr_open",
+        "pr_open",
+        "The agent reported a PR with incomplete metadata.",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::BindPr,
+        "issue-123-bind-pr",
+        json!({ "pr_number": 77 }),
+    ));
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(&instance, &decision, &validation_context())
+        .expect_err("BindPr must include a valid pr_number and pr_url payload");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::InvalidCommandPayload
+    );
+}
+
+#[test]
 fn rejects_scheduled_pr_open_transition_without_bind_pr_command() {
     let instance = issue_instance("scheduled");
     let decision = WorkflowDecision::new(
@@ -4190,6 +4216,84 @@ async fn runtime_worker_persists_bind_pr_payload_for_pr_open_transition() -> any
         WorkflowCommandType::BindPr
     );
     assert_ne!(commands[1].status, "pending");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_blocks_invalid_inline_bind_pr_before_persisting_command(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = project_issue_instance("/project-a", 123, "implementing").with_data(json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 123,
+        "task_id": "task-123",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "issue-123-implement");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+    let malformed_decision = WorkflowDecision::new(
+        &workflow.id,
+        "implementing",
+        "agent_reported_pr_open",
+        "pr_open",
+        "The agent reported a PR with incomplete metadata.",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::BindPr,
+        "issue-123-bind-pr",
+        json!({ "pr_number": 77 }),
+    ));
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded("implement_issue", "Implementation completed.")
+            .with_artifact(ActivityArtifact::new(
+                "workflow_decision",
+                serde_json::to_value(&malformed_decision).expect("decision should serialize"),
+            )),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+    assert_eq!(completed.id, job.id);
+
+    let reloaded = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(reloaded.state, "blocked");
+    assert!(reloaded.data.get("pr_number").is_none());
+    assert!(reloaded.data.get("pr_url").is_none());
+
+    let commands = store.commands_for(&workflow.id).await?;
+    assert!(commands.iter().all(|record| {
+        record.command.command_type != WorkflowCommandType::BindPr
+            && record.command.dedupe_key != "issue-123-bind-pr"
+    }));
+    assert!(commands.iter().any(|record| {
+        record.command.command_type == WorkflowCommandType::MarkBlocked
+            && record.status == "handled_inline"
+    }));
+
+    let decisions = store.decisions_for(&workflow.id).await?;
+    assert!(decisions.iter().any(|record| {
+        record.accepted && record.decision.decision == "block_invalid_agent_output"
+    }));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -3416,28 +3416,53 @@ fn rejects_pr_open_transition_without_bind_pr_command() {
 
 #[test]
 fn rejects_pr_open_transition_with_invalid_bind_pr_payload() {
-    let instance = issue_instance("implementing");
-    let decision = WorkflowDecision::new(
-        instance.id.clone(),
-        "implementing",
-        "agent_reported_pr_open",
-        "pr_open",
-        "The agent reported a PR with incomplete metadata.",
-    )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::BindPr,
-        "issue-123-bind-pr",
-        json!({ "pr_number": 77 }),
-    ));
+    let cases = [
+        ("missing pr_url", json!({ "pr_number": 77 })),
+        (
+            "missing pr_number",
+            json!({ "pr_url": "https://github.com/owner/repo/pull/77" }),
+        ),
+        (
+            "non-numeric pr_number",
+            json!({
+                "pr_number": "77",
+                "pr_url": "https://github.com/owner/repo/pull/77"
+            }),
+        ),
+        (
+            "empty pr_url",
+            json!({
+                "pr_number": 77,
+                "pr_url": "  "
+            }),
+        ),
+    ];
 
-    let err = DecisionValidator::github_issue_pr()
-        .validate(&instance, &decision, &validation_context())
-        .expect_err("BindPr must include a valid pr_number and pr_url payload");
+    for (case_name, payload) in cases {
+        let instance = issue_instance("implementing");
+        let decision = WorkflowDecision::new(
+            instance.id.clone(),
+            "implementing",
+            "agent_reported_pr_open",
+            "pr_open",
+            "The agent reported a PR with incomplete metadata.",
+        )
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::BindPr,
+            "issue-123-bind-pr",
+            payload,
+        ));
 
-    assert_eq!(
-        err.kind,
-        WorkflowDecisionRejectionKind::InvalidCommandPayload
-    );
+        let err = DecisionValidator::github_issue_pr()
+            .validate(&instance, &decision, &validation_context())
+            .expect_err("BindPr must include a valid pr_number and pr_url payload");
+
+        assert_eq!(
+            err.kind,
+            WorkflowDecisionRejectionKind::InvalidCommandPayload,
+            "failed case: {case_name}"
+        );
+    }
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -622,11 +622,11 @@ impl DecisionValidator {
             ));
         }
 
-        if !command
+        if command
             .command
             .get("pr_url")
             .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
+            .is_none_or(|value| value.trim().is_empty())
         {
             return Err(WorkflowDecisionRejection::new(
                 WorkflowDecisionRejectionKind::InvalidCommandPayload,

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -622,12 +622,12 @@ impl DecisionValidator {
             ));
         }
 
-        let has_pr_url = command
+        if !command
             .command
             .get("pr_url")
             .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty());
-        if !has_pr_url {
+            .is_some_and(|value| !value.trim().is_empty())
+        {
             return Err(WorkflowDecisionRejection::new(
                 WorkflowDecisionRejectionKind::InvalidCommandPayload,
                 "BindPr command must include non-empty pr_url",

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -396,6 +396,7 @@ pub enum WorkflowDecisionRejectionKind {
     WaitLimitExhausted,
     TerminalReopenDenied,
     RequiredCommandMissing,
+    InvalidCommandPayload,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -549,6 +550,7 @@ impl DecisionValidator {
             }
 
             self.validate_dedupe(command, &mut seen_dedupe_keys, context)?;
+            self.validate_command_payload(command)?;
 
             if command.requires_runtime_job() && !context.resource_budget_available {
                 return Err(WorkflowDecisionRejection::new(
@@ -594,6 +596,41 @@ impl DecisionValidator {
             return Err(WorkflowDecisionRejection::new(
                 WorkflowDecisionRejectionKind::ReplanLimitExhausted,
                 "run_replan decision requested after replan budget was exhausted",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_command_payload(
+        &self,
+        command: &WorkflowCommand,
+    ) -> Result<(), WorkflowDecisionRejection> {
+        if command.command_type != WorkflowCommandType::BindPr {
+            return Ok(());
+        }
+
+        if command
+            .command
+            .get("pr_number")
+            .and_then(serde_json::Value::as_u64)
+            .is_none()
+        {
+            return Err(WorkflowDecisionRejection::new(
+                WorkflowDecisionRejectionKind::InvalidCommandPayload,
+                "BindPr command must include numeric pr_number",
+            ));
+        }
+
+        let has_pr_url = command
+            .command
+            .get("pr_url")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
+        if !has_pr_url {
+            return Err(WorkflowDecisionRejection::new(
+                WorkflowDecisionRejectionKind::InvalidCommandPayload,
+                "BindPr command must include non-empty pr_url",
             ));
         }
 


### PR DESCRIPTION
## Summary
- reject malformed inline BindPr commands before runtime decisions are accepted
- require BindPr payloads to include numeric pr_number and non-empty pr_url
- cover the worker path so invalid inline BindPr output blocks the workflow without persisting the bad command

Closes #1113

## Verification
- cargo test -p harness-workflow rejects_pr_open_transition_with_invalid_bind_pr_payload -- --nocapture (failed before the fix, proving the unsafe acceptance path)
- cargo fmt --all
- cargo test -p harness-workflow rejects_pr_open_transition_with_invalid_bind_pr_payload -- --nocapture
- cargo test -p harness-workflow runtime_worker_blocks_invalid_inline_bind_pr_before_persisting_command -- --nocapture
- cargo check
- cargo test -p harness-workflow -- --nocapture
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets