### PR TITLE
fix(server): return proof for runtime tasks

### DIFF
--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -48,6 +48,12 @@ struct RuntimeTaskResponse {
     workflow: Option<TaskWorkflowSummary>,
 }
 
+enum RuntimeProofLookup {
+    Missing,
+    InFlight(String),
+    Terminal(ProofOfWork),
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawTaskListParams {
@@ -983,6 +989,132 @@ pub(crate) fn proof_from_state(task: &TaskState) -> ProofOfWork {
     }
 }
 
+fn proof_from_runtime_workflow(
+    task_id: &harness_core::types::TaskId,
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+    events: &[harness_workflow::runtime::WorkflowEvent],
+    decisions: &[harness_workflow::runtime::WorkflowDecisionRecord],
+) -> ProofOfWork {
+    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    let pr_url = runtime_string_field(&workflow.data, "pr_url")
+        .or_else(|| runtime_string_field(&workflow.data, "last_pr_url"));
+    let accepted_decisions = decisions
+        .iter()
+        .filter(|record| record.accepted)
+        .collect::<Vec<_>>();
+    let approved = events.iter().any(|event| {
+        matches!(
+            event.event_type.as_str(),
+            "PrReadyToMerge" | "MergeApproved" | "PrMerged"
+        )
+    }) || accepted_decisions.iter().any(|record| {
+        matches!(
+            record.decision.decision.as_str(),
+            "mark_ready_to_merge" | "approve_merge" | "record_pr_merged" | "quality_passed"
+        )
+    }) || workflow.state == "passed";
+    let changes_requested = events
+        .iter()
+        .any(|event| event.event_type == "FeedbackFound")
+        || accepted_decisions.iter().any(|record| {
+            matches!(
+                record.decision.decision.as_str(),
+                "address_pr_feedback" | "await_feedback_after_rework"
+            )
+        });
+
+    let review_outcome = if approved {
+        ReviewOutcome::Approved
+    } else if changes_requested {
+        ReviewOutcome::ChangesRequested
+    } else {
+        ReviewOutcome::Skipped
+    };
+    let ci_status = if status.is_failure() {
+        CiStatus::Failed
+    } else if status == TaskStatus::Done && review_outcome == ReviewOutcome::Approved {
+        CiStatus::Passed
+    } else {
+        CiStatus::Unknown
+    };
+    let review_event_count = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.event_type.as_str(),
+                "FeedbackFound"
+                    | "NoFeedbackFound"
+                    | "PrReadyToMerge"
+                    | "MergeApproved"
+                    | "PrMerged"
+            )
+        })
+        .count();
+    let review_decision_count = accepted_decisions
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.decision.decision.as_str(),
+                "address_pr_feedback"
+                    | "wait_for_pr_feedback"
+                    | "mark_ready_to_merge"
+                    | "approve_merge"
+                    | "record_pr_merged"
+                    | "quality_passed"
+            )
+        })
+        .count();
+    let review_rounds = review_event_count.max(review_decision_count) as u32;
+
+    let mut signals = vec![
+        QualitySignal {
+            name: "workflow_id".to_string(),
+            value: workflow.id.clone(),
+        },
+        QualitySignal {
+            name: "workflow_state".to_string(),
+            value: workflow.state.clone(),
+        },
+    ];
+    if let Some(error) = runtime_string_field(&workflow.data, "failure_reason") {
+        signals.push(QualitySignal {
+            name: "error".to_string(),
+            value: error,
+        });
+    }
+
+    ProofOfWork {
+        task_id: task_id.as_str().to_string(),
+        status: status.as_ref().to_string(),
+        pr_url,
+        ci_status,
+        review_outcome,
+        review_rounds,
+        quality_signals: signals,
+    }
+}
+
+async fn runtime_proof_by_handle(
+    state: &AppState,
+    task_id: &harness_core::types::TaskId,
+) -> anyhow::Result<RuntimeProofLookup> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(RuntimeProofLookup::Missing);
+    };
+    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(RuntimeProofLookup::Missing);
+    };
+    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    if !status.is_terminal() {
+        return Ok(RuntimeProofLookup::InFlight(status.as_ref().to_string()));
+    }
+    let events = store.events_for(&workflow.id).await?;
+    let decisions = store.decisions_for(&workflow.id).await?;
+    Ok(RuntimeProofLookup::Terminal(proof_from_runtime_workflow(
+        task_id, &workflow, &events, &decisions,
+    )))
+}
+
 /// GET /tasks/{id}/proof — machine-readable proof-of-work summary for a
 /// completed task.
 ///
