### PR TITLE
test(server): narrow AppState DB setup lock lifetime

### DIFF
--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -140,7 +140,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
     let dir = expand_tilde(&server.config.server.data_dir);
     let project_root = resolve_project_root(&server.config.server.project_root)?;
     #[cfg(test)]
-    let db_state_guard = Some(crate::test_helpers::acquire_db_state_guard().await);
+    let db_setup_guard = crate::test_helpers::acquire_db_state_guard().await;
 
     tracing::debug!(
         data_dir = %dir.display(),
@@ -253,6 +253,8 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
 
     let (review_store, review_status) =
         build_review_store(&dir, server.config.server.database_url.as_deref()).await?;
+    #[cfg(test)]
+    drop(db_setup_guard);
     startup_statuses.push(review_status);
 
     // NOTE: add a matching entry here whenever a new optional store is added.
@@ -315,7 +317,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             workspace_mgr: registry.workspace_mgr,
         },
         #[cfg(test)]
-        _db_state_guard: db_state_guard,
+        _db_state_guard: None,
         runtime_hosts: services.runtime_hosts,
         runtime_project_cache: services.runtime_project_cache,
         runtime_state_persist_lock: Mutex::new(()),

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -176,6 +176,7 @@ mod tests {
     }
 
     async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> {
+        let db_setup_guard = crate::test_helpers::acquire_db_state_guard().await;
         let server = Arc::new(HarnessServer::new(
             HarnessConfig::default(),
             ThreadManager::new(),
@@ -226,6 +227,7 @@ mod tests {
             None,
             vec![],
         );
+        drop(db_setup_guard);
 
         Ok(AppState {
             core: crate::http::CoreServices {
@@ -267,7 +269,7 @@ mod tests {
                 workspace_mgr: None,
             },
             #[cfg(test)]
-            _db_state_guard: Some(crate::test_helpers::acquire_db_state_guard().await),
+            _db_state_guard: None,
             runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -201,8 +201,7 @@ async fn make_state_inner(
     agent_registry: AgentRegistry,
     mut config: HarnessConfig,
 ) -> anyhow::Result<AppState> {
-    #[cfg(test)]
-    let db_state_guard = Some(acquire_db_state_guard().await);
+    let db_setup_guard = acquire_db_state_guard().await;
     let database_url = ensure_test_database_url_override()?;
     config.server.database_url = Some(database_url.clone());
     let server = Arc::new(HarnessServer::new(
@@ -266,6 +265,7 @@ async fn make_state_inner(
         None,
         vec![],
     );
+    drop(db_setup_guard);
 
     Ok(AppState {
         core: crate::http::CoreServices {
@@ -305,7 +305,7 @@ async fn make_state_inner(
             workspace_mgr: None,
         },
         #[cfg(test)]
-        _db_state_guard: db_state_guard,
+        _db_state_guard: None,
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -266,6 +266,7 @@ mod tests {
         dir: &std::path::Path,
         config: HarnessConfig,
     ) -> anyhow::Result<AppState> {
+        let db_setup_guard = crate::test_helpers::acquire_db_state_guard().await;
         let notification_broadcast_capacity = config.server.notification_broadcast_capacity.max(1);
         let notification_lag_log_every = config.server.notification_lag_log_every;
         let server = Arc::new(HarnessServer::new(
@@ -321,6 +322,8 @@ mod tests {
             None,
             vec![],
         );
+        drop(db_setup_guard);
+
         Ok(AppState {
             core: crate::http::CoreServices {
                 server,
@@ -361,7 +364,7 @@ mod tests {
                 workspace_mgr: None,
             },
             #[cfg(test)]
-            _db_state_guard: Some(crate::test_helpers::acquire_db_state_guard().await),
+            _db_state_guard: None,
             runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),


### PR DESCRIPTION
## Summary

- Release the test DB setup lock after AppState stores finish opening instead of carrying it for the whole AppState lifetime.
- Apply the narrower lock lifetime to shared server test helpers, HTTP startup construction, stdio tests, and websocket tests.
- Leave oversized http/tests.rs and router/tests.rs untouched because repo guard requires those files to be split before editing.

Refs #1011

## Test plan

- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets
- cargo test -p harness-server --lib websocket::tests::is_local_origin_accepts_localhost_variants -- --exact
- cargo test -p harness-server --lib http::background::tests::runtime_worker_loop_policy_clamps_zero_concurrency -- --exact
- cargo test -p harness-server --lib -- --list

## Local test limitation

- cargo test --workspace was attempted but this machine has no HARNESS_DATABASE_URL, so DB-backed tests fail with: database URL is not configured; set server.database_url in TOML or HARNESS_DATABASE_URL in the environment.
- cargo test --workspace -- --skip db::tests:: was also attempted and still failed on DB-backed harness-server tests for the same missing local DB configuration.
- cargo test -p harness-server --lib websocket::tests::websocket_initialize_roundtrip -- --exact --nocapture was attempted and failed for the same missing HARNESS_DATABASE_URL.