### PR TITLE
fix(runtime): address remaining review followups

### DIFF
--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -524,7 +524,7 @@ fn normalize_external_bot_chain(chain: &[String]) -> Vec<String> {
             Some(match normalized.as_str() {
                 "gemini" | "gemini_github_bot" => "gemini_github_bot".to_string(),
                 "codex" | "codex_github_bot" => "codex_github_bot".to_string(),
-                _ => trimmed.to_string(),
+                _ => normalized,
             })
         })
         .collect()

--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -515,10 +515,17 @@ fn default_review_fallback_chain() -> Vec<String> {
 fn normalize_external_bot_chain(chain: &[String]) -> Vec<String> {
     chain
         .iter()
-        .map(|provider| match provider.as_str() {
-            "gemini" | "gemini_github_bot" => "gemini_github_bot".to_string(),
-            "codex" | "codex_github_bot" => "codex_github_bot".to_string(),
-            _ => provider.clone(),
+        .filter_map(|provider| {
+            let trimmed = provider.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let normalized = trimmed.to_ascii_lowercase();
+            Some(match normalized.as_str() {
+                "gemini" | "gemini_github_bot" => "gemini_github_bot".to_string(),
+                "codex" | "codex_github_bot" => "codex_github_bot".to_string(),
+                _ => trimmed.to_string(),
+            })
         })
         .collect()
 }

--- a/crates/harness-core/src/config/agents_review_tests.rs
+++ b/crates/harness-core/src/config/agents_review_tests.rs
@@ -88,6 +88,22 @@ fn review_config_maps_legacy_fallback_chain_to_explicit_advisory_providers() {
 }
 
 #[test]
+fn review_config_normalizes_legacy_fallback_chain_case_and_whitespace(
+) -> Result<(), toml::de::Error> {
+    let toml_str = r#"
+        enabled = true
+        fallback_chain = [" Gemini ", "CODEX", " custom_provider "]
+    "#;
+    let config: AgentReviewConfig = toml::from_str(toml_str)?;
+
+    assert_eq!(
+        config.advisory_providers,
+        vec!["gemini_github_bot", "codex_github_bot", "custom_provider"]
+    );
+    Ok(())
+}
+
+#[test]
 fn review_config_partial_external_provider_inherits_provider_defaults() {
     let toml_str = r#"
         enabled = true

--- a/crates/harness-core/src/config/agents_review_tests.rs
+++ b/crates/harness-core/src/config/agents_review_tests.rs
@@ -92,7 +92,7 @@ fn review_config_normalizes_legacy_fallback_chain_case_and_whitespace(
 ) -> Result<(), toml::de::Error> {
     let toml_str = r#"
         enabled = true
-        fallback_chain = [" Gemini ", "CODEX", " custom_provider "]
+        fallback_chain = [" Gemini ", "CODEX", " Custom_Provider "]
     "#;
     let config: AgentReviewConfig = toml::from_str(toml_str)?;
 

--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -285,7 +285,10 @@ fn fenced_report_payload(raw_output: &str) -> Option<&str> {
     let end = after_newline.match_indices("```").find_map(|(index, _)| {
         let prefix_ok = index == 0 || after_newline[..index].ends_with('\n');
         let suffix = &after_newline[index + 3..];
-        let suffix_ok = suffix.is_empty() || suffix.starts_with('\n') || suffix.starts_with("\r\n");
+        let suffix_after_whitespace = suffix.trim_start_matches([' ', '\t']);
+        let suffix_ok = suffix_after_whitespace.is_empty()
+            || suffix_after_whitespace.starts_with('\n')
+            || suffix_after_whitespace.starts_with("\r\n");
         (prefix_ok && suffix_ok).then_some(index)
     })?;
     Some(after_newline[..end].trim())
@@ -422,6 +425,26 @@ mod tests {
             ),
             Some("{\"summary\":\"first\"}\n``` not closed\n{\"summary\":\"second\"}")
         );
+    }
+
+    #[test]
+    fn parses_fenced_review_report_with_trailing_whitespace_on_closing_fence() {
+        let report = parse_review_report(
+            "codex_cli_review",
+            ReviewProviderKind::LocalCli,
+            concat!(
+                "```harness-review-report\n",
+                "{\"decision\":\"approved\",\"summary\":\"No blocking issues.\",\"findings\":[]}\n",
+                "```   \n",
+                "Ignored trailing markdown."
+            ),
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::Approved);
+        assert_eq!(report.summary, "No blocking issues.");
+        assert!(report.findings.is_empty());
     }
 
     #[test]

--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -282,7 +282,9 @@ fn fenced_report_payload(raw_output: &str) -> Option<&str> {
     let start = raw_output.find(marker)?;
     let after_marker = &raw_output[start + marker.len()..];
     let after_newline = after_marker.strip_prefix('\n').unwrap_or(after_marker);
-    let end = after_newline.find("```")?;
+    let end = after_newline.match_indices("```").find_map(|(index, _)| {
+        (index == 0 || after_newline[..index].ends_with('\n')).then_some(index)
+    })?;
     Some(after_newline[..end].trim())
 }
 
@@ -387,6 +389,26 @@ mod tests {
         assert_eq!(report.elapsed_ms, 2_000);
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].category, ReviewCategory::Correctness);
+    }
+
+    #[test]
+    fn parses_fenced_review_report_with_backticks_in_string_field() {
+        let report = parse_review_report(
+            "codex_cli_review",
+            ReviewProviderKind::LocalCli,
+            r#"```harness-review-report
+{"decision":"changes_requested","summary":"One issue.","findings":[{"severity":"medium","category":"maintainability","path":"src/lib.rs","line":9,"message":"Keep example parseable","evidence":"The output included ```rust\nlet value = 1;\n``` inside the report.","recommendation":"Preserve the full JSON payload.","blocking":true,"confidence":0.8}]}
+```"#,
+            started(),
+            completed(),
+        );
+
+        assert_eq!(report.decision, ReviewDecision::ChangesRequested);
+        assert_eq!(report.findings.len(), 1);
+        assert!(report.findings[0]
+            .evidence
+            .as_deref()
+            .is_some_and(|evidence| evidence.contains("```rust")));
     }
 
     #[test]

--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -283,7 +283,10 @@ fn fenced_report_payload(raw_output: &str) -> Option<&str> {
     let after_marker = &raw_output[start + marker.len()..];
     let after_newline = after_marker.strip_prefix('\n').unwrap_or(after_marker);
     let end = after_newline.match_indices("```").find_map(|(index, _)| {
-        (index == 0 || after_newline[..index].ends_with('\n')).then_some(index)
+        let prefix_ok = index == 0 || after_newline[..index].ends_with('\n');
+        let suffix = &after_newline[index + 3..];
+        let suffix_ok = suffix.is_empty() || suffix.starts_with('\n') || suffix.starts_with("\r\n");
+        (prefix_ok && suffix_ok).then_some(index)
     })?;
     Some(after_newline[..end].trim())
 }
@@ -409,6 +412,16 @@ mod tests {
             .evidence
             .as_deref()
             .is_some_and(|evidence| evidence.contains("```rust")));
+    }
+
+    #[test]
+    fn fenced_review_report_requires_closing_fence_on_own_line() {
+        assert_eq!(
+            fenced_report_payload(
+                "```harness-review-report\n{\"summary\":\"first\"}\n``` not closed\n{\"summary\":\"second\"}\n```\n",
+            ),
+            Some("{\"summary\":\"first\"}\n``` not closed\n{\"summary\":\"second\"}")
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -820,11 +820,11 @@ impl DefaultExecutionService {
                     .await
             }
         } else {
-            let repo_key = prepared.req.repo.as_deref().unwrap_or("<none>");
-            let task_id = TaskId::from_str(&format!(
-                "repo-backlog:{project_id}:{repo_key}:pr:{pr_number}:feedback",
-                project_id = prepared.project_id,
-            ));
+            let task_id = crate::workflow_runtime_pr_feedback::synthesized_pr_feedback_task_id(
+                &prepared.project_id,
+                prepared.req.repo.as_deref(),
+                pr_number,
+            );
             crate::workflow_runtime_pr_feedback::request_pr_feedback_sweep_for_pr(
                 store,
                 crate::workflow_runtime_pr_feedback::PrFeedbackSweepRuntimeContext {

--- a/crates/harness-server/src/services/execution_tests.rs
+++ b/crates/harness-server/src/services/execution_tests.rs
@@ -539,7 +539,7 @@ async fn enqueue_background_pr_feedback_creates_pr_scoped_runtime_workflow() -> 
 
     assert_eq!(
         task_id.as_str(),
-        format!("repo-backlog:{project_id}:owner/repo:pr:77:feedback")
+        format!("repo-backlog::{project_id}::repo:owner/repo::pr:77:feedback")
     );
     assert!(
         task_store.get_with_db_fallback(&task_id).await?.is_none(),

--- a/crates/harness-server/src/task_executor/helpers/streaming.rs
+++ b/crates/harness-server/src/task_executor/helpers/streaming.rs
@@ -376,19 +376,6 @@ pub(crate) async fn run_agent_streaming_with_options(
                             }
                             StreamItem::TokenUsage { usage } => {
                                 token_usage = usage.clone();
-                                if let Some(events) = current_usage_event_store() {
-                                    log_llm_usage_event(
-                                        &events,
-                                        task_id,
-                                        turn,
-                                        &phase_str,
-                                        &agent_name,
-                                        requested_model.as_deref(),
-                                        &project,
-                                        usage,
-                                    )
-                                    .await;
-                                }
                             }
                             StreamItem::Done => {
                                 channel_closed = true;
@@ -415,6 +402,20 @@ pub(crate) async fn run_agent_streaming_with_options(
             &mut last_backfilled_issue,
             store,
             task_id,
+        )
+        .await;
+    }
+
+    if let Some(events) = current_usage_event_store() {
+        log_llm_usage_event(
+            &events,
+            task_id,
+            turn,
+            &phase_str,
+            &agent_name,
+            requested_model.as_deref(),
+            &project,
+            &token_usage,
         )
         .await;
     }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -209,21 +209,13 @@ pub(crate) async fn request_pr_feedback_sweep_for_pr(
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let instance = pr_scoped_instance(
         pr_workflow_id(&project_id, ctx.repo, ctx.pr_number),
-        project_id.clone(),
-        ctx.repo.map(ToOwned::to_owned),
-        ctx.pr_number,
-        "pr_open",
-    )
-    .with_data(pr_runtime_data(
-        ctx.project_root,
         project_id,
-        ctx.repo,
-        None,
+        ctx.repo.map(ToOwned::to_owned),
         ctx.task_id,
         ctx.pr_number,
         ctx.pr_url,
-        None,
-    ));
+        "pr_open",
+    );
     upsert_github_issue_pr_definition(store).await?;
     store.upsert_instance(&instance).await?;
     request_local_review(store, &instance.id).await
@@ -385,6 +377,17 @@ pub(crate) async fn approve_runtime_merge_by_task_id(
     approve_runtime_merge(store, instance, Some(task_id)).await
 }
 
+pub(crate) fn synthesized_pr_feedback_task_id(
+    project_id: &str,
+    repo: Option<&str>,
+    pr_number: u64,
+) -> TaskId {
+    TaskId::from_str(&format!(
+        "repo-backlog::{project_id}::repo:{}::pr:{pr_number}:feedback",
+        repo.unwrap_or("<none>")
+    ))
+}
+
 pub(crate) async fn approve_runtime_merge_by_workflow_id(
     store: &WorkflowRuntimeStore,
     workflow_id: &str,
@@ -531,6 +534,8 @@ async fn persist_pr_feedback(
         ctx.repo,
         ctx.issue_number,
         ctx.pr_number,
+        ctx.task_id,
+        ctx.pr_url,
         "pr_open",
     )
     .await?;
@@ -605,6 +610,8 @@ async fn persist_local_review_passed(
         ctx.repo,
         ctx.issue_number,
         ctx.pr_number,
+        ctx.task_id,
+        ctx.pr_url,
         "pr_open",
     )
     .await?;
@@ -746,6 +753,8 @@ async fn persist_pr_merged(
         ctx.repo,
         ctx.issue_number,
         ctx.pr_number,
+        ctx.task_id,
+        ctx.pr_url,
         "pr_open",
     )
     .await?;
@@ -1127,6 +1136,8 @@ async fn load_or_pr_runtime_target(
     repo: Option<&str>,
     issue_number: Option<u64>,
     pr_number: u64,
+    task_id: &TaskId,
+    pr_url: Option<&str>,
     state: &str,
 ) -> anyhow::Result<PrRuntimeTarget> {
     upsert_github_issue_pr_definition(store).await?;
@@ -1170,7 +1181,9 @@ async fn load_or_pr_runtime_target(
             pr_workflow_id(&project_id, repo, pr_number),
             project_id,
             repo.map(ToOwned::to_owned),
+            task_id,
             pr_number,
+            pr_url,
             state,
         ),
         new_instance: true,
@@ -1206,22 +1219,19 @@ fn pr_scoped_instance(
     workflow_id: String,
     project_id: String,
     repo: Option<String>,
+    task_id: &TaskId,
     pr_number: u64,
+    pr_url: Option<&str>,
     state: &str,
 ) -> WorkflowInstance {
-    let task_id = TaskId::from_str(&format!(
-        "pr-feedback:{}:{}",
-        repo.as_deref().unwrap_or("<none>"),
-        pr_number
-    ));
     let data = pr_runtime_data(
         Path::new(&project_id),
         project_id.clone(),
         repo.as_deref(),
         None,
-        &task_id,
+        task_id,
         pr_number,
-        None,
+        pr_url,
         None,
     );
     WorkflowInstance::new(

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests/suppression.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests/suppression.rs
@@ -175,7 +175,9 @@ async fn explicit_pr_feedback_request_starts_local_review_before_remote_suppress
         workflow_id.clone(),
         project_id,
         Some("owner/repo".to_string()),
+        &TaskId::from_str("repo-backlog::project::repo:owner/repo::pr:77:feedback"),
         77,
+        Some("https://github.com/owner/repo/pull/77"),
         "awaiting_feedback",
     )
     .with_data(json!({

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -58,7 +58,6 @@ pub struct WorkflowRejectedDecisionTransition<'a> {
     pub decision: &'a WorkflowDecision,
     pub reason: &'a str,
 }
-
 type WorkflowCommandRecordRow = (
     String,
     String,
@@ -346,7 +345,11 @@ impl WorkflowRuntimeStore {
             .bind(&record.id)
             .bind(&command_type)
             .bind(&command.dedupe_key)
-            .bind(transition.command_status)
+            .bind(if command.requires_runtime_job() {
+                transition.command_status
+            } else {
+                COMMAND_STATUS_HANDLED_INLINE
+            })
             .bind(&command_data)
             .execute(&mut *tx)
             .await?;

--- a/web/src/lib/queries.test.ts
+++ b/web/src/lib/queries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { useTasks, useWorktrees, useTaskDetail, useTaskStream } from "./queries";
+import { useAllTasks, useTasks, useWorktrees, useTaskDetail, useTaskStream } from "./queries";
 import { TOKEN_KEY } from "./api";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -183,6 +183,46 @@ describe("useTasks", () => {
       }),
     );
     expect(result.current.data?.data).toMatchObject([{ id: "t1", status: "implementing" }]);
+  });
+});
+
+describe("useAllTasks", () => {
+  it("follows task list cursors and returns the combined rows", async () => {
+    const firstPage = {
+      data: [{ id: "first", status: "done", turn: 1, project: null }],
+      page: { limit: 1, has_more: true, next_cursor: "cursor-2" },
+      counts: {
+        total: 2,
+        running: 0,
+        failed: 0,
+        by_status: { done: 2 },
+        by_scheduler_state: {},
+      },
+    };
+    const secondPage = {
+      data: [{ id: "second", status: "done", turn: 1, project: null }],
+      page: { limit: 1, has_more: false, next_cursor: null },
+      counts: firstPage.counts,
+    };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === "/tasks?status=done&limit=1") {
+        return Promise.resolve(new Response(JSON.stringify(firstPage), { status: 200 }));
+      }
+      if (url === "/tasks?status=done&limit=1&cursor=cursor-2") {
+        return Promise.resolve(new Response(JSON.stringify(secondPage), { status: 200 }));
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useAllTasks({ status: "done", limit: 1 }), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data?.data.map((task) => task.id)).toEqual(["first", "second"]);
+    expect(result.current.data?.page.has_more).toBe(false);
+    expect(result.current.data?.page.next_cursor).toBeNull();
   });
 });
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -73,6 +73,42 @@ export function useTasks(params: TaskListParams = { active: true, limit: 200 }) 
   });
 }
 
+async function fetchAllTaskPages(params: TaskListParams, signal?: AbortSignal): Promise<TaskListResponse> {
+  const seenCursors = new Set<string>();
+  const rows: TaskListResponse["data"] = [];
+  let cursor = params.cursor;
+  let latest: TaskListResponse | null = null;
+
+  for (;;) {
+    latest = await apiJson<TaskListResponse>(taskListPath({ ...params, cursor }), { signal });
+    rows.push(...latest.data);
+    const nextCursor = latest.page.next_cursor ?? null;
+    if (!latest.page.has_more || !nextCursor) break;
+    if (seenCursors.has(nextCursor)) {
+      throw new Error("Task pagination returned a repeated cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  if (!latest) {
+    throw new Error("Task pagination returned no response");
+  }
+
+  return {
+    ...latest,
+    data: rows,
+    page: { ...latest.page, has_more: false, next_cursor: null },
+  };
+}
+
+export function useAllTasks(params: TaskListParams = { limit: 200 }) {
+  return useQuery<TaskListResponse, Error>({
+    queryKey: ["tasks", "all-pages", params],
+    queryFn: ({ signal }) => fetchAllTaskPages(params, signal),
+  });
+}
+
 export function useWorkflowRuntimeTree(projectId?: string | null) {
   return useQuery<WorkflowRuntimeTreePayload, Error>({
     queryKey: ["workflow-runtime-tree", projectId ?? null],

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -4,14 +4,14 @@ import { History } from "./History";
 import type { Task } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
+  useAllTasks: vi.fn(),
   useDashboard: vi.fn(),
-  useTasks: vi.fn(),
 }));
 
-import { useDashboard, useTasks } from "@/lib/queries";
+import { useAllTasks, useDashboard } from "@/lib/queries";
 
 const mockUseDashboard = useDashboard as ReturnType<typeof vi.fn>;
-const mockUseTasks = useTasks as ReturnType<typeof vi.fn>;
+const mockUseAllTasks = useAllTasks as ReturnType<typeof vi.fn>;
 
 function makeHistoryTask(id: string, overrides: Partial<Task> = {}): Task {
   return {
@@ -75,7 +75,7 @@ describe("<History>", () => {
       created_at: "2026-02-01T00:00:00Z",
       description: "Broken review run",
     });
-    mockUseTasks.mockReturnValue({
+    mockUseAllTasks.mockReturnValue({
       data: historyTaskList([...doneTasks, failedTask]),
       isLoading: false,
       isError: false,
@@ -83,7 +83,7 @@ describe("<History>", () => {
 
     render(<History />);
 
-    expect(mockUseTasks).toHaveBeenCalledWith({
+    expect(mockUseAllTasks).toHaveBeenCalledWith({
       status: "done,failed,cancelled",
       limit: 500,
       project_id: undefined,
@@ -107,7 +107,7 @@ describe("<History>", () => {
     mockUseDashboard.mockReturnValue({
       data: { projects: [{ id: "harness", root: "/work/harness" }] },
     });
-    mockUseTasks.mockReturnValue({
+    mockUseAllTasks.mockReturnValue({
       data: historyTaskList([
         makeHistoryTask("task-a", {
           description: "Fix auth callback",
@@ -126,7 +126,7 @@ describe("<History>", () => {
 
     render(<History projectFilter="harness" />);
 
-    expect(mockUseTasks).toHaveBeenCalledWith({
+    expect(mockUseAllTasks).toHaveBeenCalledWith({
       status: "done,failed,cancelled",
       limit: 500,
       project_id: "/work/harness",

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { relativeAgo } from "@/lib/format";
-import { useDashboard, useTasks } from "@/lib/queries";
+import { useAllTasks, useDashboard } from "@/lib/queries";
 import type { Task } from "@/types";
 
 interface Props {
@@ -64,7 +64,7 @@ export function History({ projectFilter }: Props) {
   const resolvedRoot = projectFilter
     ? (dashboard?.projects.find((p) => p.id === projectFilter)?.root ?? projectFilter)
     : null;
-  const { data, isLoading, isError } = useTasks({
+  const { data, isLoading, isError } = useAllTasks({
     status: "done,failed,cancelled",
     limit: 500,
     project_id: resolvedRoot ?? undefined,


### PR DESCRIPTION
## Summary
- preserve inline workflow commands as handled inline instead of inheriting pending runtime status
- scope synthesized PR feedback task IDs by project/repo/PR and reuse caller task metadata for PR runtime instances
- harden review parsing, advisory provider normalization, final-only LLM usage logging, and History pagination

## Validation
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo test -p harness-core review::tests --all-targets`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo test -p harness-core review_config_ --all-targets`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo test -p harness-server workflow_runtime_pr_feedback --all-targets`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo test -p harness-server task_executor::helpers::streaming::tests --all-targets`
- `cd web && bun run typecheck`
- `cd web && bun run test -- src/lib/queries.test.ts src/routes/dashboard/History.test.tsx`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo check`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=target/harness-issue-1162-check cargo test --workspace --all-targets`

Closes #1162
