### PR TITLE
feat(db): automatic orphan path-schema reaper (storage RFC Phase 3b)

### DIFF
--- a/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
+++ b/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use harness_core::config::HarnessConfig;
 use harness_core::db::{
     apply_pg_schema_cleanup, configure_pg_pool_from_server, pg_open_pool, pg_schema_cleanup_plan,
-    resolve_database_url, PgSchemaCleanupAction, PgSchemaCleanupPlan,
+    reap_orphaned_path_schemas, resolve_database_url, PgSchemaCleanupAction, PgSchemaCleanupPlan,
 };
 use std::path::PathBuf;
 
@@ -30,6 +30,10 @@ struct Args {
     /// Explicitly allow an unregistered schema to be dropped with --apply.
     #[arg(long = "allow-unregistered")]
     allow_unregistered: Vec<String>,
+    /// Drop registered path-derived schemas whose owning workspace directory no
+    /// longer exists. Dry-run unless combined with --confirm-drop.
+    #[arg(long)]
+    reap_orphans: bool,
     /// Print JSON output.
     #[arg(long)]
     json: bool,
@@ -43,6 +47,37 @@ async fn main() -> anyhow::Result<()> {
     configure_pg_pool_from_server(&config.server);
     let database_url = resolve_database_url(config.server.database_url.as_deref())?;
     let pool = pg_open_pool(&database_url).await?;
+
+    if args.reap_orphans {
+        let report = reap_orphaned_path_schemas(&pool, args.confirm_drop).await?;
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else if report.orphans.is_empty() {
+            println!(
+                "No orphaned path-derived schemas (scanned {})",
+                report.scanned
+            );
+        } else {
+            println!(
+                "{} {} orphaned schema(s) of {} scanned:",
+                if report.dropped {
+                    "Reaped"
+                } else {
+                    "Would reap"
+                },
+                report.orphans.len(),
+                report.scanned
+            );
+            for schema in &report.orphans {
+                println!("  {schema}");
+            }
+            if !report.dropped {
+                println!("Re-run with --confirm-drop to drop them.");
+            }
+        }
+        pool.close().await;
+        return Ok(());
+    }
 
     if args.apply {
         if !args.confirm_drop {

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -11,9 +11,9 @@ pub use crate::db_pg::{
 };
 pub use crate::db_pg_schema_registry::{
     apply_pg_schema_cleanup, ensure_pg_schema_registry, pg_schema_cleanup_plan,
-    register_pg_schema_ownership, PgSchemaCleanupAction, PgSchemaCleanupCandidate,
-    PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership, PG_SCHEMA_REGISTRY_SCHEMA,
-    PG_SCHEMA_REGISTRY_TABLE,
+    reap_orphaned_path_schemas, register_pg_schema_ownership, PgSchemaCleanupAction,
+    PgSchemaCleanupCandidate, PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership,
+    PgSchemaReapReport, PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
 };
 
 /// Create a Postgres connection pool for the logical store at `path`.

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -373,11 +373,23 @@ fn classify_schema_cleanup_candidate(row: PgSchemaInventoryRow) -> PgSchemaClean
 }
 
 async fn drop_schema_cascade(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
-    crate::db_pg::validate_schema_name(schema)?;
-    sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", schema))
+    sqlx::query(&drop_schema_cascade_statement(schema, false)?)
         .execute(pool)
         .await?;
     Ok(())
+}
+
+async fn drop_schema_cascade_if_exists(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
+    sqlx::query(&drop_schema_cascade_statement(schema, true)?)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+fn drop_schema_cascade_statement(schema: &str, if_exists: bool) -> anyhow::Result<String> {
+    crate::db_pg::validate_schema_name(schema)?;
+    let if_exists = if if_exists { " IF EXISTS" } else { "" };
+    Ok(format!("DROP SCHEMA{if_exists} \"{schema}\" CASCADE"))
 }
 
 async fn delete_schema_ownership(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
@@ -465,7 +477,10 @@ pub async fn reap_orphaned_path_schemas(
 
     if apply {
         for schema_name in &orphans {
-            drop_schema_cascade(pool, schema_name).await?;
+            // Reaping is registry-driven, so stale rows may point at schemas
+            // already removed by manual cleanup or an interrupted prior run.
+            // Delete those ownership rows and keep processing later orphans.
+            drop_schema_cascade_if_exists(pool, schema_name).await?;
             delete_schema_ownership(pool, schema_name).await?;
         }
     }
@@ -495,6 +510,19 @@ mod tests {
         assert!(
             owner_path_is_orphaned(&dead),
             "schema whose parent dir is gone must be reaped"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn drop_schema_cascade_statement_can_tolerate_missing_schema() -> anyhow::Result<()> {
+        assert_eq!(
+            drop_schema_cascade_statement("h1234567890abcdef", true)?,
+            "DROP SCHEMA IF EXISTS \"h1234567890abcdef\" CASCADE"
+        );
+        assert_eq!(
+            drop_schema_cascade_statement("h1234567890abcdef", false)?,
+            "DROP SCHEMA \"h1234567890abcdef\" CASCADE"
         );
         Ok(())
     }

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -391,9 +391,104 @@ async fn delete_schema_ownership(pool: &PgPool, schema: &str) -> anyhow::Result<
     Ok(())
 }
 
+/// Report from a reap pass over orphaned path-derived schemas.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PgSchemaReapReport {
+    /// Number of registered path-derived schemas examined.
+    pub scanned: usize,
+    /// Schemas whose owning workspace directory no longer exists (orphans).
+    pub orphans: Vec<String>,
+    /// `true` if the orphans were dropped, `false` for a dry run.
+    pub dropped: bool,
+}
+
+/// True if a path-derived schema's owner store path is orphaned: the directory
+/// that contained the store (the owner path's *parent*) no longer exists on disk.
+///
+/// This is the conservative orphan signal. A path-derived schema is created from
+/// a store-identity path like `<workspace>/threads`; when the owning workspace is
+/// removed, that parent directory disappears and the schema is dead. Live stores
+/// (the server's fixed data dir, or an on-disk workspace) keep an existing parent
+/// directory and are therefore never considered orphaned, so this never drops a
+/// schema that could still be reopened.
+fn owner_path_is_orphaned(owner_path: &Path) -> bool {
+    match owner_path.parent() {
+        Some(parent) => !parent.exists(),
+        None => false,
+    }
+}
+
+/// Drop registered path-derived schemas whose owning workspace directory is gone.
+///
+/// This bounds Postgres catalog growth automatically: per-job / ephemeral stores
+/// create a schema under their workspace path, and once the workspace is removed
+/// the schema becomes a dead orphan that nothing can reopen. Reaping drops only
+/// those orphans (owner path's parent directory missing) and the matching
+/// registry rows — never a live store's schema.
+///
+/// With `apply = false` it reports what would be reaped (dry run) without
+/// dropping anything. Must run on the host that owns the workspace paths.
+pub async fn reap_orphaned_path_schemas(
+    pool: &PgPool,
+    apply: bool,
+) -> anyhow::Result<PgSchemaReapReport> {
+    ensure_pg_schema_registry(pool).await?;
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as(&format!(
+        "SELECT schema_name, owner_path
+         FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE owner_kind = $1"
+    ))
+    .bind(PATH_DERIVED_OWNER_KIND)
+    .fetch_all(pool)
+    .await?;
+
+    let scanned = rows.len();
+    let mut orphans = Vec::new();
+    for (schema_name, owner_path) in rows {
+        // No recorded path: cannot prove the schema is orphaned, so keep it.
+        let Some(owner_path) = owner_path else {
+            continue;
+        };
+        if owner_path_is_orphaned(Path::new(&owner_path)) {
+            orphans.push(schema_name);
+        }
+    }
+
+    if apply {
+        for schema_name in &orphans {
+            drop_schema_cascade(pool, schema_name).await?;
+            delete_schema_ownership(pool, schema_name).await?;
+        }
+    }
+
+    Ok(PgSchemaReapReport {
+        scanned,
+        orphans,
+        dropped: apply,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn owner_path_is_orphaned_detects_missing_parent() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        // Live store: its parent directory (the temp dir) exists -> kept.
+        let live = dir.path().join("threads");
+        assert!(
+            !owner_path_is_orphaned(&live),
+            "schema whose parent dir exists must never be reaped"
+        );
+        // Orphan: the owning workspace directory was removed.
+        let dead = dir.path().join("removed-workspace/threads");
+        assert!(
+            owner_path_is_orphaned(&dead),
+            "schema whose parent dir is gone must be reaped"
+        );
+        Ok(())
+    }
 
     #[test]
     fn path_derived_ownership_records_canonical_path() -> anyhow::Result<()> {

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -411,10 +411,19 @@ pub struct PgSchemaReapReport {
 /// (the server's fixed data dir, or an on-disk workspace) keep an existing parent
 /// directory and are therefore never considered orphaned, so this never drops a
 /// schema that could still be reopened.
+///
+/// Only a definitive `NotFound` counts as orphaned. Any other error reading the
+/// parent's metadata (permissions, a transiently-unavailable mount, etc.) is
+/// treated as "keep", so a transient IO failure can never cause a destructive
+/// drop of a live schema. `metadata` (not `Path::exists`) is used precisely so
+/// these two cases can be distinguished.
 fn owner_path_is_orphaned(owner_path: &Path) -> bool {
-    match owner_path.parent() {
-        Some(parent) => !parent.exists(),
-        None => false,
+    let Some(parent) = owner_path.parent() else {
+        return false;
+    };
+    match std::fs::metadata(parent) {
+        Ok(_) => false,
+        Err(error) => error.kind() == std::io::ErrorKind::NotFound,
     }
 }
 


### PR DESCRIPTION
Closes the 'never again' gap for the Postgres schema explosion (#1206), building on the schema registry (#1213).

## Problem
The registry (#1213) makes `h*` path-derived schemas trackable, and `harness-pg-schema-cleanup` can drop them — but only **manually** (operator names each). Nothing automatically bounds growth, so the catalog still re-fills as ephemeral per-job workspaces churn (~1,250 schemas/hr measured).

## This PR
`reap_orphaned_path_schemas(pool, apply)`: drops registered path-derived schemas whose **owning workspace directory no longer exists**, plus their registry rows.

Conservative orphan rule (`owner_path_is_orphaned`): a schema is reaped only when its owner store path's *parent directory* is missing on disk. Live stores (server `data_dir`, on-disk workspaces) keep an existing parent → **never reaped**. So it cannot drop a schema that could still be reopened.

CLI: `harness-pg-schema-cleanup --reap-orphans` (dry-run; add `--confirm-drop` to apply).

## Tests / proof
- DB-free regression-guard unit test `owner_path_is_orphaned_detects_missing_parent` (existing parent kept, missing parent reaped).
- `RUSTFLAGS=-Dwarnings cargo check -p harness-core -p harness-cli --all-targets` clean.

## Follow-ups (separate issues)
- Config-gated periodic background reaper sweep in the server (so it runs automatically, not just on-demand).
- Migrate ephemeral stores to the SQLite LocalFile backend (#1211) so no schema is created at all.

Refs #1206, #1215.