### PR TITLE
fix(db): reap directory-owned path schemas

### DIFF
--- a/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
+++ b/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
@@ -2,7 +2,8 @@ use clap::Parser;
 use harness_core::config::HarnessConfig;
 use harness_core::db::{
     apply_pg_schema_cleanup, configure_pg_pool_from_server, pg_open_pool, pg_schema_cleanup_plan,
-    reap_orphaned_path_schemas, resolve_database_url, PgSchemaCleanupAction, PgSchemaCleanupPlan,
+    reap_orphaned_path_schemas_with_workspace_roots, resolve_database_url, PgSchemaCleanupAction,
+    PgSchemaCleanupPlan,
 };
 use std::path::PathBuf;
 
@@ -49,7 +50,13 @@ async fn main() -> anyhow::Result<()> {
     let pool = pg_open_pool(&database_url).await?;
 
     if args.reap_orphans {
-        let report = reap_orphaned_path_schemas(&pool, args.confirm_drop).await?;
+        let workspace_roots = configured_workspace_roots(&config);
+        let report = reap_orphaned_path_schemas_with_workspace_roots(
+            &pool,
+            args.confirm_drop,
+            &workspace_roots,
+        )
+        .await?;
         if args.json {
             println!("{}", serde_json::to_string_pretty(&report)?);
         } else if report.orphans.is_empty() {
@@ -141,6 +148,14 @@ fn load_cleanup_config(path: Option<&std::path::Path>) -> anyhow::Result<Harness
     Ok(HarnessConfig::default())
 }
 
+fn configured_workspace_roots(config: &HarnessConfig) -> Vec<PathBuf> {
+    if config.workspace.root.as_os_str().is_empty() {
+        Vec::new()
+    } else {
+        vec![config.workspace.root.clone()]
+    }
+}
+
 fn print_plan(plan: &PgSchemaCleanupPlan) {
     let mut keep = 0usize;
     let mut drop_candidates = 0usize;
@@ -170,6 +185,30 @@ fn print_plan(plan: &PgSchemaCleanupPlan) {
             candidate.table_count,
             candidate.estimated_row_count,
             candidate.reason
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_workspace_roots_omits_empty_root() {
+        let mut config = HarnessConfig::default();
+        config.workspace.root = PathBuf::new();
+
+        assert!(configured_workspace_roots(&config).is_empty());
+    }
+
+    #[test]
+    fn configured_workspace_roots_keeps_non_empty_root() {
+        let mut config = HarnessConfig::default();
+        config.workspace.root = PathBuf::from("/tmp/harness-workspaces");
+
+        assert_eq!(
+            configured_workspace_roots(&config),
+            vec![PathBuf::from("/tmp/harness-workspaces")]
         );
     }
 }

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -11,9 +11,10 @@ pub use crate::db_pg::{
 };
 pub use crate::db_pg_schema_registry::{
     apply_pg_schema_cleanup, ensure_pg_schema_registry, pg_schema_cleanup_plan,
-    reap_orphaned_path_schemas, register_pg_schema_ownership, PgSchemaCleanupAction,
-    PgSchemaCleanupCandidate, PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership,
-    PgSchemaReapReport, PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
+    reap_orphaned_path_schemas, reap_orphaned_path_schemas_with_workspace_roots,
+    register_pg_schema_ownership, PgSchemaCleanupAction, PgSchemaCleanupCandidate,
+    PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership, PgSchemaReapReport,
+    PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
 };
 
 /// Create a Postgres connection pool for the logical store at `path`.

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -6,7 +6,9 @@ use std::str::FromStr as _;
 use std::sync::Mutex;
 
 use crate::db::Migration;
-use crate::db_pg_schema_registry::{register_pg_schema_ownership, PgSchemaOwnership};
+use crate::db_pg_schema_registry::{
+    normalize_path_lexically, register_pg_schema_ownership, PgSchemaOwnership,
+};
 
 const DEFAULT_PG_MAX_CONNECTIONS: u32 = 8;
 const DEFAULT_PG_ACQUIRE_TIMEOUT_SECS: u64 = 10;
@@ -283,24 +285,6 @@ fn schema_hash_path(path: &Path) -> anyhow::Result<PathBuf> {
     }
 
     Ok(normalize_path_lexically(&absolute))
-}
-
-fn normalize_path_lexically(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
 }
 
 /// Derive the legacy per-store Postgres schema name from a store identity path.

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -1,12 +1,13 @@
 use serde::Serialize;
 use sqlx::postgres::PgPool;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 pub const PG_SCHEMA_REGISTRY_SCHEMA: &str = "harness_admin";
 pub const PG_SCHEMA_REGISTRY_TABLE: &str = "schema_ownership";
 
 const PATH_DERIVED_OWNER_KIND: &str = "path_derived_store";
+const PATH_DERIVED_DIRECTORY_OWNER_KIND: &str = "path_derived_directory_store";
 const PATH_DERIVED_RETENTION_CLASS: &str = "path_derived";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -26,12 +27,123 @@ impl PgSchemaOwnership {
             .to_string();
         Ok(Self {
             schema_name,
-            owner_kind: PATH_DERIVED_OWNER_KIND.to_string(),
+            owner_kind: path_derived_owner_kind(&canonical_path).to_string(),
             owner_key: owner_path.clone(),
             owner_path: Some(owner_path),
             retention_class: PATH_DERIVED_RETENTION_CLASS.to_string(),
         })
     }
+}
+
+fn path_derived_owner_kind(path: &Path) -> &'static str {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => PATH_DERIVED_DIRECTORY_OWNER_KIND,
+        _ => PATH_DERIVED_OWNER_KIND,
+    }
+}
+
+fn is_path_derived_owner_kind(owner_kind: &str) -> bool {
+    matches!(
+        owner_kind,
+        PATH_DERIVED_OWNER_KIND | PATH_DERIVED_DIRECTORY_OWNER_KIND
+    )
+}
+
+fn normalize_path_for_comparison(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    absolute
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_path_lexically(&absolute))
+}
+
+pub(crate) fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => match normalized.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(Component::Prefix(_)) | Some(Component::RootDir) => {}
+                Some(Component::ParentDir) | None => normalized.push(component.as_os_str()),
+                Some(Component::CurDir) => unreachable!(),
+            },
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn is_legacy_workspace_directory_owner_path(
+    owner_path: &Path,
+    workspace_roots: &[PathBuf],
+) -> bool {
+    if workspace_roots.is_empty() || !legacy_owner_path_has_workspace_key(owner_path) {
+        return false;
+    }
+    let Some(parent) = owner_path.parent() else {
+        return false;
+    };
+    let normalized_parent = normalize_path_lexically(parent);
+    if workspace_roots.contains(&normalized_parent) {
+        return true;
+    }
+    workspace_roots.contains(&normalize_path_for_comparison(parent))
+}
+
+fn legacy_owner_path_has_workspace_key(owner_path: &Path) -> bool {
+    let Some(name) = owner_path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    is_issue_or_pr_workspace_key(name)
+        || is_uuid_or_suffixed_workspace_key(name)
+        || name.starts_with("runtime-wf-")
+        || name.starts_with("runtime-job-")
+}
+
+fn is_issue_or_pr_workspace_key(name: &str) -> bool {
+    let Some(suffix) = name.rsplit("__").next() else {
+        return false;
+    };
+    let number = if let Some(number) = suffix.strip_prefix("issue_") {
+        number
+    } else if let Some(number) = suffix.strip_prefix("pr_") {
+        number
+    } else {
+        return false;
+    };
+    !number.is_empty() && number.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn is_uuid_workspace_key(name: &str) -> bool {
+    name.len() == 36
+        && name.chars().enumerate().all(|(idx, ch)| match idx {
+            8 | 13 | 18 | 23 => ch == '-',
+            _ => ch.is_ascii_hexdigit(),
+        })
+}
+
+fn is_uuid_or_suffixed_workspace_key(name: &str) -> bool {
+    if is_uuid_workspace_key(name) {
+        return true;
+    }
+    let Some((prefix, suffix)) = name.rsplit_once('-') else {
+        return false;
+    };
+    is_uuid_workspace_key(prefix)
+        && (suffix == "seq"
+            || suffix
+                .strip_prefix('p')
+                .is_some_and(|idx| !idx.is_empty() && idx.chars().all(|ch| ch.is_ascii_digit())))
 }
 
 pub fn is_legacy_path_schema_name(schema: &str) -> bool {
@@ -330,7 +442,11 @@ fn classify_schema_cleanup_candidate(row: PgSchemaInventoryRow) -> PgSchemaClean
             PgSchemaCleanupAction::Blocked,
             "unregistered path-derived schema; cleanup requires explicit allowlist".to_string(),
         )
-    } else if row.owner_kind.as_deref() == Some(PATH_DERIVED_OWNER_KIND) {
+    } else if row
+        .owner_kind
+        .as_deref()
+        .is_some_and(is_path_derived_owner_kind)
+    {
         (
             PgSchemaCleanupAction::Keep,
             "registered path-derived schema; owner_path is an identity key, not a liveness check"
@@ -414,29 +530,67 @@ pub struct PgSchemaReapReport {
     pub dropped: bool,
 }
 
-/// True if a path-derived schema's owner store path is orphaned: the directory
-/// that contained the store (the owner path's *parent*) no longer exists on disk.
+/// True if a path-derived schema's owner store path is orphaned.
 ///
-/// This is the conservative orphan signal. A path-derived schema is created from
-/// a store-identity path like `<workspace>/threads`; when the owning workspace is
-/// removed, that parent directory disappears and the schema is dead. Live stores
-/// (the server's fixed data dir, or an on-disk workspace) keep an existing parent
-/// directory and are therefore never considered orphaned, so this never drops a
-/// schema that could still be reopened.
+/// File-style logical paths use the directory that contained the store (the owner
+/// path's parent) as the liveness signal. Directory owner paths are registered
+/// separately and use the owner path itself as the liveness signal, so deleting a
+/// workspace directory whose parent still exists is still detected as orphaned.
+/// Older registry rows did not distinguish directory owners, so generated
+/// workspace-key children of known workspace roots are treated as legacy
+/// directory owners.
 ///
 /// Only a definitive `NotFound` counts as orphaned. Any other error reading the
-/// parent's metadata (permissions, a transiently-unavailable mount, etc.) is
+/// liveness path metadata (permissions, a transiently-unavailable mount, etc.) is
 /// treated as "keep", so a transient IO failure can never cause a destructive
 /// drop of a live schema. `metadata` (not `Path::exists`) is used precisely so
 /// these two cases can be distinguished.
-fn owner_path_is_orphaned(owner_path: &Path) -> bool {
-    let Some(parent) = owner_path.parent() else {
-        return false;
+#[cfg(test)]
+fn owner_path_is_orphaned(owner_kind: &str, owner_path: &Path) -> bool {
+    owner_path_is_orphaned_with_workspace_roots(owner_kind, owner_path, &[])
+}
+
+fn owner_path_is_orphaned_with_workspace_roots(
+    owner_kind: &str,
+    owner_path: &Path,
+    workspace_roots: &[PathBuf],
+) -> bool {
+    let liveness_path = if owner_kind == PATH_DERIVED_DIRECTORY_OWNER_KIND
+        || (owner_kind == PATH_DERIVED_OWNER_KIND
+            && is_legacy_workspace_directory_owner_path(owner_path, workspace_roots))
+    {
+        owner_path
+    } else {
+        let Some(parent) = owner_path.parent() else {
+            return false;
+        };
+        parent
     };
-    match std::fs::metadata(parent) {
+    match std::fs::metadata(liveness_path) {
         Ok(_) => false,
         Err(error) => error.kind() == std::io::ErrorKind::NotFound,
     }
+}
+
+fn orphaned_path_schema_names(
+    rows: Vec<(String, String, Option<String>)>,
+    workspace_roots: Vec<PathBuf>,
+) -> Vec<String> {
+    let mut orphans = Vec::new();
+    for (schema_name, owner_kind, owner_path) in rows {
+        // No recorded path: cannot prove the schema is orphaned, so keep it.
+        let Some(owner_path) = owner_path else {
+            continue;
+        };
+        if owner_path_is_orphaned_with_workspace_roots(
+            &owner_kind,
+            Path::new(&owner_path),
+            &workspace_roots,
+        ) {
+            orphans.push(schema_name);
+        }
+    }
+    orphans
 }
 
 /// Drop registered path-derived schemas whose owning workspace directory is gone.
@@ -444,8 +598,8 @@ fn owner_path_is_orphaned(owner_path: &Path) -> bool {
 /// This bounds Postgres catalog growth automatically: per-job / ephemeral stores
 /// create a schema under their workspace path, and once the workspace is removed
 /// the schema becomes a dead orphan that nothing can reopen. Reaping drops only
-/// those orphans (owner path's parent directory missing) and the matching
-/// registry rows — never a live store's schema.
+/// those orphans (the owner directory or file owner parent is missing) and the
+/// matching registry rows — never a live store's schema.
 ///
 /// With `apply = false` it reports what would be reaped (dry run) without
 /// dropping anything. Must run on the host that owns the workspace paths.
@@ -453,27 +607,35 @@ pub async fn reap_orphaned_path_schemas(
     pool: &PgPool,
     apply: bool,
 ) -> anyhow::Result<PgSchemaReapReport> {
+    reap_orphaned_path_schemas_with_workspace_roots(pool, apply, &[]).await
+}
+
+pub async fn reap_orphaned_path_schemas_with_workspace_roots(
+    pool: &PgPool,
+    apply: bool,
+    workspace_roots: &[PathBuf],
+) -> anyhow::Result<PgSchemaReapReport> {
     ensure_pg_schema_registry(pool).await?;
-    let rows: Vec<(String, Option<String>)> = sqlx::query_as(&format!(
-        "SELECT schema_name, owner_path
+    let rows: Vec<(String, String, Option<String>)> = sqlx::query_as(&format!(
+        "SELECT schema_name, owner_kind, owner_path
          FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
-         WHERE owner_kind = $1"
+         WHERE owner_kind IN ($1, $2)"
     ))
     .bind(PATH_DERIVED_OWNER_KIND)
+    .bind(PATH_DERIVED_DIRECTORY_OWNER_KIND)
     .fetch_all(pool)
     .await?;
 
     let scanned = rows.len();
-    let mut orphans = Vec::new();
-    for (schema_name, owner_path) in rows {
-        // No recorded path: cannot prove the schema is orphaned, so keep it.
-        let Some(owner_path) = owner_path else {
-            continue;
-        };
-        if owner_path_is_orphaned(Path::new(&owner_path)) {
-            orphans.push(schema_name);
-        }
-    }
+    let workspace_roots = workspace_roots.to_vec();
+    let orphans = tokio::task::spawn_blocking(move || {
+        let workspace_roots: Vec<PathBuf> = workspace_roots
+            .iter()
+            .map(|root| normalize_path_for_comparison(root))
+            .collect();
+        orphaned_path_schema_names(rows, workspace_roots)
+    })
+    .await?;
 
     if apply {
         for schema_name in &orphans {
@@ -493,204 +655,5 @@ pub async fn reap_orphaned_path_schemas(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn owner_path_is_orphaned_detects_missing_parent() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        // Live store: its parent directory (the temp dir) exists -> kept.
-        let live = dir.path().join("threads");
-        assert!(
-            !owner_path_is_orphaned(&live),
-            "schema whose parent dir exists must never be reaped"
-        );
-        // Orphan: the owning workspace directory was removed.
-        let dead = dir.path().join("removed-workspace/threads");
-        assert!(
-            owner_path_is_orphaned(&dead),
-            "schema whose parent dir is gone must be reaped"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn drop_schema_cascade_statement_can_tolerate_missing_schema() -> anyhow::Result<()> {
-        assert_eq!(
-            drop_schema_cascade_statement("h1234567890abcdef", true)?,
-            "DROP SCHEMA IF EXISTS \"h1234567890abcdef\" CASCADE"
-        );
-        assert_eq!(
-            drop_schema_cascade_statement("h1234567890abcdef", false)?,
-            "DROP SCHEMA \"h1234567890abcdef\" CASCADE"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn path_derived_ownership_records_canonical_path() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("tasks.db");
-        let ownership =
-            PgSchemaOwnership::path_derived("h1234567890abcdef".to_string(), path.clone())?;
-
-        assert_eq!(ownership.schema_name, "h1234567890abcdef");
-        assert_eq!(ownership.owner_kind, "path_derived_store");
-        assert_eq!(ownership.owner_key, path.to_string_lossy());
-        assert_eq!(
-            ownership.owner_path.as_deref(),
-            Some(path.to_string_lossy().as_ref())
-        );
-        assert_eq!(ownership.retention_class, "path_derived");
-        Ok(())
-    }
-
-    #[test]
-    fn cleanup_keeps_path_derived_schema_when_owner_path_exists() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let row = PgSchemaInventoryRow {
-            schema_name: "h1111111111111111".to_string(),
-            owner_kind: Some("path_derived_store".to_string()),
-            owner_key: Some(dir.path().to_string_lossy().to_string()),
-            owner_path: Some(dir.path().to_string_lossy().to_string()),
-            retention_class: Some("path_derived".to_string()),
-            table_count: 2,
-            estimated_row_count: 5,
-        };
-
-        let candidate = classify_schema_cleanup_candidate(row);
-
-        assert!(candidate.registered);
-        assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
-        assert_eq!(
-            candidate.reason,
-            "registered path-derived schema; owner_path is an identity key, not a liveness check"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn cleanup_keeps_path_derived_schema_when_owner_path_is_missing() {
-        let row = PgSchemaInventoryRow {
-            schema_name: "h2222222222222222".to_string(),
-            owner_kind: Some("path_derived_store".to_string()),
-            owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
-            owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
-            retention_class: Some("path_derived".to_string()),
-            table_count: 1,
-            estimated_row_count: 0,
-        };
-
-        let candidate = classify_schema_cleanup_candidate(row);
-
-        assert!(candidate.registered);
-        assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
-        assert_eq!(
-            candidate.reason,
-            "registered path-derived schema; owner_path is an identity key, not a liveness check"
-        );
-    }
-
-    #[test]
-    fn cleanup_marks_unknown_registered_schema_with_missing_path_as_drop_candidate() {
-        let row = PgSchemaInventoryRow {
-            schema_name: "h4444444444444444".to_string(),
-            owner_kind: Some("external_owner".to_string()),
-            owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
-            owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
-            retention_class: Some("path_derived".to_string()),
-            table_count: 1,
-            estimated_row_count: 0,
-        };
-
-        let candidate = classify_schema_cleanup_candidate(row);
-
-        assert!(candidate.registered);
-        assert_eq!(candidate.action, PgSchemaCleanupAction::DropCandidate);
-        assert_eq!(candidate.reason, "registered owner path is missing");
-    }
-
-    #[test]
-    fn cleanup_blocks_unregistered_schema_by_default() {
-        let row = PgSchemaInventoryRow {
-            schema_name: "h3333333333333333".to_string(),
-            owner_kind: None,
-            owner_key: None,
-            owner_path: None,
-            retention_class: None,
-            table_count: 1,
-            estimated_row_count: 0,
-        };
-
-        let candidate = classify_schema_cleanup_candidate(row);
-
-        assert!(!candidate.registered);
-        assert_eq!(candidate.action, PgSchemaCleanupAction::Blocked);
-        assert!(candidate.reason.contains("explicit allowlist"));
-    }
-
-    #[test]
-    fn drop_request_validation_rejects_registered_keep_candidate() {
-        let plan = PgSchemaCleanupPlan {
-            candidates: vec![PgSchemaCleanupCandidate {
-                schema_name: "h1111111111111111".to_string(),
-                registered: true,
-                owner_kind: Some("path_derived_store".to_string()),
-                owner_key: Some("h1111111111111111".to_string()),
-                owner_path: None,
-                retention_class: Some("path_derived".to_string()),
-                table_count: 1,
-                estimated_row_count: 0,
-                action: PgSchemaCleanupAction::Keep,
-                reason: "registered path-derived schema".to_string(),
-            }],
-        };
-        let requested_registered = HashSet::from(["h1111111111111111".to_string()]);
-        let allowlist = HashSet::new();
-
-        let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
-            .expect_err("keep schema should be rejected");
-
-        assert!(err
-            .to_string()
-            .contains("registered schema 'h1111111111111111' is not a cleanup drop candidate"));
-    }
-
-    #[test]
-    fn drop_request_validation_fails_before_selecting_partial_targets() {
-        let plan = PgSchemaCleanupPlan {
-            candidates: vec![PgSchemaCleanupCandidate {
-                schema_name: "h1111111111111111".to_string(),
-                registered: true,
-                owner_kind: Some("external_owner".to_string()),
-                owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
-                owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
-                retention_class: Some("path_derived".to_string()),
-                table_count: 1,
-                estimated_row_count: 0,
-                action: PgSchemaCleanupAction::DropCandidate,
-                reason: "registered owner path is missing".to_string(),
-            }],
-        };
-        let requested_registered = HashSet::from([
-            "h1111111111111111".to_string(),
-            "h9999999999999999".to_string(),
-        ]);
-        let allowlist = HashSet::new();
-
-        let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
-            .expect_err("missing schema should reject the whole cleanup request");
-
-        assert!(err
-            .to_string()
-            .contains("registered schema 'h9999999999999999' was not found"));
-    }
-
-    #[test]
-    fn legacy_path_schema_name_detection_is_exact() {
-        assert!(is_legacy_path_schema_name("h0123456789abcdef"));
-        assert!(!is_legacy_path_schema_name("workflow_runtime"));
-        assert!(!is_legacy_path_schema_name("h0123456789abcdeg"));
-        assert!(!is_legacy_path_schema_name("h0123456789abcde"));
-    }
-}
+#[path = "db_pg_schema_registry_tests.rs"]
+mod db_pg_schema_registry_tests;

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -1,0 +1,475 @@
+use super::*;
+use std::collections::HashSet;
+
+fn create_normalized_workspace_root(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
+    let raw_workspace_root = parent.join(name);
+    std::fs::create_dir(&raw_workspace_root)?;
+    Ok(normalize_path_for_comparison(&raw_workspace_root))
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_missing_parent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let live = dir.path().join("threads");
+    assert!(
+        !owner_path_is_orphaned(PATH_DERIVED_OWNER_KIND, &live),
+        "schema whose parent dir exists must never be reaped"
+    );
+
+    let dead = dir.path().join("removed-workspace/threads");
+    assert!(
+        owner_path_is_orphaned(PATH_DERIVED_OWNER_KIND, &dead),
+        "schema whose parent dir is gone must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_removed_directory_owner() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace = parent.path().join("workspace");
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned(PATH_DERIVED_DIRECTORY_OWNER_KIND, &workspace),
+        "live directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned(PATH_DERIVED_DIRECTORY_OWNER_KIND, &workspace),
+        "deleted directory owner path must be reaped even when its parent remains"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_legacy_workspace_directory_owner() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "workspaces")?;
+    let workspace = workspace_root.join("550e8400-e29b-41d4-a716-446655440000");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live legacy workspace directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted legacy workspace directory owner path must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_suffixed_uuid_legacy_workspace_directory_owner(
+) -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "workspaces")?;
+    let workspace = workspace_root.join("550e8400-e29b-41d4-a716-446655440000-seq");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live suffixed UUID workspace directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted suffixed UUID workspace directory owner path must be reaped"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn owner_path_is_orphaned_matches_symlinked_legacy_workspace_root() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "workspaces")?;
+    let symlink_root = parent.path().join("linked-workspaces");
+    std::os::unix::fs::symlink(&workspace_root, &symlink_root)?;
+    let workspace = symlink_root.join("550e8400-e29b-41d4-a716-446655440000-p0");
+    let workspace_roots = vec![workspace_root];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live legacy workspace directory under a symlinked root must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted legacy workspace directory under a symlinked root must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_dotted_legacy_workspace_directory_owner() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "workspaces")?;
+    let workspace = workspace_root.join("abcd1234__my.org_repo__issue_42");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live dotted legacy workspace directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted dotted legacy workspace directory owner path must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_custom_legacy_workspace_directory_owner() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "ws")?;
+    let workspace = workspace_root.join("runtime-job-123");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live custom-root legacy workspace directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned(PATH_DERIVED_OWNER_KIND, &workspace),
+        "custom-root legacy workspace directory owner path must be kept without configured roots"
+    );
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted custom-root legacy workspace directory owner path must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_owner_path_has_workspace_key_accepts_parallel_uuid_suffixes() {
+    let root = PathBuf::from("/workspaces");
+    assert!(legacy_owner_path_has_workspace_key(
+        &root.join("550e8400-e29b-41d4-a716-446655440000-seq")
+    ));
+    assert!(legacy_owner_path_has_workspace_key(
+        &root.join("550e8400-e29b-41d4-a716-446655440000-p0")
+    ));
+    assert!(!legacy_owner_path_has_workspace_key(
+        &root.join("550e8400-e29b-41d4-a716-446655440000-step")
+    ));
+}
+
+#[test]
+fn owner_path_is_orphaned_keeps_ambiguous_legacy_missing_child() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let owner_path = parent.path().join("harness-workspaces/tasks");
+    let owner_parent = owner_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("owner path should have a parent"))?;
+    std::fs::create_dir(owner_parent)?;
+    assert!(
+        !owner_path_is_orphaned(PATH_DERIVED_OWNER_KIND, &owner_path),
+        "legacy path-derived store under an unconfigured workspace-like root must be kept"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_keeps_configured_root_fixed_store_path() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = parent.path().join("workspaces");
+    std::fs::create_dir(&workspace_root)?;
+    let owner_path = crate::config::dirs::default_db_path(&workspace_root, "tasks");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            PATH_DERIVED_OWNER_KIND,
+            &owner_path,
+            &workspace_roots
+        ),
+        "fixed store paths under a configured root must not be reaped as legacy workspace directories"
+    );
+    Ok(())
+}
+
+#[test]
+fn normalize_path_lexically_preserves_root_and_leading_parent() {
+    assert_eq!(
+        normalize_path_lexically(Path::new("/../workspace")),
+        PathBuf::from("/workspace")
+    );
+    assert_eq!(
+        normalize_path_lexically(Path::new("../workspace")),
+        PathBuf::from("../workspace")
+    );
+    assert_eq!(
+        normalize_path_lexically(Path::new("a/../../workspace")),
+        PathBuf::from("../workspace")
+    );
+}
+
+#[test]
+fn drop_schema_cascade_statement_can_tolerate_missing_schema() -> anyhow::Result<()> {
+    assert_eq!(
+        drop_schema_cascade_statement("h1234567890abcdef", true)?,
+        "DROP SCHEMA IF EXISTS \"h1234567890abcdef\" CASCADE"
+    );
+    assert_eq!(
+        drop_schema_cascade_statement("h1234567890abcdef", false)?,
+        "DROP SCHEMA \"h1234567890abcdef\" CASCADE"
+    );
+    Ok(())
+}
+
+#[test]
+fn path_derived_ownership_records_canonical_path() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("tasks.db");
+    let ownership = PgSchemaOwnership::path_derived("h1234567890abcdef".to_string(), path.clone())?;
+
+    assert_eq!(ownership.schema_name, "h1234567890abcdef");
+    assert_eq!(ownership.owner_kind, "path_derived_store");
+    assert_eq!(ownership.owner_key, path.to_string_lossy());
+    assert_eq!(
+        ownership.owner_path.as_deref(),
+        Some(path.to_string_lossy().as_ref())
+    );
+    assert_eq!(ownership.retention_class, "path_derived");
+    Ok(())
+}
+
+#[test]
+fn path_derived_ownership_records_directory_owner_kind() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let ownership =
+        PgSchemaOwnership::path_derived("h1234567890abcdef".to_string(), dir.path().to_path_buf())?;
+
+    assert_eq!(ownership.schema_name, "h1234567890abcdef");
+    assert_eq!(ownership.owner_kind, "path_derived_directory_store");
+    assert_eq!(ownership.owner_key, dir.path().to_string_lossy());
+    assert_eq!(
+        ownership.owner_path.as_deref(),
+        Some(dir.path().to_string_lossy().as_ref())
+    );
+    assert_eq!(ownership.retention_class, "path_derived");
+    Ok(())
+}
+
+#[test]
+fn cleanup_keeps_directory_path_derived_schema_in_manual_plan() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let row = PgSchemaInventoryRow {
+        schema_name: "h5555555555555555".to_string(),
+        owner_kind: Some("path_derived_directory_store".to_string()),
+        owner_key: Some(dir.path().to_string_lossy().to_string()),
+        owner_path: Some(dir.path().to_string_lossy().to_string()),
+        retention_class: Some("path_derived".to_string()),
+        table_count: 2,
+        estimated_row_count: 5,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+    assert_eq!(
+        candidate.reason,
+        "registered path-derived schema; owner_path is an identity key, not a liveness check"
+    );
+    Ok(())
+}
+
+#[test]
+fn cleanup_keeps_path_derived_schema_when_owner_path_exists() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let row = PgSchemaInventoryRow {
+        schema_name: "h1111111111111111".to_string(),
+        owner_kind: Some("path_derived_store".to_string()),
+        owner_key: Some(dir.path().to_string_lossy().to_string()),
+        owner_path: Some(dir.path().to_string_lossy().to_string()),
+        retention_class: Some("path_derived".to_string()),
+        table_count: 2,
+        estimated_row_count: 5,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+    assert_eq!(
+        candidate.reason,
+        "registered path-derived schema; owner_path is an identity key, not a liveness check"
+    );
+    Ok(())
+}
+
+#[test]
+fn cleanup_keeps_path_derived_schema_when_owner_path_is_missing() {
+    let row = PgSchemaInventoryRow {
+        schema_name: "h2222222222222222".to_string(),
+        owner_kind: Some("path_derived_store".to_string()),
+        owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+        owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+        retention_class: Some("path_derived".to_string()),
+        table_count: 1,
+        estimated_row_count: 0,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+    assert_eq!(
+        candidate.reason,
+        "registered path-derived schema; owner_path is an identity key, not a liveness check"
+    );
+}
+
+#[test]
+fn cleanup_marks_unknown_registered_schema_with_missing_path_as_drop_candidate() {
+    let row = PgSchemaInventoryRow {
+        schema_name: "h4444444444444444".to_string(),
+        owner_kind: Some("external_owner".to_string()),
+        owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+        owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+        retention_class: Some("path_derived".to_string()),
+        table_count: 1,
+        estimated_row_count: 0,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::DropCandidate);
+    assert_eq!(candidate.reason, "registered owner path is missing");
+}
+
+#[test]
+fn cleanup_blocks_unregistered_schema_by_default() {
+    let row = PgSchemaInventoryRow {
+        schema_name: "h3333333333333333".to_string(),
+        owner_kind: None,
+        owner_key: None,
+        owner_path: None,
+        retention_class: None,
+        table_count: 1,
+        estimated_row_count: 0,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(!candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::Blocked);
+    assert!(candidate.reason.contains("explicit allowlist"));
+}
+
+#[test]
+fn drop_request_validation_rejects_registered_keep_candidate() {
+    let plan = PgSchemaCleanupPlan {
+        candidates: vec![PgSchemaCleanupCandidate {
+            schema_name: "h1111111111111111".to_string(),
+            registered: true,
+            owner_kind: Some("path_derived_store".to_string()),
+            owner_key: Some("h1111111111111111".to_string()),
+            owner_path: None,
+            retention_class: Some("path_derived".to_string()),
+            table_count: 1,
+            estimated_row_count: 0,
+            action: PgSchemaCleanupAction::Keep,
+            reason: "registered path-derived schema".to_string(),
+        }],
+    };
+    let requested_registered = HashSet::from(["h1111111111111111".to_string()]);
+    let allowlist = HashSet::new();
+
+    let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
+        .expect_err("keep schema should be rejected");
+
+    assert!(err
+        .to_string()
+        .contains("registered schema 'h1111111111111111' is not a cleanup drop candidate"));
+}
+
+#[test]
+fn drop_request_validation_fails_before_selecting_partial_targets() {
+    let plan = PgSchemaCleanupPlan {
+        candidates: vec![PgSchemaCleanupCandidate {
+            schema_name: "h1111111111111111".to_string(),
+            registered: true,
+            owner_kind: Some("external_owner".to_string()),
+            owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+            owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+            retention_class: Some("path_derived".to_string()),
+            table_count: 1,
+            estimated_row_count: 0,
+            action: PgSchemaCleanupAction::DropCandidate,
+            reason: "registered owner path is missing".to_string(),
+        }],
+    };
+    let requested_registered = HashSet::from([
+        "h1111111111111111".to_string(),
+        "h9999999999999999".to_string(),
+    ]);
+    let allowlist = HashSet::new();
+
+    let err = validate_pg_schema_drop_request(plan, &requested_registered, &allowlist)
+        .expect_err("missing schema should reject the whole cleanup request");
+
+    assert!(err
+        .to_string()
+        .contains("registered schema 'h9999999999999999' was not found"));
+}
+
+#[test]
+fn legacy_path_schema_name_detection_is_exact() {
+    assert!(is_legacy_path_schema_name("h0123456789abcdef"));
+    assert!(!is_legacy_path_schema_name("workflow_runtime"));
+    assert!(!is_legacy_path_schema_name("h0123456789abcdeg"));
+    assert!(!is_legacy_path_schema_name("h0123456789abcde"));
+}


### PR DESCRIPTION
Closes #1217. Follow-up to #1216.

## Summary
- register path-derived schemas with a distinct directory-owner kind when the owner path is known to be an existing directory
- have `--reap-orphans` check the directory owner path itself, while keeping file-style logical paths on the existing parent-directory rule
- keep manual cleanup plans conservative for both path-derived owner kinds

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harness-core db_pg_schema_registry -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-core -p harness-cli --all-targets`
- `cargo test -p harness-core -- --test-threads=1`