### PR TITLE
fix(server): surface runtime persistence degradation

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -40,6 +40,9 @@ pub async fn register_runtime_host(
             Json(json!({ "error": "host_id must not be empty" })),
         );
     }
+    if let Err(response) = ensure_runtime_state_persistence_available(&state) {
+        return response;
+    }
     let host = state.runtime_hosts.register(
         host_id.to_string(),
         req.display_name.map(|v| v.trim().to_string()),
@@ -95,6 +98,9 @@ pub async fn deregister_runtime_host(
             Json(json!({ "error": "runtime host not found" })),
         )
     } else {
+        if let Err(response) = ensure_runtime_state_persistence_available(&state) {
+            return response;
+        }
         match state.core.tasks.release_runtime_host_claims(&host_id).await {
             Ok(released) => {
                 if !released.is_empty() {
@@ -225,15 +231,79 @@ pub async fn claim_task_for_runtime_host(
     (StatusCode::OK, Json(json!({ "claimed": false })))
 }
 
+fn ensure_runtime_state_persistence_available(
+    state: &Arc<AppState>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if let Err(e) = state.ensure_runtime_state_persistence_available() {
+        tracing::error!(
+            "runtime host mutation rejected because runtime state persistence is unavailable: {e}"
+        );
+        return Err(runtime_state_persistence_error_response(e));
+    }
+    Ok(())
+}
+
 async fn persist_runtime_state(
     state: &Arc<AppState>,
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
     if let Err(e) = state.persist_runtime_state().await {
         tracing::error!("failed to persist runtime state after runtime host mutation: {e}");
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("failed to persist runtime state: {e}") })),
-        ));
+        return Err(runtime_state_persistence_error_response(e));
     }
     Ok(())
