### PR TITLE
refactor(runtime): persist submission handles

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,84 +1,43 @@
-use crate::task_runner::{TaskId, TaskStatus, TaskStore};
+use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
-    activity_result_value_has_closed_issue_evidence, build_issue_submission_decision,
-    build_prompt_submission_decision, value_has_closed_issue_evidence, DecisionValidator,
+    build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
     IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
-    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowDecisionRecord,
-    WorkflowDefinition, WorkflowEvent, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
-    PROMPT_TASK_DEFINITION_ID, RUNTIME_JOB_COMPLETED_EVENT,
+    WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
+    WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
-use sha2::{Digest, Sha256};
-use std::{
-    collections::HashMap,
-    fmt,
-    path::Path,
-    sync::{Mutex, OnceLock},
-};
+use std::path::Path;
+
+#[cfg(test)]
+use crate::task_runner::{TaskStatus, TaskStore};
+#[cfg(test)]
+use harness_workflow::runtime::WorkflowCommandType;
 
 const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
 const EXECUTION_PATH_WORKFLOW_RUNTIME: &str = "workflow_runtime";
 const PROMPT_TASK_DESCRIPTION: &str = "prompt task";
 
-static PROMPT_SUBMISSION_PROMPTS: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+#[path = "workflow_runtime_submission/cancel.rs"]
+mod cancel;
+#[path = "workflow_runtime_submission/dependencies.rs"]
+mod dependencies;
+#[path = "workflow_runtime_submission/prompt_memory.rs"]
+mod prompt_memory;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PromptDependencyReleaseOutcome {
-    Released,
-    MissingPrompt,
-}
-
-pub(crate) fn lookup_prompt_submission_prompt(prompt_ref: &str) -> Option<String> {
-    prompt_submission_prompts()
-        .lock()
-        .ok()
-        .and_then(|prompts| prompts.get(prompt_ref).cloned())
-}
-
-fn cache_prompt_submission_prompt(prompt_ref: &str, prompt: &str) {
-    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
-        prompts.insert(prompt_ref.to_string(), prompt.to_string());
-    }
-}
-
-fn remove_prompt_submission_prompt(prompt_ref: Option<&str>) {
-    let Some(prompt_ref) = prompt_ref else {
-        return;
-    };
-    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
-        prompts.remove(prompt_ref);
-    }
-}
-
-pub(crate) fn remove_terminal_prompt_submission_prompt(instance: &WorkflowInstance) {
-    if instance.definition_id != PROMPT_TASK_DEFINITION_ID || !instance.is_terminal() {
-        return;
-    }
-    remove_prompt_submission_prompt(optional_string_field(&instance.data, "prompt_ref").as_deref());
-}
-
-fn prompt_submission_prompts() -> &'static Mutex<HashMap<String, String>> {
-    PROMPT_SUBMISSION_PROMPTS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn prompt_ref_for_submission(
-    project_id: &str,
-    external_id: Option<&str>,
-    task_id: &TaskId,
-    prompt: &str,
-) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(project_id.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(external_id.unwrap_or("").as_bytes());
-    hasher.update(b"\0");
-    hasher.update(task_id.as_str().as_bytes());
-    hasher.update(b"\0");
-    hasher.update(prompt.as_bytes());
-    let digest = hasher.finalize();
-    let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
-    format!("prompt-memory:{digest_hex}")
-}
+pub(crate) use cancel::{
+    cancel_issue_submission_by_task_id, cancel_submission_by_workflow_id,
+    RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome,
+};
+pub(crate) use dependencies::{
+    release_ready_issue_dependencies, release_ready_prompt_dependencies,
+    resolve_issue_dependency_status, RuntimeDependencyStatus,
+};
+use prompt_memory::{
+    cache_prompt_submission_prompt, prompt_ref_for_submission, remove_prompt_submission_prompt,
+};
+pub(crate) use prompt_memory::{
+    lookup_prompt_submission_prompt, remove_terminal_prompt_submission_prompt,
+};
 
 pub(crate) struct PromptSubmissionRuntimeContext<'a> {
     pub project_root: &'a Path,
