### PR TITLE
fix(runtime): pass Codex approval policy via config

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -536,10 +536,52 @@ fn push_codex_sandbox_args(args: &mut Vec<OsString>, mode: SandboxMode) {
 }
 
 fn push_codex_approval_policy_args(args: &mut Vec<OsString>, approval_policy: &str) {
+    let approval_policy = escape_codex_config_string(approval_policy);
     args.push(OsString::from("-c"));
     args.push(OsString::from(format!(
         "approval_policy=\"{approval_policy}\""
     )));
+}
+
+fn escape_codex_config_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod approval_policy_arg_tests {
+    use super::push_codex_approval_policy_args;
+
+    #[test]
+    fn approval_policy_args_escape_config_string_delimiters() {
+        let mut args = Vec::new();
+
+        push_codex_approval_policy_args(&mut args, "ask\"me\\first\nnext");
+
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "-c".to_string(),
+                "approval_policy=\"ask\\\"me\\\\first\\nnext\"".to_string()
+            ]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -99,8 +99,7 @@ impl CodexAgent {
         ];
         push_codex_sandbox_args(&mut args, sandbox_mode);
         if let Some(approval_policy) = req.approval_policy.as_deref() {
-            args.push(OsString::from("-a"));
-            args.push(OsString::from(approval_policy));
+            push_codex_approval_policy_args(&mut args, approval_policy);
         }
 
         if self.cloud.enabled {
@@ -534,6 +533,13 @@ fn push_codex_sandbox_args(args: &mut Vec<OsString>, mode: SandboxMode) {
 
     args.push(OsString::from("-s"));
     args.push(OsString::from(codex_sandbox_mode(mode)));
+}
+
+fn push_codex_approval_policy_args(args: &mut Vec<OsString>, approval_policy: &str) {
+    args.push(OsString::from("-c"));
+    args.push(OsString::from(format!(
+        "approval_policy=\"{approval_policy}\""
+    )));
 }
 
 #[cfg(test)]

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -694,7 +694,10 @@ fn base_args_uses_request_reasoning_effort_sandbox_and_approval_policy() {
         .windows(2)
         .any(|window| window == ["-c", "model_reasoning_effort=\"medium\""]));
     assert!(args.windows(2).any(|window| window == ["-s", "read-only"]));
-    assert!(args.windows(2).any(|window| window == ["-a", "on-request"]));
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-c", "approval_policy=\"on-request\""]));
+    assert!(!args.iter().any(|arg| arg == "-a"));
     assert_eq!(args.last().map(String::as_str), Some("ping"));
 }
 

--- a/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
@@ -398,7 +398,7 @@ async fn webhook_ignores_issue_tasks_when_repo_is_unmapped() -> anyhow::Result<(
 }
 
 #[tokio::test]
-async fn webhook_pull_request_review_changes_requested_requests_pr_feedback_sweep(
+async fn webhook_pull_request_review_changes_requested_requests_local_review_gate(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -453,7 +453,7 @@ async fn webhook_pull_request_review_changes_requested_requests_pr_feedback_swee
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "awaiting_feedback");
+    assert_eq!(json["status"], "local_review_gate");
     assert_eq!(json["execution_path"], "workflow_runtime");
     let runtime_task_id = json["task_id"].as_str().expect("task id should be present");
     assert_eq!(state.core.tasks.count(), before_count);
@@ -465,8 +465,8 @@ async fn webhook_pull_request_review_changes_requested_requests_pr_feedback_swee
     let instance = store
         .get_instance_by_task_id(runtime_task_id)
         .await?
-        .expect("runtime PR feedback workflow should be persisted");
-    assert_runtime_pr_feedback_requested(&state, &instance.id, runtime_task_id).await?;
+        .expect("runtime local review workflow should be persisted");
+    assert_runtime_local_review_requested(&state, &instance.id, runtime_task_id).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Fixes #1229.
- Replaces the removed `codex exec -a <approval_policy>` argument with the supported `-c approval_policy="..."` config override.
- Updates the Codex argv unit test to reject the legacy `-a` flag.
- Updates the pull_request_review webhook runtime test to assert the current local review gate behavior.

## Validation

- `codex exec --help`
- `codex exec --strict-config -c 'approval_policy="never"' --help`
- `cargo fmt --all`
- `cargo check`
- `cargo test --package harness-agents`
- `cargo test --package harness-server webhook_pull_request_review_changes_requested_requests_local_review_gate`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo build --release --bin harness`
- `cargo test`

## Runtime Note

Live smoke before this fix showed Harness could start and dispatch backlog jobs, but runtime planning failed before the agent turn started with `unexpected argument -a found`. The full autonomous server was stopped after observing that failure to avoid repeated retry token spend.
