### PR TITLE
fix(runtime): validate replayed events at event time

### DIFF
--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -43,7 +43,6 @@ use super::repo_backlog::{
     REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use super::validator::{DecisionValidator, ValidationContext};
-use chrono::Utc;
 use serde_json::{json, Value};
 
 pub const RUNTIME_JOB_COMPLETED_EVENT: &str = "RuntimeJobCompleted";
@@ -319,7 +318,7 @@ fn structured_decision_validates(
         .validate(
             instance,
             decision,
-            &ValidationContext::new(event.source.as_str(), Utc::now()),
+            &ValidationContext::new(event.source.as_str(), event.created_at),
         )
         .is_ok()
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1539,7 +1539,7 @@ impl WorkflowRuntimeStore {
                                 match validator.validate(
                                     &instance,
                                     &decision,
-                                    &ValidationContext::new(owner, Utc::now()),
+                                    &ValidationContext::new(owner, event.created_at),
                                 ) {
                                     Ok(()) => WorkflowDecisionRecord::accepted(
                                         decision.clone(),

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -36,6 +36,7 @@ use std::sync::{
 };
 
 mod p1_followups;
+mod replay_determinism;
 
 fn issue_instance(state: &str) -> WorkflowInstance {
     WorkflowInstance::new(

--- a/crates/harness-workflow/src/runtime/tests/replay_determinism.rs
+++ b/crates/harness-workflow/src/runtime/tests/replay_determinism.rs
@@ -1,0 +1,37 @@
+use super::*;
+use crate::runtime::RUNTIME_JOB_COMPLETED_EVENT;
+
+#[test]
+fn runtime_completion_validation_uses_event_time_for_replayed_lease() -> anyhow::Result<()> {
+    let event_created_at = Utc::now() - Duration::hours(1);
+    let instance = issue_instance("implementing")
+        .with_lease("runtime-1", event_created_at + Duration::minutes(5));
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        "implementing",
+        "bind_pr_from_agent",
+        "pr_open",
+        "agent reported a newly created pull request",
+    )
+    .with_command(WorkflowCommand::bind_pr(
+        123,
+        "https://github.com/owner/repo/pull/123",
+        "bind-pr-123",
+    ));
+    let result =
+        ActivityResult::succeeded("implement_issue", "created pull request").with_artifact(
+            ActivityArtifact::new("workflow_decision", serde_json::to_value(&decision)?),
+        );
+    let mut event = WorkflowEvent::new(&instance.id, 1, RUNTIME_JOB_COMPLETED_EVENT, "runtime-1")
+        .with_payload(json!({
+            "activity_result": result,
+        }));
+    event.created_at = event_created_at;
+
+    let reduced = reduce_runtime_job_completed(&instance, &event)?
+        .expect("historical event should reduce to the structured decision");
+
+    assert_eq!(reduced.decision, "bind_pr_from_agent");
+    assert_eq!(reduced.next_state, "pr_open");
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -262,7 +262,7 @@ impl<'a> RuntimeWorker<'a> {
         let validation = validator.validate(
             &instance,
             &decision,
-            &ValidationContext::new(&self.owner, Utc::now()),
+            &ValidationContext::new(&self.owner, event.created_at),
         );
         let record = match validation {
             Ok(()) => super::model::WorkflowDecisionRecord::accepted(


### PR DESCRIPTION
## Summary
- validate runtime completion decisions against the persisted workflow event timestamp instead of wall-clock time
- align structured reducer validation, store commit validation, and child-to-parent propagation validation
- add a replay determinism test for a historical event whose lease was valid at event time but expired by replay time

Fixes #1182

## Tests
- cargo fmt --all
- cargo test -p harness-workflow runtime_completion_validation_uses_event_time_for_replayed_lease
- cargo check
- cargo test -- --test-threads=1
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets