### PR TITLE
fix(runtime): stop queued jobs when worker is disabled

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use harness_core::config::workflow::{RuntimeDispatchProfileOverride, WorkflowConfig};
 use harness_core::types::{AgentId, ThreadId};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityErrorKind, ActivityResult, RuntimeJob, RuntimeJobExecutor,
-    RuntimeProfile, WorkflowInstance,
+    ActivityArtifact, ActivityResult, RuntimeJob, RuntimeJobExecutor, RuntimeProfile,
+    WorkflowInstance,
 };
 use serde_json::{json, Value};
 use std::path::Path;
@@ -268,25 +268,15 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
 
     async fn runtime_worker_disabled_result(&self, job: &RuntimeJob) -> Option<ActivityResult> {
         let activity = activity_name(job);
-        let workflow = match self.workflow_for_job(job).await {
-            Ok(workflow) => workflow,
-            Err(error) => {
-                return Some(runtime_policy_preflight_failed_result(activity, error));
-            }
-        };
-        let source_project_root = match self.project_root_for_job(job, workflow.as_ref()) {
-            Ok(project_root) => project_root,
-            Err(error) => {
-                return Some(runtime_policy_preflight_failed_result(activity, error));
-            }
-        };
+        // If any preflight helper fails (e.g. a transient database error or a
+        // missing project root), defer to the main `execute` path rather than
+        // permanently failing the job here. That path classifies transient vs
+        // fatal errors and applies the retry policy; a hard failure in preflight
+        // would bypass it.
+        let workflow = self.workflow_for_job(job).await.ok()?;
+        let source_project_root = self.project_root_for_job(job, workflow.as_ref()).ok()?;
         let workflow_document =
-            match harness_core::config::workflow::load_workflow_document(&source_project_root) {
-                Ok(document) => document,
-                Err(error) => {
-                    return Some(runtime_policy_preflight_failed_result(activity, error));
-                }
-            };
+            harness_core::config::workflow::load_workflow_document(&source_project_root).ok()?;
         runtime_worker_disabled_result_for_config(
             &activity,
             &source_project_root,
@@ -302,6 +292,14 @@ impl RuntimeJobExecutor for ServerRuntimeJobExecutor<'_> {
     }
 
     async fn preflight_result(&self, job: &RuntimeJob) -> Option<ActivityResult> {
+        // Builtin lifecycle activities (start_child_workflow, mark_bound_issue_done,
+        // recover_issue_workflow, ...) are internal state transitions that do not run
+        // a user agent. They must keep flowing even when the runtime worker is disabled,
+        // otherwise disabling the worker would strand workflows (e.g. a manually merged
+        // PR could never be marked done).
+        if is_builtin_lifecycle_activity(job) {
+            return None;
+        }
         self.runtime_worker_disabled_result(job).await
     }
 
@@ -387,18 +385,6 @@ fn default_runtime_timeout(activity: &str) -> Option<u64> {
         "poll_repo_backlog" => DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS,
         _ => DEFAULT_RUNTIME_TURN_TIMEOUT_SECS,
     })
-}
-
-fn runtime_policy_preflight_failed_result(
-    activity: String,
-    error: impl std::fmt::Display,
-) -> ActivityResult {
-    ActivityResult::failed(
-        activity,
-        "Runtime job policy preflight failed before agent execution.",
-        error.to_string(),
-    )
-    .with_error_kind(ActivityErrorKind::Configuration)
 }
 
 fn runtime_worker_disabled_result_for_config(

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -4,10 +4,11 @@ use async_trait::async_trait;
 use harness_core::config::workflow::{RuntimeDispatchProfileOverride, WorkflowConfig};
 use harness_core::types::{AgentId, ThreadId};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, RuntimeJob, RuntimeJobExecutor, RuntimeProfile,
-    WorkflowInstance,
+    ActivityArtifact, ActivityErrorKind, ActivityResult, RuntimeJob, RuntimeJobExecutor,
+    RuntimeProfile, WorkflowInstance,
 };
 use serde_json::{json, Value};
+use std::path::Path;
 use std::sync::Arc;
 
 use super::activity_result::activity_result_from_turn;
@@ -264,12 +265,44 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
         }
         Ok(self.state.core.project_root.clone())
     }
+
+    async fn runtime_worker_disabled_result(&self, job: &RuntimeJob) -> Option<ActivityResult> {
+        let activity = activity_name(job);
+        let workflow = match self.workflow_for_job(job).await {
+            Ok(workflow) => workflow,
+            Err(error) => {
+                return Some(runtime_policy_preflight_failed_result(activity, error));
+            }
+        };
+        let source_project_root = match self.project_root_for_job(job, workflow.as_ref()) {
+            Ok(project_root) => project_root,
+            Err(error) => {
+                return Some(runtime_policy_preflight_failed_result(activity, error));
+            }
+        };
+        let workflow_document =
+            match harness_core::config::workflow::load_workflow_document(&source_project_root) {
+                Ok(document) => document,
+                Err(error) => {
+                    return Some(runtime_policy_preflight_failed_result(activity, error));
+                }
+            };
+        runtime_worker_disabled_result_for_config(
+            &activity,
+            &source_project_root,
+            &workflow_document.config,
+        )
+    }
 }
 
 #[async_trait]
 impl RuntimeJobExecutor for ServerRuntimeJobExecutor<'_> {
     fn consumes_runtime_turn(&self, job: &RuntimeJob) -> bool {
         !is_builtin_lifecycle_activity(job)
+    }
+
+    async fn preflight_result(&self, job: &RuntimeJob) -> Option<ActivityResult> {
+        self.runtime_worker_disabled_result(job).await
     }
 
     async fn execute(&self, job: RuntimeJob) -> ActivityResult {
@@ -354,6 +387,35 @@ fn default_runtime_timeout(activity: &str) -> Option<u64> {
         "poll_repo_backlog" => DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS,
         _ => DEFAULT_RUNTIME_TURN_TIMEOUT_SECS,
     })
+}
+
+fn runtime_policy_preflight_failed_result(
+    activity: String,
+    error: impl std::fmt::Display,
+) -> ActivityResult {
+    ActivityResult::failed(
+        activity,
+        "Runtime job policy preflight failed before agent execution.",
+        error.to_string(),
+    )
+    .with_error_kind(ActivityErrorKind::Configuration)
+}
+
+fn runtime_worker_disabled_result_for_config(
+    activity: &str,
+    project_root: &Path,
+    workflow_config: &WorkflowConfig,
+) -> Option<ActivityResult> {
+    if workflow_config.runtime_worker.enabled {
+        return None;
+    }
+    Some(ActivityResult::cancelled(
+        activity,
+        format!(
+            "Runtime worker is disabled for project {}; claimed job was cancelled before agent execution.",
+            project_root.display()
+        ),
+    ))
 }
 
 #[cfg(test)]
@@ -458,5 +520,40 @@ mod tests {
             runtime_timeout_fallback(&config, None, &runtime_job("implement_issue")),
             Some(3600)
         );
+    }
+
+    #[test]
+    fn runtime_worker_disabled_result_for_config_cancels_agent_work() {
+        let mut config = WorkflowConfig::default();
+        config.runtime_worker.enabled = false;
+
+        let Some(result) = runtime_worker_disabled_result_for_config(
+            "implement_issue",
+            Path::new("/tmp/project"),
+            &config,
+        ) else {
+            panic!("disabled runtime worker should produce a preflight result");
+        };
+
+        assert_eq!(
+            result.status,
+            harness_workflow::runtime::ActivityStatus::Cancelled
+        );
+        assert_eq!(result.activity, "implement_issue");
+        assert!(result
+            .summary
+            .contains("Runtime worker is disabled for project /tmp/project"));
+    }
+
+    #[test]
+    fn runtime_worker_disabled_result_for_config_allows_enabled_project() {
+        let config = WorkflowConfig::default();
+
+        assert!(runtime_worker_disabled_result_for_config(
+            "implement_issue",
+            Path::new("/tmp/project"),
+            &config,
+        )
+        .is_none());
     }
 }

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -19,6 +19,10 @@ pub trait RuntimeJobExecutor: Send + Sync {
         true
     }
 
+    async fn preflight_result(&self, _job: &RuntimeJob) -> Option<ActivityResult> {
+        None
+    }
+
     async fn execute(&self, job: RuntimeJob) -> ActivityResult;
 }
 
@@ -75,24 +79,27 @@ impl<'a> RuntimeWorker<'a> {
                     .await?
                 {
                     Some(result) => result,
-                    None => {
-                        if consumes_runtime_turn {
-                            self.store
-                                .record_runtime_event(
-                                    &job.id,
-                                    "RuntimeTurnStarted",
-                                    json!({
-                                        "owner": self.owner.as_str(),
-                                    }),
-                                )
+                    None => match executor.preflight_result(&job).await {
+                        Some(result) => result,
+                        None => {
+                            if consumes_runtime_turn {
+                                self.store
+                                    .record_runtime_event(
+                                        &job.id,
+                                        "RuntimeTurnStarted",
+                                        json!({
+                                            "owner": self.owner.as_str(),
+                                        }),
+                                    )
+                                    .await?;
+                            }
+                            let execution = self
+                                .execute_with_lease_renewal(&job, executor, lease_expires_at)
                                 .await?;
+                            lease_expires_at = execution.lease_expires_at;
+                            execution.result
                         }
-                        let execution = self
-                            .execute_with_lease_renewal(&job, executor, lease_expires_at)
-                            .await?;
-                        lease_expires_at = execution.lease_expires_at;
-                        execution.result
-                    }
+                    },
                 }
             }
         };
@@ -475,5 +482,77 @@ fn runtime_budget_blocked_result(
         validation: Vec::new(),
         error: Some(error),
         error_kind: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{RuntimeJobStatus, RuntimeKind, WorkflowRuntimeStore};
+    use async_trait::async_trait;
+    use harness_core::db::resolve_database_url;
+    use serde_json::json;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    struct PreflightRuntimeExecutor {
+        result: ActivityResult,
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl RuntimeJobExecutor for PreflightRuntimeExecutor {
+        async fn preflight_result(&self, _job: &RuntimeJob) -> Option<ActivityResult> {
+            Some(self.result.clone())
+        }
+
+        async fn execute(&self, _job: RuntimeJob) -> ActivityResult {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            ActivityResult::succeeded("check", "executed")
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_result_completes_job_before_runtime_turn_starts() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&harness_core::config::dirs::default_db_path(
+            dir.path(),
+            "workflow_runtime",
+        ))
+        .await?;
+        let job = store
+            .enqueue_runtime_job(
+                "command-1",
+                RuntimeKind::CodexJsonrpc,
+                "codex-default",
+                json!({ "activity": "check" }),
+            )
+            .await?;
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executor = PreflightRuntimeExecutor {
+            result: ActivityResult::cancelled("check", "Runtime worker disabled."),
+            executions: executions.clone(),
+        };
+
+        let completed = RuntimeWorker::new(&store, "runtime-1")
+            .with_lease_ttl(Duration::minutes(5))
+            .run_once(&executor)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("worker should complete the claimed job"))?;
+
+        assert_eq!(completed.id, job.id);
+        assert_eq!(completed.status, RuntimeJobStatus::Cancelled);
+        assert_eq!(executions.load(Ordering::SeqCst), 0);
+        let events = store.runtime_events_for(&completed.id).await?;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "RuntimeJobClaimed");
+        assert_eq!(events[1].event_type, "ActivityResultReady");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add a runtime job preflight hook before recording RuntimeTurnStarted
- cancel claimed project jobs before agent execution when WORKFLOW.md disables runtime_worker
- cover the generic preflight path and disabled-worker policy with tests

Fixes #1184

## Tests
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo test -p harness-workflow preflight_result_completes_job_before_runtime_turn_starts
- cargo test -p harness-server runtime_worker_disabled_result_for_config
- cargo test -p harness-server runtime_job_worker_tick_runs_registered_agent_and_completes_job
- cargo check
- cargo test -p harness-workflow -- --test-threads=1
- cargo test -p harness-server --lib -- --test-threads=1
- cargo test -- --test-threads=1
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets