### PR TITLE
chore(release): v0.6.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.34] - 2026-05-30
+
+First release with a tracked changelog. This is a workflow-runtime reliability
+patch addressing a batch of correctness issues found in a design audit of the
+workflow runtime (dispatcher / worker / reducer / validator / store / sweepers).
+
+### Fixed
+
+- **runtime:** PR-feedback active-command detection now treats `dispatching`
+  commands as active, closing a window where a claimed-but-not-yet-dispatched
+  command could be missed and a duplicate sweep/inspect job enqueued
+  (#1178, #1185).
+- **runtime:** `prompt_task` no longer completes as `done` without validation
+  evidence, bringing it in line with the issue-implementation and quality-gate
+  completion contracts (#1179, #1186).
+- **runtime:** disabling the runtime worker now also short-circuits already
+  queued jobs, while builtin lifecycle activities (e.g. `mark_bound_issue_done`)
+  keep flowing so workflows are not stranded; transient preflight errors defer
+  to the normal execute path instead of permanently failing the job
+  (#1181, #1187).
+- **runtime:** reducer/validator now validate replayed events at the event's
+  own timestamp instead of `Utc::now()`, making event replay deterministic for
+  lease-expiry checks (#1182, #1188).
+- **runtime:** `repo_backlog` workflows stuck in `blocked` are now recovered by
+  the stale-workflow recovery tick instead of stranding a repo's intake; the
+  root-cause stateless redesign remains tracked separately (#1180, #1193).
+- **runtime:** PR-feedback child lookup is scoped by `parent_workflow_id`
+  instead of scanning every PR-feedback instance across all projects, and the
+  no-actionable-feedback suppression honors fresh PR activity (#1183, #1194).
+
+### Changed
+
+- Added crate metadata (`description`, `license`, `repository`) and internal
+  dependency versions across the workspace so the crates can be published.
+
+[0.6.34]: https://github.com/majiayu000/harness/releases/tag/v0.6.34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "harness-agents"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "harness-api"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "harness-core",
  "harness-exec",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness-cli"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "harness-core"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "harness-exec"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "harness-gc"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "harness-observe"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "harness-rules"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "harness-sandbox"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "harness-core",
  "tempfile",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "harness-server"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "harness-skills"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "harness-workflow"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,25 +17,26 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.33"
+version = "0.6.34"
 edition = "2021"
 license = "MIT"
 rust-version = "1.88"
+repository = "https://github.com/majiayu000/harness"
 
 [workspace.dependencies]
-# Internal crates
-harness-core = { path = "crates/harness-core" }
-harness-protocol = { path = "crates/harness-protocol" }
-harness-api = { path = "crates/harness-api" }
-harness-server = { path = "crates/harness-server" }
-harness-agents = { path = "crates/harness-agents" }
-harness-sandbox = { path = "crates/harness-sandbox" }
-harness-gc = { path = "crates/harness-gc" }
-harness-rules = { path = "crates/harness-rules" }
-harness-skills = { path = "crates/harness-skills" }
-harness-exec = { path = "crates/harness-exec" }
-harness-observe = { path = "crates/harness-observe" }
-harness-workflow = { path = "crates/harness-workflow" }
+# Internal crates (version required so they can be published to crates.io)
+harness-core = { path = "crates/harness-core", version = "0.6.34" }
+harness-protocol = { path = "crates/harness-protocol", version = "0.6.34" }
+harness-api = { path = "crates/harness-api", version = "0.6.34" }
+harness-server = { path = "crates/harness-server", version = "0.6.34" }
+harness-agents = { path = "crates/harness-agents", version = "0.6.34" }
+harness-sandbox = { path = "crates/harness-sandbox", version = "0.6.34" }
+harness-gc = { path = "crates/harness-gc", version = "0.6.34" }
+harness-rules = { path = "crates/harness-rules", version = "0.6.34" }
+harness-skills = { path = "crates/harness-skills", version = "0.6.34" }
+harness-exec = { path = "crates/harness-exec", version = "0.6.34" }
+harness-observe = { path = "crates/harness-observe", version = "0.6.34" }
+harness-workflow = { path = "crates/harness-workflow", version = "0.6.34" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/harness-agents/Cargo.toml
+++ b/crates/harness-agents/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-agents"
 version.workspace = true
 edition.workspace = true
+description = "Agent adapters (Claude Code, Codex) for the Harness orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-api/Cargo.toml
+++ b/crates/harness-api/Cargo.toml
@@ -2,6 +2,8 @@
 name = "harness-api"
 version.workspace = true
 edition.workspace = true
+description = "API contracts and types for the Harness agent orchestration layer"
+repository.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-cli"
 version.workspace = true
 edition.workspace = true
+description = "Command-line interface for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "harness"

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -2,6 +2,8 @@
 name = "harness-core"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Core domain model, configuration, prompts, and agent traits for Harness"
 
 [dependencies]

--- a/crates/harness-exec/Cargo.toml
+++ b/crates/harness-exec/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-exec"
 version.workspace = true
 edition.workspace = true
+description = "Process execution helpers for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-gc/Cargo.toml
+++ b/crates/harness-gc/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-gc"
 version.workspace = true
 edition.workspace = true
+description = "Garbage collection and workspace cleanup for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-observe/Cargo.toml
+++ b/crates/harness-observe/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-observe"
 version.workspace = true
 edition.workspace = true
+description = "Observability (logging, tracing, metrics) for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-protocol"
 version.workspace = true
 edition.workspace = true
+description = "Protocol and message types for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/harness-rules/Cargo.toml
+++ b/crates/harness-rules/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-rules"
 version.workspace = true
 edition.workspace = true
+description = "Rule loading and evaluation for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-sandbox/Cargo.toml
+++ b/crates/harness-sandbox/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-sandbox"
 version.workspace = true
 edition.workspace = true
+description = "Sandbox and isolation primitives for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-server"
 version.workspace = true
 edition.workspace = true
+description = "HTTP server, task runner, and workflow runtime for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-skills/Cargo.toml
+++ b/crates/harness-skills/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-skills"
 version.workspace = true
 edition.workspace = true
+description = "Skill discovery and management for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }

--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -2,6 +2,9 @@
 name = "harness-workflow"
 version.workspace = true
 edition.workspace = true
+description = "Workflow runtime and state machine for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }


### PR DESCRIPTION
## Release v0.6.34

Cuts the first changelog-tracked release and bumps the workspace `0.6.33 -> 0.6.34`.

### What / Why
A workflow-runtime reliability patch bundling six audit fixes that already merged to main:
- #1185 (#1178) treat `dispatching` PR-feedback commands as active
- #1186 (#1179) require prompt task validation evidence
- #1187 (#1181) stop queued jobs when worker is disabled (keep builtin lifecycle activities flowing)
- #1188 (#1182) validate replayed events at event time
- #1193 (#1180) recover blocked repo backlog workflows
- #1194 (#1183) scope PR-feedback child lookup by `parent_workflow_id` + honor fresh PR activity

Closes the release-history gap tracked in #1177.

### Also: crates.io publishability prep
- Added `description` to every crate, plus `license`/`repository` workspace inheritance.
- Added `version = "0.6.34"` to internal `[workspace.dependencies]` path entries (required by crates.io).
- Verified with `cargo package --workspace --no-verify` (all 13 crates package cleanly).

Note: the actual `cargo publish` to crates.io must run from an environment with crates.io network access, after confirming the `harness-*` crate names are owned by the publishing account.

### Proof
- `cargo check --workspace` green.
- `cargo package --workspace --no-verify` succeeds for all 13 crates.

### AI Role
Version bump, CHANGELOG, and crate metadata generated with AI assistance; risk low (metadata + version only, no logic changes).