+}
+
+fn runtime_state_persistence_error_response(
+    error: anyhow::Error,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": "runtime state persistence unavailable",
+            "message": error.to_string(),
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_runtime_host_rejects_required_missing_runtime_state_store(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let mut state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+        let state_mut =
+            Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+        state_mut.startup_statuses =
+            vec![
+                crate::http::state::StoreStartupResult::optional("runtime_state_store")
+                    .failed("pool timed out while waiting for an open connection"),
+            ];
+        state_mut.degraded_subsystems = vec!["runtime_state_store"];
+
+        let (status, body) = register_runtime_host(
+            State(state.clone()),
+            Json(RegisterRuntimeHostRequest {
+                host_id: "host-a".to_string(),
+                display_name: None,
+                capabilities: vec![],
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body.0["error"], "runtime state persistence unavailable");
+        assert!(
+            !state.runtime_hosts.hosts.contains_key("host-a"),
+            "host registration must not mutate memory when required persistence is unavailable"
+        );
+        assert!(state.is_runtime_state_dirty());
+        Ok(())
+    }
 }

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -85,6 +85,9 @@ pub async fn deregister_runtime_host(
     State(state): State<Arc<AppState>>,
     Path(host_id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) = ensure_runtime_state_persistence_available(&state) {
+        return response;
+    }
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         // Host already gone from memory (idempotent retry).  If a prior
         // deregister mutated memory but failed to persist, converge now.
@@ -98,9 +101,6 @@ pub async fn deregister_runtime_host(
             Json(json!({ "error": "runtime host not found" })),
         )
     } else {
-        if let Err(response) = ensure_runtime_state_persistence_available(&state) {
-            return response;
-        }
         match state.core.tasks.release_runtime_host_claims(&host_id).await {
             Ok(released) => {
                 if !released.is_empty() {
@@ -303,6 +303,33 @@ mod tests {
             !state.runtime_hosts.hosts.contains_key("host-a"),
             "host registration must not mutate memory when required persistence is unavailable"
         );
+        assert!(state.is_runtime_state_dirty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deregister_runtime_host_rejects_required_missing_runtime_state_store_before_lookup(
+    ) -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let mut state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+        let state_mut =
+            Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+        state_mut.startup_statuses =
+            vec![
+                crate::http::state::StoreStartupResult::optional("runtime_state_store")
+                    .failed("pool timed out while waiting for an open connection"),
+            ];
+        state_mut.degraded_subsystems = vec!["runtime_state_store"];
+
+        let (status, body) =
+            deregister_runtime_host(State(state.clone()), Path("ghost-host".to_string())).await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body.0["error"], "runtime state persistence unavailable");
         assert!(state.is_runtime_state_dirty());
         Ok(())
     }

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -44,6 +44,9 @@ pub async fn sync_runtime_host_projects(
     Path(host_id): Path<String>,
     Json(req): Json<SyncWatchedProjectsRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) = ensure_runtime_state_persistence_available(&state) {
+        return response;
+    }
     if !host_exists(&state, &host_id) {
         return (
             StatusCode::NOT_FOUND,
@@ -141,10 +144,31 @@ async fn persist_runtime_state(
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
     if let Err(e) = state.persist_runtime_state().await {
         tracing::error!("failed to persist runtime state after project cache sync: {e}");
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("failed to persist runtime state: {e}") })),
-        ));
+        return Err(runtime_state_persistence_error_response(e));
     }
     Ok(())
+}
+
+fn ensure_runtime_state_persistence_available(
+    state: &Arc<AppState>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if let Err(e) = state.ensure_runtime_state_persistence_available() {
+        tracing::error!(
+            "runtime project cache sync rejected because runtime state persistence is unavailable: {e}"
+        );
+        return Err(runtime_state_persistence_error_response(e));
+    }
+    Ok(())
+}
+
+fn runtime_state_persistence_error_response(
+    error: anyhow::Error,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": "runtime state persistence unavailable",
+            "message": error.to_string(),
+        })),
+    )
 }

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -132,6 +132,58 @@ async fn sync_unknown_host_returns_not_found() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sync_rejects_required_missing_runtime_state_store_before_cache_mutation(
+) -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+
+    let Some(mut state) = make_test_state(data_dir.path()).await? else {
+        return Ok(());
+    };
+    state
+        .runtime_hosts
+        .register("host-a".to_string(), None, vec![]);
+    let state_mut =
+        Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("runtime_state_store")
+                .failed("pool timed out while waiting for an open connection"),
+        ];
+    state_mut.degraded_subsystems = vec!["runtime_state_store"];
+
+    let app = runtime_project_cache_app(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "projects": [{"project": project_dir.path().to_string_lossy()}]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = http_body_util::BodyExt::collect(response.into_body())
+        .await?
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(json["error"], "runtime state persistence unavailable");
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+    assert!(state.is_runtime_state_dirty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn sync_by_project_id_resolves_registry_root() -> anyhow::Result<()> {
     let data_dir = tempfile::tempdir()?;
     let project_dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -171,6 +171,21 @@ pub struct AppState {
 }
 
 impl AppState {
+    fn runtime_state_persistence_required(&self) -> bool {
+        self.startup_statuses
+            .iter()
+            .any(|status| status.name == "runtime_state_store")
+            || self.degraded_subsystems.contains(&"runtime_state_store")
+    }
+
+    pub fn ensure_runtime_state_persistence_available(&self) -> anyhow::Result<()> {
+        if self.core.runtime_state_store.is_some() || !self.runtime_state_persistence_required() {
+            return Ok(());
+        }
+        self.runtime_state_dirty.store(true, Ordering::Release);
+        anyhow::bail!("runtime state persistence is unavailable");
+    }
+
     pub fn observe_notification_lag(&self, dropped: u64) -> u64 {
         let previous_total = self
             .notifications
@@ -192,6 +207,10 @@ impl AppState {
     pub async fn persist_runtime_state(&self) -> anyhow::Result<()> {
         let _guard = self.runtime_state_persist_lock.lock().await;
         let Some(store) = self.core.runtime_state_store.as_ref() else {
+            if self.runtime_state_persistence_required() {
+                self.runtime_state_dirty.store(true, Ordering::Release);
+                anyhow::bail!("runtime state persistence is unavailable");
+            }
             return Ok(());
         };
         let hosts = self.runtime_hosts.snapshot_state();

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -18,41 +18,11 @@ use crate::task_runner::{
 };
 use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
-/// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
-/// that requires a separate workflow-store lookup (not persisted on `TaskState` itself).
-#[derive(Serialize)]
-struct FullTaskResponse {
-    #[serde(flatten)]
-    inner: crate::task_runner::TaskState,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    workflow: Option<TaskWorkflowSummary>,
-}
+mod detail;
+pub(crate) use detail::{get_task, get_task_artifacts, get_task_prompts, get_task_proof};
 
-#[derive(Serialize)]
-struct RuntimeTaskResponse {
-    id: String,
-    task_id: String,
-    task_kind: TaskKind,
-    status: String,
-    execution_path: &'static str,
-    workflow_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    repo: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    project: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    issue: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    workflow: Option<TaskWorkflowSummary>,
-}
-
-enum RuntimeProofLookup {
-    Missing,
-    InFlight(String),
-    Terminal(ProofOfWork),
-}
+#[cfg(test)]
+pub(crate) use detail::{proof_from_runtime_workflow, proof_from_state};
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -86,6 +56,25 @@ struct TaskListResponse {
     data: Vec<TaskSummary>,
     page: TaskListPage,
     counts: TaskListCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    degraded: Option<TaskListDegradation>,
+}
+
+#[derive(Serialize)]
+struct TaskListDegradation {
+    partial: bool,
+    missing: Vec<&'static str>,
+    reason: &'static str,
+}
+
+impl TaskListDegradation {
+    fn runtime_submission_summaries(reason: &'static str) -> Self {
+        Self {
+            partial: true,
+            missing: vec!["workflow_runtime_submissions"],
+            reason,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -223,7 +212,7 @@ pub(crate) async fn list_tasks(
                     };
                 }
             }
-            if let Err(e) = append_runtime_submission_summaries(
+            let degraded = if let Err(e) = append_runtime_submission_summaries(
                 &state,
                 &mut summaries,
                 &query.filter,
@@ -233,11 +222,22 @@ pub(crate) async fn list_tasks(
             .await
             {
                 tracing::error!("list_tasks: failed to append runtime submission summaries: {e}");
-            }
+                Some(TaskListDegradation::runtime_submission_summaries(
+                    "runtime_submission_summaries_unavailable",
+                ))
+            } else {
+                None
+            };
             sort_task_summaries(&mut summaries);
             let (data, page) = paginate_task_summaries(&summaries, &query);
             let counts = task_list_counts(&data);
-            Json(TaskListResponse { data, page, counts }).into_response()
+            Json(TaskListResponse {
+                data,
+                page,
+                counts,
+                degraded,
+            })
+            .into_response()
         }
         Err(e) => {
             tracing::error!("list_tasks: database error: {e}");
@@ -544,6 +544,9 @@ async fn append_runtime_submission_summaries(
     limit: usize,
 ) -> anyhow::Result<()> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        if workflow_runtime_summaries_required(state, filter) {
+            anyhow::bail!("workflow runtime store is unavailable");
+        }
         return Ok(());
     };
     append_runtime_definition_summaries(
@@ -566,6 +569,26 @@ async fn append_runtime_submission_summaries(
         limit,
     )
     .await
+}
+
+fn workflow_runtime_summaries_required(state: &AppState, filter: &TaskSummaryFilter) -> bool {
+    workflow_runtime_store_required(state) && filter_includes_runtime_submission_kinds(filter)
+}
+
+pub(super) fn workflow_runtime_store_required(state: &AppState) -> bool {
+    state
+        .startup_statuses
+        .iter()
+        .any(|status| status.name == "workflow_runtime_store")
+        || state
+            .degraded_subsystems
+            .contains(&"workflow_runtime_store")
+}
+
+fn filter_includes_runtime_submission_kinds(filter: &TaskSummaryFilter) -> bool {
+    filter.kinds.is_empty()
+        || filter.kinds.contains(&TaskKind::Issue)
+        || filter.kinds.contains(&TaskKind::Prompt)
 }
 
 async fn append_runtime_definition_summaries(
@@ -660,7 +683,7 @@ fn runtime_workflow_task_summary(
     }
 }
 
-fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
+pub(super) fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
     match state {
         "awaiting_dependencies" => TaskStatus::AwaitingDeps,
         "scheduled" | "discovered" => TaskStatus::Pending,
@@ -714,7 +737,7 @@ fn runtime_workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSch
     }
 }
 
-fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+pub(super) fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
     data.get(field)
         .and_then(|value| value.as_str())
         .map(ToOwned::to_owned)
@@ -724,7 +747,7 @@ fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String>
 /// responses. Pulled out of two identical match blocks in
 /// [`runtime_workflow_task_summary`] and [`runtime_task_response_by_handle`]
 /// so that adding a new `TaskKind` variant only edits one place.
-fn runtime_external_id(
+pub(super) fn runtime_external_id(
     task_kind: TaskKind,
     workflow_data: &serde_json::Value,
     issue: Option<u64>,
@@ -747,463 +770,6 @@ fn runtime_task_id_array(
         .filter_map(|value| value.as_str())
         .map(harness_core::types::TaskId::from_str)
         .collect()
-}
-
-pub(crate) async fn get_task(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> Response {
-    let task_id = harness_core::types::TaskId(id);
-    match state.core.tasks.get_with_db_fallback(&task_id).await {
-        Ok(Some(task)) => {
-            let workflow = enrich_task_workflow(&state, &task).await;
-            Json(FullTaskResponse {
-                inner: task,
-                workflow,
-            })
-            .into_response()
-        }
-        Ok(None) => match runtime_task_response_by_handle(&state, &task_id).await {
-            Ok(Some(runtime_task)) => Json(runtime_task).into_response(),
-            Ok(None) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response(),
-            Err(e) => {
-                tracing::error!("get_task: runtime workflow lookup failed: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "internal server error"})),
-                )
-                    .into_response()
-            }
-        },
-        Err(e) => {
-            tracing::error!("get_task: database error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response()
-        }
-    }
-}
-
-async fn runtime_task_response_by_handle(
-    state: &AppState,
-    task_id: &harness_core::types::TaskId,
-) -> anyhow::Result<Option<RuntimeTaskResponse>> {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return Ok(None);
-    };
-    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(None);
-    };
-    let issue = workflow
-        .data
-        .get("issue_number")
-        .and_then(|value| value.as_u64());
-    let Some(task_kind) = (match workflow.definition_id.as_str() {
-        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID => Some(TaskKind::Issue),
-        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID => Some(TaskKind::Prompt),
-        _ => None,
-    }) else {
-        return Ok(None);
-    };
-    let external_id = runtime_external_id(task_kind, &workflow.data, issue);
-    Ok(Some(RuntimeTaskResponse {
-        id: task_id.as_str().to_string(),
-        task_id: task_id.as_str().to_string(),
-        task_kind,
-        status: workflow.state.clone(),
-        execution_path: "workflow_runtime",
-        workflow_id: workflow.id.clone(),
-        external_id,
-        repo: workflow
-            .data
-            .get("repo")
-            .and_then(|value| value.as_str())
-            .map(ToOwned::to_owned),
-        project: workflow
-            .data
-            .get("project_id")
-            .and_then(|value| value.as_str())
-            .map(ToOwned::to_owned),
-        issue,
-        workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
-    }))
-}
-
-/// Look up the issue-workflow instance for a task using targeted store queries.
-/// Returns `None` when the workflow store is unavailable or the task has no workflow association.
-async fn enrich_task_workflow(
-    state: &AppState,
-    task: &crate::task_runner::TaskState,
-) -> Option<TaskWorkflowSummary> {
-    let workflow_store = state.core.issue_workflow_store.as_ref()?;
-    let project_id = task.project_root.as_ref()?.to_string_lossy().into_owned();
-
-    let by_issue = task
-        .external_id
-        .as_deref()
-        .and_then(|id| id.strip_prefix("issue:"))
-        .and_then(|n| n.parse::<u64>().ok());
-    let by_pr = task
-        .external_id
-        .as_deref()
-        .and_then(|id| id.strip_prefix("pr:"))
-        .and_then(|n| n.parse::<u64>().ok())
-        .or_else(|| {
-            task.pr_url
-                .as_deref()
-                .and_then(super::parse_pr_num_from_url)
-        });
-
-    match (by_issue, by_pr) {
-        (Some(issue), _) => workflow_store
-            .get_by_issue(&project_id, task.repo.as_deref(), issue)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::warn!("get_task: workflow lookup by issue failed: {e}");
-                None
-            })
-            .map(TaskWorkflowSummary::from),
-        (None, Some(pr)) => workflow_store
-            .get_by_pr(&project_id, task.repo.as_deref(), pr)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::warn!("get_task: workflow lookup by PR failed: {e}");
-                None
-            })
-            .map(TaskWorkflowSummary::from),
-        (None, None) => None,
-    }
-}
-
-/// GET /tasks/{id}/artifacts — all persisted artifacts for a task.
-pub(crate) async fn get_task_artifacts(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> Response {
-    let task_id = harness_core::types::TaskId(id);
-    match state.core.tasks.get_with_db_fallback(&task_id).await {
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            tracing::error!("get_task_artifacts: database error: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response();
-        }
-        Ok(Some(_)) => {}
-    }
-    match state.core.tasks.list_artifacts(&task_id).await {
-        Ok(artifacts) => Json(artifacts).into_response(),
-        Err(e) => {
-            tracing::error!("get_task_artifacts: list artifacts error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response()
-        }
-    }
-}
-
-/// Derive a [`ProofOfWork`] summary from a [`TaskState`].
-///
-/// Uses only `TaskState` fields already populated by the review loop, so the
-/// derivation is a pure function and stays cheap to call from HTTP handlers.
-///
-/// CI status policy:
-/// - `Passed` requires both terminal `Done` status and an approving review,
-///   because the LGTM gate is what runs the project's test command.
-/// - `Failed` covers explicit `Failed` status and review rounds that recorded
-///   a `quota_exhausted` / `billing_failed` / `upstream_failure` / `timeout`
-///   result.
-/// - Everything else (cancelled, no review evidence) reports `Unknown`.
-pub(crate) fn proof_from_state(task: &TaskState) -> ProofOfWork {
-    let mut review_rounds: u32 = 0;
-    let mut last_review_result: Option<&str> = None;
-    let mut saw_review_failure = false;
-
-    for round in &task.rounds {
-        if !matches!(round.action.as_str(), "review" | "agent_review") {
-            continue;
-        }
-        review_rounds = review_rounds.saturating_add(1);
-        last_review_result = Some(round.result.as_str());
-        if matches!(
-            round.result.as_str(),
-            "quota_exhausted" | "billing_failed" | "upstream_failure" | "timeout" | "failed"
-        ) {
-            saw_review_failure = true;
-        }
-    }
-
-    let review_outcome = match last_review_result {
-        Some("lgtm") | Some("approved") => ReviewOutcome::Approved,
-        Some("needs_fix") | Some("fixed") => ReviewOutcome::ChangesRequested,
-        Some(result) if result.ends_with(" issues") => ReviewOutcome::ChangesRequested,
-        Some(_) => ReviewOutcome::Skipped,
-        None => ReviewOutcome::Skipped,
-    };
-
-    let ci_status =
-        if matches!(task.status, TaskStatus::Done) && review_outcome == ReviewOutcome::Approved {
-            CiStatus::Passed
-        } else if matches!(task.status, TaskStatus::Failed) || saw_review_failure {
-            CiStatus::Failed
-        } else {
-            CiStatus::Unknown
-        };
-
-    let mut signals = Vec::new();
-    signals.push(QualitySignal {
-        name: "turns".to_string(),
-        value: task.turn.to_string(),
-    });
-    if let Some(error) = task.error.as_deref().filter(|s| !s.is_empty()) {
-        signals.push(QualitySignal {
-            name: "error".to_string(),
-            value: error.to_string(),
-        });
-    }
-
-    ProofOfWork {
-        task_id: task.id.0.clone(),
-        status: task.status.as_ref().to_string(),
-        pr_url: task.pr_url.clone(),
-        ci_status,
-        review_outcome,
-        review_rounds,
-        quality_signals: signals,
-    }
-}
-
-fn proof_from_runtime_workflow(
-    task_id: &harness_core::types::TaskId,
-    workflow: &harness_workflow::runtime::WorkflowInstance,
-    events: &[harness_workflow::runtime::WorkflowEvent],
-    decisions: &[harness_workflow::runtime::WorkflowDecisionRecord],
-) -> ProofOfWork {
-    let status = runtime_workflow_state_to_task_status(&workflow.state);
-    let pr_url = runtime_string_field(&workflow.data, "pr_url")
-        .or_else(|| runtime_string_field(&workflow.data, "last_pr_url"));
-    let accepted_decisions = decisions
-        .iter()
-        .filter(|record| record.accepted)
-        .collect::<Vec<_>>();
-    let approved = events.iter().any(|event| {
-        matches!(
-            event.event_type.as_str(),
-            "PrReadyToMerge" | "MergeApproved" | "PrMerged"
-        )
-    }) || accepted_decisions.iter().any(|record| {
-        matches!(
-            record.decision.decision.as_str(),
-            "mark_ready_to_merge" | "approve_merge" | "record_pr_merged" | "quality_passed"
-        )
-    }) || workflow.state == "passed";
-    let changes_requested = events
-        .iter()
-        .any(|event| event.event_type == "FeedbackFound")
-        || accepted_decisions.iter().any(|record| {
-            matches!(
-                record.decision.decision.as_str(),
-                "address_pr_feedback" | "await_feedback_after_rework"
-            )
-        });
-
-    let review_outcome = if approved {
-        ReviewOutcome::Approved
-    } else if changes_requested {
-        ReviewOutcome::ChangesRequested
-    } else {
-        ReviewOutcome::Skipped
-    };
-    let ci_status = if status == TaskStatus::Failed {
-        CiStatus::Failed
-    } else if status == TaskStatus::Done && review_outcome == ReviewOutcome::Approved {
-        CiStatus::Passed
-    } else {
-        CiStatus::Unknown
-    };
-    let review_event_count = events
-        .iter()
-        .filter(|event| {
-            matches!(
-                event.event_type.as_str(),
-                "FeedbackFound" | "NoFeedbackFound" | "PrReadyToMerge"
-            )
-        })
-        .count();
-    let review_decision_count = accepted_decisions
-        .iter()
-        .filter(|record| {
-            matches!(
-                record.decision.decision.as_str(),
-                "address_pr_feedback"
-                    | "wait_for_pr_feedback"
-                    | "mark_ready_to_merge"
-                    | "quality_passed"
-            )
-        })
-        .count();
-    let review_rounds = review_event_count.max(review_decision_count) as u32;
-
-    let mut signals = vec![
-        QualitySignal {
-            name: "workflow_id".to_string(),
-            value: workflow.id.clone(),
-        },
-        QualitySignal {
-            name: "workflow_state".to_string(),
-            value: workflow.state.clone(),
-        },
-    ];
-    if let Some(error) = runtime_string_field(&workflow.data, "failure_reason") {
-        signals.push(QualitySignal {
-            name: "error".to_string(),
-            value: error,
-        });
-    }
-
-    ProofOfWork {
-        task_id: task_id.as_str().to_string(),
-        status: status.as_ref().to_string(),
-        pr_url,
-        ci_status,
-        review_outcome,
-        review_rounds,
-        quality_signals: signals,
-    }
-}
-
-async fn runtime_proof_by_handle(
-    state: &AppState,
-    task_id: &harness_core::types::TaskId,
-) -> anyhow::Result<RuntimeProofLookup> {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return Ok(RuntimeProofLookup::Missing);
-    };
-    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(RuntimeProofLookup::Missing);
-    };
-    let status = runtime_workflow_state_to_task_status(&workflow.state);
-    if !status.is_terminal() {
-        return Ok(RuntimeProofLookup::InFlight(status.as_ref().to_string()));
-    }
-    let events = store.events_for(&workflow.id).await?;
-    let decisions = store.decisions_for(&workflow.id).await?;
-    Ok(RuntimeProofLookup::Terminal(proof_from_runtime_workflow(
-        task_id, &workflow, &events, &decisions,
-    )))
-}
-
-/// GET /tasks/{id}/proof — machine-readable proof-of-work summary for a
-/// completed task.
-///
-/// Returns 404 for unknown task IDs, 422 while the task is still in flight,
-/// and 200 with a JSON [`ProofOfWork`] for terminal tasks (Done / Failed /
-/// Cancelled). See `harness-core::proof_of_work` for the wire format.
-pub(crate) async fn get_task_proof(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> Response {
-    let task_id = harness_core::types::TaskId(id);
-    match state.core.tasks.get_with_db_fallback(&task_id).await {
-        Ok(Some(task)) => {
-            if !task.status.is_terminal() {
-                return (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    Json(json!({
-                        "error": "task is not in a terminal state",
-                        "status": task.status.as_ref(),
-                    })),
-                )
-                    .into_response();
-            }
-            Json(proof_from_state(&task)).into_response()
-        }
-        Ok(None) => match runtime_proof_by_handle(&state, &task_id).await {
-            Ok(RuntimeProofLookup::Terminal(proof)) => Json(proof).into_response(),
-            Ok(RuntimeProofLookup::InFlight(status)) => (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(json!({
-                    "error": "task is not in a terminal state",
-                    "status": status,
-                })),
-            )
-                .into_response(),
-            Ok(RuntimeProofLookup::Missing) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response(),
-            Err(e) => {
-                tracing::error!("get_task_proof: runtime workflow lookup failed: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "internal server error"})),
-                )
-                    .into_response()
-            }
-        },
-        Err(e) => {
-            tracing::error!("get_task_proof: database error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response()
-        }
-    }
-}
-
-/// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
-pub(crate) async fn get_task_prompts(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> Response {
-    let task_id = harness_core::types::TaskId(id);
-    match state.core.tasks.get_with_db_fallback(&task_id).await {
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            tracing::error!("get_task_prompts: database error: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response();
-        }
-        Ok(Some(_)) => {}
-    }
-    match state.core.tasks.get_prompts(&task_id).await {
-        Ok(prompts) => Json(prompts).into_response(),
-        Err(e) => {
-            tracing::error!("get_task_prompts: query error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response()
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -1,0 +1,500 @@
+use super::*;
+
+/// Response type for `GET /tasks/{id}` — `TaskState` fields plus the optional workflow summary
+/// that requires a separate workflow-store lookup (not persisted on `TaskState` itself).
+#[derive(Serialize)]
+struct FullTaskResponse {
+    #[serde(flatten)]
+    inner: crate::task_runner::TaskState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow: Option<TaskWorkflowSummary>,
+}
+
+#[derive(Serialize)]
+struct RuntimeTaskResponse {
+    id: String,
+    task_id: String,
+    task_kind: TaskKind,
+    status: String,
+    execution_path: &'static str,
+    workflow_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    external_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow: Option<TaskWorkflowSummary>,
+}
+
+enum RuntimeProofLookup {
+    Missing,
+    InFlight(String),
+    Terminal(ProofOfWork),
+}
+
+pub(crate) async fn get_task(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(Some(task)) => {
+            let workflow = enrich_task_workflow(&state, &task).await;
+            Json(FullTaskResponse {
+                inner: task,
+                workflow,
+            })
+            .into_response()
+        }
+        Ok(None) => match runtime_task_response_by_handle(&state, &task_id).await {
+            Ok(Some(runtime_task)) => Json(runtime_task).into_response(),
+            Ok(None) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response(),
+            Err(e) => {
+                tracing::error!("get_task: runtime workflow lookup failed: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "internal server error"})),
+                )
+                    .into_response()
+            }
+        },
+        Err(e) => {
+            tracing::error!("get_task: database error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn runtime_task_response_by_handle(
+    state: &AppState,
+    task_id: &harness_core::types::TaskId,
+) -> anyhow::Result<Option<RuntimeTaskResponse>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        if workflow_runtime_store_required(state) {
+            anyhow::bail!("workflow runtime store is unavailable");
+        }
+        return Ok(None);
+    };
+    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(None);
+    };
+    let issue = workflow
+        .data
+        .get("issue_number")
+        .and_then(|value| value.as_u64());
+    let Some(task_kind) = (match workflow.definition_id.as_str() {
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID => Some(TaskKind::Issue),
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID => Some(TaskKind::Prompt),
+        _ => None,
+    }) else {
+        return Ok(None);
+    };
+    let external_id = runtime_external_id(task_kind, &workflow.data, issue);
+    Ok(Some(RuntimeTaskResponse {
+        id: task_id.as_str().to_string(),
+        task_id: task_id.as_str().to_string(),
+        task_kind,
+        status: workflow.state.clone(),
+        execution_path: "workflow_runtime",
+        workflow_id: workflow.id.clone(),
+        external_id,
+        repo: workflow
+            .data
+            .get("repo")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned),
+        project: workflow
+            .data
+            .get("project_id")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned),
+        issue,
+        workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
+    }))
+}
+
+/// Look up the issue-workflow instance for a task using targeted store queries.
+/// Returns `None` when the workflow store is unavailable or the task has no workflow association.
+async fn enrich_task_workflow(
+    state: &AppState,
+    task: &crate::task_runner::TaskState,
+) -> Option<TaskWorkflowSummary> {
+    let workflow_store = state.core.issue_workflow_store.as_ref()?;
+    let project_id = task.project_root.as_ref()?.to_string_lossy().into_owned();
+
+    let by_issue = task
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("issue:"))
+        .and_then(|n| n.parse::<u64>().ok());
+    let by_pr = task
+        .external_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("pr:"))
+        .and_then(|n| n.parse::<u64>().ok())
+        .or_else(|| {
+            task.pr_url
+                .as_deref()
+                .and_then(super::super::parse_pr_num_from_url)
+        });
+
+    match (by_issue, by_pr) {
+        (Some(issue), _) => workflow_store
+            .get_by_issue(&project_id, task.repo.as_deref(), issue)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("get_task: workflow lookup by issue failed: {e}");
+                None
+            })
+            .map(TaskWorkflowSummary::from),
+        (None, Some(pr)) => workflow_store
+            .get_by_pr(&project_id, task.repo.as_deref(), pr)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("get_task: workflow lookup by PR failed: {e}");
+                None
+            })
+            .map(TaskWorkflowSummary::from),
+        (None, None) => None,
+    }
+}
+
+/// GET /tasks/{id}/artifacts — all persisted artifacts for a task.
+pub(crate) async fn get_task_artifacts(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("get_task_artifacts: database error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+        Ok(Some(_)) => {}
+    }
+    match state.core.tasks.list_artifacts(&task_id).await {
+        Ok(artifacts) => Json(artifacts).into_response(),
+        Err(e) => {
+            tracing::error!("get_task_artifacts: list artifacts error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Derive a [`ProofOfWork`] summary from a [`TaskState`].
+///
+/// Uses only `TaskState` fields already populated by the review loop, so the
+/// derivation is a pure function and stays cheap to call from HTTP handlers.
+///
+/// CI status policy:
+/// - `Passed` requires both terminal `Done` status and an approving review,
+///   because the LGTM gate is what runs the project's test command.
+/// - `Failed` covers explicit `Failed` status and review rounds that recorded
+///   a `quota_exhausted` / `billing_failed` / `upstream_failure` / `timeout`
+///   result.
+/// - Everything else (cancelled, no review evidence) reports `Unknown`.
+pub(crate) fn proof_from_state(task: &TaskState) -> ProofOfWork {
+    let mut review_rounds: u32 = 0;
+    let mut last_review_result: Option<&str> = None;
+    let mut saw_review_failure = false;
+
+    for round in &task.rounds {
+        if !matches!(round.action.as_str(), "review" | "agent_review") {
+            continue;
+        }
+        review_rounds = review_rounds.saturating_add(1);
+        last_review_result = Some(round.result.as_str());
+        if matches!(
+            round.result.as_str(),
+            "quota_exhausted" | "billing_failed" | "upstream_failure" | "timeout" | "failed"
+        ) {
+            saw_review_failure = true;
+        }
+    }
+
+    let review_outcome = match last_review_result {
+        Some("lgtm") | Some("approved") => ReviewOutcome::Approved,
+        Some("needs_fix") | Some("fixed") => ReviewOutcome::ChangesRequested,
+        Some(result) if result.ends_with(" issues") => ReviewOutcome::ChangesRequested,
+        Some(_) => ReviewOutcome::Skipped,
+        None => ReviewOutcome::Skipped,
+    };
+
+    let ci_status =
+        if matches!(task.status, TaskStatus::Done) && review_outcome == ReviewOutcome::Approved {
+            CiStatus::Passed
+        } else if matches!(task.status, TaskStatus::Failed) || saw_review_failure {
+            CiStatus::Failed
+        } else {
+            CiStatus::Unknown
+        };
+
+    let mut signals = Vec::new();
+    signals.push(QualitySignal {
+        name: "turns".to_string(),
+        value: task.turn.to_string(),
+    });
+    if let Some(error) = task.error.as_deref().filter(|s| !s.is_empty()) {
+        signals.push(QualitySignal {
+            name: "error".to_string(),
+            value: error.to_string(),
+        });
+    }
+
+    ProofOfWork {
+        task_id: task.id.0.clone(),
+        status: task.status.as_ref().to_string(),
+        pr_url: task.pr_url.clone(),
+        ci_status,
+        review_outcome,
+        review_rounds,
+        quality_signals: signals,
+    }
+}
+
+pub(crate) fn proof_from_runtime_workflow(
+    task_id: &harness_core::types::TaskId,
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+    events: &[harness_workflow::runtime::WorkflowEvent],
+    decisions: &[harness_workflow::runtime::WorkflowDecisionRecord],
+) -> ProofOfWork {
+    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    let pr_url = runtime_string_field(&workflow.data, "pr_url")
+        .or_else(|| runtime_string_field(&workflow.data, "last_pr_url"));
+    let accepted_decisions = decisions
+        .iter()
+        .filter(|record| record.accepted)
+        .collect::<Vec<_>>();
+    let approved = events.iter().any(|event| {
+        matches!(
+            event.event_type.as_str(),
+            "PrReadyToMerge" | "MergeApproved" | "PrMerged"
+        )
+    }) || accepted_decisions.iter().any(|record| {
+        matches!(
+            record.decision.decision.as_str(),
+            "mark_ready_to_merge" | "approve_merge" | "record_pr_merged" | "quality_passed"
+        )
+    }) || workflow.state == "passed";
+    let changes_requested = events
+        .iter()
+        .any(|event| event.event_type == "FeedbackFound")
+        || accepted_decisions.iter().any(|record| {
+            matches!(
+                record.decision.decision.as_str(),
+                "address_pr_feedback" | "await_feedback_after_rework"
+            )
+        });
+
+    let review_outcome = if approved {
+        ReviewOutcome::Approved
+    } else if changes_requested {
+        ReviewOutcome::ChangesRequested
+    } else {
+        ReviewOutcome::Skipped
+    };
+    let ci_status = if status == TaskStatus::Failed {
+        CiStatus::Failed
+    } else if status == TaskStatus::Done && review_outcome == ReviewOutcome::Approved {
+        CiStatus::Passed
+    } else {
+        CiStatus::Unknown
+    };
+    let review_event_count = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.event_type.as_str(),
+                "FeedbackFound" | "NoFeedbackFound" | "PrReadyToMerge"
+            )
+        })
+        .count();
+    let review_decision_count = accepted_decisions
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.decision.decision.as_str(),
+                "address_pr_feedback"
+                    | "wait_for_pr_feedback"
+                    | "mark_ready_to_merge"
+                    | "quality_passed"
+            )
+        })
+        .count();
+    let review_rounds = review_event_count.max(review_decision_count) as u32;
+
+    let mut signals = vec![
+        QualitySignal {
+            name: "workflow_id".to_string(),
+            value: workflow.id.clone(),
+        },
+        QualitySignal {
+            name: "workflow_state".to_string(),
+            value: workflow.state.clone(),
+        },
+    ];
+    if let Some(error) = runtime_string_field(&workflow.data, "failure_reason") {
+        signals.push(QualitySignal {
+            name: "error".to_string(),
+            value: error,
+        });
+    }
+
+    ProofOfWork {
+        task_id: task_id.as_str().to_string(),
+        status: status.as_ref().to_string(),
+        pr_url,
+        ci_status,
+        review_outcome,
+        review_rounds,
+        quality_signals: signals,
+    }
+}
+
+async fn runtime_proof_by_handle(
+    state: &AppState,
+    task_id: &harness_core::types::TaskId,
+) -> anyhow::Result<RuntimeProofLookup> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        if workflow_runtime_store_required(state) {
+            anyhow::bail!("workflow runtime store is unavailable");
+        }
+        return Ok(RuntimeProofLookup::Missing);
+    };
+    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(RuntimeProofLookup::Missing);
+    };
+    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    if !status.is_terminal() {
+        return Ok(RuntimeProofLookup::InFlight(status.as_ref().to_string()));
+    }
+    let events = store.events_for(&workflow.id).await?;
+    let decisions = store.decisions_for(&workflow.id).await?;
+    Ok(RuntimeProofLookup::Terminal(proof_from_runtime_workflow(
+        task_id, &workflow, &events, &decisions,
+    )))
+}
+
+/// GET /tasks/{id}/proof — machine-readable proof-of-work summary for a
+/// completed task.
+///
+/// Returns 404 for unknown task IDs, 422 while the task is still in flight,
+/// and 200 with a JSON [`ProofOfWork`] for terminal tasks (Done / Failed /
+/// Cancelled). See `harness-core::proof_of_work` for the wire format.
+pub(crate) async fn get_task_proof(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(Some(task)) => {
+            if !task.status.is_terminal() {
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(json!({
+                        "error": "task is not in a terminal state",
+                        "status": task.status.as_ref(),
+                    })),
+                )
+                    .into_response();
+            }
+            Json(proof_from_state(&task)).into_response()
+        }
+        Ok(None) => match runtime_proof_by_handle(&state, &task_id).await {
+            Ok(RuntimeProofLookup::Terminal(proof)) => Json(proof).into_response(),
+            Ok(RuntimeProofLookup::InFlight(status)) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({
+                    "error": "task is not in a terminal state",
+                    "status": status,
+                })),
+            )
+                .into_response(),
+            Ok(RuntimeProofLookup::Missing) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response(),
+            Err(e) => {
+                tracing::error!("get_task_proof: runtime workflow lookup failed: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "internal server error"})),
+                )
+                    .into_response()
+            }
+        },
+        Err(e) => {
+            tracing::error!("get_task_proof: database error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// GET /tasks/{id}/prompts — all persisted redacted prompts for a task.
+pub(crate) async fn get_task_prompts(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let task_id = harness_core::types::TaskId(id);
+    match state.core.tasks.get_with_db_fallback(&task_id).await {
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "task not found"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("get_task_prompts: database error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+        Ok(Some(_)) => {}
+    }
+    match state.core.tasks.get_prompts(&task_id).await {
+        Ok(prompts) => Json(prompts).into_response(),
+        Err(e) => {
+            tracing::error!("get_task_prompts: query error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -50,22 +50,27 @@ pub(crate) async fn get_task(
             })
             .into_response()
         }
-        Ok(None) => match runtime_task_response_by_handle(&state, &task_id).await {
-            Ok(Some(runtime_task)) => Json(runtime_task).into_response(),
-            Ok(None) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response(),
-            Err(e) => {
-                tracing::error!("get_task: runtime workflow lookup failed: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "internal server error"})),
-                )
-                    .into_response()
+        Ok(None) => {
+            if workflow_runtime_store_unavailable(&state) {
+                return workflow_runtime_store_unavailable_response();
             }
-        },
+            match runtime_task_response_by_handle(&state, &task_id).await {
+                Ok(Some(runtime_task)) => Json(runtime_task).into_response(),
+                Ok(None) => (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({"error": "task not found"})),
+                )
+                    .into_response(),
+                Err(e) => {
+                    tracing::error!("get_task: runtime workflow lookup failed: {e}");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response()
+                }
+            }
+        }
         Err(e) => {
             tracing::error!("get_task: database error: {e}");
             (
@@ -82,9 +87,6 @@ async fn runtime_task_response_by_handle(
     task_id: &harness_core::types::TaskId,
 ) -> anyhow::Result<Option<RuntimeTaskResponse>> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        if workflow_runtime_store_required(state) {
-            anyhow::bail!("workflow runtime store is unavailable");
-        }
         return Ok(None);
     };
     let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
@@ -123,6 +125,21 @@ async fn runtime_task_response_by_handle(
         issue,
         workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
     }))
+}
+
+fn workflow_runtime_store_unavailable(state: &AppState) -> bool {
+    state.core.workflow_runtime_store.is_none() && workflow_runtime_store_required(state)
+}
+
+fn workflow_runtime_store_unavailable_response() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": "workflow runtime store unavailable",
+            "message": "workflow runtime store is unavailable",
+        })),
+    )
+        .into_response()
 }
 
 /// Look up the issue-workflow instance for a task using targeted store queries.
