### PR TITLE
Fix atomic PR feedback runtime transitions

### DIFF
--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -629,6 +629,7 @@ async fn apply_runtime_workflow_transition(
     let Some(_record) = runtime_store
         .apply_decision_transition(WorkflowDecisionTransition {
             expected_state: candidate.state.as_str(),
+            create_if_missing: None,
             event_type,
             source: "reconciliation",
             payload: event_payload,

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -3,8 +3,8 @@ use harness_workflow::runtime::{
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, ValidationContext, WorkflowCommand, WorkflowCommandType,
-    WorkflowDecision, WorkflowDecisionRecord, WorkflowDecisionTransition, WorkflowDefinition,
-    WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition, WorkflowEvidence,
+    WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore, WorkflowSubject,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
@@ -578,13 +578,22 @@ async fn commit_runtime_decision(
         &ValidationContext::new("workflow-policy", chrono::Utc::now()),
     );
     if let Err(error) = validation {
-        let event = store
-            .append_event(&instance.id, event_type, source, event_payload)
-            .await?;
         let reason = error.to_string();
-        let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
-        store.record_decision(&record).await?;
-        return Ok(RuntimeDecisionCommitOutcome::Rejected { reason });
+        let record = store
+            .record_rejected_decision_transition(WorkflowRejectedDecisionTransition {
+                expected_state: &expected_state,
+                create_if_missing: new_instance.then_some(&instance),
+                event_type,
+                source,
+                payload: event_payload,
+                decision: &decision,
+                reason: &reason,
+            })
+            .await?;
+        return Ok(match record {
+            Some(_) => RuntimeDecisionCommitOutcome::Rejected { reason },
+            None => RuntimeDecisionCommitOutcome::Stale,
+        });
     }
 
     let mut final_instance = instance.clone();
@@ -864,6 +873,70 @@ mod tests {
             store.events_for(&workflow_id).await?[0].event_type,
             "PrDetected"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejected_new_runtime_decision_persists_initial_instance() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => store,
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            123,
+        );
+        upsert_github_issue_pr_definition(&store).await?;
+        let instance = issue_instance(
+            workflow_id.clone(),
+            project_root.to_string_lossy().into_owned(),
+            Some("owner/repo".to_string()),
+            123,
+            "pr_open",
+        );
+        let decision = WorkflowDecision::new(
+            &workflow_id,
+            "awaiting_feedback",
+            "record_feedback",
+            "addressing_feedback",
+            "intentionally stale observed state",
+        );
+
+        let outcome = commit_runtime_decision(
+            &store,
+            instance.clone(),
+            true,
+            decision,
+            "FeedbackFound",
+            "workflow_runtime_pr_feedback_test",
+            json!({ "issue_number": 123, "pr_number": 77 }),
+            instance.data.clone(),
+        )
+        .await?;
+
+        assert!(matches!(
+            outcome,
+            RuntimeDecisionCommitOutcome::Rejected { .. }
+        ));
+        let loaded = store
+            .get_instance(&workflow_id)
+            .await?
+            .expect("rejected initial transition should still persist the workflow instance");
+        assert_eq!(loaded.state, "pr_open");
+        assert_eq!(store.events_for(&workflow_id).await?.len(), 1);
+        let decisions = store.decisions_for(&workflow_id).await?;
+        assert_eq!(decisions.len(), 1);
+        assert!(!decisions[0].accepted);
         Ok(())
     }
 

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -3,9 +3,9 @@ use harness_workflow::runtime::{
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
     DecisionValidator, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
     PrFeedbackSweepDecisionInput, ValidationContext, WorkflowCommand, WorkflowCommandType,
-    WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvidence,
-    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY,
+    WorkflowDecision, WorkflowDecisionRecord, WorkflowDecisionTransition, WorkflowDefinition,
+    WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -90,6 +90,24 @@ pub(crate) enum RuntimeMergeApprovalOutcome {
         workflow_id: String,
         reason: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeDecisionCommitOutcome {
+    Accepted,
+    Rejected { reason: String },
+    Stale,
+}
+
+impl RuntimeDecisionCommitOutcome {
+    fn into_result(self) -> anyhow::Result<()> {
+        match self {
+            Self::Accepted | Self::Rejected { .. } => Ok(()),
+            Self::Stale => anyhow::bail!(
+                "workflow state changed before the runtime transition could be committed"
+            ),
+        }
+    }
 }
 
 pub(crate) async fn record_pr_detected(
@@ -215,7 +233,7 @@ async fn persist_pr_detected(
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, ctx.issue_number);
     upsert_github_issue_pr_definition(store).await?;
-    let mut instance = load_or_issue_instance(
+    let (instance, new_instance) = load_or_issue_instance(
         store,
         workflow_id,
         project_id.clone(),
@@ -224,7 +242,7 @@ async fn persist_pr_detected(
         "implementing",
     )
     .await?;
-    instance.data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
+    let accepted_data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
         json!({
         "project_id": project_id,
@@ -235,21 +253,6 @@ async fn persist_pr_detected(
         "pr_url": ctx.pr_url,
         }),
     );
-    store.upsert_instance(&instance).await?;
-    let event = store
-        .append_event(
-            &instance.id,
-            "PrDetected",
-            "workflow_runtime_pr_feedback",
-            json!({
-                "task_id": ctx.task_id.as_str(),
-                "issue_number": ctx.issue_number,
-                "repo": ctx.repo,
-                "pr_number": ctx.pr_number,
-                "pr_url": ctx.pr_url,
-            }),
-        )
-        .await?;
     let output = build_pr_detected_decision(
         &instance,
         PrDetectedDecisionInput {
@@ -258,12 +261,29 @@ async fn persist_pr_detected(
             pr_url: ctx.pr_url,
         },
     );
-    apply_decision(store, instance, output.decision, Some(event.id)).await
+    commit_runtime_decision(
+        store,
+        instance,
+        new_instance,
+        output.decision,
+        "PrDetected",
+        "workflow_runtime_pr_feedback",
+        json!({
+            "task_id": ctx.task_id.as_str(),
+            "issue_number": ctx.issue_number,
+            "repo": ctx.repo,
+            "pr_number": ctx.pr_number,
+            "pr_url": ctx.pr_url,
+        }),
+        accepted_data,
+    )
+    .await?
+    .into_result()
 }
 
 async fn persist_pr_feedback_sweep_request(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
 ) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
     let workflow_id = instance.id.clone();
     let task_id = runtime_task_id_from_instance(&instance);
@@ -274,23 +294,12 @@ async fn persist_pr_feedback_sweep_request(
         .get("issue_number")
         .and_then(|value| value.as_u64());
     let repo = optional_string_field(&instance.data, "repo");
-    let event = store
-        .append_event(
-            &instance.id,
-            "PrFeedbackSweepRequested",
-            "workflow_runtime_pr_feedback",
-            json!({
-                "issue_number": issue_number,
-                "repo": repo.as_deref(),
-                "pr_number": pr_number,
-                "pr_url": pr_url.as_deref(),
-            }),
-        )
-        .await?;
+    let accepted_data = instance.data.clone();
+    let sweep_nonce = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
     let output = build_pr_feedback_sweep_decision(
         &instance,
         PrFeedbackSweepDecisionInput {
-            dedupe_key: &format!("pr-feedback-sweep:{}:{}", instance.id, event.id),
+            dedupe_key: &format!("pr-feedback-sweep:{}:{sweep_nonce}", instance.id),
             pr_number,
             pr_url: pr_url.as_deref(),
             issue_number,
@@ -298,38 +307,43 @@ async fn persist_pr_feedback_sweep_request(
             summary: "Runtime workflow requested a PR feedback sweep.",
         },
     );
-    let validator = DecisionValidator::github_issue_pr();
-    let validation = validator.validate(
-        &instance,
-        &output.decision,
-        &ValidationContext::new("workflow-policy", chrono::Utc::now()),
-    );
-    let record = match validation {
-        Ok(()) => WorkflowDecisionRecord::accepted(output.decision.clone(), Some(event.id)),
-        Err(error) => {
-            let reason = error.to_string();
-            let record = WorkflowDecisionRecord::rejected(output.decision, Some(event.id), &reason);
-            store.record_decision(&record).await?;
-            return Ok(PrFeedbackSweepRequestOutcome::Rejected {
-                workflow_id: instance.id,
+    let event_payload = json!({
+        "issue_number": issue_number,
+        "repo": repo.as_deref(),
+        "pr_number": pr_number,
+        "pr_url": pr_url.as_deref(),
+    });
+    match commit_runtime_decision(
+        store,
+        instance,
+        false,
+        output.decision,
+        "PrFeedbackSweepRequested",
+        "workflow_runtime_pr_feedback",
+        event_payload,
+        accepted_data,
+    )
+    .await?
+    {
+        RuntimeDecisionCommitOutcome::Accepted => Ok(PrFeedbackSweepRequestOutcome::Requested {
+            workflow_id,
+            task_id,
+        }),
+        RuntimeDecisionCommitOutcome::Rejected { reason } => {
+            Ok(PrFeedbackSweepRequestOutcome::Rejected {
+                workflow_id,
                 reason,
-            });
+            })
         }
-    };
-    store.record_decision(&record).await?;
-    for command in &output.decision.commands {
-        store
-            .enqueue_command(&instance.id, Some(&record.id), command)
-            .await?;
+        RuntimeDecisionCommitOutcome::Stale => {
+            let state = store
+                .get_instance(&workflow_id)
+                .await?
+                .map(|instance| instance.state)
+                .unwrap_or_else(|| "missing".to_string());
+            Ok(PrFeedbackSweepRequestOutcome::NotCandidate { workflow_id, state })
+        }
     }
-    instance.state = output.decision.next_state.clone();
-    instance.version = instance.version.saturating_add(1);
-    instance.data = merge_last_decision(instance.data, &output.decision.decision);
-    store.upsert_instance(&instance).await?;
-    Ok(PrFeedbackSweepRequestOutcome::Requested {
-        workflow_id,
-        task_id,
-    })
 }
 
 async fn persist_pr_feedback(
@@ -341,7 +355,7 @@ async fn persist_pr_feedback(
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, issue_number);
     upsert_github_issue_pr_definition(store).await?;
-    let mut instance = load_or_issue_instance(
+    let (instance, new_instance) = load_or_issue_instance(
         store,
         workflow_id,
         project_id.clone(),
@@ -350,7 +364,7 @@ async fn persist_pr_feedback(
         "pr_open",
     )
     .await?;
-    instance.data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
+    let accepted_data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
         json!({
         "project_id": project_id,
@@ -362,23 +376,6 @@ async fn persist_pr_feedback(
         "feedback_summary": ctx.summary,
         }),
     );
-    store.upsert_instance(&instance).await?;
-    let event = store
-        .append_event(
-            &instance.id,
-            event_type(ctx.outcome),
-            "workflow_runtime_pr_feedback",
-            json!({
-                "task_id": ctx.task_id.as_str(),
-                "issue_number": issue_number,
-                "repo": ctx.repo,
-                "pr_number": ctx.pr_number,
-                "pr_url": ctx.pr_url,
-                "outcome": outcome_label(ctx.outcome),
-                "summary": ctx.summary,
-            }),
-        )
-        .await?;
     let output = build_pr_feedback_decision(
         &instance,
         PrFeedbackDecisionInput {
@@ -389,7 +386,26 @@ async fn persist_pr_feedback(
             summary: ctx.summary,
         },
     );
-    apply_decision(store, instance, output.decision, Some(event.id)).await
+    commit_runtime_decision(
+        store,
+        instance,
+        new_instance,
+        output.decision,
+        event_type(ctx.outcome),
+        "workflow_runtime_pr_feedback",
+        json!({
+            "task_id": ctx.task_id.as_str(),
+            "issue_number": issue_number,
+            "repo": ctx.repo,
+            "pr_number": ctx.pr_number,
+            "pr_url": ctx.pr_url,
+            "outcome": outcome_label(ctx.outcome),
+            "summary": ctx.summary,
+        }),
+        accepted_data,
+    )
+    .await?
+    .into_result()
 }
 
 async fn persist_pr_merged(
@@ -401,7 +417,7 @@ async fn persist_pr_merged(
     let workflow_id =
         harness_workflow::issue_lifecycle::workflow_id(&project_id, ctx.repo, issue_number);
     upsert_github_issue_pr_definition(store).await?;
-    let mut instance = load_or_issue_instance(
+    let (instance, new_instance) = load_or_issue_instance(
         store,
         workflow_id,
         project_id.clone(),
@@ -410,7 +426,7 @@ async fn persist_pr_merged(
         "pr_open",
     )
     .await?;
-    instance.data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
+    let accepted_data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
         json!({
             "project_id": project_id,
@@ -421,21 +437,6 @@ async fn persist_pr_merged(
             "pr_url": ctx.pr_url,
         }),
     );
-    store.upsert_instance(&instance).await?;
-    let event = store
-        .append_event(
-            &instance.id,
-            "PrMerged",
-            "workflow_runtime_pr_feedback",
-            json!({
-                "task_id": ctx.task_id.as_str(),
-                "issue_number": issue_number,
-                "repo": ctx.repo,
-                "pr_number": ctx.pr_number,
-                "pr_url": ctx.pr_url,
-            }),
-        )
-        .await?;
     let decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
@@ -457,12 +458,29 @@ async fn persist_pr_merged(
         ctx.pr_url.unwrap_or("merged externally"),
     ))
     .high_confidence();
-    apply_decision(store, instance, decision, Some(event.id)).await
+    commit_runtime_decision(
+        store,
+        instance,
+        new_instance,
+        decision,
+        "PrMerged",
+        "workflow_runtime_pr_feedback",
+        json!({
+            "task_id": ctx.task_id.as_str(),
+            "issue_number": issue_number,
+            "repo": ctx.repo,
+            "pr_number": ctx.pr_number,
+            "pr_url": ctx.pr_url,
+        }),
+        accepted_data,
+    )
+    .await?
+    .into_result()
 }
 
 async fn approve_runtime_merge(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
     task_id: Option<&str>,
 ) -> anyhow::Result<RuntimeMergeApprovalOutcome> {
     if instance.definition_id != harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID {
@@ -478,20 +496,8 @@ async fn approve_runtime_merge(
         });
     }
 
-    let event = store
-        .append_event(
-            &instance.id,
-            "MergeApproved",
-            "workflow_runtime_dashboard",
-            json!({
-                "task_id": task_id,
-                "issue_number": instance.data.get("issue_number").and_then(|value| value.as_u64()),
-                "repo": optional_string_field(&instance.data, "repo"),
-                "pr_number": instance.data.get("pr_number").and_then(|value| value.as_u64()),
-                "pr_url": optional_string_field(&instance.data, "pr_url"),
-            }),
-        )
-        .await?;
+    let workflow_id = instance.id.clone();
+    let approval_nonce = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
     let decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
@@ -501,7 +507,7 @@ async fn approve_runtime_merge(
     )
     .with_command(harness_workflow::runtime::WorkflowCommand::new(
         harness_workflow::runtime::WorkflowCommandType::MarkDone,
-        format!("merge-approved:{}:{}", instance.id, event.id),
+        format!("merge-approved:{}:{approval_nonce}", instance.id),
         json!({
             "workflow_id": instance.id,
             "task_id": task_id,
@@ -513,69 +519,95 @@ async fn approve_runtime_merge(
         "dashboard merge approval for ready-to-merge workflow",
     ))
     .high_confidence();
-    let validator = DecisionValidator::github_issue_pr();
-    let validation = validator.validate(
-        &instance,
-        &decision,
-        &ValidationContext::new("workflow-policy", chrono::Utc::now()),
-    );
-    let record = match validation {
-        Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id)),
-        Err(error) => {
-            let reason = error.to_string();
-            let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
-            store.record_decision(&record).await?;
-            return Ok(RuntimeMergeApprovalOutcome::Rejected {
-                workflow_id: instance.id,
-                reason,
-            });
+    let accepted_data =
+        merge_runtime_merge_data(instance.data.clone(), &decision.decision, task_id);
+    let event_payload = json!({
+        "task_id": task_id,
+        "issue_number": instance.data.get("issue_number").and_then(|value| value.as_u64()),
+        "repo": optional_string_field(&instance.data, "repo"),
+        "pr_number": instance.data.get("pr_number").and_then(|value| value.as_u64()),
+        "pr_url": optional_string_field(&instance.data, "pr_url"),
+    });
+    match commit_runtime_decision(
+        store,
+        instance,
+        false,
+        decision,
+        "MergeApproved",
+        "workflow_runtime_dashboard",
+        event_payload,
+        accepted_data,
+    )
+    .await?
+    {
+        RuntimeDecisionCommitOutcome::Accepted => {
+            Ok(RuntimeMergeApprovalOutcome::Approved { workflow_id })
         }
-    };
-    store.record_decision(&record).await?;
-    for command in &decision.commands {
-        store
-            .enqueue_command(&instance.id, Some(&record.id), command)
-            .await?;
+        RuntimeDecisionCommitOutcome::Rejected { reason } => {
+            Ok(RuntimeMergeApprovalOutcome::Rejected {
+                workflow_id,
+                reason,
+            })
+        }
+        RuntimeDecisionCommitOutcome::Stale => {
+            let state = store
+                .get_instance(&workflow_id)
+                .await?
+                .map(|instance| instance.state)
+                .unwrap_or_else(|| "missing".to_string());
+            Ok(RuntimeMergeApprovalOutcome::NotReady { workflow_id, state })
+        }
     }
-    instance.state = decision.next_state.clone();
-    instance.version = instance.version.saturating_add(1);
-    instance.data = merge_runtime_merge_data(instance.data, &decision.decision, task_id);
-    let workflow_id = instance.id.clone();
-    store.upsert_instance(&instance).await?;
-    Ok(RuntimeMergeApprovalOutcome::Approved { workflow_id })
 }
 
-async fn apply_decision(
+async fn commit_runtime_decision(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
+    new_instance: bool,
     decision: WorkflowDecision,
-    event_id: Option<String>,
-) -> anyhow::Result<()> {
+    event_type: &'static str,
+    source: &'static str,
+    event_payload: serde_json::Value,
+    accepted_data: serde_json::Value,
+) -> anyhow::Result<RuntimeDecisionCommitOutcome> {
+    let expected_state = instance.state.clone();
     let validator = DecisionValidator::github_issue_pr();
     let validation = validator.validate(
         &instance,
         &decision,
         &ValidationContext::new("workflow-policy", chrono::Utc::now()),
     );
-    let record = match validation {
-        Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), event_id),
-        Err(error) => {
-            let reason = error.to_string();
-            let record = WorkflowDecisionRecord::rejected(decision, event_id, &reason);
-            store.record_decision(&record).await?;
-            return Ok(());
-        }
-    };
-    store.record_decision(&record).await?;
-    for command in &decision.commands {
-        store
-            .enqueue_command(&instance.id, Some(&record.id), command)
+    if let Err(error) = validation {
+        let event = store
+            .append_event(&instance.id, event_type, source, event_payload)
             .await?;
+        let reason = error.to_string();
+        let record = WorkflowDecisionRecord::rejected(decision, Some(event.id), &reason);
+        store.record_decision(&record).await?;
+        return Ok(RuntimeDecisionCommitOutcome::Rejected { reason });
     }
-    instance.state = decision.next_state.clone();
-    instance.version = instance.version.saturating_add(1);
-    instance.data = merge_last_decision(instance.data, &decision.decision);
-    store.upsert_instance(&instance).await
+
+    let mut final_instance = instance.clone();
+    final_instance.state = decision.next_state.clone();
+    final_instance.version = final_instance.version.saturating_add(1);
+    final_instance.data = merge_last_decision(accepted_data, &decision.decision);
+    let create_if_missing = new_instance.then_some(&instance);
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: &expected_state,
+            create_if_missing,
+            event_type,
+            source,
+            payload: event_payload,
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: "pending",
+        })
+        .await?;
+    Ok(match record {
+        Some(_) => RuntimeDecisionCommitOutcome::Accepted,
+        None => RuntimeDecisionCommitOutcome::Stale,
+    })
 }
 
 async fn has_active_pr_feedback_command(
@@ -698,10 +730,13 @@ async fn load_or_issue_instance(
     repo: Option<String>,
     issue_number: u64,
     state: &str,
-) -> anyhow::Result<WorkflowInstance> {
+) -> anyhow::Result<(WorkflowInstance, bool)> {
     Ok(match store.get_instance(&workflow_id).await? {
-        Some(instance) => instance,
-        None => issue_instance(workflow_id, project_id, repo, issue_number, state),
+        Some(instance) => (instance, false),
+        None => (
+            issue_instance(workflow_id, project_id, repo, issue_number, state),
+            true,
+        ),
     })
 }
 

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -64,7 +64,9 @@ pub use repo_backlog::{
     StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
     REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
-pub use store::{WorkflowDecisionTransition, WorkflowRuntimeStore};
+pub use store::{
+    WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+};
 pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
     IssueSubmissionWorkflowAction,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -215,6 +215,7 @@ pub struct WorkflowRuntimeSummaryCounts {
 
 pub struct WorkflowDecisionTransition<'a> {
     pub expected_state: &'a str,
+    pub create_if_missing: Option<&'a WorkflowInstance>,
     pub event_type: &'a str,
     pub source: &'a str,
     pub payload: Value,
@@ -385,16 +386,40 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
         let final_instance = transition.final_instance;
         let decision = transition.decision;
+        if decision.workflow_id != final_instance.id {
+            anyhow::bail!(
+                "workflow decision `{}` targets `{}` but final instance is `{}`",
+                decision.decision,
+                decision.workflow_id,
+                final_instance.id
+            );
+        }
         let mut tx = self.pool.begin().await?;
         let row: Option<(String,)> =
             sqlx::query_as("SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE")
                 .bind(&final_instance.id)
                 .fetch_optional(&mut *tx)
                 .await?;
-        let Some((data,)) = row else {
-            return Ok(None);
+        let current: WorkflowInstance = match row {
+            Some((data,)) => serde_json::from_str(&data)?,
+            None => {
+                let Some(initial_instance) = transition.create_if_missing else {
+                    return Ok(None);
+                };
+                if initial_instance.id != final_instance.id {
+                    anyhow::bail!(
+                        "initial workflow instance `{}` does not match final instance `{}`",
+                        initial_instance.id,
+                        final_instance.id
+                    );
+                }
+                if initial_instance.state != transition.expected_state {
+                    return Ok(None);
+                }
+                upsert_instance_tx(&mut tx, initial_instance).await?;
+                initial_instance.clone()
+            }
         };
-        let current: WorkflowInstance = serde_json::from_str(&data)?;
         if current.is_terminal() || current.state != transition.expected_state {
             return Ok(None);
         }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -224,6 +224,16 @@ pub struct WorkflowDecisionTransition<'a> {
     pub command_status: &'a str,
 }
 
+pub struct WorkflowRejectedDecisionTransition<'a> {
+    pub expected_state: &'a str,
+    pub create_if_missing: Option<&'a WorkflowInstance>,
+    pub event_type: &'a str,
+    pub source: &'a str,
+    pub payload: Value,
+    pub decision: &'a WorkflowDecision,
+    pub reason: &'a str,
+}
+
 type WorkflowCommandRecordRow = (
     String,
     String,
@@ -395,65 +405,27 @@ impl WorkflowRuntimeStore {
             );
         }
         let mut tx = self.pool.begin().await?;
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE")
-                .bind(&final_instance.id)
-                .fetch_optional(&mut *tx)
-                .await?;
-        let current: WorkflowInstance = match row {
-            Some((data,)) => serde_json::from_str(&data)?,
-            None => {
-                let Some(initial_instance) = transition.create_if_missing else {
-                    return Ok(None);
-                };
-                if initial_instance.id != final_instance.id {
-                    anyhow::bail!(
-                        "initial workflow instance `{}` does not match final instance `{}`",
-                        initial_instance.id,
-                        final_instance.id
-                    );
-                }
-                if initial_instance.state != transition.expected_state {
-                    return Ok(None);
-                }
-                upsert_instance_tx(&mut tx, initial_instance).await?;
-                initial_instance.clone()
-            }
+        let Some(current) = load_or_insert_initial_instance_tx(
+            &mut tx,
+            &final_instance.id,
+            transition.expected_state,
+            transition.create_if_missing,
+        )
+        .await?
+        else {
+            return Ok(None);
         };
         if current.is_terminal() || current.state != transition.expected_state {
             return Ok(None);
         }
 
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-            .bind(format!("workflow_events:{}", final_instance.id))
-            .execute(&mut *tx)
-            .await?;
-        let (next_sequence,): (i64,) = sqlx::query_as(
-            "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
-        )
-        .bind(&final_instance.id)
-        .fetch_one(&mut *tx)
-        .await?;
-        let event = WorkflowEvent::new(
+        let event = insert_event_tx(
+            &mut tx,
             &final_instance.id,
-            next_sequence as u64,
             transition.event_type,
             transition.source,
+            transition.payload,
         )
-        .with_payload(transition.payload);
-        let event_data = to_jsonb_string(&event)?;
-        sqlx::query(
-            "INSERT INTO workflow_events
-                (id, workflow_id, sequence, event_type, source, data)
-             VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
-        )
-        .bind(&event.id)
-        .bind(&event.workflow_id)
-        .bind(event.sequence as i64)
-        .bind(&event.event_type)
-        .bind(&event.source)
-        .bind(&event_data)
-        .execute(&mut *tx)
         .await?;
 
         let record = WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id));
@@ -531,6 +503,42 @@ impl WorkflowRuntimeStore {
         .bind(final_instance.version as i64)
         .execute(&mut *tx)
         .await?;
+
+        tx.commit().await?;
+        Ok(Some(record))
+    }
+
+    pub async fn record_rejected_decision_transition(
+        &self,
+        transition: WorkflowRejectedDecisionTransition<'_>,
+    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+        let decision = transition.decision;
+        let mut tx = self.pool.begin().await?;
+        let Some(current) = load_or_insert_initial_instance_tx(
+            &mut tx,
+            &decision.workflow_id,
+            transition.expected_state,
+            transition.create_if_missing,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        if current.is_terminal() || current.state != transition.expected_state {
+            return Ok(None);
+        }
+
+        let event = insert_event_tx(
+            &mut tx,
+            &decision.workflow_id,
+            transition.event_type,
+            transition.source,
+            transition.payload,
+        )
+        .await?;
+        let record =
+            WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), transition.reason);
+        insert_decision_record_tx(&mut tx, &record).await?;
 
         tx.commit().await?;
         Ok(Some(record))
@@ -2122,6 +2130,111 @@ async fn insert_workflow_command_tx(
     .fetch_one(&mut **tx)
     .await?;
     Ok(id)
+}
+
+async fn load_or_insert_initial_instance_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    expected_state: &str,
+    create_if_missing: Option<&WorkflowInstance>,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    if let Some(instance) = select_instance_for_update_tx(tx, workflow_id).await? {
+        return Ok(Some(instance));
+    }
+
+    let Some(initial_instance) = create_if_missing else {
+        return Ok(None);
+    };
+    if initial_instance.id != workflow_id {
+        anyhow::bail!(
+            "initial workflow instance `{}` does not match workflow `{}`",
+            initial_instance.id,
+            workflow_id
+        );
+    }
+    if initial_instance.state != expected_state {
+        return Ok(None);
+    }
+
+    if insert_instance_if_absent_tx(tx, initial_instance).await? {
+        return Ok(Some(initial_instance.clone()));
+    }
+
+    select_instance_for_update_tx(tx, workflow_id).await
+}
+
+async fn select_instance_for_update_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE")
+            .bind(workflow_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+    row.map(|(data,)| serde_json::from_str(&data))
+        .transpose()
+        .map_err(Into::into)
+}
+
+async fn insert_event_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    event_type: &str,
+    source: &str,
+    payload: Value,
+) -> anyhow::Result<WorkflowEvent> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(format!("workflow_events:{workflow_id}"))
+        .execute(&mut **tx)
+        .await?;
+    let (next_sequence,): (i64,) = sqlx::query_as(
+        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
+    )
+    .bind(workflow_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let event = WorkflowEvent::new(workflow_id, next_sequence as u64, event_type, source)
+        .with_payload(payload);
+    let event_data = to_jsonb_string(&event)?;
+    sqlx::query(
+        "INSERT INTO workflow_events
+            (id, workflow_id, sequence, event_type, source, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind(&event.id)
+    .bind(&event.workflow_id)
+    .bind(event.sequence as i64)
+    .bind(&event.event_type)
+    .bind(&event.source)
+    .bind(&event_data)
+    .execute(&mut **tx)
+    .await?;
+    Ok(event)
+}
+
+async fn insert_instance_if_absent_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<bool> {
+    let data = to_jsonb_string(instance)?;
+    let result = sqlx::query(
+        "INSERT INTO workflow_instances
+            (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(&instance.id)
+    .bind(&instance.definition_id)
+    .bind(&instance.state)
+    .bind(&instance.subject.subject_type)
+    .bind(&instance.subject.subject_key)
+    .bind(&instance.parent_workflow_id)
+    .bind(&data)
+    .bind(instance.version as i64)
+    .execute(&mut **tx)
+    .await?;
+    Ok(result.rows_affected() == 1)
 }
 
 async fn upsert_instance_tx(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -19,11 +19,11 @@ use super::{
     PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptSubmissionDecisionInput,
     QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogPollDecisionInput,
     RepoBacklogWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
-    RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowRuntimeStore,
-    GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY,
-    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
-    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowDecisionTransition,
+    WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID,
+    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -5030,6 +5030,74 @@ async fn durable_store_persists_workflow_runtime_bus_contract() -> anyhow::Resul
         RuntimeJobStatus::Succeeded
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn durable_store_apply_decision_transition_can_create_initial_instance() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = project_issue_instance("/project-a", 123, "implementing");
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "implementing",
+        "bind_pr",
+        "pr_open",
+        "implementation produced a pull request for the issue workflow",
+    )
+    .with_command(WorkflowCommand::bind_pr(
+        77,
+        "https://github.com/owner/repo/pull/77",
+        "pr-detected:task-1:77",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = "pr_open".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+    final_instance.data = json!({
+        "project_id": "/project-a",
+        "issue_number": 123,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "last_decision": "bind_pr",
+    });
+
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: "implementing",
+            create_if_missing: Some(&initial),
+            event_type: "PrDetected",
+            source: "workflow-runtime-test",
+            payload: json!({
+                "issue_number": 123,
+                "pr_number": 77,
+                "pr_url": "https://github.com/owner/repo/pull/77",
+            }),
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: "pending",
+        })
+        .await?
+        .expect("missing initial instance should be created inside the transition");
+
+    assert!(record.accepted);
+    assert!(record.event_id.is_some());
+    let loaded = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("transition should persist final instance");
+    assert_eq!(loaded.state, "pr_open");
+    assert_eq!(loaded.data["pr_number"], 77);
+    assert_eq!(store.events_for(&initial.id).await?.len(), 1);
+    assert_eq!(store.decisions_for(&initial.id).await?.len(), 1);
+    let commands = store.commands_for(&initial.id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].decision_id.as_deref(), Some(record.id.as_str()));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -5102,6 +5102,78 @@ async fn durable_store_apply_decision_transition_can_create_initial_instance() -
 }
 
 #[tokio::test]
+async fn durable_store_apply_decision_transition_does_not_rewind_existing_instance(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = project_issue_instance("/project-a", 124, "implementing");
+    let mut existing = initial.clone();
+    existing.state = "awaiting_feedback".to_string();
+    existing.data = json!({
+        "project_id": "/project-a",
+        "issue_number": 124,
+        "pr_number": 78,
+        "last_decision": "record_feedback",
+    });
+    store.upsert_instance(&existing).await?;
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "implementing",
+        "bind_pr",
+        "pr_open",
+        "implementation produced a pull request for the issue workflow",
+    )
+    .with_command(WorkflowCommand::bind_pr(
+        79,
+        "https://github.com/owner/repo/pull/79",
+        "pr-detected:task-2:79",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = "pr_open".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+    final_instance.data = json!({
+        "project_id": "/project-a",
+        "issue_number": 124,
+        "pr_number": 79,
+        "pr_url": "https://github.com/owner/repo/pull/79",
+        "last_decision": "bind_pr",
+    });
+
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: "implementing",
+            create_if_missing: Some(&initial),
+            event_type: "PrDetected",
+            source: "workflow-runtime-test",
+            payload: json!({
+                "issue_number": 124,
+                "pr_number": 79,
+                "pr_url": "https://github.com/owner/repo/pull/79",
+            }),
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: "pending",
+        })
+        .await?;
+
+    assert!(record.is_none());
+    let loaded = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("existing instance should remain visible");
+    assert_eq!(loaded.state, "awaiting_feedback");
+    assert_eq!(loaded.data["pr_number"], 78);
+    assert!(store.events_for(&initial.id).await?.is_empty());
+    assert!(store.decisions_for(&initial.id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn durable_store_lists_workflow_runtime_tree_inputs() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());


### PR DESCRIPTION
## Summary
- Commit PR detected, PR feedback, PR merged, feedback sweep, and dashboard merge-approval transitions through the workflow store atomic transition path.
- Allow the store transition helper to create a missing initial issue workflow instance inside the same transaction before appending the event, accepted decision, commands, and final state.
- Add durable store coverage for create-if-missing atomic transitions.

## Validation
- cargo fmt --all -- --check
- HARNESS_DATABASE_URL="postgres://harness:harness@localhost:5432/harness" CARGO_TARGET_DIR=/tmp/harness-issue1144-target cargo check --manifest-path ".../Cargo.toml"
- HARNESS_DATABASE_URL="postgres://harness:harness@localhost:5432/harness" CARGO_TARGET_DIR=/tmp/harness-issue1144-target cargo test --manifest-path ".../Cargo.toml" (broad run reached 1266/1268 harness-server tests; two workspace cleanup/order-sensitive tests failed after the runtime worktree was removed; both passed in direct serial reruns below)
- HARNESS_DATABASE_URL="postgres://harness:harness@localhost:5432/harness" CARGO_TARGET_DIR=/tmp/harness-issue1144-target cargo test --manifest-path ".../Cargo.toml" -p harness-server --lib scheduler::tests::health_tick_uses_configured_project_root_in_multi_cwd_context -- --test-threads=1
- HARNESS_DATABASE_URL="postgres://harness:harness@localhost:5432/harness" CARGO_TARGET_DIR=/tmp/harness-issue1144-target cargo test --manifest-path ".../Cargo.toml" -p harness-server --lib workspace::tests::is_registered_worktree_matches_relative_workspace_paths -- --test-threads=1
- HARNESS_DATABASE_URL="postgres://harness:harness@localhost:5432/harness" CARGO_TARGET_DIR=/tmp/harness-issue1144-target RUSTFLAGS="-Dwarnings" cargo check --manifest-path ".../Cargo.toml" --workspace --all-targets

Closes #1144