### PR TITLE
feat(review): add provider report contract

### DIFF
--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -170,9 +170,149 @@ fn default_default_agent() -> String {
     "auto".to_string()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewStrategy {
+    LocalFirst,
+    LegacyHostedBot,
+}
+
+impl Default for ReviewStrategy {
+    fn default() -> Self {
+        Self::LocalFirst
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexCliReviewConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_codex_cli_review_path")]
+    pub cli_path: PathBuf,
+    #[serde(default = "default_codex_model")]
+    pub model: String,
+    #[serde(default = "default_codex_reasoning_effort")]
+    pub reasoning_effort: String,
+    #[serde(default = "default_codex_cli_review_base_ref")]
+    pub base_ref: String,
+    #[serde(default = "default_codex_cli_review_timeout_secs")]
+    pub timeout_secs: u64,
+    #[serde(default = "default_codex_cli_review_output_format")]
+    pub output_format: String,
+}
+
+impl Default for CodexCliReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cli_path: default_codex_cli_review_path(),
+            model: default_codex_model(),
+            reasoning_effort: default_codex_reasoning_effort(),
+            base_ref: default_codex_cli_review_base_ref(),
+            timeout_secs: default_codex_cli_review_timeout_secs(),
+            output_format: default_codex_cli_review_output_format(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexAgentReviewProviderConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_reviewer_agent")]
+    pub reviewer_agent: String,
+    #[serde(default = "default_max_agent_review_rounds")]
+    pub max_rounds: u32,
+}
+
+impl Default for CodexAgentReviewProviderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            reviewer_agent: default_reviewer_agent(),
+            max_rounds: default_max_agent_review_rounds(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RawCodexAgentReviewProviderConfig {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    reviewer_agent: Option<String>,
+    #[serde(default)]
+    max_rounds: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalBotReviewProviderConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub trigger_command: String,
+    #[serde(default)]
+    pub reviewer_name: String,
+    #[serde(default)]
+    pub auto_trigger: bool,
+    #[serde(default = "default_external_bot_wait_secs")]
+    pub wait_secs: u64,
+    #[serde(default = "default_max_agent_review_rounds")]
+    pub max_rounds: u32,
+}
+
+impl ExternalBotReviewProviderConfig {
+    fn gemini(trigger_command: String, reviewer_name: String, auto_trigger: bool) -> Self {
+        Self {
+            enabled: true,
+            trigger_command,
+            reviewer_name,
+            auto_trigger,
+            wait_secs: default_external_bot_wait_secs(),
+            max_rounds: default_max_agent_review_rounds(),
+        }
+    }
+
+    fn codex(auto_trigger: bool) -> Self {
+        Self {
+            enabled: true,
+            trigger_command: "@codex".to_string(),
+            reviewer_name: "chatgpt-codex-connector[bot]".to_string(),
+            auto_trigger,
+            wait_secs: default_external_bot_wait_secs(),
+            max_rounds: default_max_agent_review_rounds(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RawExternalBotReviewProviderConfig {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    trigger_command: Option<String>,
+    #[serde(default)]
+    reviewer_name: Option<String>,
+    #[serde(default)]
+    auto_trigger: Option<bool>,
+    #[serde(default)]
+    wait_secs: Option<u64>,
+    #[serde(default)]
+    max_rounds: Option<u32>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentReviewConfig {
     pub enabled: bool,
+    pub strategy: ReviewStrategy,
+    pub required_providers: Vec<String>,
+    pub advisory_providers: Vec<String>,
+    pub external_required: bool,
+    pub publish_local_review_comment: bool,
+    pub codex_cli_review: CodexCliReviewConfig,
+    pub codex_agent_review: CodexAgentReviewProviderConfig,
+    pub gemini_github_bot: ExternalBotReviewProviderConfig,
+    pub codex_github_bot: ExternalBotReviewProviderConfig,
     /// Agent name to use as reviewer. Empty string = auto-select.
     pub reviewer_agent: String,
     pub max_rounds: u32,
@@ -202,6 +342,24 @@ impl<'de> Deserialize<'de> for AgentReviewConfig {
             #[serde(default)]
             enabled: Option<bool>,
             #[serde(default)]
+            strategy: Option<ReviewStrategy>,
+            #[serde(default)]
+            required_providers: Option<Vec<String>>,
+            #[serde(default)]
+            advisory_providers: Option<Vec<String>>,
+            #[serde(default)]
+            external_required: Option<bool>,
+            #[serde(default)]
+            publish_local_review_comment: Option<bool>,
+            #[serde(default)]
+            codex_cli_review: Option<CodexCliReviewConfig>,
+            #[serde(default)]
+            codex_agent_review: Option<RawCodexAgentReviewProviderConfig>,
+            #[serde(default)]
+            gemini_github_bot: Option<RawExternalBotReviewProviderConfig>,
+            #[serde(default)]
+            codex_github_bot: Option<RawExternalBotReviewProviderConfig>,
+            #[serde(default)]
             reviewer_agent: Option<String>,
             #[serde(default)]
             max_rounds: Option<u32>,
@@ -222,21 +380,55 @@ impl<'de> Deserialize<'de> for AgentReviewConfig {
         let raw = RawAgentReviewConfig::deserialize(deserializer)?;
         let enabled = raw.enabled.unwrap_or_else(default_agent_review_enabled);
         let review_bot_auto_trigger = raw.review_bot_auto_trigger.unwrap_or(!enabled);
+        let review_bot_command = raw
+            .review_bot_command
+            .unwrap_or_else(default_review_bot_command);
+        let reviewer_name = raw.reviewer_name.unwrap_or_else(default_reviewer_name);
+        let reviewer_agent = raw.reviewer_agent.unwrap_or_else(default_reviewer_agent);
+        let max_rounds = raw
+            .max_rounds
+            .unwrap_or_else(default_max_agent_review_rounds);
+        let fallback_chain = raw
+            .fallback_chain
+            .unwrap_or_else(default_review_fallback_chain);
+        let required_providers = raw
+            .required_providers
+            .unwrap_or_else(|| default_required_review_providers(enabled));
+        let advisory_providers = raw
+            .advisory_providers
+            .unwrap_or_else(|| normalize_external_bot_chain(&fallback_chain));
+        let default_gemini_bot = ExternalBotReviewProviderConfig::gemini(
+            review_bot_command.clone(),
+            reviewer_name.clone(),
+            review_bot_auto_trigger,
+        );
+        let default_codex_bot = ExternalBotReviewProviderConfig::codex(review_bot_auto_trigger);
+        let default_codex_agent = CodexAgentReviewProviderConfig {
+            enabled: false,
+            reviewer_agent: reviewer_agent.clone(),
+            max_rounds,
+        };
 
         Ok(Self {
             enabled,
-            reviewer_agent: raw.reviewer_agent.unwrap_or_else(default_reviewer_agent),
-            max_rounds: raw
-                .max_rounds
-                .unwrap_or_else(default_max_agent_review_rounds),
-            review_bot_command: raw
-                .review_bot_command
-                .unwrap_or_else(default_review_bot_command),
+            strategy: raw.strategy.unwrap_or_default(),
+            required_providers,
+            advisory_providers,
+            external_required: raw.external_required.unwrap_or(false),
+            publish_local_review_comment: raw.publish_local_review_comment.unwrap_or(false),
+            codex_cli_review: raw.codex_cli_review.unwrap_or_default(),
+            codex_agent_review: merge_codex_agent_review_config(
+                raw.codex_agent_review,
+                default_codex_agent,
+            ),
+            gemini_github_bot: merge_external_bot_config(raw.gemini_github_bot, default_gemini_bot),
+            codex_github_bot: merge_external_bot_config(raw.codex_github_bot, default_codex_bot),
+            reviewer_agent,
+            max_rounds,
+            review_bot_command,
             review_bot_auto_trigger,
-            reviewer_name: raw.reviewer_name.unwrap_or_else(default_reviewer_name),
-            fallback_chain: raw
-                .fallback_chain
-                .unwrap_or_else(default_review_fallback_chain),
+            reviewer_name,
+            fallback_chain,
             silence_rounds_threshold: raw
                 .silence_rounds_threshold
                 .unwrap_or_else(default_silence_rounds_threshold),
@@ -251,6 +443,21 @@ impl Default for AgentReviewConfig {
     fn default() -> Self {
         Self {
             enabled: default_agent_review_enabled(),
+            strategy: ReviewStrategy::default(),
+            required_providers: default_required_review_providers(true),
+            advisory_providers: default_advisory_review_providers(),
+            external_required: false,
+            publish_local_review_comment: false,
+            codex_cli_review: CodexCliReviewConfig::default(),
+            codex_agent_review: CodexAgentReviewProviderConfig::default(),
+            gemini_github_bot: ExternalBotReviewProviderConfig::gemini(
+                default_review_bot_command(),
+                default_reviewer_name(),
+                default_review_bot_auto_trigger(),
+            ),
+            codex_github_bot: ExternalBotReviewProviderConfig::codex(
+                default_review_bot_auto_trigger(),
+            ),
             reviewer_agent: default_reviewer_agent(),
             max_rounds: default_max_agent_review_rounds(),
             review_bot_command: default_review_bot_command(),
@@ -271,6 +478,10 @@ fn default_reviewer_agent() -> String {
     "codex".to_string()
 }
 
+fn default_true() -> bool {
+    true
+}
+
 fn default_reviewer_name() -> String {
     "gemini-code-assist[bot]".to_string()
 }
@@ -287,8 +498,94 @@ fn default_max_agent_review_rounds() -> u32 {
     3
 }
 
+fn default_required_review_providers(enabled: bool) -> Vec<String> {
+    if enabled {
+        vec!["codex_cli_review".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn default_advisory_review_providers() -> Vec<String> {
+    vec![
+        "gemini_github_bot".to_string(),
+        "codex_github_bot".to_string(),
+    ]
+}
+
 fn default_review_fallback_chain() -> Vec<String> {
     vec!["gemini".to_string(), "codex".to_string()]
+}
+
+fn normalize_external_bot_chain(chain: &[String]) -> Vec<String> {
+    chain
+        .iter()
+        .filter_map(|provider| match provider.as_str() {
+            "gemini" | "gemini_github_bot" => Some("gemini_github_bot".to_string()),
+            "codex" | "codex_github_bot" => Some("codex_github_bot".to_string()),
+            _ => Some(provider.clone()),
+        })
+        .collect()
+}
+
+fn merge_codex_agent_review_config(
+    raw: Option<RawCodexAgentReviewProviderConfig>,
+    defaults: CodexAgentReviewProviderConfig,
+) -> CodexAgentReviewProviderConfig {
+    let Some(raw) = raw else {
+        return defaults;
+    };
+    CodexAgentReviewProviderConfig {
+        enabled: raw.enabled.unwrap_or(defaults.enabled),
+        reviewer_agent: raw
+            .reviewer_agent
+            .filter(|value| !value.is_empty())
+            .unwrap_or(defaults.reviewer_agent),
+        max_rounds: raw.max_rounds.unwrap_or(defaults.max_rounds),
+    }
+}
+
+fn merge_external_bot_config(
+    raw: Option<RawExternalBotReviewProviderConfig>,
+    defaults: ExternalBotReviewProviderConfig,
+) -> ExternalBotReviewProviderConfig {
+    let Some(raw) = raw else {
+        return defaults;
+    };
+    ExternalBotReviewProviderConfig {
+        enabled: raw.enabled.unwrap_or(defaults.enabled),
+        trigger_command: raw
+            .trigger_command
+            .filter(|value| !value.is_empty())
+            .unwrap_or(defaults.trigger_command),
+        reviewer_name: raw
+            .reviewer_name
+            .filter(|value| !value.is_empty())
+            .unwrap_or(defaults.reviewer_name),
+        auto_trigger: raw.auto_trigger.unwrap_or(defaults.auto_trigger),
+        wait_secs: raw.wait_secs.unwrap_or(defaults.wait_secs),
+        max_rounds: raw.max_rounds.unwrap_or(defaults.max_rounds),
+    }
+}
+
+fn default_codex_cli_review_path() -> PathBuf {
+    PathBuf::from("codex")
+}
+
+fn default_codex_cli_review_base_ref() -> String {
+    "origin/main".to_string()
+}
+
+fn default_codex_cli_review_timeout_secs() -> u64 {
+    1800
+}
+
+fn default_codex_cli_review_output_format() -> String {
+    "json".to_string()
+}
+
+fn default_external_bot_wait_secs() -> u64 {
+    300
 }
 
 fn default_silence_rounds_threshold() -> u32 {
@@ -397,3 +694,7 @@ impl Default for AnthropicApiConfig {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "agents_review_tests.rs"]
+mod agents_review_tests;

--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -170,17 +170,12 @@ fn default_default_agent() -> String {
     "auto".to_string()
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReviewStrategy {
+    #[default]
     LocalFirst,
     LegacyHostedBot,
-}
-
-impl Default for ReviewStrategy {
-    fn default() -> Self {
-        Self::LocalFirst
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -520,10 +515,10 @@ fn default_review_fallback_chain() -> Vec<String> {
 fn normalize_external_bot_chain(chain: &[String]) -> Vec<String> {
     chain
         .iter()
-        .filter_map(|provider| match provider.as_str() {
-            "gemini" | "gemini_github_bot" => Some("gemini_github_bot".to_string()),
-            "codex" | "codex_github_bot" => Some("codex_github_bot".to_string()),
-            _ => Some(provider.clone()),
+        .map(|provider| match provider.as_str() {
+            "gemini" | "gemini_github_bot" => "gemini_github_bot".to_string(),
+            "codex" | "codex_github_bot" => "codex_github_bot".to_string(),
+            _ => provider.clone(),
         })
         .collect()
 }

--- a/crates/harness-core/src/config/agents_review_tests.rs
+++ b/crates/harness-core/src/config/agents_review_tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+#[test]
+fn review_config_defaults_to_local_first_provider_ids() {
+    let config = AgentReviewConfig::default();
+
+    assert!(config.enabled);
+    assert_eq!(config.strategy, ReviewStrategy::LocalFirst);
+    assert_eq!(config.required_providers, vec!["codex_cli_review"]);
+    assert_eq!(
+        config.advisory_providers,
+        vec!["gemini_github_bot", "codex_github_bot"]
+    );
+    assert!(!config.external_required);
+    assert!(!config.publish_local_review_comment);
+    assert!(config.codex_cli_review.enabled);
+    assert_eq!(config.codex_cli_review.cli_path, PathBuf::from("codex"));
+    assert_eq!(config.codex_cli_review.base_ref, "origin/main");
+    assert_eq!(config.codex_cli_review.timeout_secs, 1800);
+    assert!(!config.codex_agent_review.enabled);
+    assert_eq!(config.gemini_github_bot.trigger_command, "/gemini review");
+    assert_eq!(
+        config.gemini_github_bot.reviewer_name,
+        "gemini-code-assist[bot]"
+    );
+    assert_eq!(config.codex_github_bot.trigger_command, "@codex");
+}
+
+#[test]
+fn review_config_deserializes_provider_settings() {
+    let toml_str = r#"
+        enabled = true
+        strategy = "local_first"
+        required_providers = ["codex_cli_review"]
+        advisory_providers = ["gemini_github_bot"]
+        external_required = true
+        publish_local_review_comment = true
+
+        [codex_cli_review]
+        enabled = true
+        cli_path = "/opt/bin/codex"
+        model = "gpt-5.5"
+        reasoning_effort = "xhigh"
+        base_ref = "main"
+        timeout_secs = 2400
+        output_format = "json"
+
+        [gemini_github_bot]
+        enabled = true
+        trigger_command = "/gemini review"
+        reviewer_name = "gemini-code-assist[bot]"
+        auto_trigger = false
+        wait_secs = 120
+        max_rounds = 1
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+
+    assert_eq!(config.strategy, ReviewStrategy::LocalFirst);
+    assert_eq!(config.required_providers, vec!["codex_cli_review"]);
+    assert_eq!(config.advisory_providers, vec!["gemini_github_bot"]);
+    assert!(config.external_required);
+    assert!(config.publish_local_review_comment);
+    assert_eq!(
+        config.codex_cli_review.cli_path,
+        PathBuf::from("/opt/bin/codex")
+    );
+    assert_eq!(config.codex_cli_review.model, "gpt-5.5");
+    assert_eq!(config.codex_cli_review.reasoning_effort, "xhigh");
+    assert_eq!(config.codex_cli_review.base_ref, "main");
+    assert_eq!(config.codex_cli_review.timeout_secs, 2400);
+    assert_eq!(config.gemini_github_bot.wait_secs, 120);
+    assert_eq!(config.gemini_github_bot.max_rounds, 1);
+}
+
+#[test]
+fn review_config_maps_legacy_fallback_chain_to_explicit_advisory_providers() {
+    let toml_str = r#"
+        enabled = true
+        fallback_chain = ["codex", "gemini"]
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+
+    assert_eq!(config.fallback_chain, vec!["codex", "gemini"]);
+    assert_eq!(
+        config.advisory_providers,
+        vec!["codex_github_bot", "gemini_github_bot"]
+    );
+}
+
+#[test]
+fn review_config_partial_external_provider_inherits_provider_defaults() {
+    let toml_str = r#"
+        enabled = true
+
+        [codex_github_bot]
+        wait_secs = 60
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+
+    assert_eq!(config.codex_github_bot.trigger_command, "@codex");
+    assert_eq!(
+        config.codex_github_bot.reviewer_name,
+        "chatgpt-codex-connector[bot]"
+    );
+    assert_eq!(config.codex_github_bot.wait_secs, 60);
+}
+
+#[test]
+fn review_config_partial_providers_inherit_legacy_review_defaults() -> Result<(), toml::de::Error> {
+    let toml_str = r#"
+        enabled = false
+        reviewer_agent = "claude"
+        max_rounds = 5
+        review_bot_command = "/alt review"
+        reviewer_name = "alt-reviewer[bot]"
+
+        [codex_agent_review]
+        enabled = true
+
+        [gemini_github_bot]
+        wait_secs = 60
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str)?;
+
+    assert!(config.codex_agent_review.enabled);
+    assert_eq!(config.codex_agent_review.reviewer_agent, "claude");
+    assert_eq!(config.codex_agent_review.max_rounds, 5);
+    assert_eq!(config.gemini_github_bot.trigger_command, "/alt review");
+    assert_eq!(config.gemini_github_bot.reviewer_name, "alt-reviewer[bot]");
+    assert!(config.gemini_github_bot.auto_trigger);
+    assert_eq!(config.gemini_github_bot.wait_secs, 60);
+    Ok(())
+}
+
+#[test]
+fn review_config_disabled_local_review_defaults_to_hosted_review() {
+    let toml_str = r#"
+        enabled = false
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str).unwrap();
+
+    assert!(!config.enabled);
+    assert!(config.required_providers.is_empty());
+    assert!(config.review_bot_auto_trigger);
+    assert!(config.gemini_github_bot.auto_trigger);
+    assert!(config.codex_github_bot.auto_trigger);
+}

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod interceptor;
 pub mod lang_detect;
 pub mod prompts;
 pub mod proof_of_work;
+pub mod review;
 pub mod shell_safety;
 #[cfg(test)]
 mod test_support;

--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -205,8 +205,10 @@ pub fn evaluate_review_gate(
     }
 
     if external_required {
+        let mut saw_advisory = false;
         for input in reports {
             if input.role == ReviewProviderRole::Advisory {
+                saw_advisory = true;
                 match input.report.decision {
                     ReviewDecision::ChangesRequested => {
                         return gate_result(
@@ -225,6 +227,13 @@ pub fn evaluate_review_gate(
                     ReviewDecision::Approved => {}
                 }
             }
+        }
+        if !saw_advisory {
+            return ReviewGateResult {
+                decision: ReviewGateDecision::Blocked,
+                blocking_provider_id: None,
+                summary: "No external review provider report was available.".to_string(),
+            };
         }
     }
 
@@ -293,7 +302,7 @@ fn parse_payload(raw_json: &str) -> Option<ReviewReportPayload> {
 fn legacy_issue_findings(raw_output: &str) -> Vec<ReviewReportFinding> {
     raw_output
         .lines()
-        .filter_map(|line| line.trim().strip_prefix("ISSUE:"))
+        .filter_map(legacy_issue_message)
         .map(|message| ReviewReportFinding {
             severity: ReviewSeverity::High,
             category: ReviewCategory::Other,
@@ -306,6 +315,16 @@ fn legacy_issue_findings(raw_output: &str) -> Vec<ReviewReportFinding> {
             confidence: None,
         })
         .collect()
+}
+
+fn legacy_issue_message(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    let prefix = trimmed.get(..6)?;
+    if prefix.eq_ignore_ascii_case("ISSUE:") {
+        trimmed.get(6..).map(str::trim)
+    } else {
+        None
+    }
 }
 
 fn last_non_empty_line(raw_output: &str) -> Option<&str> {
@@ -402,7 +421,7 @@ mod tests {
         let report = parse_review_report(
             "codex_agent_review",
             ReviewProviderKind::LocalAgent,
-            "ISSUE: Missing retry coverage\nISSUE: Wrong timeout",
+            "ISSUE: Missing retry coverage\nIssue: Wrong timeout",
             started(),
             completed(),
         );
@@ -480,6 +499,20 @@ mod tests {
         );
 
         assert_eq!(result.decision, ReviewGateDecision::Approved);
+    }
+
+    #[test]
+    fn gate_blocks_when_external_required_without_advisory_report() {
+        let result = evaluate_review_gate(
+            &[approved_report(
+                "codex_cli_review",
+                ReviewProviderRole::Required,
+            )],
+            true,
+        );
+
+        assert_eq!(result.decision, ReviewGateDecision::Blocked);
+        assert_eq!(result.blocking_provider_id, None);
     }
 
     #[test]

--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -1,0 +1,504 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewProviderKind {
+    LocalCli,
+    LocalAgent,
+    ExternalBot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewDecision {
+    Approved,
+    ChangesRequested,
+    Failed,
+    TimedOut,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewSeverity {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewCategory {
+    Security,
+    Correctness,
+    DataIntegrity,
+    Concurrency,
+    Performance,
+    TestGap,
+    Maintainability,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewReportFinding {
+    pub severity: ReviewSeverity,
+    pub category: ReviewCategory,
+    pub path: Option<String>,
+    pub line: Option<u32>,
+    pub message: String,
+    pub evidence: Option<String>,
+    pub recommendation: Option<String>,
+    pub blocking: bool,
+    pub confidence: Option<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewReport {
+    pub provider_id: String,
+    pub provider_kind: ReviewProviderKind,
+    pub decision: ReviewDecision,
+    pub summary: String,
+    pub findings: Vec<ReviewReportFinding>,
+    pub raw_output: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewProviderRole {
+    Required,
+    Advisory,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewGateProviderReport {
+    pub role: ReviewProviderRole,
+    pub report: ReviewReport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewGateDecision {
+    Approved,
+    ChangesRequested,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewGateResult {
+    pub decision: ReviewGateDecision,
+    pub blocking_provider_id: Option<String>,
+    pub summary: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewReportPayload {
+    decision: ReviewDecision,
+    summary: String,
+    #[serde(default)]
+    findings: Vec<ReviewReportFinding>,
+}
+
+pub fn parse_review_report(
+    provider_id: &str,
+    provider_kind: ReviewProviderKind,
+    raw_output: &str,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+) -> ReviewReport {
+    if let Some(payload) = fenced_report_payload(raw_output)
+        .and_then(parse_payload)
+        .or_else(|| parse_raw_payload(raw_output))
+    {
+        return build_report(
+            provider_id,
+            provider_kind,
+            raw_output,
+            started_at,
+            completed_at,
+            payload,
+        );
+    }
+
+    let legacy_findings = legacy_issue_findings(raw_output);
+    if !legacy_findings.is_empty() {
+        return ReviewReport {
+            provider_id: provider_id.to_string(),
+            provider_kind,
+            decision: ReviewDecision::ChangesRequested,
+            summary: format!(
+                "{} blocking issue(s) reported by legacy review output.",
+                legacy_findings.len()
+            ),
+            findings: legacy_findings,
+            raw_output: Some(raw_output.to_string()),
+            started_at,
+            completed_at,
+            elapsed_ms: elapsed_ms(started_at, completed_at),
+        };
+    }
+
+    if last_non_empty_line(raw_output).is_some_and(|line| line.eq_ignore_ascii_case("APPROVED")) {
+        return ReviewReport {
+            provider_id: provider_id.to_string(),
+            provider_kind,
+            decision: ReviewDecision::Approved,
+            summary: "Review provider approved the change.".to_string(),
+            findings: Vec::new(),
+            raw_output: Some(raw_output.to_string()),
+            started_at,
+            completed_at,
+            elapsed_ms: elapsed_ms(started_at, completed_at),
+        };
+    }
+
+    ReviewReport {
+        provider_id: provider_id.to_string(),
+        provider_kind,
+        decision: ReviewDecision::Failed,
+        summary: "Review provider output did not include a parseable decision.".to_string(),
+        findings: Vec::new(),
+        raw_output: Some(raw_output.to_string()),
+        started_at,
+        completed_at,
+        elapsed_ms: elapsed_ms(started_at, completed_at),
+    }
+}
+
+pub fn evaluate_review_gate(
+    reports: &[ReviewGateProviderReport],
+    external_required: bool,
+) -> ReviewGateResult {
+    let mut saw_required = false;
+    for input in reports {
+        if input.role == ReviewProviderRole::Required {
+            saw_required = true;
+            match input.report.decision {
+                ReviewDecision::ChangesRequested => {
+                    return gate_result(
+                        ReviewGateDecision::ChangesRequested,
+                        &input.report,
+                        "Required review provider requested changes.",
+                    );
+                }
+                ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
+                    return gate_result(
+                        ReviewGateDecision::Blocked,
+                        &input.report,
+                        "Required review provider did not complete successfully.",
+                    );
+                }
+                ReviewDecision::Approved => {}
+            }
+        }
+    }
+    if !saw_required {
+        return ReviewGateResult {
+            decision: ReviewGateDecision::Blocked,
+            blocking_provider_id: None,
+            summary: "No required review provider report was available.".to_string(),
+        };
+    }
+
+    if external_required {
+        for input in reports {
+            if input.role == ReviewProviderRole::Advisory {
+                match input.report.decision {
+                    ReviewDecision::ChangesRequested => {
+                        return gate_result(
+                            ReviewGateDecision::ChangesRequested,
+                            &input.report,
+                            "External review provider requested changes.",
+                        );
+                    }
+                    ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
+                        return gate_result(
+                            ReviewGateDecision::Blocked,
+                            &input.report,
+                            "External review provider is required and did not approve.",
+                        );
+                    }
+                    ReviewDecision::Approved => {}
+                }
+            }
+        }
+    }
+
+    ReviewGateResult {
+        decision: ReviewGateDecision::Approved,
+        blocking_provider_id: None,
+        summary: "All required review providers approved.".to_string(),
+    }
+}
+
+fn build_report(
+    provider_id: &str,
+    provider_kind: ReviewProviderKind,
+    raw_output: &str,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+    payload: ReviewReportPayload,
+) -> ReviewReport {
+    ReviewReport {
+        provider_id: provider_id.to_string(),
+        provider_kind,
+        decision: payload.decision,
+        summary: payload.summary,
+        findings: payload.findings,
+        raw_output: Some(raw_output.to_string()),
+        started_at,
+        completed_at,
+        elapsed_ms: elapsed_ms(started_at, completed_at),
+    }
+}
+
+fn gate_result(
+    decision: ReviewGateDecision,
+    report: &ReviewReport,
+    summary: &str,
+) -> ReviewGateResult {
+    ReviewGateResult {
+        decision,
+        blocking_provider_id: Some(report.provider_id.clone()),
+        summary: summary.to_string(),
+    }
+}
+
+fn fenced_report_payload(raw_output: &str) -> Option<&str> {
+    let marker = "```harness-review-report";
+    let start = raw_output.find(marker)?;
+    let after_marker = &raw_output[start + marker.len()..];
+    let after_newline = after_marker.strip_prefix('\n').unwrap_or(after_marker);
+    let end = after_newline.find("```")?;
+    Some(after_newline[..end].trim())
+}
+
+fn parse_raw_payload(raw_output: &str) -> Option<ReviewReportPayload> {
+    let trimmed = raw_output.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        parse_payload(trimmed)
+    } else {
+        None
+    }
+}
+
+fn parse_payload(raw_json: &str) -> Option<ReviewReportPayload> {
+    serde_json::from_str(raw_json).ok()
+}
+
+fn legacy_issue_findings(raw_output: &str) -> Vec<ReviewReportFinding> {
+    raw_output
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("ISSUE:"))
+        .map(|message| ReviewReportFinding {
+            severity: ReviewSeverity::High,
+            category: ReviewCategory::Other,
+            path: None,
+            line: None,
+            message: message.trim().to_string(),
+            evidence: None,
+            recommendation: None,
+            blocking: true,
+            confidence: None,
+        })
+        .collect()
+}
+
+fn last_non_empty_line(raw_output: &str) -> Option<&str> {
+    raw_output.lines().rev().find_map(|line| {
+        let trimmed = line.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn elapsed_ms(started_at: DateTime<Utc>, completed_at: DateTime<Utc>) -> u64 {
+    completed_at
+        .signed_duration_since(started_at)
+        .num_milliseconds()
+        .max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn started() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 24, 8, 0, 0).unwrap()
+    }
+
+    fn completed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 24, 8, 0, 2).unwrap()
+    }
+
+    fn approved_report(provider_id: &str, role: ReviewProviderRole) -> ReviewGateProviderReport {
+        ReviewGateProviderReport {
+            role,
+            report: ReviewReport {
+                provider_id: provider_id.to_string(),
+                provider_kind: ReviewProviderKind::LocalCli,
+                decision: ReviewDecision::Approved,
+                summary: "ok".to_string(),
+                findings: Vec::new(),
+                raw_output: None,
+                started_at: started(),
+                completed_at: completed(),
+                elapsed_ms: 2_000,
+            },
+        }
+    }
+
+    #[test]
+    fn parses_fenced_review_report_json() {
+        let report = parse_review_report(
+            "codex_cli_review",
+            ReviewProviderKind::LocalCli,
+            r#"```harness-review-report
+{"decision":"changes_requested","summary":"One issue.","findings":[{"severity":"high","category":"correctness","path":"src/lib.rs","line":7,"message":"Wrong result","evidence":"The branch is not handled.","recommendation":"Handle the branch.","blocking":true,"confidence":0.9}]}
+```"#,
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::ChangesRequested);
+        assert_eq!(report.elapsed_ms, 2_000);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].category, ReviewCategory::Correctness);
+    }
+
+    #[test]
+    fn parses_raw_review_report_json() {
+        let report = parse_review_report(
+            "codex_cli_review",
+            ReviewProviderKind::LocalCli,
+            r#"{"decision":"approved","summary":"No blocking issues.","findings":[]}"#,
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::Approved);
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn parses_legacy_approved_line() {
+        let report = parse_review_report(
+            "codex_agent_review",
+            ReviewProviderKind::LocalAgent,
+            "Looks good.\nAPPROVED",
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::Approved);
+    }
+
+    #[test]
+    fn parses_legacy_issue_lines_as_blocking_findings() {
+        let report = parse_review_report(
+            "codex_agent_review",
+            ReviewProviderKind::LocalAgent,
+            "ISSUE: Missing retry coverage\nISSUE: Wrong timeout",
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::ChangesRequested);
+        assert_eq!(report.findings.len(), 2);
+        assert!(report.findings.iter().all(|finding| finding.blocking));
+    }
+
+    #[test]
+    fn malformed_output_returns_failed_report() {
+        let report = parse_review_report(
+            "codex_cli_review",
+            ReviewProviderKind::LocalCli,
+            "review text without a decision",
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::Failed);
+    }
+
+    #[test]
+    fn gate_approves_when_required_providers_approve() {
+        let result = evaluate_review_gate(
+            &[approved_report(
+                "codex_cli_review",
+                ReviewProviderRole::Required,
+            )],
+            false,
+        );
+
+        assert_eq!(result.decision, ReviewGateDecision::Approved);
+    }
+
+    #[test]
+    fn gate_blocks_on_required_failure() {
+        let mut failed = approved_report("codex_cli_review", ReviewProviderRole::Required);
+        failed.report.decision = ReviewDecision::Failed;
+
+        let result = evaluate_review_gate(&[failed], false);
+
+        assert_eq!(result.decision, ReviewGateDecision::Blocked);
+        assert_eq!(
+            result.blocking_provider_id.as_deref(),
+            Some("codex_cli_review")
+        );
+    }
+
+    #[test]
+    fn gate_blocks_when_no_required_provider_report_exists() {
+        let result = evaluate_review_gate(
+            &[approved_report(
+                "gemini_github_bot",
+                ReviewProviderRole::Advisory,
+            )],
+            false,
+        );
+
+        assert_eq!(result.decision, ReviewGateDecision::Blocked);
+        assert_eq!(result.blocking_provider_id, None);
+    }
+
+    #[test]
+    fn gate_ignores_advisory_failure_when_external_not_required() {
+        let mut failed = approved_report("gemini_github_bot", ReviewProviderRole::Advisory);
+        failed.report.decision = ReviewDecision::Failed;
+
+        let result = evaluate_review_gate(
+            &[
+                approved_report("codex_cli_review", ReviewProviderRole::Required),
+                failed,
+            ],
+            false,
+        );
+
+        assert_eq!(result.decision, ReviewGateDecision::Approved);
+    }
+
+    #[test]
+    fn gate_blocks_on_advisory_failure_when_external_required() {
+        let mut failed = approved_report("gemini_github_bot", ReviewProviderRole::Advisory);
+        failed.report.decision = ReviewDecision::TimedOut;
+
+        let result = evaluate_review_gate(
+            &[
+                approved_report("codex_cli_review", ReviewProviderRole::Required),
+                failed,
+            ],
+            true,
+        );
+
+        assert_eq!(result.decision, ReviewGateDecision::Blocked);
+        assert_eq!(
+            result.blocking_provider_id.as_deref(),
+            Some("gemini_github_bot")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit review provider config for `codex_cli_review`, `codex_agent_review`, `gemini_github_bot`, and `codex_github_bot`
- preserve legacy review bot settings while normalizing fallback providers into explicit provider ids
- add normalized review report parsing and gate evaluation for local CLI, local agent, and external bot review providers

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test -p harness-core config::agents::agents_review_tests --lib`
- `cargo test -p harness-core review::tests --lib`
- `cargo test -p harness-core --lib -- --skip db::tests::`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets`
- `git diff --check`
- `git diff --cached --check`

`cargo test` was also run. It reached `harness-core` and failed only on the 12 `db::tests::*` tests because this local machine has no database configured: `HARNESS_DATABASE_URL` is empty, `localhost:5432` is closed, local Postgres tools are absent from PATH, and `scripts/dev-db.sh` reports that Docker Compose v2 is not installed.

Refs #1106
