### PR TITLE
feat(usage): add agent usage monitor dashboard

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod runtime_project_cache;
 pub mod skills;
 pub mod thread;
 pub mod token_usage;
+pub mod usage_monitor;
 pub mod worktrees;
 
 #[cfg(test)]

--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -1,0 +1,721 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::{DateTime, Duration, Utc};
+use harness_core::types::{Event, EventFilters};
+use harness_observe::usage::UsageMetrics;
+use harness_workflow::runtime::{
+    RuntimeJob, RuntimeJobStatus, RuntimeKind, RuntimeProfile, WorkflowCommand, WorkflowInstance,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::http::AppState;
+
+#[path = "usage_monitor_process.rs"]
+mod usage_monitor_process;
+
+use usage_monitor_process::{sample_agent_processes, AgentProcess};
+
+const DEFAULT_USAGE_WINDOW_HOURS: i64 = 24;
+const MAX_USAGE_WINDOW_HOURS: i64 = 24 * 14;
+const DEFAULT_RUNTIME_JOB_LIMIT: i64 = 200;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct UsageMonitorQuery {
+    hours: Option<i64>,
+    limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct UsageMonitorResponse {
+    window: UsageWindow,
+    cost: CostConfig,
+    summary: UsageSummary,
+    tokens_by_agent: Vec<UsageGroup>,
+    tokens_by_project: Vec<UsageGroup>,
+    tokens_by_model: Vec<UsageGroup>,
+    agent_invocations: Vec<AgentInvocation>,
+    external_agent_processes: Vec<AgentProcess>,
+    active_by_repo: Vec<ActiveCount>,
+    active_by_activity: Vec<ActiveCount>,
+    diagnostics: UsageDiagnostics,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct UsageWindow {
+    hours: i64,
+    since: DateTime<Utc>,
+    now: DateTime<Utc>,
+}
+
+impl UsageWindow {
+    fn from_query(hours: Option<i64>, now: DateTime<Utc>) -> Self {
+        let hours = hours
+            .unwrap_or(DEFAULT_USAGE_WINDOW_HOURS)
+            .clamp(1, MAX_USAGE_WINDOW_HOURS);
+        Self {
+            hours,
+            since: now - Duration::hours(hours),
+            now,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CostConfig {
+    currency: &'static str,
+    configured: bool,
+    source: &'static str,
+    missing_model_count: usize,
+    message: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct UsageSummary {
+    total_tokens: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    request_count: u64,
+    estimated_cost_usd: Option<f64>,
+    running_agent_invocations: u64,
+    pending_agent_invocations: u64,
+    stale_agent_invocations: u64,
+    high_burn_invocations: u64,
+    external_agent_processes: u64,
+}
+
+#[derive(Debug, Default, Clone)]
+struct UsageAggregate {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    request_count: u64,
+    estimated_cost_usd: f64,
+    missing_price: bool,
+}
+
+impl UsageAggregate {
+    fn add(&mut self, metrics: &UsageMetrics, estimated_cost_usd: Option<f64>) {
+        self.input_tokens = self.input_tokens.saturating_add(metrics.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(metrics.output_tokens);
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(metrics.cache_read_input_tokens);
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(metrics.cache_creation_input_tokens);
+        self.request_count = self.request_count.saturating_add(1);
+        match estimated_cost_usd {
+            Some(cost) => self.estimated_cost_usd += cost,
+            None => self.missing_price = true,
+        }
+    }
+
+    fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.cache_read_input_tokens)
+            .saturating_add(self.cache_creation_input_tokens)
+    }
+
+    fn estimated_cost_json(&self, prices_configured: bool) -> Option<f64> {
+        if prices_configured && !self.missing_price {
+            Some(round_cost(self.estimated_cost_usd))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct UsageGroup {
+    name: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    total_tokens: u64,
+    request_count: u64,
+    estimated_cost_usd: Option<f64>,
+    cost_confidence: &'static str,
+}
+
+#[derive(Debug)]
+struct UsageRecord {
+    agent: String,
+    model: String,
+    project: String,
+    metrics: UsageMetrics,
+    estimated_cost_usd: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelPrice {
+    input_per_million_usd: f64,
+    output_per_million_usd: f64,
+    #[serde(default)]
+    cache_read_per_million_usd: f64,
+    #[serde(default)]
+    cache_creation_per_million_usd: f64,
+}
+
+#[derive(Debug, Default)]
+struct PriceCatalog {
+    by_model: BTreeMap<String, ModelPrice>,
+}
+
+impl PriceCatalog {
+    fn from_env() -> Self {
+        let Ok(raw) = std::env::var("HARNESS_USAGE_PRICE_CATALOG_JSON") else {
+            return Self::default();
+        };
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Self::default();
+        }
+        match serde_json::from_str::<BTreeMap<String, ModelPrice>>(raw) {
+            Ok(by_model) => Self { by_model },
+            Err(error) => {
+                tracing::warn!("usage_monitor: invalid HARNESS_USAGE_PRICE_CATALOG_JSON: {error}");
+                Self::default()
+            }
+        }
+    }
+
+    fn configured(&self) -> bool {
+        !self.by_model.is_empty()
+    }
+
+    fn estimate(&self, model: &str, metrics: &UsageMetrics) -> Option<f64> {
+        let price = self.by_model.get(model)?;
+        Some(
+            (metrics.input_tokens as f64 * price.input_per_million_usd
+                + metrics.output_tokens as f64 * price.output_per_million_usd
+                + metrics.cache_read_input_tokens as f64 * price.cache_read_per_million_usd
+                + metrics.cache_creation_input_tokens as f64
+                    * price.cache_creation_per_million_usd)
+                / 1_000_000.0,
+        )
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AgentInvocation {
+    agent_invocation_id: String,
+    source: &'static str,
+    runtime_job_id: String,
+    command_id: String,
+    workflow_id: String,
+    workflow_definition: String,
+    workflow_state: String,
+    subject_type: String,
+    subject_key: String,
+    repo: Option<String>,
+    project: Option<String>,
+    issue_number: Option<u64>,
+    pr_number: Option<u64>,
+    task_id: Option<String>,
+    activity: String,
+    status: &'static str,
+    command_status: String,
+    agent_runtime: &'static str,
+    runtime_profile: String,
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<DateTime<Utc>>,
+    stale: bool,
+    age_secs: i64,
+    updated_age_secs: i64,
+    burn_level: &'static str,
+    cost_confidence: &'static str,
+}
+
+#[derive(Debug)]
+struct RuntimeUsageRow {
+    workflow: WorkflowInstance,
+    command_id: String,
+    command_status: String,
+    command: WorkflowCommand,
+    runtime_job: RuntimeJob,
+}
+
+#[derive(Debug, Serialize)]
+struct ActiveCount {
+    name: String,
+    running: u64,
+    pending: u64,
+    high_burn: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct UsageDiagnostics {
+    runtime_store_available: bool,
+    token_source: &'static str,
+    active_cost_confidence: &'static str,
+    process_source: &'static str,
+}
+
+pub(crate) async fn usage_monitor(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<UsageMonitorQuery>,
+) -> Response {
+    match build_usage_monitor_response(&state, query).await {
+        Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "usage_monitor_unavailable",
+                "message": error.to_string(),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+async fn build_usage_monitor_response(
+    state: &AppState,
+    query: UsageMonitorQuery,
+) -> anyhow::Result<UsageMonitorResponse> {
+    let now = Utc::now();
+    let window = UsageWindow::from_query(query.hours, now);
+    let price_catalog = PriceCatalog::from_env();
+    let usage_records = load_usage_records(state, window, &price_catalog).await?;
+    let runtime_rows = load_runtime_usage_rows(state, window.since, query.limit).await?;
+    let agent_invocations = runtime_rows
+        .iter()
+        .map(|row| agent_invocation_from_row(row, now))
+        .collect::<Vec<_>>();
+    let external_agent_processes = sample_agent_processes(now);
+
+    let tokens_by_agent = aggregate_usage(
+        &usage_records,
+        |record| record.agent.clone(),
+        &price_catalog,
+    );
+    let tokens_by_project = aggregate_usage(
+        &usage_records,
+        |record| blank_label(&record.project),
+        &price_catalog,
+    );
+    let tokens_by_model = aggregate_usage(
+        &usage_records,
+        |record| record.model.clone(),
+        &price_catalog,
+    );
+    let total_usage = total_usage_aggregate(&usage_records);
+
+    let running_agent_invocations = agent_invocations
+        .iter()
+        .filter(|invocation| invocation.status == "running")
+        .count() as u64;
+    let pending_agent_invocations = agent_invocations
+        .iter()
+        .filter(|invocation| invocation.status == "pending")
+        .count() as u64;
+    let stale_agent_invocations = agent_invocations
+        .iter()
+        .filter(|invocation| invocation.stale)
+        .count() as u64;
+    let high_burn_invocations = agent_invocations
+        .iter()
+        .filter(|invocation| invocation.burn_level == "high")
+        .count() as u64;
+
+    let cost = CostConfig {
+        currency: "USD",
+        configured: price_catalog.configured(),
+        source: "HARNESS_USAGE_PRICE_CATALOG_JSON",
+        missing_model_count: usage_records
+            .iter()
+            .filter(|record| record.estimated_cost_usd.is_none())
+            .map(|record| record.model.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        message: if price_catalog.configured() {
+            "Token counts are exact when events exist; cost is estimated from the configured local price catalog."
+        } else {
+            "Token counts are exact when events exist; cost is unavailable until a local price catalog is configured."
+        },
+    };
+
+    Ok(UsageMonitorResponse {
+        window,
+        cost,
+        summary: UsageSummary {
+            total_tokens: total_usage.total_tokens(),
+            input_tokens: total_usage.input_tokens,
+            output_tokens: total_usage.output_tokens,
+            cache_read_input_tokens: total_usage.cache_read_input_tokens,
+            cache_creation_input_tokens: total_usage.cache_creation_input_tokens,
+            request_count: total_usage.request_count,
+            estimated_cost_usd: total_usage.estimated_cost_json(price_catalog.configured()),
+            running_agent_invocations,
+            pending_agent_invocations,
+            stale_agent_invocations,
+            high_burn_invocations,
+            external_agent_processes: external_agent_processes.len() as u64,
+        },
+        tokens_by_agent,
+        tokens_by_project,
+        tokens_by_model,
+        active_by_repo: aggregate_active_counts(&agent_invocations, |invocation| {
+            invocation
+                .repo
+                .clone()
+                .unwrap_or_else(|| "unassigned".to_string())
+        }),
+        active_by_activity: aggregate_active_counts(&agent_invocations, |invocation| {
+            invocation.activity.clone()
+        }),
+        agent_invocations,
+        external_agent_processes,
+        diagnostics: UsageDiagnostics {
+            runtime_store_available: state.core.workflow_runtime_store.is_some(),
+            token_source: "llm_usage_events",
+            active_cost_confidence: "estimated_from_agent_invocation_state",
+            process_source: "external_cli_process_snapshot",
+        },
+    })
+}
+
+async fn load_usage_records(
+    state: &AppState,
+    window: UsageWindow,
+    price_catalog: &PriceCatalog,
+) -> anyhow::Result<Vec<UsageRecord>> {
+    let events = state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("llm_usage".to_string()),
+            since: Some(window.since),
+            until: Some(window.now),
+            include_content: true,
+            ..Default::default()
+        })
+        .await?;
+    Ok(events
+        .iter()
+        .filter_map(|event| parse_usage_event(event, price_catalog))
+        .collect())
+}
+
+fn parse_usage_event(event: &Event, price_catalog: &PriceCatalog) -> Option<UsageRecord> {
+    let content = event.content.as_deref()?;
+    let payload: Value = serde_json::from_str(content).ok()?;
+    let metrics = UsageMetrics::from_payload(&payload)?;
+    let agent = payload
+        .get("agent")
+        .and_then(Value::as_str)
+        .unwrap_or(event.tool.as_str())
+        .to_string();
+    let model = payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let project = payload
+        .get("project")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let estimated_cost_usd = price_catalog.estimate(&model, &metrics);
+    Some(UsageRecord {
+        agent,
+        model,
+        project,
+        metrics,
+        estimated_cost_usd,
+    })
+}
+
+async fn load_runtime_usage_rows(
+    state: &AppState,
+    recent_since: DateTime<Utc>,
+    limit: Option<i64>,
+) -> anyhow::Result<Vec<RuntimeUsageRow>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let limit = limit
+        .unwrap_or(DEFAULT_RUNTIME_JOB_LIMIT)
+        .clamp(1, DEFAULT_RUNTIME_JOB_LIMIT);
+    let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+        "SELECT
+             workflow.data::text,
+             command.id,
+             command.status,
+             command.data::text,
+             job.data::text
+         FROM runtime_jobs job
+         JOIN workflow_commands command ON command.id = job.command_id
+         JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+         WHERE job.status IN ('pending', 'running')
+            OR job.updated_at >= $1
+         ORDER BY
+             CASE job.status
+                 WHEN 'running' THEN 0
+                 WHEN 'pending' THEN 1
+                 ELSE 2
+             END ASC,
+             job.updated_at DESC,
+             job.id DESC
+         LIMIT $2",
+    )
+    .bind(recent_since)
+    .bind(limit)
+    .fetch_all(store.pool())
+    .await?;
+
+    rows.into_iter()
+        .map(
+            |(workflow, command_id, command_status, command, runtime_job)| {
+                Ok(RuntimeUsageRow {
+                    workflow: serde_json::from_str(&workflow)?,
+                    command_id,
+                    command_status,
+                    command: serde_json::from_str(&command)?,
+                    runtime_job: serde_json::from_str(&runtime_job)?,
+                })
+            },
+        )
+        .collect()
+}
+
+fn agent_invocation_from_row(row: &RuntimeUsageRow, now: DateTime<Utc>) -> AgentInvocation {
+    let job = &row.runtime_job;
+    let workflow = &row.workflow;
+    let runtime_profile = runtime_profile_from_job(job);
+    let activity = job
+        .input
+        .get("activity")
+        .and_then(Value::as_str)
+        .or_else(|| row.command.activity_name())
+        .unwrap_or_else(|| row.command.command_type.as_str())
+        .to_string();
+    let lease_expires_at = job.lease.as_ref().map(|lease| lease.expires_at);
+    let stale = matches!(job.status, RuntimeJobStatus::Running)
+        && lease_expires_at.is_some_and(|expires_at| expires_at <= now);
+    let age_secs = (now - job.created_at).num_seconds().max(0);
+    let updated_age_secs = (now - job.updated_at).num_seconds().max(0);
+    let reasoning_effort = runtime_profile
+        .as_ref()
+        .and_then(|profile| profile.reasoning_effort.clone());
+    let status = runtime_job_status(job.status);
+    let burn_level = burn_level(
+        status,
+        &activity,
+        reasoning_effort.as_deref(),
+        age_secs,
+        stale,
+    );
+
+    AgentInvocation {
+        agent_invocation_id: job.id.clone(),
+        source: "workflow_runtime",
+        runtime_job_id: job.id.clone(),
+        command_id: row.command_id.clone(),
+        workflow_id: workflow.id.clone(),
+        workflow_definition: workflow.definition_id.clone(),
+        workflow_state: workflow.state.clone(),
+        subject_type: workflow.subject.subject_type.clone(),
+        subject_key: workflow.subject.subject_key.clone(),
+        repo: string_field(&workflow.data, "repo").or_else(|| string_field(&job.input, "repo")),
+        project: string_field(&workflow.data, "project_id")
+            .or_else(|| string_field(&job.input, "project_id")),
+        issue_number: u64_field(&workflow.data, "issue_number"),
+        pr_number: u64_field(&workflow.data, "pr_number"),
+        task_id: string_field(&workflow.data, "task_id")
+            .or_else(|| string_field(&job.input, "task_id")),
+        activity,
+        status,
+        command_status: row.command_status.clone(),
+        agent_runtime: runtime_kind(job.runtime_kind),
+        runtime_profile: job.runtime_profile.clone(),
+        model: runtime_profile
+            .as_ref()
+            .and_then(|profile| profile.model.clone()),
+        reasoning_effort,
+        lease_owner: job.lease.as_ref().map(|lease| lease.owner.clone()),
+        lease_expires_at,
+        stale,
+        age_secs,
+        updated_age_secs,
+        burn_level,
+        cost_confidence: "estimated_runtime_burn",
+    }
+}
+
+fn runtime_profile_from_job(job: &RuntimeJob) -> Option<RuntimeProfile> {
+    job.input
+        .get("runtime_profile")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+fn aggregate_usage<F>(
+    records: &[UsageRecord],
+    key_fn: F,
+    price_catalog: &PriceCatalog,
+) -> Vec<UsageGroup>
+where
+    F: Fn(&UsageRecord) -> String,
+{
+    let mut groups: BTreeMap<String, UsageAggregate> = BTreeMap::new();
+    for record in records {
+        groups
+            .entry(key_fn(record))
+            .or_default()
+            .add(&record.metrics, record.estimated_cost_usd);
+    }
+    let mut rows = groups
+        .into_iter()
+        .map(|(name, usage)| usage_group(name, usage, price_catalog.configured()))
+        .collect::<Vec<_>>();
+    rows.sort_by(|a, b| {
+        b.total_tokens
+            .cmp(&a.total_tokens)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+fn total_usage_aggregate(records: &[UsageRecord]) -> UsageAggregate {
+    let mut usage = UsageAggregate::default();
+    for record in records {
+        usage.add(&record.metrics, record.estimated_cost_usd);
+    }
+    usage
+}
+
+fn usage_group(name: String, usage: UsageAggregate, prices_configured: bool) -> UsageGroup {
+    UsageGroup {
+        name,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+        total_tokens: usage.total_tokens(),
+        request_count: usage.request_count,
+        estimated_cost_usd: usage.estimated_cost_json(prices_configured),
+        cost_confidence: if prices_configured && !usage.missing_price {
+            "exact_tokens_estimated_price"
+        } else {
+            "price_unavailable"
+        },
+    }
+}
+
+fn aggregate_active_counts<F>(invocations: &[AgentInvocation], key_fn: F) -> Vec<ActiveCount>
+where
+    F: Fn(&AgentInvocation) -> String,
+{
+    let mut counts: BTreeMap<String, ActiveCount> = BTreeMap::new();
+    for invocation in invocations {
+        let entry = counts
+            .entry(key_fn(invocation))
+            .or_insert_with_key(|name| ActiveCount {
+                name: name.clone(),
+                running: 0,
+                pending: 0,
+                high_burn: 0,
+            });
+        match invocation.status {
+            "running" => entry.running += 1,
+            "pending" => entry.pending += 1,
+            _ => {}
+        }
+        if invocation.burn_level == "high" {
+            entry.high_burn += 1;
+        }
+    }
+    let mut rows = counts.into_values().collect::<Vec<_>>();
+    rows.sort_by(|a, b| {
+        let a_total = a.running + a.pending;
+        let b_total = b.running + b.pending;
+        b_total.cmp(&a_total).then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+fn burn_level(
+    status: &str,
+    activity: &str,
+    reasoning_effort: Option<&str>,
+    age_secs: i64,
+    stale: bool,
+) -> &'static str {
+    if stale {
+        return "high";
+    }
+    if status != "running" {
+        return "low";
+    }
+    if matches!(reasoning_effort, Some("xhigh" | "high")) || age_secs >= 1800 {
+        return "high";
+    }
+    if activity == "poll_repo_backlog" && age_secs >= 300 {
+        return "medium";
+    }
+    if age_secs >= 900 {
+        return "medium";
+    }
+    "low"
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn u64_field(value: &Value, field: &str) -> Option<u64> {
+    value.get(field).and_then(Value::as_u64)
+}
+
+fn runtime_job_status(status: RuntimeJobStatus) -> &'static str {
+    match status {
+        RuntimeJobStatus::Pending => "pending",
+        RuntimeJobStatus::Running => "running",
+        RuntimeJobStatus::Succeeded => "succeeded",
+        RuntimeJobStatus::Failed => "failed",
+        RuntimeJobStatus::Cancelled => "cancelled",
+        RuntimeJobStatus::Expired => "expired",
+    }
+}
+
+fn runtime_kind(kind: RuntimeKind) -> &'static str {
+    match kind {
+        RuntimeKind::CodexExec => "codex_exec",
+        RuntimeKind::CodexJsonrpc => "codex_jsonrpc",
+        RuntimeKind::ClaudeCode => "claude_code",
+        RuntimeKind::AnthropicApi => "anthropic_api",
+        RuntimeKind::RemoteHost => "remote_host",
+    }
+}
+
+fn blank_label(value: &str) -> String {
+    if value.trim().is_empty() {
+        "unassigned".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn round_cost(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+#[cfg(test)]
+#[path = "usage_monitor_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -12,8 +12,8 @@ use harness_workflow::runtime::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, OnceLock};
 
 use crate::http::AppState;
 
@@ -174,6 +174,11 @@ struct PriceCatalog {
 }
 
 impl PriceCatalog {
+    fn from_env_cached() -> &'static Self {
+        static PRICE_CATALOG: OnceLock<PriceCatalog> = OnceLock::new();
+        PRICE_CATALOG.get_or_init(Self::from_env)
+    }
+
     fn from_env() -> Self {
         let Ok(raw) = std::env::var("HARNESS_USAGE_PRICE_CATALOG_JSON") else {
             return Self::default();
@@ -288,30 +293,25 @@ async fn build_usage_monitor_response(
 ) -> anyhow::Result<UsageMonitorResponse> {
     let now = Utc::now();
     let window = UsageWindow::from_query(query.hours, now);
-    let price_catalog = PriceCatalog::from_env();
-    let usage_records = load_usage_records(state, window, &price_catalog).await?;
+    let price_catalog = PriceCatalog::from_env_cached();
+    let usage_records = load_usage_records(state, window, price_catalog).await?;
     let runtime_rows = load_runtime_usage_rows(state, window.since, query.limit).await?;
     let agent_invocations = runtime_rows
         .iter()
         .map(|row| agent_invocation_from_row(row, now))
         .collect::<Vec<_>>();
-    let external_agent_processes = sample_agent_processes(now);
+    let external_agent_processes =
+        sample_agent_processes(now, &runtime_attribution_tokens(&runtime_rows));
 
-    let tokens_by_agent = aggregate_usage(
-        &usage_records,
-        |record| record.agent.clone(),
-        &price_catalog,
-    );
+    let tokens_by_agent =
+        aggregate_usage(&usage_records, |record| record.agent.clone(), price_catalog);
     let tokens_by_project = aggregate_usage(
         &usage_records,
         |record| blank_label(&record.project),
-        &price_catalog,
+        price_catalog,
     );
-    let tokens_by_model = aggregate_usage(
-        &usage_records,
-        |record| record.model.clone(),
-        &price_catalog,
-    );
+    let tokens_by_model =
+        aggregate_usage(&usage_records, |record| record.model.clone(), price_catalog);
     let total_usage = total_usage_aggregate(&usage_records);
 
     let running_agent_invocations = agent_invocations
@@ -450,8 +450,9 @@ async fn load_runtime_usage_rows(
     let limit = limit
         .unwrap_or(DEFAULT_RUNTIME_JOB_LIMIT)
         .clamp(1, DEFAULT_RUNTIME_JOB_LIMIT);
-    let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
+    let rows: Vec<(String, String, String, String, String, String)> = sqlx::query_as(
         "SELECT
+             workflow.id,
              workflow.data::text,
              command.id,
              command.status,
@@ -477,19 +478,61 @@ async fn load_runtime_usage_rows(
     .fetch_all(store.pool())
     .await?;
 
-    rows.into_iter()
-        .map(
-            |(workflow, command_id, command_status, command, runtime_job)| {
-                Ok(RuntimeUsageRow {
-                    workflow: serde_json::from_str(&workflow)?,
+    Ok(rows
+        .into_iter()
+        .filter_map(
+            |(workflow_id, workflow, command_id, command_status, command, runtime_job)| {
+                match parse_runtime_usage_row(
+                    &workflow_id,
                     command_id,
                     command_status,
-                    command: serde_json::from_str(&command)?,
-                    runtime_job: serde_json::from_str(&runtime_job)?,
-                })
+                    &workflow,
+                    &command,
+                    &runtime_job,
+                ) {
+                    Ok(row) => Some(row),
+                    Err(error) => {
+                        tracing::warn!(
+                            workflow_id = %workflow_id,
+                            "usage_monitor: skipping invalid runtime row: {error}"
+                        );
+                        None
+                    }
+                }
             },
         )
-        .collect()
+        .collect())
+}
+
+fn parse_runtime_usage_row(
+    workflow_id: &str,
+    command_id: String,
+    command_status: String,
+    workflow: &str,
+    command: &str,
+    runtime_job: &str,
+) -> anyhow::Result<RuntimeUsageRow> {
+    Ok(RuntimeUsageRow {
+        workflow: serde_json::from_str(workflow).map_err(|error| {
+            anyhow::anyhow!("workflow `{workflow_id}` JSON is invalid: {error}")
+        })?,
+        command_id: command_id.clone(),
+        command_status,
+        command: serde_json::from_str(command)
+            .map_err(|error| anyhow::anyhow!("command `{command_id}` JSON is invalid: {error}"))?,
+        runtime_job: serde_json::from_str(runtime_job).map_err(|error| {
+            anyhow::anyhow!("runtime job for command `{command_id}` JSON is invalid: {error}")
+        })?,
+    })
+}
+
+fn runtime_attribution_tokens(rows: &[RuntimeUsageRow]) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::new();
+    for row in rows {
+        tokens.insert(row.command_id.clone());
+        tokens.insert(row.runtime_job.id.clone());
+    }
+    tokens
 }
 
 fn agent_invocation_from_row(row: &RuntimeUsageRow, now: DateTime<Utc>) -> AgentInvocation {

--- a/crates/harness-server/src/handlers/usage_monitor_process.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_process.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use std::collections::BTreeSet;
 use std::path::Path;
-use sysinfo::{ProcessesToUpdate, System};
+use std::sync::{Mutex, OnceLock};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 #[derive(Debug, Serialize)]
 pub(crate) struct AgentProcess {
@@ -11,13 +13,28 @@ pub(crate) struct AgentProcess {
     pub(crate) age_secs: u64,
     pub(crate) cpu_pct: f32,
     pub(crate) memory_bytes: u64,
-    pub(crate) cwd: Option<String>,
-    pub(crate) command: String,
+    pub(crate) command_label: &'static str,
 }
 
-pub(crate) fn sample_agent_processes(now: DateTime<Utc>) -> Vec<AgentProcess> {
-    let mut system = System::new_all();
-    system.refresh_processes(ProcessesToUpdate::All, true);
+static PROCESS_SYSTEM: OnceLock<Mutex<System>> = OnceLock::new();
+
+pub(crate) fn sample_agent_processes(
+    now: DateTime<Utc>,
+    attribution_tokens: &BTreeSet<String>,
+) -> Vec<AgentProcess> {
+    let process_system = PROCESS_SYSTEM.get_or_init(|| Mutex::new(System::new()));
+    let Ok(mut system) = process_system.lock() else {
+        tracing::error!("usage_monitor: process sampler lock poisoned");
+        return Vec::new();
+    };
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::new()
+            .with_cpu()
+            .with_memory()
+            .with_cmd(UpdateKind::OnlyIfNotSet),
+    );
     let now_ts = now.timestamp().max(0) as u64;
     let mut processes = system
         .processes()
@@ -37,6 +54,9 @@ pub(crate) fn sample_agent_processes(now: DateTime<Utc>) -> Vec<AgentProcess> {
                 .map(|part| part.to_string_lossy().into_owned())
                 .unwrap_or_else(|| name.clone());
             let agent = classify_agent_process(&name, &executable, &command)?;
+            if is_attributed_runtime_process(&command, attribution_tokens) {
+                return None;
+            }
             Some(AgentProcess {
                 pid: pid.as_u32(),
                 name,
@@ -44,8 +64,7 @@ pub(crate) fn sample_agent_processes(now: DateTime<Utc>) -> Vec<AgentProcess> {
                 age_secs: now_ts.saturating_sub(process.start_time()),
                 cpu_pct: process.cpu_usage(),
                 memory_bytes: process.memory(),
-                cwd: process.cwd().map(|path| path.display().to_string()),
-                command: truncate(&command, 240),
+                command_label: command_label(agent, &command),
             })
         })
         .collect::<Vec<_>>();
@@ -80,16 +99,21 @@ fn classify_agent_process(name: &str, executable: &str, command: &str) -> Option
     None
 }
 
-fn truncate(value: &str, max_chars: usize) -> String {
-    if value.chars().count() <= max_chars {
-        return value.to_string();
+fn is_attributed_runtime_process(command: &str, attribution_tokens: &BTreeSet<String>) -> bool {
+    attribution_tokens
+        .iter()
+        .filter(|token| token.len() >= 8)
+        .any(|token| command.contains(token))
+}
+
+fn command_label(agent: &str, command: &str) -> &'static str {
+    if agent == "codex" && command.to_lowercase().contains(" exec ") {
+        return "codex exec";
     }
-    let mut out = value
-        .chars()
-        .take(max_chars.saturating_sub(1))
-        .collect::<String>();
-    out.push_str("...");
-    out
+    if agent == "claude" {
+        return "claude";
+    }
+    "codex"
 }
 
 #[cfg(test)]
@@ -129,6 +153,29 @@ mod tests {
                 "/Users/apple/.local/share/claude/versions/2.1.159 --chrome-native-host"
             ),
             None
+        );
+    }
+
+    #[test]
+    fn attributed_runtime_processes_are_not_external() {
+        let mut tokens = BTreeSet::new();
+        tokens.insert("runtime-job-123".to_string());
+        assert!(is_attributed_runtime_process(
+            "codex -p 'Runtime job id: runtime-job-123'",
+            &tokens
+        ));
+        assert!(!is_attributed_runtime_process("codex exec", &tokens));
+    }
+
+    #[test]
+    fn command_label_does_not_expose_prompt_text() {
+        assert_eq!(
+            command_label("codex", "codex exec -p 'secret prompt body'"),
+            "codex exec"
+        );
+        assert_eq!(
+            command_label("claude", "claude -p 'secret prompt body'"),
+            "claude"
         );
     }
 }

--- a/crates/harness-server/src/handlers/usage_monitor_process.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_process.rs
@@ -1,0 +1,134 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::path::Path;
+use sysinfo::{ProcessesToUpdate, System};
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentProcess {
+    pub(crate) pid: u32,
+    pub(crate) name: String,
+    pub(crate) agent: &'static str,
+    pub(crate) age_secs: u64,
+    pub(crate) cpu_pct: f32,
+    pub(crate) memory_bytes: u64,
+    pub(crate) cwd: Option<String>,
+    pub(crate) command: String,
+}
+
+pub(crate) fn sample_agent_processes(now: DateTime<Utc>) -> Vec<AgentProcess> {
+    let mut system = System::new_all();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    let now_ts = now.timestamp().max(0) as u64;
+    let mut processes = system
+        .processes()
+        .iter()
+        .filter_map(|(pid, process)| {
+            let name = process.name().to_string_lossy().into_owned();
+            let command = process
+                .cmd()
+                .iter()
+                .map(|part| part.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let executable = process
+                .cmd()
+                .first()
+                .and_then(|part| Path::new(part).file_name())
+                .map(|part| part.to_string_lossy().into_owned())
+                .unwrap_or_else(|| name.clone());
+            let agent = classify_agent_process(&name, &executable, &command)?;
+            Some(AgentProcess {
+                pid: pid.as_u32(),
+                name,
+                agent,
+                age_secs: now_ts.saturating_sub(process.start_time()),
+                cpu_pct: process.cpu_usage(),
+                memory_bytes: process.memory(),
+                cwd: process.cwd().map(|path| path.display().to_string()),
+                command: truncate(&command, 240),
+            })
+        })
+        .collect::<Vec<_>>();
+    processes.sort_by(|a, b| b.age_secs.cmp(&a.age_secs).then_with(|| a.pid.cmp(&b.pid)));
+    processes
+}
+
+fn classify_agent_process(name: &str, executable: &str, command: &str) -> Option<&'static str> {
+    let name = name.to_lowercase();
+    let executable = executable.to_lowercase();
+    let command = command.to_lowercase();
+
+    if name.contains("helper")
+        || executable.contains("helper")
+        || command.contains("--chrome-native-host")
+        || command.contains("claude helper")
+    {
+        return None;
+    }
+
+    if name == "codex"
+        || executable == "codex"
+        || (command.contains("codex") && command.contains(" exec "))
+    {
+        return Some("codex");
+    }
+
+    if name == "claude" || executable == "claude" {
+        return Some("claude");
+    }
+
+    None
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut out = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    out.push_str("...");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_agent_process_accepts_agent_cli_names() {
+        assert_eq!(
+            classify_agent_process("codex", "codex", "codex exec"),
+            Some("codex")
+        );
+        assert_eq!(
+            classify_agent_process("claude", "claude", "claude --dangerously-skip-permissions"),
+            Some("claude")
+        );
+    }
+
+    #[test]
+    fn classify_agent_process_rejects_desktop_helpers_and_shells() {
+        assert_eq!(
+            classify_agent_process(
+                "Claude Helper",
+                "Claude Helper",
+                "/Applications/Claude.app/Contents/Frameworks/Claude Helper"
+            ),
+            None
+        );
+        assert_eq!(
+            classify_agent_process("zsh", "zsh", "zsh -c 'until cd /tmp/repo && echo claude'"),
+            None
+        );
+        assert_eq!(
+            classify_agent_process(
+                "2.1.159",
+                "2.1.159",
+                "/Users/apple/.local/share/claude/versions/2.1.159 --chrome-native-host"
+            ),
+            None
+        );
+    }
+}

--- a/crates/harness-server/src/handlers/usage_monitor_tests.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_tests.rs
@@ -24,3 +24,64 @@ fn usage_aggregate_requires_configured_price_for_cost() {
     assert_eq!(usage.total_tokens(), 1_000_000);
     assert_eq!(usage.estimated_cost_json(true), None);
 }
+
+#[test]
+fn parse_runtime_usage_row_reports_corrupt_json_without_panicking() -> anyhow::Result<()> {
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("repo", "owner/repo"),
+    )
+    .with_id("workflow-1");
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "impl-1");
+    let error = parse_runtime_usage_row(
+        "workflow-1",
+        "command-1".to_string(),
+        "dispatched".to_string(),
+        &serde_json::to_string(&workflow)?,
+        &serde_json::to_string(&command)?,
+        "{not-json",
+    )
+    .err()
+    .ok_or_else(|| anyhow::anyhow!("invalid runtime job json should be reported"))?;
+
+    assert!(
+        error
+            .to_string()
+            .contains("runtime job for command `command-1` JSON is invalid"),
+        "{error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_attribution_tokens_include_runtime_job_and_command_ids() {
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("repo", "owner/repo"),
+    )
+    .with_id("workflow-1");
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "impl-1");
+    let runtime_job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexExec,
+        "codex-default",
+        serde_json::json!({ "activity": "implement_issue" }),
+    );
+    let runtime_job_id = runtime_job.id.clone();
+    let row = RuntimeUsageRow {
+        workflow,
+        command_id: "command-1".to_string(),
+        command_status: "dispatched".to_string(),
+        command,
+        runtime_job,
+    };
+
+    let tokens = runtime_attribution_tokens(&[row]);
+
+    assert!(tokens.contains("command-1"));
+    assert!(tokens.contains(&runtime_job_id));
+}

--- a/crates/harness-server/src/handlers/usage_monitor_tests.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn burn_level_marks_stale_running_job_high() {
+    assert_eq!(
+        burn_level("running", "implement_issue", Some("low"), 30, true),
+        "high"
+    );
+}
+
+#[test]
+fn usage_aggregate_requires_configured_price_for_cost() {
+    let mut usage = UsageAggregate::default();
+    usage.add(
+        &UsageMetrics {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reported_total_tokens: None,
+        },
+        None,
+    );
+    assert_eq!(usage.total_tokens(), 1_000_000);
+    assert_eq!(usage.estimated_cost_json(true), None);
+}

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -84,6 +84,12 @@ mod tests {
         assert_eq!(percent_decode("tok%2"), "tok%2");
         assert_eq!(percent_decode("tok%"), "tok%");
     }
+
+    #[test]
+    fn usage_page_html_is_auth_exempt() {
+        assert!(is_auth_exempt_path("/usage"));
+        assert!(!is_auth_exempt_path("/api/usage-monitor"));
+    }
 }
 
 /// Resolve the effective API token from server config or `HARNESS_API_TOKEN` env var.
@@ -116,6 +122,7 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
             | "/auth/reset-password"
             | "/"
             | "/overview"
+            | "/usage"
             | "/worktrees"
             | "/ws"
     ) || path.starts_with("/assets/")
@@ -124,8 +131,8 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
 /// Bearer token authentication middleware.
 ///
 /// Exempts `/health`, `/webhook`, `/webhook/feishu`, `/signals`, `/favicon.ico`,
-/// `/auth/reset-password`, `/` (dashboard HTML), `/overview` (system overview
-/// HTML), `/assets/*` (hashed React bundle assets), and `/ws` (WebSocket
+/// `/auth/reset-password`, `/` (dashboard HTML), `/overview` and `/usage`
+/// (React SPA HTML), `/assets/*` (hashed React bundle assets), and `/ws` (WebSocket
 /// upgrade).
 /// The dashboard HTML no longer embeds the token, so it is safe to serve without
 /// auth. `/ws` is exempt from *this middleware* because the WebSocket upgrade

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -18,6 +18,7 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(crate::dashboard::index))
         .route("/overview", get(crate::overview::index))
+        .route("/usage", get(crate::dashboard::index))
         .route("/worktrees", get(crate::dashboard::index))
         .route(
             "/assets/{filename}",
@@ -116,6 +117,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/token-usage",
             get(crate::handlers::token_usage::token_usage),
+        )
+        .route(
+            "/api/usage-monitor",
+            get(crate::handlers::usage_monitor::usage_monitor),
         )
         .route(
             "/webhook",

--- a/docs/cost-monitoring-dashboard-spec.md
+++ b/docs/cost-monitoring-dashboard-spec.md
@@ -1,0 +1,634 @@
+# Cost Monitoring Dashboard Spec
+
+## Problem
+
+Harness can run many Codex jobs in parallel through workflow runtime dispatch. Operators currently have to combine runtime tree JSON, process lists, GitHub PR state, and external quota screens to understand why usage is rising. This makes it too easy to confuse "one visible issue workflow" with "one active cost source" while backlog polling, PR feedback sweeps, and sprint planning continue to consume model quota in the background.
+
+The dashboard must make active and historical model usage attributable to concrete workflow work: task, workflow, command, agent invocation, runtime job, repository, activity, model, reasoning effort, and workspace.
+
+## Goals
+
+- Show every currently active Harness-owned agent invocation with repository, subject, activity, model, reasoning effort, age, stable invocation ID, and estimated burn.
+- Attribute usage to task-level units such as `repo-backlog:majiayu000/litellm-rs:issue:599`, not only to process IDs.
+- Split exact usage from estimated usage. Never present an estimate as provider-confirmed cost.
+- Explain quota movement in operator language: active high-effort jobs, low-effort pollers, retry loops, and external user-owned Codex sessions.
+- Provide controls to pause, throttle, or cancel expensive workflow categories before the operator exhausts a quota window.
+- Support a read-only first release that works without provider billing APIs.
+
+## Non-Goals
+
+- The first release does not need provider-side billing reconciliation.
+- The dashboard does not show raw prompts by default.
+- The dashboard does not replace workflow state debugging tools.
+- The dashboard does not make pricing assumptions that are hardcoded into Rust. Prices and quota weights must come from config.
+
+## Definitions
+
+- **Usage event**: a token, duration, lifecycle, or estimate event associated with a runtime job.
+- **Agent invocation**: one Harness-owned runtime job that starts or claims an agent turn. Its stable ID is the runtime job ID until a dedicated invocation table exists.
+- **Provider session ID**: a provider or runtime-specific conversation/session identifier. For Codex JSON-RPC this is the thread ID when available.
+- **Provider turn ID**: a provider or runtime-specific turn identifier. For Codex JSON-RPC this is the turn ID when available.
+- **Session key**: a display key derived from provider IDs when available, such as `<thread_id>-<turn_id>`. It is not the primary Harness attribution key.
+- **Exact usage**: token counts or billing values emitted by the model provider, Codex CLI, or Codex JSON-RPC event stream.
+- **Estimated usage**: locally derived cost or quota burn from prompt size, elapsed runtime, model, effort, and historical averages.
+- **Quota burn units**: normalized units for the operator's current quota window when exact dollar cost is unavailable.
+- **Attribution key**: the stable grouping tuple `(project_id, repo, workflow_id, command_id, agent_invocation_id, runtime_job_id, activity, model, reasoning_effort)`.
+
+## Architectural Decisions
+
+1. Harness-owned agents are tracked from workflow runtime state, not from process-name searches.
+2. Local process sampling is allowed only for external user-owned Codex or Claude CLI visibility.
+3. `runtime_job_id` is the initial `agent_invocation_id` because it is already durable, retry-scoped, and linked to workflow command state.
+4. Adapter lifecycle events add process/session/token detail to the invocation record. They do not replace the workflow runtime as the source of attribution.
+5. Token counts and costs have separate confidence. Token counts can be exact while dollars remain estimated.
+6. Budget controls gate new dispatch only. They must not silently delete or abandon already queued work.
+
+## Design Precedent
+
+Symphony's Elixir orchestrator uses a useful pattern for Codex app-server monitoring:
+
+- the orchestrator owns a `running` map keyed by issue ID
+- a running row is created at dispatch time
+- the Codex app-server adapter reports OS PID, thread ID, turn ID, session ID, token totals, and rate-limit snapshots back to the orchestrator
+- dashboards and APIs render from orchestrator state
+- token accounting prefers absolute thread totals such as `thread/tokenUsage/updated.tokenUsage.total`
+
+Harness should adapt the same principle without copying Symphony's exact identifiers. Harness already has better cross-repo attribution through workflow IDs, command IDs, and runtime job IDs. Therefore:
+
+- `agent_invocation_id` stays Harness-owned and stable
+- provider session IDs are secondary metadata
+- process PID is liveness metadata
+- token usage is attached to the invocation through adapter events
+
+## Current Evidence Shape
+
+The current manual investigation requires:
+
+- `GET /api/workflows/runtime/tree` to discover workflow state, command activity, runtime job IDs, model, effort, and stale running rows.
+- runtime DB rows to identify Harness-owned agent invocations by stable IDs.
+- external local process sampling to identify user-owned Codex or Claude CLI sessions that did not flow through Harness.
+- GitHub PR checks to explain why an issue workflow moved from implementation to feedback handling.
+- External quota UI to observe the quota percentage.
+
+The dashboard should consolidate these into one operator view and mark stale runtime rows separately from live processes.
+
+## Data Sources
+
+### Runtime Database
+
+Use workflow runtime tables as the durable source for:
+
+- workflow ID, definition, state, subject, parent workflow
+- workflow data fields such as `repo`, `project_id`, `task_id`, `issue_number`, `pr_number`, `pr_url`
+- command ID, command type, activity, dedupe key
+- agent invocation ID, runtime job ID, status, runtime kind, runtime profile, model, reasoning effort, created/updated timestamps
+- runtime event count and latest runtime event type
+
+### Agent Event Streams
+
+Parse usage-bearing events from both runtime paths:
+
+- `codex exec --json` stdout events
+- Codex JSON-RPC runtime events
+
+The parser must tolerate missing usage fields and store the raw event type metadata without storing raw prompt bodies.
+
+Agent adapters should emit normalized lifecycle events into the workflow runtime event stream:
+
+| Event | Required Fields | Optional Fields | Notes |
+|---|---|---|---|
+| `agent_invocation_started` | `runtime_job_id`, `command_id`, `workflow_id`, `agent_runtime`, `runtime_profile`, `started_at` | `pid`, `provider_session_id`, `provider_thread_id`, `model`, `reasoning_effort` | Emitted after a runtime job is claimed and the adapter has enough launch metadata. |
+| `agent_turn_started` | `agent_invocation_id`, `runtime_job_id`, `started_at` | `provider_thread_id`, `provider_turn_id`, `session_key`, `pid` | Codex JSON-RPC should set thread and turn IDs. Codex exec may omit them. |
+| `agent_usage_reported` | `agent_invocation_id`, `runtime_job_id`, `reported_at`, `usage_source`, `usage_confidence` | token fields, `provider_thread_id`, `provider_turn_id`, `raw_event_kind` | Raw prompt text must not be stored. |
+| `agent_rate_limits_reported` | `agent_invocation_id`, `runtime_job_id`, `reported_at` | redacted rate-limit payload | Optional, displayed only when available. |
+| `agent_invocation_heartbeat` | `agent_invocation_id`, `runtime_job_id`, `reported_at` | `pid`, `last_event_kind`, `lease_owner` | Keeps stale detection independent from process scanning. |
+| `agent_invocation_finished` | `agent_invocation_id`, `runtime_job_id`, `ended_at`, `terminal_status` | final token fields, failure summary | Closes the invocation and updates rollups. |
+
+These events are the target contract. The first read-only release may derive active invocations from existing `runtime_jobs`, but the API shape should already separate Harness-owned invocations from external local processes.
+
+### External Process Sampler
+
+Sample active local Codex and Claude CLI processes that are not already attributed through workflow runtime state:
+
+- PID, parent PID, elapsed time, CPU, memory
+- model and reasoning effort from command args when visible
+- workspace path
+
+This sampler is an external-session liveness hint, not the source of truth for Harness-owned agents and not an authoritative billing source. Harness-owned agents must be represented by agent invocation records from the runtime database and runtime events.
+
+Process sampling must exclude:
+
+- desktop app helper processes such as Claude Helper
+- browser native-host helper processes
+- shell wrapper or waiter processes that merely contain `codex` or `claude` in a string
+
+If a process can be matched to a Harness invocation through a recorded PID, it belongs under `agent_invocations` and must not be duplicated under `external_agent_processes`.
+
+### Provider or Plan Quota
+
+If Codex exposes a local or remote quota API, ingest it through a `QuotaProvider` trait. If not, allow manual snapshots:
+
+- observed quota percent
+- observed timestamp
+- quota window length
+- optional operator note
+
+Manual snapshots support calibration of quota burn units without pretending to know exact provider accounting.
+
+## Data Model
+
+### `usage_events`
+
+Stores raw normalized usage events.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID | Primary key |
+| `agent_invocation_id` | UUID | Nullable for external sessions until a dedicated invocation table exists |
+| `runtime_job_id` | UUID | Nullable for external Codex sessions |
+| `workflow_id` | Text | Nullable for external sessions |
+| `command_id` | UUID | Nullable |
+| `project_id` | Text | Nullable |
+| `repo` | Text | Nullable |
+| `subject_key` | Text | Nullable |
+| `activity` | Text | Nullable |
+| `runtime_kind` | Text | `codex_exec`, `codex_jsonrpc`, etc. |
+| `runtime_profile` | Text | Profile name |
+| `model` | Text | Model name from runtime profile or event |
+| `reasoning_effort` | Text | `low`, `medium`, `high`, `xhigh`, nullable |
+| `event_kind` | Text | `token_usage`, `estimate_tick`, `process_sample`, `quota_snapshot` |
+| `source` | Text | `codex_exec_json`, `codex_jsonrpc`, `process_sampler`, `manual_quota`, `provider_quota` |
+| `confidence` | Text | `exact`, `estimated`, `observed`, `unknown` |
+| `prompt_tokens` | BigInt | Nullable |
+| `completion_tokens` | BigInt | Nullable |
+| `cached_input_tokens` | BigInt | Nullable |
+| `reasoning_tokens` | BigInt | Nullable |
+| `wall_time_ms` | BigInt | Nullable |
+| `cost_usd_estimated` | Decimal | Nullable |
+| `quota_units_estimated` | Decimal | Nullable |
+| `occurred_at` | Timestamp | Event timestamp |
+| `metadata` | JSONB | Redacted metadata only |
+
+### `agent_invocations`
+
+Records Harness-owned agent starts and claims.
+
+| Field | Type | Notes |
+|---|---|---|
+| `agent_invocation_id` | UUID | Primary key; initially equal to `runtime_job_id` |
+| `runtime_job_id` | UUID | Workflow runtime job that caused the invocation |
+| `workflow_id` | Text | Required |
+| `command_id` | UUID | Required |
+| `agent_runtime` | Text | `codex_exec`, `codex_jsonrpc`, `claude_code`, etc. |
+| `runtime_profile` | Text | Profile name |
+| `model` | Text | Model requested for this invocation |
+| `reasoning_effort` | Text | Reasoning effort requested for this invocation |
+| `lease_owner` | Text | Runtime worker/host that claimed the job |
+| `pid` | Integer | Nullable until adapters emit spawn lifecycle events |
+| `provider_session_id` | Text | Nullable; provider/runtime conversation or session ID |
+| `provider_thread_id` | Text | Nullable; Codex JSON-RPC thread ID when available |
+| `provider_turn_id` | Text | Nullable; current or latest turn ID when available |
+| `session_key` | Text | Nullable; display key such as `<thread_id>-<turn_id>` |
+| `worker_host` | Text | Runtime host that executed the invocation, nullable for local execution |
+| `workspace_path` | Text | Redacted/local display path, nullable |
+| `last_event_kind` | Text | Last normalized adapter/runtime event |
+| `last_usage_reported_at` | Timestamp | Last token event timestamp |
+| `usage_confidence` | Text | `exact`, `estimated`, `observed`, or `unknown` |
+| `started_at` | Timestamp | Invocation start |
+| `last_seen_at` | Timestamp | Last runtime or usage event |
+| `ended_at` | Timestamp | Completion time |
+
+### `runtime_job_usage`
+
+Materialized or maintained rollup by runtime job.
+
+| Field | Type | Notes |
+|---|---|---|
+| `runtime_job_id` | UUID | Primary key |
+| `agent_invocation_id` | UUID | Agent invocation that produced the usage |
+| `workflow_id` | Text | Required when known |
+| `command_id` | UUID | Required when known |
+| `task_id` | Text | From workflow data |
+| `repo` | Text | Repository slug |
+| `activity` | Text | Runtime activity |
+| `status` | Text | Latest runtime job status |
+| `model` | Text | Latest model |
+| `reasoning_effort` | Text | Latest effort |
+| `started_at` | Timestamp | Runtime job creation |
+| `last_seen_at` | Timestamp | Last usage or process sample |
+| `ended_at` | Timestamp | Completion time |
+| `prompt_tokens` | BigInt | Exact when available |
+| `completion_tokens` | BigInt | Exact when available |
+| `reasoning_tokens` | BigInt | Exact when available |
+| `total_cost_usd_estimated` | Decimal | Exact price calculation or estimate |
+| `total_quota_units_estimated` | Decimal | Normalized quota burn |
+| `usage_confidence` | Text | Lowest-confidence contributor wins |
+| `provider_session_id` | Text | Nullable |
+| `provider_turn_id` | Text | Nullable |
+| `live_pid` | Integer | Nullable |
+| `stale_running` | Boolean | Runtime says running but process is gone or heartbeat is stale |
+
+### `usage_price_catalog`
+
+Configurable model and effort weights.
+
+| Field | Type | Notes |
+|---|---|---|
+| `model` | Text | Model name |
+| `effective_from` | Timestamp | Price version start |
+| `input_usd_per_million_tokens` | Decimal | Nullable |
+| `output_usd_per_million_tokens` | Decimal | Nullable |
+| `cached_input_usd_per_million_tokens` | Decimal | Nullable |
+| `reasoning_usd_per_million_tokens` | Decimal | Nullable |
+| `quota_weight` | Decimal | Relative quota burn multiplier |
+| `source_note` | Text | Where the operator entered or verified this price |
+
+### `usage_budget_policies`
+
+Stores enforcement and alert policies.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID | Primary key |
+| `scope_type` | Text | `server`, `repo`, `activity`, `workflow`, `model`, `profile` |
+| `scope_value` | Text | Scope identifier |
+| `window_secs` | Integer | Rolling window |
+| `max_quota_units` | Decimal | Nullable |
+| `max_cost_usd` | Decimal | Nullable |
+| `max_concurrency` | Integer | Nullable |
+| `action` | Text | `alert`, `throttle`, `block_new`, `require_approval`, `cancel_low_priority` |
+| `enabled` | Boolean | Policy switch |
+
+## Token Accounting Contract
+
+### Codex JSON-RPC / App-Server
+
+Codex JSON-RPC should follow absolute-total accounting:
+
+1. Prefer `thread/tokenUsage/updated.tokenUsage.total` when available.
+2. Fall back to token-count events containing `total_token_usage`.
+3. Track the last accepted absolute total per `(agent_invocation_id, provider_thread_id)`.
+4. Add only the positive delta between the new absolute total and the last accepted total.
+5. Ignore `tokenUsage.last` and `last_token_usage` for dashboard totals unless no absolute total source exists and the event contract explicitly marks it as additive.
+6. Do not reset accounting when a new turn starts on the same provider thread.
+
+The UI may display the latest provider thread/turn/session key, but all rollups group by `agent_invocation_id` and workflow attribution fields.
+
+### Codex Exec JSON
+
+`codex exec --json` should be parsed as one or more event streams:
+
+- lifecycle events update invocation status and last activity
+- usage events update exact token counters when the JSON payload has a documented usage schema
+- completion events close the invocation and mark final status
+
+If a `codex exec` payload does not include exact token usage, Harness must keep token fields null and use estimated burn only. It must not infer exact token counts from elapsed time.
+
+### Claude Code and Other Runtimes
+
+Runtimes that do not emit token usage use lifecycle and heartbeat events for live cost pressure only:
+
+- active status
+- runtime profile
+- model and effort if configured
+- elapsed time
+- historical median burn by activity and model
+
+Rows must show `usage_confidence=estimated` until exact provider or runtime usage arrives.
+
+## Cost and Quota Calculation
+
+### Exact Token Path
+
+When token counts are available:
+
+1. Store the raw token fields as exact usage events.
+2. Join to `usage_price_catalog` by model and timestamp.
+3. Calculate estimated USD from configured prices.
+4. Calculate quota units from configured quota weights.
+5. Mark confidence as `exact` for tokens and `estimated` for dollars unless provider cost is confirmed.
+
+### Estimated Path
+
+When exact tokens are unavailable:
+
+1. Estimate prompt tokens from prompt packet byte size.
+2. Estimate output tokens from rolling historical medians by `(activity, model, reasoning_effort)`.
+3. Add elapsed-time burn for running jobs with no final token data.
+4. Apply model and reasoning multipliers from config.
+5. Mark confidence as `estimated`.
+
+### Quota Calibration
+
+Manual quota snapshots can calibrate burn units:
+
+1. Operator records quota percentage at `t1`.
+2. Operator records quota percentage at `t2`.
+3. Harness compares observed quota delta with estimated job burn in the same window.
+4. The dashboard shows a calibration factor and confidence range.
+
+This allows useful "why did usage jump" debugging even when exact provider quota APIs are unavailable.
+
+## API Design
+
+### First Read-Only Release
+
+`GET /api/usage-monitor` ships the initial dashboard payload as one aggregated read-only endpoint. It combines:
+
+- exact token usage already stored in `llm_usage`
+- active and recent Harness-owned agent invocations from the workflow database
+- local Codex and Claude process samples only for external-session visibility
+- optional estimated USD values when `HARNESS_USAGE_PRICE_CATALOG_JSON` is configured
+
+The endpoint must not hardcode model prices. If no price catalog is configured, token counts remain exact and cost fields remain null with diagnostics explaining why.
+
+Current response fields:
+
+| Field | Meaning |
+|---|---|
+| `window` | Requested lookback window and server timestamp |
+| `cost` | Price catalog configuration state and cost-confidence message |
+| `summary` | Token totals, request count, active invocation counts, stale counts, high-burn counts |
+| `tokens_by_agent` | Historical exact token usage grouped by usage event agent |
+| `tokens_by_project` | Historical exact token usage grouped by project field |
+| `tokens_by_model` | Historical exact token usage grouped by model |
+| `agent_invocations` | Harness-owned runtime jobs derived from workflow runtime state |
+| `external_agent_processes` | Local Codex/Claude CLI process hints outside Harness attribution |
+| `active_by_repo` | Active Harness invocation pressure grouped by repo |
+| `active_by_activity` | Active Harness invocation pressure grouped by activity |
+| `diagnostics` | Runtime store availability and source labels |
+
+The first release may show `estimated_runtime_burn` for active invocation rows because exact per-invocation tokens are not yet wired from adapters. This is acceptable only if the row also keeps token/cost confidence labels explicit.
+
+The split endpoints below are the target API shape for follow-up releases once persistence, budget controls, and historical drill-downs mature.
+
+### `GET /api/usage/summary`
+
+Returns top-level dashboard numbers.
+
+Response fields:
+
+- active model jobs
+- active high-effort jobs
+- estimated quota burn per hour
+- total estimated quota burn in current window
+- stale running rows
+- top repositories by current-window burn
+- top activities by current-window burn
+- latest quota snapshot when available
+
+### `GET /api/usage/running`
+
+Returns active and stale-running jobs.
+
+Each row includes:
+
+- runtime job ID
+- PID and process age when alive
+- repo, subject, workflow state, activity
+- model, reasoning effort, runtime kind, profile
+- exact tokens if available
+- estimated current burn
+- usage confidence
+- links to workflow detail, workspace, issue, and PR
+
+### `GET /api/usage/jobs/{runtime_job_id}`
+
+Returns one runtime job usage timeline:
+
+- lifecycle events
+- token usage events
+- process samples
+- prompt packet digest
+- related workflow commands
+- related GitHub issue or PR metadata
+- redaction-safe metadata
+
+### `GET /api/usage/breakdown`
+
+Query params:
+
+- `group_by=repo|activity|model|reasoning_effort|task_id|workflow_id`
+- `window=5h|24h|7d|custom`
+- `confidence=all|exact|estimated`
+
+### `POST /api/usage/quota-snapshots`
+
+Records an operator-observed quota percentage when provider APIs are unavailable.
+
+### `GET /api/usage/export.csv`
+
+Exports rows for external analysis.
+
+## Dashboard UX
+
+### Top Bar
+
+Show the most operationally important numbers:
+
+- quota window remaining or latest observed quota percent
+- active burn rate
+- active jobs
+- high-effort jobs
+- stale running rows
+- estimated time to threshold
+
+Each number must show a confidence badge: `Exact`, `Estimated`, or `Observed`.
+
+### Running Jobs Table
+
+Default sort: highest estimated burn first, then highest reasoning effort, then oldest runtime.
+
+Columns:
+
+- status: live, stale, completing, blocked
+- repo
+- subject
+- activity
+- model
+- effort
+- age
+- estimated current-window burn
+- confidence
+- PID
+- PR or issue
+- actions
+
+Actions:
+
+- view details
+- pause workflow
+- cancel runtime job
+- throttle repo
+- copy diagnostic command
+
+Destructive actions require confirmation and must write an audit event.
+
+### Cost Breakdown
+
+Provide grouped views:
+
+- by repository
+- by task
+- by activity
+- by model and reasoning effort
+- by runtime profile
+
+The task grouping is the primary view for "which task is spending quota?"
+
+### Job Detail Drawer
+
+Show:
+
+- workflow and command identifiers
+- prompt packet digest and source path
+- runtime profile
+- live process sample history
+- token timeline
+- related GitHub PR checks
+- validation or failure summary
+- exact fields used for cost attribution
+
+Do not display raw prompts unless the operator explicitly expands a redacted debug section.
+
+### Budget Policy View
+
+Operators can define policies such as:
+
+- at most 1 concurrent `xhigh` job
+- pause `poll_repo_backlog` when the quota window is above 25% consumed
+- require approval before `plan_repo_sprint` starts on `gpt-5.5` with `xhigh`
+- cap `repo_backlog` to 1 concurrent job
+- disable low-priority polling while any issue implementation is active
+
+## Control Plane
+
+### Throttling
+
+Introduce a `UsageGate` before runtime job dispatch:
+
+1. Load active budget policies.
+2. Calculate current usage and active concurrency.
+3. Decide `allow`, `delay`, `require_approval`, or `deny`.
+4. Record the decision as a workflow event.
+
+The gate must never silently drop work. Delayed work remains queued with an explicit reason.
+
+### Priority Classes
+
+Recommended default priority:
+
+1. `address_pr_feedback` for existing open PRs
+2. `implement_issue`
+3. `quality_gate`
+4. `plan_repo_sprint`
+5. `poll_repo_backlog`
+
+When quota is tight, pause lower classes first.
+
+### Stale Job Handling
+
+A runtime job is `stale_running` when:
+
+- status is `running`
+- latest runtime event is older than lease TTL
+- no live process is found
+- no remote runtime host heartbeat is associated with the job
+
+Stale rows should be excluded from active burn rate, but shown as reliability issues.
+
+## Implementation Plan
+
+### Phase 0: Read-Only Visibility
+
+- Add read-only usage endpoints backed by workflow runtime state.
+- Represent Harness-owned runtime jobs as `agent_invocations`.
+- Add process sampler only for external Codex/Claude CLI visibility.
+- Show active invocations, stale rows, high-burn rows, historical token groups, and estimated burn.
+- Add optional local price catalog parsing through `HARNESS_USAGE_PRICE_CATALOG_JSON`.
+- No enforcement.
+
+### Phase 1: Usage Persistence
+
+- Add `usage_events`, `agent_invocations`, `runtime_job_usage`, and `usage_price_catalog`.
+- Emit adapter lifecycle events for invocation start, turn start, heartbeat, usage, rate-limit snapshots, and finish.
+- Parse usage events from `codex exec --json` when exact usage fields exist.
+- Parse absolute token totals from Codex JSON-RPC.
+- Reconcile usage on runtime job completion.
+- Add CSV export.
+
+### Phase 2: Dashboard UI
+
+- Add top-level usage route in the existing web UI.
+- Add running job table, grouped breakdown, and job detail drawer.
+- Add confidence labels everywhere cost or quota is displayed.
+- Link usage rows back to workflow, workspace, PR, and issue.
+
+### Phase 3: Budget Enforcement
+
+- Add `usage_budget_policies`.
+- Add `UsageGate` before runtime dispatch.
+- Add throttle and approval decisions for new runtime jobs.
+- Add audited cancel, pause, and resume actions.
+- Keep queued work visible when policy delays dispatch.
+
+### Phase 4: Provider Integration
+
+- Add optional `QuotaProvider` implementations if Codex or provider APIs expose reliable quota or billing data.
+- Keep provider integration optional so local read-only visibility still works offline.
+
+## Testing
+
+### Unit Tests
+
+- Parse token usage from known `codex exec --json` fixtures.
+- Parse token usage from known JSON-RPC fixtures.
+- Calculate USD estimates from price catalog rows.
+- Calculate quota units from model and reasoning weights.
+- Mark stale-running jobs correctly.
+- Redact metadata before persistence.
+
+### Integration Tests
+
+- Create fake runtime jobs and process samples without launching real Codex.
+- Verify `/api/usage-monitor` returns exact usage, active runtime jobs, process samples, and cost diagnostics.
+- Verify Harness-owned invocation counts come from runtime jobs even when no local process is sampled.
+- Verify external process rows do not include desktop helpers, browser native hosts, or shell waiters.
+- Verify `/api/usage/running` groups runtime database rows with live process samples.
+- Verify stale rows are not counted in active burn.
+- Verify budget policies delay or block only new dispatches.
+
+### UI Tests
+
+- Render active jobs table with exact and estimated rows.
+- Render empty state with no active model jobs.
+- Render stale-running warning.
+- Verify destructive actions require confirmation.
+
+## Security and Privacy
+
+- Do not persist raw prompts in usage tables.
+- Redact command metadata that may include secrets.
+- Treat workspace paths as local operational metadata and avoid exporting them unless explicitly requested.
+- Require an operator role for cancel, pause, resume, and budget policy changes.
+- Audit every control-plane action with actor, timestamp, target, and reason.
+
+## Acceptance Criteria
+
+- An operator can answer "what is burning quota right now?" in one screen.
+- Active jobs are grouped by task, repo, activity, model, and reasoning effort.
+- Stale runtime rows are visible but excluded from active burn.
+- Every cost number is labeled exact, estimated, or observed.
+- The dashboard can operate without provider billing APIs.
+- Harness-owned agent counts do not depend on command-line process matching.
+- External Codex/Claude processes are shown separately from Harness invocations.
+- Budget gates can prevent more than one concurrent `xhigh` job.
+- Low-priority backlog polling can be paused automatically when quota is tight.
+
+## Open Questions
+
+- Does the local Codex runtime expose exact token usage for every `codex exec --json` turn?
+- Is there a reliable local or remote source for the operator's five-hour quota percentage?
+- Should budget thresholds default to hard blocking or approval-required mode?
+- Should repo backlog polling be rewritten to use deterministic GitHub queries before invoking any model?
+- Can external user-owned Codex sessions expose enough structured usage to be imported without confusing them with Harness-owned invocations?

--- a/docs/cost-monitoring-dashboard-spec.md
+++ b/docs/cost-monitoring-dashboard-spec.md
@@ -110,9 +110,9 @@ These events are the target contract. The first read-only release may derive act
 
 Sample active local Codex and Claude CLI processes that are not already attributed through workflow runtime state:
 
-- PID, parent PID, elapsed time, CPU, memory
-- model and reasoning effort from command args when visible
-- workspace path
+- PID, elapsed time, CPU, memory
+- agent type and a coarse command label, such as `codex exec` or `claude`
+- no raw argv, prompt text, environment, or workspace path
 
 This sampler is an external-session liveness hint, not the source of truth for Harness-owned agents and not an authoritative billing source. Harness-owned agents must be represented by agent invocation records from the runtime database and runtime events.
 
@@ -122,7 +122,7 @@ Process sampling must exclude:
 - browser native-host helper processes
 - shell wrapper or waiter processes that merely contain `codex` or `claude` in a string
 
-If a process can be matched to a Harness invocation through a recorded PID, it belongs under `agent_invocations` and must not be duplicated under `external_agent_processes`.
+If a process can be matched to a Harness invocation through a recorded PID, runtime job id, or command id, it belongs under `agent_invocations` and must not be duplicated under `external_agent_processes`.
 
 ### Provider or Plan Quota
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Route, Routes, useLocation } from "react-router-dom";
 import { Dashboard } from "./routes/Dashboard";
 import { Overview } from "./routes/Overview";
+import { UsageMonitor } from "./routes/UsageMonitor";
 import { Worktrees } from "./routes/Worktrees";
 import { PaletteProvider } from "./lib/palette";
 import { TokenPrompt } from "./components/TokenPrompt";
@@ -48,6 +49,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/overview" element={<Overview />} />
+          <Route path="/usage" element={<UsageMonitor />} />
           <Route path="/worktrees" element={<Worktrees />} />
         </Routes>
         <TokenPrompt />

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -8,6 +8,7 @@ import type {
   OverviewPayload,
   StreamItem,
   TaskListResponse,
+  UsageMonitorPayload,
   WorkflowRuntimeTreePayload,
 } from "@/types";
 
@@ -30,6 +31,14 @@ export function useOperatorSnapshot() {
     queryKey: ["operator-snapshot"],
     queryFn: ({ signal }) => apiJson<OperatorSnapshotPayload>("/api/operator-snapshot", { signal }),
     refetchInterval: 30_000,
+  });
+}
+
+export function useUsageMonitor() {
+  return useQuery<UsageMonitorPayload, Error>({
+    queryKey: ["usage-monitor"],
+    queryFn: ({ signal }) => apiJson<UsageMonitorPayload>("/api/usage-monitor", { signal }),
+    refetchInterval: 5_000,
   });
 }
 

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -46,7 +46,10 @@ export function Dashboard() {
     },
     {
       label: "System",
-      items: [{ id: "overview", label: "Overview", href: "/overview" }],
+      items: [
+        { id: "overview", label: "Overview", href: "/overview" },
+        { id: "usage", label: "Usage", href: "/usage" },
+      ],
     },
   ];
 

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -43,6 +43,7 @@ export function Overview() {
       label: "System",
       items: [
         { id: "overview", label: "Overview", href: "/overview", active: true },
+        { id: "usage", label: "Usage", href: "/usage" },
         { id: "projects", label: "Projects", href: "/overview#projects", count: data?.projects.length },
         { id: "runtimes", label: "Runtimes", href: "/overview#runtimes", count: data?.runtimes.length },
         { id: "observability", label: "Observability", href: "/overview#observability" },

--- a/web/src/routes/UsageMonitor.tsx
+++ b/web/src/routes/UsageMonitor.tsx
@@ -1,0 +1,311 @@
+import { Sidebar, type SidebarSection } from "@/components/Sidebar";
+import { TopBar } from "@/components/TopBar";
+import { Panel } from "@/components/Panel";
+import { KpiCard } from "@/components/KpiCard";
+import { StatusBadge } from "@/components/StatusBadge";
+import { PaletteFab } from "@/components/PaletteFab";
+import { DOCS_URL } from "@/lib/links";
+import { fmtInt } from "@/lib/format";
+import { useUsageMonitor } from "@/lib/queries";
+import type { ActiveCount, AgentInvocation, AgentProcess, UsageGroup } from "@/types";
+
+function fmtTokens(tokens: number | null | undefined): string {
+  if (tokens == null || !Number.isFinite(tokens)) return "-";
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens >= 10_000_000 ? 0 : 1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(tokens >= 10_000 ? 0 : 1)}K`;
+  return fmtInt(tokens);
+}
+
+function fmtCost(cost: number | null | undefined): string {
+  if (cost == null || !Number.isFinite(cost)) return "-";
+  if (cost >= 100) return `$${cost.toFixed(0)}`;
+  if (cost >= 1) return `$${cost.toFixed(2)}`;
+  return `$${cost.toFixed(4)}`;
+}
+
+function fmtDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)}GB`;
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(0)}MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${bytes}B`;
+}
+
+function burnClass(level: AgentInvocation["burn_level"]): string {
+  switch (level) {
+    case "high":
+      return "text-danger border-danger/40";
+    case "medium":
+      return "text-warn border-warn/40";
+    default:
+      return "text-ink-3 border-line-2";
+  }
+}
+
+function shortPath(path: string | null): string {
+  if (!path) return "-";
+  const parts = path.split("/");
+  return parts.slice(-3).join("/");
+}
+
+function UsageGroupsTable({ rows, empty }: { rows: UsageGroup[]; empty: string }) {
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse font-mono text-[11.5px]">
+        <thead className="text-ink-3 border-b border-line">
+          <tr>
+            <th className="text-left font-medium px-4 py-2">Name</th>
+            <th className="text-right font-medium px-4 py-2">Tokens</th>
+            <th className="text-right font-medium px-4 py-2">Requests</th>
+            <th className="text-right font-medium px-4 py-2">Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length ? (
+            rows.slice(0, 12).map((row) => (
+              <tr key={row.name} className="border-b border-line/70">
+                <td className="px-4 py-2 text-ink-2 max-w-[220px] truncate" title={row.name}>{row.name}</td>
+                <td className="px-4 py-2 text-right text-ink">{fmtTokens(row.total_tokens)}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtInt(row.request_count)}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtCost(row.estimated_cost_usd)}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="px-4 py-6 text-ink-3" colSpan={4}>{empty}</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ActiveCountsList({ rows }: { rows: ActiveCount[] }) {
+  return (
+    <div className="p-4 space-y-2">
+      {rows.length ? (
+        rows.slice(0, 10).map((row) => (
+          <div key={row.name} className="grid grid-cols-[1fr_48px_48px_48px] gap-2 font-mono text-[11.5px]">
+            <span className="truncate text-ink-2" title={row.name}>{row.name}</span>
+            <span className="text-right text-ok">{fmtInt(row.running)}</span>
+            <span className="text-right text-sand">{fmtInt(row.pending)}</span>
+            <span className="text-right text-danger">{fmtInt(row.high_burn)}</span>
+          </div>
+        ))
+      ) : (
+        <div className="font-mono text-[11.5px] text-ink-3">no active runtime jobs</div>
+      )}
+    </div>
+  );
+}
+
+function AgentInvocationsTable({ invocations }: { invocations: AgentInvocation[] }) {
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse font-mono text-[11.5px]">
+        <thead className="text-ink-3 border-b border-line">
+          <tr>
+            <th className="text-left font-medium px-4 py-2">Burn</th>
+            <th className="text-left font-medium px-4 py-2">Invocation</th>
+            <th className="text-left font-medium px-4 py-2">Repo</th>
+            <th className="text-left font-medium px-4 py-2">Activity</th>
+            <th className="text-left font-medium px-4 py-2">Runtime</th>
+            <th className="text-left font-medium px-4 py-2">State</th>
+            <th className="text-right font-medium px-4 py-2">Age</th>
+            <th className="text-left font-medium px-4 py-2">Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {invocations.length ? (
+            invocations.slice(0, 100).map((invocation) => (
+              <tr key={invocation.agent_invocation_id} className="border-b border-line/70">
+                <td className="px-4 py-2">
+                  <span className={`px-1.5 py-[1px] border rounded-[10px] ${burnClass(invocation.burn_level)}`}>
+                    {invocation.burn_level}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-ink-2 max-w-[150px] truncate" title={invocation.agent_invocation_id}>
+                  {invocation.agent_invocation_id}
+                </td>
+                <td className="px-4 py-2 text-ink-2 max-w-[180px] truncate" title={invocation.repo ?? invocation.project ?? ""}>
+                  {invocation.repo ?? shortPath(invocation.project)}
+                </td>
+                <td className="px-4 py-2 text-ink max-w-[190px] truncate" title={invocation.activity}>{invocation.activity}</td>
+                <td className="px-4 py-2 text-ink-2 max-w-[210px] truncate" title={invocation.model ?? invocation.runtime_profile}>
+                  {invocation.agent_runtime}
+                  {invocation.reasoning_effort ? <span className="text-ink-4"> / {invocation.reasoning_effort}</span> : null}
+                </td>
+                <td className="px-4 py-2 text-ink-2">{invocation.status} / {invocation.workflow_state}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtDuration(invocation.age_secs)}</td>
+                <td className="px-4 py-2 text-ink-3 max-w-[160px] truncate" title={invocation.lease_owner ?? ""}>
+                  {invocation.lease_owner ?? "-"}
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="px-4 py-6 text-ink-3" colSpan={8}>no active agent invocations</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ExternalProcessesTable({ processes }: { processes: AgentProcess[] }) {
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse font-mono text-[11.5px]">
+        <thead className="text-ink-3 border-b border-line">
+          <tr>
+            <th className="text-left font-medium px-4 py-2">PID</th>
+            <th className="text-left font-medium px-4 py-2">Agent</th>
+            <th className="text-right font-medium px-4 py-2">Age</th>
+            <th className="text-right font-medium px-4 py-2">CPU</th>
+            <th className="text-right font-medium px-4 py-2">Memory</th>
+            <th className="text-left font-medium px-4 py-2">Command</th>
+          </tr>
+        </thead>
+        <tbody>
+          {processes.length ? (
+            processes.map((process) => (
+              <tr key={process.pid} className="border-b border-line/70">
+                <td className="px-4 py-2 text-ink">{process.pid}</td>
+                <td className="px-4 py-2 text-ink-2">{process.agent}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtDuration(process.age_secs)}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{process.cpu_pct.toFixed(1)}%</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtBytes(process.memory_bytes)}</td>
+                <td className="px-4 py-2 text-ink-3 max-w-[440px] truncate" title={process.command}>
+                  {process.command || process.name}
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="px-4 py-6 text-ink-3" colSpan={6}>no external agent processes</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function UsageMonitor() {
+  const { data, isError } = useUsageMonitor();
+
+  const sections: SidebarSection[] = [
+    {
+      label: "System",
+      items: [
+        { id: "overview", label: "Overview", href: "/overview" },
+        { id: "usage", label: "Usage", href: "/usage", active: true },
+        { id: "projects", label: "Projects", href: "/overview#projects" },
+        { id: "runtimes", label: "Runtimes", href: "/overview#runtimes" },
+      ],
+    },
+    {
+      label: "Fleet",
+      items: [
+        { id: "tasks", label: "All tasks", href: "/overview#projects" },
+        { id: "worktrees", label: "Worktrees", href: "/worktrees" },
+      ],
+    },
+    {
+      label: "Reference",
+      items: [{ id: "docs", label: "Docs", href: DOCS_URL }],
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-[240px_1fr] h-screen overflow-hidden">
+      <Sidebar env="local" sections={sections} />
+      <main className="flex flex-col min-h-0 min-w-0">
+        <TopBar
+          breadcrumb={[{ label: "system" }, { label: "usage", current: true }]}
+          searchPlaceholder="Search usage, jobs, processes..."
+          actions={<StatusBadge ok={!isError} />}
+        />
+        <div className="flex-1 overflow-auto min-h-0">
+          <div className="px-6 py-4.5 border-b border-line bg-bg flex items-center gap-4">
+            <h1 className="m-0 text-xl font-medium tracking-[-0.01em]">
+              Usage <em className="font-serif italic text-rust font-normal">monitor</em>
+            </h1>
+            <span className="font-mono text-[12px] text-ink-3 ml-1">
+              {data ? `${data.window.hours}h window / ${fmtInt(data.agent_invocations.length)} invocations` : "loading..."}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-6 border-b border-line">
+            <KpiCard label="Tokens" value={fmtTokens(data?.summary.total_tokens)} delta={`${fmtInt(data?.summary.request_count)} requests`} />
+            <KpiCard
+              label="Est. cost"
+              value={fmtCost(data?.summary.estimated_cost_usd)}
+              delta={data?.cost.configured ? `${data.cost.currency} catalog` : "price unavailable"}
+            />
+            <KpiCard label="Running agents" value={fmtInt(data?.summary.running_agent_invocations)} delta={`${fmtInt(data?.summary.pending_agent_invocations)} pending`} />
+            <KpiCard label="High burn" value={fmtInt(data?.summary.high_burn_invocations)} delta={`${fmtInt(data?.summary.stale_agent_invocations)} stale`} />
+            <KpiCard label="External procs" value={fmtInt(data?.summary.external_agent_processes)} delta="local CLI only" />
+            <KpiCard label="Models" value={fmtInt(data?.tokens_by_model.length)} delta={`${fmtInt(data?.cost.missing_model_count)} unpriced`} />
+          </div>
+
+          <div className="grid grid-cols-[1.2fr_1fr]">
+            <Panel title="Agent invocations" sub={`${fmtInt(data?.agent_invocations.length)} recent or active`} className="border-r border-line">
+              <AgentInvocationsTable invocations={data?.agent_invocations ?? []} />
+            </Panel>
+            <Panel
+              title="Active pressure"
+              sub="running / pending / high"
+            >
+              <div className="grid grid-cols-2">
+                <Panel title="By repo" className="border-r border-line">
+                  <ActiveCountsList rows={data?.active_by_repo ?? []} />
+                </Panel>
+                <Panel title="By activity">
+                  <ActiveCountsList rows={data?.active_by_activity ?? []} />
+                </Panel>
+              </div>
+            </Panel>
+          </div>
+
+          <div className="grid grid-cols-3">
+            <Panel title="Tokens by agent" sub="completed turns" className="border-r border-line">
+              <UsageGroupsTable rows={data?.tokens_by_agent ?? []} empty="no token events" />
+            </Panel>
+            <Panel title="Tokens by project" sub="completed turns" className="border-r border-line">
+              <UsageGroupsTable rows={data?.tokens_by_project ?? []} empty="no project usage" />
+            </Panel>
+            <Panel title="Tokens by model" sub="completed turns">
+              <UsageGroupsTable rows={data?.tokens_by_model ?? []} empty="no model usage" />
+            </Panel>
+          </div>
+
+          <Panel
+            title="External local CLI processes"
+            sub={`${fmtInt(data?.external_agent_processes.length)} codex / claude processes outside runtime attribution`}
+          >
+            <ExternalProcessesTable processes={data?.external_agent_processes ?? []} />
+          </Panel>
+
+          <Panel
+            title="Cost source"
+            sub={data?.cost.configured ? data.cost.source : "not configured"}
+          >
+            <div className="p-4 font-mono text-[11.5px] text-ink-3">
+              {data?.cost.message ?? "loading..."}
+            </div>
+          </Panel>
+        </div>
+      </main>
+      <PaletteFab />
+    </div>
+  );
+}

--- a/web/src/routes/UsageMonitor.tsx
+++ b/web/src/routes/UsageMonitor.tsx
@@ -183,8 +183,8 @@ function ExternalProcessesTable({ processes }: { processes: AgentProcess[] }) {
                 <td className="px-4 py-2 text-right text-ink-2">{fmtDuration(process.age_secs)}</td>
                 <td className="px-4 py-2 text-right text-ink-2">{process.cpu_pct.toFixed(1)}%</td>
                 <td className="px-4 py-2 text-right text-ink-2">{fmtBytes(process.memory_bytes)}</td>
-                <td className="px-4 py-2 text-ink-3 max-w-[440px] truncate" title={process.command}>
-                  {process.command || process.name}
+                <td className="px-4 py-2 text-ink-3 max-w-[220px] truncate">
+                  {process.command_label || process.name}
                 </td>
               </tr>
             ))

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -204,6 +204,7 @@ export function Worktrees() {
       label: "System",
       items: [
         { id: "overview", label: "Overview", href: "/overview" },
+        { id: "usage", label: "Usage", href: "/usage" },
         { id: "projects", label: "Projects", href: "/overview#projects", count: overview?.projects.length },
         { id: "runtimes", label: "Runtimes", href: "/overview#runtimes", count: overview?.runtimes.length },
         { id: "observability", label: "Observability", href: "/overview#observability" },

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -2,4 +2,5 @@ export * from "./dashboard";
 export * from "./operator_snapshot";
 export * from "./overview";
 export * from "./task";
+export * from "./usage_monitor";
 export * from "./workflow_runtime";

--- a/web/src/types/usage_monitor.ts
+++ b/web/src/types/usage_monitor.ts
@@ -1,0 +1,110 @@
+export interface UsageWindow {
+  hours: number;
+  since: string;
+  now: string;
+}
+
+export interface UsageCostConfig {
+  currency: "USD";
+  configured: boolean;
+  source: string;
+  missing_model_count: number;
+  message: string;
+}
+
+export interface UsageSummary {
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  request_count: number;
+  estimated_cost_usd: number | null;
+  running_agent_invocations: number;
+  pending_agent_invocations: number;
+  stale_agent_invocations: number;
+  high_burn_invocations: number;
+  external_agent_processes: number;
+}
+
+export interface UsageGroup {
+  name: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  total_tokens: number;
+  request_count: number;
+  estimated_cost_usd: number | null;
+  cost_confidence: string;
+}
+
+export interface AgentInvocation {
+  agent_invocation_id: string;
+  source: "workflow_runtime";
+  runtime_job_id: string;
+  command_id: string;
+  workflow_id: string;
+  workflow_definition: string;
+  workflow_state: string;
+  subject_type: string;
+  subject_key: string;
+  repo: string | null;
+  project: string | null;
+  issue_number: number | null;
+  pr_number: number | null;
+  task_id: string | null;
+  activity: string;
+  status: string;
+  command_status: string;
+  agent_runtime: string;
+  runtime_profile: string;
+  model: string | null;
+  reasoning_effort: string | null;
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+  stale: boolean;
+  age_secs: number;
+  updated_age_secs: number;
+  burn_level: "low" | "medium" | "high";
+  cost_confidence: string;
+}
+
+export interface AgentProcess {
+  pid: number;
+  name: string;
+  agent: "codex" | "claude";
+  age_secs: number;
+  cpu_pct: number;
+  memory_bytes: number;
+  cwd: string | null;
+  command: string;
+}
+
+export interface ActiveCount {
+  name: string;
+  running: number;
+  pending: number;
+  high_burn: number;
+}
+
+export interface UsageDiagnostics {
+  runtime_store_available: boolean;
+  token_source: string;
+  active_cost_confidence: string;
+  process_source: string;
+}
+
+export interface UsageMonitorPayload {
+  window: UsageWindow;
+  cost: UsageCostConfig;
+  summary: UsageSummary;
+  tokens_by_agent: UsageGroup[];
+  tokens_by_project: UsageGroup[];
+  tokens_by_model: UsageGroup[];
+  agent_invocations: AgentInvocation[];
+  external_agent_processes: AgentProcess[];
+  active_by_repo: ActiveCount[];
+  active_by_activity: ActiveCount[];
+  diagnostics: UsageDiagnostics;
+}

--- a/web/src/types/usage_monitor.ts
+++ b/web/src/types/usage_monitor.ts
@@ -77,8 +77,7 @@ export interface AgentProcess {
   age_secs: number;
   cpu_pct: number;
   memory_bytes: number;
-  cwd: string | null;
-  command: string;
+  command_label: string;
 }
 
 export interface ActiveCount {


### PR DESCRIPTION
## What

Adds a read-only usage monitoring surface for Harness-owned agent work:

- documents the full cost monitoring design in `docs/cost-monitoring-dashboard-spec.md`
- adds `GET /api/usage-monitor`
- adds the `/usage` web route
- shows active Harness-owned `agent_invocations` from workflow runtime state
- shows external local Codex/Claude CLI processes separately from Harness attribution
- supports optional estimated USD values from `HARNESS_USAGE_PRICE_CATALOG_JSON`

Closes #1227

## Why

Operators need to know what is spending model quota right now. Harness already has durable workflow IDs, command IDs, runtime job IDs, repo metadata, model, reasoning effort, and lease state, so Harness-owned agent counts should come from runtime state instead of command-line process matching.

The process sampler remains useful only as an external-session hint for local Codex or Claude CLI processes that did not originate from Harness.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `bun run typecheck` in `web/`
- [x] `cargo check -p harness-server`
- [x] `cargo test -p harness-server usage_monitor`
- [x] `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- [x] `bun run build` in `web/`
- [x] `bun run test` in `web/` (136 passed; existing React Router/act warnings only)
- [x] `cargo test -p harness-server` (1347 unit tests plus integration/doc tests passed)
