### PR TITLE
fix(runtime): prioritize non-backlog jobs

### DIFF
--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1168,7 +1168,18 @@ impl WorkflowRuntimeStore {
                  AND (data->'lease' ? 'expires_at')
                  AND (data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
              )
-             ORDER BY created_at ASC
+             ORDER BY
+                 CASE
+                     WHEN COALESCE(data #>> '{input,activity}', '') IN (
+                         'implement_issue',
+                         'implement_prompt',
+                         'inspect_pr_feedback',
+                         'address_pr_feedback'
+                     ) THEN 0
+                     WHEN COALESCE(data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
+                     ELSE 1
+                 END ASC,
+                 created_at ASC
              LIMIT 1
              FOR UPDATE SKIP LOCKED",
         )

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -4348,6 +4348,65 @@ async fn runtime_store_reclaims_expired_running_job() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn runtime_store_prioritizes_ready_work_over_older_backlog_jobs() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let backlog = store
+        .enqueue_runtime_job(
+            "command-backlog",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
+        )
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let sprint_plan = store
+        .enqueue_runtime_job(
+            "command-sprint-plan",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY }),
+        )
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let implementation = store
+        .enqueue_runtime_job(
+            "command-implement",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+
+    let first = store
+        .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("ready implementation job should be claimed first"))?;
+    assert_eq!(first.id, implementation.id);
+
+    let second = store
+        .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!("ready non-backlog job should be claimed before backlog scan")
+        })?;
+    assert_eq!(second.id, sprint_plan.id);
+
+    let third = store
+        .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!("backlog scan should still run when higher-priority jobs are drained")
+        })?;
+    assert_eq!(third.id, backlog.id);
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_store_does_not_reclaim_unexpired_running_job() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());


### PR DESCRIPTION
## Summary
- prioritize implementation and PR feedback runtime jobs ahead of repo backlog polling
- keep other non-backlog activities ahead of `poll_repo_backlog`
- add a regression test where an older backlog job must wait behind newer implementation and sprint-planning work

Fixes #1168.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --package harness-workflow`
- `cargo test --package harness-workflow runtime_store_prioritizes_ready_work_over_older_backlog_jobs -- --nocapture`
- `cargo test --package harness-workflow`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`