### PR TITLE
fix(store): roll back cache after persist conflict

### DIFF
--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1613,16 +1613,41 @@ pub async fn mutate_and_persist(
     f: impl FnOnce(&mut TaskState),
 ) -> anyhow::Result<()> {
     let original = store.cache.get(id).map(|entry| entry.value().clone());
+    let mut attempted = None;
     if let Some(mut entry) = store.cache.get_mut(id) {
         f(entry.value_mut());
+        entry.value_mut().reconcile_scheduler_with_status();
+        attempted = Some(entry.value().clone());
     }
     if let Err(error) = store.persist(id).await {
-        if let Some(original) = original {
-            store.cache.insert(id.clone(), original);
+        if let (Some(original), Some(attempted)) = (original, attempted) {
+            if let Some(mut entry) = store.cache.get_mut(id) {
+                if task_states_match_for_rollback(entry.value(), &attempted) {
+                    *entry.value_mut() = original;
+                } else {
+                    tracing::warn!(
+                        task_id = %id.0,
+                        "mutate_and_persist rollback skipped because cache changed after failed persist"
+                    );
+                }
+            }
         }
         return Err(error);
     }
     Ok(())
+}
+
+fn task_states_match_for_rollback(current: &TaskState, attempted: &TaskState) -> bool {
+    match (
+        serde_json::to_value(current),
+        serde_json::to_value(attempted),
+    ) {
+        (Ok(current), Ok(attempted)) => current == attempted,
+        (Err(error), _) | (_, Err(error)) => {
+            tracing::warn!("mutate_and_persist rollback comparison failed: {error}");
+            false
+        }
+    }
 }
 
 fn latest_timestamp_at_least(candidate: Option<&str>, existing: Option<&str>) -> bool {
@@ -2215,6 +2240,81 @@ mod tests {
             .expect("task should remain persisted after conflict");
         assert_eq!(persisted.status, TaskStatus::Failed);
         assert_eq!(persisted.version, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mutate_and_persist_does_not_rollback_over_newer_cache_state() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = std::sync::Arc::new(TaskStore::open(&dir.path().join("tasks.db")).await?);
+        let task_id = harness_core::types::TaskId("mutate-newer-cache".to_string());
+        let task = pending_task(task_id.as_str());
+        store.insert(&task).await;
+
+        let scheduler_json =
+            serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
+        store
+            .db
+            .update_status_only(
+                task_id.as_str(),
+                TaskStatus::Failed.as_ref(),
+                &scheduler_json,
+                0,
+            )
+            .await?;
+
+        let persist_lock = store
+            .persist_locks
+            .entry(task_id.clone())
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let guard = persist_lock.lock().await;
+
+        let worker_store = store.clone();
+        let worker_task_id = task_id.clone();
+        let worker = tokio::spawn(async move {
+            mutate_and_persist(worker_store.as_ref(), &worker_task_id, |state| {
+                state.status = TaskStatus::Done;
+                state.turn = 7;
+                state.error = Some("failed mutation".to_string());
+            })
+            .await
+        });
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        loop {
+            let mutated = store
+                .get(&task_id)
+                .is_some_and(|state| state.status == TaskStatus::Done && state.turn == 7);
+            if mutated {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "mutate_and_persist did not reach the cache mutation before persist"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        if let Some(mut entry) = store.cache.get_mut(&task_id) {
+            entry.status = TaskStatus::AwaitingDeps;
+            entry.turn = 9;
+            entry.error = Some("newer cache state".to_string());
+        }
+
+        drop(guard);
+        let error = worker
+            .await
+            .expect("mutate task should not panic")
+            .expect_err("stale cache version should fail optimistic locking");
+
+        assert!(format!("{error}").contains("optimistic-lock conflict"));
+        let cached = store
+            .get(&task_id)
+            .expect("task should remain cached after failed persist");
+        assert_eq!(cached.status, TaskStatus::AwaitingDeps);
+        assert_eq!(cached.turn, 9);
+        assert_eq!(cached.error.as_deref(), Some("newer cache state"));
         Ok(())
     }
 

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1612,15 +1612,16 @@ pub async fn mutate_and_persist(
     id: &TaskId,
     f: impl FnOnce(&mut TaskState),
 ) -> anyhow::Result<()> {
-    let original = store.cache.get(id).map(|entry| entry.value().clone());
-    let mut attempted = None;
+    let mut rollback_state = None;
     if let Some(mut entry) = store.cache.get_mut(id) {
+        let original = entry.value().clone();
         f(entry.value_mut());
         entry.value_mut().reconcile_scheduler_with_status();
-        attempted = Some(entry.value().clone());
+        let attempted = entry.value().clone();
+        rollback_state = Some((original, attempted));
     }
     if let Err(error) = store.persist(id).await {
-        if let (Some(original), Some(attempted)) = (original, attempted) {
+        if let Some((original, attempted)) = rollback_state {
             if let Some(mut entry) = store.cache.get_mut(id) {
                 if task_states_match_for_rollback(entry.value(), &attempted) {
                     *entry.value_mut() = original;

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -1612,10 +1612,17 @@ pub async fn mutate_and_persist(
     id: &TaskId,
     f: impl FnOnce(&mut TaskState),
 ) -> anyhow::Result<()> {
+    let original = store.cache.get(id).map(|entry| entry.value().clone());
     if let Some(mut entry) = store.cache.get_mut(id) {
         f(entry.value_mut());
     }
-    store.persist(id).await
+    if let Err(error) = store.persist(id).await {
+        if let Some(original) = original {
+            store.cache.insert(id.clone(), original);
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn latest_timestamp_at_least(candidate: Option<&str>, existing: Option<&str>) -> bool {
@@ -2159,6 +2166,54 @@ mod tests {
             .await?
             .expect("task should remain persisted after external_id overwrite");
         assert_eq!(persisted.external_id.as_deref(), Some("new-external-id"));
+        assert_eq!(persisted.version, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mutate_and_persist_rolls_back_cache_on_optimistic_lock_conflict() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let task_id = harness_core::types::TaskId("mutate-conflict".to_string());
+        let task = pending_task(task_id.as_str());
+        store.insert(&task).await;
+
+        let scheduler_json =
+            serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
+        store
+            .db
+            .update_status_only(
+                task_id.as_str(),
+                TaskStatus::Failed.as_ref(),
+                &scheduler_json,
+                0,
+            )
+            .await?;
+
+        let error = mutate_and_persist(&store, &task_id, |state| {
+            state.status = TaskStatus::Done;
+            state.turn = 7;
+            state.error = Some("not persisted".to_string());
+        })
+        .await
+        .expect_err("stale cache version should fail optimistic locking");
+
+        assert!(format!("{error}").contains("optimistic-lock conflict"));
+        let cached = store
+            .get(&task_id)
+            .expect("task should remain cached after rollback");
+        assert_eq!(cached.status, TaskStatus::Pending);
+        assert_eq!(cached.turn, 0);
+        assert_eq!(cached.error, None);
+        assert_eq!(cached.version, 0);
+
+        let persisted = store
+            .db
+            .get(task_id.as_str())
+            .await?
+            .expect("task should remain persisted after conflict");
+        assert_eq!(persisted.status, TaskStatus::Failed);
         assert_eq!(persisted.version, 1);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- snapshot the cached task before mutate_and_persist applies in-memory mutations
- restore the original cache entry when persistence fails, including optimistic-lock conflicts
- add a regression test that bumps the persisted version behind the cache and verifies rollback

Closes #1108

## Verification
- cargo fmt --all
- cargo test -p harness-server mutate_and_persist_rolls_back_cache_on_optimistic_lock_conflict -- --nocapture
- cargo check
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets