### PR TITLE
fix(runtime-host): claim workflow jobs through workflow runtime

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -26,6 +26,9 @@ mod runtime_project_cache_api_tests;
 #[cfg(test)]
 mod runtime_hosts_api_tests;
 
+#[cfg(test)]
+mod runtime_hosts_workflow_api_tests;
+
 /// Validate a project root path, returning early with an `INTERNAL_ERROR`
 /// response on failure.
 ///

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -4,6 +4,8 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use chrono::{DateTime, TimeDelta, Utc};
+use harness_workflow::runtime::{ActivityResult, RuntimeKind, WorkflowRuntimeStore};
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
@@ -20,6 +22,12 @@ pub struct RegisterRuntimeHostRequest {
 pub struct ClaimTaskRequest {
     pub lease_secs: Option<u64>,
     pub project: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompleteRuntimeJobRequest {
+    pub lease_expires_at: DateTime<Utc>,
+    pub result: ActivityResult,
 }
 
 pub async fn list_runtime_hosts(
@@ -231,6 +239,176 @@ pub async fn claim_task_for_runtime_host(
     (StatusCode::OK, Json(json!({ "claimed": false })))
 }
 
+pub async fn claim_runtime_job_for_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path(host_id): Path<String>,
+    Json(req): Json<ClaimTaskRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !state.runtime_hosts.hosts.contains_key(&host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
+        );
+    }
+    let store = match workflow_runtime_store(&state) {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    if let Some(project) = req.project.as_deref().map(str::trim) {
+        if !project.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "project filtering is not supported for workflow runtime-job claims"
+                })),
+            );
+        }
+    }
+    let lease_expires_at = match runtime_host_lease_expires_at(req.lease_secs) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+
+    let job = match store
+        .claim_next_runtime_job_for_runtime_kind(
+            RuntimeKind::RemoteHost,
+            &host_id,
+            lease_expires_at,
+        )
+        .await
+    {
+        Ok(Some(job)) => job,
+        Ok(None) => return (StatusCode::OK, Json(json!({ "claimed": false }))),
+        Err(e) => {
+            tracing::error!(
+                host_id = %host_id,
+                error = %e,
+                "runtime host failed to claim workflow runtime job"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("failed to claim runtime job: {e}") })),
+            );
+        }
+    };
+
+    if let Err(e) = store
+        .record_runtime_event(
+            &job.id,
+            "RuntimeJobClaimed",
+            json!({
+                "owner": host_id.as_str(),
+                "lease_expires_at": lease_expires_at,
+                "claim_api": "runtime_host",
+            }),
+        )
+        .await
+    {
+        tracing::warn!(
+            runtime_job_id = %job.id,
+            error = %e,
+            "runtime host claim succeeded but runtime event recording failed"
+        );
+    }
+
+    let runtime_job_id = job.id.clone();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "claimed": true,
+            "runtime_job": job,
+            "runtime_job_id": runtime_job_id,
+            "lease_expires_at": lease_expires_at,
+        })),
+    )
+}
+
+pub async fn complete_runtime_job_for_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path((host_id, runtime_job_id)): Path<(String, String)>,
+    Json(req): Json<CompleteRuntimeJobRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !state.runtime_hosts.hosts.contains_key(&host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
+        );
+    }
+    let store = match workflow_runtime_store(&state) {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    let result_payload = match serde_json::to_value(&req.result) {
+        Ok(value) => value,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid activity result: {e}") })),
+            );
+        }
+    };
+
+    let completion = match store
+        .commit_runtime_activity_completion_if_owned(
+            &runtime_job_id,
+            &host_id,
+            req.lease_expires_at,
+            &req.result,
+        )
+        .await
+    {
+        Ok(Some(completion)) => completion,
+        Ok(None) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "completed": false,
+                    "error": "runtime job lease is not owned by this host"
+                })),
+            );
+        }
+        Err(e) if e.to_string().contains("runtime job not found") => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                host_id = %host_id,
+                runtime_job_id = %runtime_job_id,
+                error = %e,
+                "runtime host failed to complete workflow runtime job"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("failed to complete runtime job: {e}") })),
+            );
+        }
+    };
+
+    if let Err(e) = store
+        .record_runtime_event(&runtime_job_id, "ActivityResultReady", result_payload)
+        .await
+    {
+        tracing::warn!(
+            runtime_job_id = %runtime_job_id,
+            error = %e,
+            "runtime host completion succeeded but runtime event recording failed"
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "completed": true,
+            "runtime_job": completion.runtime_job,
+            "workflow_event": completion.workflow_event,
+            "decision": completion.decision,
+        })),
+    )
+}
+
 fn ensure_runtime_state_persistence_available(
     state: &Arc<AppState>,
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
@@ -251,6 +429,58 @@ async fn persist_runtime_state(
         return Err(runtime_state_persistence_error_response(e));
     }
     Ok(())
+}
+
+fn workflow_runtime_store(
+    state: &Arc<AppState>,
+) -> Result<Arc<WorkflowRuntimeStore>, (StatusCode, Json<serde_json::Value>)> {
+    state.core.workflow_runtime_store.clone().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "workflow runtime store unavailable" })),
+        )
+    })
+}
+
+fn runtime_host_lease_expires_at(
+    lease_secs: Option<u64>,
+) -> Result<DateTime<Utc>, (StatusCode, Json<serde_json::Value>)> {
+    let lease_secs = match lease_secs {
+        Some(value) => match i64::try_from(value) {
+            Ok(value) => value,
+            Err(_) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": "lease_secs must be <= i64::MAX" })),
+                ));
+            }
+        },
+        None => crate::runtime_hosts::DEFAULT_LEASE_SECS,
+    }
+    .max(0);
+    let lease_duration = match TimeDelta::try_seconds(lease_secs) {
+        Some(value) => value,
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": format!(
+                        "lease_secs value {lease_secs} is too large to compute a valid expiration timestamp"
+                    )
+                })),
+            ));
+        }
+    };
+    Utc::now().checked_add_signed(lease_duration).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "lease_secs value {lease_secs} is too large to compute a valid expiration timestamp"
+                )
+            })),
+        )
+    })
 }
 
 fn runtime_state_persistence_error_response(

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -5,7 +5,9 @@ use axum::{
     Json,
 };
 use chrono::{DateTime, TimeDelta, Utc};
-use harness_workflow::runtime::{ActivityResult, RuntimeKind, WorkflowRuntimeStore};
+use harness_workflow::runtime::{
+    ActivityResult, RuntimeJobNotFoundError, RuntimeKind, WorkflowRuntimeStore,
+};
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
@@ -367,7 +369,7 @@ pub async fn complete_runtime_job_for_runtime_host(
                 })),
             );
         }
-        Err(e) if e.to_string().contains("runtime job not found") => {
+        Err(e) if e.downcast_ref::<RuntimeJobNotFoundError>().is_some() => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(json!({ "error": e.to_string() })),

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -69,6 +69,16 @@ async fn post_json(
     uri: String,
     body: serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
+    let (status, json) = post_json_with_status(app, uri, body).await?;
+    assert_eq!(status, StatusCode::OK);
+    Ok(json)
+}
+
+async fn post_json_with_status(
+    app: &Router,
+    uri: String,
+    body: serde_json::Value,
+) -> anyhow::Result<(StatusCode, serde_json::Value)> {
     let response = app
         .clone()
         .oneshot(
@@ -79,11 +89,11 @@ async fn post_json(
                 .body(Body::from(body.to_string()))?,
         )
         .await?;
-    assert_eq!(response.status(), StatusCode::OK);
+    let status = response.status();
     let bytes = http_body_util::BodyExt::collect(response.into_body())
         .await?
         .to_bytes();
-    Ok(serde_json::from_slice(&bytes)?)
+    Ok((status, serde_json::from_slice(&bytes)?))
 }
 
 #[tokio::test]
@@ -278,5 +288,34 @@ async fn runtime_job_completion_endpoint_accepts_terminal_activity_result() -> a
         .expect("runtime job should be persisted");
     assert_eq!(persisted.status, RuntimeJobStatus::Failed);
     assert!(persisted.lease.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_completion_endpoint_returns_not_found_for_missing_job() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, _store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+
+    let result = ActivityResult::failed(
+        "remote_check",
+        "Remote host reported a failed activity.",
+        "remote execution failed",
+    );
+    let (status, body) = post_json_with_status(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/missing-job/complete".to_string(),
+        json!({
+            "lease_expires_at": chrono::Utc::now(),
+            "result": result,
+        }),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "runtime job not found: missing-job");
     Ok(())
 }

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -1,0 +1,282 @@
+use super::runtime_hosts;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+    Router,
+};
+use harness_workflow::runtime::{
+    ActivityResult, RuntimeJobStatus, RuntimeKind, WorkflowRuntimeStore,
+};
+use serde_json::json;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/runtime-hosts/register",
+            post(runtime_hosts::register_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{id}/runtime-jobs/claim",
+            post(runtime_hosts::claim_runtime_job_for_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete",
+            post(runtime_hosts::complete_runtime_job_for_runtime_host),
+        )
+        .with_state(state)
+}
+
+async fn make_test_state_with_runtime_store(
+    dir: &std::path::Path,
+) -> anyhow::Result<Option<(Arc<crate::http::AppState>, Arc<WorkflowRuntimeStore>)>> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(None);
+    }
+    let state = match crate::test_helpers::make_test_state(dir).await {
+        Ok(state) => state,
+        Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let store = Arc::new(WorkflowRuntimeStore::open(&dir.join("workflow_runtime.db")).await?);
+    let mut state = Arc::new(state);
+    Arc::get_mut(&mut state)
+        .ok_or_else(|| anyhow::anyhow!("expected unique test state"))?
+        .core
+        .workflow_runtime_store = Some(store.clone());
+    Ok(Some((state, store)))
+}
+
+async fn register_host(app: &Router, host_id: &str) -> anyhow::Result<()> {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "host_id": host_id }).to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+async fn post_json(
+    app: &Router,
+    uri: String,
+    body: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = http_body_util::BodyExt::collect(response.into_body())
+        .await?
+        .to_bytes();
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_claims_remote_host_jobs_only() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+
+    let local_job = store
+        .enqueue_runtime_job(
+            "command-local",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "local_check" }),
+        )
+        .await?;
+    let remote_job = store
+        .enqueue_runtime_job(
+            "command-remote",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "remote_check",
+                "workflow_id": "wf-remote",
+                "runtime_profile": {
+                    "name": "remote-host-default",
+                    "kind": "remote_host"
+                }
+            }),
+        )
+        .await?;
+
+    let json = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    assert_eq!(json["claimed"], true);
+    assert_eq!(json["runtime_job_id"], remote_job.id);
+    assert_eq!(json["runtime_job"]["runtime_kind"], "remote_host");
+    assert_eq!(json["runtime_job"]["input"]["activity"], "remote_check");
+    assert_eq!(
+        json["runtime_job"]["input"]["runtime_profile"]["name"],
+        "remote-host-default"
+    );
+
+    let local = store
+        .get_runtime_job(&local_job.id)
+        .await?
+        .expect("local job should remain pending");
+    assert_eq!(local.status, RuntimeJobStatus::Pending);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_blocks_duplicate_claims() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+    register_host(&app, "host-b").await?;
+
+    let job = store
+        .enqueue_runtime_job(
+            "command-remote",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({ "activity": "remote_check" }),
+        )
+        .await?;
+    let first = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    assert_eq!(first["runtime_job_id"], job.id);
+
+    let second = post_json(
+        &app,
+        "/api/runtime-hosts/host-b/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    assert_eq!(second["claimed"], false);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_reclaims_expired_remote_job() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+    register_host(&app, "host-b").await?;
+
+    let job = store
+        .enqueue_runtime_job(
+            "command-remote",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({ "activity": "remote_check" }),
+        )
+        .await?;
+    let first = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 0 }),
+    )
+    .await?;
+    assert_eq!(first["runtime_job_id"], job.id);
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let second = post_json(
+        &app,
+        "/api/runtime-hosts/host-b/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    assert_eq!(second["runtime_job_id"], job.id);
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("runtime job should still exist"))?;
+    assert_eq!(
+        persisted
+            .lease
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("runtime job should be leased"))?
+            .owner,
+        "host-b"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_completion_endpoint_accepts_terminal_activity_result() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+
+    let job = store
+        .enqueue_runtime_job(
+            "command-remote",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({ "activity": "remote_check" }),
+        )
+        .await?;
+    let claimed = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    let lease_expires_at = claimed["lease_expires_at"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("lease_expires_at must be a string"))?;
+
+    let result = ActivityResult::failed(
+        "remote_check",
+        "Remote host reported a failed activity.",
+        "remote execution failed",
+    );
+    let completed = post_json(
+        &app,
+        format!("/api/runtime-hosts/host-a/runtime-jobs/{}/complete", job.id),
+        json!({
+            "lease_expires_at": lease_expires_at,
+            "result": result,
+        }),
+    )
+    .await?;
+    assert_eq!(completed["completed"], true);
+    assert_eq!(completed["runtime_job"]["status"], "failed");
+    assert_eq!(completed["runtime_job"]["error"], "remote execution failed");
+
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .expect("runtime job should be persisted");
+    assert_eq!(persisted.status, RuntimeJobStatus::Failed);
+    assert!(persisted.lease.is_none());
+    Ok(())
+}

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -98,6 +98,14 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             post(crate::handlers::runtime_hosts::claim_task_for_runtime_host),
         )
         .route(
+            "/api/runtime-hosts/{host_id}/runtime-jobs/claim",
+            post(crate::handlers::runtime_hosts::claim_runtime_job_for_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{host_id}/runtime-jobs/{runtime_job_id}/complete",
+            post(crate::handlers::runtime_hosts::complete_runtime_job_for_runtime_host),
+        )
+        .route(
             "/api/runtime-hosts/{host_id}/projects",
             get(crate::handlers::runtime_project_cache::list_runtime_host_projects),
         )

--- a/crates/harness-workflow/src/runtime/errors.rs
+++ b/crates/harness-workflow/src/runtime/errors.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, thiserror::Error)]
+#[error("runtime job not found: {runtime_job_id}")]
+pub struct RuntimeJobNotFoundError {
+    runtime_job_id: String,
+}
+
+impl RuntimeJobNotFoundError {
+    pub fn new(runtime_job_id: impl Into<String>) -> Self {
+        Self {
+            runtime_job_id: runtime_job_id.into(),
+        }
+    }
+
+    pub fn runtime_job_id(&self) -> &str {
+        &self.runtime_job_id
+    }
+}

--- a/crates/harness-workflow/src/runtime/job_claim.rs
+++ b/crates/harness-workflow/src/runtime/job_claim.rs
@@ -1,0 +1,98 @@
+use super::store::{enum_str, to_jsonb_string};
+use super::{RuntimeJob, RuntimeKind, WorkflowRuntimeStore};
+use chrono::{DateTime, Utc};
+
+impl WorkflowRuntimeStore {
+    pub async fn claim_next_runtime_job_for_runtime_kind(
+        &self,
+        runtime_kind: RuntimeKind,
+        owner: &str,
+        expires_at: DateTime<Utc>,
+    ) -> anyhow::Result<Option<RuntimeJob>> {
+        self.claim_next_runtime_job_matching(Some(runtime_kind), None, owner, expires_at)
+            .await
+    }
+
+    pub async fn claim_next_runtime_job_excluding_runtime_kind(
+        &self,
+        runtime_kind: RuntimeKind,
+        owner: &str,
+        expires_at: DateTime<Utc>,
+    ) -> anyhow::Result<Option<RuntimeJob>> {
+        self.claim_next_runtime_job_matching(None, Some(runtime_kind), owner, expires_at)
+            .await
+    }
+
+    async fn claim_next_runtime_job_matching(
+        &self,
+        only_runtime_kind: Option<RuntimeKind>,
+        excluded_runtime_kind: Option<RuntimeKind>,
+        owner: &str,
+        expires_at: DateTime<Utc>,
+    ) -> anyhow::Result<Option<RuntimeJob>> {
+        let only_runtime_kind = only_runtime_kind
+            .map(|runtime_kind| enum_str(&runtime_kind))
+            .transpose()?;
+        let excluded_runtime_kind = excluded_runtime_kind
+            .map(|runtime_kind| enum_str(&runtime_kind))
+            .transpose()?;
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT id, data::text FROM runtime_jobs
+             WHERE (
+                 (
+                     status = 'pending'
+                     AND (not_before IS NULL OR not_before <= CURRENT_TIMESTAMP)
+                 ) OR (
+                     status = 'running'
+                     AND data ? 'lease'
+                     AND (data->'lease' ? 'expires_at')
+                     AND (data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
+                 )
+             )
+             AND ($1::text IS NULL OR runtime_kind = $1)
+             AND ($2::text IS NULL OR runtime_kind <> $2)
+             ORDER BY
+                 CASE
+                     WHEN COALESCE(data #>> '{input,activity}', '') IN (
+                         'implement_issue',
+                         'implement_prompt',
+                         'inspect_pr_feedback',
+                         'address_pr_feedback'
+                     ) THEN 0
+                     WHEN COALESCE(data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
+                     ELSE 1
+                 END ASC,
+                 created_at ASC
+             LIMIT 1
+             FOR UPDATE SKIP LOCKED",
+        )
+        .bind(only_runtime_kind.as_deref())
+        .bind(excluded_runtime_kind.as_deref())
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some((id, data)) = row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        job.claim(owner, expires_at);
+        let updated = to_jsonb_string(&job)?;
+        let status = enum_str(&job.status)?;
+        sqlx::query(
+            "UPDATE runtime_jobs
+             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $4",
+        )
+        .bind(&status)
+        .bind(job.not_before)
+        .bind(&updated)
+        .bind(&id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(Some(job))
+    }
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod bus;
 pub mod dispatcher;
+mod job_claim;
 pub mod model;
 pub mod plan_issue;
 pub mod pr_feedback;

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod bus;
 pub mod dispatcher;
+pub mod errors;
 mod job_claim;
 pub mod model;
 pub mod plan_issue;
@@ -25,6 +26,7 @@ mod tests;
 
 pub use bus::InMemoryWorkflowBus;
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
+pub use errors::RuntimeJobNotFoundError;
 pub use model::{
     ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, ActivityStatus,
     RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind, RuntimeProfile, ValidationRecord,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1,3 +1,4 @@
+use super::errors::RuntimeJobNotFoundError;
 use super::model::{
     ActivityResult, ActivityStatus, RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind,
     WorkflowCommand, WorkflowCommandRecord, WorkflowCommandType, WorkflowDecision,
@@ -1371,7 +1372,7 @@ impl WorkflowRuntimeStore {
                 .fetch_optional(&mut *tx)
                 .await?;
         let Some((data,)) = row else {
-            anyhow::bail!("runtime job not found: {runtime_job_id}");
+            return Err(RuntimeJobNotFoundError::new(runtime_job_id).into());
         };
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
         let is_current_lease = job.status == RuntimeJobStatus::Running
@@ -1416,7 +1417,7 @@ impl WorkflowRuntimeStore {
                 .fetch_optional(&mut *tx)
                 .await?;
         let Some((command_id,)) = command_id_row else {
-            anyhow::bail!("runtime job not found: {runtime_job_id}");
+            return Err(RuntimeJobNotFoundError::new(runtime_job_id).into());
         };
         let command_row: Option<WorkflowCommandRecordRow> = sqlx::query_as(
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
@@ -1434,7 +1435,7 @@ impl WorkflowRuntimeStore {
                 .fetch_optional(&mut *tx)
                 .await?;
         let Some((data,)) = row else {
-            anyhow::bail!("runtime job not found: {runtime_job_id}");
+            return Err(RuntimeJobNotFoundError::new(runtime_job_id).into());
         };
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
         let is_current_lease = job.status == RuntimeJobStatus::Running
@@ -1638,7 +1639,7 @@ impl WorkflowRuntimeStore {
                 .fetch_optional(&mut *tx)
                 .await?;
         let Some((data,)) = row else {
-            anyhow::bail!("runtime job not found: {runtime_job_id}");
+            return Err(RuntimeJobNotFoundError::new(runtime_job_id).into());
         };
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
         let is_current_lease = job.status == RuntimeJobStatus::Running

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
 
 pub struct WorkflowRuntimeStore {
-    pool: PgPool,
+    pub(super) pool: PgPool,
 }
 
 pub struct WorkflowInstancePage {
@@ -1987,11 +1987,11 @@ impl WorkflowRuntimeStore {
     }
 }
 
-fn to_jsonb_string(value: &impl Serialize) -> anyhow::Result<String> {
+pub(super) fn to_jsonb_string(value: &impl Serialize) -> anyhow::Result<String> {
     Ok(serde_json::to_string(value)?.replace("\\u0000", ""))
 }
 
-fn enum_str(value: &impl Serialize) -> anyhow::Result<String> {
+pub(super) fn enum_str(value: &impl Serialize) -> anyhow::Result<String> {
     serde_json::to_value(value)?
         .as_str()
         .map(str::to_string)

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -1,5 +1,5 @@
 use super::model::{
-    ActivityResult, ActivityStatus, RuntimeJob, RuntimeProfile, WorkflowCommand,
+    ActivityResult, ActivityStatus, RuntimeJob, RuntimeKind, RuntimeProfile, WorkflowCommand,
     WorkflowCommandRecord, WorkflowCommandType, WorkflowInstance,
 };
 use super::reducer::reduce_runtime_job_completed;
@@ -53,7 +53,11 @@ impl<'a> RuntimeWorker<'a> {
         let mut lease_expires_at = Utc::now() + self.lease_ttl;
         let Some(job) = self
             .store
-            .claim_next_runtime_job(&self.owner, lease_expires_at)
+            .claim_next_runtime_job_excluding_runtime_kind(
+                RuntimeKind::RemoteHost,
+                &self.owner,
+                lease_expires_at,
+            )
             .await?
         else {
             return Ok(None);
@@ -553,6 +557,57 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].event_type, "RuntimeJobClaimed");
         assert_eq!(events[1].event_type, "ActivityResultReady");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_worker_skips_remote_host_jobs_for_external_claims() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&harness_core::config::dirs::default_db_path(
+            dir.path(),
+            "workflow_runtime",
+        ))
+        .await?;
+        let remote_job = store
+            .enqueue_runtime_job(
+                "command-remote",
+                RuntimeKind::RemoteHost,
+                "remote-host-default",
+                json!({ "activity": "remote_check" }),
+            )
+            .await?;
+        let local_job = store
+            .enqueue_runtime_job(
+                "command-local",
+                RuntimeKind::CodexJsonrpc,
+                "codex-default",
+                json!({ "activity": "local_check" }),
+            )
+            .await?;
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executor = PreflightRuntimeExecutor {
+            result: ActivityResult::succeeded("local_check", "Local worker completed."),
+            executions,
+        };
+
+        let completed = RuntimeWorker::new(&store, "runtime-1")
+            .with_lease_ttl(Duration::minutes(5))
+            .run_once(&executor)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("worker should claim the local job"))?;
+
+        assert_eq!(completed.id, local_job.id);
+        let remote = store
+            .get_runtime_job(&remote_job.id)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("remote job should remain pending for runtime host API")
+            })?;
+        assert_eq!(remote.status, RuntimeJobStatus::Pending);
         Ok(())
     }
 }

--- a/docs/runtime-host-model-spec.md
+++ b/docs/runtime-host-model-spec.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add a minimal runtime host control surface so Harness can track external executors and safely lease pending tasks to them.
+Add a runtime host control surface so Harness can track external executors and safely lease either legacy pending tasks or workflow runtime jobs to them.
 
 ## Why
 
@@ -19,18 +19,21 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - runtime host can claim one pending task
 - duplicate claim prevention across hosts
 - lease TTL support
-3. HTTP API endpoints:
+3. Legacy task HTTP API endpoints:
 - `GET /api/runtime-hosts`
 - `POST /api/runtime-hosts/register`
 - `POST /api/runtime-hosts/{id}/heartbeat`
 - `POST /api/runtime-hosts/{id}/deregister`
 - `POST /api/runtime-hosts/{id}/tasks/claim`
-4. Tests for lease correctness and heartbeat-driven status.
+4. Workflow runtime job HTTP API endpoints:
+- `POST /api/runtime-hosts/{id}/runtime-jobs/claim`
+- `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete`
+5. Tests for lease correctness, heartbeat-driven status, runtime job claim ownership, and terminal callback ownership.
 
 ## Out of Scope
 
-1. Remote executor callback APIs (`start/progress/complete/fail`).
-2. Scheduler integration that auto-routes all tasks to runtime hosts.
+1. Progress streaming callbacks.
+2. Scheduler integration that auto-routes all legacy tasks to runtime hosts.
 3. Workspace/multi-tenant model migration.
 
 ## Data Model (V1)
@@ -46,14 +49,24 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - `runtime_host_id: Option<String>`
 - `lease_expires_at: Option<DateTime<Utc>>`
 
+`RuntimeJob` workflow runtime lease fields
+- `runtime_kind: RuntimeKind`
+- `runtime_profile: String`
+- `lease: Option<WorkflowLease>`
+- `input: Value`
+- `output: Option<Value>`
+
 ## Behavior Rules
 
 1. `register` is idempotent by `host_id` (upsert metadata and refresh heartbeat).
 2. `heartbeat` on unknown host returns error.
 3. `deregister` removes host state and releases any pending task claims owned by that host.
-4. `claim` selects only tasks in `pending` status.
+4. Legacy task `claim` selects only tasks in `pending` status.
 5. A non-expired lease blocks claims by other hosts.
 6. Expired leases are reclaimable by any host.
+7. Workflow runtime-job claims select only `runtime_kind = remote_host` jobs.
+8. In-process runtime workers do not claim `remote_host` jobs.
+9. Runtime-job completion requires the host id and exact lease expiration timestamp from the claim response.
 
 ## API Response Shape (V1)
 
@@ -65,10 +78,23 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - success: `{ claimed: true, task_id, lease_expires_at }`
 - none available: `{ claimed: false }`
 
+`POST /api/runtime-hosts/{id}/runtime-jobs/claim`
+- request: `{ lease_secs?: number }`
+- success: `{ claimed: true, runtime_job_id, lease_expires_at, runtime_job }`
+- none available: `{ claimed: false }`
+- `runtime_job.input` carries the activity payload and runtime profile manifest needed by the external host.
+
+`POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete`
+- request: `{ lease_expires_at, result }`
+- `result` is the workflow `ActivityResult` payload and may report `succeeded`, `failed`, `blocked`, or `cancelled`.
+- success: `{ completed: true, runtime_job, workflow_event, decision }`
+- stale or wrong lease: HTTP `409` with `{ completed: false, error }`
+
 ## Risks
 
 1. Claim fairness is best-effort because pending selection is linear scan.
-2. Host state is lightweight; task lease truth is intentionally owned by the task store.
+2. Host state is lightweight; legacy task lease truth is intentionally owned by the task store.
+3. Workflow runtime-job lease truth is owned by `WorkflowRuntimeStore`.
 
 ## Verification
 
@@ -79,3 +105,5 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 2. Task-store and handler tests:
 - register + heartbeat + list returns online host
 - claim endpoint returns expected payload and prevents double-claim
+- workflow runtime-job claim endpoint ignores local runtime jobs
+- workflow runtime-job completion accepts terminal `ActivityResult` only when the exact lease is still owned by that host


### PR DESCRIPTION
## Summary
- route RemoteHost runtime jobs through workflow-runtime claim and completion endpoints
- keep local workflow workers from claiming RemoteHost jobs
- document the runtime-host workflow job API contract and add API/worker coverage

Closes #1201

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
