### PR TITLE
fix(runtime): fail closed on workflow config errors

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -630,7 +630,7 @@ async fn dispatch_runtime_command_with_project_policy(
                 .to_string();
             return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
         }
-        Err(error) => {
+        Err(RuntimeDispatchProfileSelectionError::WorkflowConfig(error)) => {
             let command_id = command.id.clone();
             let reason = format!("workflow runtime project config failed to load: {error}");
             store.mark_command_status(&command_id, "failed").await?;
@@ -647,6 +647,9 @@ async fn dispatch_runtime_command_with_project_policy(
                 .await?;
             return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
         }
+        Err(RuntimeDispatchProfileSelectionError::Other(error)) => {
+            return Err(error.context("failed to select runtime dispatch profile"));
+        }
     };
 
     RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
@@ -660,11 +663,13 @@ async fn runtime_dispatch_profile_selector_for_command(
     store: &WorkflowRuntimeStore,
     command: &WorkflowCommandRecord,
     fallback_profile_selector: &RuntimeProfileSelector,
-) -> anyhow::Result<Option<RuntimeProfileSelector>> {
-    let project_root =
-        runtime_command_project_root(store, command, &state.core.project_root).await?;
+) -> Result<Option<RuntimeProfileSelector>, RuntimeDispatchProfileSelectionError> {
+    let project_root = runtime_command_project_root(store, command, &state.core.project_root)
+        .await
+        .map_err(RuntimeDispatchProfileSelectionError::Other)?;
     let workflow_cfg =
-        load_runtime_workflow_config(&project_root, "workflow runtime command dispatcher")?;
+        load_runtime_workflow_config(&project_root, "workflow runtime command dispatcher")
+            .map_err(RuntimeDispatchProfileSelectionError::WorkflowConfig)?;
     if !workflow_cfg.runtime_dispatch.enabled || !workflow_cfg.runtime_worker.enabled {
         tracing::debug!(
             workflow_id = %command.workflow_id,
@@ -681,7 +686,8 @@ async fn runtime_dispatch_profile_selector_for_command(
         &project_root,
         Some(fallback_profile_selector.select(None, None)),
     )
-    .await?;
+    .await
+    .map_err(RuntimeDispatchProfileSelectionError::Other)?;
     persist_runtime_profile_manifest(
         store,
         &project_root,
@@ -689,12 +695,22 @@ async fn runtime_dispatch_profile_selector_for_command(
         &workflow_cfg.runtime_dispatch,
         &inherited_profile,
     )
-    .await?;
-    Ok(Some(runtime_dispatch_profile_selector(
-        &state.core.server.config,
-        &workflow_cfg.runtime_dispatch,
-        &inherited_profile,
-    )?))
+    .await
+    .map_err(RuntimeDispatchProfileSelectionError::Other)?;
+    Ok(Some(
+        runtime_dispatch_profile_selector(
+            &state.core.server.config,
+            &workflow_cfg.runtime_dispatch,
+            &inherited_profile,
+        )
+        .map_err(RuntimeDispatchProfileSelectionError::Other)?,
+    ))
+}
+
+#[derive(Debug)]
+enum RuntimeDispatchProfileSelectionError {
+    WorkflowConfig(anyhow::Error),
+    Other(anyhow::Error),
 }
 
 async fn runtime_command_project_root(

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -15,6 +15,8 @@ use harness_workflow::runtime::{
 };
 use sha2::{Digest, Sha256};
 
+const RUNTIME_WORKFLOW_CONFIG_RETRY_SECS: u64 = 30;
+
 fn parse_issue_pr(task: &task_runner::TaskState) -> (Option<u64>, Option<u64>) {
     let (issue_from_external_id, pr_from_external_id) = task
         .external_id
@@ -612,19 +614,39 @@ async fn dispatch_runtime_command_with_project_policy(
             .await;
     }
 
-    let Some(profile_selector) = runtime_dispatch_profile_selector_for_command(
+    let profile_selector = match runtime_dispatch_profile_selector_for_command(
         state,
         store,
         &command,
         &fallback_profile_selector,
     )
-    .await?
-    else {
-        let command_id = command.id.clone();
-        store.mark_command_status(&command_id, "skipped").await?;
-        let reason =
-            "workflow runtime dispatch or worker is disabled for the command project".to_string();
-        return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
+    .await
+    {
+        Ok(Some(profile_selector)) => profile_selector,
+        Ok(None) => {
+            let command_id = command.id.clone();
+            store.mark_command_status(&command_id, "skipped").await?;
+            let reason = "workflow runtime dispatch or worker is disabled for the command project"
+                .to_string();
+            return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
+        }
+        Err(error) => {
+            let command_id = command.id.clone();
+            let reason = format!("workflow runtime project config failed to load: {error}");
+            store.mark_command_status(&command_id, "failed").await?;
+            store
+                .append_event(
+                    &command.workflow_id,
+                    "WorkflowRuntimeConfigError",
+                    "workflow_runtime_command_dispatcher",
+                    serde_json::json!({
+                        "command_id": command_id.clone(),
+                        "reason": reason.clone(),
+                    }),
+                )
+                .await?;
+            return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
+        }
     };
 
     RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
@@ -641,10 +663,8 @@ async fn runtime_dispatch_profile_selector_for_command(
 ) -> anyhow::Result<Option<RuntimeProfileSelector>> {
     let project_root =
         runtime_command_project_root(store, command, &state.core.project_root).await?;
-    let workflow_cfg = load_runtime_workflow_config_or_default(
-        &project_root,
-        "workflow runtime command dispatcher",
-    );
+    let workflow_cfg =
+        load_runtime_workflow_config(&project_root, "workflow runtime command dispatcher")?;
     if !workflow_cfg.runtime_dispatch.enabled || !workflow_cfg.runtime_worker.enabled {
         tracing::debug!(
             workflow_id = %command.workflow_id,
@@ -711,16 +731,19 @@ fn workflow_project_root(instance: &WorkflowInstance) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-fn load_runtime_workflow_config_or_default(
+fn load_runtime_workflow_config(
     project_root: &Path,
     subsystem: &str,
-) -> harness_core::config::workflow::WorkflowConfig {
-    harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_else(|e| {
-        tracing::warn!(
+) -> anyhow::Result<harness_core::config::workflow::WorkflowConfig> {
+    harness_core::config::workflow::load_workflow_config(project_root).map_err(|error| {
+        tracing::error!(
             project_root = %project_root.display(),
-            "{subsystem}: failed to load WORKFLOW.md, using default config: {e}"
+            "{subsystem}: failed to load WORKFLOW.md; runtime subsystem disabled until the config is fixed: {error}"
         );
-        harness_core::config::workflow::WorkflowConfig::default()
+        anyhow::anyhow!(
+            "{subsystem}: failed to load WORKFLOW.md at {}: {error}",
+            project_root.join("WORKFLOW.md").display()
+        )
     })
 }
 
@@ -776,10 +799,16 @@ pub(super) async fn run_runtime_repo_backlog_poll_tick(
             tick.skipped += 1;
             continue;
         }
-        let workflow_cfg = load_runtime_workflow_config_or_default(
+        let workflow_cfg = match load_runtime_workflow_config(
             &project_root,
             "workflow runtime repo backlog poller",
-        );
+        ) {
+            Ok(config) => config,
+            Err(_) => {
+                tick.skipped += 1;
+                continue;
+            }
+        };
         if !workflow_cfg.repo_backlog.enabled
             || !workflow_cfg.runtime_dispatch.enabled
             || !workflow_cfg.runtime_worker.enabled
@@ -865,10 +894,19 @@ pub(super) fn spawn_runtime_repo_backlog_poller(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg = load_runtime_workflow_config_or_default(
+            let workflow_cfg = match load_runtime_workflow_config(
                 &state.core.project_root,
                 "workflow runtime repo backlog poller",
-            );
+            ) {
+                Ok(config) => config,
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
+                    ))
+                    .await;
+                    continue;
+                }
+            };
             let interval =
                 std::time::Duration::from_secs(workflow_cfg.repo_backlog.poll_interval_secs.max(1));
             let batch_limit = workflow_cfg.repo_backlog.batch_limit.max(1) as usize;
@@ -956,10 +994,16 @@ pub(super) async fn run_runtime_pr_feedback_sweep_tick(
             tick.skipped += 1;
             continue;
         }
-        let workflow_cfg = load_runtime_workflow_config_or_default(
+        let workflow_cfg = match load_runtime_workflow_config(
             &project_root,
             "workflow runtime PR feedback sweeper",
-        );
+        ) {
+            Ok(config) => config,
+            Err(_) => {
+                tick.skipped += 1;
+                continue;
+            }
+        };
         if !workflow_cfg.pr_feedback.enabled
             || !workflow_cfg.runtime_dispatch.enabled
             || !workflow_cfg.runtime_worker.enabled
@@ -1055,10 +1099,19 @@ pub(super) fn spawn_runtime_pr_feedback_sweeper(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg = load_runtime_workflow_config_or_default(
+            let workflow_cfg = match load_runtime_workflow_config(
                 &state.core.project_root,
                 "workflow runtime PR feedback sweeper",
-            );
+            ) {
+                Ok(config) => config,
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
+                    ))
+                    .await;
+                    continue;
+                }
+            };
             let interval =
                 std::time::Duration::from_secs(workflow_cfg.pr_feedback.sweep_interval_secs.max(1));
             match run_runtime_pr_feedback_sweep_tick(&state, 128).await {
@@ -1461,10 +1514,19 @@ pub(super) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg = load_runtime_workflow_config_or_default(
+            let workflow_cfg = match load_runtime_workflow_config(
                 &state.core.project_root,
                 "workflow runtime command dispatcher",
-            );
+            ) {
+                Ok(config) => config,
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
+                    ))
+                    .await;
+                    continue;
+                }
+            };
             let policy = workflow_cfg.runtime_dispatch;
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
             let inherited_profile = match runtime_default_profile_for_project(
@@ -1660,10 +1722,19 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
                 Some(state) => state,
                 None => break,
             };
-            let workflow_cfg = load_runtime_workflow_config_or_default(
+            let workflow_cfg = match load_runtime_workflow_config(
                 &state.core.project_root,
                 "workflow runtime job workers",
-            );
+            ) {
+                Ok(config) => config,
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
+                    ))
+                    .await;
+                    continue;
+                }
+            };
             let policy = runtime_worker_loop_policy(workflow_cfg.runtime_worker);
             let interval = std::time::Duration::from_secs(policy.interval_secs.max(1));
             let lease_ttl = runtime_worker_lease_ttl(&policy);

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -1644,11 +1644,10 @@ fn log_runtime_worker_tick_result(
     }
 }
 
-fn drain_finished_runtime_worker_ticks(
-    workers: &mut tokio::task::JoinSet<
-        anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
-    >,
-) {
+type RuntimeWorkerJoinSet =
+    tokio::task::JoinSet<anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>>;
+
+fn drain_finished_runtime_worker_ticks(workers: &mut RuntimeWorkerJoinSet) {
     while let Some(result) = workers.try_join_next() {
         log_runtime_worker_tick_result(result);
     }
@@ -1695,9 +1694,7 @@ impl Drop for RuntimeWorkerStateLease {
 }
 
 fn spawn_runtime_worker_ticks(
-    workers: &mut tokio::task::JoinSet<
-        anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
-    >,
+    workers: &mut RuntimeWorkerJoinSet,
     state: &Arc<AppState>,
     active_worker_state_clones: &Arc<AtomicUsize>,
     concurrency: u32,
@@ -1718,6 +1715,38 @@ fn spawn_runtime_worker_ticks(
             )
             .await
         });
+    }
+}
+
+fn stop_runtime_job_worker_supervisor_for_shutdown(
+    workers: &mut RuntimeWorkerJoinSet,
+    shutdown_result: Result<(), tokio::sync::broadcast::error::RecvError>,
+) {
+    match shutdown_result {
+        Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+            tracing::info!("workflow runtime job worker supervisor stopping for shutdown");
+        }
+        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+            tracing::warn!(
+                skipped,
+                "workflow runtime job worker supervisor lagged shutdown signal"
+            );
+        }
+    }
+    workers.abort_all();
+}
+
+async fn runtime_worker_sleep_or_shutdown(
+    delay: std::time::Duration,
+    shutdown_rx: &mut tokio::sync::broadcast::Receiver<()>,
+    workers: &mut RuntimeWorkerJoinSet,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => false,
+        shutdown_result = shutdown_rx.recv() => {
+            stop_runtime_job_worker_supervisor_for_shutdown(workers, shutdown_result);
+            true
+        }
     }
 }
 
@@ -1744,10 +1773,16 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
             ) {
                 Ok(config) => config,
                 Err(_) => {
-                    tokio::time::sleep(std::time::Duration::from_secs(
-                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
-                    ))
-                    .await;
+                    drop(state);
+                    if runtime_worker_sleep_or_shutdown(
+                        std::time::Duration::from_secs(RUNTIME_WORKFLOW_CONFIG_RETRY_SECS),
+                        &mut shutdown_rx,
+                        &mut workers,
+                    )
+                    .await
+                    {
+                        break;
+                    }
                     continue;
                 }
             };
