### PR TITLE
fix(runtime): require PR repair evidence snapshots

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -1,10 +1,10 @@
 use harness_workflow::runtime::{
     GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL,
     ISSUE_STATE_ARTIFACT, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
-    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
-    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, PR_REPAIR_SNAPSHOT_ARTIFACT,
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID,
+    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -136,7 +136,8 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "address_pr_feedback") => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_artifacts(vec!["workflow_decision"])
+                .with_accepted_artifacts(vec!["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT])
+                .requires("pr_repair_snapshot_with_action_and_validation")
         }
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)
@@ -177,6 +178,7 @@ fn pr_feedback_contract(workflow_definition: &str, activity: &str) -> ActivityCo
             "ChangesRequested",
             "ChecksFailed",
         ])
+        .with_accepted_artifacts(vec!["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT])
         .with_explicit_noop_signals(vec!["NoFeedbackFound"])
         .requires("at_least_one_feedback_outcome_signal")
 }

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -134,16 +134,17 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
             ActivityContract::new(workflow_definition, activity)
                 .with_accepted_artifacts(vec!["workflow_decision"])
         }
-        (GITHUB_ISSUE_PR_DEFINITION_ID, "address_pr_feedback") => {
-            ActivityContract::new(workflow_definition, activity)
-                .with_accepted_signals(vec![ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL])
-                .with_accepted_artifacts(vec![
-                    "workflow_decision",
-                    PR_REPAIR_SNAPSHOT_ARTIFACT,
-                    ISSUE_STATE_ARTIFACT,
-                ])
-                .requires("pr_repair_snapshot_with_action_and_validation_or_closed_issue_evidence")
-        }
+        (GITHUB_ISSUE_PR_DEFINITION_ID, "address_pr_feedback") => ActivityContract::new(
+            workflow_definition,
+            activity,
+        )
+        .with_accepted_signals(vec![ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL])
+        .with_accepted_artifacts(vec![
+            "workflow_decision",
+            PR_REPAIR_SNAPSHOT_ARTIFACT,
+            ISSUE_STATE_ARTIFACT,
+        ])
+        .requires("pr_repair_snapshot_with_action_and_passing_validation_or_closed_issue_evidence"),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)
                 .with_accepted_artifacts(vec!["validation_report"])

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -136,8 +136,13 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "address_pr_feedback") => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_artifacts(vec!["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT])
-                .requires("pr_repair_snapshot_with_action_and_validation")
+                .with_accepted_signals(vec![ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL])
+                .with_accepted_artifacts(vec![
+                    "workflow_decision",
+                    PR_REPAIR_SNAPSHOT_ARTIFACT,
+                    ISSUE_STATE_ARTIFACT,
+                ])
+                .requires("pr_repair_snapshot_with_action_and_validation_or_closed_issue_evidence")
         }
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -316,7 +316,7 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         ("github_issue_pr", "address_pr_feedback") => json!({
             "on_succeeded": {
                 "reducer_next_state": "local_review_gate",
-                "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and validation evidence, unless IssueClosed/IssueAlreadyResolved or issue_state proves the issue or PR is already closed/resolved.",
+                "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and passing validation evidence, unless IssueClosed/IssueAlreadyResolved or issue_state proves the issue or PR is already closed/resolved.",
                 "required_summary": "Describe addressed review feedback, pushed/no-code action, validation evidence, or closed issue evidence. Harness will run local review before remote feedback unless terminal closed evidence finishes the workflow."
             },
             "on_failed": {
@@ -511,7 +511,10 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 "pr_repair_snapshot": {
                     "required_when": "Feedback repair was performed, review-thread action was taken, or a no-code-change repair conclusion is returned.",
                     "required_unless": "IssueClosed/IssueAlreadyResolved signal or issue_state artifact proves the issue or PR is already closed/resolved.",
-                    "fields": ["pr_number", "pr_url", "head_sha", "head_oid", "observed_at", "changed_files", "action_taken", "no_code_change_reason", "validation_commands"]
+                    "fields": ["pr_number", "pr_url", "head_sha", "head_oid", "observed_at", "changed_files", "action_taken", "no_code_change_reason", "validation_commands"],
+                    "field_contract": {
+                        "validation_commands": "Array of validation records with command and a successful status such as passed, success, succeeded, or ok. Failed, blocked, or not_run records do not satisfy successful repair evidence."
+                    }
                 },
                 "issue_state": {
                     "required_when": "No repair is needed because the issue or PR is already closed/resolved.",

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -3,8 +3,9 @@ use harness_workflow::runtime::{
     ActivityArtifact, DecisionValidator, RuntimeJob, RuntimeProfile, WorkflowInstance,
     ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT,
     PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
+    PR_FEEDBACK_INSPECT_ACTIVITY, PR_REPAIR_SNAPSHOT_ARTIFACT, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -315,7 +316,8 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         ("github_issue_pr", "address_pr_feedback") => json!({
             "on_succeeded": {
                 "reducer_next_state": "local_review_gate",
-                "required_summary": "Describe addressed review feedback and validation evidence. Harness will run local review before remote feedback."
+                "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and validation evidence.",
+                "required_summary": "Describe addressed review feedback, pushed/no-code action, and validation evidence. Harness will run local review before remote feedback."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -342,7 +344,9 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "derived_from_structured_decision_or_signals",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
-                "required_summary": "Describe inspected PR feedback, review state, checks, and mergeability."
+                "accepted_artifacts": ["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT],
+                "success_requires": "PrReadyToMerge or mark_ready_to_merge requires pr_repair_snapshot with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads.",
+                "required_summary": "Describe inspected PR feedback, review state, checks, mergeability, draft state, unresolved review threads, and next action."
             },
             "structured_decision": {
                 "preferred": true,
@@ -357,6 +361,8 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "feedback_found_or_no_actionable_feedback_or_ready_to_merge_from_signals",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
+                "accepted_artifacts": ["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT],
+                "success_requires": "PrReadyToMerge requires pr_repair_snapshot with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads.",
                 "parent_propagation": "The same activity result is propagated to the parent github_issue_pr workflow."
             },
             "structured_decision": {
@@ -499,8 +505,14 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["direct workflow state changes"],
         }),
         ("github_issue_pr", "address_pr_feedback") => json!({
-            "must_include": ["review feedback addressed", "changed files", "validation commands", "fresh PR state checked before final response"],
-            "must_not_include": ["claiming review approval without a fresh review signal"],
+            "must_include": ["review feedback addressed or explicit no-code reason", "changed files or explicit no-code-change reason", "validation commands", "fresh PR state checked before final response", "final PR head"],
+            "must_not_include": ["claiming review approval without a fresh review signal", "marking review threads resolved without current GitHub evidence"],
+            "artifacts": {
+                "pr_repair_snapshot": {
+                    "required": true,
+                    "fields": ["pr_number", "pr_url", "head_sha_or_head_oid", "observed_at", "changed_files", "action_taken_or_no_code_change_reason", "validation_commands"]
+                }
+            }
         }),
         ("github_issue_pr", harness_workflow::runtime::LOCAL_REVIEW_ACTIVITY) => json!({
             "must_include": ["PR diff reviewed", "blocking findings or explicit approval", "validation evidence checked", "next workflow action"],
@@ -520,12 +532,16 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 "workflow_decision": {
                     "preferred": true,
                     "allowed_decisions": ["address_pr_feedback", "wait_for_pr_feedback", "mark_ready_to_merge"]
+                },
+                "pr_repair_snapshot": {
+                    "required_when": "Using PrReadyToMerge or mark_ready_to_merge.",
+                    "fields": ["pr_number", "pr_url", "head_sha_or_head_oid", "observed_at", "active_unresolved_review_threads_count", "status_check_rollup_state", "merge_state_status", "review_decision", "is_draft"]
                 }
             },
             "signals": {
                 "FeedbackFound": "Use when actionable feedback, requested changes, or failed checks require a fix round.",
                 "NoFeedbackFound": "Use when no actionable feedback is present yet.",
-                "PrReadyToMerge": "Use only when review, checks, and mergeability are all ready."
+                "PrReadyToMerge": "Use only with pr_repair_snapshot proving APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads for the final head."
             }
         }),
         ("repo_backlog", "poll_repo_backlog") => json!({

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -362,12 +362,12 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
                 "reducer_next_state": "feedback_found_or_no_actionable_feedback_or_ready_to_merge_from_signals",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
                 "accepted_artifacts": ["workflow_decision", PR_REPAIR_SNAPSHOT_ARTIFACT],
-                "success_requires": "PrReadyToMerge requires pr_repair_snapshot with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads.",
+                "success_requires": "PrReadyToMerge or any workflow_decision with next_state=ready_to_merge requires pr_repair_snapshot with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads.",
                 "parent_propagation": "The same activity result is propagated to the parent github_issue_pr workflow."
             },
             "structured_decision": {
                 "optional": true,
-                "description": "A workflow_decision artifact may update the pr_feedback child workflow, but signals are sufficient."
+                "description": "A workflow_decision artifact may update the pr_feedback child workflow, but ready_to_merge workflow_decisions still require the same pr_repair_snapshot evidence as PrReadyToMerge signals."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -316,8 +316,8 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         ("github_issue_pr", "address_pr_feedback") => json!({
             "on_succeeded": {
                 "reducer_next_state": "local_review_gate",
-                "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and validation evidence.",
-                "required_summary": "Describe addressed review feedback, pushed/no-code action, and validation evidence. Harness will run local review before remote feedback."
+                "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and validation evidence, unless IssueClosed/IssueAlreadyResolved or issue_state proves the issue or PR is already closed/resolved.",
+                "required_summary": "Describe addressed review feedback, pushed/no-code action, validation evidence, or closed issue evidence. Harness will run local review before remote feedback unless terminal closed evidence finishes the workflow."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -505,13 +505,22 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["direct workflow state changes"],
         }),
         ("github_issue_pr", "address_pr_feedback") => json!({
-            "must_include": ["review feedback addressed or explicit no-code reason", "changed files or explicit no-code-change reason", "validation commands", "fresh PR state checked before final response", "final PR head"],
+            "must_include": ["review feedback addressed or explicit no-code reason", "changed files or explicit no-code-change reason", "validation commands or closed issue evidence", "fresh PR state checked before final response", "final PR head or closed issue evidence"],
             "must_not_include": ["claiming review approval without a fresh review signal", "marking review threads resolved without current GitHub evidence"],
             "artifacts": {
                 "pr_repair_snapshot": {
-                    "required": true,
+                    "required_when": "Feedback repair was performed, review-thread action was taken, or a no-code-change repair conclusion is returned.",
+                    "required_unless": "IssueClosed/IssueAlreadyResolved signal or issue_state artifact proves the issue or PR is already closed/resolved.",
                     "fields": ["pr_number", "pr_url", "head_sha", "head_oid", "observed_at", "changed_files", "action_taken", "no_code_change_reason", "validation_commands"]
+                },
+                "issue_state": {
+                    "required_when": "No repair is needed because the issue or PR is already closed/resolved.",
+                    "fields": ["issue_number", "state", "issue_url"]
                 }
+            },
+            "signals": {
+                "IssueClosed": "Use when the issue or PR is confirmed closed and no feedback repair is needed. Include state=closed or state=resolved plus issue_number or issue_url.",
+                "IssueAlreadyResolved": "Use when the feedback task is already resolved before repair. Include state=closed or state=resolved plus issue_number or issue_url."
             }
         }),
         ("github_issue_pr", harness_workflow::runtime::LOCAL_REVIEW_ACTIVITY) => json!({

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -510,7 +510,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "artifacts": {
                 "pr_repair_snapshot": {
                     "required": true,
-                    "fields": ["pr_number", "pr_url", "head_sha_or_head_oid", "observed_at", "changed_files", "action_taken_or_no_code_change_reason", "validation_commands"]
+                    "fields": ["pr_number", "pr_url", "head_sha", "head_oid", "observed_at", "changed_files", "action_taken", "no_code_change_reason", "validation_commands"]
                 }
             }
         }),
@@ -535,7 +535,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                 },
                 "pr_repair_snapshot": {
                     "required_when": "Using PrReadyToMerge or mark_ready_to_merge.",
-                    "fields": ["pr_number", "pr_url", "head_sha_or_head_oid", "observed_at", "active_unresolved_review_threads_count", "status_check_rollup_state", "merge_state_status", "review_decision", "is_draft"]
+                    "fields": ["pr_number", "pr_url", "head_sha", "head_oid", "observed_at", "active_unresolved_review_threads_count", "status_check_rollup_state", "merge_state_status", "review_decision", "is_draft"]
                 }
             },
             "signals": {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -74,8 +74,21 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
         PR_REPAIR_SNAPSHOT_ARTIFACT
     );
     assert_eq!(
+        schema["activity_contract"]["accepted_artifacts"][2],
+        ISSUE_STATE_ARTIFACT
+    );
+    assert_eq!(
+        schema["activity_contract"]["accepted_signals"][0],
+        ISSUE_CLOSED_SIGNAL
+    );
+    assert_eq!(
         schema["activity_contract"]["success_requires"],
-        "pr_repair_snapshot_with_action_and_validation"
+        "pr_repair_snapshot_with_action_and_validation_or_closed_issue_evidence"
+    );
+    assert!(
+        schema["transition_contract"]["on_succeeded"]["success_requires"]
+            .as_str()
+            .is_some_and(|value| value.contains("IssueClosed"))
     );
     assert!(schema["agent_summary_contract"]["must_include"]
         .as_array()
@@ -83,8 +96,16 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
             |items| items.contains(&json!("fresh PR state checked before final response"))
         ));
     assert_eq!(
-        schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required"],
-        true
+        schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required_unless"],
+        "IssueClosed/IssueAlreadyResolved signal or issue_state artifact proves the issue or PR is already closed/resolved."
+    );
+    assert_eq!(
+        schema["agent_summary_contract"]["artifacts"]["issue_state"]["required_when"],
+        "No repair is needed because the issue or PR is already closed/resolved."
+    );
+    assert_eq!(
+        schema["agent_summary_contract"]["signals"]["IssueClosed"],
+        "Use when the issue or PR is confirmed closed and no feedback repair is needed. Include state=closed or state=resolved plus issue_number or issue_url."
     );
     let snapshot_fields = schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]
         ["fields"]

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use harness_workflow::runtime::{RuntimeKind, WorkflowSubject, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY};
+use harness_workflow::runtime::{
+    RuntimeKind, WorkflowSubject, PR_REPAIR_SNAPSHOT_ARTIFACT, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+};
 
 #[test]
 fn activity_result_schema_describes_issue_implementation_terminal_evidence_contract() {
@@ -67,11 +69,23 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
         schema["transition_contract"]["on_succeeded"]["reducer_next_state"],
         "local_review_gate"
     );
+    assert_eq!(
+        schema["activity_contract"]["accepted_artifacts"][1],
+        PR_REPAIR_SNAPSHOT_ARTIFACT
+    );
+    assert_eq!(
+        schema["activity_contract"]["success_requires"],
+        "pr_repair_snapshot_with_action_and_validation"
+    );
     assert!(schema["agent_summary_contract"]["must_include"]
         .as_array()
         .is_some_and(
             |items| items.contains(&json!("fresh PR state checked before final response"))
         ));
+    assert_eq!(
+        schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required"],
+        true
+    );
 }
 
 #[test]
@@ -275,7 +289,11 @@ fn activity_result_schema_describes_pr_feedback_child_contract() {
     );
     assert_eq!(
         schema["agent_summary_contract"]["signals"]["PrReadyToMerge"],
-        "Use only when review, checks, and mergeability are all ready."
+        "Use only with pr_repair_snapshot proving APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, and zero active unresolved review threads for the final head."
+    );
+    assert_eq!(
+        schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required_when"],
+        "Using PrReadyToMerge or mark_ready_to_merge."
     );
     assert!(schema["workflow_decision_contract"]["allowed_transitions"]
         .as_array()

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -320,6 +320,16 @@ fn activity_result_schema_describes_pr_feedback_child_contract() {
         schema["transition_contract"]["on_succeeded"]["parent_propagation"],
         "The same activity result is propagated to the parent github_issue_pr workflow."
     );
+    assert!(
+        schema["transition_contract"]["on_succeeded"]["success_requires"]
+            .as_str()
+            .is_some_and(|value| value.contains("next_state=ready_to_merge"))
+    );
+    assert!(
+        schema["transition_contract"]["structured_decision"]["description"]
+            .as_str()
+            .is_some_and(|value| value.contains("same pr_repair_snapshot evidence"))
+    );
     assert_eq!(
         schema["activity_contract"]["child_outcome_contract"],
         "pr_feedback_outcome"

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -86,6 +86,16 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
         schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required"],
         true
     );
+    let snapshot_fields = schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]
+        ["fields"]
+        .as_array()
+        .expect("pr_repair_snapshot fields should be an array");
+    assert!(snapshot_fields.contains(&json!("head_sha")));
+    assert!(snapshot_fields.contains(&json!("head_oid")));
+    assert!(snapshot_fields.contains(&json!("action_taken")));
+    assert!(snapshot_fields.contains(&json!("no_code_change_reason")));
+    assert!(!snapshot_fields.contains(&json!("head_sha_or_head_oid")));
+    assert!(!snapshot_fields.contains(&json!("action_taken_or_no_code_change_reason")));
 }
 
 #[test]
@@ -295,6 +305,13 @@ fn activity_result_schema_describes_pr_feedback_child_contract() {
         schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required_when"],
         "Using PrReadyToMerge or mark_ready_to_merge."
     );
+    let snapshot_fields = schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]
+        ["fields"]
+        .as_array()
+        .expect("pr_repair_snapshot fields should be an array");
+    assert!(snapshot_fields.contains(&json!("head_sha")));
+    assert!(snapshot_fields.contains(&json!("head_oid")));
+    assert!(!snapshot_fields.contains(&json!("head_sha_or_head_oid")));
     assert!(schema["workflow_decision_contract"]["allowed_transitions"]
         .as_array()
         .expect("allowed transitions should be an array")

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -83,7 +83,7 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
     );
     assert_eq!(
         schema["activity_contract"]["success_requires"],
-        "pr_repair_snapshot_with_action_and_validation_or_closed_issue_evidence"
+        "pr_repair_snapshot_with_action_and_passing_validation_or_closed_issue_evidence"
     );
     assert!(
         schema["transition_contract"]["on_succeeded"]["success_requires"]
@@ -117,6 +117,12 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
     assert!(snapshot_fields.contains(&json!("no_code_change_reason")));
     assert!(!snapshot_fields.contains(&json!("head_sha_or_head_oid")));
     assert!(!snapshot_fields.contains(&json!("action_taken_or_no_code_change_reason")));
+    assert!(
+        schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["field_contract"]
+            ["validation_commands"]
+            .as_str()
+            .is_some_and(|value| value.contains("successful status"))
+    );
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -46,7 +46,7 @@ pub use pr_feedback::{
     PrFeedbackInspectDecisionInput, PrFeedbackOutcome, PrFeedbackSweepDecisionInput,
     PrFeedbackWorkflowAction, LOCAL_REVIEW_ACTIVITY, LOCAL_REVIEW_BLOCKED_SIGNAL,
     LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY,
+    PR_FEEDBACK_INSPECT_ACTIVITY, PR_REPAIR_SNAPSHOT_ARTIFACT,
 };
 pub use prompt_task::{
     build_prompt_submission_decision, PromptSubmissionDecisionInput,

--- a/crates/harness-workflow/src/runtime/pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/pr_feedback.rs
@@ -4,6 +4,7 @@ use super::model::{
 
 pub const PR_FEEDBACK_DEFINITION_ID: &str = "pr_feedback";
 pub const PR_FEEDBACK_INSPECT_ACTIVITY: &str = "inspect_pr_feedback";
+pub const PR_REPAIR_SNAPSHOT_ARTIFACT: &str = "pr_repair_snapshot";
 pub const LOCAL_REVIEW_ACTIVITY: &str = "run_local_review";
 pub const LOCAL_REVIEW_PASSED_SIGNAL: &str = "LocalReviewPassed";
 pub const LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL: &str = "LocalReviewChangesRequested";

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -98,12 +98,15 @@ fn reduce_success(
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
     let structured_decision = workflow_decision_from_activity_result(event, result);
-    if let Some(reason) =
-        pr_feedback_success_contract_error(instance, result, structured_decision.as_ref())
-    {
-        return Some(invalid_agent_output_blocked_decision(
-            instance, event, result, &reason,
-        ));
+    let has_closed_issue_evidence = closed_issue_evidence_from_activity_result(result).is_some();
+    if !has_closed_issue_evidence {
+        if let Some(reason) =
+            pr_feedback_success_contract_error(instance, result, structured_decision.as_ref())
+        {
+            return Some(invalid_agent_output_blocked_decision(
+                instance, event, result, &reason,
+            ));
+        }
     }
     let pr_feedback_blocker_overrides_structured_ready =
         pr_feedback_blocking_signal_overrides_structured_ready(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -13,7 +13,7 @@ use self::github_issue_completion::{
 };
 use self::pr_feedback_completion::{
     local_review_decision_from_activity_result, pr_feedback_child_decision_from_activity_result,
-    pr_feedback_sweep_decision_from_activity_result,
+    pr_feedback_success_contract_error, pr_feedback_sweep_decision_from_activity_result,
 };
 use self::quality_gate_completion::{
     quality_gate_activity_matches, quality_gate_success_contract_error,
@@ -96,6 +96,13 @@ fn reduce_success(
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
     let structured_decision = workflow_decision_from_activity_result(event, result);
+    if let Some(reason) =
+        pr_feedback_success_contract_error(instance, result, structured_decision.as_ref())
+    {
+        return Some(invalid_agent_output_blocked_decision(
+            instance, event, result, &reason,
+        ));
+    }
     if let Some(decision) = structured_decision
         .as_ref()
         .filter(|decision| structured_decision_validates(instance, event, result, decision))

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -12,8 +12,10 @@ use self::github_issue_completion::{
     github_issue_closed_decision, issue_implementation_missing_result_decision,
 };
 use self::pr_feedback_completion::{
-    local_review_decision_from_activity_result, pr_feedback_child_decision_from_activity_result,
-    pr_feedback_success_contract_error, pr_feedback_sweep_decision_from_activity_result,
+    local_review_decision_from_activity_result,
+    pr_feedback_blocking_signal_overrides_structured_ready,
+    pr_feedback_child_decision_from_activity_result, pr_feedback_success_contract_error,
+    pr_feedback_sweep_decision_from_activity_result,
 };
 use self::quality_gate_completion::{
     quality_gate_activity_matches, quality_gate_success_contract_error,
@@ -103,8 +105,15 @@ fn reduce_success(
             instance, event, result, &reason,
         ));
     }
+    let pr_feedback_blocker_overrides_structured_ready =
+        pr_feedback_blocking_signal_overrides_structured_ready(
+            instance,
+            result,
+            structured_decision.as_ref(),
+        );
     if let Some(decision) = structured_decision
         .as_ref()
+        .filter(|_| !pr_feedback_blocker_overrides_structured_ready)
         .filter(|decision| structured_decision_validates(instance, event, result, decision))
         .cloned()
     {

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -98,15 +98,15 @@ fn reduce_success(
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
     let structured_decision = workflow_decision_from_activity_result(event, result);
-    let has_closed_issue_evidence = closed_issue_evidence_from_activity_result(result).is_some();
-    if !has_closed_issue_evidence {
-        if let Some(reason) =
-            pr_feedback_success_contract_error(instance, result, structured_decision.as_ref())
-        {
-            return Some(invalid_agent_output_blocked_decision(
-                instance, event, result, &reason,
-            ));
-        }
+    if let Some(decision) = github_issue_closed_decision(instance, event, result) {
+        return Some(decision);
+    }
+    if let Some(reason) =
+        pr_feedback_success_contract_error(instance, result, structured_decision.as_ref())
+    {
+        return Some(invalid_agent_output_blocked_decision(
+            instance, event, result, &reason,
+        ));
     }
     let pr_feedback_blocker_overrides_structured_ready =
         pr_feedback_blocking_signal_overrides_structured_ready(
@@ -157,10 +157,6 @@ fn reduce_success(
     }
 
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
-        return Some(decision);
-    }
-
-    if let Some(decision) = github_issue_closed_decision(instance, event, result) {
         return Some(decision);
     }
 

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -327,7 +327,16 @@ fn expected_pr_number(instance: &WorkflowInstance, result: &ActivityResult) -> O
         .data
         .get("pr_number")
         .and_then(json_value_u64)
+        .or_else(|| pr_number_from_subject(instance))
         .or_else(|| result_signal_u64(result, "pr_number"))
+}
+
+fn pr_number_from_subject(instance: &WorkflowInstance) -> Option<u64> {
+    instance
+        .subject
+        .subject_key
+        .strip_prefix("pr:")
+        .and_then(|value| value.parse::<u64>().ok())
 }
 
 fn expected_pr_url(instance: &WorkflowInstance, result: &ActivityResult) -> Option<String> {

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -76,9 +76,10 @@ pub(super) fn pr_feedback_success_contract_error(
         );
     }
 
-    if readiness_claimed(result, structured_decision)
-        && pr_feedback_outcome_from_signals(result) != Some(PrFeedbackOutcome::BlockingFeedback)
-    {
+    if readiness_claimed(result, structured_decision) {
+        if pr_feedback_outcome_from_signals(result) == Some(PrFeedbackOutcome::BlockingFeedback) {
+            return None;
+        }
         if ready_snapshot_proves_pr_ready(result) {
             return None;
         }
@@ -88,6 +89,16 @@ pub(super) fn pr_feedback_success_contract_error(
     }
 
     None
+}
+
+pub(super) fn pr_feedback_blocking_signal_overrides_structured_ready(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+    structured_decision: Option<&WorkflowDecision>,
+) -> bool {
+    github_issue_pr_feedback_activity_matches(instance, result)
+        && pr_feedback_outcome_from_signals(result) == Some(PrFeedbackOutcome::BlockingFeedback)
+        && structured_decision.is_some_and(structured_ready_decision)
 }
 
 pub(super) fn local_review_decision_from_activity_result(
@@ -254,9 +265,11 @@ fn readiness_claimed(
     structured_decision: Option<&WorkflowDecision>,
 ) -> bool {
     has_signal(result, "PrReadyToMerge")
-        || structured_decision.is_some_and(|decision| {
-            decision.next_state == "ready_to_merge" || decision.decision == "mark_ready_to_merge"
-        })
+        || structured_decision.is_some_and(structured_ready_decision)
+}
+
+fn structured_ready_decision(decision: &WorkflowDecision) -> bool {
+    decision.next_state == "ready_to_merge" || decision.decision == "mark_ready_to_merge"
 }
 
 fn ready_snapshot_proves_pr_ready(result: &ActivityResult) -> bool {

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -453,19 +453,32 @@ fn snapshot_has_repair_action(snapshot: &Value) -> bool {
 }
 
 fn snapshot_has_validation_evidence(result: &ActivityResult, snapshot: &Value) -> bool {
+    let validation_fields = &["validation", "validation_records", "validationRecords"];
+    let validation_command_fields = &["validation_commands", "validationCommands"];
+    if result
+        .validation
+        .iter()
+        .any(validation_record_reports_failure)
+        || validation_array_has_failure(snapshot, validation_fields)
+        || validation_array_has_failure(snapshot, validation_command_fields)
+    {
+        return false;
+    }
+
     result
         .validation
         .iter()
         .any(validation_record_allows_success)
-        || validation_array_has_success(
-            snapshot,
-            &["validation", "validation_records", "validationRecords"],
-        )
-        || validation_array_has_success(snapshot, &["validation_commands", "validationCommands"])
+        || validation_array_has_success(snapshot, validation_fields)
+        || validation_array_has_success(snapshot, validation_command_fields)
 }
 
 fn validation_record_allows_success(record: &ValidationRecord) -> bool {
     !record.command.trim().is_empty() && validation_status_allows_success(&record.status)
+}
+
+fn validation_record_reports_failure(record: &ValidationRecord) -> bool {
+    !record.command.trim().is_empty() && !validation_status_allows_success(&record.status)
 }
 
 fn validation_array_has_success(value: &Value, fields: &[&str]) -> bool {
@@ -473,6 +486,14 @@ fn validation_array_has_success(value: &Value, fields: &[&str]) -> bool {
         field_value(value, field)
             .and_then(Value::as_array)
             .is_some_and(|items| items.iter().any(validation_value_allows_success))
+    })
+}
+
+fn validation_array_has_failure(value: &Value, fields: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_array)
+            .is_some_and(|items| items.iter().any(validation_value_reports_failure))
     })
 }
 
@@ -486,6 +507,18 @@ fn validation_value_allows_success(value: &Value) -> bool {
             Some(true)
         );
     has_command && has_success_status
+}
+
+fn validation_value_reports_failure(value: &Value) -> bool {
+    let has_command = non_empty_string(value, &["command", "cmd", "name"])
+        || non_empty_array(value, &["commands"]);
+    let has_failure_status = string_field(value, &["status", "outcome", "result"])
+        .is_some_and(|status| !validation_status_allows_success(status))
+        || matches!(
+            field_bool(value, &["passed", "success", "succeeded"]),
+            Some(false)
+        );
+    has_command && has_failure_status
 }
 
 fn validation_status_allows_success(status: &str) -> bool {

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -1,6 +1,6 @@
 use super::support::{
-    event_field_string, has_signal, optional_data_string, result_signal_string, result_signal_u64,
-    runtime_completion_evidence,
+    event_field_string, has_signal, json_value_u64, optional_data_string, result_signal_string,
+    result_signal_u64, runtime_completion_evidence,
 };
 use super::GITHUB_ISSUE_PR_DEFINITION_ID;
 use crate::runtime::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
@@ -68,7 +68,7 @@ pub(super) fn pr_feedback_success_contract_error(
     }
 
     if result.activity == "address_pr_feedback" && instance.state == "addressing_feedback" {
-        if repair_snapshot_proves_action(result) {
+        if repair_snapshot_proves_action(instance, result) {
             return None;
         }
         return Some(
@@ -80,7 +80,7 @@ pub(super) fn pr_feedback_success_contract_error(
         if pr_feedback_outcome_from_signals(result) == Some(PrFeedbackOutcome::BlockingFeedback) {
             return None;
         }
-        if ready_snapshot_proves_pr_ready(result) {
+        if ready_snapshot_proves_pr_ready(instance, result) {
             return None;
         }
         return Some(
@@ -249,10 +249,10 @@ fn github_issue_pr_feedback_activity_matches(
     )
 }
 
-fn repair_snapshot_proves_action(result: &ActivityResult) -> bool {
+fn repair_snapshot_proves_action(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
     result.artifacts.iter().any(|artifact| {
         artifact.artifact_type == PR_REPAIR_SNAPSHOT_ARTIFACT
-            && snapshot_has_pr_identity(&artifact.artifact)
+            && snapshot_has_pr_identity(instance, result, &artifact.artifact)
             && snapshot_has_head_identity(&artifact.artifact)
             && snapshot_has_observation_time(&artifact.artifact)
             && snapshot_has_repair_action(&artifact.artifact)
@@ -272,7 +272,7 @@ fn structured_ready_decision(decision: &WorkflowDecision) -> bool {
     decision.next_state == "ready_to_merge" || decision.decision == "mark_ready_to_merge"
 }
 
-fn ready_snapshot_proves_pr_ready(result: &ActivityResult) -> bool {
+fn ready_snapshot_proves_pr_ready(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
     result
         .artifacts
         .iter()
@@ -283,7 +283,7 @@ fn ready_snapshot_proves_pr_ready(result: &ActivityResult) -> bool {
             )
         })
         .any(|artifact| {
-            snapshot_has_pr_identity(&artifact.artifact)
+            snapshot_has_pr_identity(instance, result, &artifact.artifact)
                 && snapshot_has_head_identity(&artifact.artifact)
                 && snapshot_has_observation_time(&artifact.artifact)
                 && snapshot_check_state_allows_ready(&artifact.artifact)
@@ -294,9 +294,46 @@ fn ready_snapshot_proves_pr_ready(result: &ActivityResult) -> bool {
         })
 }
 
-fn snapshot_has_pr_identity(snapshot: &Value) -> bool {
-    field_u64(snapshot, &["pr_number", "prNumber"]).is_some()
-        && non_empty_string(snapshot, &["pr_url", "prUrl", "url"])
+fn snapshot_has_pr_identity(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+    snapshot: &Value,
+) -> bool {
+    let Some(snapshot_number) = field_u64(snapshot, &["pr_number", "prNumber"]) else {
+        return false;
+    };
+    let Some(snapshot_url) = string_field(snapshot, &["pr_url", "prUrl", "url"]) else {
+        return false;
+    };
+
+    if let Some(expected_number) = expected_pr_number(instance, result) {
+        if snapshot_number != expected_number {
+            return false;
+        }
+    }
+    if let Some(expected_url) = expected_pr_url(instance, result) {
+        if normalize_pr_url(snapshot_url) != normalize_pr_url(expected_url.as_str()) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn expected_pr_number(instance: &WorkflowInstance, result: &ActivityResult) -> Option<u64> {
+    instance
+        .data
+        .get("pr_number")
+        .and_then(json_value_u64)
+        .or_else(|| result_signal_u64(result, "pr_number"))
+}
+
+fn expected_pr_url(instance: &WorkflowInstance, result: &ActivityResult) -> Option<String> {
+    optional_data_string(instance, "pr_url").or_else(|| result_signal_string(result, "pr_url"))
+}
+
+fn normalize_pr_url(value: &str) -> &str {
+    value.trim().trim_end_matches('/')
 }
 
 fn snapshot_has_head_identity(snapshot: &Value) -> bool {
@@ -435,6 +472,14 @@ fn non_empty_string(value: &Value, fields: &[&str]) -> bool {
         field_value(value, field)
             .and_then(Value::as_str)
             .is_some_and(|text| !text.trim().is_empty())
+    })
+}
+
+fn string_field<'a>(value: &'a Value, fields: &[&str]) -> Option<&'a str> {
+    fields.iter().find_map(|field| {
+        field_value(value, field)
+            .and_then(Value::as_str)
+            .filter(|text| !text.trim().is_empty())
     })
 }
 

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -3,7 +3,9 @@ use super::support::{
     result_signal_u64, runtime_completion_evidence,
 };
 use super::GITHUB_ISSUE_PR_DEFINITION_ID;
-use crate::runtime::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
+use crate::runtime::model::{
+    ActivityResult, ValidationRecord, WorkflowDecision, WorkflowEvent, WorkflowInstance,
+};
 use crate::runtime::pr_feedback::{
     build_local_review_completed_decision, build_pr_feedback_decision, LocalReviewCompletedInput,
     LocalReviewOutcome, PrFeedbackDecisionInput, PrFeedbackOutcome, LOCAL_REVIEW_ACTIVITY,
@@ -443,12 +445,43 @@ fn snapshot_has_validation_evidence(result: &ActivityResult, snapshot: &Value) -
     result
         .validation
         .iter()
-        .any(|record| !record.command.trim().is_empty())
-        || non_empty_array(
+        .any(validation_record_allows_success)
+        || validation_array_has_success(
             snapshot,
             &["validation", "validation_records", "validationRecords"],
         )
-        || non_empty_array(snapshot, &["validation_commands", "validationCommands"])
+        || validation_array_has_success(snapshot, &["validation_commands", "validationCommands"])
+}
+
+fn validation_record_allows_success(record: &ValidationRecord) -> bool {
+    !record.command.trim().is_empty() && validation_status_allows_success(&record.status)
+}
+
+fn validation_array_has_success(value: &Value, fields: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_array)
+            .is_some_and(|items| items.iter().any(validation_value_allows_success))
+    })
+}
+
+fn validation_value_allows_success(value: &Value) -> bool {
+    let has_command = non_empty_string(value, &["command", "cmd", "name"])
+        || non_empty_array(value, &["commands"]);
+    let has_success_status = string_field(value, &["status", "outcome", "result"])
+        .is_some_and(validation_status_allows_success)
+        || matches!(
+            field_bool(value, &["passed", "success", "succeeded"]),
+            Some(true)
+        );
+    has_command && has_success_status
+}
+
+fn validation_status_allows_success(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "passed" | "pass" | "success" | "succeeded" | "ok"
+    )
 }
 
 fn non_empty_array(value: &Value, fields: &[&str]) -> bool {

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -500,7 +500,7 @@ fn field_bool(value: &Value, fields: &[&str]) -> Option<bool> {
 fn field_u64(value: &Value, fields: &[&str]) -> Option<u64> {
     fields
         .iter()
-        .find_map(|field| field_value(value, field).and_then(Value::as_u64))
+        .find_map(|field| field_value(value, field).and_then(json_value_u64))
 }
 
 fn field_value<'a>(value: &'a Value, field: &str) -> Option<&'a Value> {

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -8,8 +8,11 @@ use crate::runtime::pr_feedback::{
     build_local_review_completed_decision, build_pr_feedback_decision, LocalReviewCompletedInput,
     LocalReviewOutcome, PrFeedbackDecisionInput, PrFeedbackOutcome, LOCAL_REVIEW_ACTIVITY,
     LOCAL_REVIEW_BLOCKED_SIGNAL, LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, PR_REPAIR_SNAPSHOT_ARTIFACT,
 };
+use serde_json::Value;
+
+const PR_FEEDBACK_SNAPSHOT_ARTIFACT: &str = "pr_feedback_snapshot";
 
 pub(super) fn pr_feedback_sweep_decision_from_activity_result(
     instance: &WorkflowInstance,
@@ -53,6 +56,38 @@ pub(super) fn pr_feedback_sweep_decision_from_activity_result(
         .decision
         .with_evidence(runtime_completion_evidence(event, result)),
     )
+}
+
+pub(super) fn pr_feedback_success_contract_error(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+    structured_decision: Option<&WorkflowDecision>,
+) -> Option<String> {
+    if !github_issue_pr_feedback_activity_matches(instance, result) {
+        return None;
+    }
+
+    if result.activity == "address_pr_feedback" && instance.state == "addressing_feedback" {
+        if repair_snapshot_proves_action(result) {
+            return None;
+        }
+        return Some(
+            "PR repair evidence is missing: address_pr_feedback succeeded without a pr_repair_snapshot proving pushed changes, review-thread action, or an explicit no-code-change reason plus validation".to_string(),
+        );
+    }
+
+    if readiness_claimed(result, structured_decision)
+        && pr_feedback_outcome_from_signals(result) != Some(PrFeedbackOutcome::BlockingFeedback)
+    {
+        if ready_snapshot_proves_pr_ready(result) {
+            return None;
+        }
+        return Some(
+            "PR readiness evidence is missing: ready-to-merge output requires a current pr_repair_snapshot with head, checks, mergeability, and zero active unresolved review threads".to_string(),
+        );
+    }
+
+    None
 }
 
 pub(super) fn local_review_decision_from_activity_result(
@@ -171,4 +206,247 @@ fn local_review_outcome_from_signals(result: &ActivityResult) -> Option<LocalRev
         return Some(LocalReviewOutcome::Passed);
     }
     None
+}
+
+fn github_issue_pr_feedback_activity_matches(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+) -> bool {
+    matches!(
+        (
+            instance.definition_id.as_str(),
+            instance.state.as_str(),
+            result.activity.as_str()
+        ),
+        (
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            "addressing_feedback",
+            "address_pr_feedback"
+        ) | (
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            "awaiting_feedback",
+            "sweep_pr_feedback"
+        ) | (
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            "awaiting_feedback",
+            PR_FEEDBACK_INSPECT_ACTIVITY
+        ) | (
+            PR_FEEDBACK_DEFINITION_ID,
+            "inspecting",
+            PR_FEEDBACK_INSPECT_ACTIVITY
+        )
+    )
+}
+
+fn repair_snapshot_proves_action(result: &ActivityResult) -> bool {
+    result.artifacts.iter().any(|artifact| {
+        artifact.artifact_type == PR_REPAIR_SNAPSHOT_ARTIFACT
+            && snapshot_has_pr_identity(&artifact.artifact)
+            && snapshot_has_head_identity(&artifact.artifact)
+            && snapshot_has_observation_time(&artifact.artifact)
+            && snapshot_has_repair_action(&artifact.artifact)
+            && snapshot_has_validation_evidence(result, &artifact.artifact)
+    })
+}
+
+fn readiness_claimed(
+    result: &ActivityResult,
+    structured_decision: Option<&WorkflowDecision>,
+) -> bool {
+    has_signal(result, "PrReadyToMerge")
+        || structured_decision.is_some_and(|decision| {
+            decision.next_state == "ready_to_merge" || decision.decision == "mark_ready_to_merge"
+        })
+}
+
+fn ready_snapshot_proves_pr_ready(result: &ActivityResult) -> bool {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| {
+            matches!(
+                artifact.artifact_type.as_str(),
+                PR_REPAIR_SNAPSHOT_ARTIFACT | PR_FEEDBACK_SNAPSHOT_ARTIFACT
+            )
+        })
+        .any(|artifact| {
+            snapshot_has_pr_identity(&artifact.artifact)
+                && snapshot_has_head_identity(&artifact.artifact)
+                && snapshot_has_observation_time(&artifact.artifact)
+                && snapshot_check_state_allows_ready(&artifact.artifact)
+                && snapshot_merge_state_allows_ready(&artifact.artifact)
+                && snapshot_review_state_allows_ready(&artifact.artifact)
+                && snapshot_draft_state_allows_ready(&artifact.artifact)
+                && snapshot_review_threads_allow_ready(&artifact.artifact)
+        })
+}
+
+fn snapshot_has_pr_identity(snapshot: &Value) -> bool {
+    field_u64(snapshot, &["pr_number", "prNumber"]).is_some()
+        && non_empty_string(snapshot, &["pr_url", "prUrl", "url"])
+}
+
+fn snapshot_has_head_identity(snapshot: &Value) -> bool {
+    non_empty_string(snapshot, &["head_oid", "head_sha", "headOid", "headSha"])
+}
+
+fn snapshot_has_observation_time(snapshot: &Value) -> bool {
+    non_empty_string(snapshot, &["observed_at", "observedAt"])
+}
+
+fn snapshot_check_state_allows_ready(snapshot: &Value) -> bool {
+    string_field_matches(
+        snapshot,
+        &[
+            "status_check_rollup_state",
+            "statusCheckRollupState",
+            "statusCheckRollup.state",
+            "check_state",
+            "checkState",
+        ],
+        &["SUCCESS", "PASSING", "PASSED"],
+    )
+}
+
+fn snapshot_merge_state_allows_ready(snapshot: &Value) -> bool {
+    string_field_matches(
+        snapshot,
+        &[
+            "merge_state_status",
+            "mergeStateStatus",
+            "merge_state",
+            "mergeState",
+        ],
+        &["CLEAN"],
+    )
+}
+
+fn snapshot_review_state_allows_ready(snapshot: &Value) -> bool {
+    string_field_matches(
+        snapshot,
+        &["review_decision", "reviewDecision"],
+        &["APPROVED"],
+    )
+}
+
+fn snapshot_draft_state_allows_ready(snapshot: &Value) -> bool {
+    matches!(
+        field_bool(snapshot, &["is_draft", "isDraft", "draft"]),
+        Some(false)
+    )
+}
+
+fn snapshot_review_threads_allow_ready(snapshot: &Value) -> bool {
+    if let Some(count) = field_u64(
+        snapshot,
+        &[
+            "active_unresolved_review_threads_count",
+            "activeUnresolvedReviewThreadsCount",
+            "active_unresolved_review_thread_count",
+            "unresolved_review_threads_count",
+            "unresolvedReviewThreadsCount",
+            "unresolved_threads",
+            "unresolvedThreads",
+        ],
+    ) {
+        return count == 0;
+    }
+
+    empty_array(
+        snapshot,
+        &[
+            "active_unresolved_review_threads",
+            "activeUnresolvedReviewThreads",
+            "unresolved_review_threads",
+            "unresolvedReviewThreads",
+        ],
+    )
+}
+
+fn snapshot_has_repair_action(snapshot: &Value) -> bool {
+    non_empty_string(
+        snapshot,
+        &[
+            "pushed_head_sha",
+            "pushedHeadSha",
+            "pushed_head_oid",
+            "pushedHeadOid",
+            "action_taken",
+            "actionTaken",
+            "no_code_change_reason",
+            "noCodeChangeReason",
+        ],
+    ) || non_empty_array(
+        snapshot,
+        &[
+            "changed_files",
+            "changedFiles",
+            "review_thread_actions",
+            "reviewThreadActions",
+            "resolved_review_thread_ids",
+            "resolvedReviewThreadIds",
+        ],
+    )
+}
+
+fn snapshot_has_validation_evidence(result: &ActivityResult, snapshot: &Value) -> bool {
+    result
+        .validation
+        .iter()
+        .any(|record| !record.command.trim().is_empty())
+        || non_empty_array(
+            snapshot,
+            &["validation", "validation_records", "validationRecords"],
+        )
+        || non_empty_array(snapshot, &["validation_commands", "validationCommands"])
+}
+
+fn non_empty_array(value: &Value, fields: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_array)
+            .is_some_and(|items| !items.is_empty())
+    })
+}
+
+fn empty_array(value: &Value, fields: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+    })
+}
+
+fn non_empty_string(value: &Value, fields: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_str)
+            .is_some_and(|text| !text.trim().is_empty())
+    })
+}
+
+fn string_field_matches(value: &Value, fields: &[&str], expected: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field_value(value, field)
+            .and_then(Value::as_str)
+            .is_some_and(|text| expected.iter().any(|item| text.eq_ignore_ascii_case(item)))
+    })
+}
+
+fn field_bool(value: &Value, fields: &[&str]) -> Option<bool> {
+    fields
+        .iter()
+        .find_map(|field| field_value(value, field).and_then(Value::as_bool))
+}
+
+fn field_u64(value: &Value, fields: &[&str]) -> Option<u64> {
+    fields
+        .iter()
+        .find_map(|field| field_value(value, field).and_then(Value::as_u64))
+}
+
+fn field_value<'a>(value: &'a Value, field: &str) -> Option<&'a Value> {
+    field
+        .split('.')
+        .try_fold(value, |current, part| current.get(part))
 }

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -398,6 +398,16 @@ fn snapshot_draft_state_allows_ready(snapshot: &Value) -> bool {
 }
 
 fn snapshot_review_threads_allow_ready(snapshot: &Value) -> bool {
+    let thread_array_fields = &[
+        "active_unresolved_review_threads",
+        "activeUnresolvedReviewThreads",
+        "unresolved_review_threads",
+        "unresolvedReviewThreads",
+    ];
+    if non_empty_array(snapshot, thread_array_fields) {
+        return false;
+    }
+
     if let Some(count) = field_u64(
         snapshot,
         &[
@@ -413,15 +423,7 @@ fn snapshot_review_threads_allow_ready(snapshot: &Value) -> bool {
         return count == 0;
     }
 
-    empty_array(
-        snapshot,
-        &[
-            "active_unresolved_review_threads",
-            "activeUnresolvedReviewThreads",
-            "unresolved_review_threads",
-            "unresolvedReviewThreads",
-        ],
-    )
+    empty_array(snapshot, thread_array_fields)
 }
 
 fn snapshot_has_repair_action(snapshot: &Value) -> bool {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -37,6 +37,7 @@ use std::sync::{
 
 mod local_review;
 mod p1_followups;
+mod pr_repair_evidence;
 mod replay_determinism;
 mod retry;
 

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -939,6 +939,52 @@ fn runtime_completion_reducer_finishes_feedback_closed_issue_signal_without_pr()
 }
 
 #[test]
+fn runtime_completion_reducer_finishes_succeeded_feedback_closed_issue_signal_without_pr() {
+    let instance = issue_instance("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Issue was closed while addressing PR feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueClosed",
+        json!({
+            "issue_number": 123,
+            "state": "closed",
+            "issue_url": "https://github.com/owner/repo/issues/123"
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("closed issue signal from successful feedback work should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkDone
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("successful feedback closed issue completion should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_uses_issue_state_artifact_as_closed_issue_evidence() {
     let instance = issue_instance("implementing");
     let result =

--- a/crates/harness-workflow/src/runtime/tests/local_review.rs
+++ b/crates/harness-workflow/src/runtime/tests/local_review.rs
@@ -2,6 +2,29 @@ use super::super::{
     build_local_review_completed_decision, LocalReviewCompletedInput, LocalReviewOutcome,
 };
 use super::*;
+use crate::runtime::PR_REPAIR_SNAPSHOT_ARTIFACT;
+
+fn address_pr_feedback_result(summary: &str) -> ActivityResult {
+    ActivityResult::succeeded("address_pr_feedback", summary)
+        .with_artifact(ActivityArtifact::new(
+            PR_REPAIR_SNAPSHOT_ARTIFACT,
+            json!({
+                "pr_number": 77,
+                "pr_url": "https://github.com/owner/repo/pull/77",
+                "head_sha": "repair-head-sha",
+                "observed_at": "2026-06-06T00:00:00Z",
+                "changed_files": ["crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs"],
+                "action_taken": "pushed_commit",
+                "validation_commands": [
+                    {"command": "cargo test -p harness-workflow local_review", "status": "passed"}
+                ]
+            }),
+        ))
+        .with_validation(ValidationRecord::new(
+            "cargo test -p harness-workflow local_review",
+            "passed",
+        ))
+}
 
 #[test]
 fn local_review_changes_requested_command_carries_review_findings() {
@@ -54,7 +77,7 @@ fn local_review_changes_requested_command_carries_review_findings() {
 fn local_review_after_rework_uses_completion_command_dedupe_key() {
     let instance = issue_instance("addressing_feedback");
     let command = WorkflowCommand::enqueue_activity("address_pr_feedback", "feedback-1");
-    let result = ActivityResult::succeeded("address_pr_feedback", "Feedback addressed.");
+    let result = address_pr_feedback_result("Feedback addressed.");
     let first_event = WorkflowEvent::new(
         &instance.id,
         1,
@@ -77,10 +100,7 @@ fn local_review_after_rework_uses_completion_command_dedupe_key() {
         "command_id": "command-2",
         "command": WorkflowCommand::enqueue_activity("address_pr_feedback", "feedback-2"),
         "runtime_job_id": "job-2",
-        "activity_result": ActivityResult::succeeded(
-            "address_pr_feedback",
-            "Feedback addressed again."
-        ),
+        "activity_result": address_pr_feedback_result("Feedback addressed again."),
     }));
 
     let first_decision = reduce_runtime_job_completed(&instance, &first_event)
@@ -246,10 +266,7 @@ fn local_review_after_rework_replay_keeps_command_dedupe_key() {
         "command_id": "command-1",
         "command": WorkflowCommand::enqueue_activity("address_pr_feedback", "feedback-1"),
         "runtime_job_id": "job-1",
-        "activity_result": ActivityResult::succeeded(
-            "address_pr_feedback",
-            "Feedback addressed."
-        ),
+        "activity_result": address_pr_feedback_result("Feedback addressed."),
     });
     let first_event = WorkflowEvent::new(
         &instance.id,

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -200,6 +200,42 @@ fn address_pr_feedback_success_with_repair_snapshot_requests_local_review() {
 }
 
 #[test]
+fn address_pr_feedback_snapshot_with_failed_validation_blocks() {
+    let instance = pr_workflow_state("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Runtime agent reported a repair with failed validation.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_sha": "def456",
+            "observed_at": "2026-06-06T00:05:00Z",
+            "changed_files": ["crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs"],
+            "action_taken": "pushed_commit",
+            "validation_commands": [
+                {"command": "cargo test -p harness-workflow pr_repair_evidence", "status": "failed"}
+            ]
+        }),
+    ))
+    .with_validation(ValidationRecord::new(
+        "cargo test -p harness-workflow pr_repair_evidence",
+        "failed",
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("failed validation evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR repair evidence is missing"));
+}
+
+#[test]
 fn address_pr_feedback_snapshot_for_different_pr_blocks() {
     let instance = pr_workflow_state("addressing_feedback");
     let result = ActivityResult::succeeded(

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -123,6 +123,39 @@ fn structured_ready_decision_without_current_pr_snapshot_blocks() {
 }
 
 #[test]
+fn structured_ready_decision_with_blocking_signal_uses_blocking_feedback() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "Agent reported the PR is ready.",
+    )
+    .high_confidence();
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime agent emitted both ready and blocking feedback.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ))
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("blocking signal should override structured ready output");
+
+    assert_eq!(decision.decision, "address_pr_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+}
+
+#[test]
 fn address_pr_feedback_success_without_repair_evidence_blocks() {
     let instance = pr_workflow_state("addressing_feedback");
     let result = ActivityResult::succeeded(

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -1,0 +1,265 @@
+use super::*;
+use crate::runtime::PR_REPAIR_SNAPSHOT_ARTIFACT;
+
+fn pr_workflow_state(state: &str) -> WorkflowInstance {
+    issue_instance(state).with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-1",
+    }))
+}
+
+fn event_for_result(result: ActivityResult) -> WorkflowEvent {
+    WorkflowEvent::new(
+        "workflow-1",
+        1,
+        super::super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }))
+}
+
+fn ready_snapshot_artifact() -> ActivityArtifact {
+    ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads": [],
+            "active_unresolved_review_threads_count": 0,
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "is_draft": false,
+            "changed_files": [],
+            "action_taken": "confirmed_ready",
+            "validation": [
+                {"command": "cargo test -p harness-workflow pr_repair_evidence", "status": "passed"}
+            ]
+        }),
+    )
+}
+
+fn repair_snapshot_artifact() -> ActivityArtifact {
+    ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_sha": "def456",
+            "observed_at": "2026-06-06T00:05:00Z",
+            "changed_files": ["crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs"],
+            "action_taken": "pushed_commit",
+            "validation_commands": [
+                {"command": "cargo test -p harness-workflow pr_repair_evidence", "status": "passed"}
+            ]
+        }),
+    )
+}
+
+#[test]
+fn ready_to_merge_signal_without_current_pr_snapshot_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent claimed the PR is ready to merge.",
+    )
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing snapshot should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("missing snapshot block should validate");
+}
+
+#[test]
+fn structured_ready_decision_without_current_pr_snapshot_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "Agent reported the PR is ready.",
+    )
+    .high_confidence();
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime agent emitted a ready workflow decision.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing snapshot should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+}
+
+#[test]
+fn address_pr_feedback_success_without_repair_evidence_blocks() {
+    let instance = pr_workflow_state("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Runtime agent claimed review feedback was addressed.",
+    );
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing repair evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR repair evidence is missing"));
+}
+
+#[test]
+fn address_pr_feedback_success_with_repair_snapshot_requests_local_review() {
+    let instance = pr_workflow_state("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Runtime agent addressed review feedback and pushed validation-backed changes.",
+    )
+    .with_artifact(repair_snapshot_artifact())
+    .with_validation(ValidationRecord::new(
+        "cargo test -p harness-workflow pr_repair_evidence",
+        "passed",
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("valid repair snapshot should request local review");
+
+    assert_eq!(decision.decision, "run_local_review_after_rework");
+    assert_eq!(decision.next_state, "local_review_gate");
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some(LOCAL_REVIEW_ACTIVITY)
+    );
+}
+
+#[test]
+fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent verified the PR is ready to merge.",
+    )
+    .with_artifact(ready_snapshot_artifact())
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("valid snapshot should reduce");
+
+    assert_eq!(decision.decision, "mark_ready_to_merge");
+    assert_eq!(decision.next_state, "ready_to_merge");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("ready snapshot decision should validate");
+}
+
+#[test]
+fn ready_to_merge_snapshot_with_required_review_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent claimed the PR is ready without an approval.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads_count": 0,
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "REVIEW_REQUIRED",
+            "is_draft": false
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing approval should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+}
+
+#[test]
+fn child_pr_feedback_ready_signal_without_snapshot_blocks() {
+    let instance = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-1");
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow claimed the PR is ready to merge.",
+    )
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("child missing snapshot should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    DecisionValidator::pr_feedback()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("child missing snapshot block should validate");
+}

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -273,6 +273,47 @@ fn address_pr_feedback_snapshot_with_failed_validation_blocks() {
 }
 
 #[test]
+fn address_pr_feedback_snapshot_with_mixed_validation_blocks() {
+    let instance = pr_workflow_state("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Runtime agent reported one passing and one failing validation command.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_sha": "def456",
+            "observed_at": "2026-06-06T00:05:00Z",
+            "changed_files": ["crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs"],
+            "action_taken": "pushed_commit",
+            "validation_commands": [
+                {"command": "cargo fmt --all -- --check", "status": "passed"},
+                {"command": "cargo test -p harness-workflow pr_repair_evidence", "status": "failed"}
+            ]
+        }),
+    ))
+    .with_validation(ValidationRecord::new(
+        "cargo fmt --all -- --check",
+        "passed",
+    ))
+    .with_validation(ValidationRecord::new(
+        "cargo test -p harness-workflow pr_repair_evidence",
+        "failed",
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("mixed validation evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR repair evidence is missing"));
+}
+
+#[test]
 fn address_pr_feedback_snapshot_for_different_pr_blocks() {
     let instance = pr_workflow_state("addressing_feedback");
     let result = ActivityResult::succeeded(

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -438,3 +438,53 @@ fn child_pr_feedback_ready_signal_without_snapshot_blocks() {
         )
         .expect("child missing snapshot block should validate");
 }
+
+#[test]
+fn child_pr_feedback_ready_snapshot_for_different_subject_pr_blocks() {
+    let instance = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "inspecting",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_id("pr-feedback-child-1");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "inspecting",
+        "record_ready_to_merge",
+        "ready_to_merge",
+        "Agent reported the child PR is ready.",
+    )
+    .high_confidence();
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow attached ready evidence copied from another PR.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ))
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 88,
+            "pr_url": "https://github.com/owner/repo/pull/88",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads_count": 0,
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "is_draft": false
+        }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("wrong child PR ready evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+}

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -156,6 +156,43 @@ fn structured_ready_decision_with_blocking_signal_uses_blocking_feedback() {
 }
 
 #[test]
+fn closed_issue_evidence_wins_over_structured_ready_decision() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "Agent reported the PR is ready.",
+    )
+    .high_confidence();
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime agent emitted both terminal closed evidence and a ready decision.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ))
+    .with_signal(ActivitySignal::new(
+        "IssueClosed",
+        json!({
+            "issue_number": 77,
+            "issue_url": "https://github.com/owner/repo/issues/77",
+            "state": "closed"
+        }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("closed issue evidence should finish workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+}
+
+#[test]
 fn address_pr_feedback_success_without_repair_evidence_blocks() {
     let instance = pr_workflow_state("addressing_feedback");
     let result = ActivityResult::succeeded(

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -200,6 +200,41 @@ fn address_pr_feedback_success_with_repair_snapshot_requests_local_review() {
 }
 
 #[test]
+fn address_pr_feedback_snapshot_for_different_pr_blocks() {
+    let instance = pr_workflow_state("addressing_feedback");
+    let result = ActivityResult::succeeded(
+        "address_pr_feedback",
+        "Runtime agent attached repair evidence copied from another PR.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/88",
+            "head_sha": "def456",
+            "observed_at": "2026-06-06T00:05:00Z",
+            "changed_files": ["crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs"],
+            "validation_commands": [
+                {"command": "cargo test -p harness-workflow pr_repair_evidence", "status": "passed"}
+            ]
+        }),
+    ))
+    .with_validation(ValidationRecord::new(
+        "cargo test -p harness-workflow pr_repair_evidence",
+        "passed",
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("wrong PR repair evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR repair evidence is missing"));
+}
+
+#[test]
 fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
     let instance = pr_workflow_state("awaiting_feedback");
     let result = ActivityResult::succeeded(
@@ -226,6 +261,42 @@ fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("ready snapshot decision should validate");
+}
+
+#[test]
+fn ready_to_merge_snapshot_for_different_pr_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent attached ready evidence copied from another PR.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 88,
+            "pr_url": "https://github.com/owner/repo/pull/88",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads_count": 0,
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "is_draft": false
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("wrong PR ready evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -443,6 +443,45 @@ fn ready_to_merge_snapshot_with_required_review_blocks() {
 }
 
 #[test]
+fn ready_to_merge_snapshot_with_unresolved_thread_array_blocks_even_when_count_zero() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent reported contradictory unresolved review-thread evidence.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads_count": 0,
+            "active_unresolved_review_threads": [
+                {"id": "thread-1", "path": "src/lib.rs", "line": 10}
+            ],
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "is_draft": false
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("contradictory unresolved-thread evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+}
+
+#[test]
 fn child_pr_feedback_ready_signal_without_snapshot_blocks() {
     let instance = WorkflowInstance::new(
         PR_FEEDBACK_DEFINITION_ID,

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -264,6 +264,41 @@ fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
 }
 
 #[test]
+fn ready_to_merge_snapshot_accepts_quoted_pr_number() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Runtime agent verified the PR is ready to merge.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        PR_REPAIR_SNAPSHOT_ARTIFACT,
+        json!({
+            "pr_number": "77",
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "head_oid": "abc123",
+            "observed_at": "2026-06-06T00:00:00Z",
+            "active_unresolved_review_threads_count": 0,
+            "status_check_rollup_state": "SUCCESS",
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "is_draft": false
+        }),
+    ))
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quoted snapshot PR number should reduce");
+
+    assert_eq!(decision.decision, "mark_ready_to_merge");
+    assert_eq!(decision.next_state, "ready_to_merge");
+}
+
+#[test]
 fn ready_to_merge_snapshot_for_different_pr_blocks() {
     let instance = pr_workflow_state("awaiting_feedback");
     let result = ActivityResult::succeeded(

--- a/docs/workflow-state-machine-quality-design.md
+++ b/docs/workflow-state-machine-quality-design.md
@@ -1,0 +1,716 @@
+# Workflow State Machine Quality Design
+
+Status: Draft
+Date: 2026-06-06
+Audience: Harness maintainers and operators
+
+## Purpose
+
+Harness should improve issue and PR repair quality by making workflow state,
+activity evidence, review gates, and evaluation artifacts authoritative. The
+goal is not to give the agent a larger prompt. The goal is to make the runtime
+force the right sequence of decisions and make false success impossible.
+
+This design is intentionally written before implementation. It records the
+architecture search, the current Harness gaps, the target state machine, and a
+phased implementation plan.
+
+## Research Summary
+
+The relevant external patterns are durable execution, orchestrated sagas,
+statecharts, persisted human-in-the-loop checkpoints, and trace/eval based
+agent improvement.
+
+### Durable Execution
+
+Temporal's durable workflow model is the closest reference, but Harness should
+copy the invariants rather than adopt Temporal as a dependency right now.
+
+Useful invariants:
+
+- Workflow history is the source of truth.
+- Reducers must be deterministic under replay.
+- Commands and activity results must be persisted.
+- External side effects belong in activities, not in reducer logic.
+- A replay must reuse recorded activity results instead of recomputing external
+  work.
+
+Harness already has analogous tables and concepts: workflow instances, events,
+commands, runtime jobs, and activity results. The design should strengthen those
+invariants locally instead of introducing a second workflow engine.
+
+Reference: https://docs.temporal.io/workflows
+Reference: https://docs.temporal.io/workflow-definition
+Reference: https://docs.temporal.io/activities
+
+### Saga Orchestration
+
+Issue implementation and PR repair are sagas: they span GitHub state, local
+worktrees, CI, review, mergeability, and operator approval. The correct model is
+not "one LLM turn does everything"; it is an orchestrated sequence of idempotent
+steps, hard gates, and retryable follow-up actions.
+
+Useful invariants:
+
+- The orchestrator owns the state.
+- Each local transaction records evidence.
+- Failed steps either retry idempotently, compensate, or block with a clear
+  operator action.
+- The pivot point should be explicit. For Harness, pushing a PR branch is a
+  pivot: later steps must validate and converge the PR rather than pretending
+  the work can be silently undone.
+
+Reference: https://learn.microsoft.com/en-us/azure/architecture/patterns/saga
+
+### Persisted Human-in-the-Loop
+
+Human or reviewer intervention must be a durable state, not an in-memory pause
+or an agent narration. LangGraph's interrupt/checkpoint design is useful here:
+pause state is persisted, the thread ID is the resume cursor, and resumed
+execution continues from persisted state.
+
+Harness equivalent:
+
+- `local_review_gate`, `awaiting_operator_approval`, and `blocked` states must
+  carry structured evidence and a resume action.
+- The dashboard should show exactly which gate is waiting and what evidence is
+  missing.
+
+Reference: https://docs.langchain.com/oss/python/langgraph/persistence
+Reference: https://docs.langchain.com/oss/python/langgraph/human-in-the-loop
+
+### GitHub Merge Gates
+
+GitHub branch protection concepts map directly to Harness final gates:
+
+- Required PR reviews.
+- Required status checks.
+- Conversation resolution.
+- Merge queue or up-to-date branch requirements.
+- Deployment gates when configured.
+
+Harness must collect these facts from current GitHub state, not from the agent's
+claim. Active unresolved review threads, stale head SHA evidence, failed checks,
+and dirty mergeability must block readiness.
+
+Reference: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
+
+### Agent Evals
+
+OpenAI's agent-eval guidance points to a useful order: start with traces while
+debugging behavior, then move to repeatable datasets/eval runs when comparing
+changes. Harness should follow that split:
+
+- Traces and runtime events for debugging individual failures.
+- `QualitySnapshot` and PR repair evals for before/after scoring.
+- Deterministic gates first; LLM or human judgment only for subjective code
+  quality.
+
+Reference: https://platform.openai.com/docs/guides/agent-evals
+
+## Current Harness Gaps
+
+### G1: Planning Is Reactive Instead of Normal
+
+`github_issue_pr` allows `scheduled -> planning -> implementing`, and the code
+already has `replan_issue`. However, ordinary issue submission currently moves
+directly into `implement_issue`. The normal path does not require a
+pre-implementation plan artifact.
+
+Impact:
+
+- The first mutating agent turn is doing discovery, planning, implementation,
+  validation, and PR creation at once.
+- `replan_issue` is used after the agent detects a plan concern, which is too
+  late for many quality failures.
+
+### G2: PR Repair Has Two Ownership Paths
+
+Issue-owned PR feedback uses the `github_issue_pr` lifecycle. Standalone open
+PR feedback discovered by `repo_backlog` can become a `prompt_task`.
+
+Impact:
+
+- The same "repair PR feedback" work can receive different gates depending on
+  how it was discovered.
+- `prompt_task` is intentionally generic, so it should not be the owner for
+  merge-relevant PR repair unless it explicitly delegates into a PR lifecycle.
+
+### G3: PR Readiness Can Still Trust Agent Signals Too Early
+
+Recent prompt contracts require final PR state refreshes, but the reducer must
+own the hard gate. `PrReadyToMerge`, a valid-looking `workflow_decision`, or an
+agent summary should not be enough to move a PR lifecycle forward unless a
+machine-readable PR snapshot proves the current head, active unresolved review
+threads, checks, review state, and mergeability.
+
+Impact:
+
+- The workflow can report progress from an agent conclusion rather than current
+  GitHub truth.
+- A stale review or check result can look valid when the PR head changed after
+  that evidence was collected.
+- The operator cannot distinguish "ready because GitHub facts prove it" from
+  "ready because the agent said so."
+
+### G4: Quality Gate Exists but Is Not the Main Lifecycle Gate
+
+`quality_gate` exists as a workflow, but the issue/PR lifecycle primarily relies
+on implementation validation, local review, remote feedback inspection, and CI.
+
+Impact:
+
+- Operators can see a `quality_gate` workflow but not know whether it is
+  mandatory for issue/PR readiness.
+- Quality scoring and workflow state can drift.
+
+### G5: Prompt Contracts Still Carry Too Much Authority
+
+Recent hard gates improved local review and final remote refresh requirements,
+but some success criteria are still expressed as "must include" prompt text.
+
+Impact:
+
+- Agent narration can satisfy the wording while missing machine-verifiable
+  evidence.
+- Reducers should reject missing evidence, not merely ask the agent for it.
+
+### G6: Readiness Is Not a Single Auditable Object
+
+The system has workflow state, runtime jobs, PR metadata, validation records,
+usage attribution, and eval scoring, but the operator needs one final quality
+object.
+
+Impact:
+
+- A merged PR can still hide poor quality.
+- A blocked PR can still be useful, but only if the blocker is precise and the
+  cost is bounded.
+
+## Design Principles
+
+1. Runtime state is authoritative; agent text is evidence, not authority.
+2. Reducers are deterministic and side-effect free.
+3. Activities own side effects and return structured artifacts/signals.
+4. Every mutating step has a typed evidence contract.
+5. PR readiness is a hard gate backed by current GitHub evidence.
+6. Human/local review is a durable workflow state.
+7. Eval scoring is separate from execution, but linked by workflow/job IDs.
+8. One live PR branch has one mutating owner at a time.
+9. Standalone PR feedback should converge into a PR lifecycle, not stay a free
+   prompt task.
+10. "10/10" means hard gates pass, code-quality score is high, and cost/runtime
+    behavior is bounded.
+
+## Target Workflow Model
+
+### Workflow Types
+
+Keep these workflow types:
+
+- `repo_backlog`: intake and prioritization only.
+- `github_issue_pr`: owner lifecycle for issue implementation and PR repair.
+- `pr_feedback`: remote inspection child workflow only, not a repair owner.
+- `prompt_task`: generic operator prompt tasks, not default PR repair.
+- `quality_gate`: reusable validation/eval gate, explicitly wired where used.
+
+Do not collapse everything into one workflow immediately. The risk is too high.
+Instead, make ownership explicit:
+
+- Discovery creates or updates owner workflows.
+- Owner workflows enqueue mutating activities.
+- Inspection child workflows report signals back to owners.
+- Evaluation observes and scores; it does not drive normal execution.
+
+### `github_issue_pr` Statechart
+
+```text
+discovered
+  -> awaiting_dependencies
+  -> planning
+  -> implementing
+  -> pr_open
+  -> local_review_gate
+  -> awaiting_feedback
+  -> addressing_feedback
+  -> local_review_gate
+  -> awaiting_feedback
+  -> quality_gate_pending
+  -> ready_to_merge
+  -> awaiting_operator_approval
+  -> done
+
+terminal alternates:
+  -> blocked
+  -> failed
+  -> cancelled
+```
+
+The first implementation slice should not add every state. The important
+direction is the invariant:
+
+```text
+plan before first mutation
+local review before remote-ready claim
+remote evidence before ready_to_merge
+quality snapshot before done/merge
+```
+
+### `repo_backlog` Statechart
+
+```text
+idle
+  -> scanning
+  -> planning_batch
+  -> dispatching
+  -> idle
+
+side exits:
+  -> reconciling
+  -> blocked
+  -> failed
+  -> cancelled
+```
+
+Rules:
+
+- `poll_repo_backlog` should become deterministic GitHub metadata collection
+  over time.
+- LLM use should be limited to ambiguous prioritization or sprint planning.
+- Open PR feedback should start or bind a PR lifecycle, not a generic prompt
+  task, once the PR ownership path exists.
+
+### PR Feedback Ownership
+
+Remote PR feedback inspection should be read-only:
+
+```text
+pr_feedback:
+  pending -> inspecting -> feedback_found | no_actionable_feedback | ready_to_merge
+```
+
+Mutating repair belongs to the parent:
+
+```text
+github_issue_pr:
+  awaiting_feedback -> addressing_feedback -> local_review_gate
+```
+
+### PR Repair Evidence Gate
+
+The immediate quality fix is a server-enforced evidence gate for PR repair and
+readiness. The first slice validates a machine-readable GitHub snapshot returned
+by the runtime activity. A later slice should replace this with a server-owned
+GitHub snapshot collector so the reducer no longer trusts agent-produced PR
+metadata. The gate is intentionally narrower than a full state-machine rewrite.
+
+Affected activities:
+
+- `inspect_pr_feedback`
+- `sweep_pr_feedback`
+- `address_pr_feedback`
+
+`run_local_review` stays in the existing loop for Phase 1. It already requires a
+local-review outcome signal; head/diff review evidence can be added later as a
+separate local-review quality gate.
+
+Required snapshot fields:
+
+- `pr_number`
+- `pr_url`
+- `head_sha` or `head_oid`
+- `observed_at`
+- active unresolved review-thread IDs and count
+- `statusCheckRollup` state
+- `mergeStateStatus`
+- `reviewDecision`
+- `isDraft`
+- changed files
+- validation commands and results when code changed
+- action taken, or explicit no-code-change reason
+
+Reducer rule:
+
+- Parse domain evidence before considering an agent `workflow_decision`.
+- Block successful PR feedback/readiness outputs that lack a current snapshot.
+- Accept `PrReadyToMerge` only when the snapshot proves final-head checks,
+  mergeability, review approval, non-draft state, and active review-thread
+  gates.
+- Accept `address_pr_feedback` success only when the activity proves a pushed
+  head, a reply/resolution action, or an explicit no-op reason plus validation.
+
+### Quality Gate Position
+
+`quality_gate` should be explicit:
+
+```text
+awaiting_feedback -> quality_gate_pending -> ready_to_merge
+```
+
+The gate should consume:
+
+- final PR snapshot
+- validation records
+- local review result
+- remote review thread status
+- check status
+- mergeability
+- changed files
+- runtime job status
+- usage/cost attribution when available
+
+## Evidence Contracts
+
+### `plan_issue`
+
+Purpose: force a non-mutating planning pass before first implementation.
+
+Required output:
+
+- `IssuePlanReady` signal or `issue_plan` artifact.
+- issue number and repo.
+- problem summary.
+- planned files or areas.
+- risk level.
+- validation plan.
+- explicit no-code path if the issue is already closed/resolved.
+
+Reducer behavior:
+
+- Missing plan evidence blocks.
+- Valid plan moves `planning -> implementing` and enqueues `implement_issue`.
+- `force_execute` may bypass `plan_issue` for emergency/manual override.
+
+### `pr_repair_snapshot`
+
+Purpose: make PR repair and readiness decisions machine-verifiable.
+
+Required output:
+
+- PR identity: repo, PR number, URL.
+- Head identity: final head SHA/OID and observed timestamp.
+- Review truth: active unresolved review threads, resolved/outdated status, and
+  review decision.
+- Check truth: status check rollup state and failing check names when present.
+- Merge truth: merge state status.
+- Draft truth: `isDraft` or equivalent.
+- Diff truth: changed files and whether they are in scope.
+- Action truth: pushed commit, review-thread reply/resolution, or explicit
+  no-code-change reason.
+- Validation truth: commands run and their pass/fail/blocked status when code
+  changed.
+
+Reducer behavior:
+
+- Missing snapshot blocks PR readiness and PR feedback repair success.
+- Stale or headless snapshot blocks readiness.
+- Non-zero active unresolved review threads block `PrReadyToMerge`. A justified
+  rejection can be recorded as a blocker or operator-approval request, but it
+  must not move directly to `ready_to_merge`.
+- Failed checks block readiness.
+- Dirty mergeability blocks readiness.
+- Missing or non-approved review decision blocks readiness.
+- Draft PR state blocks readiness.
+- A no-code-change result is allowed only for ready/no-op controls or
+  explicitly false-positive feedback.
+
+### `implement_issue`
+
+Required output:
+
+- PR artifact with `pr_number`, `pr_url`, and ideally `head_sha`; or
+- closed/resolved issue evidence; or
+- blocked/fatal result with reason.
+
+Reducer behavior:
+
+- Empty success blocks.
+- PR artifact binds PR and moves toward local review.
+- Closed issue evidence can finish the workflow.
+
+### `run_local_review`
+
+Required output:
+
+- `LocalReviewPassed`
+- `LocalReviewChangesRequested`
+- `LocalReviewBlocked`
+
+Reducer behavior:
+
+- Missing local-review outcome blocks.
+- Changes requested returns to `addressing_feedback`.
+- Passed moves to remote feedback/readiness inspection.
+
+### `inspect_pr_feedback`
+
+Required output:
+
+- `FeedbackFound`
+- `ChangesRequested`
+- `ChecksFailed`
+- `NoFeedbackFound`
+- `PrReadyToMerge`
+
+Reducer behavior:
+
+- Blocking signals return to `addressing_feedback`.
+- No feedback waits.
+- Ready signal is accepted only when the PR snapshot proves final head,
+  approval, non-draft state, successful checks, clean mergeability, and zero
+  active unresolved review threads.
+
+### `quality_gate`
+
+Required output:
+
+- validation evidence
+- final PR snapshot
+- no active unresolved review threads
+- checks passing for final head
+- mergeability clean
+- runtime artifact completeness
+
+Reducer behavior:
+
+- Any missing hard gate blocks.
+- Passing gate can move to `ready_to_merge`.
+
+## Quality Score Model
+
+Use the existing eval module and PR repair evaluation rubric as the scoring
+base. Do not replace it with a new scoring system.
+
+`10/10` should mean:
+
+- all hard gates pass
+- numeric score is at least 95/100
+- code-quality subscore is at least 20/22
+- final head SHA is named by validation/review evidence
+- no active unresolved non-outdated review thread remains
+- checks are successful for final head
+- no unrelated PR is opened
+- no duplicate running workflow/job remains
+- usage/cost attribution is observed or exact
+
+Hard gates cap the score. If a run claims success with stale head evidence,
+missing runtime artifacts, unresolved review threads, or wrong PR targeting, it
+cannot be an A-grade run even if the PR later merges.
+
+## Implementation Plan
+
+### Phase 0: No-Code Design and Baseline
+
+Deliverables:
+
+- This design document.
+- Baseline collect-only snapshots for open Harness PR candidates.
+- Current best historical baseline, for example the existing `#1235` eval
+  score if available in `docs/pr-repair-evals`.
+
+Validation:
+
+- No runtime code changes.
+- `git diff` should show only this design doc.
+
+### Phase 1: PR Repair Evidence Gate
+
+Deliverables:
+
+- Add a `pr_repair_snapshot` or `pr_feedback_snapshot` artifact contract.
+- Make `inspect_pr_feedback` and `sweep_pr_feedback` block successful output
+  that has no feedback outcome snapshot.
+- Make `PrReadyToMerge` require current head, active review-thread count,
+  checks, approved review decision, non-draft state, and mergeability evidence.
+- Make `address_pr_feedback` success require pushed-head evidence,
+  reply/resolution evidence, or explicit no-code-change reason plus validation.
+- Make reducer domain evidence checks run before accepting agent-provided
+  `workflow_decision` artifacts for PR feedback/readiness transitions.
+- Keep the existing local review loop intact.
+
+Non-goals:
+
+- Do not change issue submission into a new `plan_issue` phase in this slice.
+- Do not make `run_local_review` require head/diff evidence in this slice.
+- Do not claim the reducer owns remote GitHub truth until a server-side snapshot
+  collector exists.
+
+Validation:
+
+- `cargo fmt --all -- --check`
+- focused `harness-workflow` reducer tests:
+  - ready signal without snapshot blocks
+  - valid workflow decision without snapshot blocks
+  - address feedback empty success blocks
+  - valid snapshot allows the intended transition
+- focused `harness-server` prompt packet tests for the new snapshot contract
+
+Expected quality effect:
+
+- Fewer false ready-to-merge claims.
+- Fewer PR repair runs that finish while review threads/checks remain blocked.
+- Better eval artifacts for current-head scoring.
+
+### Phase 1.5: Server-Owned PR Snapshot Collector
+
+Deliverables:
+
+- Add a GitHub API/GraphQL snapshot collector outside agent prompts.
+- Persist snapshot source, observed timestamp, PR head, review decision, draft
+  state, review-thread count, check rollup, and mergeability.
+- Bind `ready_to_merge` to the latest persisted snapshot for the final head.
+- Reject agent-provided PR readiness metadata when a fresher server snapshot
+  disagrees.
+
+Validation:
+
+- Unit tests for snapshot parsing and stale/head mismatch rejection.
+- Reducer tests proving a stale agent snapshot cannot override server truth.
+- Live collect-only eval against an open PR.
+
+Expected quality effect:
+
+- Removes the remaining trust gap where an agent can produce a plausible but
+  stale or incorrect snapshot.
+
+### Phase 2: Pre-Implementation Plan Gate
+
+Deliverables:
+
+- Add `plan_issue` activity constants and contract.
+- Change non-`force_execute` issue submission to `planning`.
+- Add reducer logic for `plan_issue` success/failure.
+- Pass `issue_plan` summary into `implement_issue` command payload.
+- Update tests from direct `implementing` to `planning`.
+- Keep `force_execute` direct-to-implementation behavior.
+
+Validation:
+
+- `cargo fmt --all -- --check`
+- `cargo test -p harness-workflow issue_submission`
+- `cargo test -p harness-workflow plan_issue`
+- focused server submission tests that assert `planning -> implement_issue`
+
+Expected quality effect:
+
+- Fewer first-turn broad edits.
+- Better validation planning.
+- Cleaner failure mode when the agent cannot identify a safe path.
+
+### Phase 3: PR Repair Ownership Cleanup
+
+Deliverables:
+
+- Introduce `pr_repair` lifecycle or route standalone PR feedback into
+  `github_issue_pr` with a PR subject.
+- Stop using generic `prompt_task` as the default repair owner for open PR
+  feedback discovered by backlog.
+- Preserve `prompt_task` for explicit manual prompt tasks.
+
+Validation:
+
+- repo backlog tests for open PR feedback dispatch.
+- runtime worker child workflow tests.
+- live collect-only eval on an open PR.
+
+Expected quality effect:
+
+- Same PR repair gates regardless of discovery path.
+- Better attribution and fewer false terminal states.
+
+### Phase 4: Quality Gate Wiring
+
+Deliverables:
+
+- Wire `quality_gate` into the issue/PR lifecycle before `ready_to_merge`.
+- Require `QualitySnapshot` or equivalent hard-gate evidence.
+- Expose quality gate status in task detail and runtime tree.
+
+Validation:
+
+- quality gate reducer tests.
+- local review completion gate tests.
+- eval scorecard fixture tests.
+
+Expected quality effect:
+
+- Merge readiness becomes an auditable runtime fact.
+- "Merged" and "good" become separate but connected facts.
+
+### Phase 5: Eval-Driven Optimization Loop
+
+Deliverables:
+
+- Select one small PR candidate at a time.
+- Run collect-only baseline.
+- Run one Harness repair with bounded turns.
+- Collect final snapshot.
+- Score with existing eval rubric.
+- Commit only if score improves or the runtime blocks more correctly.
+
+Validation:
+
+- Compare against historical baseline.
+- Require score improvement before committing prompt/runtime changes.
+- Record failed attempts as eval artifacts, not silent experiments.
+
+## Rejected Alternatives
+
+### Adopt Temporal Directly
+
+Rejected for now. Temporal is a strong reference, but adopting it would create a
+dual orchestration system while Harness already has workflow instances, events,
+commands, runtime jobs, and reducers. The near-term risk is integration churn,
+not missing conceptual machinery.
+
+### One Giant LLM Workflow
+
+Rejected. A single large prompt could plan, implement, review, repair, and
+score, but it would destroy evidence boundaries and make retries/attribution
+unclear.
+
+### Only Improve Prompts
+
+Rejected as insufficient. Prompt wording helps, but the recurring failure mode
+is false success. False success requires reducer-level hard gates and current
+remote evidence.
+
+### Make `repo_backlog` the Owner
+
+Rejected. `repo_backlog` should discover and dispatch. If it owns repair state,
+repo-level polling becomes entangled with per-PR lifecycle, retries, and merge
+readiness.
+
+## Open Questions
+
+1. Should `plan_issue` be required for all non-`force_execute` issues, or only
+   for medium/high risk labels?
+2. Should standalone PR repair become a new `pr_repair` workflow, or should
+   `github_issue_pr` support `WorkflowSubject::new("pr", "pr:<number>")`?
+3. Should `quality_gate` be a child workflow or an inline state in
+   `github_issue_pr`?
+4. What budget cap should define "10/10" for small, medium, and large PR repair?
+5. Should operator approval be required before merge, or is `ready_to_merge`
+   sufficient for current automation scope?
+
+## First Slice Recommendation
+
+Implement Phase 1 first: PR repair evidence gate.
+
+Reason:
+
+- It directly addresses the user's current quality problem: real PR repair
+  should not claim success from agent narration.
+- It is small enough to test locally.
+- It does not require a full state-machine rewrite.
+- It preserves existing PR feedback/local review improvements.
+- It creates a clear before/after eval hypothesis.
+
+Success criteria:
+
+- `PrReadyToMerge` without current PR snapshot blocks.
+- `address_pr_feedback` empty success blocks.
+- A valid PR snapshot can move to the intended next state.
+- Existing local review tests continue to pass.
+- A collect-only/live eval can show fewer false-success states or a higher
+  PR repair score.


### PR DESCRIPTION
## Summary

- Add a PR repair/readiness evidence gate before accepting PR feedback workflow decisions.
- Require `pr_repair_snapshot` evidence for `address_pr_feedback` success and `PrReadyToMerge`/`mark_ready_to_merge` readiness claims.
- Update runtime prompt/activity contracts so agents know when snapshot evidence is required.
- Add a design spec for the broader workflow state-machine quality plan, including the follow-up server-owned PR snapshot collector.

## Quality impact

This prevents false success paths where an agent can mark a PR ready or repaired from narration alone. Readiness now requires machine-readable PR evidence for final head, observed timestamp, approved review decision, non-draft state, successful checks, clean mergeability, and zero active unresolved review threads.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p harness-workflow`
- `cargo test -p harness-server activity_result_schema`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`
- `scripts/evaluate_pr_repair.sh --repo majiayu000/harness --pr 1234 --collect-only --output /tmp/harness-pr1234-collect-20260606T000159Z`

Collect-only snapshot for `#1234`: `head=080e35a934e6669d0ddbef89f5d4b17aca95072a`, `merge=DIRTY`, `checks=UNKNOWN`, `unresolved_threads=1`, class `review_feedback_repair`.
