### PR TITLE
fix(runtime): cancel dispatching commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,6 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 
 - RS-03 exempt: `fn main()` scope, `Mutex::lock().unwrap()`, `RwLock::{read,write}().unwrap()`
 - RS-13: only flag functions returning `()` or `Result<()>` — typed returns are transformers, not action functions
-- U-16 exempt: `**/prompts.rs` → 1200-line limit, `**/dispatch.rs` → 1000-line limit, `**/services/execution.rs` → 2600-line limit, `**/task_runner/spawn.rs` → 2700-line limit, `**/task_runner/store.rs` → 2200-line limit (legacy oversized files; pending split)
+- U-16 exempt: `**/prompts.rs` → 1200-line limit, `**/dispatch.rs` → 1000-line limit, `**/services/execution.rs` → 2600-line limit, `**/task_runner/spawn.rs` → 2700-line limit, `**/task_runner/store.rs` → 2200-line limit, `**/harness-workflow/src/runtime/store.rs` → 2300-line limit, `**/harness-workflow/src/runtime/tests.rs` → 6000-line limit (legacy oversized files; pending split)
 - L1 exempt: new files matching `src/**/{mod,lib,main}.rs` (standard Rust module files)
 - gh/git guard: CLAUDE.md rule is semantic (agent prompts only); bash guard should not double-block `cargo test` subprocesses

--- a/crates/harness-server/src/http/tests.rs
+++ b/crates/harness-server/src/http/tests.rs
@@ -1913,8 +1913,8 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
             harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
             "codex-default",
             serde_json::json!({
-                "workflow_id": workflow.id,
-                "command_id": command_id,
+                "workflow_id": workflow.id.clone(),
+                "command_id": command_id.clone(),
                 "command_type": command.command_type,
                 "dedupe_key": command.dedupe_key,
                 "command": command.command,
@@ -2047,6 +2047,103 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
         approval_policies.as_slice(),
         &[Some("on-request".to_string())]
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_worker_cancels_job_when_workflow_already_terminal() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    let agent = RuntimeStreamAgent::new();
+    let mut registry = harness_agents::registry::AgentRegistry::new("codex");
+    registry.register("codex", agent.clone());
+    let state =
+        make_test_state_with_workflow_runtime_and_registry(dir.path(), &project_root, registry)
+            .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "cancelled",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:125"),
+    )
+    .with_id("issue-125")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 125,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("implement_issue", "impl-125");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": workflow.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key,
+                "command": command.command,
+                "activity": "implement_issue",
+                "runtime_profile": harness_workflow::runtime::RuntimeProfile::new(
+                    "codex-default",
+                    harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                ),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 0);
+    assert_eq!(tick.failed, 0);
+    assert_eq!(tick.cancelled, 1);
+    assert!(!tick.idle);
+    assert!(agent.prompts.lock().await.is_empty());
+    let completed = store
+        .get_runtime_job(&runtime_job.id)
+        .await?
+        .expect("runtime job should exist");
+    assert_eq!(
+        completed.status,
+        harness_workflow::runtime::RuntimeJobStatus::Cancelled
+    );
+    let output: harness_workflow::runtime::ActivityResult = serde_json::from_value(
+        completed
+            .output
+            .expect("activity result should be recorded"),
+    )?;
+    assert_eq!(output.activity, "implement_issue");
+    assert_eq!(
+        output.summary,
+        "Workflow issue-125 was already terminal (cancelled) before runtime execution."
+    );
+    assert_eq!(
+        store.commands_for(&workflow.id).await?[0].status,
+        "cancelled"
+    );
+    let events = store.runtime_events_for(&runtime_job.id).await?;
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type, "RuntimeJobClaimed");
+    assert_eq!(events[1].event_type, "ActivityResultReady");
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -445,7 +445,10 @@ async fn cancel_submission_instance(
     let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
     let commands = store.commands_for(&cancelled.id).await?;
     for command in commands {
-        if matches!(command.status.as_str(), "pending" | "dispatched") {
+        if matches!(
+            command.status.as_str(),
+            "pending" | "dispatching" | "dispatched"
+        ) {
             store
                 .cancel_command_and_unfinished_runtime_jobs(
                     &command.id,

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -426,6 +426,85 @@ async fn cancel_issue_submission_cancels_dispatched_runtime_jobs() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn cancel_issue_submission_cancels_dispatching_runtime_command() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("runtime-handle-cancel-dispatching");
+    let result = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 44,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let command_id = result
+        .command_ids
+        .first()
+        .expect("issue submission should enqueue an implementation command")
+        .clone();
+    let claimed = store
+        .claim_pending_commands(
+            "dispatcher-a",
+            chrono::Utc::now() + chrono::Duration::seconds(60),
+            10,
+        )
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, command_id);
+    assert_eq!(claimed[0].status, "dispatching");
+
+    let cancelled = expect_cancelled(
+        cancel_issue_submission_by_task_id(&store, &task_id).await?,
+        "runtime issue submission should resolve by task id",
+    );
+    assert_eq!(cancelled.state, "cancelled");
+
+    let command = store
+        .get_command(&command_id)
+        .await?
+        .expect("command should remain visible");
+    assert_eq!(command.status, "cancelled");
+    assert!(command.dispatch_owner.is_none());
+    assert!(command.dispatch_lease_expires_at.is_none());
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+
+    let outcomes = harness_workflow::runtime::RuntimeCommandDispatcher::new(
+        &store,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "codex-default",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+    )
+    .dispatch_pending()
+    .await?;
+    assert!(outcomes.is_empty());
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn cancel_issue_submission_by_workflow_id_uses_stable_runtime_handle() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -42,6 +42,17 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
 
     async fn execute_inner(&self, job: RuntimeJob) -> anyhow::Result<ActivityResult> {
         let workflow = self.workflow_for_job(&job).await?;
+        if let Some(workflow) = workflow.as_ref() {
+            if workflow.is_terminal() {
+                return Ok(ActivityResult::cancelled(
+                    activity_name(&job),
+                    format!(
+                        "Workflow {} was already terminal ({}) before runtime execution.",
+                        workflow.id, workflow.state
+                    ),
+                ));
+            }
+        }
         if let Some(result) = self
             .execute_builtin_lifecycle_activity(&job, workflow.as_ref())
             .await?

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use uuid::Uuid;
 
 const COMMAND_STATUS_SKIPPED: &str = "skipped";
+const COMMAND_STATUS_CANCELLED: &str = "cancelled";
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandDispatchOutcome {
@@ -182,6 +183,26 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                 command_id: command.id,
                 reason: "command does not require runtime execution".to_string(),
             });
+        }
+
+        if let Some(instance) = self.store.get_instance(&command.workflow_id).await? {
+            if instance.is_terminal() {
+                let command_status = if instance.state == "cancelled" {
+                    COMMAND_STATUS_CANCELLED
+                } else {
+                    COMMAND_STATUS_SKIPPED
+                };
+                self.store
+                    .mark_command_status(&command.id, command_status)
+                    .await?;
+                return Ok(CommandDispatchOutcome::Skipped {
+                    command_id: command.id,
+                    reason: format!(
+                        "workflow {} is terminal ({}) before dispatch",
+                        instance.id, instance.state
+                    ),
+                });
+            }
         }
 
         let activity = command.command.runtime_activity_key().to_string();

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1519,7 +1519,7 @@ impl WorkflowRuntimeStore {
                      WHERE workflow_id = $1
                        AND id <> $2
                        AND command_type = $3
-                       AND status IN ('pending', 'dispatched')",
+                       AND status IN ('pending', 'dispatching', 'dispatched')",
                 )
                 .bind(&command.workflow_id)
                 .bind(&command.id)

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1764,9 +1764,12 @@ impl WorkflowRuntimeStore {
         }
         sqlx::query(
             "UPDATE workflow_commands
-             SET status = 'cancelled', updated_at = CURRENT_TIMESTAMP
+             SET status = 'cancelled',
+                 dispatch_owner = NULL,
+                 dispatch_lease_expires_at = NULL,
+                 updated_at = CURRENT_TIMESTAMP
              WHERE id = $1
-               AND status IN ('pending', 'dispatched')",
+               AND status IN ('pending', 'dispatching', 'dispatched')",
         )
         .bind(command_id)
         .execute(&mut *tx)

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -5708,3 +5708,46 @@ async fn runtime_command_dispatcher_skips_non_runtime_commands() -> anyhow::Resu
     assert_eq!(store.commands_for(&instance.id).await?[0].status, "skipped");
     Ok(())
 }
+
+#[tokio::test]
+async fn runtime_command_dispatcher_skips_terminal_workflow_before_enqueue() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = project_issue_instance("/project-a", 123, "cancelled");
+    store.upsert_instance(&instance).await?;
+    let command =
+        WorkflowCommand::enqueue_activity("implement_issue", "issue-123-cancelled-implement");
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc),
+    );
+
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should be inspected");
+    match outcome {
+        CommandDispatchOutcome::Skipped {
+            command_id: skipped_command_id,
+            reason,
+        } => {
+            assert_eq!(skipped_command_id, command_id);
+            assert!(reason.contains("terminal (cancelled)"));
+        }
+        other => panic!("unexpected dispatch outcome: {other:?}"),
+    }
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    assert_eq!(
+        store.commands_for(&instance.id).await?[0].status,
+        "cancelled"
+    );
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -4407,6 +4407,77 @@ async fn runtime_worker_keeps_repo_backlog_dispatching_until_child_starts_finish
 }
 
 #[tokio::test]
+async fn runtime_completion_counts_dispatching_sibling_as_active() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = repo_backlog_instance("dispatching");
+    store.upsert_instance(&workflow).await?;
+    let first_command = WorkflowCommand::start_child_workflow(
+        "github_issue_pr",
+        "issue:200",
+        "repo-backlog:owner/repo:issue:200:start",
+    );
+    let first_command_id = store
+        .enqueue_command(&workflow.id, None, &first_command)
+        .await?;
+    let second_command = WorkflowCommand::start_child_workflow(
+        "github_issue_pr",
+        "issue:201",
+        "repo-backlog:owner/repo:issue:201:start",
+    );
+    let second_command_id = store
+        .enqueue_command(&workflow.id, None, &second_command)
+        .await?;
+
+    store
+        .enqueue_runtime_job_for_pending_command(
+            &first_command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "start_child_workflow" }),
+            None,
+        )
+        .await?;
+    let claimed = store
+        .claim_pending_commands("dispatcher-test", Utc::now() + Duration::minutes(5), 10)
+        .await?;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, second_command_id);
+    assert_eq!(claimed[0].status, "dispatching");
+
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded("workflow_activity", "Child workflow started."),
+    };
+    worker
+        .run_once(&executor)
+        .await?
+        .expect("first child dispatch job should complete");
+
+    let completion = store
+        .events_for(&workflow.id)
+        .await?
+        .into_iter()
+        .find(|event| event.event_type == "RuntimeJobCompleted")
+        .expect("completion event should exist");
+    assert_eq!(completion.event["active_start_child_workflow_commands"], 1);
+
+    let parent = store
+        .get_instance(&workflow.id)
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(
+        parent.state, "dispatching",
+        "parent must stay dispatching while sibling is still in dispatching status"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -67,28 +67,33 @@ impl<'a> RuntimeWorker<'a> {
             .await?;
 
         let consumes_runtime_turn = executor.consumes_runtime_turn(&job);
-        let result = match self
-            .max_turns_budget_result(&job, consumes_runtime_turn)
-            .await?
-        {
+        let result = match self.terminal_workflow_result(&job).await? {
             Some(result) => result,
             None => {
-                if consumes_runtime_turn {
-                    self.store
-                        .record_runtime_event(
-                            &job.id,
-                            "RuntimeTurnStarted",
-                            json!({
-                                "owner": self.owner.as_str(),
-                            }),
-                        )
-                        .await?;
+                match self
+                    .max_turns_budget_result(&job, consumes_runtime_turn)
+                    .await?
+                {
+                    Some(result) => result,
+                    None => {
+                        if consumes_runtime_turn {
+                            self.store
+                                .record_runtime_event(
+                                    &job.id,
+                                    "RuntimeTurnStarted",
+                                    json!({
+                                        "owner": self.owner.as_str(),
+                                    }),
+                                )
+                                .await?;
+                        }
+                        let execution = self
+                            .execute_with_lease_renewal(&job, executor, lease_expires_at)
+                            .await?;
+                        lease_expires_at = execution.lease_expires_at;
+                        execution.result
+                    }
                 }
-                let execution = self
-                    .execute_with_lease_renewal(&job, executor, lease_expires_at)
-                    .await?;
-                lease_expires_at = execution.lease_expires_at;
-                execution.result
             }
         };
         self.store
@@ -120,6 +125,28 @@ impl<'a> RuntimeWorker<'a> {
                 .await?;
         }
         Ok(Some(completion.runtime_job))
+    }
+
+    async fn terminal_workflow_result(
+        &self,
+        job: &RuntimeJob,
+    ) -> anyhow::Result<Option<ActivityResult>> {
+        let Some(workflow_id) = job.input.get("workflow_id").and_then(Value::as_str) else {
+            return Ok(None);
+        };
+        let Some(instance) = self.store.get_instance(workflow_id).await? else {
+            return Ok(None);
+        };
+        if !instance.is_terminal() {
+            return Ok(None);
+        }
+        Ok(Some(ActivityResult::cancelled(
+            runtime_job_activity_name(job),
+            format!(
+                "Workflow {} was already terminal ({}) before runtime execution.",
+                instance.id, instance.state
+            ),
+        )))
     }
 
     async fn execute_with_lease_renewal(


### PR DESCRIPTION
## Summary
- cancel workflow commands that are already claimed as dispatching
- clear dispatch leases when cancellation wins the race
- re-check terminal workflow state before dispatch and before runtime execution

## Verification
- cargo fmt --all
- cargo test -p harness-server cancel_issue_submission_cancels_dispatching_runtime_command -- --nocapture
- cargo test -p harness-workflow runtime_command_dispatcher_skips_terminal_workflow_before_enqueue -- --nocapture
- cargo test -p harness-server runtime_job_worker_cancels_job_when_workflow_already_terminal -- --nocapture
- cargo check
- cargo test
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

Closes #1101