### PR TITLE
feat(usage): add ccstats local summaries

### DIFF
--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -17,9 +17,12 @@ use std::sync::{Arc, OnceLock};
 
 use crate::http::AppState;
 
+#[path = "usage_monitor_local_usage.rs"]
+mod usage_monitor_local_usage;
 #[path = "usage_monitor_process.rs"]
 mod usage_monitor_process;
 
+use usage_monitor_local_usage::{load_local_usage_summaries, LocalUsageSourceSummary};
 use usage_monitor_process::{sample_agent_processes, AgentProcess};
 
 const DEFAULT_USAGE_WINDOW_HOURS: i64 = 24;
@@ -42,6 +45,7 @@ struct UsageMonitorResponse {
     tokens_by_model: Vec<UsageGroup>,
     agent_invocations: Vec<AgentInvocation>,
     external_agent_processes: Vec<AgentProcess>,
+    local_usage_sources: Vec<LocalUsageSourceSummary>,
     active_by_repo: Vec<ActiveCount>,
     active_by_activity: Vec<ActiveCount>,
     diagnostics: UsageDiagnostics,
@@ -302,6 +306,7 @@ async fn build_usage_monitor_response(
         .collect::<Vec<_>>();
     let external_agent_processes =
         sample_agent_processes(now, &runtime_attribution_tokens(&runtime_rows));
+    let local_usage_sources = load_local_usage_summaries(window).await;
 
     let tokens_by_agent =
         aggregate_usage(&usage_records, |record| record.agent.clone(), price_catalog);
@@ -342,9 +347,9 @@ async fn build_usage_monitor_response(
             .collect::<std::collections::BTreeSet<_>>()
             .len(),
         message: if price_catalog.configured() {
-            "Token counts are exact when events exist; cost is estimated from the configured local price catalog."
+            "Harness-attributed token costs use the configured local price catalog. ccstats local source totals are reported separately from workflow and task attribution."
         } else {
-            "Token counts are exact when events exist; cost is unavailable until a local price catalog is configured."
+            "Harness-attributed token costs need a local price catalog. ccstats local source totals may still report global Codex and Claude costs separately."
         },
     };
 
@@ -379,6 +384,7 @@ async fn build_usage_monitor_response(
         }),
         agent_invocations,
         external_agent_processes,
+        local_usage_sources,
         diagnostics: UsageDiagnostics {
             runtime_store_available: state.core.workflow_runtime_store.is_some(),
             token_source: "llm_usage_events",

--- a/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
@@ -1,8 +1,9 @@
-use chrono::NaiveDate;
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::process::{Command, Output};
+use std::collections::BTreeSet;
+use std::process::Output;
 use std::time::Instant;
+use tokio::process::Command;
 
 use super::{round_cost, UsageWindow};
 
@@ -61,7 +62,7 @@ struct LocalUsageModelSummary {
 }
 
 #[derive(Debug, Deserialize)]
-struct CcstatsPeriodRow {
+struct CcstatsSessionRow {
     #[serde(default)]
     input_tokens: i64,
     #[serde(default)]
@@ -76,25 +77,9 @@ struct CcstatsPeriodRow {
     total_tokens: i64,
     cost: Option<f64>,
     #[serde(default)]
-    breakdown: Vec<CcstatsModelRow>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CcstatsModelRow {
-    model: String,
-    #[serde(default)]
-    input_tokens: i64,
-    #[serde(default)]
-    output_tokens: i64,
-    #[serde(default)]
-    reasoning_tokens: i64,
-    #[serde(default)]
-    cache_read_tokens: i64,
-    #[serde(default)]
-    cache_creation_tokens: i64,
-    #[serde(default)]
-    total_tokens: i64,
-    cost: Option<f64>,
+    models: Vec<String>,
+    first_timestamp: Option<DateTime<Utc>>,
+    last_timestamp: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Default)]
@@ -112,40 +97,35 @@ struct LocalUsageAccumulator {
 pub(super) async fn load_local_usage_summaries(
     window: UsageWindow,
 ) -> Vec<LocalUsageSourceSummary> {
-    let since = window.since.date_naive();
-    let until = window.now.date_naive();
-    match tokio::task::spawn_blocking(move || {
-        collect_local_usage_summaries_with(since, until, summarize_source_with_ccstats_cli)
-    })
-    .await
-    {
-        Ok(summaries) => summaries,
-        Err(error) => LOCAL_USAGE_SOURCES
-            .into_iter()
-            .map(|source| {
-                unavailable_summary(
-                    source,
-                    since,
-                    until,
-                    0.0,
-                    format!("ccstats worker failed before summarizing local usage: {error}"),
-                )
-            })
-            .collect(),
-    }
+    let since = window.since;
+    let until = window.now;
+    let codex = load_local_usage_source_summary(LOCAL_USAGE_SOURCES[0], since, until);
+    let claude = load_local_usage_source_summary(LOCAL_USAGE_SOURCES[1], since, until);
+    let (codex, claude) = tokio::join!(codex, claude);
+    vec![codex, claude]
 }
 
+async fn load_local_usage_source_summary(
+    source: LocalUsageSource,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+) -> LocalUsageSourceSummary {
+    let result = summarize_source_with_ccstats_cli(source, since, until).await;
+    local_usage_source_summary_from_result(source, since, until, result)
+}
+
+#[cfg(test)]
 fn collect_local_usage_summaries_with<F>(
-    since: NaiveDate,
-    until: NaiveDate,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
     mut summarize: F,
 ) -> Vec<LocalUsageSourceSummary>
 where
     F: FnMut(
         LocalUsageSource,
-        NaiveDate,
-        NaiveDate,
-    ) -> Result<(Vec<CcstatsPeriodRow>, f64), String>,
+        DateTime<Utc>,
+        DateTime<Utc>,
+    ) -> Result<(Vec<CcstatsSessionRow>, f64), String>,
 {
     LOCAL_USAGE_SOURCES
         .into_iter()
@@ -156,28 +136,32 @@ where
         .collect()
 }
 
-fn summarize_source_with_ccstats_cli(
+async fn summarize_source_with_ccstats_cli(
     source: LocalUsageSource,
-    since: NaiveDate,
-    until: NaiveDate,
-) -> Result<(Vec<CcstatsPeriodRow>, f64), String> {
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+) -> Result<(Vec<CcstatsSessionRow>, f64), String> {
     let started = Instant::now();
+    let since_date = since.date_naive().to_string();
+    let until_date = until.date_naive().to_string();
     let output = Command::new(CCSTATS_BIN)
         .args([
-            "daily",
+            "session",
             "--source",
             source.source,
             "--since",
-            &since.to_string(),
+            &since_date,
             "--until",
-            &until.to_string(),
+            &until_date,
             "--json",
-            "--breakdown",
             "--offline",
             "--currency",
             "USD",
+            "--timezone",
+            "UTC",
         ])
         .output()
+        .await
         .map_err(|error| format!("failed to run `{CCSTATS_BIN}`: {error}"))?;
     let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
 
@@ -187,16 +171,16 @@ fn summarize_source_with_ccstats_cli(
 
     let stdout = std::str::from_utf8(&output.stdout)
         .map_err(|error| format!("ccstats stdout was not UTF-8: {error}"))?;
-    serde_json::from_str::<Vec<CcstatsPeriodRow>>(stdout.trim())
+    parse_ccstats_session_rows(stdout)
         .map(|rows| (rows, elapsed_ms))
         .map_err(|error| format!("ccstats JSON output was invalid: {error}"))
 }
 
 fn local_usage_source_summary_from_result(
     source: LocalUsageSource,
-    since: NaiveDate,
-    until: NaiveDate,
-    result: Result<(Vec<CcstatsPeriodRow>, f64), String>,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+    result: Result<(Vec<CcstatsSessionRow>, f64), String>,
 ) -> LocalUsageSourceSummary {
     match result {
         Ok((rows, elapsed_ms)) => available_summary(source, since, until, rows, elapsed_ms),
@@ -206,41 +190,39 @@ fn local_usage_source_summary_from_result(
 
 fn available_summary(
     source: LocalUsageSource,
-    since: NaiveDate,
-    until: NaiveDate,
-    rows: Vec<CcstatsPeriodRow>,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+    rows: Vec<CcstatsSessionRow>,
     elapsed_ms: f64,
 ) -> LocalUsageSourceSummary {
     let mut total = LocalUsageAccumulator::default();
-    let mut models: BTreeMap<String, LocalUsageAccumulator> = BTreeMap::new();
-    for row in &rows {
-        total.add_period(row);
-        for model in &row.breakdown {
-            models
-                .entry(model.model.clone())
-                .or_default()
-                .add_model(model);
+    let mut model_names = BTreeSet::new();
+    let mut period_count = 0;
+    for row in rows {
+        match row.overlaps_window(since, until) {
+            Ok(true) => {
+                total.add_session(&row);
+                period_count += 1;
+                model_names.extend(
+                    row.models
+                        .iter()
+                        .map(|model| model.trim())
+                        .filter(|model| !model.is_empty())
+                        .map(ToString::to_string),
+                );
+            }
+            Ok(false) => {}
+            Err(error) => return unavailable_summary(source, since, until, elapsed_ms, error),
         }
     }
-    let mut models = models
-        .into_iter()
-        .map(|(model, usage)| local_usage_model_summary(model, usage))
-        .collect::<Vec<_>>();
-    models.sort_by(|a, b| {
-        b.estimated_cost_usd
-            .partial_cmp(&a.estimated_cost_usd)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| b.total_tokens.cmp(&a.total_tokens))
-            .then_with(|| a.model.cmp(&b.model))
-    });
 
     LocalUsageSourceSummary {
         source: source.source,
         display_name: source.display_name,
         attribution: "global_local_source_logs",
         status: "available",
-        since: since.to_string(),
-        until: until.to_string(),
+        since: format_window_timestamp(since),
+        until: format_window_timestamp(until),
         currency: "USD",
         estimated_cost_usd: total.cost_json(),
         input_tokens: total.input_tokens,
@@ -249,13 +231,13 @@ fn available_summary(
         cache_read_input_tokens: total.cache_read_input_tokens,
         cache_creation_input_tokens: total.cache_creation_input_tokens,
         total_tokens: total.total_tokens,
-        period_count: rows.len() as u64,
-        model_count: models.len(),
-        models,
+        period_count,
+        model_count: model_names.len(),
+        models: Vec::new(),
         cost_confidence: if total.has_cost {
-            "ccstats_cli_estimated_price"
+            "ccstats_session_window_estimated_price"
         } else {
-            "ccstats_cli_price_unavailable"
+            "ccstats_session_window_price_unavailable"
         },
         elapsed_ms,
         error: None,
@@ -264,8 +246,8 @@ fn available_summary(
 
 fn unavailable_summary(
     source: LocalUsageSource,
-    since: NaiveDate,
-    until: NaiveDate,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
     elapsed_ms: f64,
     error: String,
 ) -> LocalUsageSourceSummary {
@@ -274,8 +256,8 @@ fn unavailable_summary(
         display_name: source.display_name,
         attribution: "global_local_source_logs",
         status: "unavailable",
-        since: since.to_string(),
-        until: until.to_string(),
+        since: format_window_timestamp(since),
+        until: format_window_timestamp(until),
         currency: "USD",
         estimated_cost_usd: None,
         input_tokens: 0,
@@ -293,46 +275,37 @@ fn unavailable_summary(
     }
 }
 
-fn local_usage_model_summary(
-    model: String,
-    usage: LocalUsageAccumulator,
-) -> LocalUsageModelSummary {
-    LocalUsageModelSummary {
-        model,
-        estimated_cost_usd: usage.cost_json(),
-        input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens,
-        reasoning_tokens: usage.reasoning_tokens,
-        cache_read_input_tokens: usage.cache_read_input_tokens,
-        cache_creation_input_tokens: usage.cache_creation_input_tokens,
-        total_tokens: usage.total_tokens,
+fn parse_ccstats_session_rows(stdout: &str) -> Result<Vec<CcstatsSessionRow>, serde_json::Error> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() || trimmed.contains(" session data found in the selected date range") {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str::<Vec<CcstatsSessionRow>>(trimmed)
+}
+
+fn format_window_timestamp(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+impl CcstatsSessionRow {
+    fn overlaps_window(&self, since: DateTime<Utc>, until: DateTime<Utc>) -> Result<bool, String> {
+        let Some(first_timestamp) = self.first_timestamp else {
+            return Err("ccstats session row was missing first_timestamp".to_string());
+        };
+        let Some(last_timestamp) = self.last_timestamp else {
+            return Err("ccstats session row was missing last_timestamp".to_string());
+        };
+        if last_timestamp < first_timestamp {
+            return Err(
+                "ccstats session row had last_timestamp before first_timestamp".to_string(),
+            );
+        }
+        Ok(last_timestamp >= since && first_timestamp <= until)
     }
 }
 
 impl LocalUsageAccumulator {
-    fn add_period(&mut self, row: &CcstatsPeriodRow) {
-        self.input_tokens = self
-            .input_tokens
-            .saturating_add(nonnegative_tokens(row.input_tokens));
-        self.output_tokens = self
-            .output_tokens
-            .saturating_add(nonnegative_tokens(row.output_tokens));
-        self.reasoning_tokens = self
-            .reasoning_tokens
-            .saturating_add(nonnegative_tokens(row.reasoning_tokens));
-        self.cache_read_input_tokens = self
-            .cache_read_input_tokens
-            .saturating_add(nonnegative_tokens(row.cache_read_tokens));
-        self.cache_creation_input_tokens = self
-            .cache_creation_input_tokens
-            .saturating_add(nonnegative_tokens(row.cache_creation_tokens));
-        self.total_tokens = self
-            .total_tokens
-            .saturating_add(nonnegative_tokens(row.total_tokens));
-        self.add_cost(row.cost);
-    }
-
-    fn add_model(&mut self, row: &CcstatsModelRow) {
+    fn add_session(&mut self, row: &CcstatsSessionRow) {
         self.input_tokens = self
             .input_tokens
             .saturating_add(nonnegative_tokens(row.input_tokens));
@@ -404,12 +377,12 @@ mod tests {
 
     #[test]
     fn collect_local_usage_summaries_shapes_success_and_failure() {
-        let since = NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
-        let until = NaiveDate::from_ymd_opt(2026, 6, 4).unwrap();
+        let since = utc_timestamp("2026-06-03T14:00:00Z");
+        let until = utc_timestamp("2026-06-04T14:00:00Z");
 
         let summaries = collect_local_usage_summaries_with(since, until, |source, _, _| {
             if source.source == "codex" {
-                Ok((vec![fake_period_row()], 7.5))
+                Ok((vec![fake_session_row()], 7.5))
             } else {
                 Err("local logs are unreadable".to_string())
             }
@@ -430,8 +403,10 @@ mod tests {
         assert_eq!(codex.total_tokens, 24);
         assert_eq!(codex.period_count, 1);
         assert_eq!(codex.model_count, 1);
-        assert_eq!(codex.models[0].model, "gpt-5");
+        assert!(codex.models.is_empty());
         assert_eq!(codex.elapsed_ms, 7.5);
+        assert_eq!(codex.since, "2026-06-03T14:00:00Z");
+        assert_eq!(codex.until, "2026-06-04T14:00:00Z");
 
         let claude = summaries
             .iter()
@@ -447,22 +422,28 @@ mod tests {
     }
 
     #[test]
-    fn available_summary_aggregates_models_across_periods() {
-        let since = NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
-        let until = NaiveDate::from_ymd_opt(2026, 6, 4).unwrap();
-        let mut second = fake_period_row();
+    fn available_summary_filters_sessions_to_requested_window() {
+        let since = utc_timestamp("2026-06-03T14:00:00Z");
+        let until = utc_timestamp("2026-06-04T14:00:00Z");
+        let mut second = fake_session_row();
         second.input_tokens = 20;
         second.total_tokens = 30;
         second.cost = Some(0.5);
-        second.breakdown[0].input_tokens = 20;
-        second.breakdown[0].total_tokens = 30;
-        second.breakdown[0].cost = Some(0.5);
+        second.models = vec!["gpt-5.5".to_string()];
+        second.first_timestamp = Some(utc_timestamp("2026-06-04T12:00:00Z"));
+        second.last_timestamp = Some(utc_timestamp("2026-06-04T12:10:00Z"));
+        let mut outside_window = fake_session_row();
+        outside_window.input_tokens = 100;
+        outside_window.total_tokens = 100;
+        outside_window.cost = Some(10.0);
+        outside_window.first_timestamp = Some(utc_timestamp("2026-06-03T08:00:00Z"));
+        outside_window.last_timestamp = Some(utc_timestamp("2026-06-03T08:10:00Z"));
 
         let summary = available_summary(
             LOCAL_USAGE_SOURCES[0],
             since,
             until,
-            vec![fake_period_row(), second],
+            vec![fake_session_row(), second, outside_window],
             12.0,
         );
 
@@ -470,13 +451,24 @@ mod tests {
         assert_eq!(summary.input_tokens, 30);
         assert_eq!(summary.total_tokens, 54);
         assert_eq!(summary.estimated_cost_usd, Some(0.6235));
-        assert_eq!(summary.models.len(), 1);
-        assert_eq!(summary.models[0].input_tokens, 30);
-        assert_eq!(summary.models[0].estimated_cost_usd, Some(0.6235));
+        assert_eq!(summary.model_count, 2);
+        assert!(summary.models.is_empty());
     }
 
-    fn fake_period_row() -> CcstatsPeriodRow {
-        CcstatsPeriodRow {
+    #[test]
+    fn parse_ccstats_session_rows_treats_no_data_message_as_empty() {
+        let rows = match parse_ccstats_session_rows(
+            "No OpenAI Codex session data found in the selected date range.",
+        ) {
+            Ok(rows) => rows,
+            Err(error) => panic!("no-data ccstats output should parse as empty: {error}"),
+        };
+
+        assert!(rows.is_empty());
+    }
+
+    fn fake_session_row() -> CcstatsSessionRow {
+        CcstatsSessionRow {
             input_tokens: 10,
             output_tokens: 5,
             reasoning_tokens: 2,
@@ -484,16 +476,16 @@ mod tests {
             cache_creation_tokens: 4,
             total_tokens: 24,
             cost: Some(0.123456),
-            breakdown: vec![CcstatsModelRow {
-                model: "gpt-5".to_string(),
-                input_tokens: 10,
-                output_tokens: 5,
-                reasoning_tokens: 2,
-                cache_read_tokens: 3,
-                cache_creation_tokens: 4,
-                total_tokens: 24,
-                cost: Some(0.123456),
-            }],
+            models: vec!["gpt-5".to_string()],
+            first_timestamp: Some(utc_timestamp("2026-06-04T08:00:00Z")),
+            last_timestamp: Some(utc_timestamp("2026-06-04T08:10:00Z")),
+        }
+    }
+
+    fn utc_timestamp(raw: &str) -> DateTime<Utc> {
+        match DateTime::parse_from_rfc3339(raw) {
+            Ok(timestamp) => timestamp.with_timezone(&Utc),
+            Err(error) => panic!("valid RFC3339 timestamp: {error}"),
         }
     }
 }

--- a/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
@@ -1,0 +1,499 @@
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::process::{Command, Output};
+use std::time::Instant;
+
+use super::{round_cost, UsageWindow};
+
+const CCSTATS_BIN: &str = "ccstats";
+const LOCAL_USAGE_SOURCES: [LocalUsageSource; 2] = [
+    LocalUsageSource {
+        source: "codex",
+        display_name: "OpenAI Codex",
+    },
+    LocalUsageSource {
+        source: "claude",
+        display_name: "Claude Code",
+    },
+];
+
+#[derive(Debug, Clone, Copy)]
+struct LocalUsageSource {
+    source: &'static str,
+    display_name: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct LocalUsageSourceSummary {
+    source: &'static str,
+    display_name: &'static str,
+    attribution: &'static str,
+    status: &'static str,
+    since: String,
+    until: String,
+    currency: &'static str,
+    estimated_cost_usd: Option<f64>,
+    input_tokens: u64,
+    output_tokens: u64,
+    reasoning_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    total_tokens: u64,
+    period_count: u64,
+    model_count: usize,
+    models: Vec<LocalUsageModelSummary>,
+    cost_confidence: &'static str,
+    elapsed_ms: f64,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LocalUsageModelSummary {
+    model: String,
+    estimated_cost_usd: Option<f64>,
+    input_tokens: u64,
+    output_tokens: u64,
+    reasoning_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    total_tokens: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CcstatsPeriodRow {
+    #[serde(default)]
+    input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
+    #[serde(default)]
+    reasoning_tokens: i64,
+    #[serde(default)]
+    cache_read_tokens: i64,
+    #[serde(default)]
+    cache_creation_tokens: i64,
+    #[serde(default)]
+    total_tokens: i64,
+    cost: Option<f64>,
+    #[serde(default)]
+    breakdown: Vec<CcstatsModelRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CcstatsModelRow {
+    model: String,
+    #[serde(default)]
+    input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
+    #[serde(default)]
+    reasoning_tokens: i64,
+    #[serde(default)]
+    cache_read_tokens: i64,
+    #[serde(default)]
+    cache_creation_tokens: i64,
+    #[serde(default)]
+    total_tokens: i64,
+    cost: Option<f64>,
+}
+
+#[derive(Debug, Default)]
+struct LocalUsageAccumulator {
+    input_tokens: u64,
+    output_tokens: u64,
+    reasoning_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    total_tokens: u64,
+    estimated_cost_usd: f64,
+    has_cost: bool,
+}
+
+pub(super) async fn load_local_usage_summaries(
+    window: UsageWindow,
+) -> Vec<LocalUsageSourceSummary> {
+    let since = window.since.date_naive();
+    let until = window.now.date_naive();
+    match tokio::task::spawn_blocking(move || {
+        collect_local_usage_summaries_with(since, until, summarize_source_with_ccstats_cli)
+    })
+    .await
+    {
+        Ok(summaries) => summaries,
+        Err(error) => LOCAL_USAGE_SOURCES
+            .into_iter()
+            .map(|source| {
+                unavailable_summary(
+                    source,
+                    since,
+                    until,
+                    0.0,
+                    format!("ccstats worker failed before summarizing local usage: {error}"),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn collect_local_usage_summaries_with<F>(
+    since: NaiveDate,
+    until: NaiveDate,
+    mut summarize: F,
+) -> Vec<LocalUsageSourceSummary>
+where
+    F: FnMut(
+        LocalUsageSource,
+        NaiveDate,
+        NaiveDate,
+    ) -> Result<(Vec<CcstatsPeriodRow>, f64), String>,
+{
+    LOCAL_USAGE_SOURCES
+        .into_iter()
+        .map(|source| {
+            let result = summarize(source, since, until);
+            local_usage_source_summary_from_result(source, since, until, result)
+        })
+        .collect()
+}
+
+fn summarize_source_with_ccstats_cli(
+    source: LocalUsageSource,
+    since: NaiveDate,
+    until: NaiveDate,
+) -> Result<(Vec<CcstatsPeriodRow>, f64), String> {
+    let started = Instant::now();
+    let output = Command::new(CCSTATS_BIN)
+        .args([
+            "daily",
+            "--source",
+            source.source,
+            "--since",
+            &since.to_string(),
+            "--until",
+            &until.to_string(),
+            "--json",
+            "--breakdown",
+            "--offline",
+            "--currency",
+            "USD",
+        ])
+        .output()
+        .map_err(|error| format!("failed to run `{CCSTATS_BIN}`: {error}"))?;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    if !output.status.success() {
+        return Err(ccstats_failure_message(&output));
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout)
+        .map_err(|error| format!("ccstats stdout was not UTF-8: {error}"))?;
+    serde_json::from_str::<Vec<CcstatsPeriodRow>>(stdout.trim())
+        .map(|rows| (rows, elapsed_ms))
+        .map_err(|error| format!("ccstats JSON output was invalid: {error}"))
+}
+
+fn local_usage_source_summary_from_result(
+    source: LocalUsageSource,
+    since: NaiveDate,
+    until: NaiveDate,
+    result: Result<(Vec<CcstatsPeriodRow>, f64), String>,
+) -> LocalUsageSourceSummary {
+    match result {
+        Ok((rows, elapsed_ms)) => available_summary(source, since, until, rows, elapsed_ms),
+        Err(error) => unavailable_summary(source, since, until, 0.0, error),
+    }
+}
+
+fn available_summary(
+    source: LocalUsageSource,
+    since: NaiveDate,
+    until: NaiveDate,
+    rows: Vec<CcstatsPeriodRow>,
+    elapsed_ms: f64,
+) -> LocalUsageSourceSummary {
+    let mut total = LocalUsageAccumulator::default();
+    let mut models: BTreeMap<String, LocalUsageAccumulator> = BTreeMap::new();
+    for row in &rows {
+        total.add_period(row);
+        for model in &row.breakdown {
+            models
+                .entry(model.model.clone())
+                .or_default()
+                .add_model(model);
+        }
+    }
+    let mut models = models
+        .into_iter()
+        .map(|(model, usage)| local_usage_model_summary(model, usage))
+        .collect::<Vec<_>>();
+    models.sort_by(|a, b| {
+        b.estimated_cost_usd
+            .partial_cmp(&a.estimated_cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.total_tokens.cmp(&a.total_tokens))
+            .then_with(|| a.model.cmp(&b.model))
+    });
+
+    LocalUsageSourceSummary {
+        source: source.source,
+        display_name: source.display_name,
+        attribution: "global_local_source_logs",
+        status: "available",
+        since: since.to_string(),
+        until: until.to_string(),
+        currency: "USD",
+        estimated_cost_usd: total.cost_json(),
+        input_tokens: total.input_tokens,
+        output_tokens: total.output_tokens,
+        reasoning_tokens: total.reasoning_tokens,
+        cache_read_input_tokens: total.cache_read_input_tokens,
+        cache_creation_input_tokens: total.cache_creation_input_tokens,
+        total_tokens: total.total_tokens,
+        period_count: rows.len() as u64,
+        model_count: models.len(),
+        models,
+        cost_confidence: if total.has_cost {
+            "ccstats_cli_estimated_price"
+        } else {
+            "ccstats_cli_price_unavailable"
+        },
+        elapsed_ms,
+        error: None,
+    }
+}
+
+fn unavailable_summary(
+    source: LocalUsageSource,
+    since: NaiveDate,
+    until: NaiveDate,
+    elapsed_ms: f64,
+    error: String,
+) -> LocalUsageSourceSummary {
+    LocalUsageSourceSummary {
+        source: source.source,
+        display_name: source.display_name,
+        attribution: "global_local_source_logs",
+        status: "unavailable",
+        since: since.to_string(),
+        until: until.to_string(),
+        currency: "USD",
+        estimated_cost_usd: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        reasoning_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        total_tokens: 0,
+        period_count: 0,
+        model_count: 0,
+        models: Vec::new(),
+        cost_confidence: "ccstats_cli_unavailable",
+        elapsed_ms,
+        error: Some(error),
+    }
+}
+
+fn local_usage_model_summary(
+    model: String,
+    usage: LocalUsageAccumulator,
+) -> LocalUsageModelSummary {
+    LocalUsageModelSummary {
+        model,
+        estimated_cost_usd: usage.cost_json(),
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        reasoning_tokens: usage.reasoning_tokens,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+        total_tokens: usage.total_tokens,
+    }
+}
+
+impl LocalUsageAccumulator {
+    fn add_period(&mut self, row: &CcstatsPeriodRow) {
+        self.input_tokens = self
+            .input_tokens
+            .saturating_add(nonnegative_tokens(row.input_tokens));
+        self.output_tokens = self
+            .output_tokens
+            .saturating_add(nonnegative_tokens(row.output_tokens));
+        self.reasoning_tokens = self
+            .reasoning_tokens
+            .saturating_add(nonnegative_tokens(row.reasoning_tokens));
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(nonnegative_tokens(row.cache_read_tokens));
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(nonnegative_tokens(row.cache_creation_tokens));
+        self.total_tokens = self
+            .total_tokens
+            .saturating_add(nonnegative_tokens(row.total_tokens));
+        self.add_cost(row.cost);
+    }
+
+    fn add_model(&mut self, row: &CcstatsModelRow) {
+        self.input_tokens = self
+            .input_tokens
+            .saturating_add(nonnegative_tokens(row.input_tokens));
+        self.output_tokens = self
+            .output_tokens
+            .saturating_add(nonnegative_tokens(row.output_tokens));
+        self.reasoning_tokens = self
+            .reasoning_tokens
+            .saturating_add(nonnegative_tokens(row.reasoning_tokens));
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(nonnegative_tokens(row.cache_read_tokens));
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(nonnegative_tokens(row.cache_creation_tokens));
+        self.total_tokens = self
+            .total_tokens
+            .saturating_add(nonnegative_tokens(row.total_tokens));
+        self.add_cost(row.cost);
+    }
+
+    fn add_cost(&mut self, cost: Option<f64>) {
+        if let Some(cost) = cost.filter(|cost| cost.is_finite()) {
+            self.estimated_cost_usd += cost;
+            self.has_cost = true;
+        }
+    }
+
+    fn cost_json(&self) -> Option<f64> {
+        self.has_cost.then_some(round_cost(self.estimated_cost_usd))
+    }
+}
+
+fn ccstats_failure_message(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let message = if stderr.trim().is_empty() {
+        stdout.as_ref()
+    } else {
+        stderr.as_ref()
+    };
+    let single_line = message
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if single_line.is_empty() {
+        format!("ccstats exited with status {}", output.status)
+    } else {
+        truncate_message(&single_line, 500)
+    }
+}
+
+fn truncate_message(message: &str, max_len: usize) -> String {
+    if message.chars().count() <= max_len {
+        return message.to_string();
+    }
+    format!("{}...", message.chars().take(max_len).collect::<String>())
+}
+
+fn nonnegative_tokens(value: i64) -> u64 {
+    u64::try_from(value.max(0)).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_local_usage_summaries_shapes_success_and_failure() {
+        let since = NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
+        let until = NaiveDate::from_ymd_opt(2026, 6, 4).unwrap();
+
+        let summaries = collect_local_usage_summaries_with(since, until, |source, _, _| {
+            if source.source == "codex" {
+                Ok((vec![fake_period_row()], 7.5))
+            } else {
+                Err("local logs are unreadable".to_string())
+            }
+        });
+
+        assert_eq!(summaries.len(), 2);
+        let codex = summaries
+            .iter()
+            .find(|summary| summary.source == "codex")
+            .expect("codex summary");
+        assert_eq!(codex.status, "available");
+        assert_eq!(codex.attribution, "global_local_source_logs");
+        assert_eq!(codex.estimated_cost_usd, Some(0.1235));
+        assert_eq!(codex.input_tokens, 10);
+        assert_eq!(codex.reasoning_tokens, 2);
+        assert_eq!(codex.cache_read_input_tokens, 3);
+        assert_eq!(codex.cache_creation_input_tokens, 4);
+        assert_eq!(codex.total_tokens, 24);
+        assert_eq!(codex.period_count, 1);
+        assert_eq!(codex.model_count, 1);
+        assert_eq!(codex.models[0].model, "gpt-5");
+        assert_eq!(codex.elapsed_ms, 7.5);
+
+        let claude = summaries
+            .iter()
+            .find(|summary| summary.source == "claude")
+            .expect("claude summary");
+        assert_eq!(claude.status, "unavailable");
+        assert_eq!(claude.display_name, "Claude Code");
+        assert_eq!(claude.total_tokens, 0);
+        assert!(claude
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("local logs are unreadable")));
+    }
+
+    #[test]
+    fn available_summary_aggregates_models_across_periods() {
+        let since = NaiveDate::from_ymd_opt(2026, 6, 3).unwrap();
+        let until = NaiveDate::from_ymd_opt(2026, 6, 4).unwrap();
+        let mut second = fake_period_row();
+        second.input_tokens = 20;
+        second.total_tokens = 30;
+        second.cost = Some(0.5);
+        second.breakdown[0].input_tokens = 20;
+        second.breakdown[0].total_tokens = 30;
+        second.breakdown[0].cost = Some(0.5);
+
+        let summary = available_summary(
+            LOCAL_USAGE_SOURCES[0],
+            since,
+            until,
+            vec![fake_period_row(), second],
+            12.0,
+        );
+
+        assert_eq!(summary.period_count, 2);
+        assert_eq!(summary.input_tokens, 30);
+        assert_eq!(summary.total_tokens, 54);
+        assert_eq!(summary.estimated_cost_usd, Some(0.6235));
+        assert_eq!(summary.models.len(), 1);
+        assert_eq!(summary.models[0].input_tokens, 30);
+        assert_eq!(summary.models[0].estimated_cost_usd, Some(0.6235));
+    }
+
+    fn fake_period_row() -> CcstatsPeriodRow {
+        CcstatsPeriodRow {
+            input_tokens: 10,
+            output_tokens: 5,
+            reasoning_tokens: 2,
+            cache_read_tokens: 3,
+            cache_creation_tokens: 4,
+            total_tokens: 24,
+            cost: Some(0.123456),
+            breakdown: vec![CcstatsModelRow {
+                model: "gpt-5".to_string(),
+                input_tokens: 10,
+                output_tokens: 5,
+                reasoning_tokens: 2,
+                cache_read_tokens: 3,
+                cache_creation_tokens: 4,
+                total_tokens: 24,
+                cost: Some(0.123456),
+            }],
+        }
+    }
+}

--- a/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_local_usage.rs
@@ -199,7 +199,7 @@ fn available_summary(
     let mut model_names = BTreeSet::new();
     let mut period_count = 0;
     for row in rows {
-        match row.overlaps_window(since, until) {
+        match row.is_fully_within_window(since, until) {
             Ok(true) => {
                 total.add_session(&row);
                 period_count += 1;
@@ -288,7 +288,11 @@ fn format_window_timestamp(timestamp: DateTime<Utc>) -> String {
 }
 
 impl CcstatsSessionRow {
-    fn overlaps_window(&self, since: DateTime<Utc>, until: DateTime<Utc>) -> Result<bool, String> {
+    fn is_fully_within_window(
+        &self,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    ) -> Result<bool, String> {
         let Some(first_timestamp) = self.first_timestamp else {
             return Err("ccstats session row was missing first_timestamp".to_string());
         };
@@ -300,7 +304,15 @@ impl CcstatsSessionRow {
                 "ccstats session row had last_timestamp before first_timestamp".to_string(),
             );
         }
-        Ok(last_timestamp >= since && first_timestamp <= until)
+        if last_timestamp < since || first_timestamp > until {
+            return Ok(false);
+        }
+        if first_timestamp < since || last_timestamp > until {
+            return Err(
+                "ccstats session row crossed the requested window boundary; session-level totals cannot be trimmed safely".to_string(),
+            );
+        }
+        Ok(true)
     }
 }
 
@@ -453,6 +465,30 @@ mod tests {
         assert_eq!(summary.estimated_cost_usd, Some(0.6235));
         assert_eq!(summary.model_count, 2);
         assert!(summary.models.is_empty());
+    }
+
+    #[test]
+    fn available_summary_rejects_boundary_crossing_session_totals() {
+        let since = utc_timestamp("2026-06-03T14:00:00Z");
+        let until = utc_timestamp("2026-06-04T14:00:00Z");
+        let mut boundary_crossing = fake_session_row();
+        boundary_crossing.first_timestamp = Some(utc_timestamp("2026-06-03T13:55:00Z"));
+        boundary_crossing.last_timestamp = Some(utc_timestamp("2026-06-03T14:05:00Z"));
+
+        let summary = available_summary(
+            LOCAL_USAGE_SOURCES[0],
+            since,
+            until,
+            vec![boundary_crossing],
+            12.0,
+        );
+
+        assert_eq!(summary.status, "unavailable");
+        assert_eq!(summary.total_tokens, 0);
+        assert!(summary
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("crossed the requested window boundary")));
     }
 
     #[test]

--- a/web/src/routes/UsageMonitor.tsx
+++ b/web/src/routes/UsageMonitor.tsx
@@ -7,7 +7,7 @@ import { PaletteFab } from "@/components/PaletteFab";
 import { DOCS_URL } from "@/lib/links";
 import { fmtInt } from "@/lib/format";
 import { useUsageMonitor } from "@/lib/queries";
-import type { ActiveCount, AgentInvocation, AgentProcess, UsageGroup } from "@/types";
+import type { ActiveCount, AgentInvocation, AgentProcess, LocalUsageSourceSummary, UsageGroup } from "@/types";
 
 function fmtTokens(tokens: number | null | undefined): string {
   if (tokens == null || !Number.isFinite(tokens)) return "-";
@@ -199,6 +199,46 @@ function ExternalProcessesTable({ processes }: { processes: AgentProcess[] }) {
   );
 }
 
+function LocalUsageSourcesTable({ sources }: { sources: LocalUsageSourceSummary[] }) {
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse font-mono text-[11.5px]">
+        <thead className="text-ink-3 border-b border-line">
+          <tr>
+            <th className="text-left font-medium px-4 py-2">Source</th>
+            <th className="text-left font-medium px-4 py-2">Range</th>
+            <th className="text-right font-medium px-4 py-2">Tokens</th>
+            <th className="text-right font-medium px-4 py-2">Periods</th>
+            <th className="text-right font-medium px-4 py-2">Cost</th>
+            <th className="text-left font-medium px-4 py-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sources.length ? (
+            sources.map((source) => (
+              <tr key={source.source} className="border-b border-line/70">
+                <td className="px-4 py-2 text-ink">{source.display_name}</td>
+                <td className="px-4 py-2 text-ink-3">{source.since} / {source.until}</td>
+                <td className="px-4 py-2 text-right text-ink">{fmtTokens(source.total_tokens)}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtInt(source.period_count)}</td>
+                <td className="px-4 py-2 text-right text-ink-2">{fmtCost(source.estimated_cost_usd)}</td>
+                <td className="px-4 py-2 text-ink-3 max-w-[260px] truncate" title={source.error ?? source.cost_confidence}>
+                  {source.status}
+                  {source.model_count ? <span className="text-ink-4"> / {fmtInt(source.model_count)} models</span> : null}
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="px-4 py-6 text-ink-3" colSpan={6}>no local source summaries</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function UsageMonitor() {
   const { data, isError } = useUsageMonitor();
 
@@ -287,6 +327,13 @@ export function UsageMonitor() {
               <UsageGroupsTable rows={data?.tokens_by_model ?? []} empty="no model usage" />
             </Panel>
           </div>
+
+          <Panel
+            title="Local ccstats sources"
+            sub="global Codex and Claude logs outside workflow attribution"
+          >
+            <LocalUsageSourcesTable sources={data?.local_usage_sources ?? []} />
+          </Panel>
 
           <Panel
             title="External local CLI processes"

--- a/web/src/types/usage_monitor.ts
+++ b/web/src/types/usage_monitor.ts
@@ -39,6 +39,40 @@ export interface UsageGroup {
   cost_confidence: string;
 }
 
+export interface LocalUsageModelSummary {
+  model: string;
+  estimated_cost_usd: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  reasoning_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  total_tokens: number;
+}
+
+export interface LocalUsageSourceSummary {
+  source: string;
+  display_name: string;
+  attribution: "global_local_source_logs";
+  status: "available" | "unavailable";
+  since: string;
+  until: string;
+  currency: string;
+  estimated_cost_usd: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  reasoning_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  total_tokens: number;
+  period_count: number;
+  model_count: number;
+  models: LocalUsageModelSummary[];
+  cost_confidence: string;
+  elapsed_ms: number;
+  error: string | null;
+}
+
 export interface AgentInvocation {
   agent_invocation_id: string;
   source: "workflow_runtime";
@@ -103,6 +137,7 @@ export interface UsageMonitorPayload {
   tokens_by_model: UsageGroup[];
   agent_invocations: AgentInvocation[];
   external_agent_processes: AgentProcess[];
+  local_usage_sources: LocalUsageSourceSummary[];
   active_by_repo: ActiveCount[];
   active_by_activity: ActiveCount[];
   diagnostics: UsageDiagnostics;


### PR DESCRIPTION
## Summary
- add `/api/usage-monitor` local ccstats source summaries for Codex and Claude
- keep Harness-attributed `llm_usage` cost separate from global local ccstats totals
- surface per-source ccstats failures as `unavailable` rows instead of failing the endpoint
- add a dashboard table for global local source totals outside workflow/task attribution

Implementation note: a direct `ccstats` crate dependency currently conflicts with the server binary's existing `sqlx` SQLite link dependency, so the adapter consumes the local `ccstats` CLI JSON output through fixed argument arrays.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server usage_monitor --lib`
- `cd web && npx tsc --noEmit`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1231