@@ -383,9 +400,6 @@ async fn runtime_proof_by_handle(
     task_id: &harness_core::types::TaskId,
 ) -> anyhow::Result<RuntimeProofLookup> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        if workflow_runtime_store_required(state) {
-            anyhow::bail!("workflow runtime store is unavailable");
-        }
         return Ok(RuntimeProofLookup::Missing);
     };
     let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
@@ -427,30 +441,35 @@ pub(crate) async fn get_task_proof(
             }
             Json(proof_from_state(&task)).into_response()
         }
-        Ok(None) => match runtime_proof_by_handle(&state, &task_id).await {
-            Ok(RuntimeProofLookup::Terminal(proof)) => Json(proof).into_response(),
-            Ok(RuntimeProofLookup::InFlight(status)) => (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(json!({
-                    "error": "task is not in a terminal state",
-                    "status": status,
-                })),
-            )
-                .into_response(),
-            Ok(RuntimeProofLookup::Missing) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "task not found"})),
-            )
-                .into_response(),
-            Err(e) => {
-                tracing::error!("get_task_proof: runtime workflow lookup failed: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "internal server error"})),
-                )
-                    .into_response()
+        Ok(None) => {
+            if workflow_runtime_store_unavailable(&state) {
+                return workflow_runtime_store_unavailable_response();
             }
-        },
+            match runtime_proof_by_handle(&state, &task_id).await {
+                Ok(RuntimeProofLookup::Terminal(proof)) => Json(proof).into_response(),
+                Ok(RuntimeProofLookup::InFlight(status)) => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(json!({
+                        "error": "task is not in a terminal state",
+                        "status": status,
+                    })),
+                )
+                    .into_response(),
+                Ok(RuntimeProofLookup::Missing) => (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({"error": "task not found"})),
+                )
+                    .into_response(),
+                Err(e) => {
+                    tracing::error!("get_task_proof: runtime workflow lookup failed: {e}");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response()
+                }
+            }
+        }
         Err(e) => {
             tracing::error!("get_task_proof: database error: {e}");
             (

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -1,6 +1,42 @@
 use super::*;
 
 #[tokio::test]
+async fn list_tasks_marks_runtime_submission_summaries_degraded_when_store_failed(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut =
+        Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("workflow_runtime_store")
+                .failed("failed to connect to Postgres"),
+        ];
+    state_mut.degraded_subsystems = vec!["workflow_runtime_store"];
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .with_state(state.clone());
+
+    let response = app
+        .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(0));
+    assert_eq!(body["degraded"]["partial"], true);
+    assert_eq!(
+        body["degraded"]["missing"],
+        serde_json::json!(["workflow_runtime_submissions"])
+    );
+    assert_eq!(
+        body["degraded"]["reason"],
+        "runtime_submission_summaries_unavailable"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests/task_detail_sse_tests.rs
+++ b/crates/harness-server/src/http/tests/task_detail_sse_tests.rs
@@ -20,6 +20,68 @@ async fn get_task_returns_not_found_for_missing_id() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn get_task_returns_service_unavailable_when_required_workflow_runtime_store_missing(
+) -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut =
+        Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("workflow_runtime_store")
+                .failed("failed to connect to Postgres"),
+        ];
+    state_mut.degraded_subsystems = vec!["workflow_runtime_store"];
+    let app = task_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/runtime-only-task")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "workflow runtime store unavailable");
+    assert_eq!(body["message"], "workflow runtime store is unavailable");
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_task_proof_returns_service_unavailable_when_required_workflow_runtime_store_missing(
+) -> anyhow::Result<()> {
+    let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut =
+        Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("workflow_runtime_store")
+                .failed("failed to connect to Postgres"),
+        ];
+    state_mut.degraded_subsystems = vec!["workflow_runtime_store"];
+    let app = task_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/runtime-only-task/proof")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response_json(response).await?;
+    assert_eq!(body["error"], "workflow runtime store unavailable");
+    assert_eq!(body["message"], "workflow runtime store is unavailable");
+    Ok(())
+}
+
+#[tokio::test]
 async fn create_then_get_task_returns_state() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -55,10 +55,14 @@ array reports each store by name with `critical`, `ready`, and a redacted
 }
 ```
 
-Runtime-host mutations fail with `503 Service Unavailable` when runtime state
-persistence was required at startup but the runtime state store is unavailable.
-This prevents a successful registration or deregistration response from hiding
-non-durable host state.
+`GET /tasks/{id}` and `GET /tasks/{id}/proof` return `503 Service Unavailable`
+with `error: "workflow runtime store unavailable"` when the requested handle
+could be runtime-backed but the required workflow runtime store is unavailable.
+
+Runtime-host mutations, including watched-project sync, fail with
+`503 Service Unavailable` when runtime state persistence was required at startup
+but the runtime state store is unavailable. This prevents a successful response
+from hiding non-durable host state.
 
 Authentication: when `api_token` is configured, all routes require proof of the
 token; without a configured token the middleware is a no-op (backward

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -34,6 +34,32 @@ observes results. The following capabilities are **only available over HTTP**:
 | `POST /signals` | ingest | Signal ingestion (rate-limited) |
 | `GET  /health` | health | Server health check |
 
+#### Degraded persistence responses
+
+Runtime persistence failures are part of the HTTP contract, not log-only
+events. `GET /health` returns a JSON `status` of `degraded` when startup store
+initialization failed or runtime state is dirty; the `persistence.startup.stores`
+array reports each store by name with `critical`, `ready`, and a redacted
+`error` code.
+
+`GET /tasks` keeps returning the task rows it can safely load, but includes a
+`degraded` object when runtime-only submissions could not be loaded:
+
+```json
+{
+  "degraded": {
+    "partial": true,
+    "missing": ["workflow_runtime_submissions"],
+    "reason": "runtime_submission_summaries_unavailable"
+  }
+}
+```
+
+Runtime-host mutations fail with `503 Service Unavailable` when runtime state
+persistence was required at startup but the runtime state store is unavailable.
+This prevents a successful registration or deregistration response from hiding
+non-durable host state.
+
 Authentication: when `api_token` is configured, all routes require proof of the
 token; without a configured token the middleware is a no-op (backward
 compatibility).  Exempt routes that bypass auth entirely: `/health`,


### PR DESCRIPTION
Closes #1202

Summary:
- Split task detail/proof handlers out of the oversized task query route before changing the runtime submission paths.
- Mark `GET /tasks` responses as partially degraded when required workflow runtime submissions cannot be loaded.
- Return 503 for runtime-backed task detail/proof lookups when the required workflow runtime store is unavailable.
- Reject runtime-host register/deregister and watched-project sync mutations with 503 before mutating memory when required runtime state persistence is unavailable.
- Document the degraded persistence response contract.

Review fixes:
- Moved deregister persistence availability checks ahead of host lookup.
- Guarded watched-project sync before cache mutation.
- Added 503 responses and regression tests for `GET /tasks/{id}` and `/proof` during required workflow runtime store outages.

Validation:
- `cargo check`
- `cargo test --package harness-server list_tasks_marks_runtime_submission_summaries_degraded_when_store_failed -- --nocapture`
- `cargo test --package harness-server register_runtime_host_rejects_required_missing_runtime_state_store -- --nocapture`
- `cargo test --package harness-server task_query_routes -- --nocapture`
- `cargo test --package harness-server runtime_hosts -- --nocapture`
- `cargo test --package harness-server service_unavailable_when_required_workflow_runtime_store_missing -- --nocapture`
- `cargo test --package harness-server required_missing_runtime_state_store -- --nocapture`
- `cargo test --package harness-server runtime_project_cache -- --nocapture`
- `cargo test --package harness-server task_detail_sse_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test`
- `git diff --check`
- `git diff --cached --check`