### PR TITLE
feat(web): render paginated task history

### DIFF
--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Sidebar, type SidebarSection } from "@/components/Sidebar";
 import { TopBar } from "@/components/TopBar";
@@ -12,11 +11,28 @@ import { useDashboard } from "@/lib/queries";
 
 type Tab = "board" | "history" | "channels" | "submit";
 
+function parseTab(value: string | null): Tab | null {
+  if (value === "board" || value === "history" || value === "channels" || value === "submit") {
+    return value;
+  }
+  return null;
+}
+
 export function Dashboard() {
-  const [tab, setTab] = useState<Tab>("board");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = parseTab(searchParams.get("tab")) ?? "board";
   const { isError } = useDashboard();
-  const [searchParams] = useSearchParams();
   const projectFilter = searchParams.get("project");
+
+  function selectTab(nextTab: Tab) {
+    const next = new URLSearchParams(searchParams);
+    if (nextTab === "board") {
+      next.delete("tab");
+    } else {
+      next.set("tab", nextTab);
+    }
+    setSearchParams(next);
+  }
 
   const sections: SidebarSection[] = [
     {
@@ -39,7 +55,7 @@ export function Dashboard() {
       <Sidebar
         env="local"
         sections={sections}
-        onItemClick={(id) => setTab(id as Tab)}
+        onItemClick={(id) => selectTab(id as Tab)}
       />
       <main className="flex flex-col min-h-0 min-w-0">
         <TopBar

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -4,11 +4,13 @@ import { History } from "./History";
 import type { Task } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
+  useDashboard: vi.fn(),
   useTasks: vi.fn(),
 }));
 
-import { useTasks } from "@/lib/queries";
+import { useDashboard, useTasks } from "@/lib/queries";
 
+const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
 const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
 
 function makeHistoryTask(id: string, overrides: Partial<Task> = {}): Task {
@@ -58,6 +60,7 @@ function historyTaskList(data: Task[]) {
 describe("<History>", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseDashboard.mockReturnValue({ data: { projects: [] } });
   });
 
   it("paginates terminal tasks and resets pagination when filtering", () => {
@@ -101,6 +104,9 @@ describe("<History>", () => {
   });
 
   it("searches description repo and PR URL, then shows the submit CTA when empty", () => {
+    mockUseDashboard.mockReturnValue({
+      data: { projects: [{ id: "harness", root: "/work/harness" }] },
+    });
     mockUseTasks.mockReturnValue({
       data: historyTaskList([
         makeHistoryTask("task-a", {
@@ -119,6 +125,12 @@ describe("<History>", () => {
     });
 
     render(<History projectFilter="harness" />);
+
+    expect(mockUseTasks).toHaveBeenCalledWith({
+      status: "done,failed,cancelled",
+      limit: 500,
+      project_id: "/work/harness",
+    });
 
     fireEvent.change(screen.getByPlaceholderText("Search description, repo, PR…"), {
       target: { value: "frontend/pull/42" },

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { History } from "./History";
+import type { Task } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useTasks: vi.fn(),
+}));
+
+import { useTasks } from "@/lib/queries";
+
+const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+
+function makeHistoryTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    task_kind: "issue",
+    status: "done",
+    turn: 1,
+    pr_url: null,
+    error: null,
+    source: null,
+    parent_id: null,
+    external_id: null,
+    repo: "owner/repo",
+    description: id,
+    created_at: "2026-01-01T00:00:00Z",
+    phase: null,
+    depends_on: [],
+    subtask_ids: [],
+    project: "harness",
+    workflow: null,
+    scheduler: {
+      authority_state: "completed",
+      owner: null,
+      run_generation: 1,
+      recovery_generation: 0,
+      lease_expires_at: null,
+    },
+    ...overrides,
+  };
+}
+
+function historyTaskList(data: Task[]) {
+  return {
+    data,
+    page: { limit: 500, has_more: false, next_cursor: null },
+    counts: {
+      total: data.length,
+      running: 0,
+      failed: data.filter((task) => task.status === "failed").length,
+      by_status: {},
+      by_scheduler_state: {},
+    },
+  };
+}
+
+describe("<History>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("paginates terminal tasks and resets pagination when filtering", () => {
+    const doneTasks = Array.from({ length: 21 }, (_, index) =>
+      makeHistoryTask(`done-${index}`, {
+        description: `Done task ${index}`,
+        created_at: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
+      }),
+    );
+    const failedTask = makeHistoryTask("failed-important", {
+      status: "failed",
+      created_at: "2026-02-01T00:00:00Z",
+      description: "Broken review run",
+    });
+    mockUseTasks.mockReturnValue({
+      data: historyTaskList([...doneTasks, failedTask]),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<History />);
+
+    expect(mockUseTasks).toHaveBeenCalledWith({
+      status: "done,failed,cancelled",
+      limit: 500,
+      project_id: undefined,
+    });
+    expect(screen.getByText("page 1/2")).toBeInTheDocument();
+    expect(screen.getByText("Broken review run")).toBeInTheDocument();
+    expect(screen.getByText("Done task 20")).toBeInTheDocument();
+    expect(screen.queryByText("Done task 0")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("page 2/2")).toBeInTheDocument();
+    expect(screen.getByText("Done task 0")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "failed" } });
+    expect(screen.getByText("page 1/1")).toBeInTheDocument();
+    expect(screen.getByText("Broken review run")).toBeInTheDocument();
+    expect(screen.queryByText("Done task 0")).not.toBeInTheDocument();
+  });
+
+  it("searches description repo and PR URL, then shows the submit CTA when empty", () => {
+    mockUseTasks.mockReturnValue({
+      data: historyTaskList([
+        makeHistoryTask("task-a", {
+          description: "Fix auth callback",
+          repo: "owner/frontend",
+          pr_url: "https://github.com/owner/frontend/pull/42",
+        }),
+        makeHistoryTask("task-b", {
+          description: "Repair worker retry",
+          repo: "owner/backend",
+          pr_url: "https://github.com/owner/backend/pull/77",
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<History projectFilter="harness" />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search description, repo, PR…"), {
+      target: { value: "frontend/pull/42" },
+    });
+    expect(screen.getByText("Fix auth callback")).toBeInTheDocument();
+    expect(screen.queryByText("Repair worker retry")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search description, repo, PR…"), {
+      target: { value: "missing" },
+    });
+    expect(screen.getByText("No terminal tasks found.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Submit task" })).toHaveAttribute(
+      "href",
+      "/dashboard?tab=submit&project=harness",
+    );
+  });
+});

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,21 +1,89 @@
-import { useState } from "react";
-import { useDashboard } from "@/lib/queries";
+import { useEffect, useMemo, useState } from "react";
+import { relativeAgo } from "@/lib/format";
+import { useTasks } from "@/lib/queries";
+import type { Task } from "@/types";
 
 interface Props {
   projectFilter?: string | null;
 }
 
+const PAGE_SIZE = 20;
+const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
+
+function timestampValue(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function statusLabel(status: string): string {
+  if (status === "done") return "Done";
+  if (status === "failed") return "Failed";
+  if (status === "cancelled") return "Cancelled";
+  return status;
+}
+
+function statusClass(status: string): string {
+  if (status === "done") return "border-mint/40 bg-mint/10 text-mint";
+  if (status === "failed") return "border-rust/40 bg-rust/10 text-rust";
+  if (status === "cancelled") return "border-line-3 bg-bg text-ink-3";
+  return "border-line bg-bg text-ink-2";
+}
+
+function taskTitle(task: Task): string {
+  const title = task.description?.trim();
+  if (title) return title;
+  if (task.repo) return task.repo;
+  return task.id.slice(0, 8);
+}
+
+function prLabel(prUrl: string): string {
+  const match = prUrl.match(/\/pull\/(\d+)(?:$|[/?#])/);
+  return match ? `PR #${match[1]}` : prUrl.replace(/^https:\/\/github\.com\//, "");
+}
+
+function matchesQuery(task: Task, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [task.description, task.repo, task.pr_url].some((value) => value?.toLowerCase().includes(q));
+}
+
+function sortHistoryTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    const byTime = timestampValue(b.created_at) - timestampValue(a.created_at);
+    if (byTime !== 0) return byTime;
+    return a.id.localeCompare(b.id);
+  });
+}
+
 export function History({ projectFilter }: Props) {
-  const { data } = useDashboard();
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
-  const scopedProject = projectFilter ? (data?.projects.find((p) => p.id === projectFilter) ?? null) : null;
-  const totalDone = projectFilter
-    ? (scopedProject?.tasks.done ?? 0)
-    : (data?.projects.reduce((a, p) => a + p.tasks.done, 0) ?? 0);
-  const totalFailed = projectFilter
-    ? (scopedProject?.tasks.failed ?? 0)
-    : (data?.projects.reduce((a, p) => a + p.tasks.failed, 0) ?? 0);
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isError } = useTasks({
+    status: "done,failed,cancelled",
+    limit: 500,
+    project_id: projectFilter ?? undefined,
+  });
+  const submitHref = projectFilter ? `/dashboard?tab=submit&project=${encodeURIComponent(projectFilter)}` : "/dashboard?tab=submit";
+
+  const rows = useMemo(() => {
+    const statusFiltered =
+      data?.data.filter((task) => {
+        if (!TERMINAL_STATUSES.has(task.status)) return false;
+        if (filter !== "all" && task.status !== filter) return false;
+        return matchesQuery(task, query);
+      }) ?? [];
+    return sortHistoryTasks(statusFiltered);
+  }, [data?.data, filter, query]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filter, query, projectFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageRows = rows.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   return (
     <div>
@@ -23,7 +91,7 @@ export function History({ projectFilter }: Props) {
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search history…"
+          placeholder="Search description, repo, PR…"
           className="flex-1 h-[30px] bg-bg-1 border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
         />
         <select
@@ -36,10 +104,98 @@ export function History({ projectFilter }: Props) {
           <option value="failed">Failed</option>
         </select>
       </div>
-      <div className="border border-line bg-bg-1 p-4 font-mono text-[12px] text-ink-3">
-        done {totalDone} · failed {totalFailed} · filter {filter} · query {query || "(none)"}
-        <div className="mt-3 text-ink-4 text-[11px]">
-          Task list endpoint is /tasks with server-side filters and cursor pagination.
+
+      <div className="border border-line bg-bg-1">
+        <div className="flex items-center justify-between border-b border-line px-3 py-2 font-mono text-[11px] text-ink-3">
+          <span>{rows.length} terminal tasks</span>
+          <span>
+            page {currentPage}/{totalPages}
+          </span>
+        </div>
+
+        {isLoading ? (
+          <div className="px-3 py-8 text-center font-mono text-[12px] text-ink-3">Loading history…</div>
+        ) : isError ? (
+          <div className="px-3 py-8 text-center font-mono text-[12px] text-rust">History unavailable</div>
+        ) : pageRows.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 px-3 py-10 text-center">
+            <div className="font-mono text-[12px] text-ink-3">No terminal tasks found.</div>
+            <a
+              href={submitHref}
+              className="border border-line-2 bg-bg px-3 py-1.5 font-mono text-[12px] text-ink hover:border-line-3 transition-colors"
+            >
+              Submit task
+            </a>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[760px] border-collapse text-left">
+              <thead className="border-b border-line bg-bg">
+                <tr className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-4">
+                  <th className="w-[90px] px-3 py-2 font-normal">Time</th>
+                  <th className="w-[110px] px-3 py-2 font-normal">Status</th>
+                  <th className="px-3 py-2 font-normal">Task</th>
+                  <th className="w-[180px] px-3 py-2 font-normal">Repo</th>
+                  <th className="w-[120px] px-3 py-2 font-normal">PR</th>
+                  <th className="w-[80px] px-3 py-2 text-right font-normal">Turns</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageRows.map((task) => (
+                  <tr key={task.id} className="border-b border-line last:border-b-0">
+                    <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+                      {task.created_at ? relativeAgo(task.created_at) : "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className={`inline-block border px-1.5 py-[1px] font-mono text-[10px] ${statusClass(task.status)}`}>
+                        {statusLabel(task.status)}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="line-clamp-2 text-[12.5px] leading-snug text-ink" title={taskTitle(task)}>
+                        {taskTitle(task)}
+                      </div>
+                      <div className="mt-1 font-mono text-[10px] text-ink-4">{task.id.slice(0, 8)}</div>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+                      <span className="block truncate" title={task.repo ?? undefined}>
+                        {task.repo ?? "—"}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px]">
+                      {task.pr_url ? (
+                        <a href={task.pr_url} target="_blank" rel="noreferrer" className="text-rust hover:underline">
+                          {prLabel(task.pr_url)}
+                        </a>
+                      ) : (
+                        <span className="text-ink-4">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-3">{task.turn}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 border-t border-line px-3 py-2">
+          <button
+            type="button"
+            disabled={currentPage <= 1}
+            onClick={() => setPage((value) => Math.max(1, value - 1))}
+            className="h-[28px] border border-line bg-bg px-2 font-mono text-[11px] text-ink-2 hover:border-line-3 hover:text-ink disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            disabled={currentPage >= totalPages}
+            onClick={() => setPage((value) => Math.min(totalPages, value + 1))}
+            className="h-[28px] border border-line bg-bg px-2 font-mono text-[11px] text-ink-2 hover:border-line-3 hover:text-ink disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
         </div>
       </div>
     </div>

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { relativeAgo } from "@/lib/format";
-import { useTasks } from "@/lib/queries";
+import { useDashboard, useTasks } from "@/lib/queries";
 import type { Task } from "@/types";
 
 interface Props {
@@ -60,12 +60,18 @@ export function History({ projectFilter }: Props) {
   const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
+  const { data: dashboard } = useDashboard();
+  const resolvedRoot = projectFilter
+    ? (dashboard?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
+    : null;
   const { data, isLoading, isError } = useTasks({
     status: "done,failed,cancelled",
     limit: 500,
-    project_id: projectFilter ?? undefined,
+    project_id: resolvedRoot ?? undefined,
   });
-  const submitHref = projectFilter ? `/dashboard?tab=submit&project=${encodeURIComponent(projectFilter)}` : "/dashboard?tab=submit";
+  const submitHref = projectFilter
+    ? `/dashboard?tab=submit&project=${encodeURIComponent(projectFilter)}`
+    : "/dashboard?tab=submit";
 
   const rows = useMemo(() => {
     const statusFiltered =
@@ -79,7 +85,7 @@ export function History({ projectFilter }: Props) {
 
   useEffect(() => {
     setPage(1);
-  }, [filter, query, projectFilter]);
+  }, [filter, query, resolvedRoot]);
 
   const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,1 +1,45 @@
 import "@testing-library/jest-dom/vitest";
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+if (typeof window !== "undefined") {
+  const globalStorage = globalThis.localStorage;
+  const hasUsableStorage =
+    typeof globalStorage?.getItem === "function" &&
+    typeof globalStorage?.setItem === "function" &&
+    typeof globalStorage?.clear === "function";
+
+  if (!hasUsableStorage) {
+    const storage = createMemoryStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Render terminal task history from `/tasks` in the Dashboard History tab
- Add search, done/failed filtering, newest-first sorting, PR links, and 20-row pagination
- Support `/dashboard?tab=submit` deep links and stabilize web test localStorage under Bun/jsdom

Refs #837

## Tests
- `bun run typecheck`
- `bun run test -- History`
- `bun run test`
- `bun run build`
- `cargo fmt --all -- --check`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace` attempted locally; blocked by missing `HARNESS_DATABASE_URL` for database-backed tests