@@ -128,236 +87,6 @@ pub(crate) async fn record_prompt_submission(
     persist_prompt_submission(store, &ctx).await
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DependencyReleaseSummary {
-    pub released: usize,
-    pub failed: usize,
-    pub waiting: usize,
-    pub skipped: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RuntimeDependencyStatus {
-    Done,
-    Failed,
-    Cancelled,
-    Waiting,
-}
-
-pub(crate) async fn resolve_issue_dependency_status(
-    store: Option<&WorkflowRuntimeStore>,
-    tasks: &TaskStore,
-    task_id: &TaskId,
-) -> anyhow::Result<RuntimeDependencyStatus> {
-    match tasks.dep_status(task_id).await {
-        Some(TaskStatus::Done) => return Ok(RuntimeDependencyStatus::Done),
-        Some(TaskStatus::Failed) => return Ok(RuntimeDependencyStatus::Failed),
-        Some(TaskStatus::Cancelled) => return Ok(RuntimeDependencyStatus::Cancelled),
-        Some(_) => return Ok(RuntimeDependencyStatus::Waiting),
-        None => {}
-    }
-
-    let Some(store) = store else {
-        return Ok(RuntimeDependencyStatus::Waiting);
-    };
-    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(RuntimeDependencyStatus::Waiting);
-    };
-    runtime_dependency_status_from_instance(store, &instance).await
-}
-
-async fn runtime_dependency_status_from_instance(
-    store: &WorkflowRuntimeStore,
-    instance: &WorkflowInstance,
-) -> anyhow::Result<RuntimeDependencyStatus> {
-    Ok(match instance.state.as_str() {
-        "done" => RuntimeDependencyStatus::Done,
-        "failed" => RuntimeDependencyStatus::Failed,
-        "cancelled" => RuntimeDependencyStatus::Cancelled,
-        "blocked" if blocked_issue_dependency_is_satisfied(store, instance).await? => {
-            RuntimeDependencyStatus::Done
-        }
-        _ => RuntimeDependencyStatus::Waiting,
-    })
-}
-
-async fn blocked_issue_dependency_is_satisfied(
-    store: &WorkflowRuntimeStore,
-    instance: &WorkflowInstance,
-) -> anyhow::Result<bool> {
-    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID || instance.state != "blocked" {
-        return Ok(false);
-    }
-    if instance_data_has_closed_issue_evidence(&instance.data) {
-        return Ok(true);
-    }
-    Ok(store
-        .latest_event_for_type(&instance.id, RUNTIME_JOB_COMPLETED_EVENT)
-        .await?
-        .as_ref()
-        .is_some_and(runtime_event_has_closed_issue_evidence))
-}
-
-fn instance_data_has_closed_issue_evidence(data: &serde_json::Value) -> bool {
-    ["closed_issue_evidence", "issue_state"]
-        .iter()
-        .filter_map(|field| data.get(field))
-        .any(value_has_closed_issue_evidence)
-}
-
-fn runtime_event_has_closed_issue_evidence(event: &WorkflowEvent) -> bool {
-    if event.event_type != RUNTIME_JOB_COMPLETED_EVENT {
-        return false;
-    }
-    event
-        .event
-        .get("activity_result")
-        .is_some_and(activity_result_value_has_closed_issue_evidence)
-}
-
-pub(crate) async fn release_ready_issue_dependencies(
-    store: &WorkflowRuntimeStore,
-    tasks: &TaskStore,
-    limit: i64,
-) -> anyhow::Result<DependencyReleaseSummary> {
-    let instances = store
-        .list_instances_by_state(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            "awaiting_dependencies",
-            limit,
-        )
-        .await?;
-    let mut summary = DependencyReleaseSummary::default();
-    for instance in instances {
-        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
-            Ok(depends_on) => depends_on,
-            Err(error) => {
-                tracing::warn!(
-                    workflow_id = %instance.id,
-                    "workflow runtime dependency release skipped malformed issue data: {error}"
-                );
-                summary.skipped += 1;
-                store.touch_instance(&instance.id).await?;
-                continue;
-            }
-        };
-        let mut all_done = true;
-        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
-        for dep_id in &depends_on {
-            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
-                RuntimeDependencyStatus::Done => {}
-                RuntimeDependencyStatus::Failed => {
-                    terminal_failure = Some((dep_id.clone(), "failed"));
-                    break;
-                }
-                RuntimeDependencyStatus::Cancelled => {
-                    terminal_failure = Some((dep_id.clone(), "cancelled"));
-                    break;
-                }
-                RuntimeDependencyStatus::Waiting => all_done = false,
-            }
-        }
-        if let Some((dep_id, label)) = terminal_failure {
-            fail_issue_for_dependency(store, instance, &dep_id, label).await?;
-            summary.failed += 1;
-        } else if all_done {
-            release_issue_after_dependencies(store, instance, &depends_on).await?;
-            summary.released += 1;
-        } else {
-            store.touch_instance(&instance.id).await?;
-            summary.waiting += 1;
-        }
-    }
-    Ok(summary)
-}
-
-pub(crate) async fn release_ready_prompt_dependencies(
-    store: &WorkflowRuntimeStore,
-    tasks: &TaskStore,
-    limit: i64,
-) -> anyhow::Result<DependencyReleaseSummary> {
-    let instances = store
-        .list_instances_by_state(PROMPT_TASK_DEFINITION_ID, "awaiting_dependencies", limit)
-        .await?;
-    let mut summary = DependencyReleaseSummary::default();
-    for instance in instances {
-        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
-            Ok(depends_on) => depends_on,
-            Err(error) => {
-                tracing::warn!(
-                    workflow_id = %instance.id,
-                    "workflow runtime dependency release skipped malformed prompt data: {error}"
-                );
-                summary.skipped += 1;
-                store.touch_instance(&instance.id).await?;
-                continue;
-            }
-        };
-        let serialization_depends_on = match task_ids_from_data(
-            &instance.data,
-            "serialization_depends_on",
-        ) {
-            Ok(depends_on) => depends_on,
-            Err(error) => {
-                tracing::warn!(
-                    workflow_id = %instance.id,
-                    "workflow runtime dependency release skipped malformed prompt serialization data: {error}"
-                );
-                summary.skipped += 1;
-                store.touch_instance(&instance.id).await?;
-                continue;
-            }
-        };
-        let required_depends_on = match task_ids_from_data(&instance.data, "required_depends_on") {
-            Ok(depends_on) => depends_on,
-            Err(error) => {
-                tracing::warn!(
-                    workflow_id = %instance.id,
-                    "workflow runtime dependency release skipped malformed prompt required dependency data: {error}"
-                );
-                summary.skipped += 1;
-                store.touch_instance(&instance.id).await?;
-                continue;
-            }
-        };
-        let mut all_done = true;
-        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
-        for dep_id in &depends_on {
-            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
-                RuntimeDependencyStatus::Done => {}
-                RuntimeDependencyStatus::Failed
-                    if serialization_depends_on.iter().any(|id| id == dep_id)
-                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
-                RuntimeDependencyStatus::Failed => {
-                    terminal_failure = Some((dep_id.clone(), "failed"));
-                    break;
-                }
-                RuntimeDependencyStatus::Cancelled
-                    if serialization_depends_on.iter().any(|id| id == dep_id)
-                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
-                RuntimeDependencyStatus::Cancelled => {
-                    terminal_failure = Some((dep_id.clone(), "cancelled"));
-                    break;
-                }
-                RuntimeDependencyStatus::Waiting => all_done = false,
-            }
-        }
-        if let Some((dep_id, label)) = terminal_failure {
-            fail_prompt_for_dependency(store, instance, &dep_id, label).await?;
-            summary.failed += 1;
-        } else if all_done {
-            match release_prompt_after_dependencies(store, instance, &depends_on).await? {
-                PromptDependencyReleaseOutcome::Released => summary.released += 1,
-                PromptDependencyReleaseOutcome::MissingPrompt => summary.failed += 1,
-            }
-        } else {
-            store.touch_instance(&instance.id).await?;
-            summary.waiting += 1;
-        }
-    }
-    Ok(summary)
-}
-
 pub(crate) async fn runtime_issue_by_task_id(
     store: &WorkflowRuntimeStore,
     task_id: &TaskId,
@@ -366,151 +95,7 @@ pub(crate) async fn runtime_issue_by_task_id(
 }
 
 pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<TaskId> {
-    string_array_field(&instance.data, "task_ids")
-        .ok()
-        .and_then(|task_ids| task_ids.into_iter().next())
-        .or_else(|| optional_string_field(&instance.data, "task_id"))
-        .map(|task_id| TaskId::from_str(&task_id))
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum RuntimeSubmissionCancelOutcome {
-    Cancelled(WorkflowInstance),
-    AlreadyTerminal(WorkflowInstance),
-    NotFound,
-}
-
-#[derive(Debug)]
-pub(crate) enum RuntimeSubmissionCancelError {
-    UnsupportedDefinition { definition_id: String },
-    Store(anyhow::Error),
-}
-
-impl fmt::Display for RuntimeSubmissionCancelError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnsupportedDefinition { definition_id } => write!(
-                formatter,
-                "workflow definition `{definition_id}` cannot be cancelled as a runtime submission"
-            ),
-            Self::Store(error) => write!(formatter, "{error}"),
-        }
-    }
-}
-
-impl std::error::Error for RuntimeSubmissionCancelError {}
-
-impl From<anyhow::Error> for RuntimeSubmissionCancelError {
-    fn from(error: anyhow::Error) -> Self {
-        Self::Store(error)
-    }
-}
-
-pub(crate) async fn cancel_issue_submission_by_task_id(
-    store: &WorkflowRuntimeStore,
-    task_id: &TaskId,
-) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
-    };
-    cancel_submission_instance(store, instance, task_id.as_str()).await
-}
-
-pub(crate) async fn cancel_submission_by_workflow_id(
-    store: &WorkflowRuntimeStore,
-    workflow_id: &str,
-) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    let Some(instance) = store.get_instance(workflow_id).await? else {
-        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
-    };
-    let correlation_id = runtime_issue_task_handle(&instance)
-        .map(|task_id| task_id.0)
-        .unwrap_or_else(|| format!("workflow:{workflow_id}"));
-    cancel_submission_instance(store, instance, &correlation_id).await
-}
-
-async fn cancel_submission_instance(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    correlation_id: &str,
-) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    if instance.is_terminal() {
-        return Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance));
-    }
-    let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
-    if !is_prompt && instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
-        return Err(RuntimeSubmissionCancelError::UnsupportedDefinition {
-            definition_id: instance.definition_id,
-        });
-    }
-    let event_type = if is_prompt {
-        "PromptSubmissionCancelled"
-    } else {
-        "IssueSubmissionCancelled"
-    };
-    let decision_name = if is_prompt {
-        "cancel_prompt_submission"
-    } else {
-        "cancel_issue_submission"
-    };
-    let reason = if is_prompt {
-        "operator cancelled the runtime prompt submission"
-    } else {
-        "operator cancelled the runtime issue submission"
-    };
-    let command_prefix = if is_prompt {
-        "prompt-submit"
-    } else {
-        "issue-submit"
-    };
-    let event = store
-        .append_event(
-            &instance.id,
-            event_type,
-            "workflow_runtime_submission",
-            json!({
-                "task_id": correlation_id,
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        decision_name,
-        "cancelled",
-        reason,
-    )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::MarkCancelled,
-        format!("{command_prefix}:{correlation_id}:cancel"),
-        json!({ "task_id": correlation_id }),
-    ))
-    .high_confidence();
-    let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
-    let commands = store.commands_for(&cancelled.id).await?;
-    for command in commands {
-        if matches!(
-            command.status.as_str(),
-            "pending" | "dispatching" | "dispatched"
-        ) {
-            store
-                .cancel_command_and_unfinished_runtime_jobs(
-                    &command.id,
-                    decision_name,
-                    "Runtime submission was cancelled before execution.",
-                )
-                .await?;
-        }
-    }
-    cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
-    store.upsert_instance(&cancelled).await?;
-    if is_prompt {
-        remove_prompt_submission_prompt(
-            optional_string_field(&cancelled.data, "prompt_ref").as_deref(),
-        );
-    }
-    Ok(RuntimeSubmissionCancelOutcome::Cancelled(cancelled))
+    runtime_submission_id(&instance.data).map(|submission_id| TaskId::from_str(&submission_id))
 }
 
 async fn persist_issue_submission(
@@ -767,229 +352,6 @@ async fn apply_prompt_decision(
     })
 }
 
