### PR TITLE
fix(eval): preserve task submission failures

### DIFF
--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -377,6 +377,73 @@ print(data.get("status") or data.get("workflow", {}).get("state") or "unknown")
 PY
 }
 
+annotate_submission() {
+  local submission="$1"
+  local mode="$2"
+  local http_status="$3"
+  python3 - "$submission" "$mode" "$http_status" <<'PY'
+import json
+import sys
+
+path, mode, http_status = sys.argv[1:]
+raw = ""
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        raw = fh.read()
+except OSError:
+    raw = ""
+
+try:
+    data = json.loads(raw) if raw else {}
+except json.JSONDecodeError:
+    data = {"raw_response": raw}
+
+if not isinstance(data, dict):
+    data = {"raw_response": data}
+
+data["eval_submission_mode"] = mode
+data["http_status"] = http_status
+
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+}
+
+write_submission_failure_detail() {
+  local submission="$1"
+  local http_status="$2"
+  local task_detail="$3"
+  python3 - "$submission" "$http_status" "$task_detail" <<'PY'
+import json
+import sys
+
+submission_path, http_status, task_detail_path = sys.argv[1:]
+try:
+    with open(submission_path, "r", encoding="utf-8") as fh:
+        submission = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    submission = {}
+
+error = (
+    submission.get("error")
+    or submission.get("message")
+    or submission.get("detail")
+    or submission.get("raw_response")
+    or "POST /tasks did not return a task"
+)
+
+detail = {
+    "status": "failed",
+    "error": error,
+    "http_status": http_status,
+}
+with open(task_detail_path, "w", encoding="utf-8") as fh:
+    json.dump(detail, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+}
+
 snapshot_summary() {
   python3 - "$1" <<'PY'
 import json
@@ -403,6 +470,41 @@ from urllib.parse import quote
 
 print(quote(sys.argv[1], safe=""))
 PY
+}
+
+post_task() {
+  local body="$1"
+  local out="$2"
+  local status_file="$3"
+  local response
+  local http_status
+  local curl_status
+  response="$(mktemp)"
+
+  set +e
+  http_status="$(
+    curl "${post_curl_args[@]}" \
+      -X POST "$SERVER_URL/tasks" \
+      -H "Content-Type: application/json" \
+      --data @"$body" \
+      -o "$response" \
+      -w "%{http_code}"
+  )"
+  curl_status=$?
+  set -e
+
+  cp "$response" "$out"
+  rm -f "$response"
+
+  if [[ "$curl_status" -ne 0 ]]; then
+    printf "000\n" > "$status_file"
+    return "$curl_status"
+  fi
+
+  printf "%s\n" "$http_status" > "$status_file"
+  if [[ ! "$http_status" =~ ^2 ]]; then
+    return 22
+  fi
 }
 
 classify_snapshot() {
@@ -512,6 +614,12 @@ def facts(pr):
 def markdown_cell(value):
     return str(value).replace("|", "\\|")
 
+def compact(value, limit=240):
+    text = str(value).replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit - 3]}..."
+
 def file_rows(files):
     rows = []
     for item in sorted(files, key=lambda f: f.get("path") or ""):
@@ -542,6 +650,15 @@ removed_changed_paths = sorted(set(before["changed_file_paths"]) - set(after["ch
 task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
 workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
 task_id = submission.get("task_id") or task_detail.get("id")
+submission_mode = submission.get("eval_submission_mode") or "unknown"
+submission_http_status = submission.get("http_status") or task_detail.get("http_status")
+submission_error = (
+    submission.get("error")
+    or submission.get("message")
+    or submission.get("detail")
+    or submission.get("raw_response")
+    or task_detail.get("error")
+)
 timed_out = timed_out_arg == "1"
 
 if before["unresolved"] > 0:
@@ -597,6 +714,11 @@ print(f"- Candidate class: `{candidate}`")
 print(f"- Task ID: `{task_id}`")
 print(f"- Workflow ID: `{workflow_id}`")
 print(f"- Task status: `{task_status}`")
+print(f"- Submission mode: `{submission_mode}`")
+if submission_http_status:
+    print(f"- Submission HTTP status: `{submission_http_status}`")
+if submission_error:
+    print(f"- Submission error: `{markdown_cell(compact(submission_error))}`")
 print(f"- Timed out: `{str(timed_out).lower()}`")
 print(f"- Grade: `{grade}`")
 print()
@@ -654,6 +776,7 @@ FINAL_JSON="$OUTPUT_DIR/final_pr.json"
 SUBMISSION_JSON="$OUTPUT_DIR/submission.json"
 TASK_DETAIL_JSON="$OUTPUT_DIR/task_detail_final.json"
 TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
+SUBMISSION_STATUS_TXT="$OUTPUT_DIR/submission.http_status"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
 
 echo "Collecting baseline for $REPO#$PR"
@@ -667,8 +790,10 @@ if [[ "$COLLECT_ONLY" -eq 1 ]]; then
 fi
 
 curl_args=(-fsS --max-time 5)
+post_curl_args=(-sS --max-time 5)
 if [[ -n "${HARNESS_API_TOKEN:-}" ]]; then
   curl_args+=(-H "Authorization: Bearer ${HARNESS_API_TOKEN}")
+  post_curl_args+=(-H "Authorization: Bearer ${HARNESS_API_TOKEN}")
 fi
 
 if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
@@ -710,10 +835,20 @@ print(json.dumps(body, indent=2))
 PY
 
 echo "Submitting Harness PR repair task"
-curl "${curl_args[@]}" \
-  -X POST "$SERVER_URL/tasks" \
-  -H "Content-Type: application/json" \
-  --data @"$TASK_BODY_JSON" > "$SUBMISSION_JSON"
+if ! post_task "$TASK_BODY_JSON" "$SUBMISSION_JSON" "$SUBMISSION_STATUS_TXT"; then
+  submission_http_status="$(cat "$SUBMISSION_STATUS_TXT")"
+  annotate_submission "$SUBMISSION_JSON" "prompt_task" "$submission_http_status"
+  write_submission_failure_detail "$SUBMISSION_JSON" "$submission_http_status" "$TASK_DETAIL_JSON"
+  echo "POST /tasks failed with HTTP $submission_http_status; see $SUBMISSION_JSON" >&2
+  echo "Collecting final PR snapshot"
+  collect_snapshot "$FINAL_JSON"
+  snapshot_summary "$FINAL_JSON"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
+  echo "Evaluation report: $OUTPUT_DIR/summary.md"
+  exit 4
+fi
+submission_http_status="$(cat "$SUBMISSION_STATUS_TXT")"
+annotate_submission "$SUBMISSION_JSON" "prompt_task" "$submission_http_status"
 
 TASK_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
 import json
@@ -729,7 +864,13 @@ print(data.get("task_id") or data.get("submission_id") or "")
 PY
 )"
 if [[ -z "$TASK_ID" ]]; then
+  write_submission_failure_detail "$SUBMISSION_JSON" "$submission_http_status" "$TASK_DETAIL_JSON"
   echo "POST /tasks did not return task_id; see $SUBMISSION_JSON" >&2
+  echo "Collecting final PR snapshot"
+  collect_snapshot "$FINAL_JSON"
+  snapshot_summary "$FINAL_JSON"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
+  echo "Evaluation report: $OUTPUT_DIR/summary.md"
   exit 4
 fi
 

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -377,73 +377,6 @@ print(data.get("status") or data.get("workflow", {}).get("state") or "unknown")
 PY
 }
 
-annotate_submission() {
-  local submission="$1"
-  local mode="$2"
-  local http_status="$3"
-  python3 - "$submission" "$mode" "$http_status" <<'PY'
-import json
-import sys
-
-path, mode, http_status = sys.argv[1:]
-raw = ""
-try:
-    with open(path, "r", encoding="utf-8") as fh:
-        raw = fh.read()
-except OSError:
-    raw = ""
-
-try:
-    data = json.loads(raw) if raw else {}
-except json.JSONDecodeError:
-    data = {"raw_response": raw}
-
-if not isinstance(data, dict):
-    data = {"raw_response": data}
-
-data["eval_submission_mode"] = mode
-data["http_status"] = http_status
-
-with open(path, "w", encoding="utf-8") as fh:
-    json.dump(data, fh, indent=2, sort_keys=True)
-    fh.write("\n")
-PY
-}
-
-write_submission_failure_detail() {
-  local submission="$1"
-  local http_status="$2"
-  local task_detail="$3"
-  python3 - "$submission" "$http_status" "$task_detail" <<'PY'
-import json
-import sys
-
-submission_path, http_status, task_detail_path = sys.argv[1:]
-try:
-    with open(submission_path, "r", encoding="utf-8") as fh:
-        submission = json.load(fh)
-except (OSError, json.JSONDecodeError):
-    submission = {}
-
-error = (
-    submission.get("error")
-    or submission.get("message")
-    or submission.get("detail")
-    or submission.get("raw_response")
-    or "POST /tasks did not return a task"
-)
-
-detail = {
-    "status": "failed",
-    "error": error,
-    "http_status": http_status,
-}
-with open(task_detail_path, "w", encoding="utf-8") as fh:
-    json.dump(detail, fh, indent=2, sort_keys=True)
-    fh.write("\n")
-PY
-}
-
 snapshot_summary() {
   python3 - "$1" <<'PY'
 import json
@@ -470,41 +403,6 @@ from urllib.parse import quote
 
 print(quote(sys.argv[1], safe=""))
 PY
-}
-
-post_task() {
-  local body="$1"
-  local out="$2"
-  local status_file="$3"
-  local response
-  local http_status
-  local curl_status
-  response="$(mktemp)"
-
-  set +e
-  http_status="$(
-    curl "${post_curl_args[@]}" \
-      -X POST "$SERVER_URL/tasks" \
-      -H "Content-Type: application/json" \
-      --data @"$body" \
-      -o "$response" \
-      -w "%{http_code}"
-  )"
-  curl_status=$?
-  set -e
-
-  cp "$response" "$out"
-  rm -f "$response"
-
-  if [[ "$curl_status" -ne 0 ]]; then
-    printf "000\n" > "$status_file"
-    return "$curl_status"
-  fi
-
-  printf "%s\n" "$http_status" > "$status_file"
-  if [[ ! "$http_status" =~ ^2 ]]; then
-    return 22
-  fi
 }
 
 classify_snapshot() {
@@ -776,7 +674,6 @@ FINAL_JSON="$OUTPUT_DIR/final_pr.json"
 SUBMISSION_JSON="$OUTPUT_DIR/submission.json"
 TASK_DETAIL_JSON="$OUTPUT_DIR/task_detail_final.json"
 TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
-SUBMISSION_STATUS_TXT="$OUTPUT_DIR/submission.http_status"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
 
 echo "Collecting baseline for $REPO#$PR"
@@ -790,10 +687,8 @@ if [[ "$COLLECT_ONLY" -eq 1 ]]; then
 fi
 
 curl_args=(-fsS --max-time 5)
-post_curl_args=(-sS --max-time 5)
 if [[ -n "${HARNESS_API_TOKEN:-}" ]]; then
   curl_args+=(-H "Authorization: Bearer ${HARNESS_API_TOKEN}")
-  post_curl_args+=(-H "Authorization: Bearer ${HARNESS_API_TOKEN}")
 fi
 
 if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
@@ -835,11 +730,9 @@ print(json.dumps(body, indent=2))
 PY
 
 echo "Submitting Harness PR repair task"
-if ! post_task "$TASK_BODY_JSON" "$SUBMISSION_JSON" "$SUBMISSION_STATUS_TXT"; then
-  submission_http_status="$(cat "$SUBMISSION_STATUS_TXT")"
-  annotate_submission "$SUBMISSION_JSON" "prompt_task" "$submission_http_status"
-  write_submission_failure_detail "$SUBMISSION_JSON" "$submission_http_status" "$TASK_DETAIL_JSON"
-  echo "POST /tasks failed with HTTP $submission_http_status; see $SUBMISSION_JSON" >&2
+if ! python3 "$(dirname "$0")/evaluate_pr_repair_submit.py" --server-url "$SERVER_URL" --body "$TASK_BODY_JSON" --output "$SUBMISSION_JSON" --mode prompt_task; then
+  printf '{"status":"failed"}\n' > "$TASK_DETAIL_JSON"
+  echo "POST /tasks failed; see $SUBMISSION_JSON" >&2
   echo "Collecting final PR snapshot"
   collect_snapshot "$FINAL_JSON"
   snapshot_summary "$FINAL_JSON"
@@ -847,8 +740,6 @@ if ! post_task "$TASK_BODY_JSON" "$SUBMISSION_JSON" "$SUBMISSION_STATUS_TXT"; th
   echo "Evaluation report: $OUTPUT_DIR/summary.md"
   exit 4
 fi
-submission_http_status="$(cat "$SUBMISSION_STATUS_TXT")"
-annotate_submission "$SUBMISSION_JSON" "prompt_task" "$submission_http_status"
 
 TASK_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
 import json
@@ -864,7 +755,7 @@ print(data.get("task_id") or data.get("submission_id") or "")
 PY
 )"
 if [[ -z "$TASK_ID" ]]; then
-  write_submission_failure_detail "$SUBMISSION_JSON" "$submission_http_status" "$TASK_DETAIL_JSON"
+  printf '{"status":"failed"}\n' > "$TASK_DETAIL_JSON"
   echo "POST /tasks did not return task_id; see $SUBMISSION_JSON" >&2
   echo "Collecting final PR snapshot"
   collect_snapshot "$FINAL_JSON"

--- a/scripts/evaluate_pr_repair_submit.py
+++ b/scripts/evaluate_pr_repair_submit.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Submit a PR repair eval task and preserve non-2xx response bodies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def load_response(raw: str) -> dict[str, object]:
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {"raw_response": raw}
+    if isinstance(data, dict):
+        return data
+    return {"raw_response": data}
+
+
+def write_json(path: str, data: dict[str, object]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server-url", required=True)
+    parser.add_argument("--body", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--mode", required=True)
+    args = parser.parse_args()
+
+    with open(args.body, "rb") as fh:
+        body = fh.read()
+
+    request = urllib.request.Request(
+        f"{args.server_url.rstrip('/')}/tasks",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    token = os.environ.get("HARNESS_API_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        status = exc.code
+    except urllib.error.URLError as exc:
+        data = {
+            "error": str(exc.reason),
+            "eval_submission_mode": args.mode,
+            "http_status": "000",
+            "status": "failed",
+        }
+        write_json(args.output, data)
+        return 7
+
+    data = load_response(raw)
+    data["eval_submission_mode"] = args.mode
+    data["http_status"] = str(status)
+    if status < 200 or status >= 300:
+        data.setdefault("status", "failed")
+    write_json(args.output, data)
+    return 0 if 200 <= status < 300 else 22
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/evaluate_pr_repair_submit.py
+++ b/scripts/evaluate_pr_repair_submit.py
@@ -27,6 +27,16 @@ def write_json(path: str, data: dict[str, object]) -> None:
         fh.write("\n")
 
 
+def write_failed_submission(path: str, mode: str, error: object) -> None:
+    data = {
+        "error": str(error),
+        "eval_submission_mode": mode,
+        "http_status": "000",
+        "status": "failed",
+    }
+    write_json(path, data)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--server-url", required=True)
@@ -55,14 +65,8 @@ def main() -> int:
     except urllib.error.HTTPError as exc:
         raw = exc.read().decode("utf-8", errors="replace")
         status = exc.code
-    except urllib.error.URLError as exc:
-        data = {
-            "error": str(exc.reason),
-            "eval_submission_mode": args.mode,
-            "http_status": "000",
-            "status": "failed",
-        }
-        write_json(args.output, data)
+    except (urllib.error.URLError, OSError) as exc:
+        write_failed_submission(args.output, args.mode, getattr(exc, "reason", exc))
         return 7
 
     data = load_response(raw)

--- a/scripts/test_evaluate_pr_repair_submit.py
+++ b/scripts/test_evaluate_pr_repair_submit.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Tests for the PR repair task submission helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("evaluate_pr_repair_submit.py")
+SPEC = importlib.util.spec_from_file_location("evaluate_pr_repair_submit", SCRIPT_PATH)
+assert SPEC is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class SubmitHelperTests(unittest.TestCase):
+    def test_network_errors_write_failed_submission_artifact(self) -> None:
+        cases = [
+            (TimeoutError("timed out"), "timed out"),
+            (OSError("socket closed"), "socket closed"),
+        ]
+        for exc, expected_error in cases:
+            with self.subTest(error=expected_error):
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = Path(tmp)
+                    body_path = tmp_path / "body.json"
+                    output_path = tmp_path / "submission.json"
+                    body_path.write_text('{"prompt":"fix it"}\n', encoding="utf-8")
+
+                    argv = [
+                        "evaluate_pr_repair_submit.py",
+                        "--server-url",
+                        "http://127.0.0.1:1",
+                        "--body",
+                        str(body_path),
+                        "--output",
+                        str(output_path),
+                        "--mode",
+                        "prompt_task",
+                    ]
+                    with mock.patch.object(sys, "argv", argv):
+                        with mock.patch.object(
+                            MODULE.urllib.request,
+                            "urlopen",
+                            side_effect=exc,
+                        ):
+                            status = MODULE.main()
+
+                    self.assertEqual(status, 7)
+                    self.assertEqual(
+                        json.loads(output_path.read_text(encoding="utf-8")),
+                        {
+                            "error": expected_error,
+                            "eval_submission_mode": "prompt_task",
+                            "http_status": "000",
+                            "status": "failed",
+                        },
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve non-2xx `POST /tasks` response bodies for PR repair eval submissions
- annotate `submission.json` with eval submission mode and HTTP status
- write `task_detail_final.json` and `summary.md` even when task submission fails before returning a task id

Closes #1246.

## Validation

- `bash -n scripts/evaluate_pr_repair.sh`
- mock eval submission failure scenario: verified HTTP 400 response body, task detail, and summary artifacts
- mock eval submission success scenario: verified HTTP 202 task submission metadata and summary artifacts
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p harness-eval`
- `cargo check --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

## Not run

- `cargo test --workspace` was started and then cancelled because the full workspace test run is too expensive for this script-only change; CI should cover the remaining integration surface.