### PR TITLE
fix(runtime): require prompt task validation evidence

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -132,6 +132,7 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)
                 .with_accepted_artifacts(vec!["validation_report"])
+                .requires("validation_evidence")
         }
         (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -401,6 +401,7 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({
             "on_succeeded": {
                 "reducer_next_state": "done",
+                "success_requires": "A succeeded implement_prompt result MUST include validation evidence via validation records or a validation_report artifact.",
                 "required_summary": "Include changed files, validation commands, and remaining blockers."
             },
             "on_failed": {
@@ -473,7 +474,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["workflow table mutations", "unverified merge claims"],
             "artifacts": {
                 "validation_report": {
-                    "optional": true,
+                    "required_when": "No validation records are present in the activity result.",
                     "fields": ["commands", "passed", "failed", "blocked"]
                 }
             }

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -129,6 +129,14 @@ fn reduce_success(
         return quality_gate_success_decision(instance, event, result);
     }
 
+    if prompt_task_activity_matches(instance, result) {
+        if let Some(reason) = prompt_task_success_contract_error(result) {
+            return Some(invalid_agent_output_blocked_decision(
+                instance, event, result, reason,
+            ));
+        }
+    }
+
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
         return Some(decision);
     }
@@ -307,11 +315,18 @@ fn structured_decision_validates(
     {
         return false;
     }
+    if prompt_task_activity_matches(instance, result)
+        && decision.next_state == "done"
+        && prompt_task_success_contract_error(result).is_some()
+    {
+        return false;
+    }
 
     let validator = match instance.definition_id.as_str() {
         GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
         QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
         PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
+        PROMPT_TASK_DEFINITION_ID => DecisionValidator::prompt_task(),
         REPO_BACKLOG_DEFINITION_ID => DecisionValidator::repo_backlog(),
         _ => return true,
     };
@@ -322,4 +337,87 @@ fn structured_decision_validates(
             &ValidationContext::new(event.source.as_str(), Utc::now()),
         )
         .is_ok()
+}
+
+fn prompt_task_activity_matches(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
+    (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) == (
+        PROMPT_TASK_DEFINITION_ID,
+        "implementing",
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    )
+}
+
+fn prompt_task_success_contract_error(result: &ActivityResult) -> Option<&'static str> {
+    if prompt_task_has_validation_evidence(result) {
+        None
+    } else {
+        Some("implement_prompt succeeded without validation evidence")
+    }
+}
+
+fn prompt_task_has_validation_evidence(result: &ActivityResult) -> bool {
+    result
+        .validation
+        .iter()
+        .any(|record| !record.command.trim().is_empty())
+        || result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_type == "validation_report")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::model::{
+        ActivityResult, WorkflowCommandType, WorkflowEvent, WorkflowInstance, WorkflowSubject,
+    };
+    use crate::runtime::validator::{DecisionValidator, ValidationContext};
+    use chrono::Utc;
+    use serde_json::json;
+
+    #[test]
+    fn prompt_task_success_without_validation_evidence_blocks() -> anyhow::Result<()> {
+        let instance = WorkflowInstance::new(
+            PROMPT_TASK_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("prompt", "task-123"),
+        );
+        let result = ActivityResult::succeeded(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "Prompt implementation completed.",
+        );
+        let event = WorkflowEvent::new(&instance.id, 1, RUNTIME_JOB_COMPLETED_EVENT, "runtime-1")
+            .with_payload(json!({
+                "command_id": "command-1",
+                "runtime_job_id": "job-1",
+                "activity_result": result,
+            }));
+
+        let decision = reduce_runtime_job_completed(&instance, &event)?.ok_or_else(|| {
+            anyhow::anyhow!("prompt success without validation evidence should block")
+        })?;
+
+        assert_eq!(decision.decision, "block_invalid_agent_output");
+        assert_eq!(decision.next_state, "blocked");
+        assert!(decision
+            .commands
+            .iter()
+            .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+        assert!(decision
+            .commands
+            .iter()
+            .any(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention));
+        DecisionValidator::prompt_task().validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )?;
+        Ok(())
+    }
 }

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -683,7 +683,8 @@ fn runtime_completion_reducer_finishes_prompt_task_after_implementation() {
     let result = ActivityResult::succeeded(
         PROMPT_TASK_IMPLEMENT_ACTIVITY,
         "Prompt implementation completed.",
-    );
+    )
+    .with_validation(ValidationRecord::new("cargo test", "passed"));
     let event = WorkflowEvent::new(
         &instance.id,
         1,


### PR DESCRIPTION
Fixes #1179.

## Summary
- block successful prompt_task implement_prompt results that do not include validation evidence
- validate prompt_task structured done decisions before accepting them
- document the prompt runtime contract so agents must provide validation records or a validation_report artifact

## Validation
- cargo check
- cargo test --package harness-workflow prompt_task
- cargo test --package harness-server prompt_packet
- cargo test --package harness-server --lib -- --test-threads=1
- cargo test -- --test-threads=1
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
