### PR TITLE
fix(runtime): refresh PR feedback prompt checks

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -101,7 +101,7 @@ PR feedback flow:
 4. Treat actionable remote feedback as blocking until it is fixed or explicitly answered with a justified response.
 5. Re-run validation after feedback-driven changes, then return to local review before remote feedback.
 6. Before the final response, refresh the PR state from GitHub again, including review threads, review states, checks, mergeability, and the current head commit.
-7. If any actionable review thread, requested change, failed check, or mergeability blocker remains, report the activity as blocked or needing another feedback round instead of done.
+7. If any actionable review thread, requested change, failed check, or mergeability blocker remains, report the activity status as blocked instead of succeeded.
 
 Final response:
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -100,6 +100,8 @@ PR feedback flow:
 3. Only after local review passes, inspect top-level PR comments, inline review comments, review states, checks, and mergeability.
 4. Treat actionable remote feedback as blocking until it is fixed or explicitly answered with a justified response.
 5. Re-run validation after feedback-driven changes, then return to local review before remote feedback.
+6. Before the final response, refresh the PR state from GitHub again, including review threads, review states, checks, mergeability, and the current head commit.
+7. If any actionable review thread, requested change, failed check, or mergeability blocker remains, report the activity as blocked or needing another feedback round instead of done.
 
 Final response:
 

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -99,6 +99,8 @@ PR feedback flow:
 1. Inspect top-level PR comments, inline review comments, review states, checks, and mergeability.
 2. Treat actionable feedback as blocking until it is fixed or explicitly answered with a justified response.
 3. Re-run validation after feedback-driven changes.
+4. Before the final response, refresh the PR state from GitHub again, including review threads, review states, checks, mergeability, and the current head commit.
+5. If any actionable review thread, requested change, failed check, or mergeability blocker remains, report the activity status as blocked instead of succeeded.
 
 Final response:
 

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -499,7 +499,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["direct workflow state changes"],
         }),
         ("github_issue_pr", "address_pr_feedback") => json!({
-            "must_include": ["review feedback addressed", "changed files", "validation commands"],
+            "must_include": ["review feedback addressed", "changed files", "validation commands", "fresh PR state checked before final response"],
             "must_not_include": ["claiming review approval without a fresh review signal"],
         }),
         ("github_issue_pr", harness_workflow::runtime::LOCAL_REVIEW_ACTIVITY) => json!({

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -44,6 +44,37 @@ fn activity_result_schema_describes_issue_implementation_terminal_evidence_contr
 }
 
 #[test]
+fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "address_pr_feedback"
+        }),
+    );
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "addressing_feedback",
+        WorkflowSubject::new("issue", "issue:123"),
+    )
+    .with_id("issue-123");
+
+    let schema = activity_result_schema(&job, Some(&workflow));
+
+    assert_eq!(
+        schema["transition_contract"]["on_succeeded"]["reducer_next_state"],
+        "local_review_gate"
+    );
+    assert!(schema["agent_summary_contract"]["must_include"]
+        .as_array()
+        .is_some_and(
+            |items| items.contains(&json!("fresh PR state checked before final response"))
+        ));
+}
+
+#[test]
 fn activity_result_schema_describes_quality_gate_contract() {
     let job = RuntimeJob::pending(
         "command-1",


### PR DESCRIPTION
Closes #1248.

## Summary

- Update the repository workflow prompt so PR feedback repair jobs refresh GitHub PR state before the final response.
- Require agents to report blocked or needing another feedback round when actionable review threads, requested changes, failed checks, or mergeability blockers remain.
- Add a focused prompt packet test that keeps the address_pr_feedback summary contract aligned with the final-state prompt.

## Validation

- cargo fmt --all -- --check
- cargo test -p harness-server activity_result_schema_reminds_pr_feedback_to_recheck_pr_state
- cargo test -p harness-server prompt_packet
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets