### PR TITLE
feat(eval): persist eval runs and quality snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
  "futures",
  "harness-agents",
  "harness-core",
+ "harness-eval",
  "harness-exec",
  "harness-gc",
  "harness-observe",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -16,6 +16,7 @@ harness-rules = { workspace = true }
 harness-skills = { workspace = true }
 harness-observe = { workspace = true }
 harness-exec = { workspace = true }
+harness-eval = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower = { workspace = true }

--- a/crates/harness-server/src/eval_store.rs
+++ b/crates/harness-server/src/eval_store.rs
@@ -1,0 +1,422 @@
+use chrono::{DateTime, Utc};
+use harness_core::db::{Migration, PgStoreContext};
+use harness_eval::{
+    score_pr_repair_eval, EvalScenario, EvalTarget, PrRepairEvalInput, QualitySnapshot,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPool;
+use std::path::Path;
+use uuid::Uuid;
+
+static EVAL_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create eval runs table",
+        sql: "CREATE TABLE IF NOT EXISTS eval_runs (
+            id                  TEXT PRIMARY KEY,
+            scenario            TEXT NOT NULL,
+            target_kind         TEXT NOT NULL,
+            target_repo         TEXT,
+            target_pr_number    BIGINT,
+            target_issue_number BIGINT,
+            source_task_id      TEXT,
+            status              TEXT NOT NULL,
+            quality_snapshot_id TEXT,
+            data                TEXT NOT NULL,
+            created_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            completed_at        TIMESTAMPTZ
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "create eval artifacts table",
+        sql: "CREATE TABLE IF NOT EXISTS eval_artifacts (
+            id            TEXT PRIMARY KEY,
+            run_id        TEXT NOT NULL,
+            artifact_type TEXT NOT NULL,
+            label         TEXT,
+            content_type  TEXT,
+            body          TEXT NOT NULL,
+            data          TEXT NOT NULL,
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 3,
+        description: "create quality snapshots table",
+        sql: "CREATE TABLE IF NOT EXISTS quality_snapshots (
+            id               TEXT PRIMARY KEY,
+            run_id           TEXT NOT NULL,
+            scenario         TEXT NOT NULL,
+            target_repo      TEXT,
+            target_pr_number BIGINT,
+            final_score      BIGINT NOT NULL,
+            final_grade      TEXT NOT NULL,
+            data             TEXT NOT NULL,
+            created_at       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 4,
+        description: "create eval lookup indexes",
+        sql: "CREATE INDEX IF NOT EXISTS idx_eval_runs_updated
+              ON eval_runs(updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_eval_runs_pr
+              ON eval_runs(target_repo, target_pr_number, updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_eval_artifacts_run
+              ON eval_artifacts(run_id, created_at);
+              CREATE INDEX IF NOT EXISTS idx_quality_snapshots_run
+              ON quality_snapshots(run_id, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_quality_snapshots_pr
+              ON quality_snapshots(target_repo, target_pr_number, created_at DESC)",
+    },
+];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalRunStatus {
+    Created,
+    Scored,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalRun {
+    pub id: String,
+    pub scenario: EvalScenario,
+    pub target: EvalTarget,
+    pub source_task_id: Option<String>,
+    pub status: EvalRunStatus,
+    pub quality_snapshot_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CreateEvalRun {
+    pub scenario: EvalScenario,
+    pub target: EvalTarget,
+    pub source_task_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalArtifact {
+    pub id: String,
+    pub run_id: String,
+    pub artifact_type: String,
+    pub label: Option<String>,
+    pub content_type: Option<String>,
+    pub body: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AddEvalArtifact {
+    pub artifact_type: String,
+    pub label: Option<String>,
+    pub content_type: Option<String>,
+    pub body: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct QualitySnapshotRecord {
+    pub id: String,
+    pub run_id: String,
+    pub snapshot: QualitySnapshot,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalScoreResult {
+    pub run: EvalRun,
+    pub quality_snapshot: QualitySnapshotRecord,
+}
+
+pub struct EvalStore {
+    pool: PgPool,
+}
+
+impl EvalStore {
+    pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        Self::open_with_database_url(path, None).await
+    }
+
+    pub async fn open_with_database_url(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let pool = context.open_migrated_pool(EVAL_MIGRATIONS).await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn open_with_context(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        let pool = context
+            .open_migrated_pool_with_setup_pool(setup_pool, EVAL_MIGRATIONS)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn create_run(&self, input: CreateEvalRun) -> anyhow::Result<EvalRun> {
+        let now = Utc::now();
+        let run = EvalRun {
+            id: Uuid::new_v4().to_string(),
+            scenario: input.scenario,
+            target: input.target,
+            source_task_id: input.source_task_id,
+            status: EvalRunStatus::Created,
+            quality_snapshot_id: None,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+        };
+        let data = serde_json::to_string(&run)?;
+        let fields = target_fields(&run.target)?;
+        sqlx::query(
+            "INSERT INTO eval_runs
+             (id, scenario, target_kind, target_repo, target_pr_number, target_issue_number,
+              source_task_id, status, quality_snapshot_id, data, created_at, updated_at,
+              completed_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+        )
+        .bind(&run.id)
+        .bind(scenario_key(&run.scenario))
+        .bind(fields.kind)
+        .bind(fields.repo)
+        .bind(fields.pr_number)
+        .bind(fields.issue_number)
+        .bind(&run.source_task_id)
+        .bind(status_key(&run.status))
+        .bind(&run.quality_snapshot_id)
+        .bind(&data)
+        .bind(run.created_at)
+        .bind(run.updated_at)
+        .bind(run.completed_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(run)
+    }
+
+    pub async fn get_run(&self, run_id: &str) -> anyhow::Result<Option<EvalRun>> {
+        let row: Option<(String,)> = sqlx::query_as("SELECT data FROM eval_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn list_runs(&self, limit: i64) -> anyhow::Result<Vec<EvalRun>> {
+        let limit = limit.clamp(1, 100);
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT data FROM eval_runs ORDER BY updated_at DESC LIMIT $1")
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
+            .collect()
+    }
+
+    pub async fn add_artifact(
+        &self,
+        run_id: &str,
+        input: AddEvalArtifact,
+    ) -> anyhow::Result<Option<EvalArtifact>> {
+        if self.get_run(run_id).await?.is_none() {
+            return Ok(None);
+        }
+        let artifact = EvalArtifact {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.to_string(),
+            artifact_type: input.artifact_type,
+            label: input.label,
+            content_type: input.content_type,
+            body: input.body,
+            created_at: Utc::now(),
+        };
+        let data = serde_json::to_string(&artifact)?;
+        sqlx::query(
+            "INSERT INTO eval_artifacts
+             (id, run_id, artifact_type, label, content_type, body, data, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(&artifact.id)
+        .bind(&artifact.run_id)
+        .bind(&artifact.artifact_type)
+        .bind(&artifact.label)
+        .bind(&artifact.content_type)
+        .bind(&artifact.body)
+        .bind(&data)
+        .bind(artifact.created_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(Some(artifact))
+    }
+
+    pub async fn list_artifacts(&self, run_id: &str) -> anyhow::Result<Vec<EvalArtifact>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT data FROM eval_artifacts WHERE run_id = $1 ORDER BY created_at")
+                .bind(run_id)
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
+            .collect()
+    }
+
+    pub async fn score_run(
+        &self,
+        run_id: &str,
+        input: PrRepairEvalInput,
+    ) -> anyhow::Result<Option<EvalScoreResult>> {
+        let Some(mut run) = self.get_run(run_id).await? else {
+            return Ok(None);
+        };
+        if run.scenario != input.scenario || run.target != input.target {
+            anyhow::bail!("eval input scenario and target must match the eval run");
+        }
+        let snapshot = score_pr_repair_eval(input)?;
+        let now = Utc::now();
+        let record = QualitySnapshotRecord {
+            id: Uuid::new_v4().to_string(),
+            run_id: run.id.clone(),
+            snapshot,
+            created_at: now,
+        };
+        run.status = EvalRunStatus::Scored;
+        run.quality_snapshot_id = Some(record.id.clone());
+        run.updated_at = now;
+        run.completed_at = Some(now);
+        let run_data = serde_json::to_string(&run)?;
+        let record_data = serde_json::to_string(&record)?;
+        let fields = target_fields(&run.target)?;
+
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "INSERT INTO quality_snapshots
+             (id, run_id, scenario, target_repo, target_pr_number, final_score, final_grade,
+              data, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(&record.id)
+        .bind(&record.run_id)
+        .bind(scenario_key(&run.scenario))
+        .bind(fields.repo)
+        .bind(fields.pr_number)
+        .bind(i64::from(record.snapshot.final_score))
+        .bind(format!("{:?}", record.snapshot.final_grade))
+        .bind(&record_data)
+        .bind(record.created_at)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "UPDATE eval_runs
+             SET status = $2, quality_snapshot_id = $3, data = $4, updated_at = $5,
+                 completed_at = $6
+             WHERE id = $1",
+        )
+        .bind(&run.id)
+        .bind(status_key(&run.status))
+        .bind(&run.quality_snapshot_id)
+        .bind(&run_data)
+        .bind(run.updated_at)
+        .bind(run.completed_at)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(Some(EvalScoreResult {
+            run,
+            quality_snapshot: record,
+        }))
+    }
+
+    pub async fn get_quality_snapshot(
+        &self,
+        snapshot_id: &str,
+    ) -> anyhow::Result<Option<QualitySnapshotRecord>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM quality_snapshots WHERE id = $1")
+                .bind(snapshot_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn list_quality_snapshots_for_pr(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        limit: i64,
+    ) -> anyhow::Result<Vec<QualitySnapshotRecord>> {
+        let pr_number = i64::try_from(pr_number)?;
+        let limit = limit.clamp(1, 100);
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM quality_snapshots
+             WHERE target_repo = $1 AND target_pr_number = $2
+             ORDER BY created_at DESC
+             LIMIT $3",
+        )
+        .bind(repo)
+        .bind(pr_number)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
+            .collect()
+    }
+}
+
+struct TargetFields<'a> {
+    kind: &'static str,
+    repo: Option<&'a str>,
+    pr_number: Option<i64>,
+    issue_number: Option<i64>,
+}
+
+fn target_fields(target: &EvalTarget) -> anyhow::Result<TargetFields<'_>> {
+    match target {
+        EvalTarget::PullRequest {
+            repo, pr_number, ..
+        } => Ok(TargetFields {
+            kind: "pull_request",
+            repo: Some(repo.as_str()),
+            pr_number: Some(i64::try_from(*pr_number)?),
+            issue_number: None,
+        }),
+        EvalTarget::Issue { repo, issue_number } => Ok(TargetFields {
+            kind: "issue",
+            repo: Some(repo.as_str()),
+            pr_number: None,
+            issue_number: Some(i64::try_from(*issue_number)?),
+        }),
+        EvalTarget::PromptTask { .. } => Ok(TargetFields {
+            kind: "prompt_task",
+            repo: None,
+            pr_number: None,
+            issue_number: None,
+        }),
+    }
+}
+
+fn scenario_key(scenario: &EvalScenario) -> &'static str {
+    match scenario {
+        EvalScenario::PrRepair => "pr_repair",
+        EvalScenario::ReadyNoopControl => "ready_noop_control",
+    }
+}
+
+fn status_key(status: &EvalRunStatus) -> &'static str {
+    match status {
+        EvalRunStatus::Created => "created",
+        EvalRunStatus::Scored => "scored",
+    }
+}

--- a/crates/harness-server/src/handlers/evals.rs
+++ b/crates/harness-server/src/handlers/evals.rs
@@ -1,0 +1,257 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use harness_eval::PrRepairEvalInput;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::eval_store::{AddEvalArtifact, CreateEvalRun, EvalStore};
+use crate::http::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct EvalListQuery {
+    limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScoreEvalRunRequest {
+    pub input: Option<PrRepairEvalInput>,
+}
+
+pub async fn create_eval_run(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateEvalRun>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.create_run(req).await {
+        Ok(run) => (StatusCode::CREATED, Json(json!({ "run": run }))),
+        Err(error) => internal_error("failed to create eval run", error),
+    }
+}
+
+pub async fn list_eval_runs(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<EvalListQuery>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.list_runs(query.limit.unwrap_or(50)).await {
+        Ok(runs) => (StatusCode::OK, Json(json!({ "runs": runs }))),
+        Err(error) => internal_error("failed to list eval runs", error),
+    }
+}
+
+pub async fn get_eval_run(
+    State(state): State<Arc<AppState>>,
+    Path(run_id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.get_run(&run_id).await {
+        Ok(Some(run)) => (StatusCode::OK, Json(json!({ "run": run }))),
+        Ok(None) => not_found("eval run not found"),
+        Err(error) => internal_error("failed to get eval run", error),
+    }
+}
+
+pub async fn add_eval_artifact(
+    State(state): State<Arc<AppState>>,
+    Path(run_id): Path<String>,
+    Json(req): Json<AddEvalArtifact>,
+) -> (StatusCode, Json<Value>) {
+    let artifact_type = req.artifact_type.trim();
+    if artifact_type.is_empty() {
+        return bad_request("artifact_type must not be empty");
+    }
+    if req.body.is_empty() {
+        return bad_request("body must not be empty");
+    }
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.add_artifact(&run_id, req).await {
+        Ok(Some(artifact)) => (StatusCode::CREATED, Json(json!({ "artifact": artifact }))),
+        Ok(None) => not_found("eval run not found"),
+        Err(error) => internal_error("failed to add eval artifact", error),
+    }
+}
+
+pub async fn list_eval_artifacts(
+    State(state): State<Arc<AppState>>,
+    Path(run_id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.get_run(&run_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return not_found("eval run not found"),
+        Err(error) => return internal_error("failed to get eval run", error),
+    }
+    match store.list_artifacts(&run_id).await {
+        Ok(artifacts) => (StatusCode::OK, Json(json!({ "artifacts": artifacts }))),
+        Err(error) => internal_error("failed to list eval artifacts", error),
+    }
+}
+
+pub async fn score_eval_run(
+    State(state): State<Arc<AppState>>,
+    Path(run_id): Path<String>,
+    Json(req): Json<ScoreEvalRunRequest>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    let input = match req.input {
+        Some(input) => input,
+        None => match load_input_artifact(&store, &run_id).await {
+            Ok(Some(input)) => input,
+            Ok(None) => {
+                return bad_request(
+                    "score input missing and no pr_repair_eval_input artifact was found",
+                )
+            }
+            Err(error) if is_request_error(&error) => return bad_request(error.to_string()),
+            Err(error) => return internal_error("failed to load eval input artifact", error),
+        },
+    };
+    match store.score_run(&run_id, input).await {
+        Ok(Some(result)) => (StatusCode::OK, Json(json!(result))),
+        Ok(None) => not_found("eval run not found"),
+        Err(error) if is_request_error(&error) => bad_request(error.to_string()),
+        Err(error) => internal_error("failed to score eval run", error),
+    }
+}
+
+pub async fn get_eval_quality_snapshot(
+    State(state): State<Arc<AppState>>,
+    Path(snapshot_id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    match store.get_quality_snapshot(&snapshot_id).await {
+        Ok(Some(snapshot)) => (
+            StatusCode::OK,
+            Json(json!({ "quality_snapshot": snapshot })),
+        ),
+        Ok(None) => not_found("quality snapshot not found"),
+        Err(error) => internal_error("failed to get quality snapshot", error),
+    }
+}
+
+pub async fn list_eval_quality_snapshots_for_pr(
+    State(state): State<Arc<AppState>>,
+    Path((owner, repo, pr_number)): Path<(String, String, u64)>,
+    Query(query): Query<EvalListQuery>,
+) -> (StatusCode, Json<Value>) {
+    let store = match open_eval_store(&state).await {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    let repo_slug = format!("{owner}/{repo}");
+    match store
+        .list_quality_snapshots_for_pr(&repo_slug, pr_number, query.limit.unwrap_or(50))
+        .await
+    {
+        Ok(snapshots) => (
+            StatusCode::OK,
+            Json(json!({ "quality_snapshots": snapshots })),
+        ),
+        Err(error) => internal_error("failed to list quality snapshots", error),
+    }
+}
+
+async fn open_eval_store(state: &Arc<AppState>) -> Result<EvalStore, (StatusCode, Json<Value>)> {
+    if let Some(status) = state
+        .startup_statuses
+        .iter()
+        .find(|status| status.name == "eval_store" && !status.ready)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "eval store unavailable",
+                "message": status.error.as_deref().unwrap_or("eval store failed to initialize"),
+            })),
+        ));
+    }
+    let data_dir = crate::http::init::expand_tilde(&state.core.server.config.server.data_dir);
+    let db_path = harness_core::config::dirs::default_db_path(&data_dir, "evals");
+    EvalStore::open_with_database_url(
+        &db_path,
+        state.core.server.config.server.database_url.as_deref(),
+    )
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "failed to open eval store",
+                "message": error.to_string(),
+            })),
+        )
+    })
+}
+
+async fn load_input_artifact(
+    store: &EvalStore,
+    run_id: &str,
+) -> anyhow::Result<Option<PrRepairEvalInput>> {
+    let artifacts = store.list_artifacts(run_id).await?;
+    let Some(artifact) = artifacts
+        .iter()
+        .rev()
+        .find(|artifact| artifact.artifact_type == "pr_repair_eval_input")
+    else {
+        return Ok(None);
+    };
+    let input = serde_json::from_str(&artifact.body)?;
+    Ok(Some(input))
+}
+
+fn is_request_error(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("eval input scenario and target")
+        || message.contains("PR repair scoring requires a pull request target")
+        || message.contains("missing field")
+        || message.contains("unknown variant")
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "error": message.into() })),
+    )
+}
+
+fn not_found(message: &'static str) -> (StatusCode, Json<Value>) {
+    (StatusCode::NOT_FOUND, Json(json!({ "error": message })))
+}
+
+fn internal_error(
+    summary: &'static str,
+    error: impl std::fmt::Display,
+) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": summary,
+            "message": error.to_string(),
+        })),
+    )
+}

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod classify;
 pub mod cross_review;
 pub mod dashboard;
 pub mod error;
+pub mod evals;
 pub mod exec;
 pub mod gc;
 pub mod health;

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::http::state::StoreStartupResult;
-use crate::{q_value_store::QValueStore, task_runner::TaskStore};
+use crate::{eval_store::EvalStore, q_value_store::QValueStore, task_runner::TaskStore};
 
 /// Outputs of the storage initialization phase.
 pub(crate) struct StorageBundle {
@@ -15,6 +15,7 @@ pub(crate) struct StorageBundle {
 fn failed_storage_startup_results(error: &str) -> Vec<StoreStartupResult> {
     vec![
         StoreStartupResult::critical("tasks").failed(error),
+        StoreStartupResult::optional("eval_store").failed(error),
         StoreStartupResult::optional("q_value_store").failed(error),
     ]
 }
@@ -65,6 +66,8 @@ pub(crate) async fn build_storage_with_database_url(
     tracing::debug!("task db: {}", db_path.display());
     let q_values_db_path = harness_core::config::dirs::default_db_path(data_dir, "q_values");
     tracing::debug!("q_value db: {}", q_values_db_path.display());
+    let eval_db_path = harness_core::config::dirs::default_db_path(data_dir, "evals");
+    tracing::debug!("eval db: {}", eval_db_path.display());
 
     let database_url = match harness_core::db::resolve_database_url(configured_database_url) {
         Ok(database_url) => database_url,
@@ -91,6 +94,33 @@ pub(crate) async fn build_storage_with_database_url(
                 StoreStartupResult::critical("tasks").failed(error.to_string()),
             ),
         },
+    };
+
+    let (eval_store, eval_result) = match super::forced_startup_error("eval_store") {
+        Some(error) => (
+            None,
+            StoreStartupResult::optional("eval_store").failed(error),
+        ),
+        None => {
+            match harness_core::db::PgStoreContext::from_path(&eval_db_path, Some(&database_url)) {
+                Ok(eval_context) => {
+                    match EvalStore::open_with_context(&eval_context, &setup_pool).await {
+                        Ok(store) => (
+                            Some(Arc::new(store)),
+                            StoreStartupResult::optional("eval_store"),
+                        ),
+                        Err(error) => (
+                            None,
+                            StoreStartupResult::optional("eval_store").failed(error.to_string()),
+                        ),
+                    }
+                }
+                Err(error) => (
+                    None,
+                    StoreStartupResult::optional("eval_store").failed(error.to_string()),
+                ),
+            }
+        }
     };
 
     let (q_values, q_value_result) = match super::forced_startup_error("q_value_store") {
@@ -127,13 +157,20 @@ pub(crate) async fn build_storage_with_database_url(
             "q_value store init failed, rule utility tracking will be disabled: {error}"
         );
     }
+    if let Some(error) = eval_result.error.as_deref() {
+        tracing::warn!(
+            path = %eval_db_path.display(),
+            "eval store init failed, eval persistence APIs will be disabled: {error}"
+        );
+    }
 
     setup_pool.close().await;
+    drop(eval_store);
 
     Ok(StorageBundle {
         tasks,
         q_values,
-        startup_results: vec![task_result, q_value_result],
+        startup_results: vec![task_result, eval_result, q_value_result],
     })
 }
 
@@ -171,22 +208,26 @@ mod tests {
             bundle.q_values.is_none(),
             "optional q_value store should stay disabled"
         );
-        assert_eq!(bundle.startup_results.len(), 2);
+        assert_eq!(bundle.startup_results.len(), 3);
         assert!(bundle.startup_results[0].ready);
-        assert!(!bundle.startup_results[1].ready);
-        assert!(!bundle.startup_results[1].is_critical());
+        assert!(bundle.startup_results[1].ready);
+        assert!(!bundle.startup_results[2].ready);
+        assert!(!bundle.startup_results[2].is_critical());
     }
 
     #[test]
     fn bootstrap_failure_records_all_storage_statuses() {
         let statuses = failed_storage_startup_results("database unavailable");
-        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses.len(), 3);
         assert_eq!(statuses[0].name, "tasks");
         assert!(statuses[0].is_critical());
         assert!(!statuses[0].ready);
