### PR TITLE
fix(agent): fail turns on terminal adapter errors

### DIFF
--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod review_loop;
 mod run_task;
 pub(crate) mod triage_pipeline;
 pub(crate) mod turn_lifecycle;
+#[cfg(test)]
+mod turn_lifecycle_terminal_error_tests;
 mod validation_gate;
 
 use harness_core::config::agents::CapabilityProfile;

--- a/crates/harness-server/src/task_executor/turn_lifecycle.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle.rs
@@ -236,6 +236,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
     };
     let mut stream_closed = false;
     let mut execution_result: Option<harness_core::error::Result<()>> = None;
+    let mut stream_error: Option<String> = None;
     let mut last_activity = Instant::now();
     let execution_deadline = options
         .timeout_secs
@@ -258,6 +259,9 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                 match incoming {
                     Some(item) => {
                         last_activity = Instant::now();
+                        if let StreamItem::Error { message } = &item {
+                            stream_error.get_or_insert_with(|| message.clone());
+                        }
                         process_stream_item(
                             &server,
                             &thread_db,
@@ -311,39 +315,8 @@ pub(crate) async fn run_turn_lifecycle_with_options(
             "turn execution ended without agent result".to_string(),
         ))
     }) {
-        Ok(()) => match server.thread_manager.complete_turn(&thread_id, &turn_id) {
-            Ok(Some(usage)) => {
-                persist_runtime_thread(&thread_db, &server, &thread_id).await;
-                emit_runtime_notification(
-                    &notify_tx,
-                    &notification_tx,
-                    Notification::TurnCompleted {
-                        turn_id: turn_id.clone(),
-                        status: harness_core::types::TurnStatus::Completed,
-                        token_usage: usage,
-                    },
-                );
-            }
-            Ok(None) => {}
-            Err(err) => {
-                let error_msg = err.to_string();
-                tracing::error!(
-                    thread_id = %thread_id,
-                    turn_id = %turn_id,
-                    "failed to complete turn after execution: {error_msg}"
-                );
-                if let Err(e) = server.thread_manager.add_item(
-                    &thread_id,
-                    &turn_id,
-                    harness_core::types::Item::Error {
-                        code: -1,
-                        message: format!("Failed to complete turn: {error_msg}"),
-                    },
-                ) {
-                    tracing::warn!("failed to add error item to turn: {e}");
-                } else {
-                    persist_runtime_thread(&thread_db, &server, &thread_id).await;
-                }
+        Ok(()) => {
+            if let Some(error_msg) = stream_error {
                 mark_turn_failed(
                     &server,
                     &thread_db,
@@ -354,8 +327,54 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                     error_msg,
                 )
                 .await;
+                return;
             }
-        },
+            match server.thread_manager.complete_turn(&thread_id, &turn_id) {
+                Ok(Some(usage)) => {
+                    persist_runtime_thread(&thread_db, &server, &thread_id).await;
+                    emit_runtime_notification(
+                        &notify_tx,
+                        &notification_tx,
+                        Notification::TurnCompleted {
+                            turn_id: turn_id.clone(),
+                            status: harness_core::types::TurnStatus::Completed,
+                            token_usage: usage,
+                        },
+                    );
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    let error_msg = err.to_string();
+                    tracing::error!(
+                        thread_id = %thread_id,
+                        turn_id = %turn_id,
+                        "failed to complete turn after execution: {error_msg}"
+                    );
+                    if let Err(e) = server.thread_manager.add_item(
+                        &thread_id,
+                        &turn_id,
+                        harness_core::types::Item::Error {
+                            code: -1,
+                            message: format!("Failed to complete turn: {error_msg}"),
+                        },
+                    ) {
+                        tracing::warn!("failed to add error item to turn: {e}");
+                    } else {
+                        persist_runtime_thread(&thread_db, &server, &thread_id).await;
+                    }
+                    mark_turn_failed(
+                        &server,
+                        &thread_db,
+                        &notify_tx,
+                        &notification_tx,
+                        &thread_id,
+                        &turn_id,
+                        error_msg,
+                    )
+                    .await;
+                }
+            }
+        }
         Err(err) => {
             let error_msg = err.to_string();
             if let Err(e) = server.thread_manager.add_item(

--- a/crates/harness-server/src/task_executor/turn_lifecycle_terminal_error_tests.rs
+++ b/crates/harness-server/src/task_executor/turn_lifecycle_terminal_error_tests.rs
@@ -1,0 +1,170 @@
+use super::turn_lifecycle::{run_turn_lifecycle_with_options, TurnLifecycleOptions};
+use crate::{server::HarnessServer, thread_manager::ThreadManager};
+use harness_agents::registry::{AdapterExecutionStrategy, AgentRegistry};
+use harness_core::agent::{
+    AgentAdapter, AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
+};
+use harness_core::config::HarnessConfig;
+use harness_core::error::HarnessError;
+use harness_core::types::{AgentId, Capability, Item, TokenUsage, TurnStatus};
+use harness_protocol::notifications::Notification;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use tokio::sync::mpsc;
+
+struct UnusedAgent {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CodeAgent for UnusedAgent {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::Read]
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        Ok(AgentResponse {
+            output: "unused".to_string(),
+            stderr: String::new(),
+            items: Vec::new(),
+            token_usage: TokenUsage::default(),
+            model: "codex".to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        _tx: mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+struct TerminalErrorAdapter {
+    calls: Arc<AtomicUsize>,
+    message: String,
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for TerminalErrorAdapter {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        tx: mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        tx.send(AgentEvent::Error {
+            message: self.message.clone(),
+        })
+        .await
+        .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+fn server_with_terminal_error_adapter(
+    root: &std::path::Path,
+    agent_calls: Arc<AtomicUsize>,
+    adapter_calls: Arc<AtomicUsize>,
+    adapter_error: String,
+) -> anyhow::Result<Arc<HarnessServer>> {
+    let mut config = HarnessConfig::default();
+    config.server.project_root = root.to_path_buf();
+    config.agents.default_agent = "codex".to_string();
+
+    let mut registry = AgentRegistry::new("codex");
+    registry.register("codex", Arc::new(UnusedAgent { calls: agent_calls }));
+    let adapter_error_for_factory = adapter_error.clone();
+    registry
+        .register_adapter_factory_with_strategy(
+            "codex",
+            move || {
+                Arc::new(TerminalErrorAdapter {
+                    calls: adapter_calls.clone(),
+                    message: adapter_error_for_factory.clone(),
+                })
+            },
+            AdapterExecutionStrategy::ExecuteTurns,
+        )
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    Ok(Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        registry,
+    )))
+}
+
+#[tokio::test]
+async fn adapter_terminal_error_fails_turn_and_notification() -> anyhow::Result<()> {
+    let root = tempfile::tempdir()?;
+    let agent_calls = Arc::new(AtomicUsize::new(0));
+    let adapter_calls = Arc::new(AtomicUsize::new(0));
+    let adapter_error = "adapter protocol failed".to_string();
+    let server = server_with_terminal_error_adapter(
+        root.path(),
+        agent_calls.clone(),
+        adapter_calls.clone(),
+        adapter_error.clone(),
+    )?;
+    let thread_id = server
+        .thread_manager
+        .start_thread(root.path().to_path_buf());
+    let turn_id = server
+        .thread_manager
+        .start_turn(&thread_id, "prompt".to_string(), AgentId::from_str("codex"))
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let (notification_tx, _) = tokio::sync::broadcast::channel(16);
+    let mut notification_rx = notification_tx.subscribe();
+
+    run_turn_lifecycle_with_options(
+        server.clone(),
+        None,
+        None,
+        notification_tx,
+        thread_id.clone(),
+        turn_id.clone(),
+        "prompt".to_string(),
+        "codex".to_string(),
+        TurnLifecycleOptions::default(),
+    )
+    .await;
+
+    assert_eq!(agent_calls.load(Ordering::Acquire), 0);
+    assert_eq!(adapter_calls.load(Ordering::Acquire), 1);
+    let turn = server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+    assert_eq!(turn.status, TurnStatus::Failed);
+    assert!(turn.items.iter().any(|item| matches!(
+        item,
+        Item::Error { message, .. } if message == &adapter_error
+    )));
+
+    let mut completion_statuses = Vec::new();
+    while let Ok(notification) = notification_rx.try_recv() {
+        if let Notification::TurnCompleted { status, .. } = notification.notification {
+            completion_statuses.push(status);
+        }
+    }
+    assert_eq!(completion_statuses, vec![TurnStatus::Failed]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- fail the turn lifecycle when an adapter/agent stream emits `StreamItem::Error` even if execution returns `Ok(())`
- preserve the error item already appended to the turn for operator inspection
- add regression coverage for an adapter that emits `AgentEvent::Error` and then returns `Ok(())`, including failed turn notification status

Closes #1203

## Validation

- `cargo fmt --all` — passed
- `cargo check` — passed
- `cargo test -p harness-server task_executor::turn_lifecycle_terminal_error_tests::adapter_terminal_error_fails_turn_and_notification` — passed (1 passed)
- `cargo test -p harness-server workflow_runtime_worker::activity_result::tests::activity_result_from_turn_classifies_timeout_error_kind` — passed (1 passed)
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — passed; build script warned that `bun run build` exited 137 and reused existing `web/dist` bundle
- `cargo test` — passed (full workspace; includes `harness-server` 1329 passed and `harness-workflow` 214 passed)