-async fn release_issue_after_dependencies(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    depends_on: &[TaskId],
-) -> anyhow::Result<()> {
-    let fields = issue_submission_fields(&instance)?;
-    let output = build_issue_submission_decision(
-        &instance,
-        IssueSubmissionDecisionInput {
-            task_id: &fields.task_id,
-            repo: fields.repo.as_deref(),
-            issue_number: fields.issue_number,
-            labels: &fields.labels,
-            force_execute: fields.force_execute,
-            additional_prompt: fields.additional_prompt.as_deref(),
-            depends_on: &depends_on_strings(depends_on),
-            dependencies_blocked: false,
-        },
-    );
-    let event = store
-        .append_event(
-            &instance.id,
-            "IssueDependenciesSatisfied",
-            "workflow_runtime_submission",
-            json!({
-                "task_id": fields.task_id,
-                "repo": fields.repo,
-                "issue_number": fields.issue_number,
-                "depends_on": depends_on_strings(depends_on),
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
-    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
-    Ok(())
-}
-
-async fn fail_issue_for_dependency(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    dependency_id: &TaskId,
-    dependency_status: &str,
-) -> anyhow::Result<()> {
-    let event = store
-        .append_event(
-            &instance.id,
-            "IssueDependencyFailed",
-            "workflow_runtime_submission",
-            json!({
-                "dependency_task_id": dependency_id.as_str(),
-                "dependency_status": dependency_status,
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        "dependency_failed",
-        "failed",
-        format!(
-            "dependency task {} {} before runtime issue submission could start",
-            dependency_id.as_str(),
-            dependency_status
-        ),
-    )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::MarkFailed,
-        format!("issue-submit:{}:dependency-failed", dependency_id.as_str()),
-        json!({
-            "dependency_task_id": dependency_id.as_str(),
-            "dependency_status": dependency_status,
-        }),
-    ))
-    .high_confidence();
-    let data = set_data_string(
-        set_data_string(
-            instance.data.clone(),
-            "dependency_failure_task_id",
-            dependency_id.as_str(),
-        ),
-        "dependency_failure_status",
-        dependency_status,
-    );
-    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
-    Ok(())
-}
-
-async fn release_prompt_after_dependencies(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    depends_on: &[TaskId],
-) -> anyhow::Result<PromptDependencyReleaseOutcome> {
-    let fields = prompt_submission_fields(&instance)?;
-    let Some(prompt) = lookup_prompt_submission_prompt(&fields.prompt_ref) else {
-        fail_prompt_for_missing_prompt(store, instance, &fields).await?;
-        return Ok(PromptDependencyReleaseOutcome::MissingPrompt);
-    };
-    let output = build_prompt_submission_decision(
-        &instance,
-        PromptSubmissionDecisionInput {
-            task_id: &fields.task_id,
-            prompt: &prompt,
-            prompt_ref: &fields.prompt_ref,
-            source: fields.source.as_deref(),
-            external_id: fields.external_id.as_deref(),
-            depends_on: &depends_on_strings(depends_on),
-            dependencies_blocked: false,
-        },
-    );
-    let event = store
-        .append_event(
-            &instance.id,
-            "PromptDependenciesSatisfied",
-            "workflow_runtime_submission",
-            json!({
-                "task_id": fields.task_id,
-                "depends_on": depends_on_strings(depends_on),
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
-    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
-    Ok(PromptDependencyReleaseOutcome::Released)
-}
-
-async fn fail_prompt_for_dependency(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    dependency_id: &TaskId,
-    dependency_status: &str,
-) -> anyhow::Result<()> {
-    let prompt_ref = optional_string_field(&instance.data, "prompt_ref");
-    let event = store
-        .append_event(
-            &instance.id,
-            "PromptDependencyFailed",
-            "workflow_runtime_submission",
-            json!({
-                "dependency_task_id": dependency_id.as_str(),
-                "dependency_status": dependency_status,
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        "dependency_failed",
-        "failed",
-        format!(
-            "dependency task {} {} before runtime prompt submission could start",
-            dependency_id.as_str(),
-            dependency_status
-        ),
-    )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::MarkFailed,
-        format!("prompt-submit:{}:dependency-failed", dependency_id.as_str()),
-        json!({
-            "dependency_task_id": dependency_id.as_str(),
-            "dependency_status": dependency_status,
-        }),
-    ))
-    .high_confidence();
-    let data = set_data_string(
-        set_data_string(
-            instance.data.clone(),
-            "dependency_failure_task_id",
-            dependency_id.as_str(),
-        ),
-        "dependency_failure_status",
-        dependency_status,
-    );
-    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
-    remove_prompt_submission_prompt(prompt_ref.as_deref());
-    Ok(())
-}
-
-async fn fail_prompt_for_missing_prompt(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    fields: &PromptSubmissionFields,
-) -> anyhow::Result<()> {
-    let event = store
-        .append_event(
-            &instance.id,
-            "PromptSubmissionPromptMissing",
-            "workflow_runtime_submission",
-            json!({
-                "task_id": fields.task_id.as_str(),
-                "prompt_ref": fields.prompt_ref.as_str(),
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?;
-    let decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        "prompt_unavailable",
-        "failed",
-        "prompt-only runtime submission cannot resume because its in-memory prompt is unavailable",
-    )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::MarkFailed,
-        format!("prompt-submit:{}:prompt-missing", fields.task_id),
-        json!({
-            "task_id": fields.task_id.as_str(),
-            "prompt_ref": fields.prompt_ref.as_str(),
-        }),
-    ))
-    .high_confidence();
-    let data = set_data_string(
-        instance.data.clone(),
-        "failure_reason",
-        "prompt unavailable",
-    );
-    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
-    Ok(())
-}
-
 async fn commit_runtime_decision(
     store: &WorkflowRuntimeStore,
     mut instance: WorkflowInstance,
@@ -1123,6 +485,7 @@ fn issue_submission_data(
             "project_id": project_id,
             "repo": ctx.repo,
             "issue_number": ctx.issue_number,
+            "submission_id": submission_id_for_data(existing_data, ctx.task_id),
             "task_id": ctx.task_id.as_str(),
             "task_ids": task_id_history(existing_data, ctx.task_id),
             "labels": ctx.labels,
@@ -1147,6 +510,7 @@ fn prompt_submission_data(
         ctx.project_root,
         json!({
             "project_id": project_id,
+            "submission_id": submission_id_for_data(existing_data, ctx.task_id),
             "task_id": ctx.task_id.as_str(),
             "task_ids": task_id_history(existing_data, ctx.task_id),
             "prompt_summary": PROMPT_TASK_DESCRIPTION,
@@ -1228,6 +592,9 @@ fn task_ids_from_data(data: &serde_json::Value, field: &str) -> anyhow::Result<V
 
 fn task_id_history(existing_data: &serde_json::Value, new_task_id: &TaskId) -> Vec<String> {
     let mut task_ids = Vec::new();
+    if let Some(submission_id) = optional_string_field(existing_data, "submission_id") {
+        push_unique_task_id(&mut task_ids, submission_id);
+    }
     if let Ok(existing_ids) = string_array_field(existing_data, "task_ids") {
         for task_id in existing_ids {
             push_unique_task_id(&mut task_ids, task_id);
@@ -1238,6 +605,20 @@ fn task_id_history(existing_data: &serde_json::Value, new_task_id: &TaskId) -> V
     }
     push_unique_task_id(&mut task_ids, new_task_id.as_str().to_string());
     task_ids
+}
+
+fn submission_id_for_data(existing_data: &serde_json::Value, new_task_id: &TaskId) -> String {
+    runtime_submission_id(existing_data).unwrap_or_else(|| new_task_id.as_str().to_string())
+}
+
+fn runtime_submission_id(data: &serde_json::Value) -> Option<String> {
+    optional_string_field(data, "submission_id")
+        .or_else(|| {
+            string_array_field(data, "task_ids")
+                .ok()
+                .and_then(|task_ids| task_ids.into_iter().next())
+        })
+        .or_else(|| optional_string_field(data, "task_id"))
 }
 
 fn push_unique_task_id(task_ids: &mut Vec<String>, task_id: String) {
@@ -1296,6 +677,10 @@ fn set_data_string(mut data: serde_json::Value, key: &str, value: &str) -> serde
     }
     data
 }
+
+#[cfg(test)]
+#[path = "workflow_runtime_submission/identity_tests.rs"]
+mod identity_tests;
 
 #[cfg(test)]
 #[path = "workflow_runtime_submission_tests.rs"]

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -1,0 +1,152 @@
+use harness_workflow::runtime::{
+    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance, WorkflowRuntimeStore,
+    PROMPT_TASK_DEFINITION_ID,
+};
+use serde_json::json;
+use std::fmt;
+
+use super::prompt_memory::remove_prompt_submission_prompt;
+use super::{
+    commit_runtime_decision, optional_string_field, runtime_issue_task_handle, set_data_bool,
+    GITHUB_ISSUE_PR_DEFINITION_ID,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeSubmissionCancelOutcome {
+    Cancelled(WorkflowInstance),
+    AlreadyTerminal(WorkflowInstance),
+    NotFound,
+}
+
+#[derive(Debug)]
+pub(crate) enum RuntimeSubmissionCancelError {
+    UnsupportedDefinition { definition_id: String },
+    Store(anyhow::Error),
+}
+
+impl fmt::Display for RuntimeSubmissionCancelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedDefinition { definition_id } => write!(
+                formatter,
+                "workflow definition `{definition_id}` cannot be cancelled as a runtime submission"
+            ),
+            Self::Store(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeSubmissionCancelError {}
+
+impl From<anyhow::Error> for RuntimeSubmissionCancelError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Store(error)
+    }
+}
+
+pub(crate) async fn cancel_issue_submission_by_task_id(
+    store: &WorkflowRuntimeStore,
+    task_id: &crate::task_runner::TaskId,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
+    };
+    cancel_submission_instance(store, instance, task_id.as_str()).await
+}
+
+pub(crate) async fn cancel_submission_by_workflow_id(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    let Some(instance) = store.get_instance(workflow_id).await? else {
+        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
+    };
+    let correlation_id = runtime_issue_task_handle(&instance)
+        .map(|task_id| task_id.0)
+        .unwrap_or_else(|| format!("workflow:{workflow_id}"));
+    cancel_submission_instance(store, instance, &correlation_id).await
+}
+
+async fn cancel_submission_instance(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    correlation_id: &str,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    if instance.is_terminal() {
+        return Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance));
+    }
+    let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
+    if !is_prompt && instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
+        return Err(RuntimeSubmissionCancelError::UnsupportedDefinition {
+            definition_id: instance.definition_id,
+        });
+    }
+    let event_type = if is_prompt {
+        "PromptSubmissionCancelled"
+    } else {
+        "IssueSubmissionCancelled"
+    };
+    let decision_name = if is_prompt {
+        "cancel_prompt_submission"
+    } else {
+        "cancel_issue_submission"
+    };
+    let reason = if is_prompt {
+        "operator cancelled the runtime prompt submission"
+    } else {
+        "operator cancelled the runtime issue submission"
+    };
+    let command_prefix = if is_prompt {
+        "prompt-submit"
+    } else {
+        "issue-submit"
+    };
+    let event = store
+        .append_event(
+            &instance.id,
+            event_type,
+            "workflow_runtime_submission",
+            json!({
+                "task_id": correlation_id,
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        decision_name,
+        "cancelled",
+        reason,
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkCancelled,
+        format!("{command_prefix}:{correlation_id}:cancel"),
+        json!({ "task_id": correlation_id }),
+    ))
+    .high_confidence();
+    let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
+    let commands = store.commands_for(&cancelled.id).await?;
+    for command in commands {
+        if matches!(
+            command.status.as_str(),
+            "pending" | "dispatching" | "dispatched"
+        ) {
+            store
+                .cancel_command_and_unfinished_runtime_jobs(
+                    &command.id,
+                    decision_name,
+                    "Runtime submission was cancelled before execution.",
+                )
+                .await?;
+        }
+    }
+    cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
+    store.upsert_instance(&cancelled).await?;
+    if is_prompt {
+        remove_prompt_submission_prompt(
+            optional_string_field(&cancelled.data, "prompt_ref").as_deref(),
+        );
+    }
+    Ok(RuntimeSubmissionCancelOutcome::Cancelled(cancelled))
+}

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -1,0 +1,476 @@
+use crate::task_runner::{TaskId, TaskStatus, TaskStore};
+use harness_workflow::runtime::{
+    activity_result_value_has_closed_issue_evidence, build_issue_submission_decision,
+    build_prompt_submission_decision, value_has_closed_issue_evidence,
+    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, WorkflowCommand,
+    WorkflowCommandType, WorkflowDecision, WorkflowEvent, WorkflowInstance, WorkflowRuntimeStore,
+    RUNTIME_JOB_COMPLETED_EVENT,
+};
+use serde_json::json;
+
+use super::prompt_memory::remove_prompt_submission_prompt;
+use super::{
+    commit_runtime_decision, depends_on_strings, issue_submission_fields,
+    lookup_prompt_submission_prompt, optional_string_field, prompt_submission_fields,
+    set_data_bool, set_data_string, task_ids_from_data, GITHUB_ISSUE_PR_DEFINITION_ID,
+    PROMPT_TASK_DEFINITION_ID,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptDependencyReleaseOutcome {
+    Released,
+    MissingPrompt,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DependencyReleaseSummary {
+    pub released: usize,
+    pub failed: usize,
+    pub waiting: usize,
+    pub skipped: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeDependencyStatus {
+    Done,
+    Failed,
+    Cancelled,
+    Waiting,
+}
+
+pub(crate) async fn resolve_issue_dependency_status(
+    store: Option<&WorkflowRuntimeStore>,
+    tasks: &TaskStore,
+    task_id: &TaskId,
+) -> anyhow::Result<RuntimeDependencyStatus> {
+    match tasks.dep_status(task_id).await {
+        Some(TaskStatus::Done) => return Ok(RuntimeDependencyStatus::Done),
+        Some(TaskStatus::Failed) => return Ok(RuntimeDependencyStatus::Failed),
+        Some(TaskStatus::Cancelled) => return Ok(RuntimeDependencyStatus::Cancelled),
+        Some(_) => return Ok(RuntimeDependencyStatus::Waiting),
+        None => {}
+    }
+
+    let Some(store) = store else {
+        return Ok(RuntimeDependencyStatus::Waiting);
+    };
+    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(RuntimeDependencyStatus::Waiting);
+    };
+    runtime_dependency_status_from_instance(store, &instance).await
+}
+
+async fn runtime_dependency_status_from_instance(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<RuntimeDependencyStatus> {
+    Ok(match instance.state.as_str() {
+        "done" => RuntimeDependencyStatus::Done,
+        "failed" => RuntimeDependencyStatus::Failed,
+        "cancelled" => RuntimeDependencyStatus::Cancelled,
+        "blocked" if blocked_issue_dependency_is_satisfied(store, instance).await? => {
+            RuntimeDependencyStatus::Done
+        }
+        _ => RuntimeDependencyStatus::Waiting,
+    })
+}
+
+async fn blocked_issue_dependency_is_satisfied(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<bool> {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID || instance.state != "blocked" {
+        return Ok(false);
+    }
+    if instance_data_has_closed_issue_evidence(&instance.data) {
+        return Ok(true);
+    }
+    Ok(store
+        .latest_event_for_type(&instance.id, RUNTIME_JOB_COMPLETED_EVENT)
+        .await?
+        .as_ref()
+        .is_some_and(runtime_event_has_closed_issue_evidence))
+}
+
+fn instance_data_has_closed_issue_evidence(data: &serde_json::Value) -> bool {
+    ["closed_issue_evidence", "issue_state"]
+        .iter()
+        .filter_map(|field| data.get(field))
+        .any(value_has_closed_issue_evidence)
+}
+
+fn runtime_event_has_closed_issue_evidence(event: &WorkflowEvent) -> bool {
+    if event.event_type != RUNTIME_JOB_COMPLETED_EVENT {
+        return false;
+    }
+    event
+        .event
+        .get("activity_result")
+        .is_some_and(activity_result_value_has_closed_issue_evidence)
+}
+
+pub(crate) async fn release_ready_issue_dependencies(
+    store: &WorkflowRuntimeStore,
+    tasks: &TaskStore,
+    limit: i64,
+) -> anyhow::Result<DependencyReleaseSummary> {
+    let instances = store
+        .list_instances_by_state(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            "awaiting_dependencies",
+            limit,
+        )
+        .await?;
+    let mut summary = DependencyReleaseSummary::default();
+    for instance in instances {
+        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed issue data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let mut all_done = true;
+        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
+        for dep_id in &depends_on {
+            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
+                RuntimeDependencyStatus::Done => {}
+                RuntimeDependencyStatus::Failed => {
+                    terminal_failure = Some((dep_id.clone(), "failed"));
+                    break;
+                }
+                RuntimeDependencyStatus::Cancelled => {
+                    terminal_failure = Some((dep_id.clone(), "cancelled"));
+                    break;
+                }
+                RuntimeDependencyStatus::Waiting => all_done = false,
+            }
+        }
+        if let Some((dep_id, label)) = terminal_failure {
+            fail_issue_for_dependency(store, instance, &dep_id, label).await?;
+            summary.failed += 1;
+        } else if all_done {
+            release_issue_after_dependencies(store, instance, &depends_on).await?;
+            summary.released += 1;
+        } else {
+            store.touch_instance(&instance.id).await?;
+            summary.waiting += 1;
+        }
+    }
+    Ok(summary)
+}
+
+pub(crate) async fn release_ready_prompt_dependencies(
+    store: &WorkflowRuntimeStore,
+    tasks: &TaskStore,
+    limit: i64,
+) -> anyhow::Result<DependencyReleaseSummary> {
+    let instances = store
+        .list_instances_by_state(PROMPT_TASK_DEFINITION_ID, "awaiting_dependencies", limit)
+        .await?;
+    let mut summary = DependencyReleaseSummary::default();
+    for instance in instances {
+        let depends_on = match task_ids_from_data(&instance.data, "depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let serialization_depends_on = match task_ids_from_data(
+            &instance.data,
+            "serialization_depends_on",
+        ) {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt serialization data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let required_depends_on = match task_ids_from_data(&instance.data, "required_depends_on") {
+            Ok(depends_on) => depends_on,
+            Err(error) => {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    "workflow runtime dependency release skipped malformed prompt required dependency data: {error}"
+                );
+                summary.skipped += 1;
+                store.touch_instance(&instance.id).await?;
+                continue;
+            }
+        };
+        let mut all_done = true;
+        let mut terminal_failure: Option<(TaskId, &'static str)> = None;
+        for dep_id in &depends_on {
+            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
+                RuntimeDependencyStatus::Done => {}
+                RuntimeDependencyStatus::Failed
+                    if serialization_depends_on.iter().any(|id| id == dep_id)
+                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
+                RuntimeDependencyStatus::Failed => {
+                    terminal_failure = Some((dep_id.clone(), "failed"));
+                    break;
+                }
+                RuntimeDependencyStatus::Cancelled
+                    if serialization_depends_on.iter().any(|id| id == dep_id)
+                        && !required_depends_on.iter().any(|id| id == dep_id) => {}
+                RuntimeDependencyStatus::Cancelled => {
+                    terminal_failure = Some((dep_id.clone(), "cancelled"));
+                    break;
+                }
+                RuntimeDependencyStatus::Waiting => all_done = false,
+            }
+        }
+        if let Some((dep_id, label)) = terminal_failure {
+            fail_prompt_for_dependency(store, instance, &dep_id, label).await?;
+            summary.failed += 1;
+        } else if all_done {
+            match release_prompt_after_dependencies(store, instance, &depends_on).await? {
+                PromptDependencyReleaseOutcome::Released => summary.released += 1,
+                PromptDependencyReleaseOutcome::MissingPrompt => summary.failed += 1,
+            }
+        } else {
+            store.touch_instance(&instance.id).await?;
+            summary.waiting += 1;
+        }
+    }
+    Ok(summary)
+}
+
+async fn release_issue_after_dependencies(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    depends_on: &[TaskId],
+) -> anyhow::Result<()> {
+    let fields = issue_submission_fields(&instance)?;
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: &fields.task_id,
+            repo: fields.repo.as_deref(),
+            issue_number: fields.issue_number,
+            labels: &fields.labels,
+            force_execute: fields.force_execute,
+            additional_prompt: fields.additional_prompt.as_deref(),
+            depends_on: &depends_on_strings(depends_on),
+            dependencies_blocked: false,
+        },
+    );
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueDependenciesSatisfied",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id,
+                "repo": fields.repo,
+                "issue_number": fields.issue_number,
+                "depends_on": depends_on_strings(depends_on),
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
+    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
+async fn fail_issue_for_dependency(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    dependency_id: &TaskId,
+    dependency_status: &str,
+) -> anyhow::Result<()> {
+    let event = store
+        .append_event(
+            &instance.id,
+            "IssueDependencyFailed",
+            "workflow_runtime_submission",
+            json!({
+                "dependency_task_id": dependency_id.as_str(),
+                "dependency_status": dependency_status,
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "dependency_failed",
+        "failed",
+        format!(
+            "dependency task {} {} before runtime issue submission could start",
+            dependency_id.as_str(),
+            dependency_status
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("issue-submit:{}:dependency-failed", dependency_id.as_str()),
+        json!({
+            "dependency_task_id": dependency_id.as_str(),
+            "dependency_status": dependency_status,
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        set_data_string(
+            instance.data.clone(),
+            "dependency_failure_task_id",
+            dependency_id.as_str(),
+        ),
+        "dependency_failure_status",
+        dependency_status,
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    Ok(())
+}
+
+async fn release_prompt_after_dependencies(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    depends_on: &[TaskId],
+) -> anyhow::Result<PromptDependencyReleaseOutcome> {
+    let fields = prompt_submission_fields(&instance)?;
+    let Some(prompt) = lookup_prompt_submission_prompt(&fields.prompt_ref) else {
+        fail_prompt_for_missing_prompt(store, instance, &fields).await?;
+        return Ok(PromptDependencyReleaseOutcome::MissingPrompt);
+    };
+    let output = build_prompt_submission_decision(
+        &instance,
+        PromptSubmissionDecisionInput {
+            task_id: &fields.task_id,
+            prompt: &prompt,
+            prompt_ref: &fields.prompt_ref,
+            source: fields.source.as_deref(),
+            external_id: fields.external_id.as_deref(),
+            depends_on: &depends_on_strings(depends_on),
+            dependencies_blocked: false,
+        },
+    );
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptDependenciesSatisfied",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id,
+                "depends_on": depends_on_strings(depends_on),
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let data = set_data_bool(instance.data.clone(), "dependencies_blocked", false);
+    commit_runtime_decision(store, instance, output.decision, event.id, Some(data)).await?;
+    Ok(PromptDependencyReleaseOutcome::Released)
+}
+
+async fn fail_prompt_for_dependency(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    dependency_id: &TaskId,
+    dependency_status: &str,
+) -> anyhow::Result<()> {
+    let prompt_ref = optional_string_field(&instance.data, "prompt_ref");
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptDependencyFailed",
+            "workflow_runtime_submission",
+            json!({
+                "dependency_task_id": dependency_id.as_str(),
+                "dependency_status": dependency_status,
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "dependency_failed",
+        "failed",
+        format!(
+            "dependency task {} {} before runtime prompt submission could start",
+            dependency_id.as_str(),
+            dependency_status
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("prompt-submit:{}:dependency-failed", dependency_id.as_str()),
+        json!({
+            "dependency_task_id": dependency_id.as_str(),
+            "dependency_status": dependency_status,
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        set_data_string(
+            instance.data.clone(),
+            "dependency_failure_task_id",
+            dependency_id.as_str(),
+        ),
+        "dependency_failure_status",
+        dependency_status,
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    remove_prompt_submission_prompt(prompt_ref.as_deref());
+    Ok(())
+}
+
+async fn fail_prompt_for_missing_prompt(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    fields: &super::PromptSubmissionFields,
+) -> anyhow::Result<()> {
+    let event = store
+        .append_event(
+            &instance.id,
+            "PromptSubmissionPromptMissing",
+            "workflow_runtime_submission",
+            json!({
+                "task_id": fields.task_id.as_str(),
+                "prompt_ref": fields.prompt_ref.as_str(),
+                "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
+            }),
+        )
+        .await?;
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "prompt_unavailable",
+        "failed",
+        "prompt-only runtime submission cannot resume because its in-memory prompt is unavailable",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        format!("prompt-submit:{}:prompt-missing", fields.task_id),
+        json!({
+            "task_id": fields.task_id.as_str(),
+            "prompt_ref": fields.prompt_ref.as_str(),
+        }),
+    ))
+    .high_confidence();
+    let data = set_data_string(
+        instance.data.clone(),
+        "failure_reason",
+        "prompt unavailable",
+    );
+    commit_runtime_decision(store, instance, decision, event.id, Some(data)).await?;
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use harness_core::db::resolve_database_url;
+use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject};
+use serde_json::json;
+
+#[tokio::test]
+async fn issue_submission_records_explicit_submission_id() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let database_url = resolve_database_url(None)?;
+    let store =
+        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("issue-submission-id");
+
+    record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 1129,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:1129"),
+        },
+    )
+    .await?;
+
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_root.to_string_lossy(),
+        Some("owner/repo"),
+        1129,
+    );
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("issue workflow should be persisted");
+    assert_eq!(instance.data["submission_id"], "issue-submission-id");
+    assert_eq!(
+        runtime_issue_task_handle(&instance)
+            .expect("issue workflow should expose submission id")
+            .as_str(),
+        "issue-submission-id"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn prompt_submission_records_explicit_submission_id() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let database_url = resolve_database_url(None)?;
+    let store =
+        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("prompt-submission-id");
+
+    let result = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &task_id,
+            prompt: "keep prompt submission identity explicit",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("dashboard"),
+            external_id: Some("manual:prompt:1129"),
+        },
+    )
+    .await?;
+
+    let instance = store
+        .get_instance(&result.workflow_id)
+        .await?
+        .expect("prompt workflow should be persisted");
+    assert_eq!(instance.data["submission_id"], "prompt-submission-id");
+    assert_eq!(
+        runtime_issue_task_handle(&instance)
+            .expect("prompt workflow should expose submission id")
+            .as_str(),
+        "prompt-submission-id"
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_issue_task_handle_prefers_explicit_submission_id() {
+    let workflow = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", "issue:1129"),
+    )
+    .with_data(json!({
+        "submission_id": "runtime-submission",
+        "task_id": "latest-task",
+        "task_ids": ["historical-task", "latest-task"]
+    }));
+
+    assert_eq!(
+        runtime_issue_task_handle(&workflow)
+            .expect("runtime workflow should expose submission id")
+            .as_str(),
+        "runtime-submission"
+    );
+}
+
+#[test]
+fn task_id_history_preserves_existing_submission_id_first() {
+    let new_task_id = TaskId::from_str("retry-task");
+    let task_ids = task_id_history(
+        &json!({
+            "submission_id": "stable-submission",
+            "task_id": "previous-task",
+            "task_ids": ["previous-task", "older-task"]
+        }),
+        &new_task_id,
+    );
+
+    assert_eq!(
+        task_ids,
+        vec![
+            "stable-submission".to_string(),
+            "previous-task".to_string(),
+            "older-task".to_string(),
+            "retry-task".to_string()
+        ]
+    );
+}

--- a/crates/harness-server/src/workflow_runtime_submission/prompt_memory.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/prompt_memory.rs
@@ -1,0 +1,63 @@
+use crate::task_runner::TaskId;
+use harness_workflow::runtime::{WorkflowInstance, PROMPT_TASK_DEFINITION_ID};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
+
+use super::optional_string_field;
+
+static PROMPT_SUBMISSION_PROMPTS: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+pub(crate) fn lookup_prompt_submission_prompt(prompt_ref: &str) -> Option<String> {
+    prompt_submission_prompts()
+        .lock()
+        .ok()
+        .and_then(|prompts| prompts.get(prompt_ref).cloned())
+}
+
+pub(super) fn cache_prompt_submission_prompt(prompt_ref: &str, prompt: &str) {
+    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
+        prompts.insert(prompt_ref.to_string(), prompt.to_string());
+    }
+}
+
+pub(super) fn remove_prompt_submission_prompt(prompt_ref: Option<&str>) {
+    let Some(prompt_ref) = prompt_ref else {
+        return;
+    };
+    if let Ok(mut prompts) = prompt_submission_prompts().lock() {
+        prompts.remove(prompt_ref);
+    }
+}
+
+pub(crate) fn remove_terminal_prompt_submission_prompt(instance: &WorkflowInstance) {
+    if instance.definition_id != PROMPT_TASK_DEFINITION_ID || !instance.is_terminal() {
+        return;
+    }
+    remove_prompt_submission_prompt(optional_string_field(&instance.data, "prompt_ref").as_deref());
+}
+
+fn prompt_submission_prompts() -> &'static Mutex<HashMap<String, String>> {
+    PROMPT_SUBMISSION_PROMPTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(super) fn prompt_ref_for_submission(
+    project_id: &str,
+    external_id: Option<&str>,
+    task_id: &TaskId,
+    prompt: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(project_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(external_id.unwrap_or("").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(task_id.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(prompt.as_bytes());
+    let digest = hasher.finalize();
+    let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("prompt-memory:{digest_hex}")
+}


### PR DESCRIPTION
## Summary
- Split `workflow_runtime_submission.rs` into focused cancel, dependency, and prompt-memory modules so the runtime submission code stays under the project file-size guard.
- Persist an explicit `submission_id` on new runtime issue and prompt submissions.
- Prefer the stable `submission_id` as the public runtime handle while preserving historical `task_id` aliases for existing links and retries.

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo check -p harness-server`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test -p harness-server workflow_runtime_submission --lib`
- `cargo test` still fails locally at the existing database boundary: `harness-core` reports 409 passed and 12 DB tests failed because `HARNESS_DATABASE_URL` is unset. Local `scripts/dev-db.sh` cannot start the DB because Docker Compose v2 is not installed, and `docker`, `psql`, `initdb`, `pg_ctl`, and localhost:5432 are unavailable.

Refs #1129