-        assert_eq!(statuses[1].name, "q_value_store");
+        assert_eq!(statuses[1].name, "eval_store");
         assert!(!statuses[1].is_critical());
         assert!(!statuses[1].ready);
+        assert_eq!(statuses[2].name, "q_value_store");
+        assert!(!statuses[2].is_critical());
+        assert!(!statuses[2].ready);
     }
 
     #[cfg(unix)]

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -123,6 +123,32 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             get(crate::handlers::usage_monitor::usage_monitor),
         )
         .route(
+            "/api/evals/runs",
+            post(crate::handlers::evals::create_eval_run)
+                .get(crate::handlers::evals::list_eval_runs),
+        )
+        .route(
+            "/api/evals/runs/{run_id}",
+            get(crate::handlers::evals::get_eval_run),
+        )
+        .route(
+            "/api/evals/runs/{run_id}/artifacts",
+            post(crate::handlers::evals::add_eval_artifact)
+                .get(crate::handlers::evals::list_eval_artifacts),
+        )
+        .route(
+            "/api/evals/runs/{run_id}/score",
+            post(crate::handlers::evals::score_eval_run),
+        )
+        .route(
+            "/api/evals/quality-snapshots/{snapshot_id}",
+            get(crate::handlers::evals::get_eval_quality_snapshot),
+        )
+        .route(
+            "/api/evals/pr/{owner}/{repo}/{pr_number}",
+            get(crate::handlers::evals::list_eval_quality_snapshots_for_pr),
+        )
+        .route(
             "/webhook",
             post(github_webhook).layer(DefaultBodyLimit::max(
                 state.core.server.config.server.max_webhook_body_bytes,

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -29,7 +29,7 @@ fn resolve_project_root(configured_root: &std::path::Path) -> anyhow::Result<std
 
 /// Expand a leading `~/` or standalone `~` to the value of `$HOME`.
 /// Returns the path unchanged when `~` is not present or `HOME` is unset.
-pub(super) fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
+pub(crate) fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
     if let Some(s) = path.to_str() {
         if let Some(rest) = s.strip_prefix("~/") {
             if let Ok(home) = std::env::var("HOME") {

--- a/crates/harness-server/src/http/tests/evals_api_tests.rs
+++ b/crates/harness-server/src/http/tests/evals_api_tests.rs
@@ -1,0 +1,236 @@
+use super::*;
+use axum::routing::{get, post};
+
+fn evals_app(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/evals/runs",
+            post(crate::handlers::evals::create_eval_run)
+                .get(crate::handlers::evals::list_eval_runs),
+        )
+        .route(
+            "/api/evals/runs/{run_id}",
+            get(crate::handlers::evals::get_eval_run),
+        )
+        .route(
+            "/api/evals/runs/{run_id}/artifacts",
+            post(crate::handlers::evals::add_eval_artifact)
+                .get(crate::handlers::evals::list_eval_artifacts),
+        )
+        .route(
+            "/api/evals/runs/{run_id}/score",
+            post(crate::handlers::evals::score_eval_run),
+        )
+        .route(
+            "/api/evals/quality-snapshots/{snapshot_id}",
+            get(crate::handlers::evals::get_eval_quality_snapshot),
+        )
+        .route(
+            "/api/evals/pr/{owner}/{repo}/{pr_number}",
+            get(crate::handlers::evals::list_eval_quality_snapshots_for_pr),
+        )
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn eval_routes_persist_score_and_pr_lookup() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.data_dir = dir.path().to_path_buf();
+    let state = make_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = evals_app(state);
+
+    let create_body = serde_json::json!({
+        "scenario": "pr_repair",
+        "target": {
+            "kind": "pull_request",
+            "repo": "owner/repo",
+            "pr_number": 7,
+            "base_ref": "main",
+            "head_ref": "fix/review"
+        },
+        "source_task_id": "task-7"
+    });
+    let create = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/evals/runs")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(create.status(), axum::http::StatusCode::CREATED);
+    let created = response_json(create).await?;
+    let run_id = created["run"]["id"].as_str().expect("run id").to_string();
+
+    let artifact_body = serde_json::json!({
+        "artifact_type": "pr_repair_eval_input",
+        "label": "canonical input",
+        "content_type": "application/json",
+        "body": pr_repair_input().to_string()
+    });
+    let artifact = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/evals/runs/{run_id}/artifacts"))
+                .header("content-type", "application/json")
+                .body(Body::from(artifact_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(artifact.status(), axum::http::StatusCode::CREATED);
+
+    let score_body = serde_json::json!({});
+    let score = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/evals/runs/{run_id}/score"))
+                .header("content-type", "application/json")
+                .body(Body::from(score_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(score.status(), axum::http::StatusCode::OK);
+    let scored = response_json(score).await?;
+    assert_eq!(scored["run"]["status"], "scored");
+    assert!(
+        scored["quality_snapshot"]["snapshot"]["final_score"]
+            .as_u64()
+            .expect("final score")
+            > 0
+    );
+    let snapshot_id = scored["quality_snapshot"]["id"]
+        .as_str()
+        .expect("snapshot id")
+        .to_string();
+
+    let snapshot = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/evals/quality-snapshots/{snapshot_id}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(snapshot.status(), axum::http::StatusCode::OK);
+    let snapshot_json = response_json(snapshot).await?;
+    assert_eq!(snapshot_json["quality_snapshot"]["id"], snapshot_id);
+
+    let pr_lookup = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/evals/pr/owner/repo/7")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(pr_lookup.status(), axum::http::StatusCode::OK);
+    let pr_lookup_json = response_json(pr_lookup).await?;
+    assert_eq!(pr_lookup_json["quality_snapshots"][0]["id"], snapshot_id);
+    Ok(())
+}
+
+fn pr_repair_input() -> serde_json::Value {
+    serde_json::json!({
+        "scenario": "pr_repair",
+        "target": {
+            "kind": "pull_request",
+            "repo": "owner/repo",
+            "pr_number": 7,
+            "base_ref": "main",
+            "head_ref": "fix/review"
+        },
+        "baseline_pr": pr_snapshot_json("base-head", "passing", "clean", true),
+        "final_pr": pr_snapshot_json("final-head", "passing", "clean", false),
+        "final_evidence_head_oid": "final-head",
+        "runtime": {
+            "task_id": "task-7",
+            "workflow_id": "workflow-7",
+            "workflow_state": "done",
+            "runtime_jobs": [{
+                "runtime_job_id": "job-7",
+                "state": "completed",
+                "artifact_count": 1,
+                "terminal_state": "succeeded"
+            }],
+            "latest_activity": "address_pr_feedback",
+            "terminal_state": "done",
+            "collected_at": "2026-06-05T00:00:00Z"
+        },
+        "usage": [{
+            "agent_invocation_id": "agent-7",
+            "runtime_job_id": "job-7",
+            "workflow_id": "workflow-7",
+            "model": "codex-test",
+            "reasoning_effort": "medium",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cached_input_tokens": 0,
+            "total_tokens": 1500,
+            "cost_usd_micros": 1234,
+            "token_confidence": "exact",
+            "cost_confidence": "estimated"
+        }],
+        "reviewer_judgment": {
+            "reviewer_kind": "llm",
+            "judged_head_oid": "final-head",
+            "code_quality_score": 90,
+            "trajectory_score": 90,
+            "findings": [],
+            "residual_risks": []
+        },
+        "created_unrelated_pr": false,
+        "scope_violations": []
+    })
+}
+
+fn pr_snapshot_json(
+    head_oid: &str,
+    check_state: &str,
+    merge_state: &str,
+    unresolved_thread: bool,
+) -> serde_json::Value {
+    let active_unresolved_review_threads = if unresolved_thread {
+        serde_json::json!([{
+            "id": "thread-1",
+            "path": "src/lib.rs",
+            "is_resolved": false,
+            "is_outdated": false
+        }])
+    } else {
+        serde_json::json!([])
+    };
+    serde_json::json!({
+        "repo": "owner/repo",
+        "pr_number": 7,
+        "url": "https://github.com/owner/repo/pull/7",
+        "title": "Fix review feedback",
+        "base_ref": "main",
+        "head_ref": "fix/review",
+        "head_oid": head_oid,
+        "is_draft": false,
+        "merge_state": merge_state,
+        "check_state": check_state,
+        "review_decision": "approved",
+        "active_unresolved_review_threads": active_unresolved_review_threads,
+        "changed_files": [{
+            "path": "src/lib.rs",
+            "additions": 4,
+            "deletions": 1,
+            "status": "modified"
+        }],
+        "collected_at": "2026-06-05T00:00:00Z"
+    })
+}

--- a/crates/harness-server/src/http/tests/mod.rs
+++ b/crates/harness-server/src/http/tests/mod.rs
@@ -26,6 +26,7 @@ use state_support::*;
 mod route_helpers;
 use route_helpers::*;
 
+mod evals_api_tests;
 mod health_route_tests;
 mod intake_auth_list_tests;
 mod recovery_followup_tests;

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod complexity_router;
 pub mod contract_validator;
 pub mod dashboard;
 pub mod db;
+pub mod eval_store;
 pub mod event_replay;
 pub(crate) mod github_auth;
 pub mod handlers;

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -404,8 +404,9 @@ GET  /api/evals/pr/{owner}/{repo}/{pr_number}
 ```
 
 `POST /api/evals/runs/{run_id}/score` runs deterministic scoring inside
-`harness-eval` from already-ingested artifacts. It should not fetch GitHub or
-start an agent.
+`harness-eval`. The request may include a canonical `PrRepairEvalInput`
+directly, or omit it and score from the latest uploaded
+`pr_repair_eval_input` artifact. It should not fetch GitHub or start an agent.
 
 ## CLI and Script Flow
 
@@ -430,6 +431,10 @@ harness eval pr-repair --repo OWNER/REPO --pr N --server-url URL
 harness eval report --run-id UUID
 harness eval cases --suite pr-repair-smoke
 ```
+
+The CLI is optional product surface. The durable contract is the server API and
+the persisted eval records; a CLI should only be a thin wrapper around those
+APIs after the storage path is stable.
 
 ## Dashboard Design
 

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -1,6 +1,6 @@
 # Eval Module Implementation Plan
 
-Status: Draft
+Status: In progress
 Date: 2026-06-05
 Related spec: [`docs/eval-module-design.md`](eval-module-design.md)
 
@@ -63,7 +63,8 @@ Scope:
 - Add migrations for `eval_runs`, `eval_artifacts`, and `quality_snapshots`.
 - Add API routes for run creation, artifact upload, scoring, snapshot lookup, and
   latest snapshot by PR.
-- Score only from already-ingested artifacts.
+- Score from a canonical `PrRepairEvalInput` request or the latest uploaded
+  `pr_repair_eval_input` artifact.
 
 Out of scope:
 
@@ -76,6 +77,14 @@ Acceptance:
 - API tests cover creating a run, uploading baseline/final artifacts, scoring a
   run, and fetching the latest snapshot for a PR.
 - Raw prompt text is not stored.
+
+Implementation status:
+
+- Added optional `eval_store` startup validation and migrations for
+  `eval_runs`, `eval_artifacts`, and `quality_snapshots`.
+- Added `/api/evals/*` routes for run lifecycle, artifacts, deterministic
+  scoring, snapshot lookup, and PR-scoped snapshot history.
+- Added route coverage for artifact-first scoring and PR lookup.
 
 ### Issue 4: Join usage attribution into eval snapshots
 

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -216,13 +216,15 @@ Each run should produce a report with:
 
 ## Next Implementation Targets
 
-The current script can evaluate live PR repair from outside the server. The next
-Harness-owned implementation should persist this same report shape as a
-`QualitySnapshot`. The module-level design is in
+The current script can evaluate live PR repair from outside the server. The
+Harness-owned implementation now has a server-side persistence path for this
+same report shape as a `QualitySnapshot`. The module-level design is in
 [`docs/eval-module-design.md`](eval-module-design.md):
 
-1. Add a read-only `/api/quality/pr/{repo}/{pr}` endpoint.
-2. Store PR repair eval reports under workflow runtime events.
+1. Use `/api/evals/runs`, `/api/evals/runs/{run_id}/artifacts`,
+   `/api/evals/runs/{run_id}/score`, and `/api/evals/pr/{owner}/{repo}/{pr}` as
+   the durable eval contract.
+2. Store PR repair eval reports as `quality_snapshots` linked to eval runs.
 3. Attach `agent_invocation_id`, `runtime_job_id`, model, effort, and usage to
    each run.
 4. Block ready-to-merge when the report has stale head SHA, failing checks, or


### PR DESCRIPTION
## Summary

- Add server-owned eval persistence for runs, artifacts, and quality snapshots.
- Add `/api/evals` endpoints to create/list runs, attach artifacts, score a run, fetch snapshots, and look up snapshots by PR.
- Allow scoring from either a direct `PrRepairEvalInput` request or the latest uploaded `pr_repair_eval_input` artifact.
- Wire optional startup validation for the eval store and document the storage/API stage.

Stacked on #1237.
Closes #1239.

## Verification

- `bash -n scripts/evaluate_pr_repair.sh`
- `cargo check`
- `cargo test -p harness-server eval_routes_persist_score_and_pr_lookup`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