@@ -1008,11 +1140,30 @@ pub(crate) async fn get_task_proof(
             }
             Json(proof_from_state(&task)).into_response()
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "task not found"})),
-        )
-            .into_response(),
+        Ok(None) => match runtime_proof_by_handle(&state, &task_id).await {
+            Ok(RuntimeProofLookup::Terminal(proof)) => Json(proof).into_response(),
+            Ok(RuntimeProofLookup::InFlight(status)) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({
+                    "error": "task is not in a terminal state",
+                    "status": status,
+                })),
+            )
+                .into_response(),
+            Ok(RuntimeProofLookup::Missing) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response(),
+            Err(e) => {
+                tracing::error!("get_task_proof: runtime workflow lookup failed: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "internal server error"})),
+                )
+                    .into_response()
+            }
+        },
         Err(e) => {
             tracing::error!("get_task_proof: database error: {e}");
             (

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -1030,7 +1030,7 @@ fn proof_from_runtime_workflow(
     } else {
         ReviewOutcome::Skipped
     };
-    let ci_status = if status.is_failure() {
+    let ci_status = if status == TaskStatus::Failed {
         CiStatus::Failed
     } else if status == TaskStatus::Done && review_outcome == ReviewOutcome::Approved {
         CiStatus::Passed
@@ -1042,11 +1042,7 @@ fn proof_from_runtime_workflow(
         .filter(|event| {
             matches!(
                 event.event_type.as_str(),
-                "FeedbackFound"
-                    | "NoFeedbackFound"
-                    | "PrReadyToMerge"
-                    | "MergeApproved"
-                    | "PrMerged"
+                "FeedbackFound" | "NoFeedbackFound" | "PrReadyToMerge"
             )
         })
         .count();
@@ -1058,8 +1054,6 @@ fn proof_from_runtime_workflow(
                 "address_pr_feedback"
                     | "wait_for_pr_feedback"
                     | "mark_ready_to_merge"
-                    | "approve_merge"
-                    | "record_pr_merged"
                     | "quality_passed"
             )
         })

--- a/crates/harness-server/src/http/task_query_routes_tests.rs
+++ b/crates/harness-server/src/http/task_query_routes_tests.rs
@@ -149,6 +149,97 @@ fn proof_counts_agent_review_issues_as_changes_requested() {
 }
 
 #[test]
+fn runtime_proof_reports_cancelled_ci_as_unknown() {
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "cancelled",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1139"),
+    )
+    .with_id("runtime-cancelled-proof")
+    .with_data(json!({
+        "task_id": "runtime-cancelled-proof-task",
+        "pr_url": "https://github.com/owner/repo/pull/1139",
+    }));
+
+    let task_id = harness_core::types::TaskId("runtime-cancelled-proof-task".to_string());
+    let proof = proof_from_runtime_workflow(&task_id, &workflow, &[], &[]);
+
+    assert_eq!(proof.status, "cancelled");
+    assert_eq!(proof.ci_status, CiStatus::Unknown);
+    assert_eq!(proof.review_outcome, ReviewOutcome::Skipped);
+}
+
+#[test]
+fn runtime_proof_excludes_merge_events_from_review_rounds() {
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "done",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1140"),
+    )
+    .with_id("runtime-merged-proof")
+    .with_data(json!({
+        "task_id": "runtime-merged-proof-task",
+        "pr_url": "https://github.com/owner/repo/pull/1140",
+    }));
+    let events = vec![
+        harness_workflow::runtime::WorkflowEvent::new(
+            workflow.id.clone(),
+            1,
+            "PrReadyToMerge",
+            "test",
+        ),
+        harness_workflow::runtime::WorkflowEvent::new(
+            workflow.id.clone(),
+            2,
+            "MergeApproved",
+            "test",
+        ),
+        harness_workflow::runtime::WorkflowEvent::new(workflow.id.clone(), 3, "PrMerged", "test"),
+    ];
+    let decisions = vec![
+        harness_workflow::runtime::WorkflowDecisionRecord::accepted(
+            harness_workflow::runtime::WorkflowDecision::new(
+                workflow.id.clone(),
+                "awaiting_feedback",
+                "mark_ready_to_merge",
+                "ready_to_merge",
+                "review passed",
+            ),
+            Some(events[0].id.clone()),
+        ),
+        harness_workflow::runtime::WorkflowDecisionRecord::accepted(
+            harness_workflow::runtime::WorkflowDecision::new(
+                workflow.id.clone(),
+                "ready_to_merge",
+                "approve_merge",
+                "merging",
+                "operator approved merge",
+            ),
+            Some(events[1].id.clone()),
+        ),
+        harness_workflow::runtime::WorkflowDecisionRecord::accepted(
+            harness_workflow::runtime::WorkflowDecision::new(
+                workflow.id.clone(),
+                "merging",
+                "record_pr_merged",
+                "done",
+                "PR merged",
+            ),
+            Some(events[2].id.clone()),
+        ),
+    ];
+
+    let task_id = harness_core::types::TaskId("runtime-merged-proof-task".to_string());
+    let proof = proof_from_runtime_workflow(&task_id, &workflow, &events, &decisions);
+
+    assert_eq!(proof.review_outcome, ReviewOutcome::Approved);
+    assert_eq!(proof.ci_status, CiStatus::Passed);
+    assert_eq!(proof.review_rounds, 1);
+}
+
+#[test]
 fn runtime_workflow_scheduler_state_only_marks_executing_states_running() {
     let blocked = runtime_workflow_scheduler_state("blocked", &TaskStatus::Waiting);
     assert_eq!(blocked.authority_state, SchedulerAuthorityState::Queued);

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -634,7 +634,139 @@ fn task_app(state: Arc<AppState>) -> Router {
         .route("/tasks", post(task_routes::create_task))
         .route("/tasks/batch", post(task_routes::create_tasks_batch))
         .route("/tasks/{id}", get(get_task))
+        .route("/tasks/{id}/proof", get(get_task_proof))
         .with_state(state)
+}
+
+#[tokio::test]
+async fn get_task_proof_returns_runtime_backed_terminal_task() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = "runtime-proof-task";
+    let pr_url = "https://github.com/owner/repo/pull/77";
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "done",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1111"),
+    )
+    .with_id("runtime-proof-workflow")
+    .with_data(serde_json::json!({
+        "task_id": task_id,
+        "task_ids": [task_id],
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 1111,
+        "pr_number": 77,
+        "pr_url": pr_url,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let event = store
+        .append_event(
+            &workflow.id,
+            "PrReadyToMerge",
+            "workflow-runtime-test",
+            serde_json::json!({ "task_id": task_id, "pr_url": pr_url }),
+        )
+        .await?;
+    let decision = harness_workflow::runtime::WorkflowDecision::new(
+        &workflow.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "review, checks, and mergeability are ready",
+    )
+    .high_confidence();
+    store
+        .record_decision(
+            &harness_workflow::runtime::WorkflowDecisionRecord::accepted(decision, Some(event.id)),
+        )
+        .await?;
+    assert!(
+        state
+            .core
+            .tasks
+            .get_with_db_fallback(&task_runner::TaskId::from_str(task_id))
+            .await?
+            .is_none(),
+        "runtime-backed task should not have a legacy task row"
+    );
+
+    let response = task_app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{task_id}/proof"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["task_id"], task_id);
+    assert_eq!(body["status"], "done");
+    assert_eq!(body["pr_url"], pr_url);
+    assert_eq!(body["ci_status"], "passed");
+    assert_eq!(body["review_outcome"], "approved");
+    assert_eq!(body["review_rounds"], 1);
+    assert!(body["quality_signals"]
+        .as_array()
+        .expect("quality signals should be an array")
+        .iter()
+        .any(
+            |signal| signal["name"] == "workflow_id" && signal["value"] == "runtime-proof-workflow"
+        ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_task_proof_rejects_nonterminal_runtime_task() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = "runtime-proof-active";
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("prompt", "prompt:active"),
+    )
+    .with_id("runtime-proof-active-workflow")
+    .with_data(serde_json::json!({
+        "task_id": task_id,
+        "project_id": "/project-a",
+    }));
+    store.upsert_instance(&workflow).await?;
+
+    let response = task_app(state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{task_id}/proof"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "task is not in a terminal state");
+    assert_eq!(body["status"], "implementing");
+    Ok(())
 }
 
 fn intake_app(state: Arc<AppState>) -> Router {


### PR DESCRIPTION
## Summary
- add runtime fallback for GET /tasks/{id}/proof when the legacy task row is absent
- derive proof-of-work from runtime workflow state, events, and accepted decisions
- return 422 for non-terminal runtime workflows instead of 404

Closes #1111

## Verification
- cargo fmt --all
- cargo test -p harness-server get_task_proof_ -- --nocapture
- cargo check
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets