### PR TITLE
fix(db): register path-derived Postgres schemas

### DIFF
--- a/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
+++ b/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
@@ -1,0 +1,140 @@
+use clap::Parser;
+use harness_core::config::HarnessConfig;
+use harness_core::db::{
+    apply_pg_schema_cleanup, configure_pg_pool_from_server, pg_open_pool, pg_schema_cleanup_plan,
+    resolve_database_url, PgSchemaCleanupAction, PgSchemaCleanupPlan,
+};
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "harness-pg-schema-cleanup",
+    about = "Plan or apply cleanup for legacy path-derived Postgres schemas"
+)]
+struct Args {
+    /// Config file path.
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Drop explicitly named registered cleanup candidates. Defaults to dry-run.
+    #[arg(long)]
+    apply: bool,
+    /// Required with --apply to acknowledge DROP SCHEMA CASCADE.
+    #[arg(long)]
+    confirm_drop: bool,
+    /// Registered drop-candidate schema to drop with --apply. Repeatable.
+    #[arg(long = "schema")]
+    schema: Vec<String>,
+    /// Include unregistered h* schemas in the dry-run report as blocked.
+    #[arg(long)]
+    include_unregistered: bool,
+    /// Explicitly allow an unregistered schema to be dropped with --apply.
+    #[arg(long = "allow-unregistered")]
+    allow_unregistered: Vec<String>,
+    /// Print JSON output.
+    #[arg(long)]
+    json: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let mut config = load_cleanup_config(args.config.as_deref())?;
+    config.apply_env_overrides()?;
+    configure_pg_pool_from_server(&config.server);
+    let database_url = resolve_database_url(config.server.database_url.as_deref())?;
+    let pool = pg_open_pool(&database_url).await?;
+
+    if args.apply {
+        if !args.confirm_drop {
+            anyhow::bail!("--apply requires --confirm-drop");
+        }
+        if args.schema.is_empty() && args.allow_unregistered.is_empty() {
+            anyhow::bail!("--apply requires at least one --schema or --allow-unregistered");
+        }
+        let dropped =
+            apply_pg_schema_cleanup(&pool, &args.schema, &args.allow_unregistered).await?;
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&dropped)?);
+        } else if dropped.is_empty() {
+            println!("No schemas dropped");
+        } else {
+            println!("Dropped {} schema(s):", dropped.len());
+            for result in dropped {
+                println!(
+                    "  {}{}",
+                    result.schema_name,
+                    if result.registered {
+                        ""
+                    } else {
+                        " (explicit allowlist)"
+                    }
+                );
+            }
+        }
+    } else {
+        let plan = pg_schema_cleanup_plan(&pool, args.include_unregistered).await?;
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+        } else {
+            print_plan(&plan);
+        }
+    }
+
+    pool.close().await;
+    Ok(())
+}
+
+fn load_cleanup_config(path: Option<&std::path::Path>) -> anyhow::Result<HarnessConfig> {
+    if let Some(path) = path {
+        let content = std::fs::read_to_string(path)?;
+        let mut config: HarnessConfig = toml::from_str(&content)?;
+        if let Some(dir) = path.parent() {
+            config.rebase_relative_paths(dir);
+        }
+        return Ok(config);
+    }
+
+    if let Some(discovered) = harness_core::config::dirs::find_config_file() {
+        let content = std::fs::read_to_string(&discovered)?;
+        let mut config: HarnessConfig = toml::from_str(&content)?;
+        if let Some(dir) = discovered.parent() {
+            config.rebase_relative_paths(dir);
+        }
+        return Ok(config);
+    }
+
+    Ok(HarnessConfig::default())
+}
+
+fn print_plan(plan: &PgSchemaCleanupPlan) {
+    let mut keep = 0usize;
+    let mut drop_candidates = 0usize;
+    let mut blocked = 0usize;
+    for candidate in &plan.candidates {
+        match candidate.action {
+            PgSchemaCleanupAction::Keep => keep += 1,
+            PgSchemaCleanupAction::DropCandidate => drop_candidates += 1,
+            PgSchemaCleanupAction::Blocked => blocked += 1,
+        }
+    }
+
+    println!("Postgres path-derived schema cleanup dry-run");
+    println!("  keep:            {keep}");
+    println!("  drop candidates: {drop_candidates}");
+    println!("  blocked:         {blocked}");
+
+    for candidate in &plan.candidates {
+        let action = match candidate.action {
+            PgSchemaCleanupAction::Keep => "KEEP",
+            PgSchemaCleanupAction::DropCandidate => "DROP_CANDIDATE",
+            PgSchemaCleanupAction::Blocked => "BLOCKED",
+        };
+        println!(
+            "{action}\t{}\ttables={}\testimated_rows={}\t{}",
+            candidate.schema_name,
+            candidate.table_count,
+            candidate.estimated_row_count,
+            candidate.reason
+        );
+    }
+}

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -9,6 +9,12 @@ pub use crate::db_pg::{
     configure_pg_pool_from_server, pg_create_schema_if_not_exists, pg_open_pool,
     pg_open_pool_schematized, pg_schema_for_path, resolve_database_url, PgMigrator, PgStoreContext,
 };
