### PR TITLE
feat(eval): add PR repair quality snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness-eval"
+version = "0.6.34"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "harness-exec"
 version = "0.6.34"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/harness-rules",
     "crates/harness-skills",
     "crates/harness-exec",
+    "crates/harness-eval",
     "crates/harness-observe",
     "crates/harness-cli",
     "crates/harness-workflow",
@@ -35,6 +36,7 @@ harness-gc = { path = "crates/harness-gc", version = "0.6.34" }
 harness-rules = { path = "crates/harness-rules", version = "0.6.34" }
 harness-skills = { path = "crates/harness-skills", version = "0.6.34" }
 harness-exec = { path = "crates/harness-exec", version = "0.6.34" }
+harness-eval = { path = "crates/harness-eval", version = "0.6.34" }
 harness-observe = { path = "crates/harness-observe", version = "0.6.34" }
 harness-workflow = { path = "crates/harness-workflow", version = "0.6.34" }
 

--- a/crates/harness-eval/Cargo.toml
+++ b/crates/harness-eval/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "harness-eval"
+version.workspace = true
+edition.workspace = true
+description = "Pure evaluation models and deterministic scoring for Harness runs"
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }

--- a/crates/harness-eval/src/lib.rs
+++ b/crates/harness-eval/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod model;
+pub mod scoring;
+
+pub use model::*;
+pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -188,6 +188,7 @@ pub enum HardGateName {
     HeadChange,
     HeadFreshness,
     RequiredChecks,
+    MergeabilityClean,
     ReviewThreadClosure,
     RuntimeArtifactCompleteness,
     ReviewerJudgmentFreshness,

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -1,0 +1,318 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalScenario {
+    PrRepair,
+    ReadyNoopControl,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EvalTarget {
+    PullRequest {
+        repo: String,
+        pr_number: u64,
+        base_ref: Option<String>,
+        head_ref: Option<String>,
+    },
+    Issue {
+        repo: String,
+        issue_number: u64,
+    },
+    PromptTask {
+        task_id: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeState {
+    Unknown,
+    Clean,
+    Dirty,
+    Blocked,
+    Behind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckState {
+    Unknown,
+    Pending,
+    Passing,
+    Failing,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewDecision {
+    Approved,
+    ChangesRequested,
+    ReviewRequired,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewThreadSnapshot {
+    pub id: String,
+    pub path: Option<String>,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangedFileSnapshot {
+    pub path: String,
+    pub additions: u64,
+    pub deletions: u64,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestSnapshot {
+    pub repo: String,
+    pub pr_number: u64,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub head_oid: String,
+    pub is_draft: bool,
+    pub merge_state: MergeState,
+    pub check_state: CheckState,
+    pub review_decision: Option<ReviewDecision>,
+    pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
+    pub changed_files: Vec<ChangedFileSnapshot>,
+    pub collected_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeJobSnapshot {
+    pub runtime_job_id: String,
+    pub state: String,
+    pub artifact_count: u64,
+    pub terminal_state: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSnapshot {
+    pub task_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub workflow_state: Option<String>,
+    pub runtime_jobs: Vec<RuntimeJobSnapshot>,
+    pub latest_activity: Option<String>,
+    pub terminal_state: Option<String>,
+    pub collected_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Exact,
+    Estimated,
+    Observed,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UsageSnapshot {
+    pub agent_invocation_id: Option<String>,
+    pub runtime_job_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cached_input_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+    pub cost_usd: Option<f64>,
+    pub token_confidence: Confidence,
+    pub cost_confidence: Confidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewerKind {
+    Human,
+    Llm,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSeverity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewerFinding {
+    pub path: Option<String>,
+    pub summary: String,
+    pub severity: FindingSeverity,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewerJudgment {
+    pub reviewer_kind: ReviewerKind,
+    pub judged_head_oid: String,
+    pub code_quality_score: u8,
+    pub trajectory_score: u8,
+    pub findings: Vec<ReviewerFinding>,
+    pub residual_risks: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PrRepairEvalInput {
+    pub scenario: EvalScenario,
+    pub target: EvalTarget,
+    pub baseline_pr: PullRequestSnapshot,
+    pub final_pr: PullRequestSnapshot,
+    pub final_evidence_head_oid: Option<String>,
+    pub runtime: Option<RuntimeSnapshot>,
+    pub usage: Vec<UsageSnapshot>,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardGateName {
+    TargetCorrectness,
+    BranchSafety,
+    HeadChange,
+    HeadFreshness,
+    RequiredChecks,
+    ReviewThreadClosure,
+    RuntimeArtifactCompleteness,
+    ReviewerJudgmentFreshness,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateStatus {
+    Pass,
+    Fail,
+    NotApplicable,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvalGrade {
+    F,
+    D,
+    C,
+    B,
+    A,
+}
+
+impl EvalGrade {
+    pub fn from_score(score: u8) -> Self {
+        match score {
+            90..=100 => Self::A,
+            80..=89 => Self::B,
+            65..=79 => Self::C,
+            50..=64 => Self::D,
+            _ => Self::F,
+        }
+    }
+
+    pub fn cap_at(self, cap: Self) -> Self {
+        if self.rank() > cap.rank() {
+            cap
+        } else {
+            self
+        }
+    }
+
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::F => 0,
+            Self::D => 1,
+            Self::C => 2,
+            Self::B => 3,
+            Self::A => 4,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardGateResult {
+    pub name: HardGateName,
+    pub status: GateStatus,
+    pub grade_cap: Option<EvalGrade>,
+    pub message: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScoreDimensionName {
+    TaskClassificationAndBaselineEvidence,
+    FeedbackDiscoveryAndPrioritization,
+    BranchAndPrSafety,
+    FixCorrectnessAndScope,
+    VerificationAndCurrentHeadGates,
+    RuntimeWorkflowBehaviorAndPersistence,
+    CostAndTimeEfficiency,
+    ReportingAndAttributionQuality,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoreComponent {
+    pub name: ScoreDimensionName,
+    pub points: u8,
+    pub max_points: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoreBreakdown {
+    pub task_classification_and_baseline_evidence: ScoreComponent,
+    pub feedback_discovery_and_prioritization: ScoreComponent,
+    pub branch_and_pr_safety: ScoreComponent,
+    pub fix_correctness_and_scope: ScoreComponent,
+    pub verification_and_current_head_gates: ScoreComponent,
+    pub runtime_workflow_behavior_and_persistence: ScoreComponent,
+    pub cost_and_time_efficiency: ScoreComponent,
+    pub reporting_and_attribution_quality: ScoreComponent,
+}
+
+impl ScoreBreakdown {
+    pub fn total(&self) -> u8 {
+        self.task_classification_and_baseline_evidence.points
+            + self.feedback_discovery_and_prioritization.points
+            + self.branch_and_pr_safety.points
+            + self.fix_correctness_and_scope.points
+            + self.verification_and_current_head_gates.points
+            + self.runtime_workflow_behavior_and_persistence.points
+            + self.cost_and_time_efficiency.points
+            + self.reporting_and_attribution_quality.points
+    }
+
+    pub fn max_total(&self) -> u8 {
+        self.task_classification_and_baseline_evidence.max_points
+            + self.feedback_discovery_and_prioritization.max_points
+            + self.branch_and_pr_safety.max_points
+            + self.fix_correctness_and_scope.max_points
+            + self.verification_and_current_head_gates.max_points
+            + self.runtime_workflow_behavior_and_persistence.max_points
+            + self.cost_and_time_efficiency.max_points
+            + self.reporting_and_attribution_quality.max_points
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct QualitySnapshot {
+    pub scenario: EvalScenario,
+    pub target: EvalTarget,
+    pub baseline_pr: PullRequestSnapshot,
+    pub final_pr: PullRequestSnapshot,
+    pub runtime: Option<RuntimeSnapshot>,
+    pub usage: Vec<UsageSnapshot>,
+    pub hard_gates: Vec<HardGateResult>,
+    pub objective_score: ScoreBreakdown,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
+    pub final_score: u8,
+    pub final_grade: EvalGrade,
+    pub grade_cap: Option<EvalGrade>,
+    pub blocker_summary: Vec<String>,
+}

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -125,7 +125,7 @@ pub struct UsageSnapshot {
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
     pub total_tokens: Option<u64>,
-    pub cost_usd: Option<f64>,
+    pub cost_usd_micros: Option<u64>,
     pub token_confidence: Confidence,
     pub cost_confidence: Confidence,
 }
@@ -174,6 +174,8 @@ pub struct PrRepairEvalInput {
     pub runtime: Option<RuntimeSnapshot>,
     pub usage: Vec<UsageSnapshot>,
     pub reviewer_judgment: Option<ReviewerJudgment>,
+    pub created_unrelated_pr: bool,
+    pub scope_violations: Vec<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -181,6 +183,8 @@ pub struct PrRepairEvalInput {
 pub enum HardGateName {
     TargetCorrectness,
     BranchSafety,
+    NoUnrelatedPrCreation,
+    ScopeContainment,
     HeadChange,
     HeadFreshness,
     RequiredChecks,
@@ -304,8 +308,8 @@ impl ScoreBreakdown {
 pub struct QualitySnapshot {
     pub scenario: EvalScenario,
     pub target: EvalTarget,
-    pub baseline_pr: PullRequestSnapshot,
-    pub final_pr: PullRequestSnapshot,
+    pub baseline_pr: Option<PullRequestSnapshot>,
+    pub final_pr: Option<PullRequestSnapshot>,
     pub runtime: Option<RuntimeSnapshot>,
     pub usage: Vec<UsageSnapshot>,
     pub hard_gates: Vec<HardGateResult>,

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -98,8 +98,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         reviewer_gate(&input),
     ];
 
-    let objective_score = score_breakdown(
-        &input,
+    let gate_signals = GateSignals {
         target_matches,
         branch_safe,
         no_unrelated_pr,
@@ -108,7 +107,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         checks_passing,
         review_threads_closed,
         runtime_complete,
-    );
+    };
+    let objective_score = score_breakdown(&input, gate_signals);
     let final_score = objective_score.total();
     let raw_grade = EvalGrade::from_score(final_score);
     let grade_cap = most_restrictive_cap(&hard_gates);
@@ -246,8 +246,8 @@ fn most_restrictive_cap(gates: &[HardGateResult]) -> Option<EvalGrade> {
         .min_by_key(|grade| grade.rank())
 }
 
-fn score_breakdown(
-    input: &PrRepairEvalInput,
+#[derive(Copy, Clone)]
+struct GateSignals {
     target_matches: bool,
     branch_safe: bool,
     no_unrelated_pr: bool,
@@ -256,10 +256,12 @@ fn score_breakdown(
     checks_passing: bool,
     review_threads_closed: bool,
     runtime_complete: bool,
-) -> ScoreBreakdown {
+}
+
+fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakdown {
     let changed_or_noop = input.scenario == EvalScenario::ReadyNoopControl
         || input.baseline_pr.head_oid != input.final_pr.head_oid;
-    let current_head_verified = final_evidence_fresh && checks_passing;
+    let current_head_verified = gates.final_evidence_fresh && gates.checks_passing;
     let has_usage = input.usage.iter().any(|usage| usage.total_tokens.is_some());
     let has_confident_usage = input.usage.iter().any(|usage| {
         usage.token_confidence != Confidence::Unknown
@@ -269,7 +271,7 @@ fn score_breakdown(
     ScoreBreakdown {
         task_classification_and_baseline_evidence: component(
             ScoreDimensionName::TaskClassificationAndBaselineEvidence,
-            if target_matches && !input.baseline_pr.collected_at.is_empty() {
+            if gates.target_matches && !input.baseline_pr.collected_at.is_empty() {
                 12
             } else {
                 4
@@ -278,12 +280,16 @@ fn score_breakdown(
         ),
         feedback_discovery_and_prioritization: component(
             ScoreDimensionName::FeedbackDiscoveryAndPrioritization,
-            if review_threads_closed { 14 } else { 4 },
+            if gates.review_threads_closed { 14 } else { 4 },
             14,
         ),
         branch_and_pr_safety: component(
             ScoreDimensionName::BranchAndPrSafety,
-            if target_matches && branch_safe && no_unrelated_pr && scope_contained {
+            if gates.target_matches
+                && gates.branch_safe
+                && gates.no_unrelated_pr
+                && gates.scope_contained
+            {
                 10
             } else {
                 0
@@ -302,7 +308,7 @@ fn score_breakdown(
         ),
         runtime_workflow_behavior_and_persistence: component(
             ScoreDimensionName::RuntimeWorkflowBehaviorAndPersistence,
-            if runtime_complete { 12 } else { 0 },
+            if gates.runtime_complete { 12 } else { 0 },
             12,
         ),
         cost_and_time_efficiency: component(
@@ -312,7 +318,7 @@ fn score_breakdown(
         ),
         reporting_and_attribution_quality: component(
             ScoreDimensionName::ReportingAndAttributionQuality,
-            if runtime_complete && final_evidence_fresh && has_confident_usage {
+            if gates.runtime_complete && gates.final_evidence_fresh && has_confident_usage {
                 6
             } else {
                 2

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -9,23 +9,14 @@ use std::fmt;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScoringError {
     UnsupportedTarget,
-    ReviewerHeadMismatch {
-        judged_head_oid: String,
-        final_head_oid: String,
-    },
 }
 
 impl fmt::Display for ScoringError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnsupportedTarget => write!(f, "PR repair scoring requires a pull request target"),
-            Self::ReviewerHeadMismatch {
-                judged_head_oid,
-                final_head_oid,
-            } => write!(
-                f,
-                "reviewer judgment head {judged_head_oid} does not match final PR head {final_head_oid}"
-            ),
+            Self::UnsupportedTarget => {
+                write!(f, "PR repair scoring requires a pull request target")
+            }
         }
     }
 }
@@ -33,17 +24,10 @@ impl fmt::Display for ScoringError {
 impl Error for ScoringError {}
 
 pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
-    if let Some(judgment) = &input.reviewer_judgment {
-        if judgment.judged_head_oid != input.final_pr.head_oid {
-            return Err(ScoringError::ReviewerHeadMismatch {
-                judged_head_oid: judgment.judged_head_oid.clone(),
-                final_head_oid: input.final_pr.head_oid.clone(),
-            });
-        }
-    }
-
     let target_matches = target_matches_pr(&input)?;
     let branch_safe = branch_safe(&input);
+    let no_unrelated_pr = !input.created_unrelated_pr;
+    let scope_contained = input.scope_violations.is_empty();
     let head_changed = input.baseline_pr.head_oid != input.final_pr.head_oid;
     let final_evidence_fresh = input
         .final_evidence_head_oid
@@ -67,6 +51,20 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
             Some(EvalGrade::F),
             "base and head refs stayed on the requested PR",
             "base or head refs changed during evaluation",
+        ),
+        gate(
+            HardGateName::NoUnrelatedPrCreation,
+            no_unrelated_pr,
+            Some(EvalGrade::F),
+            "evaluation did not create an unrelated PR",
+            "evaluation created or reported an unrelated PR",
+        ),
+        gate(
+            HardGateName::ScopeContainment,
+            scope_contained,
+            Some(EvalGrade::F),
+            "final diff stayed within the repair scope",
+            "destructive or unrelated scope changes were detected",
         ),
         head_change_gate(&input.scenario, head_changed),
         gate(
@@ -104,6 +102,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         &input,
         target_matches,
         branch_safe,
+        no_unrelated_pr,
+        scope_contained,
         final_evidence_fresh,
         checks_passing,
         review_threads_closed,
@@ -122,8 +122,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
     Ok(QualitySnapshot {
         scenario: input.scenario,
         target: input.target,
-        baseline_pr: input.baseline_pr,
-        final_pr: input.final_pr,
+        baseline_pr: Some(input.baseline_pr),
+        final_pr: Some(input.final_pr),
         runtime: input.runtime,
         usage: input.usage,
         hard_gates,
@@ -153,10 +153,10 @@ fn target_matches_pr(input: &PrRepairEvalInput) -> Result<bool, ScoringError> {
         && input.final_pr.pr_number == *pr_number
         && base_ref
             .as_deref()
-            .is_none_or(|base_ref| input.final_pr.base_ref == base_ref)
+            .is_none_or(|expected_base_ref| input.final_pr.base_ref == expected_base_ref)
         && head_ref
             .as_deref()
-            .is_none_or(|head_ref| input.final_pr.head_ref == head_ref);
+            .is_none_or(|expected_head_ref| input.final_pr.head_ref == expected_head_ref);
 
     Ok(target_matches)
 }
@@ -217,20 +217,25 @@ fn head_change_gate(scenario: &EvalScenario, head_changed: bool) -> HardGateResu
 }
 
 fn reviewer_gate(input: &PrRepairEvalInput) -> HardGateResult {
-    if input.reviewer_judgment.is_some() {
-        HardGateResult {
+    match &input.reviewer_judgment {
+        Some(judgment) if judgment.judged_head_oid == input.final_pr.head_oid => HardGateResult {
             name: HardGateName::ReviewerJudgmentFreshness,
             status: GateStatus::Pass,
             grade_cap: None,
             message: "reviewer judgment matches the final PR head".to_string(),
-        }
-    } else {
-        HardGateResult {
+        },
+        Some(_) => HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::Fail,
+            grade_cap: Some(EvalGrade::C),
+            message: "reviewer judgment is stale for the final PR head".to_string(),
+        },
+        None => HardGateResult {
             name: HardGateName::ReviewerJudgmentFreshness,
             status: GateStatus::NotApplicable,
-            grade_cap: None,
-            message: "reviewer judgment was not provided".to_string(),
-        }
+            grade_cap: Some(EvalGrade::B),
+            message: "reviewer judgment was not provided; grade is capped at B".to_string(),
+        },
     }
 }
 
@@ -245,6 +250,8 @@ fn score_breakdown(
     input: &PrRepairEvalInput,
     target_matches: bool,
     branch_safe: bool,
+    no_unrelated_pr: bool,
+    scope_contained: bool,
     final_evidence_fresh: bool,
     checks_passing: bool,
     review_threads_closed: bool,
@@ -276,7 +283,11 @@ fn score_breakdown(
         ),
         branch_and_pr_safety: component(
             ScoreDimensionName::BranchAndPrSafety,
-            if target_matches && branch_safe { 10 } else { 0 },
+            if target_matches && branch_safe && no_unrelated_pr && scope_contained {
+                10
+            } else {
+                0
+            },
             10,
         ),
         fix_correctness_and_scope: component(
@@ -312,13 +323,19 @@ fn score_breakdown(
 }
 
 fn fix_correctness_points(input: &PrRepairEvalInput, changed_or_noop: bool) -> u8 {
+    if input.created_unrelated_pr || !input.scope_violations.is_empty() {
+        return 4;
+    }
+
     if let Some(judgment) = &input.reviewer_judgment {
-        let bounded = judgment.code_quality_score.min(100) as u16;
+        let code_quality = judgment.code_quality_score.min(100) as u16;
+        let trajectory = judgment.trajectory_score.min(100) as u16;
+        let bounded = (code_quality * 3 + trajectory + 2) / 4;
         return ((bounded * 22 + 50) / 100) as u8;
     }
 
     if changed_or_noop {
-        18
+        13
     } else {
         8
     }
@@ -433,18 +450,80 @@ mod tests {
     }
 
     #[test]
-    fn reviewer_judgment_with_mismatched_head_is_rejected() {
+    fn stale_reviewer_judgment_caps_and_fails() {
         let mut input = perfect_input();
         input.reviewer_judgment = Some(reviewer_judgment("old-head"));
 
-        let error = score_pr_repair_eval(input).expect_err("mismatched reviewer head");
+        let snapshot = score_pr_repair_eval(input).expect("score stale reviewer input");
+        let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.final_grade, EvalGrade::C);
+        assert!(snapshot
+            .blocker_summary
+            .contains(&"reviewer judgment is stale for the final PR head".to_string()));
+    }
+
+    #[test]
+    fn missing_reviewer_judgment_caps_at_b() {
+        let mut input = perfect_input();
+        input.reviewer_judgment = None;
+
+        let snapshot = score_pr_repair_eval(input).expect("score missing reviewer input");
+        let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+        assert_eq!(gate.status, GateStatus::NotApplicable);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.final_grade, EvalGrade::B);
+    }
+
+    #[test]
+    fn unrelated_pr_creation_caps_at_f() {
+        let mut input = perfect_input();
+        input.created_unrelated_pr = true;
+
+        let snapshot = score_pr_repair_eval(input).expect("score unrelated PR input");
+        let gate = find_gate(&snapshot, HardGateName::NoUnrelatedPrCreation);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+        assert_eq!(snapshot.final_grade, EvalGrade::F);
+    }
+
+    #[test]
+    fn destructive_or_unrelated_scope_changes_cap_at_f() {
+        let mut input = perfect_input();
+        input
+            .scope_violations
+            .push("changed unrelated dashboard files".to_string());
+
+        let snapshot = score_pr_repair_eval(input).expect("score scope violation input");
+        let gate = find_gate(&snapshot, HardGateName::ScopeContainment);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+        assert_eq!(snapshot.final_grade, EvalGrade::F);
+    }
+
+    #[test]
+    fn trajectory_score_contributes_to_fix_correctness() {
+        let mut input = perfect_input();
+        input.reviewer_judgment = Some(ReviewerJudgment {
+            code_quality_score: 100,
+            trajectory_score: 0,
+            ..reviewer_judgment("final-head")
+        });
+
+        let snapshot = score_pr_repair_eval(input).expect("score low trajectory input");
 
         assert_eq!(
-            error,
-            ScoringError::ReviewerHeadMismatch {
-                judged_head_oid: "old-head".to_string(),
-                final_head_oid: "final-head".to_string(),
-            }
+            snapshot.objective_score.fix_correctness_and_scope.points,
+            17
         );
     }
 
@@ -511,11 +590,13 @@ mod tests {
                 output_tokens: Some(200),
                 cached_input_tokens: Some(100),
                 total_tokens: Some(1200),
-                cost_usd: Some(0.12),
+                cost_usd_micros: Some(120_000),
                 token_confidence: Confidence::Exact,
                 cost_confidence: Confidence::Estimated,
             }],
             reviewer_judgment: Some(reviewer_judgment("final-head")),
+            created_unrelated_pr: false,
+            scope_violations: Vec::new(),
         }
     }
 

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -1,7 +1,7 @@
 use crate::model::{
     CheckState, Confidence, EvalGrade, EvalScenario, EvalTarget, GateStatus, HardGateName,
-    HardGateResult, PrRepairEvalInput, QualitySnapshot, RuntimeSnapshot, ScoreBreakdown,
-    ScoreComponent, ScoreDimensionName,
+    HardGateResult, MergeState, PrRepairEvalInput, QualitySnapshot, RuntimeSnapshot,
+    ScoreBreakdown, ScoreComponent, ScoreDimensionName,
 };
 use std::error::Error;
 use std::fmt;
@@ -34,6 +34,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         .as_deref()
         .is_some_and(|head_oid| head_oid == input.final_pr.head_oid);
     let checks_passing = input.final_pr.check_state == CheckState::Passing;
+    let mergeability_clean = input.final_pr.merge_state == MergeState::Clean;
     let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty();
     let runtime_complete = input.runtime.as_ref().is_some_and(runtime_has_artifact);
 
@@ -82,6 +83,13 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
             "required checks are not passing on the final PR head",
         ),
         gate(
+            HardGateName::MergeabilityClean,
+            mergeability_clean,
+            Some(EvalGrade::C),
+            "final PR mergeability is clean",
+            "final PR mergeability is not clean",
+        ),
+        gate(
             HardGateName::ReviewThreadClosure,
             review_threads_closed,
             Some(EvalGrade::C),
@@ -105,6 +113,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         scope_contained,
         final_evidence_fresh,
         checks_passing,
+        mergeability_clean,
         review_threads_closed,
         runtime_complete,
     };
@@ -200,12 +209,13 @@ fn gate(
 
 fn head_change_gate(scenario: &EvalScenario, head_changed: bool) -> HardGateResult {
     match scenario {
-        EvalScenario::ReadyNoopControl => HardGateResult {
-            name: HardGateName::HeadChange,
-            status: GateStatus::NotApplicable,
-            grade_cap: None,
-            message: "ready/no-op control does not require a head change".to_string(),
-        },
+        EvalScenario::ReadyNoopControl => gate(
+            HardGateName::HeadChange,
+            !head_changed,
+            Some(EvalGrade::C),
+            "ready/no-op control kept the PR head unchanged",
+            "ready/no-op control changed the PR head",
+        ),
         EvalScenario::PrRepair => gate(
             HardGateName::HeadChange,
             head_changed,
@@ -254,14 +264,19 @@ struct GateSignals {
     scope_contained: bool,
     final_evidence_fresh: bool,
     checks_passing: bool,
+    mergeability_clean: bool,
     review_threads_closed: bool,
     runtime_complete: bool,
 }
 
 fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakdown {
-    let changed_or_noop = input.scenario == EvalScenario::ReadyNoopControl
-        || input.baseline_pr.head_oid != input.final_pr.head_oid;
-    let current_head_verified = gates.final_evidence_fresh && gates.checks_passing;
+    let head_changed = input.baseline_pr.head_oid != input.final_pr.head_oid;
+    let scenario_head_behavior_ok = match input.scenario {
+        EvalScenario::PrRepair => head_changed,
+        EvalScenario::ReadyNoopControl => !head_changed,
+    };
+    let current_head_verified =
+        gates.final_evidence_fresh && gates.checks_passing && gates.mergeability_clean;
     let has_usage = input.usage.iter().any(|usage| usage.total_tokens.is_some());
     let has_confident_usage = input.usage.iter().any(|usage| {
         usage.token_confidence != Confidence::Unknown
@@ -298,7 +313,7 @@ fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakd
         ),
         fix_correctness_and_scope: component(
             ScoreDimensionName::FixCorrectnessAndScope,
-            fix_correctness_points(input, changed_or_noop),
+            fix_correctness_points(input, scenario_head_behavior_ok),
             22,
         ),
         verification_and_current_head_gates: component(
@@ -364,7 +379,7 @@ mod tests {
     };
 
     #[test]
-    fn ready_noop_control_does_not_require_head_change() {
+    fn ready_noop_control_accepts_unchanged_head() {
         let mut input = perfect_input();
         input.scenario = EvalScenario::ReadyNoopControl;
         input.baseline_pr.head_oid = "same-head".to_string();
@@ -376,9 +391,31 @@ mod tests {
         let snapshot = score_pr_repair_eval(input).expect("score ready/no-op input");
         let gate = find_gate(&snapshot, HardGateName::HeadChange);
 
-        assert_eq!(gate.status, GateStatus::NotApplicable);
+        assert_eq!(gate.status, GateStatus::Pass);
         assert_eq!(gate.grade_cap, None);
         assert_eq!(snapshot.grade_cap, None);
+    }
+
+    #[test]
+    fn ready_noop_control_changed_head_caps_and_penalizes() {
+        let mut input = perfect_input();
+        input.scenario = EvalScenario::ReadyNoopControl;
+        input.baseline_pr.head_oid = "base-head".to_string();
+        input.final_pr.head_oid = "changed-head".to_string();
+        input.final_evidence_head_oid = Some("changed-head".to_string());
+        input.reviewer_judgment = None;
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score changed ready/no-op input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.final_grade, EvalGrade::C);
+        assert_eq!(snapshot.objective_score.fix_correctness_and_scope.points, 8);
     }
 
     #[test]
@@ -401,6 +438,26 @@ mod tests {
         assert_eq!(gate.grade_cap, Some(EvalGrade::C));
         assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
         assert_eq!(snapshot.final_grade, EvalGrade::C);
+    }
+
+    #[test]
+    fn non_clean_mergeability_caps_and_fails() {
+        let mut input = perfect_input();
+        input.final_pr.merge_state = MergeState::Blocked;
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score non-clean mergeability input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::MergeabilityClean);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.final_grade, EvalGrade::C);
+        assert!(snapshot
+            .blocker_summary
+            .contains(&"final PR mergeability is not clean".to_string()));
     }
 
     #[test]

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -1,0 +1,551 @@
+use crate::model::{
+    CheckState, Confidence, EvalGrade, EvalScenario, EvalTarget, GateStatus, HardGateName,
+    HardGateResult, PrRepairEvalInput, QualitySnapshot, RuntimeSnapshot, ScoreBreakdown,
+    ScoreComponent, ScoreDimensionName,
+};
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ScoringError {
+    UnsupportedTarget,
+    ReviewerHeadMismatch {
+        judged_head_oid: String,
+        final_head_oid: String,
+    },
+}
+
+impl fmt::Display for ScoringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedTarget => write!(f, "PR repair scoring requires a pull request target"),
+            Self::ReviewerHeadMismatch {
+                judged_head_oid,
+                final_head_oid,
+            } => write!(
+                f,
+                "reviewer judgment head {judged_head_oid} does not match final PR head {final_head_oid}"
+            ),
+        }
+    }
+}
+
+impl Error for ScoringError {}
+
+pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
+    if let Some(judgment) = &input.reviewer_judgment {
+        if judgment.judged_head_oid != input.final_pr.head_oid {
+            return Err(ScoringError::ReviewerHeadMismatch {
+                judged_head_oid: judgment.judged_head_oid.clone(),
+                final_head_oid: input.final_pr.head_oid.clone(),
+            });
+        }
+    }
+
+    let target_matches = target_matches_pr(&input)?;
+    let branch_safe = branch_safe(&input);
+    let head_changed = input.baseline_pr.head_oid != input.final_pr.head_oid;
+    let final_evidence_fresh = input
+        .final_evidence_head_oid
+        .as_deref()
+        .is_some_and(|head_oid| head_oid == input.final_pr.head_oid);
+    let checks_passing = input.final_pr.check_state == CheckState::Passing;
+    let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty();
+    let runtime_complete = input.runtime.as_ref().is_some_and(runtime_has_artifact);
+
+    let hard_gates = vec![
+        gate(
+            HardGateName::TargetCorrectness,
+            target_matches,
+            Some(EvalGrade::F),
+            "final PR matches the requested target",
+            "final PR does not match the requested target",
+        ),
+        gate(
+            HardGateName::BranchSafety,
+            branch_safe,
+            Some(EvalGrade::F),
+            "base and head refs stayed on the requested PR",
+            "base or head refs changed during evaluation",
+        ),
+        head_change_gate(&input.scenario, head_changed),
+        gate(
+            HardGateName::HeadFreshness,
+            final_evidence_fresh,
+            Some(EvalGrade::C),
+            "final evidence was collected for the final PR head",
+            "final evidence is missing or stale for the final PR head",
+        ),
+        gate(
+            HardGateName::RequiredChecks,
+            checks_passing,
+            Some(EvalGrade::C),
+            "required checks passed on the final PR head",
+            "required checks are not passing on the final PR head",
+        ),
+        gate(
+            HardGateName::ReviewThreadClosure,
+            review_threads_closed,
+            Some(EvalGrade::C),
+            "no active unresolved review threads remain",
+            "active unresolved review threads remain",
+        ),
+        gate(
+            HardGateName::RuntimeArtifactCompleteness,
+            runtime_complete,
+            Some(EvalGrade::B),
+            "runtime task, workflow, or job artifact is present",
+            "runtime artifact is missing or empty",
+        ),
+        reviewer_gate(&input),
+    ];
+
+    let objective_score = score_breakdown(
+        &input,
+        target_matches,
+        branch_safe,
+        final_evidence_fresh,
+        checks_passing,
+        review_threads_closed,
+        runtime_complete,
+    );
+    let final_score = objective_score.total();
+    let raw_grade = EvalGrade::from_score(final_score);
+    let grade_cap = most_restrictive_cap(&hard_gates);
+    let final_grade = grade_cap.map_or(raw_grade, |cap| raw_grade.cap_at(cap));
+    let blocker_summary = hard_gates
+        .iter()
+        .filter(|gate| gate.status == GateStatus::Fail)
+        .map(|gate| gate.message.clone())
+        .collect();
+
+    Ok(QualitySnapshot {
+        scenario: input.scenario,
+        target: input.target,
+        baseline_pr: input.baseline_pr,
+        final_pr: input.final_pr,
+        runtime: input.runtime,
+        usage: input.usage,
+        hard_gates,
+        objective_score,
+        reviewer_judgment: input.reviewer_judgment,
+        final_score,
+        final_grade,
+        grade_cap,
+        blocker_summary,
+    })
+}
+
+fn target_matches_pr(input: &PrRepairEvalInput) -> Result<bool, ScoringError> {
+    let EvalTarget::PullRequest {
+        repo,
+        pr_number,
+        base_ref,
+        head_ref,
+    } = &input.target
+    else {
+        return Err(ScoringError::UnsupportedTarget);
+    };
+
+    let target_matches = input.baseline_pr.repo == repo.as_str()
+        && input.final_pr.repo == repo.as_str()
+        && input.baseline_pr.pr_number == *pr_number
+        && input.final_pr.pr_number == *pr_number
+        && base_ref
+            .as_deref()
+            .is_none_or(|base_ref| input.final_pr.base_ref == base_ref)
+        && head_ref
+            .as_deref()
+            .is_none_or(|head_ref| input.final_pr.head_ref == head_ref);
+
+    Ok(target_matches)
+}
+
+fn branch_safe(input: &PrRepairEvalInput) -> bool {
+    input.baseline_pr.repo == input.final_pr.repo
+        && input.baseline_pr.pr_number == input.final_pr.pr_number
+        && input.baseline_pr.base_ref == input.final_pr.base_ref
+        && input.baseline_pr.head_ref == input.final_pr.head_ref
+}
+
+fn runtime_has_artifact(runtime: &RuntimeSnapshot) -> bool {
+    let has_runtime_identity = runtime.task_id.is_some() && runtime.workflow_id.is_some();
+    let has_terminal_or_job_evidence = runtime.terminal_state.is_some()
+        || runtime
+            .runtime_jobs
+            .iter()
+            .any(|job| job.artifact_count > 0 || job.terminal_state.is_some());
+
+    has_runtime_identity && has_terminal_or_job_evidence
+}
+
+fn gate(
+    name: HardGateName,
+    passed: bool,
+    grade_cap: Option<EvalGrade>,
+    pass_message: &str,
+    fail_message: &str,
+) -> HardGateResult {
+    HardGateResult {
+        name,
+        status: if passed {
+            GateStatus::Pass
+        } else {
+            GateStatus::Fail
+        },
+        grade_cap: if passed { None } else { grade_cap },
+        message: if passed { pass_message } else { fail_message }.to_string(),
+    }
+}
+
+fn head_change_gate(scenario: &EvalScenario, head_changed: bool) -> HardGateResult {
+    match scenario {
+        EvalScenario::ReadyNoopControl => HardGateResult {
+            name: HardGateName::HeadChange,
+            status: GateStatus::NotApplicable,
+            grade_cap: None,
+            message: "ready/no-op control does not require a head change".to_string(),
+        },
+        EvalScenario::PrRepair => gate(
+            HardGateName::HeadChange,
+            head_changed,
+            Some(EvalGrade::C),
+            "PR repair changed the PR head",
+            "PR repair did not change the PR head",
+        ),
+    }
+}
+
+fn reviewer_gate(input: &PrRepairEvalInput) -> HardGateResult {
+    if input.reviewer_judgment.is_some() {
+        HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::Pass,
+            grade_cap: None,
+            message: "reviewer judgment matches the final PR head".to_string(),
+        }
+    } else {
+        HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::NotApplicable,
+            grade_cap: None,
+            message: "reviewer judgment was not provided".to_string(),
+        }
+    }
+}
+
+fn most_restrictive_cap(gates: &[HardGateResult]) -> Option<EvalGrade> {
+    gates
+        .iter()
+        .filter_map(|gate| gate.grade_cap)
+        .min_by_key(|grade| grade.rank())
+}
+
+fn score_breakdown(
+    input: &PrRepairEvalInput,
+    target_matches: bool,
+    branch_safe: bool,
+    final_evidence_fresh: bool,
+    checks_passing: bool,
+    review_threads_closed: bool,
+    runtime_complete: bool,
+) -> ScoreBreakdown {
+    let changed_or_noop = input.scenario == EvalScenario::ReadyNoopControl
+        || input.baseline_pr.head_oid != input.final_pr.head_oid;
+    let current_head_verified = final_evidence_fresh && checks_passing;
+    let has_usage = input.usage.iter().any(|usage| usage.total_tokens.is_some());
+    let has_confident_usage = input.usage.iter().any(|usage| {
+        usage.token_confidence != Confidence::Unknown
+            || usage.cost_confidence != Confidence::Unknown
+    });
+
+    ScoreBreakdown {
+        task_classification_and_baseline_evidence: component(
+            ScoreDimensionName::TaskClassificationAndBaselineEvidence,
+            if target_matches && !input.baseline_pr.collected_at.is_empty() {
+                12
+            } else {
+                4
+            },
+            12,
+        ),
+        feedback_discovery_and_prioritization: component(
+            ScoreDimensionName::FeedbackDiscoveryAndPrioritization,
+            if review_threads_closed { 14 } else { 4 },
+            14,
+        ),
+        branch_and_pr_safety: component(
+            ScoreDimensionName::BranchAndPrSafety,
+            if target_matches && branch_safe { 10 } else { 0 },
+            10,
+        ),
+        fix_correctness_and_scope: component(
+            ScoreDimensionName::FixCorrectnessAndScope,
+            fix_correctness_points(input, changed_or_noop),
+            22,
+        ),
+        verification_and_current_head_gates: component(
+            ScoreDimensionName::VerificationAndCurrentHeadGates,
+            if current_head_verified { 16 } else { 4 },
+            16,
+        ),
+        runtime_workflow_behavior_and_persistence: component(
+            ScoreDimensionName::RuntimeWorkflowBehaviorAndPersistence,
+            if runtime_complete { 12 } else { 0 },
+            12,
+        ),
+        cost_and_time_efficiency: component(
+            ScoreDimensionName::CostAndTimeEfficiency,
+            if has_usage { 8 } else { 4 },
+            8,
+        ),
+        reporting_and_attribution_quality: component(
+            ScoreDimensionName::ReportingAndAttributionQuality,
+            if runtime_complete && final_evidence_fresh && has_confident_usage {
+                6
+            } else {
+                2
+            },
+            6,
+        ),
+    }
+}
+
+fn fix_correctness_points(input: &PrRepairEvalInput, changed_or_noop: bool) -> u8 {
+    if let Some(judgment) = &input.reviewer_judgment {
+        let bounded = judgment.code_quality_score.min(100) as u16;
+        return ((bounded * 22 + 50) / 100) as u8;
+    }
+
+    if changed_or_noop {
+        18
+    } else {
+        8
+    }
+}
+
+fn component(name: ScoreDimensionName, points: u8, max_points: u8) -> ScoreComponent {
+    ScoreComponent {
+        name,
+        points: points.min(max_points),
+        max_points,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        ChangedFileSnapshot, MergeState, PullRequestSnapshot, ReviewerJudgment, ReviewerKind,
+        RuntimeJobSnapshot, UsageSnapshot,
+    };
+
+    #[test]
+    fn ready_noop_control_does_not_require_head_change() {
+        let mut input = perfect_input();
+        input.scenario = EvalScenario::ReadyNoopControl;
+        input.baseline_pr.head_oid = "same-head".to_string();
+        input.final_pr.head_oid = "same-head".to_string();
+        input.final_pr.changed_files.clear();
+        input.final_evidence_head_oid = Some("same-head".to_string());
+        input.reviewer_judgment = Some(reviewer_judgment("same-head"));
+
+        let snapshot = score_pr_repair_eval(input).expect("score ready/no-op input");
+        let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+        assert_eq!(gate.status, GateStatus::NotApplicable);
+        assert_eq!(gate.grade_cap, None);
+        assert_eq!(snapshot.grade_cap, None);
+    }
+
+    #[test]
+    fn unresolved_active_review_threads_cap_and_fail() {
+        let mut input = perfect_input();
+        input
+            .final_pr
+            .active_unresolved_review_threads
+            .push(crate::model::ReviewThreadSnapshot {
+                id: "thread-1".to_string(),
+                path: Some("src/lib.rs".to_string()),
+                is_resolved: false,
+                is_outdated: false,
+            });
+
+        let snapshot = score_pr_repair_eval(input).expect("score input with unresolved thread");
+        let gate = find_gate(&snapshot, HardGateName::ReviewThreadClosure);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.final_grade, EvalGrade::C);
+    }
+
+    #[test]
+    fn stale_final_evidence_caps_and_fails() {
+        let mut input = perfect_input();
+        input.final_evidence_head_oid = Some("old-head".to_string());
+
+        let snapshot = score_pr_repair_eval(input).expect("score stale final evidence");
+        let gate = find_gate(&snapshot, HardGateName::HeadFreshness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+        assert_eq!(snapshot.final_grade, EvalGrade::C);
+    }
+
+    #[test]
+    fn missing_runtime_artifact_caps_at_b() {
+        let mut input = perfect_input();
+        input.runtime = None;
+
+        let snapshot = score_pr_repair_eval(input).expect("score missing runtime input");
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.final_grade, EvalGrade::B);
+    }
+
+    #[test]
+    fn partial_runtime_artifact_without_workflow_identity_caps_at_b() {
+        let mut input = perfect_input();
+        input.runtime = Some(RuntimeSnapshot {
+            task_id: Some("task-1".to_string()),
+            workflow_id: None,
+            workflow_state: None,
+            runtime_jobs: Vec::new(),
+            latest_activity: None,
+            terminal_state: Some("succeeded".to_string()),
+            collected_at: "2026-06-05T00:10:00Z".to_string(),
+        });
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score partial runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    }
+
+    #[test]
+    fn reviewer_judgment_with_mismatched_head_is_rejected() {
+        let mut input = perfect_input();
+        input.reviewer_judgment = Some(reviewer_judgment("old-head"));
+
+        let error = score_pr_repair_eval(input).expect_err("mismatched reviewer head");
+
+        assert_eq!(
+            error,
+            ScoringError::ReviewerHeadMismatch {
+                judged_head_oid: "old-head".to_string(),
+                final_head_oid: "final-head".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn basic_score_breakdown_returns_deterministic_total() {
+        let snapshot = score_pr_repair_eval(perfect_input()).expect("score perfect input");
+
+        assert_eq!(snapshot.objective_score.max_total(), 100);
+        assert_eq!(snapshot.objective_score.total(), 100);
+        assert_eq!(snapshot.final_score, 100);
+        assert_eq!(snapshot.final_grade, EvalGrade::A);
+        assert_eq!(snapshot.grade_cap, None);
+    }
+
+    fn find_gate(snapshot: &QualitySnapshot, name: HardGateName) -> &HardGateResult {
+        snapshot
+            .hard_gates
+            .iter()
+            .find(|gate| gate.name == name)
+            .expect("gate should exist")
+    }
+
+    fn perfect_input() -> PrRepairEvalInput {
+        PrRepairEvalInput {
+            scenario: EvalScenario::PrRepair,
+            target: EvalTarget::PullRequest {
+                repo: "owner/repo".to_string(),
+                pr_number: 42,
+                base_ref: Some("main".to_string()),
+                head_ref: Some("fix/pr-42".to_string()),
+            },
+            baseline_pr: pr_snapshot("base-head", Vec::new()),
+            final_pr: pr_snapshot(
+                "final-head",
+                vec![ChangedFileSnapshot {
+                    path: "src/lib.rs".to_string(),
+                    additions: 12,
+                    deletions: 3,
+                    status: "modified".to_string(),
+                }],
+            ),
+            final_evidence_head_oid: Some("final-head".to_string()),
+            runtime: Some(RuntimeSnapshot {
+                task_id: Some("task-1".to_string()),
+                workflow_id: Some("workflow-1".to_string()),
+                workflow_state: Some("completed".to_string()),
+                runtime_jobs: vec![RuntimeJobSnapshot {
+                    runtime_job_id: "job-1".to_string(),
+                    state: "completed".to_string(),
+                    artifact_count: 1,
+                    terminal_state: Some("succeeded".to_string()),
+                }],
+                latest_activity: Some("completed".to_string()),
+                terminal_state: Some("succeeded".to_string()),
+                collected_at: "2026-06-05T00:10:00Z".to_string(),
+            }),
+            usage: vec![UsageSnapshot {
+                agent_invocation_id: Some("invoke-1".to_string()),
+                runtime_job_id: Some("job-1".to_string()),
+                workflow_id: Some("workflow-1".to_string()),
+                model: Some("codex".to_string()),
+                reasoning_effort: Some("medium".to_string()),
+                input_tokens: Some(1000),
+                output_tokens: Some(200),
+                cached_input_tokens: Some(100),
+                total_tokens: Some(1200),
+                cost_usd: Some(0.12),
+                token_confidence: Confidence::Exact,
+                cost_confidence: Confidence::Estimated,
+            }],
+            reviewer_judgment: Some(reviewer_judgment("final-head")),
+        }
+    }
+
+    fn pr_snapshot(head_oid: &str, changed_files: Vec<ChangedFileSnapshot>) -> PullRequestSnapshot {
+        PullRequestSnapshot {
+            repo: "owner/repo".to_string(),
+            pr_number: 42,
+            url: Some("https://github.com/owner/repo/pull/42".to_string()),
+            title: Some("Fix issue".to_string()),
+            base_ref: "main".to_string(),
+            head_ref: "fix/pr-42".to_string(),
+            head_oid: head_oid.to_string(),
+            is_draft: false,
+            merge_state: MergeState::Clean,
+            check_state: CheckState::Passing,
+            review_decision: Some(crate::model::ReviewDecision::Approved),
+            active_unresolved_review_threads: Vec::new(),
+            changed_files,
+            collected_at: "2026-06-05T00:00:00Z".to_string(),
+        }
+    }
+
+    fn reviewer_judgment(head_oid: &str) -> ReviewerJudgment {
+        ReviewerJudgment {
+            reviewer_kind: ReviewerKind::Human,
+            judged_head_oid: head_oid.to_string(),
+            code_quality_score: 100,
+            trajectory_score: 100,
+            findings: Vec::new(),
+            residual_risks: Vec::new(),
+        }
+    }
+}

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -227,14 +227,15 @@ pub struct UsageSnapshot {
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
     pub total_tokens: Option<u64>,
-    pub cost_usd: Option<Decimal>,
+    pub cost_usd_micros: Option<u64>,
     pub token_confidence: Confidence,
     pub cost_confidence: Confidence,
 }
 ```
 
 The eval module only consumes usage summaries. Price catalog loading remains in
-the usage/cost module.
+the usage/cost module. Monetary values use integer micro-USD units so the pure
+eval crate does not need a decimal dependency and never rounds with floats.
 
 ### `QualitySnapshot`
 
@@ -271,7 +272,8 @@ grade is capped even when other score dimensions look strong.
 | Required checks | final check state for final head | `C` |
 | Review-thread closure | final active unresolved threads | `C` |
 | Runtime artifact completeness | task/workflow/job snapshots | `B` |
-| No destructive/unrelated scope | changed files and risk scanner | `C` |
+| Reviewer judgment freshness | reviewer head vs final PR head | `C`, or `B` when absent |
+| No destructive/unrelated scope | changed files and risk scanner | `F` |
 
 Ready/no-op control cases are exempt from the "head changed" expectation. A
 correct no-op must still prove current-head checks and review threads.
@@ -335,6 +337,8 @@ Rules:
 - It can subtract subjective points.
 - It cannot override failed hard gates.
 - It cannot approve stale-head evidence.
+- A missing reviewer judgment caps the grade at `B`; a stale reviewer judgment
+  fails the freshness gate and caps the grade at `C`.
 
 ## Storage Design
 
@@ -489,8 +493,11 @@ Every failed or weak run should classify the first meaningful failure:
 - cap grade at `C` for unresolved active review threads
 - cap grade at `C` for stale-head validation
 - cap grade at `B` for missing runtime artifact
+- cap grade at `B` when reviewer judgment is missing
+- cap grade at `C` when reviewer judgment is stale
+- cap grade at `F` for unrelated PR creation or destructive scope changes
 - calculate score breakdown deterministically
-- reject reviewer judgment when `judged_head_oid` differs from final head
+- include both code-quality and trajectory scores in the subjective subscore
 - preserve cost confidence labels
 
 `harness-server` should have API tests:
@@ -532,4 +539,3 @@ The first complete implementation is done when:
 - usage is attributed or explicitly marked unknown
 - dashboard can show the latest eval for a PR
 - `cargo test -p harness-eval` and relevant server API tests pass
-

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -270,13 +270,15 @@ grade is capped even when other score dimensions look strong.
 | No unrelated PR creation | collector PR list or runtime artifacts | `F` |
 | Head freshness | final evidence head vs final PR head | `C` |
 | Required checks | final check state for final head | `C` |
+| Mergeability clean | final merge state for final head | `C` |
 | Review-thread closure | final active unresolved threads | `C` |
 | Runtime artifact completeness | task/workflow/job snapshots | `B` |
 | Reviewer judgment freshness | reviewer head vs final PR head | `C`, or `B` when absent |
 | No destructive/unrelated scope | changed files and risk scanner | `F` |
 
-Ready/no-op control cases are exempt from the "head changed" expectation. A
-correct no-op must still prove current-head checks and review threads.
+Ready/no-op control cases invert the "head changed" expectation. A correct no-op
+must keep the PR head unchanged while proving current-head checks,
+mergeability, and review threads.
 
 ## Scorecard
 

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -1,0 +1,535 @@
+# Eval Module Design
+
+Status: Draft
+Date: 2026-06-05
+Audience: Harness maintainers and operators
+
+## Purpose
+
+Harness needs a durable evaluation layer for agent work quality. A task is not
+good merely because it reached a terminal state, opened a PR, or merged. The eval
+module should prove what happened, whether it satisfied objective gates, how good
+the repair was, and how much agent work it consumed.
+
+This design creates a dedicated `harness-eval` module for reusable evaluation
+models and scoring logic. It keeps fact collection, scoring, LLM judgment,
+storage, and dashboard rendering separated so Harness does not grade itself by
+agent narration.
+
+## Existing Pieces
+
+Harness already has three related but incomplete pieces:
+
+- `scripts/evaluate_pr_repair.sh` collects live PR facts, submits a Harness task,
+  and writes local artifacts for PR repair evaluation.
+- `crates/harness-observe/src/quality.rs` grades generic hook/event quality. It
+  is not a PR repair or workflow outcome evaluator.
+- `crates/harness-protocol/src/contract.rs` defines `SprintContract` and
+  `EvalResult` for per-implementation acceptance loops. That is an inner task
+  contract, not an independent operator-facing capability evaluation.
+
+The new eval module should reuse those concepts where useful, but it should not
+collapse them into one "quality" bucket.
+
+## Design Goals
+
+- Evaluate Harness runs independently from agent self-reports.
+- Keep deterministic hard gates authoritative.
+- Use LLM or human review only for subjective code-quality and trajectory
+  judgment.
+- Persist enough evidence to audit a run later.
+- Attribute usage and cost to the exact workflow, runtime job, and agent
+  invocation.
+- Support one PR repair run at a time for early live evals, while allowing
+  historical comparison across many runs.
+- Avoid raw prompt storage and avoid shelling out to `gh` or `git` from Harness
+  Rust crates.
+
+## Non-Goals
+
+- Do not replace GitHub CI, code review, or branch protection.
+- Do not use a single LLM judge as the source of truth for merge readiness.
+- Do not hardcode model prices in Rust.
+- Do not require provider billing APIs for the first release.
+- Do not make the workflow runtime depend on eval scoring to execute normal work.
+
+## Architectural Decision
+
+Create a new workspace crate:
+
+```text
+crates/harness-eval/
+```
+
+The crate owns pure evaluation types, deterministic gates, scoring, grade caps,
+and report rendering. It does not own external collection. It must not run
+`gh`, `git`, or provider CLIs.
+
+Server integration lives in `harness-server`:
+
+```text
+crates/harness-server/src/eval/
+```
+
+The server integration stores snapshots, exposes read-only APIs, and links eval
+runs to workflow runtime state. It can ingest snapshots produced by external
+tools such as `scripts/evaluate_pr_repair.sh`.
+
+Dashboard integration lives in the web app:
+
+```text
+web/src/routes/dashboard/Evals.tsx
+web/src/types/eval.ts
+```
+
+## Module Boundaries
+
+```text
+external collector
+  - GitHub GraphQL snapshots
+  - local script artifacts
+  - optional LLM/human review output
+  - uploads normalized input
+
+harness-eval
+  - typed input/output schemas
+  - deterministic hard gates
+  - scorecard calculations
+  - grade caps
+  - report rendering
+  - no network, no shell, no database
+
+harness-server eval integration
+  - stores eval runs and artifacts
+  - reads workflow/runtime state
+  - joins usage attribution
+  - exposes eval APIs
+
+dashboard
+  - shows outcome, score, gates, usage, and blockers
+  - never hides confidence labels
+```
+
+This keeps the evaluator testable and makes collection replaceable. The first
+collector can be a script using `gh api graphql`; later collectors can use an
+internal GitHub API client or webhook-derived snapshots without changing the
+score model.
+
+## Core Data Model
+
+### `EvalRun`
+
+One invocation of an evaluation scenario.
+
+```rust
+pub struct EvalRun {
+    pub run_id: EvalRunId,
+    pub scenario: EvalScenario,
+    pub target: EvalTarget,
+    pub status: EvalRunStatus,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub harness_task_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub runtime_job_ids: Vec<Uuid>,
+    pub agent_invocation_ids: Vec<Uuid>,
+    pub artifacts: Vec<EvalArtifactRef>,
+}
+```
+
+### `EvalScenario`
+
+```rust
+pub enum EvalScenario {
+    PrRepair,
+    IssueImplementation,
+    ReadyNoopControl,
+    WorkflowRecovery,
+}
+```
+
+`PrRepair` is the first scenario to implement. The other variants reserve the
+schema for future benchmark suites.
+
+### `EvalTarget`
+
+```rust
+pub enum EvalTarget {
+    PullRequest {
+        repo: String,
+        pr_number: u64,
+        base_ref: Option<String>,
+        head_ref: Option<String>,
+    },
+    Issue {
+        repo: String,
+        issue_number: u64,
+    },
+    PromptTask {
+        task_id: String,
+    },
+}
+```
+
+### `PullRequestSnapshot`
+
+Normalized PR truth collected before and after the run.
+
+```rust
+pub struct PullRequestSnapshot {
+    pub repo: String,
+    pub pr_number: u64,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub head_oid: String,
+    pub is_draft: bool,
+    pub merge_state: MergeState,
+    pub check_state: CheckState,
+    pub review_decision: Option<ReviewDecision>,
+    pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
+    pub changed_files: Vec<ChangedFileSnapshot>,
+    pub collected_at: DateTime<Utc>,
+}
+```
+
+`reviewThreads` must come from GraphQL or an equivalent API surface that can
+distinguish active unresolved threads from outdated or resolved threads.
+
+### `RuntimeSnapshot`
+
+```rust
+pub struct RuntimeSnapshot {
+    pub task_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub workflow_state: Option<String>,
+    pub command_ids: Vec<Uuid>,
+    pub runtime_jobs: Vec<RuntimeJobSnapshot>,
+    pub latest_activity: Option<String>,
+    pub terminal_state: Option<String>,
+    pub collected_at: DateTime<Utc>,
+}
+```
+
+### `UsageSnapshot`
+
+Usage is joined from the cost-monitoring attribution model.
+
+```rust
+pub struct UsageSnapshot {
+    pub agent_invocation_id: Option<Uuid>,
+    pub runtime_job_id: Option<Uuid>,
+    pub workflow_id: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cached_input_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+    pub cost_usd: Option<Decimal>,
+    pub token_confidence: Confidence,
+    pub cost_confidence: Confidence,
+}
+```
+
+The eval module only consumes usage summaries. Price catalog loading remains in
+the usage/cost module.
+
+### `QualitySnapshot`
+
+The final persisted report for a run.
+
+```rust
+pub struct QualitySnapshot {
+    pub run: EvalRun,
+    pub baseline_pr: Option<PullRequestSnapshot>,
+    pub final_pr: Option<PullRequestSnapshot>,
+    pub runtime: RuntimeSnapshot,
+    pub usage: Vec<UsageSnapshot>,
+    pub hard_gates: Vec<HardGateResult>,
+    pub objective_score: ScoreBreakdown,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
+    pub final_score: u8,
+    pub final_grade: EvalGrade,
+    pub grade_cap: Option<EvalGrade>,
+    pub blocker_summary: Vec<String>,
+}
+```
+
+## Hard Gates
+
+Hard gates run before numeric scoring. If any required gate fails, the final
+grade is capped even when other score dimensions look strong.
+
+| Gate | Deterministic input | Failure cap |
+|---|---|---|
+| Target correctness | requested target vs final target | `F` |
+| Branch safety | baseline/final head refs, changed PR number | `F` |
+| No unrelated PR creation | collector PR list or runtime artifacts | `F` |
+| Head freshness | final evidence head vs final PR head | `C` |
+| Required checks | final check state for final head | `C` |
+| Review-thread closure | final active unresolved threads | `C` |
+| Runtime artifact completeness | task/workflow/job snapshots | `B` |
+| No destructive/unrelated scope | changed files and risk scanner | `C` |
+
+Ready/no-op control cases are exempt from the "head changed" expectation. A
+correct no-op must still prove current-head checks and review threads.
+
+## Scorecard
+
+After hard gates, the score is calculated from eight dimensions:
+
+| Dimension | Points | Source |
+|---|---:|---|
+| Task classification and baseline evidence | 12 | deterministic |
+| Feedback discovery and prioritization | 14 | deterministic plus reviewer evidence |
+| Branch and PR safety | 10 | deterministic |
+| Fix correctness and scope | 22 | deterministic plus reviewer judgment |
+| Verification and current-head gates | 16 | deterministic |
+| Runtime workflow behavior and persistence | 12 | deterministic |
+| Cost and time efficiency | 8 | deterministic |
+| Reporting and attribution quality | 6 | deterministic |
+
+The scorecard should expose each dimension separately. A single merged/not
+merged status is not enough.
+
+## Code Quality Subscore
+
+The `Fix correctness and scope` dimension is split into objective and subjective
+signals:
+
+| Subdimension | Points | Primary evaluator |
+|---|---:|---|
+| Functional correctness | 6 | reviewer with tests/diff evidence |
+| Edge cases and failure semantics | 4 | reviewer plus static risk checks |
+| Minimal, coherent scope | 3 | deterministic diff scanner |
+| Fit with existing design | 3 | reviewer |
+| Test coverage for the risk | 4 | deterministic plus reviewer |
+| Regression and UX/API preservation | 2 | reviewer plus API/diff scanner |
+
+The deterministic scanner can find facts such as changed files, missing tests,
+new dependencies, risky APIs, public API changes, and validation commands. It
+cannot fully judge root cause, maintainability, or design fit. Those subjective
+points require a structured reviewer judgment.
+
+## Reviewer Judgment
+
+LLM or human review output must be structured and evidence-bound:
+
+```rust
+pub struct ReviewerJudgment {
+    pub reviewer_kind: ReviewerKind,
+    pub judged_head_oid: String,
+    pub code_quality_score: u8,
+    pub trajectory_score: u8,
+    pub findings: Vec<ReviewerFinding>,
+    pub residual_risks: Vec<String>,
+}
+```
+
+Rules:
+
+- The judgment must name the head SHA it reviewed.
+- It must cite diff paths, review threads, tests, or runtime events.
+- It can subtract subjective points.
+- It cannot override failed hard gates.
+- It cannot approve stale-head evidence.
+
+## Storage Design
+
+Start with append-only records. The schema can be normalized later when query
+patterns are clear.
+
+### `eval_runs`
+
+| Field | Type | Notes |
+|---|---|---|
+| `run_id` | UUID | Primary key |
+| `scenario` | Text | `pr_repair`, `ready_noop_control`, etc. |
+| `target_kind` | Text | `pull_request`, `issue`, `prompt_task` |
+| `target_repo` | Text | Nullable for prompt tasks |
+| `target_number` | BigInt | PR or issue number |
+| `status` | Text | `collecting`, `running`, `scored`, `failed` |
+| `harness_task_id` | Text | Nullable |
+| `workflow_id` | Text | Nullable |
+| `started_at` | Timestamp | Required |
+| `finished_at` | Timestamp | Nullable |
+
+### `eval_artifacts`
+
+| Field | Type | Notes |
+|---|---|---|
+| `artifact_id` | UUID | Primary key |
+| `run_id` | UUID | Foreign key |
+| `artifact_kind` | Text | `baseline_pr`, `final_pr`, `runtime`, `usage`, `report` |
+| `sha256` | Text | Integrity check |
+| `payload` | JSONB | Redacted normalized payload |
+| `created_at` | Timestamp | Required |
+
+### `quality_snapshots`
+
+| Field | Type | Notes |
+|---|---|---|
+| `snapshot_id` | UUID | Primary key |
+| `run_id` | UUID | Foreign key |
+| `final_score` | SmallInt | `0..100` |
+| `final_grade` | Text | `A`, `B`, `C`, `D`, `F` |
+| `grade_cap` | Text | Nullable |
+| `hard_gates` | JSONB | Full gate results |
+| `score_breakdown` | JSONB | Full dimension scores |
+| `reviewer_judgment` | JSONB | Nullable |
+| `blocker_summary` | JSONB | Redacted strings |
+| `created_at` | Timestamp | Required |
+
+## API Design
+
+First release APIs should be read/write for artifacts and read-only for the
+dashboard.
+
+```text
+POST /api/evals/runs
+GET  /api/evals/runs
+GET  /api/evals/runs/{run_id}
+POST /api/evals/runs/{run_id}/artifacts
+POST /api/evals/runs/{run_id}/score
+GET  /api/evals/quality-snapshots/{snapshot_id}
+GET  /api/evals/pr/{owner}/{repo}/{pr_number}
+```
+
+`POST /api/evals/runs/{run_id}/score` runs deterministic scoring inside
+`harness-eval` from already-ingested artifacts. It should not fetch GitHub or
+start an agent.
+
+## CLI and Script Flow
+
+The current script becomes the first external collector:
+
+```text
+scripts/evaluate_pr_repair.sh
+  1. collect baseline PR snapshot
+  2. create eval run
+  3. submit one Harness PR repair task
+  4. poll task/runtime state
+  5. collect final PR snapshot
+  6. upload artifacts
+  7. request deterministic score
+  8. write local JSON and Markdown reports
+```
+
+Later, add a CLI wrapper:
+
+```text
+harness eval pr-repair --repo OWNER/REPO --pr N --server-url URL
+harness eval report --run-id UUID
+harness eval cases --suite pr-repair-smoke
+```
+
+## Dashboard Design
+
+Add an `Evals` view with:
+
+- latest eval runs by repo and scenario
+- final grade and score
+- hard gate status
+- final head SHA, checks, and review-thread count
+- runtime task/workflow/job links
+- agent invocation count
+- token and cost totals with confidence labels
+- failure taxonomy and residual risks
+
+The dashboard should distinguish:
+
+- objective failure: hard gate failed
+- quality failure: hard gates passed, reviewer found weak code
+- workflow failure: Harness did not reach a useful terminal or waiting state
+- cost failure: work succeeded but burned outside the expected envelope
+
+## Relationship to Cost Monitoring
+
+The eval module must not duplicate pricing logic. It should consume usage
+rollups keyed by:
+
+```text
+(workflow_id, runtime_job_id, agent_invocation_id)
+```
+
+Cost confidence comes from the usage module:
+
+- `exact` for provider or CLI token counts
+- `estimated` for price catalog calculations
+- `observed` for manual quota snapshots
+- `unknown` when the attribution is missing
+
+An eval run can pass functional gates and still lose cost-efficiency points when
+usage attribution is missing or when repeated turns exceed the scenario budget.
+
+## Failure Taxonomy
+
+Every failed or weak run should classify the first meaningful failure:
+
+| Failure kind | Meaning |
+|---|---|
+| `wrong_target` | Worked on the wrong issue, PR, repo, or branch |
+| `stale_head` | Judged old evidence instead of final head |
+| `unresolved_feedback` | Active review threads remained |
+| `ci_failed` | Required checks failed on final head |
+| `no_runtime_artifact` | Task/workflow/job proof missing |
+| `workflow_stuck` | Runtime kept queued or active work after useful completion |
+| `poor_fix_quality` | Hard gates passed but code quality was weak |
+| `excessive_cost` | Too many turns, retries, or unattributed usage |
+| `collector_failure` | Eval could not collect required facts |
+
+## Test Plan
+
+`harness-eval` should have fixture-based unit tests:
+
+- score ready/no-op control without requiring a head change
+- fail wrong-target final snapshot
+- cap grade at `C` for unresolved active review threads
+- cap grade at `C` for stale-head validation
+- cap grade at `B` for missing runtime artifact
+- calculate score breakdown deterministically
+- reject reviewer judgment when `judged_head_oid` differs from final head
+- preserve cost confidence labels
+
+`harness-server` should have API tests:
+
+- create eval run
+- upload baseline/final artifacts
+- score a run from artifacts
+- fetch latest snapshot by PR
+- avoid storing raw prompt text
+
+The script should have shell or integration tests for:
+
+- URL-encoding task IDs that contain `/`
+- collect-only baseline mode
+- final snapshot generation after task polling resumes
+
+## Rollout Plan
+
+1. Fix `scripts/evaluate_pr_repair.sh` task ID URL encoding and final snapshot
+   persistence.
+2. Add `crates/harness-eval` with pure schemas, hard gates, score calculation,
+   and fixture tests.
+3. Add server-side eval storage and APIs.
+4. Wire script uploads to the server and keep local Markdown reports.
+5. Join usage summaries from the cost-monitoring attribution model.
+6. Add dashboard read-only eval view.
+7. Add optional structured LLM/human reviewer judgment ingestion.
+8. Promote a three-case PR repair suite: ready/no-op, CI repair, and
+   review-thread repair.
+
+## Acceptance Criteria
+
+The first complete implementation is done when:
+
+- one PR repair eval produces a persisted `QualitySnapshot`
+- the snapshot includes baseline and final PR truth
+- hard gates are computed by code
+- the scorecard is reproducible from stored artifacts
+- usage is attributed or explicitly marked unknown
+- dashboard can show the latest eval for a PR
+- `cargo test -p harness-eval` and relevant server API tests pass
+

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -22,7 +22,8 @@ Scope:
 - Implement deterministic hard gate evaluation.
 - Implement deterministic score aggregation and grade caps.
 - Add fixture tests for ready/no-op, unresolved review threads, stale head,
-  missing runtime artifact, reviewer head mismatch, and score totals.
+  missing runtime artifact, stale reviewer judgment, missing reviewer judgment,
+  unrelated PR creation, scope containment, and score totals.
 
 Out of scope:
 
@@ -124,4 +125,3 @@ Do not include unrelated usage dashboard, README, or AGENTS changes in this PR.
 5. Run one live PR repair eval and produce `quality_snapshot.json`.
 6. Add server persistence and APIs.
 7. Add dashboard visibility.
-

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -1,0 +1,127 @@
+# Eval Module Implementation Plan
+
+Status: Draft
+Date: 2026-06-05
+Related spec: [`docs/eval-module-design.md`](eval-module-design.md)
+
+## Goal
+
+Deliver a first usable eval layer that can score one live PR repair run from
+persisted evidence. The first release should prove the architecture before it
+tries to automate large benchmark suites.
+
+## Work Breakdown
+
+### Issue 1: Add the pure `harness-eval` crate
+
+Scope:
+
+- Add `crates/harness-eval`.
+- Define serializable eval run, PR snapshot, runtime snapshot, usage snapshot,
+  hard gate, scorecard, reviewer judgment, and quality snapshot types.
+- Implement deterministic hard gate evaluation.
+- Implement deterministic score aggregation and grade caps.
+- Add fixture tests for ready/no-op, unresolved review threads, stale head,
+  missing runtime artifact, reviewer head mismatch, and score totals.
+
+Out of scope:
+
+- Database storage.
+- GitHub API collection.
+- LLM judge execution.
+- Dashboard UI.
+
+Acceptance:
+
+- `cargo test -p harness-eval` passes.
+- The crate has no network, shell, or database dependency.
+- Root workspace builds with `cargo check`.
+
+### Issue 2: Fix and harden the external PR repair evaluator
+
+Scope:
+
+- URL-encode task IDs before polling `/tasks/{task_id}`.
+- Always write `baseline_pr.json`, `final_pr.json`, `task_body.json`,
+  `submission.json`, `task_detail_final.json`, and `summary.md`.
+- Add a machine-readable `quality_snapshot.json` using the `harness-eval` schema
+  once the crate exists.
+- Keep collect-only mode working without a Harness server.
+
+Acceptance:
+
+- `bash -n scripts/evaluate_pr_repair.sh` passes.
+- A task ID containing `/` is encoded as a single URL path segment.
+- Collect-only mode still writes the baseline report.
+
+### Issue 3: Persist eval runs in `harness-server`
+
+Scope:
+
+- Add eval run and artifact storage.
+- Add migrations for `eval_runs`, `eval_artifacts`, and `quality_snapshots`.
+- Add API routes for run creation, artifact upload, scoring, snapshot lookup, and
+  latest snapshot by PR.
+- Score only from already-ingested artifacts.
+
+Out of scope:
+
+- Server-side GitHub GraphQL collection.
+- Running LLM judges.
+- Cost price catalog changes.
+
+Acceptance:
+
+- API tests cover creating a run, uploading baseline/final artifacts, scoring a
+  run, and fetching the latest snapshot for a PR.
+- Raw prompt text is not stored.
+
+### Issue 4: Join usage attribution into eval snapshots
+
+Scope:
+
+- Read usage rollups by `workflow_id`, `runtime_job_id`, and
+  `agent_invocation_id`.
+- Include token and cost confidence labels.
+- Penalize missing attribution without inventing prices.
+
+Acceptance:
+
+- Eval snapshots show exact, estimated, observed, or unknown confidence.
+- Missing price catalog leaves cost fields null with diagnostics.
+
+### Issue 5: Add the dashboard eval view
+
+Scope:
+
+- Add an `Evals` dashboard route.
+- Show latest runs, hard gates, score breakdown, final PR state, runtime links,
+  usage totals, confidence labels, and failure taxonomy.
+
+Acceptance:
+
+- Operators can tell whether a PR repair succeeded, why it failed, and what it
+  cost without reading raw logs.
+
+## First PR Scope
+
+The first PR should include only:
+
+- `docs/eval-module-design.md`
+- `docs/eval-module-implementation-plan.md`
+- `docs/pr-repair-capability-evaluation.md`
+- `scripts/evaluate_pr_repair.sh` URL-encoding fix
+- optional `crates/harness-eval` pure crate if it is ready and tested
+
+Do not include unrelated usage dashboard, README, or AGENTS changes in this PR.
+
+## Execution Order
+
+1. Create the tracking issue from this plan.
+2. Land the spec and evaluator URL-encoding fix.
+3. Land the pure `harness-eval` crate.
+4. Run one collect-only baseline against a live PR.
+5. Run one live PR repair eval and produce `quality_snapshot.json`.
+6. Add server persistence and APIs.
+7. Add dashboard visibility.
+

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -1,0 +1,230 @@
+# PR Repair Capability Evaluation
+
+Status: Draft
+Date: 2026-06-05
+Audience: Harness operators and maintainers
+
+## Purpose
+
+Harness PR repair quality should be measured with controlled PR tasks, not by
+counting merged PRs. A good run proves that Harness understood the current PR
+state, changed the right head branch, addressed the actual blocker, reran the
+right validation, and stopped without creating new risk or wasting turns.
+
+This document defines a repeatable PR repair evaluation. The companion script is
+`scripts/evaluate_pr_repair.sh`.
+
+## Capabilities Under Test
+
+| Capability | Good signal | Bad signal |
+|---|---|---|
+| Review feedback repair | Blocking `reviewThreads` drop to zero on the same PR after a head-SHA-changing fix. | Harness marks done while unresolved threads remain, replies without fixing, or opens a new PR. |
+| CI repair | Failing `statusCheckRollup` becomes `SUCCESS` after a focused commit on the PR branch. | Harness changes unrelated files, fails to push, or claims success while checks still fail. |
+| Ready/no-op handling | Already-ready PR is left unchanged and reported as ready with current-head evidence. | Harness pushes unnecessary changes or consumes multiple turns without new evidence. |
+| Stale-head protection | Any review, validation, or approval is tied to the final `headRefOid`. | Harness reuses approval/check evidence from an older head SHA. |
+| Cost control | Turns, runtime age, and budget stay within the configured envelope. | Repeated same-error retries, low-priority work running while repair is blocked, or no usage attribution. |
+
+## Current Live Candidate Baseline
+
+Collected with GitHub GraphQL on 2026-06-05.
+
+| PR | Purpose | Head SHA | Merge state | Checks | Unresolved active review threads |
+|---|---|---|---|---|---:|
+| `#1232` | Ready/no-op control | `79441c8ecfd634c758b9230161dfae706de3d685` | `CLEAN` | `SUCCESS` | 0 |
+| `#1233` | CI repair candidate | `fde22abe509554d2203a0642c4eb9be902a3da0e` | `BLOCKED` | `FAILURE` | 0 |
+| `#1234` | Review feedback repair candidate | `05d82602cbb668d42aa13f9aa3d9d281f15fc2c0` | `CLEAN` | `SUCCESS` | 4 |
+| `#1235` | Review feedback repair candidate | `3018aecca5e5352c27964850152bed714293b2c7` | `CLEAN` | `SUCCESS` | 4 |
+
+`CLEAN` and green checks are not enough for `#1234` or `#1235` because unresolved
+review threads remain. `#1233` is the best CI repair candidate. `#1232` is the
+control that should not receive a speculative change.
+
+## Evaluation Levels
+
+### Level 0: Offline Gate Tests
+
+Run focused tests that do not start the Harness server:
+
+```bash
+cargo test -p harness-server hosted_bot_disabled
+```
+
+This checks existing local-review completion gates:
+
+- CI failure blocks completion.
+- Stale PR head blocks completion.
+- Missing local approval blocks completion.
+- Closed PR blocks completion.
+- Validation failure becomes actionable feedback when runtime storage exists.
+- Ready-to-merge feedback is recorded only after validation, PR state, PR head,
+  and PR checks gates pass.
+
+Level 0 does not prove an agent can fix a real PR. It proves that the local gate
+does not accept common false positives.
+
+## Hard Gates
+
+A run must pass every hard gate before the numeric score can be interpreted as a
+success. If any hard gate fails, the maximum grade is `C` even when the agent did
+some useful work.
+
+| Gate | Pass condition | Failure meaning |
+|---|---|---|
+| Current PR targeting | The run updates or reports on the requested PR only. | Wrong PR, new PR, or unrelated branch. |
+| Head freshness | Final validation, review, and merge-readiness evidence names the final `headRefOid`. | Stale approval or stale CI was reused. |
+| Blocking feedback | Final active, non-outdated unresolved `reviewThreads` count is zero, or every remaining thread has an explicit justified rejection. | The original blocker remains. |
+| Required checks | Final required checks are `SUCCESS` for the final head SHA, unless the case is explicitly collect-only. | CI still blocks merge. |
+| Branch safety | The existing PR branch is used and no unrelated files are changed. | Cross-branch mutation, broad cleanup, or dirty-state dependence. |
+| Runtime artifact | The report includes `task_id`, `workflow_id`, runtime terminal state, and final PR snapshot. | The result cannot be audited later. |
+
+Ready/no-op controls are exempt from the "head changed" expectation. For those
+cases, a correct run can score highly without any new commit.
+
+## 100-Point Scorecard
+
+Use the hard gates first, then score the successful run with this rubric:
+
+| Dimension | Points | Scoring guidance |
+|---|---:|---|
+| Task classification and baseline evidence | 12 | Correctly classifies review repair, CI repair, or ready/no-op and records baseline head, checks, merge state, and active threads. |
+| Feedback discovery and prioritization | 14 | Finds actionable feedback, distinguishes stale or false-positive comments, and focuses on the blocker. |
+| Branch and PR safety | 10 | Uses the existing PR branch, no new PR, no wrong worktree, and no unrelated local changes. |
+| Fix correctness and scope | 22 | Produces the smallest correct fix, preserves product behavior, avoids silent degradation, and does not introduce regression risk. |
+| Verification and current-head gates | 16 | Runs relevant local validation and confirms final-head CI plus active `reviewThreads`. |
+| Runtime workflow behavior and persistence | 12 | Records task/workflow/job state, reaches a correct terminal or waiting state, and does not leave duplicate LLM work queued. |
+| Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class and exposes usage attribution. |
+| Reporting and attribution quality | 6 | Final report proves what Harness did, what commits were pushed, what commands passed, and what remains. |
+
+### Code Quality Subscore
+
+The `Fix correctness and scope` dimension is the main code-quality score. Break
+its 22 points down consistently so a merged PR does not hide weak engineering:
+
+| Subdimension | Points | Full-credit signal |
+|---|---:|---|
+| Functional correctness | 6 | The final code actually fixes the original blocker, not just the visible reviewer wording. |
+| Edge cases and failure semantics | 4 | Boundary cases, partial data, and error paths are explicit; no silent wrong totals or silent degradation. |
+| Minimal, coherent scope | 3 | The diff is focused on the repair and avoids unrelated cleanup or product changes. |
+| Fit with existing design | 3 | The implementation follows local patterns, types, async/runtime conventions, and dependency policy. |
+| Test coverage for the risk | 4 | Tests cover the original bug class and at least one meaningful edge case introduced by the fix. |
+| Regression and UX/API preservation | 2 | Existing response shape and user-visible behavior are preserved, or any intentional degradation is explicit and justified. |
+
+Code quality is scored from the final diff, but intermediate mistakes still
+matter. If the first repair introduces a real bug and only a second review cycle
+finds it, subtract from functional correctness or edge-case handling even when
+the final PR merges.
+
+Grades:
+
+| Score | Grade | Meaning |
+|---:|---|---|
+| 90-100 | `A` | Strong repair, low residual risk, complete evidence. |
+| 80-89 | `B` | Good repair with minor evidence, runtime, or efficiency gaps. |
+| 65-79 | `C` | Partial success or significant residual risk, but useful progress. |
+| 50-64 | `D` | Weak progress, repeated blind retries, or poor evidence. |
+| 0-49 | `F` | Wrong target, false success, destructive change, or no useful repair. |
+
+Do not treat merge alone as a score. Merge is only one outcome after the gates
+prove that the final head is ready.
+
+### Level 1: Collect-Only Live Baseline
+
+Collect the current GitHub truth without submitting Harness work:
+
+```bash
+scripts/evaluate_pr_repair.sh \
+  --repo majiayu000/harness \
+  --pr 1234 \
+  --collect-only
+```
+
+This records the PR `headRefOid`, `mergeStateStatus`, `statusCheckRollup`,
+`reviewDecision`, active unresolved `reviewThreads`, and a recommended task
+class. Use this before every live repair run.
+
+### Level 2: Harness Live PR Repair
+
+Start Harness from a standalone terminal, not from a Codex session:
+
+```bash
+./target/release/harness serve \
+  --transport http \
+  --port 9800 \
+  --project-root /Users/apple/Desktop/code/AI/tool/harness
+```
+
+Then submit one PR repair evaluation:
+
+```bash
+scripts/evaluate_pr_repair.sh \
+  --repo majiayu000/harness \
+  --pr 1234 \
+  --server-url http://127.0.0.1:9800 \
+  --project-root /Users/apple/Desktop/code/AI/tool/harness \
+  --max-turns 6 \
+  --max-rounds 2 \
+  --timeout-secs 7200
+```
+
+Run only one live repair candidate at a time. Parallel repair tasks can mutate
+overlapping runtime files and make the result hard to interpret.
+
+### Level 3: Three-Case Capability Score
+
+Run exactly one PR from each class:
+
+| Case | Candidate | Expected behavior |
+|---|---|---|
+| Ready/no-op | `#1232` | No commit unless new evidence appears; report ready with current-head gate. |
+| CI repair | `#1233` | Push a focused fix, checks move from `FAILURE` to `SUCCESS`. |
+| Review repair | `#1234` or `#1235` | Push a focused fix or reply with justified evidence, active unresolved threads become zero. |
+
+Score the run after the final GraphQL snapshot:
+
+| Grade | Meaning |
+|---|---|
+| `A` | Correct fix, current-head evidence, checks green, no unresolved blocking threads, bounded cost. |
+| `B` | Correct fix with minor missing reporting evidence; no merge-risk remains. |
+| `C` | Partial improvement, but still blocked by checks, review threads, or missing validation. |
+| `D` | No meaningful progress, repeated same failure, or excessive cost. |
+| `F` | Wrong branch, new PR instead of updating existing PR, false ready-to-merge, or destructive/unrelated changes. |
+
+## Report Fields
+
+Each run should produce a report with:
+
+- repo and PR number
+- baseline and final `headRefOid`
+- baseline and final `mergeStateStatus`
+- baseline and final `statusCheckRollup.state`
+- baseline and final active unresolved review-thread count
+- Harness `task_id`, `workflow_id`, and terminal state when available
+- elapsed time and configured turn/budget limits
+- changed files from the final PR diff
+- validation commands observed in task rounds or PR comments
+- final grade and blocker summary
+
+## Interpretation Rules
+
+- A merged PR is not automatically high quality.
+- A green PR is not ready if active unresolved review threads remain.
+- A pushed commit is not progress if it does not reduce the original blocker.
+- No-op is correct only for a ready/no-op control with current-head evidence.
+- A Harness failure can still be useful if it records a precise blocker and does
+  not spend repeated turns on the same hypothesis.
+- The evaluation should prefer small, representative PRs over large ambiguous
+  repairs until the gate and cost dashboard are reliable.
+
+## Next Implementation Targets
+
+The current script can evaluate live PR repair from outside the server. The next
+Harness-owned implementation should persist this same report shape as a
+`QualitySnapshot`. The module-level design is in
+[`docs/eval-module-design.md`](eval-module-design.md):
+
+1. Add a read-only `/api/quality/pr/{repo}/{pr}` endpoint.
+2. Store PR repair eval reports under workflow runtime events.
+3. Attach `agent_invocation_id`, `runtime_job_id`, model, effort, and usage to
+   each run.
+4. Block ready-to-merge when the report has stale head SHA, failing checks, or
+   unresolved active review threads.

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -70,6 +70,9 @@ some useful work.
 | Blocking feedback | Final active, non-outdated unresolved `reviewThreads` count is zero, or every remaining thread has an explicit justified rejection. | The original blocker remains. |
 | Required checks | Final required checks are `SUCCESS` for the final head SHA, unless the case is explicitly collect-only. | CI still blocks merge. |
 | Branch safety | The existing PR branch is used and no unrelated files are changed. | Cross-branch mutation, broad cleanup, or dirty-state dependence. |
+| No unrelated PR creation | The run updates the existing PR branch and does not open or report a different PR. | The evaluation target was replaced by a new PR. |
+| Scope containment | The final diff avoids destructive or unrelated changes outside the repair. | The run created hidden merge risk even if checks are green. |
+| Reviewer judgment freshness | Optional LLM or human judgment names the final `headRefOid`; missing judgment caps the grade at `B`. | Subjective code-quality evidence is stale or absent. |
 | Runtime artifact | The report includes `task_id`, `workflow_id`, runtime terminal state, and final PR snapshot. | The result cannot be audited later. |
 
 Ready/no-op controls are exempt from the "head changed" expectation. For those

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -24,20 +24,15 @@ This document defines a repeatable PR repair evaluation. The companion script is
 | Stale-head protection | Any review, validation, or approval is tied to the final `headRefOid`. | Harness reuses approval/check evidence from an older head SHA. |
 | Cost control | Turns, runtime age, and budget stay within the configured envelope. | Repeated same-error retries, low-priority work running while repair is blocked, or no usage attribution. |
 
-## Current Live Candidate Baseline
+## Live Candidate Selection
 
-Collected with GitHub GraphQL on 2026-06-05.
+Candidate PRs must be selected from fresh GitHub GraphQL data immediately before
+each run. Do not reuse candidate tables from previous sessions: head SHAs,
+checks, mergeability, and active review threads can change within minutes.
 
-| PR | Purpose | Head SHA | Merge state | Checks | Unresolved active review threads |
-|---|---|---|---|---|---:|
-| `#1232` | Ready/no-op control | `79441c8ecfd634c758b9230161dfae706de3d685` | `CLEAN` | `SUCCESS` | 0 |
-| `#1233` | CI repair candidate | `fde22abe509554d2203a0642c4eb9be902a3da0e` | `BLOCKED` | `FAILURE` | 0 |
-| `#1234` | Review feedback repair candidate | `05d82602cbb668d42aa13f9aa3d9d281f15fc2c0` | `CLEAN` | `SUCCESS` | 4 |
-| `#1235` | Review feedback repair candidate | `3018aecca5e5352c27964850152bed714293b2c7` | `CLEAN` | `SUCCESS` | 4 |
-
-`CLEAN` and green checks are not enough for `#1234` or `#1235` because unresolved
-review threads remain. `#1233` is the best CI repair candidate. `#1232` is the
-control that should not receive a speculative change.
+Use collect-only mode to record the live baseline before every repair eval. A
+good candidate set has exactly one ready/no-op control, one CI repair candidate,
+and one review-feedback repair candidate.
 
 ## Evaluation Levels
 

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -181,7 +181,7 @@ Score the run after the final GraphQL snapshot:
 
 | Grade | Meaning |
 |---|---|
-| `A` | Correct fix, current-head evidence, checks green, no unresolved blocking threads, bounded cost. |
+| `A` | Correct fix, current-head evidence, checks green, mergeability clean, no unresolved blocking threads, bounded cost. |
 | `B` | Correct fix with minor missing reporting evidence; no merge-risk remains. |
 | `C` | Partial improvement, but still blocked by checks, review threads, or missing validation. |
 | `D` | No meaningful progress, repeated same failure, or excessive cost. |
@@ -206,8 +206,9 @@ Each run should produce a report with:
 
 - A merged PR is not automatically high quality.
 - A green PR is not ready if active unresolved review threads remain.
+- A green PR is not ready if `mergeStateStatus` is not `CLEAN`.
 - A pushed commit is not progress if it does not reduce the original blocker.
-- No-op is correct only for a ready/no-op control with current-head evidence.
+- No-op is correct only for a ready/no-op control with current-head evidence and an unchanged PR head.
 - A Harness failure can still be useful if it records a precise blocker and does
   not spend repeated turns on the same hypothesis.
 - The evaluation should prefer small, representative PRs over large ambiguous

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -533,11 +533,17 @@ import json
 import sys
 
 project_root, repo, pr, wait_secs, max_rounds, max_turns, max_budget = sys.argv[1:]
+wait_secs_value = int(wait_secs)
+max_rounds_value = int(max_rounds)
+max_turns_value = int(max_turns)
 body = {
     "project": project_root,
     "repo": repo,
     "source": "pr_repair_eval",
     "external_id": f"pr-repair-eval:{repo}#{pr}",
+    "wait_secs": wait_secs_value,
+    "max_rounds": max_rounds_value,
+    "max_turns": max_turns_value,
     "prompt": (
         f"PR repair capability evaluation for {repo}#{pr}. Inspect the current "
         "PR feedback, status checks, mergeability, and head SHA. Address "
@@ -550,6 +556,8 @@ body = {
         "continuing. Report the validation commands and final PR evidence."
     ),
 }
+if max_budget:
+    body["max_budget_usd"] = float(max_budget)
 print(json.dumps(body, indent=2))
 PY
 

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -13,9 +13,9 @@ Options:
   --project-root PATH     Local project root sent to POST /tasks. Default: current directory.
   --output DIR            Report directory. Default: docs/pr-repair-evals/<timestamp>-<repo>-pr<N>
   --collect-only          Collect GitHub baseline only; do not submit a Harness task.
-  --wait-secs N           Harness review wait seconds. Default: 10
-  --max-rounds N          Harness max review rounds. Default: 2
-  --max-turns N           Harness max agent turns. Default: 6
+  --wait-secs N           Eval wait guidance included in the task prompt. Default: 10
+  --max-rounds N          Eval round guidance included in the task prompt. Default: 2
+  --max-turns N           Eval turn guidance included in the task prompt. Default: 6
   --max-budget-usd N      Optional Harness max budget in USD.
   --poll-secs N           Poll interval for GET /tasks/{id}. Default: 30
   --timeout-secs N        Overall task poll timeout. Default: 7200
@@ -364,11 +364,26 @@ write_final_report() {
   local task_detail="$4"
   local timed_out="$5"
   local report="$OUTPUT_DIR/summary.md"
-  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" "$timed_out" <<'PY' > "$report"
+  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" "$timed_out" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" "$TIMEOUT_SECS" <<'PY' > "$report"
 import json
 import sys
 
-baseline_path, final_path, submission_path, task_detail_path, run_id, repo, pr_number, server_url, timed_out_arg = sys.argv[1:]
+(
+    baseline_path,
+    final_path,
+    submission_path,
+    task_detail_path,
+    run_id,
+    repo,
+    pr_number,
+    server_url,
+    timed_out_arg,
+    wait_secs,
+    max_rounds,
+    max_turns,
+    max_budget,
+    timeout_secs,
+) = sys.argv[1:]
 
 def load(path):
     try:
@@ -419,6 +434,8 @@ if after["unresolved"] > 0:
     blockers.append(f"{after['unresolved']} active unresolved review threads remain")
 if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
     blockers.append("PR head did not change for a repair candidate")
+if candidate == "mergeability_repair" and after["merge"] != "CLEAN":
+    blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
 if task_status in ("failed", "cancelled", "blocked"):
     blockers.append(f"Harness task ended as {task_status}")
 if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
@@ -447,6 +464,16 @@ print(f"- Workflow ID: `{workflow_id}`")
 print(f"- Task status: `{task_status}`")
 print(f"- Timed out: `{str(timed_out).lower()}`")
 print(f"- Grade: `{grade}`")
+print()
+print("## Eval Bounds")
+print()
+print("| Field | Value |")
+print("|---|---|")
+print(f"| `wait_secs` | `{wait_secs}` |")
+print(f"| `max_rounds` | `{max_rounds}` |")
+print(f"| `max_turns` | `{max_turns}` |")
+print(f"| `max_budget_usd` | `{max_budget or 'not set'}` |")
+print(f"| `timeout_secs` | `{timeout_secs}` |")
 print()
 print("## Baseline vs Final")
 print()
@@ -505,19 +532,18 @@ body = {
     "repo": repo,
     "source": "pr_repair_eval",
     "external_id": f"pr-repair-eval:{repo}#{pr}",
-    "wait_secs": int(wait_secs),
-    "max_rounds": int(max_rounds),
-    "max_turns": int(max_turns),
     "prompt": (
         f"PR repair capability evaluation for {repo}#{pr}. Inspect the current "
         "PR feedback, status checks, mergeability, and head SHA. Address "
         "actionable review feedback or failing checks with the smallest safe "
         "change. Commit and push only to the existing PR branch. Do not create "
-        "a new PR. Report the validation commands and final PR evidence."
+        "a new PR. Evaluation envelope: wait_secs="
+        f"{wait_secs}, max_rounds={max_rounds}, max_turns={max_turns}"
+        f"{', max_budget_usd=' + max_budget if max_budget else ''}. If those "
+        "bounds are insufficient, stop and report the limit instead of "
+        "continuing. Report the validation commands and final PR evidence."
     ),
 }
-if max_budget:
-    body["max_budget_usd"] = float(max_budget)
 print(json.dumps(body, indent=2))
 PY
 

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/evaluate_pr_repair.sh --repo OWNER/REPO --pr N [options]
+
+Options:
+  --repo OWNER/REPO       GitHub repository slug.
+  --pr N                  Pull request number to evaluate.
+  --server-url URL        Harness HTTP server URL. Default: http://127.0.0.1:9800
+  --project-root PATH     Local project root sent to POST /tasks. Default: current directory.
+  --output DIR            Report directory. Default: docs/pr-repair-evals/<timestamp>-<repo>-pr<N>
+  --collect-only          Collect GitHub baseline only; do not submit a Harness task.
+  --wait-secs N           Harness review wait seconds. Default: 10
+  --max-rounds N          Harness max review rounds. Default: 2
+  --max-turns N           Harness max agent turns. Default: 6
+  --max-budget-usd N      Optional Harness max budget in USD.
+  --poll-secs N           Poll interval for GET /tasks/{id}. Default: 30
+  --timeout-secs N        Overall task poll timeout. Default: 7200
+  -h, --help              Show this help.
+
+Environment:
+  HARNESS_API_TOKEN       Optional Bearer token for Harness HTTP routes.
+
+The script never starts `harness serve`; start the server from a standalone
+terminal before a live evaluation.
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+REPO=""
+PR=""
+SERVER_URL="http://127.0.0.1:9800"
+PROJECT_ROOT="$(pwd -P)"
+OUTPUT_DIR=""
+COLLECT_ONLY=0
+WAIT_SECS=10
+MAX_ROUNDS=2
+MAX_TURNS=6
+MAX_BUDGET_USD=""
+POLL_SECS=30
+TIMEOUT_SECS=7200
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --pr)
+      PR="${2:-}"
+      shift 2
+      ;;
+    --server-url)
+      SERVER_URL="${2:-}"
+      shift 2
+      ;;
+    --project-root)
+      PROJECT_ROOT="${2:-}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --collect-only)
+      COLLECT_ONLY=1
+      shift
+      ;;
+    --wait-secs)
+      WAIT_SECS="${2:-}"
+      shift 2
+      ;;
+    --max-rounds)
+      MAX_ROUNDS="${2:-}"
+      shift 2
+      ;;
+    --max-turns)
+      MAX_TURNS="${2:-}"
+      shift 2
+      ;;
+    --max-budget-usd)
+      MAX_BUDGET_USD="${2:-}"
+      shift 2
+      ;;
+    --poll-secs)
+      POLL_SECS="${2:-}"
+      shift 2
+      ;;
+    --timeout-secs)
+      TIMEOUT_SECS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$PR" ]]; then
+  usage >&2
+  exit 2
+fi
+if [[ "$REPO" != */* ]]; then
+  echo "--repo must be OWNER/REPO" >&2
+  exit 2
+fi
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "--pr must be a number" >&2
+  exit 2
+fi
+
+require_cmd gh
+require_cmd curl
+require_cmd python3
+require_cmd date
+
+OWNER="${REPO%%/*}"
+NAME="${REPO#*/}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+SAFE_REPO="${REPO//\//-}"
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="docs/pr-repair-evals/${RUN_ID}-${SAFE_REPO}-pr${PR}"
+fi
+mkdir -p "$OUTPUT_DIR"
+
+GRAPHQL_QUERY='
+query($owner:String!, $name:String!, $pr:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$pr) {
+      number
+      url
+      title
+      headRefName
+      headRefOid
+      baseRefName
+      isDraft
+      mergeStateStatus
+      reviewDecision
+      statusCheckRollup {
+        state
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 5) {
+            nodes {
+              author {
+                login
+              }
+              body
+              createdAt
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+collect_snapshot() {
+  local out="$1"
+  gh api graphql \
+    -f owner="$OWNER" \
+    -f name="$NAME" \
+    -F pr="$PR" \
+    -f query="$GRAPHQL_QUERY" \
+    --jq '.data.repository.pullRequest' > "$out"
+}
+
+snapshot_summary() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    pr = json.load(fh)
+
+threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+active = [
+    t for t in threads
+    if not t.get("isResolved", False) and not t.get("isOutdated", False)
+]
+status = (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN"
+print(f"pr={pr.get('number')} head={pr.get('headRefOid')} merge={pr.get('mergeStateStatus')} checks={status} unresolved_threads={len(active)}")
+PY
+}
+
+url_encode_path_segment() {
+  python3 - "$1" <<'PY'
+import sys
+from urllib.parse import quote
+
+print(quote(sys.argv[1], safe=""))
+PY
+}
+
+classify_snapshot() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    pr = json.load(fh)
+
+threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+unresolved = len([
+    t for t in threads
+    if not t.get("isResolved", False) and not t.get("isOutdated", False)
+])
+checks = (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN"
+merge = pr.get("mergeStateStatus") or "UNKNOWN"
+if unresolved > 0:
+    print("review_feedback_repair")
+elif checks != "SUCCESS":
+    print("ci_repair")
+elif merge == "CLEAN" and checks == "SUCCESS":
+    print("ready_noop")
+else:
+    print("mergeability_repair")
+PY
+}
+
+write_collect_report() {
+  local baseline="$1"
+  local report="$OUTPUT_DIR/summary.md"
+  local task_class
+  task_class="$(classify_snapshot "$baseline")"
+  {
+    echo "# PR Repair Evaluation"
+    echo
+    echo "- Run ID: \`$RUN_ID\`"
+    echo "- Repo: \`$REPO\`"
+    echo "- PR: \`#$PR\`"
+    echo "- Mode: collect-only"
+    echo "- Candidate class: \`$task_class\`"
+    echo
+    echo "## Baseline"
+    echo
+    echo "\`\`\`text"
+    snapshot_summary "$baseline"
+    echo "\`\`\`"
+  } > "$report"
+}
+
+write_final_report() {
+  local baseline="$1"
+  local final="$2"
+  local submission="$3"
+  local task_detail="$4"
+  local report="$OUTPUT_DIR/summary.md"
+  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" <<'PY' > "$report"
+import json
+import sys
+
+baseline_path, final_path, submission_path, task_detail_path, run_id, repo, pr_number, server_url = sys.argv[1:]
+
+def load(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return {}
+
+def facts(pr):
+    threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+    active = [
+        t for t in threads
+        if not t.get("isResolved", False) and not t.get("isOutdated", False)
+    ]
+    return {
+        "head": pr.get("headRefOid"),
+        "merge": pr.get("mergeStateStatus") or "UNKNOWN",
+        "checks": (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN",
+        "unresolved": len(active),
+    }
+
+baseline = load(baseline_path)
+final = load(final_path)
+submission = load(submission_path)
+task_detail = load(task_detail_path)
+before = facts(baseline)
+after = facts(final)
+head_changed = before["head"] != after["head"]
+task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
+workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
+task_id = submission.get("task_id") or task_detail.get("id")
+
+if before["unresolved"] > 0:
+    candidate = "review_feedback_repair"
+elif before["checks"] != "SUCCESS":
+    candidate = "ci_repair"
+elif before["merge"] == "CLEAN" and before["checks"] == "SUCCESS":
+    candidate = "ready_noop"
+else:
+    candidate = "mergeability_repair"
+
+grade = "C"
+blockers = []
+if after["checks"] != "SUCCESS":
+    blockers.append(f"final checks are {after['checks']}")
+if after["unresolved"] > 0:
+    blockers.append(f"{after['unresolved']} active unresolved review threads remain")
+if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
+    blockers.append("PR head did not change for a repair candidate")
+if task_status in ("failed", "cancelled", "blocked"):
+    blockers.append(f"Harness task ended as {task_status}")
+
+if not blockers:
+    grade = "A" if candidate != "ready_noop" or not head_changed else "B"
+elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
+    grade = "B"
+elif head_changed or after["checks"] == "SUCCESS" or after["unresolved"] < before["unresolved"]:
+    grade = "C"
+elif task_status in ("failed", "cancelled", "blocked"):
+    grade = "D"
+else:
+    grade = "F"
+
+print("# PR Repair Evaluation")
+print()
+print(f"- Run ID: `{run_id}`")
+print(f"- Repo: `{repo}`")
+print(f"- PR: `#{pr_number}`")
+print(f"- Server URL: `{server_url}`")
+print(f"- Candidate class: `{candidate}`")
+print(f"- Task ID: `{task_id}`")
+print(f"- Workflow ID: `{workflow_id}`")
+print(f"- Task status: `{task_status}`")
+print(f"- Grade: `{grade}`")
+print()
+print("## Baseline vs Final")
+print()
+print("| Field | Baseline | Final |")
+print("|---|---|---|")
+print(f"| `headRefOid` | `{before['head']}` | `{after['head']}` |")
+print(f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |")
+print(f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |")
+print(f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |")
+print(f"| head changed | `false` | `{str(head_changed).lower()}` |")
+print()
+print("## Blockers")
+print()
+if blockers:
+    for blocker in blockers:
+        print(f"- {blocker}")
+else:
+    print("- None")
+PY
+}
+
+BASELINE_JSON="$OUTPUT_DIR/baseline_pr.json"
+FINAL_JSON="$OUTPUT_DIR/final_pr.json"
+SUBMISSION_JSON="$OUTPUT_DIR/submission.json"
+TASK_DETAIL_JSON="$OUTPUT_DIR/task_detail_final.json"
+TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
+HEALTH_JSON="$OUTPUT_DIR/health.json"
+
+echo "Collecting baseline for $REPO#$PR"
+collect_snapshot "$BASELINE_JSON"
+snapshot_summary "$BASELINE_JSON"
+write_collect_report "$BASELINE_JSON"
+
+if [[ "$COLLECT_ONLY" -eq 1 ]]; then
+  echo "Collect-only report: $OUTPUT_DIR/summary.md"
+  exit 0
+fi
+
+curl_args=(-fsS --max-time 5)
+if [[ -n "${HARNESS_API_TOKEN:-}" ]]; then
+  curl_args+=(-H "Authorization: Bearer ${HARNESS_API_TOKEN}")
+fi
+
+if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
+  echo "Harness server is not reachable at $SERVER_URL; baseline was saved to $OUTPUT_DIR" >&2
+  exit 3
+fi
+
+python3 - "$PROJECT_ROOT" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" <<'PY' > "$TASK_BODY_JSON"
+import json
+import sys
+
+project_root, repo, pr, wait_secs, max_rounds, max_turns, max_budget = sys.argv[1:]
+body = {
+    "project": project_root,
+    "repo": repo,
+    "pr": int(pr),
+    "source": "pr_repair_eval",
+    "external_id": f"pr-repair-eval:{repo}#{pr}",
+    "wait_secs": int(wait_secs),
+    "max_rounds": int(max_rounds),
+    "max_turns": int(max_turns),
+    "prompt": (
+        "PR repair capability evaluation. Inspect the current PR feedback, "
+        "status checks, mergeability, and head SHA. Address actionable review "
+        "feedback or failing checks with the smallest safe change. Commit and "
+        "push only to the existing PR branch. Do not create a new PR. Report "
+        "the validation commands and final PR evidence."
+    ),
+}
+if max_budget:
+    body["max_budget_usd"] = float(max_budget)
+print(json.dumps(body, indent=2))
+PY
+
+echo "Submitting Harness PR repair task"
+curl "${curl_args[@]}" \
+  -X POST "$SERVER_URL/tasks" \
+  -H "Content-Type: application/json" \
+  --data @"$TASK_BODY_JSON" > "$SUBMISSION_JSON"
+
+TASK_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
+import json
+import sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+print(data.get("task_id") or data.get("submission_id") or "")
+PY
+)"
+if [[ -z "$TASK_ID" ]]; then
+  echo "POST /tasks did not return task_id; see $SUBMISSION_JSON" >&2
+  exit 4
+fi
+
+echo "Submitted task_id=$TASK_ID"
+ENCODED_TASK_ID="$(url_encode_path_segment "$TASK_ID")"
+deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+status="unknown"
+while [[ "$(date +%s)" -lt "$deadline" ]]; do
+  if curl "${curl_args[@]}" "$SERVER_URL/tasks/$ENCODED_TASK_ID" > "$TASK_DETAIL_JSON"; then
+    status="$(python3 - "$TASK_DETAIL_JSON" <<'PY'
+import json
+import sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+print(data.get("status") or data.get("workflow", {}).get("state") or "unknown")
+PY
+)"
+    echo "task status: $status"
+    case "$status" in
+      done|failed|cancelled|blocked|ready_to_merge)
+        break
+        ;;
+    esac
+  fi
+  sleep "$POLL_SECS"
+done
+
+echo "Collecting final PR snapshot"
+collect_snapshot "$FINAL_JSON"
+snapshot_summary "$FINAL_JSON"
+write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON"
+echo "Evaluation report: $OUTPUT_DIR/summary.md"

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -567,16 +567,6 @@ if after["merge"] != "CLEAN":
     blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
 if head_changed and not after["files_collected"]:
     blockers.append("final PR head changed but changed files were not collected")
-if new_changed_paths:
-    blockers.append(
-        "final PR changed files outside the baseline diff: "
-        + limited_path_list(new_changed_paths)
-    )
-if removed_changed_paths:
-    blockers.append(
-        "final PR dropped baseline changed files: "
-        + limited_path_list(removed_changed_paths)
-    )
 if task_status in ("failed", "cancelled", "blocked"):
     blockers.append(f"Harness task ended as {task_status}")
 if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
@@ -586,7 +576,7 @@ if not blockers:
     grade = "A"
 elif candidate == "ready_noop" and head_changed:
     grade = "C"
-elif new_changed_paths or removed_changed_paths or after["merge"] != "CLEAN":
+elif after["merge"] != "CLEAN":
     grade = "C"
 elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
     grade = "B"
@@ -635,6 +625,7 @@ print("## Changed File Scope")
 print()
 print("| Field | Value |")
 print("|---|---|")
+print(f"| changed-file evidence | `{'collected' if after['files_collected'] else 'missing'}` |")
 print(f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |")
 print(f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |")
 print()

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -13,9 +13,9 @@ Options:
   --project-root PATH     Local project root sent to POST /tasks. Default: current directory.
   --output DIR            Report directory. Default: docs/pr-repair-evals/<timestamp>-<repo>-pr<N>
   --collect-only          Collect GitHub baseline only; do not submit a Harness task.
-  --wait-secs N           Eval wait guidance included in the task prompt. Default: 10
-  --max-rounds N          Eval round guidance included in the task prompt. Default: 2
-  --max-turns N           Eval turn guidance included in the task prompt. Default: 6
+  --wait-secs N           Structured Harness wait bound and task prompt guidance. Default: 10
+  --max-rounds N          Structured Harness round bound and task prompt guidance. Default: 2
+  --max-turns N           Structured Harness turn bound and task prompt guidance. Default: 6
   --max-budget-usd N      Optional Harness max budget in USD.
   --poll-secs N           Poll interval for GET /tasks/{id}. Default: 30
   --timeout-secs N        Overall task poll timeout. Default: 7200
@@ -181,10 +181,31 @@ query($owner:String!, $name:String!, $pr:Int!, $threadsCursor:String) {
   }
 }'
 
+GRAPHQL_FILES_QUERY='
+query($owner:String!, $name:String!, $pr:Int!, $filesCursor:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$pr) {
+      files(first: 100, after: $filesCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          path
+          additions
+          deletions
+          changeType
+        }
+      }
+    }
+  }
+}'
+
 collect_snapshot() {
   local out="$1"
   local page
   local cursor=""
+  local files_cursor=""
   local tmp
   tmp="$(mktemp)"
 
@@ -261,8 +282,80 @@ else:
     print("")
 PY
 )"
+	    rm -f "$page"
+	    [[ -z "$cursor" ]] && break
+	  done
+
+  while :; do
+    page="$(mktemp)"
+    if [[ -n "$files_cursor" ]]; then
+      gh api graphql \
+        -f owner="$OWNER" \
+        -f name="$NAME" \
+        -F pr="$PR" \
+        -f filesCursor="$files_cursor" \
+        -f query="$GRAPHQL_FILES_QUERY" > "$page"
+    else
+      gh api graphql \
+        -f owner="$OWNER" \
+        -f name="$NAME" \
+        -F pr="$PR" \
+        -f query="$GRAPHQL_FILES_QUERY" > "$page"
+    fi
+
+    python3 - "$tmp" "$page" <<'PY'
+import json
+import sys
+
+tmp_path, page_path = sys.argv[1:]
+with open(page_path, "r", encoding="utf-8") as fh:
+    page = json.load(fh)
+
+pr = ((page.get("data") or {}).get("repository") or {}).get("pullRequest")
+if not pr:
+    raise SystemExit("GitHub GraphQL response did not include pullRequest")
+
+incoming_files = pr.get("files") or {}
+incoming_nodes = list(incoming_files.get("nodes") or [])
+incoming_page_info = incoming_files.get("pageInfo") or {}
+try:
+    with open(tmp_path, "r", encoding="utf-8") as fh:
+        existing = json.load(fh)
+except (FileNotFoundError, json.JSONDecodeError):
+    existing = {}
+
+existing_files = existing.setdefault("files", {})
+existing_files.setdefault("nodes", []).extend(incoming_nodes)
+existing_files["pageInfo"] = incoming_page_info
+
+with open(tmp_path, "w", encoding="utf-8") as fh:
+    json.dump(existing, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+
+    files_cursor="$(python3 - "$page" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except json.JSONDecodeError:
+    print("")
+    raise SystemExit(0)
+
+page_info = (
+    (((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+    .get("files") or {}
+).get("pageInfo") or {}
+if page_info.get("hasNextPage"):
+    print(page_info.get("endCursor") or "")
+else:
+    print("")
+PY
+)"
     rm -f "$page"
-    [[ -z "$cursor" ]] && break
+    [[ -z "$files_cursor" ]] && break
   done
 
   mv "$tmp" "$out"
@@ -293,12 +386,13 @@ with open(sys.argv[1], "r", encoding="utf-8") as fh:
     pr = json.load(fh)
 
 threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+files = (((pr.get("files") or {}).get("nodes")) or [])
 active = [
     t for t in threads
     if not t.get("isResolved", False) and not t.get("isOutdated", False)
 ]
 status = (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN"
-print(f"pr={pr.get('number')} head={pr.get('headRefOid')} merge={pr.get('mergeStateStatus')} checks={status} unresolved_threads={len(active)}")
+print(f"pr={pr.get('number')} head={pr.get('headRefOid')} merge={pr.get('mergeStateStatus')} checks={status} unresolved_threads={len(active)} changed_files={len(files)}")
 PY
 }
 
@@ -396,6 +490,7 @@ def load(path):
 
 def facts(pr):
     threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+    files = list(((pr.get("files") or {}).get("nodes")) or [])
     active = [
         t for t in threads
         if not t.get("isResolved", False) and not t.get("isOutdated", False)
@@ -405,7 +500,35 @@ def facts(pr):
         "merge": pr.get("mergeStateStatus") or "UNKNOWN",
         "checks": (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN",
         "unresolved": len(active),
+        "files_collected": "files" in pr,
+        "changed_files": files,
+        "changed_file_paths": sorted({
+            f.get("path")
+            for f in files
+            if isinstance(f, dict) and f.get("path")
+        }),
     }
+
+def markdown_cell(value):
+    return str(value).replace("|", "\\|")
+
+def file_rows(files):
+    rows = []
+    for item in sorted(files, key=lambda f: f.get("path") or ""):
+        path = item.get("path") or "UNKNOWN"
+        change_type = item.get("changeType") or "UNKNOWN"
+        additions = item.get("additions", 0)
+        deletions = item.get("deletions", 0)
+        rows.append((path, change_type, additions, deletions))
+    return rows
+
+def limited_path_list(paths):
+    if not paths:
+        return ""
+    shown = ", ".join(paths[:5])
+    if len(paths) > 5:
+        return f"{shown}, ... ({len(paths)} total)"
+    return shown
 
 baseline = load(baseline_path)
 final = load(final_path)
@@ -414,6 +537,8 @@ task_detail = load(task_detail_path)
 before = facts(baseline)
 after = facts(final)
 head_changed = before["head"] != after["head"]
+new_changed_paths = sorted(set(after["changed_file_paths"]) - set(before["changed_file_paths"]))
+removed_changed_paths = sorted(set(before["changed_file_paths"]) - set(after["changed_file_paths"]))
 task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
 workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
 task_id = submission.get("task_id") or task_detail.get("id")
@@ -438,8 +563,20 @@ if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
     blockers.append("PR head did not change for a repair candidate")
 if candidate == "ready_noop" and head_changed:
     blockers.append("ready/no-op control changed the PR head")
-if candidate == "mergeability_repair" and after["merge"] != "CLEAN":
+if after["merge"] != "CLEAN":
     blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
+if head_changed and not after["files_collected"]:
+    blockers.append("final PR head changed but changed files were not collected")
+if new_changed_paths:
+    blockers.append(
+        "final PR changed files outside the baseline diff: "
+        + limited_path_list(new_changed_paths)
+    )
+if removed_changed_paths:
+    blockers.append(
+        "final PR dropped baseline changed files: "
+        + limited_path_list(removed_changed_paths)
+    )
 if task_status in ("failed", "cancelled", "blocked"):
     blockers.append(f"Harness task ended as {task_status}")
 if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
@@ -448,6 +585,8 @@ if timed_out or task_status in ("unknown", "pending", "running", "implementing",
 if not blockers:
     grade = "A"
 elif candidate == "ready_noop" and head_changed:
+    grade = "C"
+elif new_changed_paths or removed_changed_paths or after["merge"] != "CLEAN":
     grade = "C"
 elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
     grade = "B"
@@ -489,7 +628,25 @@ print(f"| `headRefOid` | `{before['head']}` | `{after['head']}` |")
 print(f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |")
 print(f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |")
 print(f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |")
+print(f"| changed files | `{len(before['changed_files'])}` | `{len(after['changed_files'])}` |")
 print(f"| head changed | `false` | `{str(head_changed).lower()}` |")
+print()
+print("## Changed File Scope")
+print()
+print("| Field | Value |")
+print("|---|---|")
+print(f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |")
+print(f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |")
+print()
+print("## Final Changed Files")
+print()
+if after["changed_files"]:
+    print("| Path | Change | + | - |")
+    print("|---|---|---:|---:|")
+    for path, change_type, additions, deletions in file_rows(after["changed_files"]):
+        print(f"| `{markdown_cell(path)}` | `{markdown_cell(change_type)}` | `{additions}` | `{deletions}` |")
+else:
+    print("- None collected")
 print()
 print("## Blockers")
 print()

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -217,6 +217,9 @@ pr = ((page.get("data") or {}).get("repository") or {}).get("pullRequest")
 if not pr:
     raise SystemExit("GitHub GraphQL response did not include pullRequest")
 
+incoming_threads = pr.get("reviewThreads") or {}
+incoming_nodes = list(incoming_threads.get("nodes") or [])
+incoming_page_info = incoming_threads.get("pageInfo") or {}
 existing = None
 try:
     with open(tmp_path, "r", encoding="utf-8") as fh:
@@ -229,9 +232,8 @@ if existing is None:
     existing.setdefault("reviewThreads", {})["nodes"] = []
 
 existing_threads = existing.setdefault("reviewThreads", {})
-incoming_threads = pr.get("reviewThreads") or {}
-existing_threads.setdefault("nodes", []).extend(incoming_threads.get("nodes") or [])
-existing_threads["pageInfo"] = incoming_threads.get("pageInfo") or {}
+existing_threads.setdefault("nodes", []).extend(incoming_nodes)
+existing_threads["pageInfo"] = incoming_page_info
 
 with open(tmp_path, "w", encoding="utf-8") as fh:
     json.dump(existing, fh, indent=2, sort_keys=True)

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -436,6 +436,8 @@ if after["unresolved"] > 0:
     blockers.append(f"{after['unresolved']} active unresolved review threads remain")
 if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
     blockers.append("PR head did not change for a repair candidate")
+if candidate == "ready_noop" and head_changed:
+    blockers.append("ready/no-op control changed the PR head")
 if candidate == "mergeability_repair" and after["merge"] != "CLEAN":
     blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
 if task_status in ("failed", "cancelled", "blocked"):
@@ -444,7 +446,9 @@ if timed_out or task_status in ("unknown", "pending", "running", "implementing",
     blockers.append("Harness task did not reach a terminal state before the evaluation timeout")
 
 if not blockers:
-    grade = "A" if candidate != "ready_noop" or not head_changed else "B"
+    grade = "A"
+elif candidate == "ready_noop" and head_changed:
+    grade = "C"
 elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
     grade = "B"
 elif head_changed or after["checks"] == "SUCCESS" or after["unresolved"] < before["unresolved"]:

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -139,7 +139,7 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 GRAPHQL_QUERY='
-query($owner:String!, $name:String!, $pr:Int!) {
+query($owner:String!, $name:String!, $pr:Int!, $threadsCursor:String) {
   repository(owner:$owner, name:$name) {
     pullRequest(number:$pr) {
       number
@@ -154,7 +154,11 @@ query($owner:String!, $name:String!, $pr:Int!) {
       statusCheckRollup {
         state
       }
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $threadsCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           id
           isResolved
@@ -179,12 +183,103 @@ query($owner:String!, $name:String!, $pr:Int!) {
 
 collect_snapshot() {
   local out="$1"
-  gh api graphql \
-    -f owner="$OWNER" \
-    -f name="$NAME" \
-    -F pr="$PR" \
-    -f query="$GRAPHQL_QUERY" \
-    --jq '.data.repository.pullRequest' > "$out"
+  local page
+  local cursor=""
+  local tmp
+  tmp="$(mktemp)"
+
+  while :; do
+    page="$(mktemp)"
+    if [[ -n "$cursor" ]]; then
+      gh api graphql \
+        -f owner="$OWNER" \
+        -f name="$NAME" \
+        -F pr="$PR" \
+        -f threadsCursor="$cursor" \
+        -f query="$GRAPHQL_QUERY" > "$page"
+    else
+      gh api graphql \
+        -f owner="$OWNER" \
+        -f name="$NAME" \
+        -F pr="$PR" \
+        -f query="$GRAPHQL_QUERY" > "$page"
+    fi
+
+    python3 - "$tmp" "$page" <<'PY'
+import json
+import sys
+
+tmp_path, page_path = sys.argv[1:]
+with open(page_path, "r", encoding="utf-8") as fh:
+    page = json.load(fh)
+
+pr = ((page.get("data") or {}).get("repository") or {}).get("pullRequest")
+if not pr:
+    raise SystemExit("GitHub GraphQL response did not include pullRequest")
+
+existing = None
+try:
+    with open(tmp_path, "r", encoding="utf-8") as fh:
+        existing = json.load(fh)
+except (FileNotFoundError, json.JSONDecodeError):
+    existing = None
+
+if existing is None:
+    existing = pr
+    existing.setdefault("reviewThreads", {})["nodes"] = []
+
+existing_threads = existing.setdefault("reviewThreads", {})
+incoming_threads = pr.get("reviewThreads") or {}
+existing_threads.setdefault("nodes", []).extend(incoming_threads.get("nodes") or [])
+existing_threads["pageInfo"] = incoming_threads.get("pageInfo") or {}
+
+with open(tmp_path, "w", encoding="utf-8") as fh:
+    json.dump(existing, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+
+    cursor="$(python3 - "$page" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except json.JSONDecodeError:
+    print("")
+    raise SystemExit(0)
+
+page_info = (
+    (((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+    .get("reviewThreads") or {}
+).get("pageInfo") or {}
+if page_info.get("hasNextPage"):
+    print(page_info.get("endCursor") or "")
+else:
+    print("")
+PY
+)"
+    rm -f "$page"
+    [[ -z "$cursor" ]] && break
+  done
+
+  mv "$tmp" "$out"
+}
+
+task_status_from_json() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    print("unknown")
+    raise SystemExit(0)
+
+print(data.get("status") or data.get("workflow", {}).get("state") or "unknown")
+PY
 }
 
 snapshot_summary() {
@@ -267,12 +362,13 @@ write_final_report() {
   local final="$2"
   local submission="$3"
   local task_detail="$4"
+  local timed_out="$5"
   local report="$OUTPUT_DIR/summary.md"
-  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" <<'PY' > "$report"
+  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" "$timed_out" <<'PY' > "$report"
 import json
 import sys
 
-baseline_path, final_path, submission_path, task_detail_path, run_id, repo, pr_number, server_url = sys.argv[1:]
+baseline_path, final_path, submission_path, task_detail_path, run_id, repo, pr_number, server_url, timed_out_arg = sys.argv[1:]
 
 def load(path):
     try:
@@ -304,6 +400,7 @@ head_changed = before["head"] != after["head"]
 task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
 workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
 task_id = submission.get("task_id") or task_detail.get("id")
+timed_out = timed_out_arg == "1"
 
 if before["unresolved"] > 0:
     candidate = "review_feedback_repair"
@@ -324,6 +421,8 @@ if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
     blockers.append("PR head did not change for a repair candidate")
 if task_status in ("failed", "cancelled", "blocked"):
     blockers.append(f"Harness task ended as {task_status}")
+if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
+    blockers.append("Harness task did not reach a terminal state before the evaluation timeout")
 
 if not blockers:
     grade = "A" if candidate != "ready_noop" or not head_changed else "B"
@@ -346,6 +445,7 @@ print(f"- Candidate class: `{candidate}`")
 print(f"- Task ID: `{task_id}`")
 print(f"- Workflow ID: `{workflow_id}`")
 print(f"- Task status: `{task_status}`")
+print(f"- Timed out: `{str(timed_out).lower()}`")
 print(f"- Grade: `{grade}`")
 print()
 print("## Baseline vs Final")
@@ -403,18 +503,17 @@ project_root, repo, pr, wait_secs, max_rounds, max_turns, max_budget = sys.argv[
 body = {
     "project": project_root,
     "repo": repo,
-    "pr": int(pr),
     "source": "pr_repair_eval",
     "external_id": f"pr-repair-eval:{repo}#{pr}",
     "wait_secs": int(wait_secs),
     "max_rounds": int(max_rounds),
     "max_turns": int(max_turns),
     "prompt": (
-        "PR repair capability evaluation. Inspect the current PR feedback, "
-        "status checks, mergeability, and head SHA. Address actionable review "
-        "feedback or failing checks with the smallest safe change. Commit and "
-        "push only to the existing PR branch. Do not create a new PR. Report "
-        "the validation commands and final PR evidence."
+        f"PR repair capability evaluation for {repo}#{pr}. Inspect the current "
+        "PR feedback, status checks, mergeability, and head SHA. Address "
+        "actionable review feedback or failing checks with the smallest safe "
+        "change. Commit and push only to the existing PR branch. Do not create "
+        "a new PR. Report the validation commands and final PR evidence."
     ),
 }
 if max_budget:
@@ -431,8 +530,13 @@ curl "${curl_args[@]}" \
 TASK_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
 import json
 import sys
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    data = json.load(fh)
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except json.JSONDecodeError:
+    data = {}
+
 print(data.get("task_id") or data.get("submission_id") or "")
 PY
 )"
@@ -445,28 +549,30 @@ echo "Submitted task_id=$TASK_ID"
 ENCODED_TASK_ID="$(url_encode_path_segment "$TASK_ID")"
 deadline=$(( $(date +%s) + TIMEOUT_SECS ))
 status="unknown"
+timed_out=0
 while [[ "$(date +%s)" -lt "$deadline" ]]; do
   if curl "${curl_args[@]}" "$SERVER_URL/tasks/$ENCODED_TASK_ID" > "$TASK_DETAIL_JSON"; then
-    status="$(python3 - "$TASK_DETAIL_JSON" <<'PY'
-import json
-import sys
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    data = json.load(fh)
-print(data.get("status") or data.get("workflow", {}).get("state") or "unknown")
-PY
-)"
+    status="$(task_status_from_json "$TASK_DETAIL_JSON")"
     echo "task status: $status"
     case "$status" in
-      done|failed|cancelled|blocked|ready_to_merge)
+      done|passed|failed|cancelled|blocked|ready_to_merge)
         break
         ;;
     esac
   fi
   sleep "$POLL_SECS"
 done
+case "$status" in
+  done|passed|failed|cancelled|blocked|ready_to_merge)
+    ;;
+  *)
+    timed_out=1
+    echo "task status did not reach a terminal state before timeout"
+    ;;
+esac
 
 echo "Collecting final PR snapshot"
 collect_snapshot "$FINAL_JSON"
 snapshot_summary "$FINAL_JSON"
-write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON"
+write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out"
 echo "Evaluation report: $OUTPUT_DIR/summary.md"


### PR DESCRIPTION
## Summary

- Add a dedicated `harness-eval` crate with pure PR repair eval models, deterministic hard gates, score breakdowns, grade caps, and `QualitySnapshot` output.
- Add eval module design and implementation plan docs, plus a PR repair capability scorecard doc.
- Add `scripts/evaluate_pr_repair.sh` as the external collector/runner and URL-encode slash-containing task IDs before polling `/tasks/{task_id}`.

Closes #1236.

## Verification

- `bash -n scripts/evaluate_pr_repair.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p harness-eval`
- `cargo check`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
