### PR TITLE
feat(eval): summarize PR repair benchmarks

### DIFF
--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -220,11 +220,10 @@ fn failed_hard_gates(gates: &[HardGateResult]) -> Vec<HardGateName> {
 }
 
 fn rounded_div(numerator: u64, denominator: u64) -> u64 {
-    if denominator == 0 {
-        0
-    } else {
-        (numerator + denominator / 2) / denominator
-    }
+    numerator
+        .saturating_add(denominator / 2)
+        .checked_div(denominator)
+        .unwrap_or(0)
 }
 
 fn confidence_for_case_count(case_count: u64) -> BenchmarkConfidence {

--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -180,8 +180,9 @@ pub fn summarize_pr_repair_benchmark(input: PrRepairBenchmarkInput) -> PrRepairB
         acceptable_cases,
         blocked_cases,
         grade_counts: grade_counts
-            .into_values()
-            .map(|(grade, count)| GradeCount { grade, count })
+            .into_iter()
+            .rev()
+            .map(|(_, (grade, count))| GradeCount { grade, count })
             .collect(),
         hard_gate_failures: hard_gate_failures
             .into_values()
@@ -339,6 +340,26 @@ mod tests {
                 count: 1,
             }]
         );
+    }
+
+    #[test]
+    fn grade_counts_sort_high_to_low() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "grades".to_string(),
+            cases: vec![
+                case("case-1", snapshot(49, EvalGrade::F, Vec::new())),
+                case("case-2", snapshot(89, EvalGrade::B, Vec::new())),
+                case("case-3", snapshot(100, EvalGrade::A, Vec::new())),
+            ],
+        });
+
+        let grades: Vec<_> = summary
+            .grade_counts
+            .into_iter()
+            .map(|count| count.grade)
+            .collect();
+
+        assert_eq!(grades, vec![EvalGrade::A, EvalGrade::B, EvalGrade::F]);
     }
 
     fn case(case_id: &str, snapshot: QualitySnapshot) -> PrRepairBenchmarkCase {

--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -1,0 +1,419 @@
+use crate::model::{EvalGrade, GateStatus, HardGateName, HardGateResult, QualitySnapshot};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PrRepairBenchmarkInput {
+    pub suite: String,
+    pub cases: Vec<PrRepairBenchmarkCase>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PrRepairBenchmarkCase {
+    pub case_id: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default = "default_case_weight")]
+    pub weight: u32,
+    pub snapshot: QualitySnapshot,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BenchmarkConfidence {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BenchmarkStatus {
+    Empty,
+    Failing,
+    NeedsReview,
+    Passing,
+    Excellent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GradeCount {
+    pub grade: EvalGrade,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardGateFailureCount {
+    pub name: HardGateName,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrRepairBenchmarkCaseSummary {
+    pub case_id: String,
+    pub final_score: u8,
+    pub effective_score: u8,
+    pub final_grade: EvalGrade,
+    pub failed_hard_gates: Vec<HardGateName>,
+    pub blocker_count: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrRepairBenchmarkSummary {
+    pub suite: String,
+    pub case_count: u64,
+    pub weighted_case_count: u64,
+    pub confidence: BenchmarkConfidence,
+    pub status: BenchmarkStatus,
+    pub capability_score: u8,
+    pub average_effective_score: u8,
+    pub min_effective_score: u8,
+    pub max_effective_score: u8,
+    pub excellent_cases: u64,
+    pub acceptable_cases: u64,
+    pub blocked_cases: u64,
+    pub grade_counts: Vec<GradeCount>,
+    pub hard_gate_failures: Vec<HardGateFailureCount>,
+    pub cases: Vec<PrRepairBenchmarkCaseSummary>,
+}
+
+pub fn summarize_pr_repair_benchmark(input: PrRepairBenchmarkInput) -> PrRepairBenchmarkSummary {
+    if input.cases.is_empty() {
+        return PrRepairBenchmarkSummary {
+            suite: input.suite,
+            case_count: 0,
+            weighted_case_count: 0,
+            confidence: BenchmarkConfidence::None,
+            status: BenchmarkStatus::Empty,
+            capability_score: 0,
+            average_effective_score: 0,
+            min_effective_score: 0,
+            max_effective_score: 0,
+            excellent_cases: 0,
+            acceptable_cases: 0,
+            blocked_cases: 0,
+            grade_counts: Vec::new(),
+            hard_gate_failures: Vec::new(),
+            cases: Vec::new(),
+        };
+    }
+
+    let mut weighted_score_sum = 0u64;
+    let mut weighted_case_count = 0u64;
+    let mut min_effective_score = u8::MAX;
+    let mut max_effective_score = 0u8;
+    let mut excellent_cases = 0u64;
+    let mut acceptable_cases = 0u64;
+    let mut blocked_cases = 0u64;
+    let mut grade_counts = BTreeMap::<u8, (EvalGrade, u64)>::new();
+    let mut hard_gate_failures = BTreeMap::<String, (HardGateName, u64)>::new();
+    let mut case_summaries = Vec::with_capacity(input.cases.len());
+
+    for case in input.cases {
+        let weight = case.weight.max(1) as u64;
+        let effective_score = effective_score(&case.snapshot);
+        weighted_score_sum += u64::from(effective_score) * weight;
+        weighted_case_count += weight;
+        min_effective_score = min_effective_score.min(effective_score);
+        max_effective_score = max_effective_score.max(effective_score);
+
+        let final_grade = case.snapshot.final_grade;
+        grade_counts
+            .entry(final_grade.rank())
+            .and_modify(|(_, count)| *count += 1)
+            .or_insert((final_grade, 1));
+
+        let failed_hard_gates = failed_hard_gates(&case.snapshot.hard_gates);
+        for gate in &failed_hard_gates {
+            hard_gate_failures
+                .entry(format!("{gate:?}"))
+                .and_modify(|(_, count)| *count += 1)
+                .or_insert((*gate, 1));
+        }
+
+        let blocked = !failed_hard_gates.is_empty() || !case.snapshot.blocker_summary.is_empty();
+        if blocked {
+            blocked_cases += 1;
+        }
+        if final_grade.rank() >= EvalGrade::B.rank() && !blocked {
+            acceptable_cases += 1;
+        }
+        if final_grade == EvalGrade::A && !blocked {
+            excellent_cases += 1;
+        }
+
+        case_summaries.push(PrRepairBenchmarkCaseSummary {
+            case_id: case.case_id,
+            final_score: case.snapshot.final_score,
+            effective_score,
+            final_grade,
+            failed_hard_gates,
+            blocker_count: case.snapshot.blocker_summary.len() as u64,
+        });
+    }
+
+    let average_effective_score = rounded_div(weighted_score_sum, weighted_case_count) as u8;
+    let capability_score = ((u16::from(average_effective_score) + 5) / 10).min(10) as u8;
+    let case_count = case_summaries.len() as u64;
+    let confidence = confidence_for_case_count(case_count);
+    let status = benchmark_status(
+        confidence,
+        capability_score,
+        case_count,
+        excellent_cases,
+        acceptable_cases,
+        blocked_cases,
+    );
+
+    PrRepairBenchmarkSummary {
+        suite: input.suite,
+        case_count,
+        weighted_case_count,
+        confidence,
+        status,
+        capability_score,
+        average_effective_score,
+        min_effective_score,
+        max_effective_score,
+        excellent_cases,
+        acceptable_cases,
+        blocked_cases,
+        grade_counts: grade_counts
+            .into_values()
+            .map(|(grade, count)| GradeCount { grade, count })
+            .collect(),
+        hard_gate_failures: hard_gate_failures
+            .into_values()
+            .map(|(name, count)| HardGateFailureCount { name, count })
+            .collect(),
+        cases: case_summaries,
+    }
+}
+
+fn default_case_weight() -> u32 {
+    1
+}
+
+fn effective_score(snapshot: &QualitySnapshot) -> u8 {
+    snapshot
+        .final_score
+        .min(grade_score_ceiling(snapshot.final_grade))
+}
+
+fn grade_score_ceiling(grade: EvalGrade) -> u8 {
+    match grade {
+        EvalGrade::A => 100,
+        EvalGrade::B => 89,
+        EvalGrade::C => 79,
+        EvalGrade::D => 64,
+        EvalGrade::F => 49,
+    }
+}
+
+fn failed_hard_gates(gates: &[HardGateResult]) -> Vec<HardGateName> {
+    gates
+        .iter()
+        .filter(|gate| gate.status == GateStatus::Fail)
+        .map(|gate| gate.name)
+        .collect()
+}
+
+fn rounded_div(numerator: u64, denominator: u64) -> u64 {
+    if denominator == 0 {
+        0
+    } else {
+        (numerator + denominator / 2) / denominator
+    }
+}
+
+fn confidence_for_case_count(case_count: u64) -> BenchmarkConfidence {
+    match case_count {
+        0 => BenchmarkConfidence::None,
+        1..=2 => BenchmarkConfidence::Low,
+        3..=4 => BenchmarkConfidence::Medium,
+        _ => BenchmarkConfidence::High,
+    }
+}
+
+fn benchmark_status(
+    confidence: BenchmarkConfidence,
+    capability_score: u8,
+    case_count: u64,
+    excellent_cases: u64,
+    acceptable_cases: u64,
+    blocked_cases: u64,
+) -> BenchmarkStatus {
+    if case_count == 0 {
+        return BenchmarkStatus::Empty;
+    }
+    if blocked_cases > 0 || capability_score < 7 {
+        return BenchmarkStatus::Failing;
+    }
+    if confidence == BenchmarkConfidence::Low || acceptable_cases < case_count {
+        return BenchmarkStatus::NeedsReview;
+    }
+    if capability_score == 10 && excellent_cases == case_count {
+        return BenchmarkStatus::Excellent;
+    }
+    BenchmarkStatus::Passing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        EvalScenario, EvalTarget, GateStatus, HardGateResult, ScoreBreakdown, ScoreComponent,
+        ScoreDimensionName,
+    };
+
+    #[test]
+    fn empty_benchmark_has_no_confidence() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "empty".to_string(),
+            cases: Vec::new(),
+        });
+
+        assert_eq!(summary.confidence, BenchmarkConfidence::None);
+        assert_eq!(summary.status, BenchmarkStatus::Empty);
+        assert_eq!(summary.capability_score, 0);
+    }
+
+    #[test]
+    fn single_perfect_case_is_low_confidence_not_excellent() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "smoke".to_string(),
+            cases: vec![case("case-1", snapshot(100, EvalGrade::A, Vec::new()))],
+        });
+
+        assert_eq!(summary.capability_score, 10);
+        assert_eq!(summary.confidence, BenchmarkConfidence::Low);
+        assert_eq!(summary.status, BenchmarkStatus::NeedsReview);
+        assert_eq!(summary.excellent_cases, 1);
+    }
+
+    #[test]
+    fn grade_cap_lowers_effective_score() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "caps".to_string(),
+            cases: vec![case("case-1", snapshot(100, EvalGrade::C, Vec::new()))],
+        });
+
+        assert_eq!(summary.average_effective_score, 79);
+        assert_eq!(summary.capability_score, 8);
+        assert_eq!(summary.cases[0].effective_score, 79);
+    }
+
+    #[test]
+    fn three_clean_a_cases_are_excellent() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "regression".to_string(),
+            cases: vec![
+                case("case-1", snapshot(98, EvalGrade::A, Vec::new())),
+                case("case-2", snapshot(99, EvalGrade::A, Vec::new())),
+                case("case-3", snapshot(100, EvalGrade::A, Vec::new())),
+            ],
+        });
+
+        assert_eq!(summary.confidence, BenchmarkConfidence::Medium);
+        assert_eq!(summary.status, BenchmarkStatus::Excellent);
+        assert_eq!(summary.capability_score, 10);
+        assert_eq!(summary.blocked_cases, 0);
+    }
+
+    #[test]
+    fn failed_gate_blocks_and_counts_failure_kind() {
+        let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+            suite: "blocked".to_string(),
+            cases: vec![case(
+                "case-1",
+                snapshot(92, EvalGrade::C, vec![HardGateName::ReviewThreadClosure]),
+            )],
+        });
+
+        assert_eq!(summary.status, BenchmarkStatus::Failing);
+        assert_eq!(summary.blocked_cases, 1);
+        assert_eq!(
+            summary.hard_gate_failures,
+            vec![HardGateFailureCount {
+                name: HardGateName::ReviewThreadClosure,
+                count: 1,
+            }]
+        );
+    }
+
+    fn case(case_id: &str, snapshot: QualitySnapshot) -> PrRepairBenchmarkCase {
+        PrRepairBenchmarkCase {
+            case_id: case_id.to_string(),
+            tags: Vec::new(),
+            weight: 1,
+            snapshot,
+        }
+    }
+
+    fn snapshot(
+        final_score: u8,
+        final_grade: EvalGrade,
+        failed_gates: Vec<HardGateName>,
+    ) -> QualitySnapshot {
+        QualitySnapshot {
+            scenario: EvalScenario::PrRepair,
+            target: EvalTarget::PullRequest {
+                repo: "owner/repo".to_string(),
+                pr_number: 7,
+                base_ref: Some("main".to_string()),
+                head_ref: Some("feature".to_string()),
+            },
+            baseline_pr: None,
+            final_pr: None,
+            runtime: None,
+            usage: Vec::new(),
+            hard_gates: failed_gates
+                .into_iter()
+                .map(|name| HardGateResult {
+                    name,
+                    status: GateStatus::Fail,
+                    grade_cap: Some(EvalGrade::C),
+                    message: "failed gate".to_string(),
+                })
+                .collect(),
+            objective_score: score_breakdown(),
+            reviewer_judgment: None,
+            final_score,
+            final_grade,
+            grade_cap: None,
+            blocker_summary: Vec::new(),
+        }
+    }
+
+    fn score_breakdown() -> ScoreBreakdown {
+        ScoreBreakdown {
+            task_classification_and_baseline_evidence: test_component(
+                ScoreDimensionName::TaskClassificationAndBaselineEvidence,
+            ),
+            feedback_discovery_and_prioritization: test_component(
+                ScoreDimensionName::FeedbackDiscoveryAndPrioritization,
+            ),
+            branch_and_pr_safety: test_component(ScoreDimensionName::BranchAndPrSafety),
+            fix_correctness_and_scope: test_component(ScoreDimensionName::FixCorrectnessAndScope),
+            verification_and_current_head_gates: test_component(
+                ScoreDimensionName::VerificationAndCurrentHeadGates,
+            ),
+            runtime_workflow_behavior_and_persistence: test_component(
+                ScoreDimensionName::RuntimeWorkflowBehaviorAndPersistence,
+            ),
+            cost_and_time_efficiency: test_component(ScoreDimensionName::CostAndTimeEfficiency),
+            reporting_and_attribution_quality: test_component(
+                ScoreDimensionName::ReportingAndAttributionQuality,
+            ),
+        }
+    }
+
+    fn test_component(name: ScoreDimensionName) -> ScoreComponent {
+        ScoreComponent {
+            name,
+            points: 0,
+            max_points: 0,
+        }
+    }
+}

--- a/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
@@ -1,0 +1,126 @@
+use harness_eval::{
+    summarize_pr_repair_benchmark, PrRepairBenchmarkCase, PrRepairBenchmarkInput, QualitySnapshot,
+};
+use serde_json::Value;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Default)]
+struct Args {
+    suite: String,
+    snapshots: Vec<PathBuf>,
+    cases: Vec<(String, PathBuf)>,
+    output: PathBuf,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args(env::args().skip(1))?;
+    let mut cases = Vec::new();
+
+    for path in args.snapshots {
+        let case_id = case_id_from_path(&path)?;
+        cases.push(read_case(case_id, &path)?);
+    }
+    for (case_id, path) in args.cases {
+        cases.push(read_case(case_id, &path)?);
+    }
+
+    let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
+        suite: args.suite,
+        cases,
+    });
+    write_json(
+        &args.output,
+        &serde_json::to_value(summary).map_err(|err| err.to_string())?,
+    )
+}
+
+fn parse_args<I>(mut args: I) -> Result<Args, String>
+where
+    I: Iterator<Item = String>,
+{
+    let mut parsed = Args::default();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--suite" => parsed.suite = required_value(&mut args, "--suite")?,
+            "--snapshot" => {
+                parsed
+                    .snapshots
+                    .push(PathBuf::from(required_value(&mut args, "--snapshot")?));
+            }
+            "--case" => parsed
+                .cases
+                .push(parse_case(&required_value(&mut args, "--case")?)?),
+            "--output" => parsed.output = PathBuf::from(required_value(&mut args, "--output")?),
+            "-h" | "--help" => return Err(usage()),
+            _ => return Err(format!("unknown argument: {arg}\n{}", usage())),
+        }
+    }
+
+    if parsed.suite.is_empty()
+        || parsed.output.as_os_str().is_empty()
+        || (parsed.snapshots.is_empty() && parsed.cases.is_empty())
+    {
+        return Err(usage());
+    }
+
+    Ok(parsed)
+}
+
+fn parse_case(value: &str) -> Result<(String, PathBuf), String> {
+    let Some((case_id, path)) = value.split_once('=') else {
+        return Err("--case must use CASE_ID=PATH".to_string());
+    };
+    if case_id.trim().is_empty() || path.trim().is_empty() {
+        return Err("--case must use non-empty CASE_ID=PATH".to_string());
+    }
+    Ok((case_id.to_string(), PathBuf::from(path)))
+}
+
+fn required_value<I>(args: &mut I, flag: &str) -> Result<String, String>
+where
+    I: Iterator<Item = String>,
+{
+    args.next()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn read_case(case_id: String, path: &Path) -> Result<PrRepairBenchmarkCase, String> {
+    let body = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+    let snapshot: QualitySnapshot = serde_json::from_str(&body)
+        .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+    Ok(PrRepairBenchmarkCase {
+        case_id,
+        tags: Vec::new(),
+        weight: 1,
+        snapshot,
+    })
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), String> {
+    let body = serde_json::to_string_pretty(value).map_err(|err| err.to_string())?;
+    fs::write(path, format!("{body}\n"))
+        .map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn case_id_from_path(path: &Path) -> Result<String, String> {
+    path.file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("failed to derive case id from {}", path.display()))
+}
+
+fn usage() -> String {
+    "Usage: score_pr_repair_benchmark --suite NAME (--snapshot quality_snapshot.json | --case CASE_ID=quality_snapshot.json)... --output benchmark_summary.json".to_string()
+}

--- a/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
@@ -2,6 +2,7 @@ use harness_eval::{
     summarize_pr_repair_benchmark, PrRepairBenchmarkCase, PrRepairBenchmarkInput, QualitySnapshot,
 };
 use serde_json::Value;
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -24,13 +25,14 @@ fn main() {
 fn run() -> Result<(), String> {
     let args = parse_args(env::args().skip(1))?;
     let mut cases = Vec::new();
+    let mut seen_case_ids = HashSet::new();
 
     for path in args.snapshots {
         let case_id = case_id_from_path(&path)?;
-        cases.push(read_case(case_id, &path)?);
+        push_case(&mut cases, &mut seen_case_ids, case_id, &path)?;
     }
     for (case_id, path) in args.cases {
-        cases.push(read_case(case_id, &path)?);
+        push_case(&mut cases, &mut seen_case_ids, case_id, &path)?;
     }
 
     let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
@@ -79,7 +81,9 @@ fn parse_case(value: &str) -> Result<(String, PathBuf), String> {
     let Some((case_id, path)) = value.split_once('=') else {
         return Err("--case must use CASE_ID=PATH".to_string());
     };
-    if case_id.trim().is_empty() || path.trim().is_empty() {
+    let case_id = case_id.trim();
+    let path = path.trim();
+    if case_id.is_empty() || path.is_empty() {
         return Err("--case must use non-empty CASE_ID=PATH".to_string());
     }
     Ok((case_id.to_string(), PathBuf::from(path)))
@@ -107,8 +111,28 @@ fn read_case(case_id: String, path: &Path) -> Result<PrRepairBenchmarkCase, Stri
     })
 }
 
+fn push_case(
+    cases: &mut Vec<PrRepairBenchmarkCase>,
+    seen_case_ids: &mut HashSet<String>,
+    case_id: String,
+    path: &Path,
+) -> Result<(), String> {
+    if !seen_case_ids.insert(case_id.clone()) {
+        return Err(format!("duplicate case ID: {case_id}"));
+    }
+    cases.push(read_case(case_id, path)?);
+    Ok(())
+}
+
 fn write_json(path: &Path, value: &Value) -> Result<(), String> {
     let body = serde_json::to_string_pretty(value).map_err(|err| err.to_string())?;
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create directory {}: {err}", parent.display()))?;
+    }
     fs::write(path, format!("{body}\n"))
         .map_err(|err| format!("failed to write {}: {err}", path.display()))
 }

--- a/crates/harness-eval/src/lib.rs
+++ b/crates/harness-eval/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod benchmark;
 pub mod ingest;
 pub mod model;
 pub mod scoring;
 
+pub use benchmark::*;
 pub use ingest::*;
 pub use model::*;
 pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -298,6 +298,54 @@ After hard gates, the score is calculated from eight dimensions:
 The scorecard should expose each dimension separately. A single merged/not
 merged status is not enough.
 
+## Benchmark Suites
+
+A single `QualitySnapshot` proves one run. It is not enough to claim Harness PR
+repair quality is "10/10", because one easy or lucky PR can hide regressions in
+harder cases. Benchmark suites aggregate multiple snapshots into a capability
+summary.
+
+```rust
+pub struct PrRepairBenchmarkInput {
+    pub suite: String,
+    pub cases: Vec<PrRepairBenchmarkCase>,
+}
+
+pub struct PrRepairBenchmarkSummary {
+    pub suite: String,
+    pub case_count: u64,
+    pub confidence: BenchmarkConfidence,
+    pub status: BenchmarkStatus,
+    pub capability_score: u8, // 0..10
+    pub average_effective_score: u8,
+    pub min_effective_score: u8,
+    pub excellent_cases: u64,
+    pub acceptable_cases: u64,
+    pub blocked_cases: u64,
+    pub hard_gate_failures: Vec<HardGateFailureCount>,
+}
+```
+
+The benchmark uses an effective score, not the raw final score alone. If a run
+is grade-capped by missing reviewer judgment, stale evidence, failed checks, or
+unresolved review threads, the effective score is capped by the final grade.
+This prevents a high raw score with a failed hard gate from looking like a
+10/10 outcome.
+
+Confidence is sample-size based for the first release:
+
+| Case count | Confidence |
+|---:|---|
+| 0 | `none` |
+| 1-2 | `low` |
+| 3-4 | `medium` |
+| 5+ | `high` |
+
+`excellent` requires at least medium confidence, a 10/10 capability score, all
+cases graded `A`, and no blocked cases. A one-case perfect run can score 10, but
+it remains `needs_review` because the benchmark does not have enough evidence to
+claim system-level quality.
+
 ## Code Quality Subscore
 
 The `Fix correctness and scope` dimension is split into objective and subjective
@@ -435,6 +483,20 @@ harness eval cases --suite pr-repair-smoke
 The CLI is optional product surface. The durable contract is the server API and
 the persisted eval records; a CLI should only be a thin wrapper around those
 APIs after the storage path is stable.
+
+The first benchmark CLI is intentionally file-based:
+
+```text
+score_pr_repair_benchmark \
+  --suite pr-repair-smoke \
+  --case pr-1233=docs/pr-repair-evals/.../quality_snapshot.json \
+  --case pr-1254=docs/pr-repair-evals/.../quality_snapshot.json \
+  --output benchmark_summary.json
+```
+
+It reads existing `quality_snapshot.json` artifacts and writes a deterministic
+benchmark summary. It does not fetch GitHub, start Harness, or grade code with an
+LLM.
 
 ## Dashboard Design
 

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -127,6 +127,35 @@ Acceptance:
 - Operators can tell whether a PR repair succeeded, why it failed, and what it
   cost without reading raw logs.
 
+### Issue 6: Add PR repair benchmark summaries
+
+Scope:
+
+- Aggregate multiple `quality_snapshot.json` artifacts into a deterministic
+  benchmark summary.
+- Report a 0-10 capability score, confidence, status, grade distribution,
+  blocked-case count, and hard-gate failure counts.
+- Cap the effective per-case score by the final grade so hard-gate failures do
+  not look like 10/10 wins.
+- Add a file-based `score_pr_repair_benchmark` binary for local benchmark runs.
+
+Out of scope:
+
+- Selecting live GitHub PRs automatically.
+- Starting Harness tasks.
+- Running LLM or human code-quality reviewers.
+- Dashboard rendering.
+
+Acceptance:
+
+- `cargo test -p harness-eval benchmark` passes.
+- A single perfect case produces 10/10 with low confidence and `needs_review`.
+- Three clean `A` cases produce `excellent`.
+- A failed hard gate increments the matching failure count and blocks the
+  benchmark status.
+- The benchmark binary reads multiple quality snapshots and writes
+  `benchmark_summary.json`.
+
 ## First PR Scope
 
 The first PR should include only:


### PR DESCRIPTION
## Summary

- Add a pure `harness-eval` PR repair benchmark summary model.
- Aggregate multiple quality snapshots into a 0-10 capability score, confidence, status, grade distribution, blocked-case count, and hard-gate failure counts.
- Add a file-based `score_pr_repair_benchmark` binary for local benchmark summaries.
- Document why one perfect run is not enough to claim system-level 10/10 quality.

Closes #1255.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p harness-eval -- --nocapture`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-eval --all-targets`
- CLI smoke with `score_pr_repair` plus `score_pr_repair_benchmark`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`
- `git diff --check`
