### PR TITLE
fix(server): cap LGTM test gate output

### DIFF
--- a/crates/harness-server/src/task_executor/local_review_completion.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion.rs
@@ -2,6 +2,7 @@ use super::{review_loop, run_test_gate};
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskStatus, TaskStore,
 };
+use harness_core::validation::ShellValidationExecutor;
 use harness_workflow::runtime::PrFeedbackOutcome;
 use std::collections::HashMap;
 use std::path::Path;
@@ -357,7 +358,9 @@ pub(crate) async fn complete_after_local_review_without_hosted_bot(
     task_start: Instant,
 ) -> anyhow::Result<()> {
     tracing::info!("review_bot_auto_trigger disabled; running validation gate before completion");
+    let validation_executor = ShellValidationExecutor::new();
     match run_test_gate(
+        &validation_executor,
         project,
         &project_config.validation.pre_push,
         project_config.validation.test_gate_timeout_secs,

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -22,6 +22,7 @@ use crate::task_runner::{
 use anyhow::Context;
 use harness_core::agent::CodeAgent;
 use harness_core::config::agents::CapabilityProfile;
+use harness_core::validation::{ValidationExecutor, ValidationOutcomeKind, ValidationRequest};
 use harness_core::{config::project::load_project_config, lang_detect, prompts};
 use std::collections::HashMap;
 
@@ -73,9 +74,6 @@ impl Drop for TaskTargetDir {
         }
     }
 }
-
-use tokio::process::Command as TokioCommand;
-use tokio::time::timeout;
 
 /// State shared across pipeline stages within a single task execution.
 #[allow(dead_code)]
@@ -137,6 +135,7 @@ fn review_repo_slug(pr_url: Option<&str>, detected_repo_slug: &str) -> String {
 ///
 /// Returns `Err(output)` containing stdout/stderr of the first failing command.
 async fn run_test_gate(
+    validation_executor: &dyn ValidationExecutor,
     project_root: &std::path::Path,
     custom_cmds: &[String],
     timeout_secs: u64,
@@ -169,39 +168,40 @@ async fn run_test_gate(
     for cmd in &cmds {
         tracing::info!(cmd = %cmd, "test gate: running tests before accepting LGTM");
 
-        let child = match TokioCommand::new("sh")
-            .args(["-c", cmd])
-            .current_dir(project_root)
-            // Issue 3 fix: inherit the per-task CARGO_TARGET_DIR so parallel
-            // Rust tasks do not contend on the same build directory (issue #488).
-            .envs(extra_env)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => return Err(format!("test gate: failed to spawn `{cmd}`: {e}")),
-        };
+        let env: Vec<(&str, &str)> = extra_env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
+        let outcome = validation_executor
+            .run(ValidationRequest {
+                command: cmd,
+                cwd: project_root,
+                env: &env,
+                timeout: Duration::from_secs(timeout_secs),
+            })
+            .await;
 
-        match timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await {
-            Ok(Ok(out)) if out.status.success() => {
+        match outcome.kind {
+            ValidationOutcomeKind::Success => {
                 tracing::info!(cmd = %cmd, "test gate: tests passed");
             }
-            Ok(Ok(out)) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let stderr = String::from_utf8_lossy(&out.stderr);
-                let code = out.status.code().unwrap_or(-1);
+            ValidationOutcomeKind::NonZeroExit { code } => {
                 return Err(format!(
-                    "Test gate failed (exit {code})\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                    "Test gate failed (exit {code})\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                    stdout = outcome.stdout,
+                    stderr = outcome.stderr,
                 ));
             }
-            Ok(Err(e)) => return Err(format!("test gate: `{cmd}` failed to wait: {e}")),
-            Err(_) => {
+            ValidationOutcomeKind::SpawnFailed { reason } => {
+                return Err(format!("test gate: failed to spawn `{cmd}`: {reason}"));
+            }
+            ValidationOutcomeKind::WaitFailed { reason } => {
+                return Err(format!("test gate: `{cmd}` failed to wait: {reason}"));
+            }
+            ValidationOutcomeKind::TimedOut => {
                 return Err(format!(
                     "Test gate timed out after {timeout_secs}s (command: `{cmd}`)"
-                ))
+                ));
             }
         }
     }

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -165,13 +165,14 @@ async fn run_test_gate(
         }
     };
 
+    let env: Vec<(&str, &str)> = extra_env
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+
     for cmd in &cmds {
         tracing::info!(cmd = %cmd, "test gate: running tests before accepting LGTM");
 
-        let env: Vec<(&str, &str)> = extra_env
-            .iter()
-            .map(|(key, value)| (key.as_str(), value.as_str()))
-            .collect();
         let outcome = validation_executor
             .run(ValidationRequest {
                 command: cmd,

--- a/crates/harness-server/src/task_executor/mod_tests.rs
+++ b/crates/harness-server/src/task_executor/mod_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use harness_core::validation::{
+    ShellValidationExecutor, ValidationExecutor, ValidationOutcome, ValidationOutcomeKind,
+    ValidationRequest, MAX_CAPTURED_OUTPUT_BYTES,
+};
 
 #[test]
 fn periodic_review_source_uses_standard_allowed_tools() {
@@ -359,6 +363,92 @@ async fn prompt_only_nonempty_output_no_pr_stays_done() -> anyhow::Result<()> {
     assert!(
         matches!(final_state.status, TaskStatus::Done),
         "prompt-only task with non-empty output and no PR must be Done"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_gate_caps_large_failure_output() -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir()?;
+    let script = dir.path().join("large-output-test");
+    std::fs::write(
+        &script,
+        "#!/bin/sh\ndd if=/dev/zero bs=4096 count=256 2>/dev/null\nexit 7\n",
+    )?;
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))?;
+    let cmd = "./large-output-test".to_string();
+    let validation_executor = ShellValidationExecutor::new();
+
+    let err = run_test_gate(
+        &validation_executor,
+        dir.path(),
+        &[cmd],
+        10,
+        &HashMap::new(),
+    )
+    .await
+    .expect_err("failing test command should reject LGTM");
+
+    assert!(err.contains("Test gate failed (exit 7)"));
+    let stdout = err
+        .split_once("stdout:\n")
+        .and_then(|(_, tail)| tail.split_once("\nstderr:\n").map(|(stdout, _)| stdout))
+        .expect("test gate error should include stdout and stderr sections");
+    assert_eq!(
+        stdout.len(),
+        MAX_CAPTURED_OUTPUT_BYTES,
+        "test gate must cap captured stdout using the validation executor"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_gate_passes_extra_env_to_validation_executor() -> anyhow::Result<()> {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    struct RecordingValidationExecutor {
+        env: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ValidationExecutor for RecordingValidationExecutor {
+        async fn run<'a>(&self, request: ValidationRequest<'a>) -> ValidationOutcome {
+            self.env.lock().unwrap().extend(
+                request
+                    .env
+                    .iter()
+                    .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+            );
+            ValidationOutcome {
+                kind: ValidationOutcomeKind::Success,
+                stdout: String::new(),
+                stderr: String::new(),
+            }
+        }
+    }
+
+    let dir = tempfile::tempdir()?;
+    let executor = RecordingValidationExecutor::default();
+    let captured = Arc::clone(&executor.env);
+    let mut extra_env = HashMap::new();
+    extra_env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/tmp/harness-task-target".to_string(),
+    );
+
+    run_test_gate(&executor, dir.path(), &["true".to_string()], 10, &extra_env)
+        .await
+        .expect("successful executor outcome should pass the test gate");
+
+    assert_eq!(
+        captured.lock().unwrap().as_slice(),
+        &[(
+            "CARGO_TARGET_DIR".to_string(),
+            "/tmp/harness-task-target".to_string(),
+        )]
     );
     Ok(())
 }

--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -11,6 +11,7 @@ use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::prompts;
 use harness_core::tool_isolation::validate_tool_usage;
 use harness_core::types::{Decision, ExecutionPhase, TurnFailure, TurnFailureKind};
+use harness_core::validation::ShellValidationExecutor;
 use harness_workflow::runtime::PrFeedbackOutcome;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -1673,7 +1674,9 @@ pub(crate) async fn run_review_loop(
             // Hard gate: run the project's tests before accepting LGTM.
             // This prevents agents from gaming the review by manipulating tests
             // rather than fixing code (OpenAI "Monitoring Reasoning Models", 2026).
+            let validation_executor = ShellValidationExecutor::new();
             match super::run_test_gate(
+                &validation_executor,
                 project,
                 &project_config.validation.pre_push,
                 project_config.validation.test_gate_timeout_secs,


### PR DESCRIPTION
## Summary
- route the LGTM pre-merge test gate through the shared ValidationExecutor
- preserve existing test-gate error wording while using capped stdout/stderr capture
- pass per-task extra env through ValidationRequest so CARGO_TARGET_DIR isolation still applies

Closes #1112

## Verification
- cargo test -p harness-server test_gate_caps_large_failure_output -- --nocapture (failed before the fix: captured 1 MiB instead of 256 KiB)
- cargo fmt --all
- cargo test -p harness-server test_gate_ -- --nocapture
- cargo check
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets