### PR TITLE
fix(runtime): extend repo backlog timeout

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -39,7 +39,7 @@ runtime_dispatch:
     poll_repo_backlog:
       runtime_kind: codex_exec
       runtime_profile: codex-backlog-exec
-      timeout_secs: 600
+      timeout_secs: 3600
 runtime_worker:
   enabled: true
   interval_secs: 5

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -137,7 +137,7 @@ pub struct RuntimeDispatchPolicy {
     pub timeout_secs: Option<u64>,
     #[serde(default)]
     pub workflow_profiles: BTreeMap<String, RuntimeDispatchProfileOverride>,
-    #[serde(default)]
+    #[serde(default = "default_runtime_dispatch_activity_profiles")]
     pub activity_profiles: BTreeMap<String, RuntimeDispatchProfileOverride>,
     #[serde(default)]
     pub workflow_activity_profiles:
@@ -288,8 +288,48 @@ impl Default for RuntimeDispatchPolicy {
             max_turns: None,
             timeout_secs: None,
             workflow_profiles: BTreeMap::new(),
-            activity_profiles: BTreeMap::new(),
+            activity_profiles: default_runtime_dispatch_activity_profiles(),
             workflow_activity_profiles: BTreeMap::new(),
+        }
+    }
+}
+
+impl RuntimeDispatchPolicy {
+    fn apply_default_activity_profiles(&mut self) {
+        for (activity, default_profile) in default_runtime_dispatch_activity_profiles() {
+            self.activity_profiles
+                .entry(activity)
+                .and_modify(|profile| profile.apply_defaults_from(&default_profile))
+                .or_insert(default_profile);
+        }
+    }
+}
+
+impl RuntimeDispatchProfileOverride {
+    fn apply_defaults_from(&mut self, default: &Self) {
+        if self.runtime_kind.is_none() {
+            self.runtime_kind = default.runtime_kind.clone();
+        }
+        if self.runtime_profile.is_none() {
+            self.runtime_profile = default.runtime_profile.clone();
+        }
+        if self.model.is_none() {
+            self.model = default.model.clone();
+        }
+        if self.reasoning_effort.is_none() {
+            self.reasoning_effort = default.reasoning_effort.clone();
+        }
+        if self.sandbox.is_none() {
+            self.sandbox = default.sandbox.clone();
+        }
+        if self.approval_policy.is_none() {
+            self.approval_policy = default.approval_policy.clone();
+        }
+        if self.max_turns.is_none() {
+            self.max_turns = default.max_turns;
+        }
+        if self.timeout_secs.is_none() {
+            self.timeout_secs = default.timeout_secs;
         }
     }
 }
@@ -412,6 +452,19 @@ fn default_runtime_dispatch_batch_limit() -> u32 {
     25
 }
 
+fn default_runtime_dispatch_activity_profiles() -> BTreeMap<String, RuntimeDispatchProfileOverride>
+{
+    BTreeMap::from([(
+        "poll_repo_backlog".to_string(),
+        RuntimeDispatchProfileOverride {
+            runtime_kind: Some("codex_exec".to_string()),
+            runtime_profile: Some("codex-backlog-exec".to_string()),
+            timeout_secs: Some(3600),
+            ..Default::default()
+        },
+    )])
+}
+
 fn default_runtime_worker_interval_secs() -> u64 {
     5
 }
@@ -456,7 +509,7 @@ pub fn load_workflow_document(project_root: &Path) -> anyhow::Result<WorkflowDoc
     };
 
     let (front_matter, prompt_template) = split_front_matter_and_body(&contents);
-    let config = match front_matter {
+    let mut config = match front_matter {
         None => WorkflowConfig::default(),
         Some(front_matter) if front_matter.trim().is_empty() => WorkflowConfig::default(),
         Some(front_matter) => serde_yaml::from_str(front_matter).map_err(|e| {
@@ -466,6 +519,7 @@ pub fn load_workflow_document(project_root: &Path) -> anyhow::Result<WorkflowDoc
             )
         })?,
     };
