### PR TITLE
feat(store): route thread_db builder through Backend seam (storage RFC Phase 2.2)

### DIFF
--- a/crates/harness-core/src/store_backend.rs
+++ b/crates/harness-core/src/store_backend.rs
@@ -82,14 +82,14 @@ impl PostgresBackend {
     /// lands (Phase 3).
     pub fn store_context(&self, loc: &StoreLocation) -> anyhow::Result<PgStoreContext> {
         let url = self.configured_database_url.as_deref();
-        Ok(match loc {
-            StoreLocation::SharedSchema(schema) => PgStoreContext::from_schema(schema, url)?,
-            StoreLocation::PathDerivedSchema(path) => PgStoreContext::from_path(path, url)?,
-            StoreLocation::LocalFile(path) => anyhow::bail!(
+        match loc {
+            StoreLocation::SharedSchema(schema) => PgStoreContext::from_schema(schema, url),
+            StoreLocation::PathDerivedSchema(path) => PgStoreContext::from_path(path, url),
+            StoreLocation::LocalFile(path) => Err(anyhow::anyhow!(
                 "LocalFile backend is not implemented yet (RFC storage redesign Phase 3): {}",
                 path.display()
-            ),
-        })
+            )),
+        }
     }
 }
 

--- a/crates/harness-core/src/store_backend.rs
+++ b/crates/harness-core/src/store_backend.rs
@@ -70,6 +70,27 @@ impl PostgresBackend {
             configured_database_url,
         }
     }
+
+    /// Resolve the `PgStoreContext` for `loc`.
+    ///
+    /// This is the Postgres-specific construction seam: it centralizes the schema
+    /// strategy (shared vs path-derived) in one place, so callers no longer compute
+    /// `pg_schema_for_path` inline. Builders that open against a shared setup pool
+    /// (`*_with_context`) use this; the `Backend::open_migrated` convenience below
+    /// delegates to it. The handle (`PgStoreContext`/`PgPool`) is Postgres-specific
+    /// by design in Phase 2 and will be generalized when the local-file backend
+    /// lands (Phase 3).
+    pub fn store_context(&self, loc: &StoreLocation) -> anyhow::Result<PgStoreContext> {
+        let url = self.configured_database_url.as_deref();
+        Ok(match loc {
+            StoreLocation::SharedSchema(schema) => PgStoreContext::from_schema(schema, url)?,
+            StoreLocation::PathDerivedSchema(path) => PgStoreContext::from_path(path, url)?,
+            StoreLocation::LocalFile(path) => anyhow::bail!(
+                "LocalFile backend is not implemented yet (RFC storage redesign Phase 3): {}",
+                path.display()
+            ),
+        })
+    }
 }
 
 #[async_trait]
@@ -79,16 +100,9 @@ impl Backend for PostgresBackend {
         loc: &StoreLocation,
         migrations: &[Migration],
     ) -> anyhow::Result<PgPool> {
-        let url = self.configured_database_url.as_deref();
-        let context = match loc {
-            StoreLocation::SharedSchema(schema) => PgStoreContext::from_schema(schema, url)?,
-            StoreLocation::PathDerivedSchema(path) => PgStoreContext::from_path(path, url)?,
-            StoreLocation::LocalFile(path) => anyhow::bail!(
-                "LocalFile backend is not implemented yet (RFC storage redesign Phase 3): {}",
-                path.display()
-            ),
-        };
-        context.open_migrated_pool(migrations).await
+        self.store_context(loc)?
+            .open_migrated_pool(migrations)
+            .await
     }
 }
 

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -89,11 +89,18 @@ pub(crate) async fn build_registry(
     };
 
     // ── Thread DB ─────────────────────────────────────────────────────────────
+    // Constructed through the storage `Backend` seam (RFC Phase 2.2 sample). This
+    // is behavior-identical to the previous inline `PgStoreContext::new(url,
+    // pg_schema_for_path(path))`, but routes the schema strategy through
+    // `StoreLocation` so it lives in one place. `PathDerivedSchema` preserves the
+    // legacy per-path schema for now; switching this store to a shared schema is a
+    // later, deliberate (behavior-changing) step.
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
-    let thread_context = harness_core::db::PgStoreContext::new(
-        database_url.clone(),
-        harness_core::db::pg_schema_for_path(&thread_db_path)?,
-    )?;
+    let thread_context =
+        harness_core::store_backend::PostgresBackend::new(Some(database_url.clone()))
+            .store_context(
+                &harness_core::store_backend::StoreLocation::PathDerivedSchema(thread_db_path),
+            )?;
     let thread_db = match super::forced_startup_error("thread_db") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("thread_db").failed(error));


### PR DESCRIPTION
Builds on the merged Phase 2.1 seam (#1208). Migrates **one** store builder (thread_db) to construct its `PgStoreContext` via the storage seam instead of inline `pg_schema_for_path`, and adds `PostgresBackend::store_context` (location → PgStoreContext) — which the builders' shared-setup-pool path (`open_with_context`) needs. `Backend::open_migrated` now delegates to it.

**Behavior-identical**: `PathDerivedSchema(path)` == the previous `PgStoreContext::new(url, pg_schema_for_path(path))`. One-store sample to validate the seam shape against a real builder before deciding the generalized handle / migrating more stores (per review guidance on #1208).

Proof: `RUSTFLAGS=-Dwarnings cargo check -p harness-server` clean. Refs #1206.