### PR TITLE
test(server): add fast and full DB validation profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,12 @@ jobs:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'scripts/test-server-*.sh'
             server:
               - 'crates/harness-server/**'
               - 'crates/harness-core/**'
               - 'crates/harness-workflow/**'
+              - 'scripts/test-server-*.sh'
             agents:
               - 'crates/harness-agents/**'
               - 'crates/harness-core/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,15 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun run build
-      - run: cargo test --workspace
+      - run: cargo test --workspace --exclude harness-server
+        env:
+          HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
+      - name: Harness-server fast profile
+        run: scripts/test-server-fast.sh
+        env:
+          HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
+      - name: Harness-server full DB profile
+        run: scripts/test-server-db.sh
         env:
           HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ full DB profile for final handoff or changes that touch startup, recovery,
 full `AppState`, route persistence, or workflow runtime behavior:
 
 ```bash
-scripts/test-server-fast.sh
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@ cargo build
 cargo test
 ```
 
+For `harness-server` work, start with the fast local ladder and reserve the
+full DB profile for final handoff or changes that touch startup, recovery,
+full `AppState`, route persistence, or workflow runtime behavior:
+
+```bash
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
+```
+
 ## Pull Request Guidelines
 
 1. Keep PRs focused and small when possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ full DB profile for final handoff or changes that touch startup, recovery,
 full `AppState`, route persistence, or workflow runtime behavior:
 
 ```bash
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
+scripts/test-server-fast.sh
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ is configured.
 
 ```bash
 # Routine server work: fast module and lightweight route path.
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
+scripts/test-server-fast.sh
 
 # Full server DB, startup, recovery, route, and workflow profile.
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ is configured.
 
 ```bash
 # Routine server work: fast module and lightweight route path.
-scripts/test-server-fast.sh
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
 
 # Full server DB, startup, recovery, route, and workflow profile.
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
@@ -168,9 +168,10 @@ HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo tes
 ```
 
 `scripts/test-server-fast.sh` is the warm local feedback path for routine
-`harness-server` changes. `scripts/test-server-db.sh` runs the full server suite
-single-threaded so DB-backed startup, recovery, full `AppState`, route, and
-workflow-runtime coverage remains explicit and stable.
+`harness-server` changes once a test database URL is configured.
+`scripts/test-server-db.sh` runs the full server suite single-threaded so
+DB-backed startup, recovery, full `AppState`, route, and workflow-runtime
+coverage remains explicit and stable.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ Integration tests that require a database (e.g. `runtime_state_store`,
 `thread_db`, `q_value_store`) skip automatically when no Harness database URL
 is configured.
 
+**Harness-server validation ladder:**
+
+```bash
+# Routine server work: fast module and lightweight route path.
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
+
+# Full server DB, startup, recovery, route, and workflow profile.
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
+
+# Final PR handoff: full workspace coverage.
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
+```
+
+`scripts/test-server-fast.sh` is the warm local feedback path for routine
+`harness-server` changes. `scripts/test-server-db.sh` runs the full server suite
+single-threaded so DB-backed startup, recovery, full `AppState`, route, and
+workflow-runtime coverage remains explicit and stable.
+
 ### Run
 
 **HTTP server:**

--- a/scripts/test-server-db.sh
+++ b/scripts/test-server-db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -z "${HARNESS_DATABASE_URL:-}" ]]; then
+  cat >&2 <<'EOF'
+HARNESS_DATABASE_URL is required for the full harness-server DB test profile.
+
+Start the local dev database with:
+  bash scripts/dev-db.sh
+
+Then run:
+  HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
+EOF
+  exit 2
+fi
+
+cargo test -p harness-server --lib -- --test-threads=1 "$@"
+cargo test -p harness-server --tests -- --test-threads=1 "$@"

--- a/scripts/test-server-db.sh
+++ b/scripts/test-server-db.sh
@@ -17,4 +17,13 @@ EOF
 fi
 
 RUST_TEST_THREADS=1 cargo test -p harness-server --lib "$@"
-RUST_TEST_THREADS=1 cargo test -p harness-server --tests "$@"
+
+for test_file in crates/harness-server/tests/*.rs; do
+  test_name="${test_file##*/}"
+  test_name="${test_name%.rs}"
+  if [[ "$test_name" == "common" ]]; then
+    continue
+  fi
+
+  RUST_TEST_THREADS=1 cargo test -p harness-server --test "$test_name" "$@"
+done

--- a/scripts/test-server-db.sh
+++ b/scripts/test-server-db.sh
@@ -16,5 +16,5 @@ EOF
   exit 2
 fi
 
-cargo test -p harness-server --lib -- --test-threads=1 "$@"
-cargo test -p harness-server --tests -- --test-threads=1 "$@"
+RUST_TEST_THREADS=1 cargo test -p harness-server --lib "$@"
+RUST_TEST_THREADS=1 cargo test -p harness-server --tests "$@"

--- a/scripts/test-server-fast.sh
+++ b/scripts/test-server-fast.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+filters=(
+  "task_runner::"
+  "services::"
+  "router::"
+  "http::tests::health_route_tests::"
+  "http::tests::intake_auth_list_tests::"
+)
+
+for filter in "${filters[@]}"; do
+  echo "==> cargo test -p harness-server --lib ${filter} $*"
+  cargo test -p harness-server --lib "${filter}" "$@"
+done


### PR DESCRIPTION
## Summary
- Add `scripts/test-server-fast.sh` for the warm routine `harness-server` validation path.
- Add `scripts/test-server-db.sh` for the explicit full server DB/startup/recovery/route/workflow profile.
- Update README, CONTRIBUTING, and CI so server tests run through explicit fast/full profiles while workspace tests cover the remaining crates.

## Validation
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh --list`
- `cargo fmt --all -- --check`
- `bash -n scripts/test-server-fast.sh scripts/test-server-db.sh`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1189