### PR TITLE
fix(runtime): address unresolved P1 review followups

### DIFF
--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -14,6 +14,7 @@ pub mod quality_gate;
 pub mod reducer;
 pub mod repo_backlog;
 pub mod store;
+mod store_migrations;
 pub mod submission;
 pub mod validator;
 pub mod worker;

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -8,10 +8,11 @@ use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
 use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
 use super::reducer::{reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID};
 use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
+use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
 use super::validator::{DecisionValidator, ValidationContext};
 use anyhow::Context;
 use chrono::{DateTime, Utc};
-use harness_core::db::{Migration, PgStoreContext};
+use harness_core::db::PgStoreContext;
 use serde::Serialize;
 use serde_json::{json, Value};
 use sqlx::postgres::PgPool;
@@ -20,183 +21,6 @@ use std::path::Path;
 use uuid::Uuid;
 
 const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
-
-static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
-    Migration {
-        version: 1,
-        description: "create generic workflow runtime tables",
-        sql: "CREATE TABLE IF NOT EXISTS workflow_definitions (
-            id              TEXT NOT NULL,
-            version         BIGINT NOT NULL,
-            data            JSONB NOT NULL,
-            active          BOOLEAN NOT NULL DEFAULT TRUE,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (id, version)
-        );
-
-        CREATE TABLE IF NOT EXISTS workflow_instances (
-            id              TEXT PRIMARY KEY,
-            definition_id   TEXT NOT NULL,
-            state           TEXT NOT NULL,
-            subject_type    TEXT NOT NULL,
-            subject_key     TEXT NOT NULL,
-            parent_workflow_id TEXT,
-            data            JSONB NOT NULL,
-            version         BIGINT NOT NULL DEFAULT 0,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-
-        CREATE TABLE IF NOT EXISTS workflow_events (
-            id              TEXT PRIMARY KEY,
-            workflow_id     TEXT NOT NULL,
-            sequence        BIGINT NOT NULL,
-            event_type      TEXT NOT NULL,
-            source          TEXT NOT NULL,
-            data            JSONB NOT NULL,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE (workflow_id, sequence)
-        );
-
-        CREATE TABLE IF NOT EXISTS workflow_decisions (
-            id              TEXT PRIMARY KEY,
-            workflow_id     TEXT NOT NULL,
-            event_id        TEXT,
-            accepted        BOOLEAN NOT NULL,
-            data            JSONB NOT NULL,
-            rejection_reason TEXT,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-
-        CREATE TABLE IF NOT EXISTS workflow_commands (
-            id              TEXT PRIMARY KEY,
-            workflow_id     TEXT NOT NULL,
-            decision_id     TEXT,
-            command_type    TEXT NOT NULL,
-            dedupe_key      TEXT NOT NULL,
-            status          TEXT NOT NULL,
-            data            JSONB NOT NULL,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE (workflow_id, dedupe_key)
-        );
-
-        CREATE TABLE IF NOT EXISTS runtime_jobs (
-            id              TEXT PRIMARY KEY,
-            command_id      TEXT NOT NULL,
-            runtime_kind    TEXT NOT NULL,
-            runtime_profile TEXT NOT NULL,
-            status          TEXT NOT NULL,
-            data            JSONB NOT NULL,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-
-        CREATE TABLE IF NOT EXISTS runtime_events (
-            id              TEXT PRIMARY KEY,
-            runtime_job_id  TEXT NOT NULL,
-            sequence        BIGINT NOT NULL,
-            event_type      TEXT NOT NULL,
-            data            JSONB NOT NULL,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE (runtime_job_id, sequence)
-        );
-
-        CREATE TABLE IF NOT EXISTS workflow_artifacts (
-            id              TEXT PRIMARY KEY,
-            workflow_id     TEXT NOT NULL,
-            runtime_job_id  TEXT,
-            artifact_type   TEXT NOT NULL,
-            data            JSONB NOT NULL,
-            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        )",
-    },
-    Migration {
-        version: 2,
-        description: "index generic workflow runtime lookups",
-        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_subject
-              ON workflow_instances (definition_id, subject_type, subject_key);
-              CREATE INDEX IF NOT EXISTS idx_workflow_events_workflow_sequence
-              ON workflow_events (workflow_id, sequence);
-              CREATE INDEX IF NOT EXISTS idx_workflow_commands_status
-              ON workflow_commands (status, created_at);
-              CREATE INDEX IF NOT EXISTS idx_runtime_jobs_status
-              ON runtime_jobs (status, created_at);
-              CREATE INDEX IF NOT EXISTS idx_runtime_events_job_sequence
-              ON runtime_events (runtime_job_id, sequence)",
-    },
-    Migration {
-        version: 3,
-        description: "promote runtime job not_before to indexed column",
-        sql: "ALTER TABLE runtime_jobs
-              ADD COLUMN IF NOT EXISTS not_before TIMESTAMPTZ;
-              UPDATE runtime_jobs
-              SET not_before = (data->>'not_before')::timestamptz
-              WHERE not_before IS NULL
-                AND jsonb_typeof(data->'not_before') = 'string'
-                AND data->>'not_before' ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}';
-              CREATE INDEX IF NOT EXISTS idx_runtime_jobs_ready
-              ON runtime_jobs (status, not_before, created_at)",
-    },
-    Migration {
-        version: 4,
-        description: "index runtime workflow handle lookups",
-        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_state
-              ON workflow_instances (definition_id, state, updated_at);
-              CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_id
-              ON workflow_instances ((data->'data'->>'task_id'))",
-    },
-    Migration {
-        version: 5,
-        description: "index runtime workflow handle history",
-        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_ids
-              ON workflow_instances USING GIN ((data->'data'->'task_ids'))",
-    },
-    Migration {
-        version: 6,
-        description: "add workflow command dispatch leases",
-        sql: "ALTER TABLE workflow_commands
-              ADD COLUMN IF NOT EXISTS dispatch_owner TEXT;
-              ALTER TABLE workflow_commands
-              ADD COLUMN IF NOT EXISTS dispatch_lease_expires_at TIMESTAMPTZ;
-              CREATE INDEX IF NOT EXISTS idx_workflow_commands_dispatch_claim
-              ON workflow_commands (status, dispatch_lease_expires_at, created_at)",
-    },
-    Migration {
-        version: 7,
-        description: "index runtime issue workflow PR lookups",
-        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_project_pr
-              ON workflow_instances (
-                  definition_id,
-                  (data->'data'->>'project_id'),
-                  (data->'data'->>'pr_number'),
-                  updated_at DESC
-              )
-              WHERE data->'data'->>'pr_number' IS NOT NULL;
-              CREATE INDEX IF NOT EXISTS idx_workflow_instances_project_repo_pr
-              ON workflow_instances (
-                  definition_id,
-                  (data->'data'->>'project_id'),
-                  (data->'data'->>'repo'),
-                  (data->'data'->>'pr_number'),
-                  updated_at DESC
-              )
-              WHERE data->'data'->>'pr_number' IS NOT NULL",
-    },
-    Migration {
-        version: 8,
-        description: "index runtime job command pagination",
-        sql: "CREATE INDEX IF NOT EXISTS idx_runtime_jobs_command_created
-              ON runtime_jobs (command_id, created_at DESC, id DESC)",
-    },
-    Migration {
-        version: 9,
-        description: "index workflow events by type",
-        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_events_workflow_type_sequence
-              ON workflow_events (workflow_id, event_type, sequence DESC)",
-    },
-];
 
 pub struct WorkflowRuntimeStore {
     pool: PgPool,
@@ -597,7 +421,12 @@ impl WorkflowRuntimeStore {
                AND data->'data'->>'project_id' = $2
                AND ($3::text IS NULL OR data->'data'->>'repo' = $3)
                AND data->'data'->>'pr_number' = $4
-             ORDER BY updated_at DESC
+             ORDER BY
+               CASE
+                 WHEN subject_type = 'issue' OR data->'data' ? 'issue_number' THEN 0
+                 ELSE 1
+               END,
+               updated_at DESC
              LIMIT 1",
         )
         .bind(definition_id)
@@ -1500,6 +1329,24 @@ impl WorkflowRuntimeStore {
         result: &ActivityResult,
     ) -> anyhow::Result<Option<RuntimeActivityCompletion>> {
         let mut tx = self.pool.begin().await?;
+        let command_id_row: Option<(String,)> =
+            sqlx::query_as("SELECT command_id FROM runtime_jobs WHERE id = $1")
+                .bind(runtime_job_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((command_id,)) = command_id_row else {
+            anyhow::bail!("runtime job not found: {runtime_job_id}");
+        };
+        let command_row: Option<WorkflowCommandRecordRow> = sqlx::query_as(
+            "SELECT id, workflow_id, decision_id, status, dispatch_owner,
+                    dispatch_lease_expires_at, data::text, created_at, updated_at
+             FROM workflow_commands
+             WHERE id = $1
+             FOR UPDATE",
+        )
+        .bind(&command_id)
+        .fetch_optional(&mut *tx)
+        .await?;
         let row: Option<(String,)> =
             sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1 FOR UPDATE")
                 .bind(runtime_job_id)
@@ -1532,16 +1379,6 @@ impl WorkflowRuntimeStore {
         .bind(&updated)
         .bind(runtime_job_id)
         .execute(&mut *tx)
-        .await?;
-        let command_row: Option<WorkflowCommandRecordRow> = sqlx::query_as(
-            "SELECT id, workflow_id, decision_id, status, dispatch_owner,
-                    dispatch_lease_expires_at, data::text, created_at, updated_at
-             FROM workflow_commands
-             WHERE id = $1
-             FOR UPDATE",
-        )
-        .bind(&job.command_id)
-        .fetch_optional(&mut *tx)
         .await?;
         let Some(command_row) = command_row else {
             tx.commit().await?;

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -1,0 +1,178 @@
+use harness_core::db::Migration;
+
+pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create generic workflow runtime tables",
+        sql: "CREATE TABLE IF NOT EXISTS workflow_definitions (
+            id              TEXT NOT NULL,
+            version         BIGINT NOT NULL,
+            data            JSONB NOT NULL,
+            active          BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id, version)
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_instances (
+            id              TEXT PRIMARY KEY,
+            definition_id   TEXT NOT NULL,
+            state           TEXT NOT NULL,
+            subject_type    TEXT NOT NULL,
+            subject_key     TEXT NOT NULL,
+            parent_workflow_id TEXT,
+            data            JSONB NOT NULL,
+            version         BIGINT NOT NULL DEFAULT 0,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_events (
+            id              TEXT PRIMARY KEY,
+            workflow_id     TEXT NOT NULL,
+            sequence        BIGINT NOT NULL,
+            event_type      TEXT NOT NULL,
+            source          TEXT NOT NULL,
+            data            JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (workflow_id, sequence)
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_decisions (
+            id              TEXT PRIMARY KEY,
+            workflow_id     TEXT NOT NULL,
+            event_id        TEXT,
+            accepted        BOOLEAN NOT NULL,
+            data            JSONB NOT NULL,
+            rejection_reason TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_commands (
+            id              TEXT PRIMARY KEY,
+            workflow_id     TEXT NOT NULL,
+            decision_id     TEXT,
+            command_type    TEXT NOT NULL,
+            dedupe_key      TEXT NOT NULL,
+            status          TEXT NOT NULL,
+            data            JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (workflow_id, dedupe_key)
+        );
+
+        CREATE TABLE IF NOT EXISTS runtime_jobs (
+            id              TEXT PRIMARY KEY,
+            command_id      TEXT NOT NULL,
+            runtime_kind    TEXT NOT NULL,
+            runtime_profile TEXT NOT NULL,
+            status          TEXT NOT NULL,
+            data            JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS runtime_events (
+            id              TEXT PRIMARY KEY,
+            runtime_job_id  TEXT NOT NULL,
+            sequence        BIGINT NOT NULL,
+            event_type      TEXT NOT NULL,
+            data            JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (runtime_job_id, sequence)
+        );
+
+        CREATE TABLE IF NOT EXISTS workflow_artifacts (
+            id              TEXT PRIMARY KEY,
+            workflow_id     TEXT NOT NULL,
+            runtime_job_id  TEXT,
+            artifact_type   TEXT NOT NULL,
+            data            JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "index generic workflow runtime lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_subject
+              ON workflow_instances (definition_id, subject_type, subject_key);
+              CREATE INDEX IF NOT EXISTS idx_workflow_events_workflow_sequence
+              ON workflow_events (workflow_id, sequence);
+              CREATE INDEX IF NOT EXISTS idx_workflow_commands_status
+              ON workflow_commands (status, created_at);
+              CREATE INDEX IF NOT EXISTS idx_runtime_jobs_status
+              ON runtime_jobs (status, created_at);
+              CREATE INDEX IF NOT EXISTS idx_runtime_events_job_sequence
+              ON runtime_events (runtime_job_id, sequence)",
+    },
+    Migration {
+        version: 3,
+        description: "promote runtime job not_before to indexed column",
+        sql: "ALTER TABLE runtime_jobs
+              ADD COLUMN IF NOT EXISTS not_before TIMESTAMPTZ;
+              UPDATE runtime_jobs
+              SET not_before = (data->>'not_before')::timestamptz
+              WHERE not_before IS NULL
+                AND jsonb_typeof(data->'not_before') = 'string'
+                AND data->>'not_before' ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}';
+              CREATE INDEX IF NOT EXISTS idx_runtime_jobs_ready
+              ON runtime_jobs (status, not_before, created_at)",
+    },
+    Migration {
+        version: 4,
+        description: "index runtime workflow handle lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_state
+              ON workflow_instances (definition_id, state, updated_at);
+              CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_id
+              ON workflow_instances ((data->'data'->>'task_id'))",
+    },
+    Migration {
+        version: 5,
+        description: "index runtime workflow handle history",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_task_ids
+              ON workflow_instances USING GIN ((data->'data'->'task_ids'))",
+    },
+    Migration {
+        version: 6,
+        description: "add workflow command dispatch leases",
+        sql: "ALTER TABLE workflow_commands
+              ADD COLUMN IF NOT EXISTS dispatch_owner TEXT;
+              ALTER TABLE workflow_commands
+              ADD COLUMN IF NOT EXISTS dispatch_lease_expires_at TIMESTAMPTZ;
+              CREATE INDEX IF NOT EXISTS idx_workflow_commands_dispatch_claim
+              ON workflow_commands (status, dispatch_lease_expires_at, created_at)",
+    },
+    Migration {
+        version: 7,
+        description: "index runtime issue workflow PR lookups",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_project_pr
+              ON workflow_instances (
+                  definition_id,
+                  (data->'data'->>'project_id'),
+                  (data->'data'->>'pr_number'),
+                  updated_at DESC
+              )
+              WHERE data->'data'->>'pr_number' IS NOT NULL;
+              CREATE INDEX IF NOT EXISTS idx_workflow_instances_project_repo_pr
+              ON workflow_instances (
+                  definition_id,
+                  (data->'data'->>'project_id'),
+                  (data->'data'->>'repo'),
+                  (data->'data'->>'pr_number'),
+                  updated_at DESC
+              )
+              WHERE data->'data'->>'pr_number' IS NOT NULL",
+    },
+    Migration {
+        version: 8,
+        description: "index runtime job command pagination",
+        sql: "CREATE INDEX IF NOT EXISTS idx_runtime_jobs_command_created
+              ON runtime_jobs (command_id, created_at DESC, id DESC)",
+    },
+    Migration {
+        version: 9,
+        description: "index workflow events by type",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_events_workflow_type_sequence
+              ON workflow_events (workflow_id, event_type, sequence DESC)",
+    },
+];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -35,6 +35,8 @@ use std::sync::{
     Arc, Mutex,
 };
 
+mod p1_followups;
+
 fn issue_instance(state: &str) -> WorkflowInstance {
     WorkflowInstance::new(
         "github_issue_pr",

--- a/crates/harness-workflow/src/runtime/tests/p1_followups.rs
+++ b/crates/harness-workflow/src/runtime/tests/p1_followups.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[tokio::test]
+async fn runtime_store_get_instance_by_pr_prefers_issue_bound_workflow() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let issue_bound = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "pr_open",
+        WorkflowSubject::new("issue", "issue:77"),
+    )
+    .with_id("project-a::owner/repo::issue:77")
+    .with_data(json!({
+        "project_id": "project-a",
+        "repo": "owner/repo",
+        "issue_number": 77,
+        "pr_number": 880,
+    }));
+    let pr_only = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "awaiting_feedback",
+        WorkflowSubject::new("pull_request", "pr:880"),
+    )
+    .with_id("project-a::owner/repo::pr:880")
+    .with_data(json!({
+        "project_id": "project-a",
+        "repo": "owner/repo",
+        "pr_number": 880,
+    }));
+    store.upsert_instance(&issue_bound).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    store.upsert_instance(&pr_only).await?;
+
+    let found = store
+        .get_instance_by_pr("github_issue_pr", "project-a", Some("owner/repo"), 880)
+        .await?
+        .expect("matching runtime workflow should be found");
+    assert_eq!(found.id, issue_bound.id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_completes_job_when_workflow_already_done() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = issue_instance("done");
+    store.upsert_instance(&instance).await?;
+    let job = store
+        .enqueue_runtime_job(
+            "command-terminal-done",
+            RuntimeKind::ClaudeCode,
+            "claude-default",
+            json!({ "activity": "implement_issue", "workflow_id": instance.id }),
+        )
+        .await?;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let worker = RuntimeWorker::new(&store, "runtime-1");
+    let executor = CountingRuntimeExecutor {
+        result: ActivityResult::failed("implement_issue", "should not run", "unexpected call"),
+        calls: calls.clone(),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should complete stale terminal job");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(completed.id, job.id);
+    assert_eq!(completed.status, RuntimeJobStatus::Succeeded);
+    let output: ActivityResult =
+        serde_json::from_value(completed.output.expect("activity result output"))?;
+    assert_eq!(output.status, ActivityStatus::Succeeded);
+    assert!(output.summary.contains("already terminal (done)"));
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -140,13 +140,17 @@ impl<'a> RuntimeWorker<'a> {
         if !instance.is_terminal() {
             return Ok(None);
         }
-        Ok(Some(ActivityResult::cancelled(
-            runtime_job_activity_name(job),
-            format!(
-                "Workflow {} was already terminal ({}) before runtime execution.",
-                instance.id, instance.state
-            ),
-        )))
+        let activity = runtime_job_activity_name(job);
+        let summary = format!(
+            "Workflow {} was already terminal ({}) before runtime execution.",
+            instance.id, instance.state
+        );
+        let result = match instance.state.as_str() {
+            "cancelled" => ActivityResult::cancelled(activity, summary),
+            "failed" => ActivityResult::failed(activity, summary, "workflow already failed"),
+            _ => ActivityResult::succeeded(activity, summary),
+        };
+        Ok(Some(result))
     }
 
     async fn execute_with_lease_renewal(

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -24,8 +24,16 @@ function createMemoryStorage(): Storage {
   };
 }
 
+function readGlobalStorage(): Storage | null {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return null;
+  }
+}
+
 if (typeof window !== "undefined") {
-  const globalStorage = globalThis.localStorage;
+  const globalStorage = readGlobalStorage();
   const hasUsableStorage =
     typeof globalStorage?.getItem === "function" &&
     typeof globalStorage?.setItem === "function" &&


### PR DESCRIPTION
## Summary
- prefer issue-bound workflow instances when resolving PR feedback by PR number
- keep runtime completion and cancellation paths on a command-first lock order
- mark stale runtime jobs for already-terminal workflows according to the terminal state instead of always cancelling them
- guard web test setup localStorage access for opaque-origin environments
- move workflow runtime migrations into a focused module so store.rs stays below the U-16 limit

Refs #1162.

## Verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=target/cargo-check cargo check --workspace --all-targets -j 6
- CARGO_TARGET_DIR=target/cargo-check RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets -j 6
- CARGO_TARGET_DIR=target/cargo-test cargo test -p harness-workflow p1_followups -- --nocapture
- CARGO_TARGET_DIR=target/cargo-test cargo test -p harness-workflow --all-targets -j 6
- npx tsc --noEmit (web)
- npx vitest run (web)

## Note
- cargo test --workspace --all-targets -j 6 was attempted, but existing harness-core db tests failed because HARNESS_DATABASE_URL/server.database_url is not configured in this environment.