### PR TITLE
feat(eval): emit PR repair quality snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ name = "harness-eval"
 version = "0.6.34"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/harness-eval/Cargo.toml
+++ b/crates/harness-eval/Cargo.toml
@@ -9,3 +9,4 @@ rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/harness-eval/src/bin/score_pr_repair.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair.rs
@@ -1,4 +1,4 @@
-use harness_eval::{pr_repair_eval_input_from_values, score_pr_repair_eval};
+use harness_eval::{pr_repair_eval_input_from_values, score_pr_repair_eval, PrRepairEvalIngest};
 use serde_json::Value;
 use std::env;
 use std::fs;
@@ -31,16 +31,16 @@ fn run() -> Result<(), String> {
     let final_pr = read_json(&args.final_pr)?;
     let submission = args.submission.as_ref().map(read_json).transpose()?;
     let task_detail = args.task_detail.as_ref().map(read_json).transpose()?;
-    let input = pr_repair_eval_input_from_values(
-        &args.repo,
-        args.pr_number,
-        &args.baseline_collected_at,
-        &args.final_collected_at,
-        &baseline,
-        &final_pr,
-        submission.as_ref(),
-        task_detail.as_ref(),
-    );
+    let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+        repo: &args.repo,
+        pr_number: args.pr_number,
+        baseline_collected_at: &args.baseline_collected_at,
+        final_collected_at: &args.final_collected_at,
+        baseline: &baseline,
+        final_pr: &final_pr,
+        submission: submission.as_ref(),
+        task_detail: task_detail.as_ref(),
+    });
     let snapshot = score_pr_repair_eval(input.clone()).map_err(|err| err.to_string())?;
 
     if let Some(path) = args.input_output {

--- a/crates/harness-eval/src/bin/score_pr_repair.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair.rs
@@ -1,0 +1,142 @@
+use harness_eval::{pr_repair_eval_input_from_values, score_pr_repair_eval};
+use serde_json::Value;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct Args {
+    repo: String,
+    pr_number: u64,
+    baseline: PathBuf,
+    final_pr: PathBuf,
+    submission: Option<PathBuf>,
+    task_detail: Option<PathBuf>,
+    baseline_collected_at: String,
+    final_collected_at: String,
+    input_output: Option<PathBuf>,
+    snapshot_output: PathBuf,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args(env::args().skip(1))?;
+    let baseline = read_json(&args.baseline)?;
+    let final_pr = read_json(&args.final_pr)?;
+    let submission = args.submission.as_ref().map(read_json).transpose()?;
+    let task_detail = args.task_detail.as_ref().map(read_json).transpose()?;
+    let input = pr_repair_eval_input_from_values(
+        &args.repo,
+        args.pr_number,
+        &args.baseline_collected_at,
+        &args.final_collected_at,
+        &baseline,
+        &final_pr,
+        submission.as_ref(),
+        task_detail.as_ref(),
+    );
+    let snapshot = score_pr_repair_eval(input.clone()).map_err(|err| err.to_string())?;
+
+    if let Some(path) = args.input_output {
+        write_json(
+            &path,
+            &serde_json::to_value(input).map_err(|err| err.to_string())?,
+        )?;
+    }
+    write_json(
+        &args.snapshot_output,
+        &serde_json::to_value(snapshot).map_err(|err| err.to_string())?,
+    )?;
+    Ok(())
+}
+
+fn parse_args<I>(mut args: I) -> Result<Args, String>
+where
+    I: Iterator<Item = String>,
+{
+    let mut parsed = Args::default();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" => parsed.repo = required_value(&mut args, "--repo")?,
+            "--pr" => {
+                parsed.pr_number = required_value(&mut args, "--pr")?
+                    .parse::<u64>()
+                    .map_err(|_| "--pr must be a number".to_string())?;
+            }
+            "--baseline" => {
+                parsed.baseline = PathBuf::from(required_value(&mut args, "--baseline")?)
+            }
+            "--final" => parsed.final_pr = PathBuf::from(required_value(&mut args, "--final")?),
+            "--submission" => {
+                parsed.submission = Some(PathBuf::from(required_value(&mut args, "--submission")?));
+            }
+            "--task-detail" => {
+                parsed.task_detail =
+                    Some(PathBuf::from(required_value(&mut args, "--task-detail")?));
+            }
+            "--baseline-collected-at" => {
+                parsed.baseline_collected_at =
+                    required_value(&mut args, "--baseline-collected-at")?;
+            }
+            "--final-collected-at" => {
+                parsed.final_collected_at = required_value(&mut args, "--final-collected-at")?;
+            }
+            "--input-output" => {
+                parsed.input_output =
+                    Some(PathBuf::from(required_value(&mut args, "--input-output")?));
+            }
+            "--snapshot-output" => {
+                parsed.snapshot_output =
+                    PathBuf::from(required_value(&mut args, "--snapshot-output")?);
+            }
+            "-h" | "--help" => {
+                return Err(usage());
+            }
+            _ => return Err(format!("unknown argument: {arg}\n{}", usage())),
+        }
+    }
+
+    if parsed.repo.is_empty()
+        || parsed.pr_number == 0
+        || parsed.baseline.as_os_str().is_empty()
+        || parsed.final_pr.as_os_str().is_empty()
+        || parsed.baseline_collected_at.is_empty()
+        || parsed.final_collected_at.is_empty()
+        || parsed.snapshot_output.as_os_str().is_empty()
+    {
+        return Err(usage());
+    }
+
+    Ok(parsed)
+}
+
+fn required_value<I>(args: &mut I, flag: &str) -> Result<String, String>
+where
+    I: Iterator<Item = String>,
+{
+    args.next()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn read_json(path: &PathBuf) -> Result<Value, String> {
+    let body = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    serde_json::from_str(&body).map_err(|err| format!("failed to parse {}: {err}", path.display()))
+}
+
+fn write_json(path: &PathBuf, value: &Value) -> Result<(), String> {
+    let body = serde_json::to_string_pretty(value).map_err(|err| err.to_string())?;
+    fs::write(path, format!("{body}\n"))
+        .map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn usage() -> String {
+    "Usage: score_pr_repair --repo OWNER/REPO --pr N --baseline baseline_pr.json --final final_pr.json --baseline-collected-at RFC3339 --final-collected-at RFC3339 --snapshot-output quality_snapshot.json [--submission submission.json --task-detail task_detail_final.json --input-output pr_repair_eval_input.json]".to_string()
+}

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -154,7 +154,9 @@ pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepa
 }
 
 fn scenario_from_baseline(snapshot: &PullRequestSnapshot) -> EvalScenario {
-    if snapshot.active_unresolved_review_threads.is_empty()
+    if !snapshot.is_draft
+        && review_decision_allows_noop(snapshot.review_decision.as_ref())
+        && snapshot.active_unresolved_review_threads.is_empty()
         && snapshot.check_state == CheckState::Passing
         && snapshot.merge_state == MergeState::Clean
     {
@@ -162,6 +164,13 @@ fn scenario_from_baseline(snapshot: &PullRequestSnapshot) -> EvalScenario {
     } else {
         EvalScenario::PrRepair
     }
+}
+
+fn review_decision_allows_noop(review_decision: Option<&ReviewDecision>) -> bool {
+    !matches!(
+        review_decision,
+        Some(ReviewDecision::ChangesRequested | ReviewDecision::ReviewRequired)
+    )
 }
 
 fn runtime_jobs_from_value(value: &Value) -> Vec<RuntimeJobSnapshot> {
@@ -338,5 +347,67 @@ mod tests {
 
         assert_eq!(input.scenario, EvalScenario::ReadyNoopControl);
         assert!(input.runtime.is_none());
+    }
+
+    #[test]
+    fn review_required_baseline_is_pr_repair() {
+        let pr = json!({
+            "number": 7,
+            "url": "https://github.com/owner/repo/pull/7",
+            "title": "Example",
+            "baseRefName": "main",
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewDecision": "CHANGES_REQUESTED",
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: None,
+        });
+
+        assert_eq!(input.scenario, EvalScenario::PrRepair);
+    }
+
+    #[test]
+    fn draft_baseline_is_pr_repair() {
+        let pr = json!({
+            "number": 7,
+            "url": "https://github.com/owner/repo/pull/7",
+            "title": "Example",
+            "baseRefName": "main",
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "isDraft": true,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewDecision": "APPROVED",
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: None,
+        });
+
+        assert_eq!(input.scenario, EvalScenario::PrRepair);
     }
 }

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -252,6 +252,8 @@ fn is_terminal_state(state: &str) -> bool {
             | "succeeded"
             | "success"
             | "passed"
+            | "ready_to_merge"
+            | "blocked"
             | "failed"
             | "cancelled"
             | "canceled"
@@ -478,5 +480,31 @@ mod tests {
         assert_eq!(snapshot.terminal_state, None);
         assert_eq!(snapshot.runtime_jobs.len(), 1);
         assert_eq!(snapshot.runtime_jobs[0].terminal_state, None);
+    }
+
+    #[test]
+    fn pr_repair_terminal_workflow_states_are_runtime_evidence() {
+        for state in ["ready_to_merge", "blocked"] {
+            let submission = json!({
+                "task_id": "task-1",
+                "workflow_id": "workflow-1"
+            });
+            let task_detail = json!({
+                "id": "task-1",
+                "status": state,
+                "workflow": {
+                    "id": "workflow-1",
+                    "state": state
+                }
+            });
+
+            let Some(snapshot) =
+                runtime_snapshot_from_values(&submission, &task_detail, "2026-06-06T00:01:00Z")
+            else {
+                panic!("runtime identity should produce a runtime snapshot");
+            };
+
+            assert_eq!(snapshot.terminal_state.as_deref(), Some(state));
+        }
     }
 }

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -4,6 +4,17 @@ use crate::model::{
 };
 use serde_json::Value;
 
+pub struct PrRepairEvalIngest<'a> {
+    pub repo: &'a str,
+    pub pr_number: u64,
+    pub baseline_collected_at: &'a str,
+    pub final_collected_at: &'a str,
+    pub baseline: &'a Value,
+    pub final_pr: &'a Value,
+    pub submission: Option<&'a Value>,
+    pub task_detail: Option<&'a Value>,
+}
+
 pub fn github_pr_snapshot_from_value(
     repo: &str,
     collected_at: &str,
@@ -110,22 +121,15 @@ pub fn runtime_snapshot_from_values(
     })
 }
 
-pub fn pr_repair_eval_input_from_values(
-    repo: &str,
-    pr_number: u64,
-    baseline_collected_at: &str,
-    final_collected_at: &str,
-    baseline: &Value,
-    final_pr: &Value,
-    submission: Option<&Value>,
-    task_detail: Option<&Value>,
-) -> PrRepairEvalInput {
-    let baseline_pr = github_pr_snapshot_from_value(repo, baseline_collected_at, baseline);
-    let final_pr_snapshot = github_pr_snapshot_from_value(repo, final_collected_at, final_pr);
+pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepairEvalInput {
+    let baseline_pr =
+        github_pr_snapshot_from_value(input.repo, input.baseline_collected_at, input.baseline);
+    let final_pr_snapshot =
+        github_pr_snapshot_from_value(input.repo, input.final_collected_at, input.final_pr);
     let scenario = scenario_from_baseline(&baseline_pr);
-    let runtime = match (submission, task_detail) {
+    let runtime = match (input.submission, input.task_detail) {
         (Some(submission), Some(task_detail)) => {
-            runtime_snapshot_from_values(submission, task_detail, final_collected_at)
+            runtime_snapshot_from_values(submission, task_detail, input.final_collected_at)
         }
         _ => None,
     };
@@ -133,8 +137,8 @@ pub fn pr_repair_eval_input_from_values(
     PrRepairEvalInput {
         scenario,
         target: EvalTarget::PullRequest {
-            repo: repo.to_string(),
-            pr_number,
+            repo: input.repo.to_string(),
+            pr_number: input.pr_number,
             base_ref: Some(baseline_pr.base_ref.clone()),
             head_ref: Some(baseline_pr.head_ref.clone()),
         },
@@ -321,16 +325,16 @@ mod tests {
             "files": {"nodes": []}
         });
 
-        let input = pr_repair_eval_input_from_values(
-            "owner/repo",
-            7,
-            "2026-06-06T00:00:00Z",
-            "2026-06-06T00:01:00Z",
-            &pr,
-            &pr,
-            None,
-            None,
-        );
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: None,
+        });
 
         assert_eq!(input.scenario, EvalScenario::ReadyNoopControl);
         assert!(input.runtime.is_none());

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -1,0 +1,338 @@
+use crate::model::{
+    ChangedFileSnapshot, CheckState, EvalScenario, EvalTarget, MergeState, PrRepairEvalInput,
+    PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, RuntimeJobSnapshot, RuntimeSnapshot,
+};
+use serde_json::Value;
+
+pub fn github_pr_snapshot_from_value(
+    repo: &str,
+    collected_at: &str,
+    value: &Value,
+) -> PullRequestSnapshot {
+    let review_threads = value
+        .pointer("/reviewThreads/nodes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|thread| {
+            !thread
+                .get("isResolved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                && !thread
+                    .get("isOutdated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+        })
+        .map(|thread| ReviewThreadSnapshot {
+            id: string_field(thread, "id"),
+            path: optional_string_field(thread, "path"),
+            is_resolved: thread
+                .get("isResolved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            is_outdated: thread
+                .get("isOutdated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        })
+        .collect();
+
+    let changed_files = value
+        .pointer("/files/nodes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|file| ChangedFileSnapshot {
+            path: string_field(file, "path"),
+            additions: u64_field(file, "additions"),
+            deletions: u64_field(file, "deletions"),
+            status: string_field(file, "changeType"),
+        })
+        .collect();
+
+    PullRequestSnapshot {
+        repo: repo.to_string(),
+        pr_number: u64_field(value, "number"),
+        url: optional_string_field(value, "url"),
+        title: optional_string_field(value, "title"),
+        base_ref: string_field(value, "baseRefName"),
+        head_ref: string_field(value, "headRefName"),
+        head_oid: string_field(value, "headRefOid"),
+        is_draft: value
+            .get("isDraft")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        merge_state: merge_state_from_github(value.get("mergeStateStatus")),
+        check_state: check_state_from_github(value.pointer("/statusCheckRollup/state")),
+        review_decision: review_decision_from_github(value.get("reviewDecision")),
+        active_unresolved_review_threads: review_threads,
+        changed_files,
+        collected_at: collected_at.to_string(),
+    }
+}
+
+pub fn runtime_snapshot_from_values(
+    submission: &Value,
+    task_detail: &Value,
+    collected_at: &str,
+) -> Option<RuntimeSnapshot> {
+    let task_id = optional_string_field(submission, "task_id")
+        .or_else(|| optional_string_field(submission, "submission_id"))
+        .or_else(|| optional_string_field(task_detail, "id"));
+    let workflow_id = optional_string_field(submission, "workflow_id")
+        .or_else(|| optional_string_at_pointer(task_detail, "/workflow/id"));
+    let terminal_state = optional_string_field(task_detail, "status")
+        .or_else(|| optional_string_at_pointer(task_detail, "/workflow/state"))
+        .or_else(|| optional_string_field(submission, "status"));
+    let workflow_state = optional_string_at_pointer(task_detail, "/workflow/state");
+    let latest_activity = optional_string_field(task_detail, "latest_activity")
+        .or_else(|| optional_string_at_pointer(task_detail, "/workflow/latest_activity"));
+    let runtime_jobs = runtime_jobs_from_value(task_detail);
+
+    if task_id.is_none()
+        && workflow_id.is_none()
+        && terminal_state.is_none()
+        && workflow_state.is_none()
+        && runtime_jobs.is_empty()
+    {
+        return None;
+    }
+
+    Some(RuntimeSnapshot {
+        task_id,
+        workflow_id,
+        workflow_state,
+        runtime_jobs,
+        latest_activity,
+        terminal_state,
+        collected_at: collected_at.to_string(),
+    })
+}
+
+pub fn pr_repair_eval_input_from_values(
+    repo: &str,
+    pr_number: u64,
+    baseline_collected_at: &str,
+    final_collected_at: &str,
+    baseline: &Value,
+    final_pr: &Value,
+    submission: Option<&Value>,
+    task_detail: Option<&Value>,
+) -> PrRepairEvalInput {
+    let baseline_pr = github_pr_snapshot_from_value(repo, baseline_collected_at, baseline);
+    let final_pr_snapshot = github_pr_snapshot_from_value(repo, final_collected_at, final_pr);
+    let scenario = scenario_from_baseline(&baseline_pr);
+    let runtime = match (submission, task_detail) {
+        (Some(submission), Some(task_detail)) => {
+            runtime_snapshot_from_values(submission, task_detail, final_collected_at)
+        }
+        _ => None,
+    };
+
+    PrRepairEvalInput {
+        scenario,
+        target: EvalTarget::PullRequest {
+            repo: repo.to_string(),
+            pr_number,
+            base_ref: Some(baseline_pr.base_ref.clone()),
+            head_ref: Some(baseline_pr.head_ref.clone()),
+        },
+        final_evidence_head_oid: Some(final_pr_snapshot.head_oid.clone()),
+        baseline_pr,
+        final_pr: final_pr_snapshot,
+        runtime,
+        usage: Vec::new(),
+        reviewer_judgment: None,
+        created_unrelated_pr: false,
+        scope_violations: Vec::new(),
+    }
+}
+
+fn scenario_from_baseline(snapshot: &PullRequestSnapshot) -> EvalScenario {
+    if snapshot.active_unresolved_review_threads.is_empty()
+        && snapshot.check_state == CheckState::Passing
+        && snapshot.merge_state == MergeState::Clean
+    {
+        EvalScenario::ReadyNoopControl
+    } else {
+        EvalScenario::PrRepair
+    }
+}
+
+fn runtime_jobs_from_value(value: &Value) -> Vec<RuntimeJobSnapshot> {
+    let Some(jobs) = value
+        .get("runtime_jobs")
+        .or_else(|| value.get("runtimeJobs"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    jobs.iter()
+        .map(|job| RuntimeJobSnapshot {
+            runtime_job_id: string_field(job, "runtime_job_id")
+                .or_else_empty(|| string_field(job, "runtimeJobId"))
+                .or_else_empty(|| string_field(job, "id")),
+            state: string_field(job, "state").or_else_empty(|| string_field(job, "status")),
+            artifact_count: job
+                .get("artifact_count")
+                .or_else(|| job.get("artifactCount"))
+                .and_then(json_u64)
+                .unwrap_or(0),
+            terminal_state: optional_string_field(job, "terminal_state")
+                .or_else(|| optional_string_field(job, "terminalState")),
+        })
+        .collect()
+}
+
+fn merge_state_from_github(value: Option<&Value>) -> MergeState {
+    match value.and_then(Value::as_str).unwrap_or_default() {
+        "CLEAN" => MergeState::Clean,
+        "DIRTY" => MergeState::Dirty,
+        "BLOCKED" => MergeState::Blocked,
+        "BEHIND" => MergeState::Behind,
+        _ => MergeState::Unknown,
+    }
+}
+
+fn check_state_from_github(value: Option<&Value>) -> CheckState {
+    match value.and_then(Value::as_str).unwrap_or_default() {
+        "SUCCESS" => CheckState::Passing,
+        "PENDING" | "EXPECTED" => CheckState::Pending,
+        "FAILURE" | "ERROR" => CheckState::Failing,
+        _ => CheckState::Unknown,
+    }
+}
+
+fn review_decision_from_github(value: Option<&Value>) -> Option<ReviewDecision> {
+    match value.and_then(Value::as_str).unwrap_or_default() {
+        "APPROVED" => Some(ReviewDecision::Approved),
+        "CHANGES_REQUESTED" => Some(ReviewDecision::ChangesRequested),
+        "REVIEW_REQUIRED" => Some(ReviewDecision::ReviewRequired),
+        _ => None,
+    }
+}
+
+fn optional_string_at_pointer(value: &Value, pointer: &str) -> Option<String> {
+    value.pointer(pointer).and_then(json_string)
+}
+
+fn optional_string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(json_string)
+}
+
+fn string_field(value: &Value, field: &str) -> String {
+    optional_string_field(value, field).unwrap_or_default()
+}
+
+fn u64_field(value: &Value, field: &str) -> u64 {
+    value.get(field).and_then(json_u64).unwrap_or(0)
+}
+
+fn json_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) if !text.trim().is_empty() => Some(text.to_string()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn json_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|text| text.parse::<u64>().ok()))
+}
+
+trait NonEmptyStringExt {
+    fn or_else_empty<F>(self, fallback: F) -> String
+    where
+        F: FnOnce() -> String;
+}
+
+impl NonEmptyStringExt for String {
+    fn or_else_empty<F>(self, fallback: F) -> String
+    where
+        F: FnOnce() -> String,
+    {
+        if self.trim().is_empty() {
+            fallback()
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn maps_github_pr_snapshot_to_eval_model() {
+        let snapshot = github_pr_snapshot_from_value(
+            "owner/repo",
+            "2026-06-06T00:00:00Z",
+            &json!({
+                "number": 7,
+                "url": "https://github.com/owner/repo/pull/7",
+                "title": "Fix CI",
+                "headRefName": "fix/ci",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+                "isDraft": false,
+                "mergeStateStatus": "CLEAN",
+                "reviewDecision": "APPROVED",
+                "statusCheckRollup": {"state": "SUCCESS"},
+                "reviewThreads": {
+                    "nodes": [
+                        {"id": "active", "path": "src/lib.rs", "isResolved": false, "isOutdated": false},
+                        {"id": "resolved", "path": "src/main.rs", "isResolved": true, "isOutdated": false},
+                        {"id": "old", "path": "src/old.rs", "isResolved": false, "isOutdated": true}
+                    ]
+                },
+                "files": {
+                    "nodes": [
+                        {"path": "src/lib.rs", "additions": 3, "deletions": 1, "changeType": "MODIFIED"}
+                    ]
+                }
+            }),
+        );
+
+        assert_eq!(snapshot.repo, "owner/repo");
+        assert_eq!(snapshot.pr_number, 7);
+        assert_eq!(snapshot.check_state, CheckState::Passing);
+        assert_eq!(snapshot.merge_state, MergeState::Clean);
+        assert_eq!(snapshot.active_unresolved_review_threads.len(), 1);
+        assert_eq!(snapshot.changed_files.len(), 1);
+    }
+
+    #[test]
+    fn builds_ready_noop_input_from_clean_baseline() {
+        let pr = json!({
+            "number": 7,
+            "headRefName": "ready",
+            "headRefOid": "same",
+            "baseRefName": "main",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+
+        let input = pr_repair_eval_input_from_values(
+            "owner/repo",
+            7,
+            "2026-06-06T00:00:00Z",
+            "2026-06-06T00:01:00Z",
+            &pr,
+            &pr,
+            None,
+            None,
+        );
+
+        assert_eq!(input.scenario, EvalScenario::ReadyNoopControl);
+        assert!(input.runtime.is_none());
+    }
+}

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -93,9 +93,9 @@ pub fn runtime_snapshot_from_values(
         .or_else(|| optional_string_field(task_detail, "id"));
     let workflow_id = optional_string_field(submission, "workflow_id")
         .or_else(|| optional_string_at_pointer(task_detail, "/workflow/id"));
-    let terminal_state = optional_string_field(task_detail, "status")
-        .or_else(|| optional_string_at_pointer(task_detail, "/workflow/state"))
-        .or_else(|| optional_string_field(submission, "status"));
+    let terminal_state = terminal_string_field(task_detail, "status")
+        .or_else(|| terminal_string_at_pointer(task_detail, "/workflow/state"))
+        .or_else(|| terminal_string_field(submission, "status"));
     let workflow_state = optional_string_at_pointer(task_detail, "/workflow/state");
     let latest_activity = optional_string_field(task_detail, "latest_activity")
         .or_else(|| optional_string_at_pointer(task_detail, "/workflow/latest_activity"));
@@ -193,8 +193,9 @@ fn runtime_jobs_from_value(value: &Value) -> Vec<RuntimeJobSnapshot> {
                 .or_else(|| job.get("artifactCount"))
                 .and_then(json_u64)
                 .unwrap_or(0),
-            terminal_state: optional_string_field(job, "terminal_state")
-                .or_else(|| optional_string_field(job, "terminalState")),
+            terminal_state: terminal_string_field(job, "terminal_state")
+                .or_else(|| terminal_string_field(job, "terminalState"))
+                .or_else(|| terminal_string_field(job, "status")),
         })
         .collect()
 }
@@ -233,6 +234,32 @@ fn optional_string_at_pointer(value: &Value, pointer: &str) -> Option<String> {
 
 fn optional_string_field(value: &Value, field: &str) -> Option<String> {
     value.get(field).and_then(json_string)
+}
+
+fn terminal_string_at_pointer(value: &Value, pointer: &str) -> Option<String> {
+    optional_string_at_pointer(value, pointer).filter(|state| is_terminal_state(state))
+}
+
+fn terminal_string_field(value: &Value, field: &str) -> Option<String> {
+    optional_string_field(value, field).filter(|state| is_terminal_state(state))
+}
+
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state.trim().to_ascii_lowercase().as_str(),
+        "done"
+            | "completed"
+            | "succeeded"
+            | "success"
+            | "passed"
+            | "failed"
+            | "cancelled"
+            | "canceled"
+            | "timed_out"
+            | "timeout"
+            | "errored"
+            | "error"
+    )
 }
 
 fn string_field(value: &Value, field: &str) -> String {
@@ -409,5 +436,47 @@ mod tests {
         });
 
         assert_eq!(input.scenario, EvalScenario::PrRepair);
+    }
+
+    #[test]
+    fn running_runtime_status_is_not_terminal_evidence() {
+        let submission = json!({
+            "task_id": "task-1",
+            "workflow_id": "workflow-1",
+            "status": "implementing"
+        });
+        let task_detail = json!({
+            "id": "task-1",
+            "status": "running",
+            "workflow": {
+                "id": "workflow-1",
+                "state": "addressing_feedback",
+                "latest_activity": "implementing"
+            },
+            "runtime_jobs": [
+                {
+                    "id": "job-1",
+                    "state": "running",
+                    "status": "running",
+                    "artifact_count": 0
+                }
+            ]
+        });
+
+        let Some(snapshot) =
+            runtime_snapshot_from_values(&submission, &task_detail, "2026-06-06T00:01:00Z")
+        else {
+            panic!("runtime identity should still produce a runtime snapshot");
+        };
+
+        assert_eq!(snapshot.task_id.as_deref(), Some("task-1"));
+        assert_eq!(snapshot.workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(
+            snapshot.workflow_state.as_deref(),
+            Some("addressing_feedback")
+        );
+        assert_eq!(snapshot.terminal_state, None);
+        assert_eq!(snapshot.runtime_jobs.len(), 1);
+        assert_eq!(snapshot.runtime_jobs[0].terminal_state, None);
     }
 }

--- a/crates/harness-eval/src/lib.rs
+++ b/crates/harness-eval/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod ingest;
 pub mod model;
 pub mod scoring;
 
+pub use ingest::*;
 pub use model::*;
 pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -100,8 +100,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
             HardGateName::RuntimeArtifactCompleteness,
             runtime_complete,
             Some(EvalGrade::B),
-            "runtime task, workflow, or job artifact is present",
-            "runtime artifact is missing or empty",
+            "usable runtime task, workflow, or job artifact is present",
+            "runtime artifact is missing, failed, or empty",
         ),
         reviewer_gate(&input),
     ];
@@ -179,13 +179,36 @@ fn branch_safe(input: &PrRepairEvalInput) -> bool {
 
 fn runtime_has_artifact(runtime: &RuntimeSnapshot) -> bool {
     let has_runtime_identity = runtime.task_id.is_some() && runtime.workflow_id.is_some();
+    if !has_runtime_identity || runtime_has_failed_terminal_state(runtime) {
+        return false;
+    }
+
     let has_terminal_or_job_evidence = runtime.terminal_state.is_some()
         || runtime
             .runtime_jobs
             .iter()
             .any(|job| job.artifact_count > 0 || job.terminal_state.is_some());
 
-    has_runtime_identity && has_terminal_or_job_evidence
+    has_terminal_or_job_evidence
+}
+
+fn runtime_has_failed_terminal_state(runtime: &RuntimeSnapshot) -> bool {
+    runtime
+        .terminal_state
+        .as_deref()
+        .is_some_and(is_failed_runtime_terminal_state)
+        || runtime.runtime_jobs.iter().any(|job| {
+            job.terminal_state
+                .as_deref()
+                .is_some_and(is_failed_runtime_terminal_state)
+        })
+}
+
+fn is_failed_runtime_terminal_state(state: &str) -> bool {
+    matches!(
+        state.trim().to_ascii_lowercase().as_str(),
+        "failed" | "cancelled" | "canceled" | "timed_out" | "timeout" | "errored" | "error"
+    )
 }
 
 fn gate(
@@ -510,6 +533,81 @@ mod tests {
         assert_eq!(gate.status, GateStatus::Fail);
         assert_eq!(gate.grade_cap, Some(EvalGrade::B));
         assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    }
+
+    #[test]
+    fn failed_runtime_terminal_states_cap_at_b() {
+        for state in [
+            "failed",
+            "cancelled",
+            "canceled",
+            "timed_out",
+            "timeout",
+            "errored",
+            "error",
+        ] {
+            let mut input = perfect_input();
+            let Some(runtime) = input.runtime.as_mut() else {
+                panic!("runtime should exist");
+            };
+            runtime.terminal_state = Some(state.to_string());
+            runtime.runtime_jobs[0].artifact_count = 1;
+            runtime.runtime_jobs[0].terminal_state = Some("succeeded".to_string());
+
+            let snapshot = match score_pr_repair_eval(input) {
+                Ok(snapshot) => snapshot,
+                Err(error) => panic!("score failed runtime input failed: {error}"),
+            };
+            let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+            assert_eq!(gate.status, GateStatus::Fail);
+            assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+            assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+            assert_eq!(snapshot.final_grade, EvalGrade::B);
+        }
+    }
+
+    #[test]
+    fn failed_runtime_job_terminal_state_caps_at_b_even_with_artifacts() {
+        let mut input = perfect_input();
+        let Some(runtime) = input.runtime.as_mut() else {
+            panic!("runtime should exist");
+        };
+        runtime.terminal_state = Some("succeeded".to_string());
+        runtime.runtime_jobs[0].artifact_count = 1;
+        runtime.runtime_jobs[0].terminal_state = Some("failed".to_string());
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score failed job runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    }
+
+    #[test]
+    fn auditable_runtime_terminal_states_count_as_runtime_evidence() {
+        for state in ["ready_to_merge", "blocked"] {
+            let mut input = perfect_input();
+            let Some(runtime) = input.runtime.as_mut() else {
+                panic!("runtime should exist");
+            };
+            runtime.terminal_state = Some(state.to_string());
+            runtime.runtime_jobs.clear();
+
+            let snapshot = match score_pr_repair_eval(input) {
+                Ok(snapshot) => snapshot,
+                Err(error) => panic!("score auditable runtime input failed: {error}"),
+            };
+            let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+            assert_eq!(gate.status, GateStatus::Pass);
+            assert_eq!(gate.grade_cap, None);
+            assert_eq!(snapshot.grade_cap, None);
+        }
     }
 
     #[test]

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -53,7 +53,21 @@ Acceptance:
 
 - `bash -n scripts/evaluate_pr_repair.sh` passes.
 - A task ID containing `/` is encoded as a single URL path segment.
-- Collect-only mode still writes the baseline report.
+- Collect-only mode writes `baseline_pr.json`, `final_pr.json`,
+  `pr_repair_eval_input.json`, `quality_snapshot.json`, and `summary.md`
+  without requiring a Harness server.
+- Live mode writes the same machine-readable eval input and quality snapshot
+  after terminal, failed-submission, missing-task-id, or timeout outcomes.
+- The quality snapshot is produced by `harness-eval`, not the Markdown report
+  heuristic.
+
+Implementation status:
+
+- Added `evaluate_pr_repair_submit.py` so non-2xx submission responses and
+  network errors are preserved as artifacts.
+- Added `score_pr_repair` ingestion in `harness-eval` so external GitHub
+  snapshots can be converted into canonical `PrRepairEvalInput` and scored
+  into `QualitySnapshot`.
 
 ### Issue 3: Persist eval runs in `harness-server`
 

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -202,6 +202,16 @@ Each run should produce a report with:
 - validation commands observed in task rounds or PR comments
 - final grade and blocker summary
 
+Each run must also write machine-readable eval artifacts:
+
+- `pr_repair_eval_input.json`: canonical `PrRepairEvalInput` consumed by
+  `harness-eval` and `/api/evals/runs/{run_id}/score`.
+- `quality_snapshot.json`: deterministic `QualitySnapshot` with hard gates,
+  score breakdown, grade caps, blocker summary, runtime evidence, and PR facts.
+
+The Markdown summary is an operator convenience layer. It must not be the source
+of truth for eval scoring, dashboards, or merge readiness.
+
 ## Interpretation Rules
 
 - A merged PR is not automatically high quality.

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -128,7 +128,10 @@ require_cmd gh
 require_cmd curl
 require_cmd python3
 require_cmd date
+require_cmd cargo
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OWNER="${REPO%%/*}"
 NAME="${REPO#*/}"
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -674,15 +677,54 @@ FINAL_JSON="$OUTPUT_DIR/final_pr.json"
 SUBMISSION_JSON="$OUTPUT_DIR/submission.json"
 TASK_DETAIL_JSON="$OUTPUT_DIR/task_detail_final.json"
 TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
+PR_REPAIR_EVAL_INPUT_JSON="$OUTPUT_DIR/pr_repair_eval_input.json"
+QUALITY_SNAPSHOT_JSON="$OUTPUT_DIR/quality_snapshot.json"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
 
+write_quality_snapshot() {
+  local baseline="$1"
+  local final="$2"
+  local submission="$3"
+  local task_detail="$4"
+  local baseline_collected_at="$5"
+  local final_collected_at="$6"
+  local args=(
+    run
+    --quiet
+    --manifest-path "$REPO_ROOT/Cargo.toml"
+    -p harness-eval
+    --bin score_pr_repair
+    --
+    --repo "$REPO"
+    --pr "$PR"
+    --baseline "$baseline"
+    --final "$final"
+    --baseline-collected-at "$baseline_collected_at"
+    --final-collected-at "$final_collected_at"
+    --input-output "$PR_REPAIR_EVAL_INPUT_JSON"
+    --snapshot-output "$QUALITY_SNAPSHOT_JSON"
+  )
+  if [[ -s "$submission" ]]; then
+    args+=(--submission "$submission")
+  fi
+  if [[ -s "$task_detail" ]]; then
+    args+=(--task-detail "$task_detail")
+  fi
+  cargo "${args[@]}"
+}
+
 echo "Collecting baseline for $REPO#$PR"
+BASELINE_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 collect_snapshot "$BASELINE_JSON"
 snapshot_summary "$BASELINE_JSON"
+cp "$BASELINE_JSON" "$FINAL_JSON"
+FINAL_COLLECTED_AT="$BASELINE_COLLECTED_AT"
+write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
 write_collect_report "$BASELINE_JSON"
 
 if [[ "$COLLECT_ONLY" -eq 1 ]]; then
   echo "Collect-only report: $OUTPUT_DIR/summary.md"
+  echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
   exit 0
 fi
 
@@ -730,14 +772,17 @@ print(json.dumps(body, indent=2))
 PY
 
 echo "Submitting Harness PR repair task"
-if ! python3 "$(dirname "$0")/evaluate_pr_repair_submit.py" --server-url "$SERVER_URL" --body "$TASK_BODY_JSON" --output "$SUBMISSION_JSON" --mode prompt_task; then
+if ! python3 "$SCRIPT_DIR/evaluate_pr_repair_submit.py" --server-url "$SERVER_URL" --body "$TASK_BODY_JSON" --output "$SUBMISSION_JSON" --mode prompt_task; then
   printf '{"status":"failed"}\n' > "$TASK_DETAIL_JSON"
   echo "POST /tasks failed; see $SUBMISSION_JSON" >&2
   echo "Collecting final PR snapshot"
+  FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   collect_snapshot "$FINAL_JSON"
   snapshot_summary "$FINAL_JSON"
+  write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
   write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
   echo "Evaluation report: $OUTPUT_DIR/summary.md"
+  echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
   exit 4
 fi
 
@@ -758,10 +803,13 @@ if [[ -z "$TASK_ID" ]]; then
   printf '{"status":"failed"}\n' > "$TASK_DETAIL_JSON"
   echo "POST /tasks did not return task_id; see $SUBMISSION_JSON" >&2
   echo "Collecting final PR snapshot"
+  FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   collect_snapshot "$FINAL_JSON"
   snapshot_summary "$FINAL_JSON"
+  write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
   write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
   echo "Evaluation report: $OUTPUT_DIR/summary.md"
+  echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
   exit 4
 fi
 
@@ -792,7 +840,10 @@ case "$status" in
 esac
 
 echo "Collecting final PR snapshot"
+FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 collect_snapshot "$FINAL_JSON"
 snapshot_summary "$FINAL_JSON"
+write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
 write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out"
 echo "Evaluation report: $OUTPUT_DIR/summary.md"
+echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"


### PR DESCRIPTION
## Summary

- Add `harness-eval` ingestion for GitHub PR snapshots, runtime task details, and PR repair eval inputs.
- Add `score_pr_repair` so external evaluator artifacts can be converted into canonical `PrRepairEvalInput` and deterministic `QualitySnapshot` JSON.
- Update `scripts/evaluate_pr_repair.sh` to write `pr_repair_eval_input.json` and `quality_snapshot.json` for collect-only, failed submission, missing task id, timeout, and terminal live runs.
- Update eval docs to make machine-readable quality snapshots the scoring source of truth instead of the Markdown heuristic.

## Quality impact

This is the next eval slice after #1245 and #1247. It does not complete server-owned PR snapshot collection from #1251, but it gives PR repair runs an auditable machine-readable scorecard with hard gates, grade caps, blocker summaries, PR facts, runtime evidence, and changed-file evidence.

## Verification

- `cargo fmt --all`
- `bash -n scripts/evaluate_pr_repair.sh`
- `cargo test -p harness-eval`
- `cargo fmt --all -- --check`
- `python3 -m unittest scripts/test_evaluate_pr_repair_submit.py`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`
- `scripts/evaluate_pr_repair.sh --repo majiayu000/harness --pr 1232 --collect-only --output /tmp/harness-pr-repair-eval-collect-cwd-20260606T033418Z`

## Eval sample

Collect-only output for `majiayu000/harness#1232` wrote:

- `baseline_pr.json`
- `final_pr.json`
- `pr_repair_eval_input.json`
- `quality_snapshot.json`
- `summary.md`

The generated quality snapshot scored the collect-only run as `71/C` with the blocker `runtime artifact is missing or empty`, which is expected because collect-only mode is evidence collection, not a completed Harness repair trial.

Related: #1251