+pub use crate::db_pg_schema_registry::{
+    apply_pg_schema_cleanup, ensure_pg_schema_registry, pg_schema_cleanup_plan,
+    register_pg_schema_ownership, PgSchemaCleanupAction, PgSchemaCleanupCandidate,
+    PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership, PG_SCHEMA_REGISTRY_SCHEMA,
+    PG_SCHEMA_REGISTRY_TABLE,
+};
 
 /// Create a Postgres connection pool for the logical store at `path`.
 ///

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -6,6 +6,7 @@ use std::str::FromStr as _;
 use std::sync::Mutex;
 
 use crate::db::Migration;
+use crate::db_pg_schema_registry::{register_pg_schema_ownership, PgSchemaOwnership};
 
 const DEFAULT_PG_MAX_CONNECTIONS: u32 = 8;
 const DEFAULT_PG_ACQUIRE_TIMEOUT_SECS: u64 = 10;
@@ -330,6 +331,7 @@ pub fn pg_schema_for_path(path: &Path) -> anyhow::Result<String> {
 pub struct PgStoreContext {
     database_url: String,
     schema: String,
+    ownership: Option<PgSchemaOwnership>,
 }
 
 impl std::fmt::Debug for PgStoreContext {
@@ -337,6 +339,7 @@ impl std::fmt::Debug for PgStoreContext {
         f.debug_struct("PgStoreContext")
             .field("database_url", &"[REDACTED]")
             .field("schema", &self.schema)
+            .field("ownership", &self.ownership)
             .finish()
     }
 }
@@ -344,7 +347,10 @@ impl std::fmt::Debug for PgStoreContext {
 impl PgStoreContext {
     pub fn from_path(path: &Path, configured_database_url: Option<&str>) -> anyhow::Result<Self> {
         let database_url = resolve_database_url(configured_database_url)?;
-        Self::new(database_url, pg_schema_for_path(path)?)
+        let hash_path = schema_hash_path(path)?;
+        let schema = pg_schema_for_path(&hash_path)?;
+        let ownership = PgSchemaOwnership::path_derived(schema.clone(), hash_path)?;
+        Ok(Self::new(database_url, schema)?.with_ownership(ownership))
     }
 
     pub fn from_schema(
@@ -365,7 +371,13 @@ impl PgStoreContext {
         Ok(Self {
             database_url,
             schema,
+            ownership: None,
         })
+    }
+
+    pub fn with_ownership(mut self, ownership: PgSchemaOwnership) -> Self {
+        self.ownership = Some(ownership);
+        self
     }
 
     pub fn database_url(&self) -> &str {
@@ -376,6 +388,10 @@ impl PgStoreContext {
         &self.schema
     }
 
+    pub fn ownership(&self) -> Option<&PgSchemaOwnership> {
+        self.ownership.as_ref()
+    }
+
     pub async fn ensure_schema(&self, setup_pool: &PgPool) -> anyhow::Result<()> {
         pg_create_schema_if_not_exists(setup_pool, &self.schema)
             .await
@@ -384,7 +400,18 @@ impl PgStoreContext {
                     "failed to ensure Postgres schema '{}' is ready: {error}",
                     self.schema
                 )
-            })
+            })?;
+        if let Some(ownership) = &self.ownership {
+            register_pg_schema_ownership(setup_pool, ownership)
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to register Postgres schema '{}' ownership: {error}",
+                        self.schema
+                    )
+                })?;
+        }
+        Ok(())
     }
 
     pub async fn open_runtime_pool(&self) -> anyhow::Result<PgPool> {
@@ -467,7 +494,7 @@ pub async fn pg_open_pool(database_url: &str) -> anyhow::Result<PgPool> {
 /// PostgreSQL's 63-byte identifier limit (NAMEDATALEN-1). Rejects the name
 /// before it is ever interpolated into SQL, providing defence in depth against
 /// injection if the schema-name construction ever changes.
-fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
+pub(crate) fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
     let mut chars = schema.chars();
     let first = match chars.next() {
         Some(c) => c,

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -1,0 +1,564 @@
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub const PG_SCHEMA_REGISTRY_SCHEMA: &str = "harness_admin";
+pub const PG_SCHEMA_REGISTRY_TABLE: &str = "schema_ownership";
+
+const PATH_DERIVED_OWNER_KIND: &str = "path_derived_store";
+const PATH_DERIVED_RETENTION_CLASS: &str = "path_derived";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgSchemaOwnership {
+    pub schema_name: String,
+    pub owner_kind: String,
+    pub owner_key: String,
+    pub owner_path: Option<String>,
+    pub retention_class: String,
+}
+
+impl PgSchemaOwnership {
+    pub fn path_derived(schema_name: String, canonical_path: PathBuf) -> anyhow::Result<Self> {
+        let owner_path = canonical_path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {:?}", canonical_path))?
+            .to_string();
+        Ok(Self {
+            schema_name,
+            owner_kind: PATH_DERIVED_OWNER_KIND.to_string(),
+            owner_key: owner_path.clone(),
+            owner_path: Some(owner_path),
+            retention_class: PATH_DERIVED_RETENTION_CLASS.to_string(),
+        })
+    }
+}
+
+pub fn is_legacy_path_schema_name(schema: &str) -> bool {
+    schema.len() == 17
+        && schema.starts_with('h')
+        && schema[1..].chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PgSchemaCleanupAction {
+    Keep,
+    DropCandidate,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgSchemaCleanupCandidate {
+    pub schema_name: String,
+    pub registered: bool,
+    pub owner_kind: Option<String>,
+    pub owner_key: Option<String>,
+    pub owner_path: Option<String>,
+    pub retention_class: Option<String>,
+    pub table_count: i64,
+    pub estimated_row_count: i64,
+    pub action: PgSchemaCleanupAction,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgSchemaCleanupPlan {
+    pub candidates: Vec<PgSchemaCleanupCandidate>,
+}
+
+impl PgSchemaCleanupPlan {
+    pub fn drop_candidates(&self) -> impl Iterator<Item = &PgSchemaCleanupCandidate> {
+        self.candidates
+            .iter()
+            .filter(|candidate| candidate.action == PgSchemaCleanupAction::DropCandidate)
+    }
+
+    pub fn blocked_unregistered(&self) -> impl Iterator<Item = &PgSchemaCleanupCandidate> {
+        self.candidates.iter().filter(|candidate| {
+            !candidate.registered && candidate.action == PgSchemaCleanupAction::Blocked
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgSchemaDropResult {
+    pub schema_name: String,
+    pub registered: bool,
+    pub dropped: bool,
+}
+
+struct PgSchemaInventoryRow {
+    schema_name: String,
+    owner_kind: Option<String>,
+    owner_key: Option<String>,
+    owner_path: Option<String>,
+    retention_class: Option<String>,
+    table_count: i64,
+    estimated_row_count: i64,
+}
+
+pub async fn ensure_pg_schema_registry(pool: &PgPool) -> anyhow::Result<()> {
+    sqlx::query(&format!(
+        "CREATE SCHEMA IF NOT EXISTS \"{PG_SCHEMA_REGISTRY_SCHEMA}\""
+    ))
+    .execute(pool)
+    .await?;
+    sqlx::query(&format!(
+        "CREATE TABLE IF NOT EXISTS \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\" (
+            schema_name     TEXT PRIMARY KEY,
+            owner_kind      TEXT NOT NULL,
+            owner_key       TEXT NOT NULL,
+            owner_path      TEXT,
+            retention_class TEXT NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )"
+    ))
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn register_pg_schema_ownership(
+    pool: &PgPool,
+    ownership: &PgSchemaOwnership,
+) -> anyhow::Result<()> {
+    crate::db_pg::validate_schema_name(&ownership.schema_name)?;
+    ensure_pg_schema_registry(pool).await?;
+    sqlx::query(&format!(
+        "INSERT INTO \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+            (schema_name, owner_kind, owner_key, owner_path, retention_class)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (schema_name) DO UPDATE SET
+            owner_kind = EXCLUDED.owner_kind,
+            owner_key = EXCLUDED.owner_key,
+            owner_path = EXCLUDED.owner_path,
+            retention_class = EXCLUDED.retention_class,
+            last_seen_at = CURRENT_TIMESTAMP"
+    ))
+    .bind(&ownership.schema_name)
+    .bind(&ownership.owner_kind)
+    .bind(&ownership.owner_key)
+    .bind(&ownership.owner_path)
+    .bind(&ownership.retention_class)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn pg_schema_cleanup_plan(
+    pool: &PgPool,
+    include_unregistered: bool,
+) -> anyhow::Result<PgSchemaCleanupPlan> {
+    let registry_exists = pg_schema_registry_exists(pool).await?;
+    let owner_select = if registry_exists {
+        "o.owner_kind,
+            o.owner_key,
+            o.owner_path,
+            o.retention_class"
+    } else {
+        "NULL::TEXT AS owner_kind,
+            NULL::TEXT AS owner_key,
+            NULL::TEXT AS owner_path,
+            NULL::TEXT AS retention_class"
+    };
+    let registry_join = if registry_exists {
+        format!(
+            "LEFT JOIN \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\" o
+               ON o.schema_name = n.nspname"
+        )
+    } else {
+        String::new()
+    };
+    let owner_group_by = if registry_exists {
+        ", o.owner_kind, o.owner_key, o.owner_path, o.retention_class"
+    } else {
+        ""
+    };
+    let rows = sqlx::query_as::<
+        _,
+        (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+            i64,
+        ),
+    >(&format!(
+        "SELECT
+            n.nspname AS schema_name,
+            {owner_select},
+            COUNT(c.oid) FILTER (WHERE c.relkind IN ('r', 'p'))::BIGINT AS table_count,
+            COALESCE(SUM(GREATEST(c.reltuples, 0::REAL)), 0)::BIGINT AS estimated_row_count
+         FROM pg_namespace n
+         LEFT JOIN pg_class c
+           ON c.relnamespace = n.oid AND c.relkind IN ('r', 'p')
+         {registry_join}
+         WHERE n.nspname ~ '^h[0-9a-f]{{16}}$'
+         GROUP BY n.nspname{owner_group_by}
+         ORDER BY n.nspname"
+    ))
+    .fetch_all(pool)
+    .await?;
+
+    let candidates = rows
+        .into_iter()
+        .filter_map(
+            |(
+                schema_name,
+                owner_kind,
+                owner_key,
+                owner_path,
+                retention_class,
+                table_count,
+                estimated_row_count,
+            )| {
+                if owner_kind.is_none() && !include_unregistered {
+                    return None;
+                }
+                let row = PgSchemaInventoryRow {
+                    schema_name,
+                    owner_kind,
+                    owner_key,
+                    owner_path,
+                    retention_class,
+                    table_count,
+                    estimated_row_count,
+                };
+                Some(classify_schema_cleanup_candidate(row))
+            },
+        )
+        .collect();
+
+    Ok(PgSchemaCleanupPlan { candidates })
+}
+
+async fn pg_schema_registry_exists(pool: &PgPool) -> anyhow::Result<bool> {
+    let qualified_name = format!("\"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"");
+    let table_name: Option<String> = sqlx::query_scalar("SELECT to_regclass($1::TEXT)::TEXT")
+        .bind(qualified_name)
+        .fetch_one(pool)
+        .await?;
+    Ok(table_name.is_some())
+}
+
+pub async fn apply_pg_schema_cleanup(
+    pool: &PgPool,
+    registered_schemas: &[String],
+    allow_unregistered: &[String],
+) -> anyhow::Result<Vec<PgSchemaDropResult>> {
+    let requested_registered: HashSet<String> = registered_schemas.iter().cloned().collect();
+    let allowlist: HashSet<String> = allow_unregistered.iter().cloned().collect();
+    for schema in &requested_registered {
+        crate::db_pg::validate_schema_name(schema)?;
+    }
+    for schema in &allowlist {
+        crate::db_pg::validate_schema_name(schema)?;
+    }
+
+    let plan = pg_schema_cleanup_plan(pool, true).await?;
+    let targets = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)?;
+
+    let mut results = Vec::new();
+    for candidate in targets {
+        drop_schema_cascade(pool, &candidate.schema_name).await?;
+        if candidate.registered {
+            delete_schema_ownership(pool, &candidate.schema_name).await?;
+        }
+        results.push(PgSchemaDropResult {
+            schema_name: candidate.schema_name,
+            registered: candidate.registered,
+            dropped: true,
+        });
+    }
+    Ok(results)
+}
+
+fn validate_pg_schema_drop_request(
+    plan: PgSchemaCleanupPlan,
+    requested_registered: &HashSet<String>,
+    allowlist: &HashSet<String>,
+) -> anyhow::Result<Vec<PgSchemaCleanupCandidate>> {
+    let mut targets = Vec::new();
+    let mut seen_registered = HashSet::new();
+    let mut seen_allowlisted = HashSet::new();
+    for candidate in plan.candidates {
+        let requested_registered_drop =
+            candidate.registered && requested_registered.contains(&candidate.schema_name);
+        let allowed_unregistered =
+            !candidate.registered && allowlist.contains(&candidate.schema_name);
+        if requested_registered_drop {
+            seen_registered.insert(candidate.schema_name.clone());
+            if candidate.action != PgSchemaCleanupAction::DropCandidate {
+                anyhow::bail!(
+                    "registered schema '{}' is not a cleanup drop candidate: {}",
+                    candidate.schema_name,
+                    candidate.reason
+                );
+            }
+        }
+        if allowed_unregistered {
+            seen_allowlisted.insert(candidate.schema_name.clone());
+        }
+        if !requested_registered_drop && !allowed_unregistered {
+            continue;
+        }
+        targets.push(candidate);
+    }
+    if let Some(schema) = requested_registered.difference(&seen_registered).next() {
+        anyhow::bail!(
+            "registered schema '{}' was not found in cleanup plan",
+            schema
+        );
+    }
+    if let Some(schema) = allowlist.difference(&seen_allowlisted).next() {
+        anyhow::bail!(
+            "allowlisted unregistered schema '{}' was not found in cleanup plan",
+            schema
+        );
+    }
+    Ok(targets)
+}
+
+fn classify_schema_cleanup_candidate(row: PgSchemaInventoryRow) -> PgSchemaCleanupCandidate {
+    let registered = row.owner_kind.is_some();
+    let (action, reason) = if !registered {
+        (
+            PgSchemaCleanupAction::Blocked,
+            "unregistered path-derived schema; cleanup requires explicit allowlist".to_string(),
+        )
+    } else if row.owner_kind.as_deref() == Some(PATH_DERIVED_OWNER_KIND) {
+        (
+            PgSchemaCleanupAction::Keep,
+            "registered path-derived schema; owner_path is an identity key, not a liveness check"
+                .to_string(),
+        )
+    } else if let Some(owner_path) = row.owner_path.as_deref() {
+        match Path::new(owner_path).try_exists() {
+            Ok(true) => (
+                PgSchemaCleanupAction::Keep,
+                "registered owner path still exists".to_string(),
+            ),
+            Ok(false) => (
+                PgSchemaCleanupAction::DropCandidate,
+                "registered owner path is missing".to_string(),
+            ),
+            Err(error) => (
+                PgSchemaCleanupAction::Keep,
+                format!("could not check registered owner path; keep for operator review: {error}"),
+            ),
+        }
+    } else {
+        (
+            PgSchemaCleanupAction::Keep,
+            "registered schema has no owner_path; keep for operator review".to_string(),
+        )
+    };
+
+    PgSchemaCleanupCandidate {
+        schema_name: row.schema_name,
+        registered,
+        owner_kind: row.owner_kind,
+        owner_key: row.owner_key,
+        owner_path: row.owner_path,
+        retention_class: row.retention_class,
+        table_count: row.table_count,
+        estimated_row_count: row.estimated_row_count,
+        action,
+        reason,
+    }
+}
+
+async fn drop_schema_cascade(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
+    crate::db_pg::validate_schema_name(schema)?;
+    sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", schema))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn delete_schema_ownership(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
+    sqlx::query(&format!(
+        "DELETE FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE schema_name = $1"
+    ))
+    .bind(schema)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_derived_ownership_records_canonical_path() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("tasks.db");
+        let ownership =
+            PgSchemaOwnership::path_derived("h1234567890abcdef".to_string(), path.clone())?;
+
+        assert_eq!(ownership.schema_name, "h1234567890abcdef");
+        assert_eq!(ownership.owner_kind, "path_derived_store");
+        assert_eq!(ownership.owner_key, path.to_string_lossy());
+        assert_eq!(
+            ownership.owner_path.as_deref(),
+            Some(path.to_string_lossy().as_ref())
+        );
+        assert_eq!(ownership.retention_class, "path_derived");
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_keeps_path_derived_schema_when_owner_path_exists() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let row = PgSchemaInventoryRow {
+            schema_name: "h1111111111111111".to_string(),
+            owner_kind: Some("path_derived_store".to_string()),
+            owner_key: Some(dir.path().to_string_lossy().to_string()),
+            owner_path: Some(dir.path().to_string_lossy().to_string()),
+            retention_class: Some("path_derived".to_string()),
+            table_count: 2,
+            estimated_row_count: 5,
+        };
+
+        let candidate = classify_schema_cleanup_candidate(row);
+
+        assert!(candidate.registered);
+        assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+        assert_eq!(
+            candidate.reason,
+            "registered path-derived schema; owner_path is an identity key, not a liveness check"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_keeps_path_derived_schema_when_owner_path_is_missing() {
+        let row = PgSchemaInventoryRow {
+            schema_name: "h2222222222222222".to_string(),
+            owner_kind: Some("path_derived_store".to_string()),
+            owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+            owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+            retention_class: Some("path_derived".to_string()),
+            table_count: 1,
+            estimated_row_count: 0,
+        };
+
+        let candidate = classify_schema_cleanup_candidate(row);
+
+        assert!(candidate.registered);
+        assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+        assert_eq!(
+            candidate.reason,
+            "registered path-derived schema; owner_path is an identity key, not a liveness check"
+        );
+    }
+
+    #[test]
+    fn cleanup_marks_unknown_registered_schema_with_missing_path_as_drop_candidate() {
+        let row = PgSchemaInventoryRow {
+            schema_name: "h4444444444444444".to_string(),
+            owner_kind: Some("external_owner".to_string()),
+            owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+            owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+            retention_class: Some("path_derived".to_string()),
+            table_count: 1,
+            estimated_row_count: 0,
+        };
+
+        let candidate = classify_schema_cleanup_candidate(row);
+
+        assert!(candidate.registered);
+        assert_eq!(candidate.action, PgSchemaCleanupAction::DropCandidate);
+        assert_eq!(candidate.reason, "registered owner path is missing");
+    }
+
+    #[test]
+    fn cleanup_blocks_unregistered_schema_by_default() {
+        let row = PgSchemaInventoryRow {
+            schema_name: "h3333333333333333".to_string(),
+            owner_kind: None,
+            owner_key: None,
+            owner_path: None,
+            retention_class: None,
+            table_count: 1,
+            estimated_row_count: 0,
+        };
+
+        let candidate = classify_schema_cleanup_candidate(row);
+
+        assert!(!candidate.registered);
+        assert_eq!(candidate.action, PgSchemaCleanupAction::Blocked);
+        assert!(candidate.reason.contains("explicit allowlist"));
+    }
+
+    #[test]
+    fn drop_request_validation_rejects_registered_keep_candidate() {
+        let plan = PgSchemaCleanupPlan {
+            candidates: vec![PgSchemaCleanupCandidate {
+                schema_name: "h1111111111111111".to_string(),
+                registered: true,
+                owner_kind: Some("path_derived_store".to_string()),
+                owner_key: Some("h1111111111111111".to_string()),
+                owner_path: None,
+                retention_class: Some("path_derived".to_string()),
+                table_count: 1,
+                estimated_row_count: 0,
+                action: PgSchemaCleanupAction::Keep,
+                reason: "registered path-derived schema".to_string(),
+            }],
+        };
+        let requested_registered = HashSet::from(["h1111111111111111".to_string()]);
+        let allowlist = HashSet::new();
+
+        let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
+            .expect_err("keep schema should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("registered schema 'h1111111111111111' is not a cleanup drop candidate"));
+    }
+
+    #[test]
+    fn drop_request_validation_fails_before_selecting_partial_targets() {
+        let plan = PgSchemaCleanupPlan {
+            candidates: vec![PgSchemaCleanupCandidate {
+                schema_name: "h1111111111111111".to_string(),
+                registered: true,
+                owner_kind: Some("external_owner".to_string()),
+                owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+                owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+                retention_class: Some("path_derived".to_string()),
+                table_count: 1,
+                estimated_row_count: 0,
+                action: PgSchemaCleanupAction::DropCandidate,
+                reason: "registered owner path is missing".to_string(),
+            }],
+        };
+        let requested_registered = HashSet::from([
+            "h1111111111111111".to_string(),
+            "h9999999999999999".to_string(),
+        ]);
+        let allowlist = HashSet::new();
+
+        let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
+            .expect_err("missing schema should reject the whole cleanup request");
+
+        assert!(err
+            .to_string()
+            .contains("registered schema 'h9999999999999999' was not found"));
+    }
+
+    #[test]
+    fn legacy_path_schema_name_detection_is_exact() {
+        assert!(is_legacy_path_schema_name("h0123456789abcdef"));
+        assert!(!is_legacy_path_schema_name("workflow_runtime"));
+        assert!(!is_legacy_path_schema_name("h0123456789abcdeg"));
+        assert!(!is_legacy_path_schema_name("h0123456789abcde"));
+    }
+}

--- a/crates/harness-core/src/db_pg_tests.rs
+++ b/crates/harness-core/src/db_pg_tests.rs
@@ -4,6 +4,7 @@ use super::{
     DEFAULT_PG_MAX_CONNECTIONS,
 };
 use crate::config::server::ServerConfig;
+use crate::db_pg_schema_registry::{PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE};
 use crate::test_support::process_env_lock;
 use std::path::Path;
 
@@ -159,7 +160,7 @@ fn pg_schema_for_path_normalizes_absolute_aliases() {
 }
 
 #[test]
-fn pg_store_context_from_path_uses_configured_url_and_path_schema() {
+fn pg_store_context_from_path_uses_configured_url_and_path_schema() -> anyhow::Result<()> {
     let context = PgStoreContext::from_path(
         Path::new("/tmp/harness/tasks.db"),
         Some(" postgres://user:pass@localhost:5432/harness "),
@@ -171,6 +172,16 @@ fn pg_store_context_from_path_uses_configured_url_and_path_schema() {
         "postgres://user:pass@localhost:5432/harness"
     );
     assert_eq!(context.schema(), "h1b76aa87802f7705");
+    let ownership = context
+        .ownership()
+        .ok_or_else(|| anyhow::anyhow!("path-derived context should carry ownership metadata"))?;
+    assert_eq!(ownership.owner_kind, "path_derived_store");
+    assert_eq!(ownership.retention_class, "path_derived");
+    assert_eq!(
+        ownership.owner_path.as_deref(),
+        Some("/tmp/harness/tasks.db")
+    );
+    Ok(())
 }
 
 #[test]
@@ -188,6 +199,28 @@ fn pg_store_context_debug_redacts_database_url() {
         !debug.contains("secret"),
         "debug output must not expose database credentials: {debug}"
     );
+}
+
+#[test]
+fn pg_store_context_from_schema_leaves_legacy_hash_schemas_unowned() -> anyhow::Result<()> {
+    let context = PgStoreContext::from_schema(
+        "h0123456789abcdef",
+        Some("postgres://user:pass@localhost:5432/harness"),
+    )?;
+
+    assert!(context.ownership().is_none());
+    Ok(())
+}
+
+#[test]
+fn pg_store_context_from_schema_leaves_shared_schema_canonical() -> anyhow::Result<()> {
+    let context = PgStoreContext::from_schema(
+        "workflow_runtime",
+        Some("postgres://user:pass@localhost:5432/harness"),
+    )?;
+
+    assert!(context.ownership().is_none());
+    Ok(())
 }
 
 #[test]
@@ -240,6 +273,62 @@ fn pg_store_context_can_reuse_shared_setup_pool() {
         pool.close().await;
         setup_pool.close().await;
     });
+}
+
+#[tokio::test]
+async fn pg_store_context_registers_path_schema_with_shared_setup_pool() -> anyhow::Result<()> {
+    let database_url = {
+        let _lock = process_env_lock();
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        database_url
+    };
+    let setup_pool = match pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let store_path = dir.path().join(format!(
+        "registered-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let context = PgStoreContext::from_path(&store_path, Some(&database_url))?;
+    let schema = context.schema().to_string();
+    let expected_owner_path = context
+        .ownership()
+        .and_then(|ownership| ownership.owner_path.clone())
+        .ok_or_else(|| anyhow::anyhow!("path-derived context should carry owner_path"))?;
+    let pool = context.open_pool_with_setup_pool(&setup_pool).await?;
+
+    let row: (String, String, Option<String>, String) = sqlx::query_as(&format!(
+        "SELECT owner_kind, owner_key, owner_path, retention_class
+         FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE schema_name = $1"
+    ))
+    .bind(&schema)
+    .fetch_one(&setup_pool)
+    .await?;
+
+    pool.close().await;
+    sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", schema))
+        .execute(&setup_pool)
+        .await?;
+    sqlx::query(&format!(
+        "DELETE FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE schema_name = $1"
+    ))
+    .bind(&schema)
+    .execute(&setup_pool)
+    .await?;
+    setup_pool.close().await;
+
+    assert_eq!(row.0, "path_derived_store");
+    assert_eq!(row.1, expected_owner_path);
+    assert_eq!(row.2.as_deref(), Some(expected_owner_path.as_str()));
+    assert_eq!(row.3, "path_derived");
+    Ok(())
 }
 
 #[test]

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod capability;
 pub mod config;
 pub mod db;
 pub mod db_pg;
+pub mod db_pg_schema_registry;
 mod db_pg_split;
 pub mod error;
 pub mod interceptor;

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -100,9 +100,9 @@ pub(crate) async fn build_engines(
             match database_url {
                 Ok(database_url) => match harness_core::db::pg_open_pool(&database_url).await {
                     Ok(setup_pool) => {
-                        let event_context = harness_core::db::PgStoreContext::new(
-                            database_url,
-                            harness_core::db::pg_schema_for_path(&data_dir.join("events.db"))?,
+                        let event_context = harness_core::db::PgStoreContext::from_path(
+                            &data_dir.join("events.db"),
+                            Some(&database_url),
                         )?;
                         let store = harness_observe::event_store::EventStore::with_policies_and_otel_with_context(
                             data_dir,

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -140,10 +140,8 @@ pub(crate) async fn build_registry(
 
     // ── Plan DB + cache ───────────────────────────────────────────────────────
     let plans_db_path = harness_core::config::dirs::default_db_path(data_dir, "plans");
-    let plan_context = harness_core::db::PgStoreContext::new(
-        database_url.clone(),
-        harness_core::db::pg_schema_for_path(&plans_db_path)?,
-    )?;
+    let plan_context =
+        harness_core::db::PgStoreContext::from_path(&plans_db_path, Some(&database_url))?;
     let plan_db = match super::forced_startup_error("plan_db") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("plan_db").failed(error));
@@ -386,10 +384,8 @@ pub(crate) async fn build_registry(
 
     // ── Project registry ──────────────────────────────────────────────────────
     let projects_db_path = harness_core::config::dirs::default_db_path(data_dir, "projects");
-    let project_context = harness_core::db::PgStoreContext::new(
-        database_url.clone(),
-        harness_core::db::pg_schema_for_path(&projects_db_path)?,
-    )?;
+    let project_context =
+        harness_core::db::PgStoreContext::from_path(&projects_db_path, Some(&database_url))?;
     let project_registry = match super::forced_startup_error("project_registry") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("project_registry").failed(error));
@@ -539,8 +535,9 @@ pub(crate) async fn build_registry(
                     .push(StoreStartupResult::optional("runtime_state_store").failed(error));
                 None
             }
-            None => match harness_core::db::pg_schema_for_path(&runtime_state_db_path).and_then(
-                |schema| harness_core::db::PgStoreContext::new(database_url.clone(), schema),
+            None => match harness_core::db::PgStoreContext::from_path(
+                &runtime_state_db_path,
+                Some(&database_url),
             ) {
                 Ok(context) => {
                     match crate::runtime_state_store::RuntimeStateStore::open_with_context(

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -81,10 +81,7 @@ pub(crate) async fn build_storage_with_database_url(
         }
     };
 
-    let task_context = harness_core::db::PgStoreContext::new(
-        database_url.clone(),
-        harness_core::db::pg_schema_for_path(&db_path)?,
-    )?;
+    let task_context = harness_core::db::PgStoreContext::from_path(&db_path, Some(&database_url))?;
     let (tasks, task_result) = match super::forced_startup_error("tasks") {
         Some(error) => (None, StoreStartupResult::critical("tasks").failed(error)),
         None => match TaskStore::open_with_context(&db_path, &task_context, &setup_pool).await {
@@ -101,9 +98,10 @@ pub(crate) async fn build_storage_with_database_url(
             None,
             StoreStartupResult::optional("q_value_store").failed(error),
         ),
-        None => match harness_core::db::pg_schema_for_path(&q_values_db_path)
-            .and_then(|schema| harness_core::db::PgStoreContext::new(database_url, schema))
-        {
+        None => match harness_core::db::PgStoreContext::from_path(
+            &q_values_db_path,
+            Some(&database_url),
+        ) {
             Ok(q_value_context) => {
                 match QValueStore::open_with_context(&q_value_context, &setup_pool).await {
                     Ok(store) => (

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -101,18 +101,17 @@ async fn build_review_store(
         }
     };
 
-    let context = match harness_core::db::pg_schema_for_path(&review_db_path)
-        .and_then(|schema| harness_core::db::PgStoreContext::new(database_url, schema))
-    {
-        Ok(context) => context,
-        Err(error) => {
-            setup_pool.close().await;
-            return Ok((
-                None,
-                StoreStartupResult::optional("review_store").failed(error.to_string()),
-            ));
-        }
-    };
+    let context =
+        match harness_core::db::PgStoreContext::from_path(&review_db_path, Some(&database_url)) {
+            Ok(context) => context,
+            Err(error) => {
+                setup_pool.close().await;
+                return Ok((
+                    None,
+                    StoreStartupResult::optional("review_store").failed(error.to_string()),
+                ));
+            }
+        };
     let review_store =
         crate::review_store::ReviewStore::open_with_context(&context, &setup_pool).await;
     setup_pool.close().await;

--- a/docs/postgres-schema-cleanup.md
+++ b/docs/postgres-schema-cleanup.md
@@ -1,0 +1,59 @@
+# Postgres Path-Derived Schema Cleanup
+
+This workflow is for legacy `h[0-9a-f]{16}` schemas created from store identity
+paths. It is intentionally conservative: dry-run first, registry-backed drops
+only, and explicit allowlisting for any unregistered schema.
+
+## Preconditions
+
+1. Run from the same host namespace that owns the Harness workspace paths.
+2. Confirm the database URL via config or `HARNESS_DATABASE_URL`.
+3. Back up candidate schemas before any destructive cleanup:
+
+```bash
+pg_dump "$HARNESS_DATABASE_URL" --schema <schema> --file backups/<schema>.sql
+```
+
+## Dry Run
+
+```bash
+harness-pg-schema-cleanup --include-unregistered
+```
+
+The report classifies schemas as:
+
+- `KEEP`: registered path-derived schema, or a registered schema missing enough
+  ownership data for automated cleanup.
+- `DROP_CANDIDATE`: registered non-path-derived schema whose owner path is
+  missing.
+- `BLOCKED`: unregistered path-derived schema. It is never dropped unless named
+  with `--allow-unregistered`.
+
+Table counts and estimated row counts are included so operators can compare the
+plan against backups and production expectations.
+
+## Apply
+
+After reviewing backups, live traffic, and the dry-run output, name the exact
+registered drop-candidate schema(s) to remove:
+
+```bash
+harness-pg-schema-cleanup --apply --confirm-drop --schema h0123456789abcdef
+```
+
+Unregistered schemas require an explicit allowlist:
+
+```bash
+harness-pg-schema-cleanup --apply --confirm-drop --allow-unregistered h0123456789abcdef
+```
+
+`--apply` validates the full request before any destructive operation, then uses
+`DROP SCHEMA "<schema>" CASCADE` and removes registry rows for registered schemas
+it dropped. If a registered schema is not a drop candidate, is not registered,
+or is unregistered and not explicitly allowlisted, cleanup refuses to drop it.
+
+## Rollback Boundary
+
+Cleanup is destructive after `DROP SCHEMA CASCADE`. Restore by replaying the
+matching `pg_dump` output into the same database and then re-running the dry-run
+to confirm the restored schema is visible.


### PR DESCRIPTION
Closes #1199

## Summary

- Register ownership metadata for path-derived Postgres schemas in `harness_admin.schema_ownership` when a real path is available through `PgStoreContext::from_path`.
- Route production startup stores that derive schemas from paths through `from_path`, and keep explicit/shared schemas unowned unless ownership is supplied explicitly.
- Add a cleanup planner and `harness-pg-schema-cleanup` dry-run/apply binary for `h[0-9a-f]{16}` schemas.
- Keep registered path-derived schemas by default: `owner_path` is an identity key, not a live database-file check. Destructive cleanup requires exact registered drop-candidate schema names, or explicit unregistered allowlist names.
- Keep dry-run planning read-only when the ownership registry is absent, prevalidate the full cleanup request before any `DROP SCHEMA CASCADE`, use `pg_class.reltuples` for approximate row estimates, and document backup/apply/rollback boundaries.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo check --package harness-core --package harness-cli --all-targets`
- `cargo test --package harness-core pg_store_context -- --nocapture`
- `cargo test --package harness-core db_pg_schema_registry -- --nocapture`
- `cargo test --package harness-core pg_store_context_registers_path_schema_with_shared_setup_pool -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test`
- `git diff --check`
- `target/debug/harness-pg-schema-cleanup --include-unregistered --json | jq ...` -> `total=18195`, `drop_candidates=0`, `blocked=9844`, `keep=8351`