+    config.runtime_dispatch.apply_default_activity_profiles();
 
     Ok(WorkflowDocument {
         config,

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -42,7 +42,27 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.runtime_dispatch.max_turns, None);
     assert_eq!(cfg.runtime_dispatch.timeout_secs, None);
     assert!(cfg.runtime_dispatch.workflow_profiles.is_empty());
-    assert!(cfg.runtime_dispatch.activity_profiles.is_empty());
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.runtime_kind.as_deref()),
+        Some("codex_exec")
+    );
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.runtime_profile.as_deref()),
+        Some("codex-backlog-exec")
+    );
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.timeout_secs),
+        Some(3600)
+    );
     assert!(cfg.runtime_dispatch.workflow_activity_profiles.is_empty());
     assert!(cfg.runtime_worker.enabled);
     assert_eq!(cfg.runtime_worker.interval_secs, 5);
@@ -256,6 +276,27 @@ Body
     );
     assert_eq!(replan_profile.model.as_deref(), Some("gpt-5.4-mini"));
     assert_eq!(replan_profile.timeout_secs, Some(180));
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.runtime_kind.as_deref()),
+        Some("codex_exec")
+    );
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.runtime_profile.as_deref()),
+        Some("codex-backlog-exec")
+    );
+    assert_eq!(
+        cfg.runtime_dispatch
+            .activity_profiles
+            .get("poll_repo_backlog")
+            .and_then(|profile| profile.timeout_secs),
+        Some(3600)
+    );
     let issue_replan_profile = cfg
         .runtime_dispatch
         .workflow_activity_profiles
@@ -324,6 +365,53 @@ fn load_workflow_document_reads_prompt_template_body() -> anyhow::Result<()> {
         .source_path
         .as_deref()
         .is_some_and(|path| { path.ends_with("WORKFLOW.md") }));
+    Ok(())
+}
+
+#[test]
+fn load_workflow_config_merges_poll_activity_profile_defaults() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    std::fs::write(
+        dir.path().join("WORKFLOW.md"),
+        r#"---
+runtime_dispatch:
+  activity_profiles:
+    poll_repo_backlog:
+      timeout_secs: 7200
+  workflow_activity_profiles:
+    repo_backlog:
+      poll_repo_backlog:
+        timeout_secs: 5400
+---
+Body
+"#,
+    )?;
+
+    let cfg = load_workflow_config(dir.path())?;
+    let poll_profile = cfg
+        .runtime_dispatch
+        .activity_profiles
+        .get("poll_repo_backlog");
+    assert_eq!(
+        poll_profile.and_then(|profile| profile.runtime_kind.as_deref()),
+        Some("codex_exec")
+    );
+    assert_eq!(
+        poll_profile.and_then(|profile| profile.runtime_profile.as_deref()),
+        Some("codex-backlog-exec")
+    );
+    assert_eq!(
+        poll_profile.and_then(|profile| profile.timeout_secs),
+        Some(7200)
+    );
+    assert_eq!(
+        cfg.runtime_dispatch
+            .workflow_activity_profiles
+            .get("repo_backlog")
+            .and_then(|profiles| profiles.get("poll_repo_backlog"))
+            .and_then(|profile| profile.timeout_secs),
+        Some(5400)
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -155,7 +155,7 @@ async fn workflow_has_active_repo_backlog_work(
     workflow_id: &str,
 ) -> anyhow::Result<bool> {
     let commands = store.commands_for(workflow_id).await?;
-    for command in commands.iter().filter(is_repo_backlog_poll_command) {
+    for command in commands.iter().rev().filter(is_repo_backlog_poll_command) {
         match command.status.as_str() {
             "pending" | "dispatching" => return Ok(true),
             "dispatched" => {

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -26,7 +26,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use harness_workflow::runtime::WorkflowRuntimeStore;
+use harness_workflow::runtime::{
+    RuntimeJobStatus, WorkflowCommandRecord, WorkflowRuntimeStore, REPO_BACKLOG_POLL_ACTIVITY,
+};
 
 use crate::http::AppState;
 
@@ -66,11 +68,12 @@ pub struct StaleRecoveryTick {
     pub scanned: usize,
     pub recovered: usize,
     pub failed: usize,
+    pub skipped_active: usize,
 }
 
 impl StaleRecoveryTick {
     fn has_recovery_activity(&self) -> bool {
-        self.scanned > 0
+        self.scanned > 0 || self.skipped_active > 0
     }
 }
 
@@ -93,6 +96,16 @@ pub async fn run_stale_workflow_recovery_tick(
             tick.scanned += 1;
             let original_state = instance.state.clone();
             let stuck_secs = (Utc::now() - instance.updated_at).num_seconds();
+            if workflow_has_active_repo_backlog_work(store, &instance.id).await? {
+                tick.skipped_active += 1;
+                tracing::debug!(
+                    workflow_id = %instance.id,
+                    state = %original_state,
+                    stuck_secs,
+                    "stale_workflow_recovery: skipped workflow with active repo backlog runtime work"
+                );
+                continue;
+            }
             instance.state = RECOVERY_TARGET_STATE.to_string();
             instance.version = instance.version.saturating_add(1);
             // Bump the JSON-baked updated_at so subsequent recovery ticks see a
@@ -137,6 +150,35 @@ pub async fn run_stale_workflow_recovery_tick(
     Ok(tick)
 }
 
+async fn workflow_has_active_repo_backlog_work(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
+    let commands = store.commands_for(workflow_id).await?;
+    for command in commands.iter().filter(is_repo_backlog_poll_command) {
+        match command.status.as_str() {
+            "pending" | "dispatching" => return Ok(true),
+            "dispatched" => {
+                let jobs = store.runtime_jobs_for_command(&command.id).await?;
+                if jobs.iter().any(|job| {
+                    matches!(
+                        job.status,
+                        RuntimeJobStatus::Pending | RuntimeJobStatus::Running
+                    )
+                }) {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+fn is_repo_backlog_poll_command(command: &&WorkflowCommandRecord) -> bool {
+    command.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
+}
+
 /// Spawn the periodic recovery loop. Idempotent across restarts because each
 /// tick is itself idempotent: workflows that have moved out of the stuck
 /// state set since the last tick are simply not returned by the query.
@@ -162,6 +204,7 @@ pub fn spawn_stale_workflow_recovery(state: &Arc<AppState>) {
                         scanned = tick.scanned,
                         recovered = tick.recovered,
                         failed = tick.failed,
+                        skipped_active = tick.skipped_active,
                         "stale_workflow_recovery: tick complete"
                     );
                 }
@@ -180,7 +223,10 @@ pub fn spawn_stale_workflow_recovery(state: &Arc<AppState>) {
 mod tests {
     use super::*;
     use harness_core::db::resolve_database_url;
-    use harness_workflow::runtime::{WorkflowInstance, WorkflowSubject};
+    use harness_workflow::runtime::{
+        RuntimeKind, WorkflowCommand, WorkflowInstance, WorkflowSubject,
+    };
+    use serde_json::json;
     use std::sync::Arc;
 
     async fn open_recovery_test_store() -> Option<Arc<WorkflowRuntimeStore>> {
@@ -334,5 +380,44 @@ mod tests {
             "fresh stuck workflow should not be reset before threshold"
         );
         assert_eq!(tick.recovered, 0);
+    }
+
+    #[tokio::test]
+    async fn recovery_tick_skips_workflow_with_active_runtime_job() -> anyhow::Result<()> {
+        let Some(store) = open_recovery_test_store().await else {
+            return Ok(());
+        };
+        let id = "test::stale-recovery::active-runtime-job";
+        let mut instance = stuck_instance(id, "scanning");
+        instance.updated_at = Utc::now() - chrono::Duration::hours(1);
+        store.upsert_instance(&instance).await?;
+        let command =
+            WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "active-runtime-job");
+        let command_id = store.enqueue_command(id, None, &command).await?;
+        store
+            .enqueue_runtime_job(
+                &command_id,
+                RuntimeKind::CodexJsonrpc,
+                "codex-default",
+                json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
+            )
+            .await?;
+        store.mark_command_status(&command_id, "dispatched").await?;
+
+        let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
+
+        let after = store.get_instance(id).await?.ok_or_else(|| {
+            anyhow::anyhow!("active runtime workflow missing after recovery tick")
+        })?;
+        assert_eq!(
+            after.state, "scanning",
+            "active runtime work must protect the workflow from stale recovery"
+        );
+        assert_eq!(tick.recovered, 0);
+        assert!(
+            tick.skipped_active >= 1,
+            "active runtime job should be counted as an active skip"
+        );
+        Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -29,7 +29,7 @@ use super::workspace::{finish_runtime_workspace, prepare_runtime_workspace};
 
 const DEFAULT_RUNTIME_TURN_TIMEOUT_SECS: u64 = 3600;
 const DEFAULT_PR_FEEDBACK_INSPECT_TIMEOUT_SECS: u64 = 3600;
-const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 3600;
 
 pub(super) struct ServerRuntimeJobExecutor<'a> {
     state: &'a Arc<AppState>,
@@ -450,7 +450,7 @@ mod tests {
         );
         assert_eq!(
             runtime_timeout_fallback(&config, None, &runtime_job("poll_repo_backlog")),
-            Some(600)
+            Some(3600)
         );
         assert_eq!(
             runtime_timeout_fallback(&config, None, &runtime_job("implement_issue")),

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -38,17 +38,24 @@ pub struct RuntimeProfileSelector {
 
 impl RuntimeProfileSelector {
     pub fn new(default_profile: RuntimeProfile) -> Self {
-        let mut activity_profiles = BTreeMap::new();
-        activity_profiles.insert(
-            REPO_BACKLOG_POLL_ACTIVITY.to_string(),
-            default_repo_backlog_poll_runtime_profile(&default_profile),
-        );
+        let activity_profiles = Self::default_activity_profiles(&default_profile);
         Self {
             default_profile,
             workflow_profiles: BTreeMap::new(),
             activity_profiles,
             workflow_activity_profiles: BTreeMap::new(),
         }
+    }
+
+    fn default_activity_profiles(
+        default_profile: &RuntimeProfile,
+    ) -> BTreeMap<String, RuntimeProfile> {
+        let mut activity_profiles = BTreeMap::new();
+        activity_profiles.insert(
+            REPO_BACKLOG_POLL_ACTIVITY.to_string(),
+            default_repo_backlog_poll_runtime_profile(default_profile),
+        );
+        activity_profiles
     }
 
     pub fn with_workflow_profile(

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,4 +1,5 @@
-use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord};
+use super::model::{RuntimeJob, RuntimeKind, RuntimeProfile, WorkflowCommandRecord};
+use super::repo_backlog::REPO_BACKLOG_POLL_ACTIVITY;
 use super::store::{RuntimeJobEnqueueOutcome, WorkflowRuntimeStore};
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
@@ -8,6 +9,8 @@ use uuid::Uuid;
 
 const COMMAND_STATUS_SKIPPED: &str = "skipped";
 const COMMAND_STATUS_CANCELLED: &str = "cancelled";
+const DEFAULT_REPO_BACKLOG_POLL_RUNTIME_PROFILE: &str = "codex-backlog-exec";
+const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 3600;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandDispatchOutcome {
@@ -35,10 +38,15 @@ pub struct RuntimeProfileSelector {
 
 impl RuntimeProfileSelector {
     pub fn new(default_profile: RuntimeProfile) -> Self {
+        let mut activity_profiles = BTreeMap::new();
+        activity_profiles.insert(
+            REPO_BACKLOG_POLL_ACTIVITY.to_string(),
+            default_repo_backlog_poll_runtime_profile(&default_profile),
+        );
         Self {
             default_profile,
             workflow_profiles: BTreeMap::new(),
-            activity_profiles: BTreeMap::new(),
+            activity_profiles,
             workflow_activity_profiles: BTreeMap::new(),
         }
     }
@@ -93,6 +101,25 @@ impl RuntimeProfileSelector {
             .and_then(|id| self.workflow_profiles.get(id))
             .unwrap_or(&self.default_profile)
     }
+}
+
+fn default_repo_backlog_poll_runtime_profile(default_profile: &RuntimeProfile) -> RuntimeProfile {
+    let mut profile = RuntimeProfile::new(
+        DEFAULT_REPO_BACKLOG_POLL_RUNTIME_PROFILE,
+        RuntimeKind::CodexExec,
+    );
+    if matches!(
+        default_profile.kind,
+        RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc
+    ) {
+        profile.model = default_profile.model.clone();
+        profile.reasoning_effort = default_profile.reasoning_effort.clone();
+        profile.approval_policy = default_profile.approval_policy.clone();
+    }
+    profile.sandbox = default_profile.sandbox.clone();
+    profile.max_turns = default_profile.max_turns;
+    profile.timeout_secs = Some(DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS);
+    profile
 }
 
 impl From<RuntimeProfile> for RuntimeProfileSelector {
@@ -286,4 +313,43 @@ fn retry_not_before_for_command(
                 command.id
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_selector_defaults_repo_backlog_poll_to_codex_exec() {
+        let mut default_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        default_profile.model = Some("gpt-5.5".to_string());
+        default_profile.reasoning_effort = Some("high".to_string());
+
+        let selector = RuntimeProfileSelector::new(default_profile);
+        let profile = selector.select(Some("repo_backlog"), Some(REPO_BACKLOG_POLL_ACTIVITY));
+
+        assert_eq!(profile.kind, RuntimeKind::CodexExec);
+        assert_eq!(profile.name, DEFAULT_REPO_BACKLOG_POLL_RUNTIME_PROFILE);
+        assert_eq!(profile.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(profile.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(
+            profile.timeout_secs,
+            Some(DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn profile_selector_allows_explicit_repo_backlog_poll_override() {
+        let default_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        let mut override_profile = RuntimeProfile::new("custom-backlog", RuntimeKind::ClaudeCode);
+        override_profile.timeout_secs = Some(7200);
+
+        let selector = RuntimeProfileSelector::new(default_profile)
+            .with_activity_profile(REPO_BACKLOG_POLL_ACTIVITY, override_profile);
+        let profile = selector.select(Some("repo_backlog"), Some(REPO_BACKLOG_POLL_ACTIVITY));
+
+        assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
+        assert_eq!(profile.name, "custom-backlog");
+        assert_eq!(profile.timeout_secs, Some(7200));
+    }
 }


### PR DESCRIPTION
## Summary
- extend the repo backlog poll timeout from 600s to 3600s in the default workflow profile
- align the server fallback timeout for `poll_repo_backlog` runtime jobs with the 3600s global turn timeout
- prevent stale workflow recovery from resetting repo backlog workflows while their poll command or runtime job is still active

## Why
The backlog poll activity can run longer than 600s when a repository has a large issue/PR backlog. Increasing the timeout alone exposed a second mismatch: stale workflow recovery could reset `repo_backlog` workflows after 1800s even though their runtime jobs were still legitimately running. This PR fixes both parts so the workflow state remains consistent for long backlog polls.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --package harness-server`
- `cargo test --package harness-server stale_workflow_recovery`
- `cargo test --package harness-server runtime_timeout_fallback_has_global_activity_defaults`
- `cargo test --package harness-server`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `git diff --check`