@@ -1777,25 +1812,8 @@ pub(super) fn spawn_runtime_job_workers(state: &Arc<AppState>) {
                 &mut next_worker_id,
             );
             drop(state);
-            tokio::select! {
-                _ = tokio::time::sleep(interval) => {}
-                shutdown_result = shutdown_rx.recv() => {
-                    match shutdown_result {
-                        Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            tracing::info!("workflow runtime job worker supervisor stopping for shutdown");
-                            workers.abort_all();
-                            break;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                            tracing::warn!(
-                                skipped,
-                                "workflow runtime job worker supervisor lagged shutdown signal"
-                            );
-                            workers.abort_all();
-                            break;
-                        }
-                    }
-                }
+            if runtime_worker_sleep_or_shutdown(interval, &mut shutdown_rx, &mut workers).await {
+                break;
             }
         }
     });
@@ -3159,6 +3177,35 @@ mod tests {
         .expect("finished worker should be drained without waiting for hung worker");
 
         workers.abort_all();
+        while workers.join_next().await.is_some() {}
+    }
+
+    #[tokio::test]
+    async fn runtime_worker_sleep_or_shutdown_exits_before_retry_delay() {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel(1);
+        let mut workers = tokio::task::JoinSet::new();
+        workers.spawn(async {
+            std::future::pending::<
+                anyhow::Result<crate::workflow_runtime_worker::RuntimeJobWorkerTick>,
+            >()
+            .await
+        });
+        shutdown_tx
+            .send(())
+            .expect("shutdown signal should be sent to subscribed receiver");
+
+        let stopped = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            runtime_worker_sleep_or_shutdown(
+                std::time::Duration::from_secs(RUNTIME_WORKFLOW_CONFIG_RETRY_SECS),
+                &mut shutdown_rx,
+                &mut workers,
+            ),
+        )
+        .await
+        .expect("shutdown should interrupt retry delay");
+
+        assert!(stopped);
         while workers.join_next().await.is_some() {}
     }
 

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1497,6 +1497,73 @@ async fn runtime_command_dispatch_tick_fails_command_when_workflow_config_is_mal
 }
 
 #[tokio::test]
+async fn runtime_command_dispatch_tick_retries_non_workflow_config_errors() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-malformed-project-config");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: true\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let harness_dir = project_root.join(".harness");
+    std::fs::create_dir(&harness_dir)?;
+    std::fs::write(harness_dir.join("config.toml"), "agent = [")?;
+
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "replanning",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:125"),
+    )
+    .with_id("issue-125")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 125,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("replan_issue", "replan-125");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+
+    let err = super::background::run_runtime_command_dispatch_tick(
+        &state,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "server-fallback",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+        10,
+    )
+    .await
+    .expect_err("non-WORKFLOW config errors should remain retryable");
+
+    assert!(format!("{err:#}").contains("failed to load project config"));
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    assert_eq!(
+        store.commands_for(&workflow.id).await?[0].status,
+        "dispatching"
+    );
+    let events = store.events_for(&workflow.id).await?;
+    assert!(!events
+        .iter()
+        .any(|event| event.event_type == "WorkflowRuntimeConfigError"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_pr_feedback_sweep_tick_enqueues_runtime_command() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1429,6 +1429,74 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
 }
 
 #[tokio::test]
+async fn runtime_command_dispatch_tick_fails_command_when_workflow_config_is_malformed(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-malformed-runtime");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch: [\n---\n",
+    )?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "replanning",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:124"),
+    )
+    .with_id("issue-124")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 124,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("replan_issue", "replan-124");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+
+    let tick = super::background::run_runtime_command_dispatch_tick(
+        &state,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "server-fallback",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+        10,
+    )
+    .await?;
+
+    assert_eq!(tick.enqueued, 0);
+    assert_eq!(tick.already_dispatched, 0);
+    assert_eq!(tick.skipped, 1);
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    assert_eq!(store.commands_for(&workflow.id).await?[0].status, "failed");
+    let events = store.events_for(&workflow.id).await?;
+    let config_event = events
+        .iter()
+        .find(|event| event.event_type == "WorkflowRuntimeConfigError")
+        .expect("config error event should be recorded");
+    assert_eq!(config_event.event["command_id"], command_id);
+    assert!(config_event.event["reason"]
+        .as_str()
+        .expect("reason should be a string")
+        .contains("failed to load WORKFLOW.md"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_pr_feedback_sweep_tick_enqueues_runtime_command() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -1622,6 +1690,59 @@ async fn runtime_repo_backlog_poll_tick_enqueues_runtime_command() -> anyhow::Re
         commands[0].command.activity_name(),
         Some(harness_workflow::runtime::REPO_BACKLOG_POLL_ACTIVITY)
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_repo_backlog_poll_tick_skips_malformed_workflow_config() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-backlog-malformed");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nrepo_backlog: [\n---\n",
+    )?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repos: vec![harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            project_root: Some(project_root.to_string_lossy().into_owned()),
+        }],
+        ..Default::default()
+    });
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+
+    let tick = super::background::run_runtime_repo_backlog_poll_tick(&state, 10).await?;
+
+    assert_eq!(tick.requested, 0);
+    assert_eq!(tick.active_command_exists, 0);
+    assert_eq!(tick.skipped, 1);
+    assert_eq!(tick.rejected, 0);
+    let instances = store
+        .list_instances_by_definition(
+            harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+            None,
+            None,
+        )
+        .await?;
+    assert!(instances.is_empty());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- replace runtime background fallback-to-default workflow config loading with fail-closed error handling
- skip repo backlog and PR feedback sweeps when project WORKFLOW.md cannot be parsed
- fail claimed runtime commands with a WorkflowRuntimeConfigError event instead of dispatching under default-enabled policy

Closes #1102

## Verification
- cargo fmt --all
- cargo test -p harness-server runtime_command_dispatch_tick_fails_command_when_workflow_config_is_malformed -- --nocapture
- cargo test -p harness-server runtime_repo_backlog_poll_tick_skips_malformed_workflow_config -- --nocapture
- cargo check
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets