### PR TITLE
fix(eval): preflight live PR repair runs

### DIFF
--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -472,6 +472,15 @@ scripts/evaluate_pr_repair.sh
   8. write local JSON and Markdown reports
 ```
 
+Live mode must verify that `--project-root` resolves to an active project in the
+running Harness server before submitting `POST /tasks`. An unregistered local
+worktree can otherwise produce a workflow handle that no runtime worker will
+execute, which creates false-negative quality data. When that preflight fails,
+the collector should fail fast but still emit `submission.json`,
+`task_detail_final.json`, `quality_snapshot.json`, and `summary.md`. The Markdown
+report must render grade, score, grade cap, hard gates, and blockers from
+`quality_snapshot.json`; it must not maintain an independent grading heuristic.
+
 Later, add a CLI wrapper:
 
 ```text

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -10,7 +10,7 @@ Options:
   --repo OWNER/REPO       GitHub repository slug.
   --pr N                  Pull request number to evaluate.
   --server-url URL        Harness HTTP server URL. Default: http://127.0.0.1:9800
-  --project-root PATH     Local project root sent to POST /tasks. Default: current directory.
+  --project-root PROJECT  Project root, registry id, or name sent to POST /tasks. Must be registered for live mode.
   --output DIR            Report directory. Default: docs/pr-repair-evals/<timestamp>-<repo>-pr<N>
   --collect-only          Collect GitHub baseline only; do not submit a Harness task.
   --wait-secs N           Structured Harness wait bound and task prompt guidance. Default: 10
@@ -434,11 +434,28 @@ else:
 PY
 }
 
+snapshot_scenario() {
+  local fallback="$1"
+  python3 - "$QUALITY_SNAPSHOT_JSON" "$fallback" <<'PY'
+import json
+import sys
+
+snapshot_path, fallback = sys.argv[1:]
+try:
+    with open(snapshot_path, "r", encoding="utf-8") as fh:
+        snapshot = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    snapshot = {}
+
+print(snapshot.get("scenario") or fallback)
+PY
+}
+
 write_collect_report() {
   local baseline="$1"
   local report="$OUTPUT_DIR/summary.md"
   local task_class
-  task_class="$(classify_snapshot "$baseline")"
+  task_class="$(snapshot_scenario "$(classify_snapshot "$baseline")")"
   {
     echo "# PR Repair Evaluation"
     echo
@@ -446,7 +463,7 @@ write_collect_report() {
     echo "- Repo: \`$REPO\`"
     echo "- PR: \`#$PR\`"
     echo "- Mode: collect-only"
-    echo "- Candidate class: \`$task_class\`"
+    echo "- Scenario: \`$task_class\`"
     echo
     echo "## Baseline"
     echo
@@ -463,213 +480,46 @@ write_final_report() {
   local task_detail="$4"
   local timed_out="$5"
   local report="$OUTPUT_DIR/summary.md"
-  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" "$timed_out" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" "$TIMEOUT_SECS" <<'PY' > "$report"
-import json
-import sys
+  local timed_out_flag=()
+  if [[ "$timed_out" == "1" ]]; then
+    timed_out_flag=(--timed-out)
+  fi
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_render_report.py" \
+    --baseline "$baseline" \
+    --final "$final" \
+    --submission "$submission" \
+    --task-detail "$task_detail" \
+    --quality-snapshot "$QUALITY_SNAPSHOT_JSON" \
+    --output "$report" \
+    --run-id "$RUN_ID" \
+    --repo "$REPO" \
+    --pr "$PR" \
+    --server-url "$SERVER_URL" \
+    "${timed_out_flag[@]}" \
+    --wait-secs "$WAIT_SECS" \
+    --max-rounds "$MAX_ROUNDS" \
+    --max-turns "$MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --timeout-secs "$TIMEOUT_SECS"
+}
 
-(
-    baseline_path,
-    final_path,
-    submission_path,
-    task_detail_path,
-    run_id,
-    repo,
-    pr_number,
-    server_url,
-    timed_out_arg,
-    wait_secs,
-    max_rounds,
-    max_turns,
-    max_budget,
-    timeout_secs,
-) = sys.argv[1:]
-
-def load(path):
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except Exception:
-        return {}
-
-def facts(pr):
-    threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
-    files = list(((pr.get("files") or {}).get("nodes")) or [])
-    active = [
-        t for t in threads
-        if not t.get("isResolved", False) and not t.get("isOutdated", False)
-    ]
-    return {
-        "head": pr.get("headRefOid"),
-        "merge": pr.get("mergeStateStatus") or "UNKNOWN",
-        "checks": (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN",
-        "unresolved": len(active),
-        "files_collected": "files" in pr,
-        "changed_files": files,
-        "changed_file_paths": sorted({
-            f.get("path")
-            for f in files
-            if isinstance(f, dict) and f.get("path")
-        }),
-    }
-
-def markdown_cell(value):
-    return str(value).replace("|", "\\|")
-
-def compact(value, limit=240):
-    text = str(value).replace("\n", " ").strip()
-    if len(text) <= limit:
-        return text
-    return f"{text[:limit - 3]}..."
-
-def file_rows(files):
-    rows = []
-    for item in sorted(files, key=lambda f: f.get("path") or ""):
-        path = item.get("path") or "UNKNOWN"
-        change_type = item.get("changeType") or "UNKNOWN"
-        additions = item.get("additions", 0)
-        deletions = item.get("deletions", 0)
-        rows.append((path, change_type, additions, deletions))
-    return rows
-
-def limited_path_list(paths):
-    if not paths:
-        return ""
-    shown = ", ".join(paths[:5])
-    if len(paths) > 5:
-        return f"{shown}, ... ({len(paths)} total)"
-    return shown
-
-baseline = load(baseline_path)
-final = load(final_path)
-submission = load(submission_path)
-task_detail = load(task_detail_path)
-before = facts(baseline)
-after = facts(final)
-head_changed = before["head"] != after["head"]
-new_changed_paths = sorted(set(after["changed_file_paths"]) - set(before["changed_file_paths"]))
-removed_changed_paths = sorted(set(before["changed_file_paths"]) - set(after["changed_file_paths"]))
-task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
-workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
-task_id = submission.get("task_id") or task_detail.get("id")
-submission_mode = submission.get("eval_submission_mode") or "unknown"
-submission_http_status = submission.get("http_status") or task_detail.get("http_status")
-submission_error = (
-    submission.get("error")
-    or submission.get("message")
-    or submission.get("detail")
-    or submission.get("raw_response")
-    or task_detail.get("error")
-)
-timed_out = timed_out_arg == "1"
-
-if before["unresolved"] > 0:
-    candidate = "review_feedback_repair"
-elif before["checks"] != "SUCCESS":
-    candidate = "ci_repair"
-elif before["merge"] == "CLEAN" and before["checks"] == "SUCCESS":
-    candidate = "ready_noop"
-else:
-    candidate = "mergeability_repair"
-
-grade = "C"
-blockers = []
-if after["checks"] != "SUCCESS":
-    blockers.append(f"final checks are {after['checks']}")
-if after["unresolved"] > 0:
-    blockers.append(f"{after['unresolved']} active unresolved review threads remain")
-if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
-    blockers.append("PR head did not change for a repair candidate")
-if candidate == "ready_noop" and head_changed:
-    blockers.append("ready/no-op control changed the PR head")
-if after["merge"] != "CLEAN":
-    blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
-if head_changed and not after["files_collected"]:
-    blockers.append("final PR head changed but changed files were not collected")
-if task_status in ("failed", "cancelled", "blocked"):
-    blockers.append(f"Harness task ended as {task_status}")
-if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
-    blockers.append("Harness task did not reach a terminal state before the evaluation timeout")
-
-if not blockers:
-    grade = "A"
-elif candidate == "ready_noop" and head_changed:
-    grade = "C"
-elif after["merge"] != "CLEAN":
-    grade = "C"
-elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
-    grade = "B"
-elif head_changed or after["checks"] == "SUCCESS" or after["unresolved"] < before["unresolved"]:
-    grade = "C"
-elif task_status in ("failed", "cancelled", "blocked"):
-    grade = "D"
-else:
-    grade = "F"
-
-print("# PR Repair Evaluation")
-print()
-print(f"- Run ID: `{run_id}`")
-print(f"- Repo: `{repo}`")
-print(f"- PR: `#{pr_number}`")
-print(f"- Server URL: `{server_url}`")
-print(f"- Candidate class: `{candidate}`")
-print(f"- Task ID: `{task_id}`")
-print(f"- Workflow ID: `{workflow_id}`")
-print(f"- Task status: `{task_status}`")
-print(f"- Submission mode: `{submission_mode}`")
-if submission_http_status:
-    print(f"- Submission HTTP status: `{submission_http_status}`")
-if submission_error:
-    print(f"- Submission error: `{markdown_cell(compact(submission_error))}`")
-print(f"- Timed out: `{str(timed_out).lower()}`")
-print(f"- Grade: `{grade}`")
-print()
-print("## Eval Bounds")
-print()
-print("| Field | Value |")
-print("|---|---|")
-print(f"| `wait_secs` | `{wait_secs}` |")
-print(f"| `max_rounds` | `{max_rounds}` |")
-print(f"| `max_turns` | `{max_turns}` |")
-print(f"| `max_budget_usd` | `{max_budget or 'not set'}` |")
-print(f"| `timeout_secs` | `{timeout_secs}` |")
-print()
-print("## Baseline vs Final")
-print()
-print("| Field | Baseline | Final |")
-print("|---|---|---|")
-print(f"| `headRefOid` | `{before['head']}` | `{after['head']}` |")
-print(f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |")
-print(f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |")
-print(f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |")
-print(f"| changed files | `{len(before['changed_files'])}` | `{len(after['changed_files'])}` |")
-print(f"| head changed | `false` | `{str(head_changed).lower()}` |")
-print()
-print("## Changed File Scope")
-print()
-print("| Field | Value |")
-print("|---|---|")
-print(f"| changed-file evidence | `{'collected' if after['files_collected'] else 'missing'}` |")
-print(f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |")
-print(f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |")
-print()
-print("## Final Changed Files")
-print()
-if after["changed_files"]:
-    print("| Path | Change | + | - |")
-    print("|---|---|---:|---:|")
-    for path, change_type, additions, deletions in file_rows(after["changed_files"]):
-        print(f"| `{markdown_cell(path)}` | `{markdown_cell(change_type)}` | `{additions}` | `{deletions}` |")
-else:
-    print("- None collected")
-print()
-print("## Blockers")
-print()
-if blockers:
-    for blocker in blockers:
-        print(f"- {blocker}")
-else:
-    print("- None")
-PY
+write_live_preflight_failure_report() {
+  local reason="$1"
+  local exit_code="$2"
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_preflight.py" write-failure \
+    --submission "$SUBMISSION_JSON" \
+    --task-detail "$TASK_DETAIL_JSON" \
+    --reason "$reason"
+  echo "$reason" >&2
+  echo "Collecting final PR snapshot"
+  FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  collect_snapshot "$FINAL_JSON"
+  snapshot_summary "$FINAL_JSON"
+  write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
+  echo "Evaluation report: $OUTPUT_DIR/summary.md"
+  echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
+  exit "$exit_code"
 }
 
 BASELINE_JSON="$OUTPUT_DIR/baseline_pr.json"
@@ -680,6 +530,7 @@ TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
 PR_REPAIR_EVAL_INPUT_JSON="$OUTPUT_DIR/pr_repair_eval_input.json"
 QUALITY_SNAPSHOT_JSON="$OUTPUT_DIR/quality_snapshot.json"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
+PROJECTS_JSON="$OUTPUT_DIR/projects.json"
 
 write_quality_snapshot() {
   local baseline="$1"
@@ -734,11 +585,30 @@ if [[ -n "${HARNESS_API_TOKEN:-}" ]]; then
 fi
 
 if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
-  echo "Harness server is not reachable at $SERVER_URL; baseline was saved to $OUTPUT_DIR" >&2
-  exit 3
+  write_live_preflight_failure_report \
+    "Harness server is not reachable at $SERVER_URL/health" \
+    3
 fi
 
-python3 - "$PROJECT_ROOT" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" <<'PY' > "$TASK_BODY_JSON"
+echo "Checking Harness project registry for $PROJECT_ROOT"
+if ! curl "${curl_args[@]}" "$SERVER_URL/projects" > "$PROJECTS_JSON"; then
+  write_live_preflight_failure_report \
+    "Harness project registry is not reachable at $SERVER_URL/projects" \
+    5
+fi
+
+PREFLIGHT_ERROR="$OUTPUT_DIR/project_preflight_error.txt"
+if ! registered_project="$(python3 "$SCRIPT_DIR/evaluate_pr_repair_preflight.py" check-project --project-root "$PROJECT_ROOT" --projects-json "$PROJECTS_JSON" 2>"$PREFLIGHT_ERROR")"; then
+  reason="$(tr '\n' ' ' < "$PREFLIGHT_ERROR")"
+  if [[ -z "$reason" ]]; then
+    reason="Harness project root is not registered for live eval: $PROJECT_ROOT"
+  fi
+  echo "Register the project with POST /projects or pass a registered --project-root." >&2
+  write_live_preflight_failure_report "$reason" 5
+fi
+echo "Registered project: $registered_project"
+
+python3 - "$registered_project" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" <<'PY' > "$TASK_BODY_JSON"
 import json
 import sys
 

--- a/scripts/evaluate_pr_repair_preflight.py
+++ b/scripts/evaluate_pr_repair_preflight.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Preflight helpers for PR repair eval runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_projects(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"failed to read Harness project registry: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError("Harness project registry response is not a project list")
+    return [project for project in data if isinstance(project, dict)]
+
+
+def find_registered_project(raw_project: str, projects: list[dict[str, Any]]) -> str:
+    project_exists = os.path.isdir(raw_project)
+    canonical_project = os.path.realpath(raw_project) if project_exists else None
+    inactive_matches: list[str] = []
+    registered: list[str] = []
+
+    for project in projects:
+        project_id = project.get("id")
+        project_name = project.get("name")
+        root = project.get("root")
+        if isinstance(root, str) and root:
+            registered.append(root)
+
+        root_matches = False
+        if isinstance(root, str) and root:
+            root_matches = raw_project == root
+            if canonical_project is not None:
+                root_matches = root_matches or os.path.realpath(root) == canonical_project
+
+        id_matches = isinstance(project_id, str) and raw_project == project_id
+        name_matches = isinstance(project_name, str) and raw_project == project_name
+        if not (root_matches or id_matches or name_matches):
+            continue
+
+        display = str(root or project_id or project_name or raw_project)
+        if project.get("active") is False:
+            inactive_matches.append(display)
+            continue
+        if isinstance(root, str) and root:
+            return root
+        raise ValueError(f"matched project has no usable root: {display}")
+
+    if inactive_matches:
+        raise ValueError("matched project is inactive: " + ", ".join(sorted(inactive_matches)))
+
+    preview = ", ".join(sorted(set(registered))[:8])
+    suffix = f"; registered roots: {preview}" if preview else "; no registered roots returned"
+    raise ValueError(f"Harness project root is not registered: {raw_project}{suffix}")
+
+
+def write_preflight_failure(submission_path: Path, task_detail_path: Path, reason: str) -> None:
+    submission = {
+        "error": reason,
+        "eval_submission_mode": "prompt_task",
+        "http_status": "000",
+        "preflight": "server_project_registry",
+        "status": "failed",
+    }
+    task_detail = {
+        "error": reason,
+        "preflight": "server_project_registry",
+        "status": "failed",
+    }
+    for path, payload in ((submission_path, submission), (task_detail_path, task_detail)):
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check-project")
+    check.add_argument("--project-root", required=True)
+    check.add_argument("--projects-json", required=True, type=Path)
+
+    failure = subparsers.add_parser("write-failure")
+    failure.add_argument("--submission", required=True, type=Path)
+    failure.add_argument("--task-detail", required=True, type=Path)
+    failure.add_argument("--reason", required=True)
+
+    args = parser.parse_args()
+    if args.command == "check-project":
+        try:
+            print(find_registered_project(args.project_root, load_projects(args.projects_json)))
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        return 0
+
+    if args.command == "write-failure":
+        write_preflight_failure(args.submission, args.task_detail, args.reason)
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/evaluate_pr_repair_render_report.py
+++ b/scripts/evaluate_pr_repair_render_report.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Render a Markdown PR repair eval report from collected artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path, *, required: bool = False) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        if required:
+            raise
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def pr_facts(pr: dict[str, Any]) -> dict[str, Any]:
+    review_threads = pr.get("reviewThreads")
+    thread_nodes = review_threads.get("nodes") if isinstance(review_threads, dict) else None
+    threads = [thread for thread in (thread_nodes or []) if isinstance(thread, dict)]
+    files_container = pr.get("files")
+    file_nodes = files_container.get("nodes") if isinstance(files_container, dict) else None
+    files = [item for item in (file_nodes or []) if isinstance(item, dict)]
+    status_check_rollup = pr.get("statusCheckRollup")
+    active = [
+        thread
+        for thread in threads
+        if not thread.get("isResolved", False) and not thread.get("isOutdated", False)
+    ]
+    return {
+        "head": pr.get("headRefOid"),
+        "merge": pr.get("mergeStateStatus") or "UNKNOWN",
+        "checks": (
+            status_check_rollup.get("state") if isinstance(status_check_rollup, dict) else None
+        )
+        or "UNKNOWN",
+        "unresolved": len(active),
+        "files_collected": isinstance(files_container, dict),
+        "changed_files": files,
+        "changed_file_paths": sorted(
+            {
+                item.get("path")
+                for item in files
+                if item.get("path")
+            }
+        ),
+    }
+
+
+def markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|")
+
+
+def compact(value: object, limit: int = 240) -> str:
+    text = str(value).replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit - 3]}..."
+
+
+def file_rows(files: list[dict[str, Any]]) -> list[tuple[str, str, int, int]]:
+    rows = []
+    valid_files = [item for item in files if isinstance(item, dict)]
+    for item in sorted(valid_files, key=lambda row: row.get("path") or ""):
+        rows.append(
+            (
+                item.get("path") or "UNKNOWN",
+                item.get("changeType") or "UNKNOWN",
+                item.get("additions", 0),
+                item.get("deletions", 0),
+            )
+        )
+    return rows
+
+
+def limited_path_list(paths: list[str]) -> str:
+    if not paths:
+        return ""
+    shown = ", ".join(paths[:5])
+    if len(paths) > 5:
+        return f"{shown}, ... ({len(paths)} total)"
+    return shown
+
+
+def candidate_class(before: dict[str, Any]) -> str:
+    if before["unresolved"] > 0:
+        return "review_feedback_repair"
+    if before["checks"] != "SUCCESS":
+        return "ci_repair"
+    if before["merge"] == "CLEAN" and before["checks"] == "SUCCESS":
+        return "ready_noop"
+    return "mergeability_repair"
+
+
+def render_report(args: argparse.Namespace) -> str:
+    baseline = load_json(args.baseline)
+    final = load_json(args.final)
+    submission = load_json(args.submission)
+    task_detail = load_json(args.task_detail)
+    quality_snapshot = load_json(args.quality_snapshot, required=True)
+
+    before = pr_facts(baseline)
+    after = pr_facts(final)
+    head_changed = before["head"] != after["head"]
+    new_changed_paths = sorted(set(after["changed_file_paths"]) - set(before["changed_file_paths"]))
+    removed_changed_paths = sorted(
+        set(before["changed_file_paths"]) - set(after["changed_file_paths"])
+    )
+    workflow = task_detail.get("workflow")
+    workflow_dict = workflow if isinstance(workflow, dict) else {}
+    task_status = (
+        task_detail.get("status")
+        or workflow_dict.get("state")
+        or submission.get("status")
+        or "unknown"
+    )
+    workflow_id = submission.get("workflow_id") or workflow_dict.get("id")
+    task_id = submission.get("task_id") or task_detail.get("id")
+    submission_mode = submission.get("eval_submission_mode") or "unknown"
+    submission_http_status = submission.get("http_status") or task_detail.get("http_status")
+    submission_error = (
+        submission.get("error")
+        or submission.get("message")
+        or submission.get("detail")
+        or submission.get("raw_response")
+        or task_detail.get("error")
+    )
+
+    snapshot_blockers = quality_snapshot.get("blocker_summary")
+    if not isinstance(snapshot_blockers, list):
+        snapshot_blockers = []
+    hard_gates = quality_snapshot.get("hard_gates")
+    if not isinstance(hard_gates, list):
+        hard_gates = []
+    failed_gates = [
+        gate for gate in hard_gates if isinstance(gate, dict) and gate.get("status") == "fail"
+    ]
+    scenario = quality_snapshot.get("scenario") or candidate_class(before)
+
+    lines = [
+        "# PR Repair Evaluation",
+        "",
+        f"- Run ID: `{args.run_id}`",
+        f"- Repo: `{args.repo}`",
+        f"- PR: `#{args.pr}`",
+        f"- Server URL: `{args.server_url}`",
+        f"- Scenario: `{scenario}`",
+        f"- Task ID: `{task_id}`",
+        f"- Workflow ID: `{workflow_id}`",
+        f"- Task status: `{task_status}`",
+        f"- Submission mode: `{submission_mode}`",
+    ]
+    if submission_http_status:
+        lines.append(f"- Submission HTTP status: `{submission_http_status}`")
+    if submission_error:
+        lines.append(f"- Submission error: `{markdown_cell(compact(submission_error))}`")
+    lines.extend(
+        [
+            f"- Timed out: `{str(args.timed_out).lower()}`",
+            f"- Grade: `{quality_snapshot.get('final_grade')}`",
+        ]
+    )
+    if quality_snapshot.get("final_score") is not None:
+        lines.append(f"- Score: `{quality_snapshot.get('final_score')}`")
+    lines.extend(
+        [
+            f"- Grade cap: `{quality_snapshot.get('grade_cap') or 'none'}`",
+            "",
+            "## Eval Bounds",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| `wait_secs` | `{args.wait_secs}` |",
+            f"| `max_rounds` | `{args.max_rounds}` |",
+            f"| `max_turns` | `{args.max_turns}` |",
+            f"| `max_budget_usd` | `{args.max_budget_usd or 'not set'}` |",
+            f"| `timeout_secs` | `{args.timeout_secs}` |",
+            "",
+            "## Baseline vs Final",
+            "",
+            "| Field | Baseline | Final |",
+            "|---|---|---|",
+            f"| `headRefOid` | `{before['head']}` | `{after['head']}` |",
+            f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |",
+            f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |",
+            f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |",
+            f"| changed files | `{len(before['changed_files'])}` | `{len(after['changed_files'])}` |",
+            f"| head changed | `false` | `{str(head_changed).lower()}` |",
+            "",
+            "## Changed File Scope",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| changed-file evidence | `{'collected' if after['files_collected'] else 'missing'}` |",
+            f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |",
+            f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |",
+            "",
+            "## Final Changed Files",
+            "",
+        ]
+    )
+    if after["changed_files"]:
+        lines.extend(["| Path | Change | + | - |", "|---|---|---:|---:|"])
+        for path, change_type, additions, deletions in file_rows(after["changed_files"]):
+            lines.append(
+                f"| `{markdown_cell(path)}` | `{markdown_cell(change_type)}` | `{additions}` | `{deletions}` |"
+            )
+    else:
+        lines.append("- None collected")
+
+    lines.extend(["", "## Blockers", ""])
+    if snapshot_blockers:
+        lines.extend([f"- {blocker}" for blocker in snapshot_blockers])
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Failed Hard Gates", ""])
+    if failed_gates:
+        lines.extend(["| Gate | Grade cap | Message |", "|---|---|---|"])
+        for gate in failed_gates:
+            lines.append(
+                f"| `{markdown_cell(gate.get('name', 'unknown'))}` "
+                f"| `{markdown_cell(gate.get('grade_cap') or 'none')}` "
+                f"| {markdown_cell(gate.get('message', ''))} |"
+            )
+    else:
+        lines.append("- None")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--final", required=True, type=Path)
+    parser.add_argument("--submission", required=True, type=Path)
+    parser.add_argument("--task-detail", required=True, type=Path)
+    parser.add_argument("--quality-snapshot", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", required=True)
+    parser.add_argument("--server-url", required=True)
+    parser.add_argument("--timed-out", action="store_true")
+    parser.add_argument("--wait-secs", required=True)
+    parser.add_argument("--max-rounds", required=True)
+    parser.add_argument("--max-turns", required=True)
+    parser.add_argument("--max-budget-usd", default="")
+    parser.add_argument("--timeout-secs", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.output.write_text(render_report(args), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_evaluate_pr_repair_helpers.py
+++ b/scripts/test_evaluate_pr_repair_helpers.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Tests for PR repair eval helper scripts."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPT_DIR = Path(__file__).parent
+PREFLIGHT = load_module(
+    "evaluate_pr_repair_preflight",
+    SCRIPT_DIR / "evaluate_pr_repair_preflight.py",
+)
+REPORT = load_module(
+    "evaluate_pr_repair_render_report",
+    SCRIPT_DIR / "evaluate_pr_repair_render_report.py",
+)
+
+
+class PreflightTests(unittest.TestCase):
+    def test_find_registered_project_matches_canonical_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            projects = [{"root": str(root.resolve()), "active": True}]
+
+            self.assertEqual(
+                PREFLIGHT.find_registered_project(str(root), projects),
+                str(root.resolve()),
+            )
+
+    def test_find_registered_project_rejects_unregistered_root(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not registered"):
+            PREFLIGHT.find_registered_project("/tmp/missing", [{"root": "/tmp/other"}])
+
+    def test_find_registered_project_rejects_existing_unregistered_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+
+            with self.assertRaisesRegex(ValueError, "not registered"):
+                PREFLIGHT.find_registered_project(str(root), [{"root": "/tmp/other"}])
+
+    def test_find_registered_project_matches_id_and_name(self) -> None:
+        projects = [
+            {
+                "id": "/tmp/project-root",
+                "name": "harness",
+                "root": "/tmp/project-root",
+                "active": True,
+            }
+        ]
+
+        self.assertEqual(
+            PREFLIGHT.find_registered_project("harness", projects),
+            "/tmp/project-root",
+        )
+        self.assertEqual(
+            PREFLIGHT.find_registered_project("/tmp/project-root", projects),
+            "/tmp/project-root",
+        )
+
+    def test_find_registered_project_requires_usable_root_for_name_match(self) -> None:
+        projects = [{"id": "project-id", "name": "harness", "root": 42, "active": True}]
+
+        with self.assertRaisesRegex(ValueError, "no usable root"):
+            PREFLIGHT.find_registered_project("harness", projects)
+
+    def test_write_preflight_failure_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            submission = Path(tmp) / "submission.json"
+            task_detail = Path(tmp) / "task_detail.json"
+
+            PREFLIGHT.write_preflight_failure(submission, task_detail, "not registered")
+
+            self.assertEqual(json.loads(submission.read_text())["status"], "failed")
+            self.assertEqual(json.loads(task_detail.read_text())["preflight"], "server_project_registry")
+
+
+class RenderReportTests(unittest.TestCase):
+    def test_render_report_uses_quality_snapshot_grade(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            baseline = root / "baseline.json"
+            final = root / "final.json"
+            submission = root / "submission.json"
+            task_detail = root / "task_detail.json"
+            quality = root / "quality.json"
+
+            pr = {
+                "headRefOid": "a",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": {"state": "SUCCESS"},
+                "reviewThreads": {"nodes": []},
+                "files": {"nodes": []},
+            }
+            baseline.write_text(json.dumps({**pr, "number": 1}), encoding="utf-8")
+            final.write_text(json.dumps({**pr, "number": 1}), encoding="utf-8")
+            submission.write_text(json.dumps({"status": "failed"}), encoding="utf-8")
+            task_detail.write_text(json.dumps({"status": "failed"}), encoding="utf-8")
+            quality.write_text(
+                json.dumps(
+                    {
+                        "scenario": "pr_repair",
+                        "final_grade": "D",
+                        "final_score": 54,
+                        "grade_cap": "C",
+                        "blocker_summary": ["runtime artifact is missing"],
+                        "hard_gates": [
+                            {
+                                "name": "runtime_artifact_completeness",
+                                "status": "fail",
+                                "grade_cap": "B",
+                                "message": "runtime artifact is missing",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(
+                baseline=baseline,
+                final=final,
+                submission=submission,
+                task_detail=task_detail,
+                quality_snapshot=quality,
+                run_id="run",
+                repo="owner/repo",
+                pr="1",
+                server_url="http://127.0.0.1:9800",
+                timed_out=False,
+                wait_secs="1",
+                max_rounds="1",
+                max_turns="1",
+                max_budget_usd="",
+                timeout_secs="5",
+            )
+
+            rendered = REPORT.render_report(args)
+
+            self.assertIn("- Scenario: `pr_repair`", rendered)
+            self.assertIn("- Grade: `D`", rendered)
+            self.assertIn("- Score: `54`", rendered)
+            self.assertIn("- runtime artifact is missing", rendered)
+            self.assertIn("`runtime_artifact_completeness`", rendered)
+
+    def test_render_report_tolerates_malformed_optional_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            baseline = root / "baseline.json"
+            final = root / "final.json"
+            submission = root / "submission.json"
+            task_detail = root / "task_detail.json"
+            quality = root / "quality.json"
+
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "headRefOid": "a",
+                        "mergeStateStatus": "DIRTY",
+                        "statusCheckRollup": "unexpected",
+                        "reviewThreads": "unexpected",
+                        "files": {"nodes": ["unexpected", {"path": "src/lib.rs"}]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            final.write_text(
+                json.dumps(
+                    {
+                        "headRefOid": "b",
+                        "mergeStateStatus": "CLEAN",
+                        "statusCheckRollup": {"state": "SUCCESS"},
+                        "reviewThreads": {"nodes": ["unexpected"]},
+                        "files": "unexpected",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            submission.write_text(json.dumps({"status": "running"}), encoding="utf-8")
+            task_detail.write_text(json.dumps({"workflow": "unexpected"}), encoding="utf-8")
+            quality.write_text(
+                json.dumps({"scenario": "pr_repair", "final_grade": "C"}),
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(
+                baseline=baseline,
+                final=final,
+                submission=submission,
+                task_detail=task_detail,
+                quality_snapshot=quality,
+                run_id="run",
+                repo="owner/repo",
+                pr="1",
+                server_url="http://127.0.0.1:9800",
+                timed_out=False,
+                wait_secs="1",
+                max_rounds="1",
+                max_turns="1",
+                max_budget_usd="",
+                timeout_secs="5",
+            )
+
+            rendered = REPORT.render_report(args)
+
+            self.assertIn("- Scenario: `pr_repair`", rendered)
+            self.assertIn("| `statusCheckRollup.state` | `UNKNOWN` | `SUCCESS` |", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require live PR repair eval submissions to resolve `--project-root` against the running server project registry before `POST /tasks`
- emit full failure artifacts when the live server or project registry preflight fails
- render Markdown reports from `quality_snapshot.json` so scenario, score, grade cap, hard gates, and blockers have one authoritative source

Closes #1257

## Validation
- `bash -n scripts/evaluate_pr_repair.sh`
- `python3 -m unittest scripts/test_evaluate_pr_repair_submit.py scripts/test_evaluate_pr_repair_helpers.py`
- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`
