### PR TITLE
Fix PR repair eval live preflight and reporting

### DIFF
--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -130,6 +130,11 @@ require_cmd python3
 require_cmd date
 require_cmd cargo
 
+if ! PROJECT_ROOT="$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P)"; then
+  echo "--project-root must be an existing directory: $PROJECT_ROOT" >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OWNER="${REPO%%/*}"
@@ -408,52 +413,17 @@ print(quote(sys.argv[1], safe=""))
 PY
 }
 
-classify_snapshot() {
-  python3 - "$1" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    pr = json.load(fh)
-
-threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
-unresolved = len([
-    t for t in threads
-    if not t.get("isResolved", False) and not t.get("isOutdated", False)
-])
-checks = (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN"
-merge = pr.get("mergeStateStatus") or "UNKNOWN"
-if unresolved > 0:
-    print("review_feedback_repair")
-elif checks != "SUCCESS":
-    print("ci_repair")
-elif merge == "CLEAN" and checks == "SUCCESS":
-    print("ready_noop")
-else:
-    print("mergeability_repair")
-PY
-}
-
 write_collect_report() {
   local baseline="$1"
+  local quality="$2"
   local report="$OUTPUT_DIR/summary.md"
-  local task_class
-  task_class="$(classify_snapshot "$baseline")"
-  {
-    echo "# PR Repair Evaluation"
-    echo
-    echo "- Run ID: \`$RUN_ID\`"
-    echo "- Repo: \`$REPO\`"
-    echo "- PR: \`#$PR\`"
-    echo "- Mode: collect-only"
-    echo "- Candidate class: \`$task_class\`"
-    echo
-    echo "## Baseline"
-    echo
-    echo "\`\`\`text"
-    snapshot_summary "$baseline"
-    echo "\`\`\`"
-  } > "$report"
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" write-collect-report \
+    --baseline "$baseline" \
+    --quality "$quality" \
+    --output "$report" \
+    --run-id "$RUN_ID" \
+    --repo "$REPO" \
+    --pr "$PR"
 }
 
 write_final_report() {
@@ -462,214 +432,47 @@ write_final_report() {
   local submission="$3"
   local task_detail="$4"
   local timed_out="$5"
+  local quality="$6"
   local report="$OUTPUT_DIR/summary.md"
-  python3 - "$baseline" "$final" "$submission" "$task_detail" "$RUN_ID" "$REPO" "$PR" "$SERVER_URL" "$timed_out" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" "$TIMEOUT_SECS" <<'PY' > "$report"
-import json
-import sys
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" write-final-report \
+    --baseline "$baseline" \
+    --final "$final" \
+    --submission "$submission" \
+    --task-detail "$task_detail" \
+    --quality "$quality" \
+    --output "$report" \
+    --run-id "$RUN_ID" \
+    --repo "$REPO" \
+    --pr "$PR" \
+    --server-url "$SERVER_URL" \
+    --timed-out "$timed_out" \
+    --wait-secs "$WAIT_SECS" \
+    --max-rounds "$MAX_ROUNDS" \
+    --max-turns "$MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --timeout-secs "$TIMEOUT_SECS"
+}
 
-(
-    baseline_path,
-    final_path,
-    submission_path,
-    task_detail_path,
-    run_id,
-    repo,
-    pr_number,
-    server_url,
-    timed_out_arg,
-    wait_secs,
-    max_rounds,
-    max_turns,
-    max_budget,
-    timeout_secs,
-) = sys.argv[1:]
+preflight_project_registry() {
+  local projects_json="$1"
+  if ! curl "${curl_args[@]}" "$SERVER_URL/projects" > "$projects_json"; then
+    echo "project registry preflight failed: unable to fetch $SERVER_URL/projects"
+    return 2
+  fi
 
-def load(path):
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except Exception:
-        return {}
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" preflight-project-registry \
+    --project-root "$PROJECT_ROOT" \
+    --projects-json "$projects_json"
+}
 
-def facts(pr):
-    threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
-    files = list(((pr.get("files") or {}).get("nodes")) or [])
-    active = [
-        t for t in threads
-        if not t.get("isResolved", False) and not t.get("isOutdated", False)
-    ]
-    return {
-        "head": pr.get("headRefOid"),
-        "merge": pr.get("mergeStateStatus") or "UNKNOWN",
-        "checks": (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN",
-        "unresolved": len(active),
-        "files_collected": "files" in pr,
-        "changed_files": files,
-        "changed_file_paths": sorted({
-            f.get("path")
-            for f in files
-            if isinstance(f, dict) and f.get("path")
-        }),
-    }
-
-def markdown_cell(value):
-    return str(value).replace("|", "\\|")
-
-def compact(value, limit=240):
-    text = str(value).replace("\n", " ").strip()
-    if len(text) <= limit:
-        return text
-    return f"{text[:limit - 3]}..."
-
-def file_rows(files):
-    rows = []
-    for item in sorted(files, key=lambda f: f.get("path") or ""):
-        path = item.get("path") or "UNKNOWN"
-        change_type = item.get("changeType") or "UNKNOWN"
-        additions = item.get("additions", 0)
-        deletions = item.get("deletions", 0)
-        rows.append((path, change_type, additions, deletions))
-    return rows
-
-def limited_path_list(paths):
-    if not paths:
-        return ""
-    shown = ", ".join(paths[:5])
-    if len(paths) > 5:
-        return f"{shown}, ... ({len(paths)} total)"
-    return shown
-
-baseline = load(baseline_path)
-final = load(final_path)
-submission = load(submission_path)
-task_detail = load(task_detail_path)
-before = facts(baseline)
-after = facts(final)
-head_changed = before["head"] != after["head"]
-new_changed_paths = sorted(set(after["changed_file_paths"]) - set(before["changed_file_paths"]))
-removed_changed_paths = sorted(set(before["changed_file_paths"]) - set(after["changed_file_paths"]))
-task_status = task_detail.get("status") or task_detail.get("workflow", {}).get("state") or submission.get("status") or "unknown"
-workflow_id = submission.get("workflow_id") or task_detail.get("workflow", {}).get("id")
-task_id = submission.get("task_id") or task_detail.get("id")
-submission_mode = submission.get("eval_submission_mode") or "unknown"
-submission_http_status = submission.get("http_status") or task_detail.get("http_status")
-submission_error = (
-    submission.get("error")
-    or submission.get("message")
-    or submission.get("detail")
-    or submission.get("raw_response")
-    or task_detail.get("error")
-)
-timed_out = timed_out_arg == "1"
-
-if before["unresolved"] > 0:
-    candidate = "review_feedback_repair"
-elif before["checks"] != "SUCCESS":
-    candidate = "ci_repair"
-elif before["merge"] == "CLEAN" and before["checks"] == "SUCCESS":
-    candidate = "ready_noop"
-else:
-    candidate = "mergeability_repair"
-
-grade = "C"
-blockers = []
-if after["checks"] != "SUCCESS":
-    blockers.append(f"final checks are {after['checks']}")
-if after["unresolved"] > 0:
-    blockers.append(f"{after['unresolved']} active unresolved review threads remain")
-if candidate in ("review_feedback_repair", "ci_repair") and not head_changed:
-    blockers.append("PR head did not change for a repair candidate")
-if candidate == "ready_noop" and head_changed:
-    blockers.append("ready/no-op control changed the PR head")
-if after["merge"] != "CLEAN":
-    blockers.append(f"final mergeStateStatus is {after['merge']}, not CLEAN")
-if head_changed and not after["files_collected"]:
-    blockers.append("final PR head changed but changed files were not collected")
-if task_status in ("failed", "cancelled", "blocked"):
-    blockers.append(f"Harness task ended as {task_status}")
-if timed_out or task_status in ("unknown", "pending", "running", "implementing", "reviewing"):
-    blockers.append("Harness task did not reach a terminal state before the evaluation timeout")
-
-if not blockers:
-    grade = "A"
-elif candidate == "ready_noop" and head_changed:
-    grade = "C"
-elif after["merge"] != "CLEAN":
-    grade = "C"
-elif after["checks"] == "SUCCESS" and after["unresolved"] == 0:
-    grade = "B"
-elif head_changed or after["checks"] == "SUCCESS" or after["unresolved"] < before["unresolved"]:
-    grade = "C"
-elif task_status in ("failed", "cancelled", "blocked"):
-    grade = "D"
-else:
-    grade = "F"
-
-print("# PR Repair Evaluation")
-print()
-print(f"- Run ID: `{run_id}`")
-print(f"- Repo: `{repo}`")
-print(f"- PR: `#{pr_number}`")
-print(f"- Server URL: `{server_url}`")
-print(f"- Candidate class: `{candidate}`")
-print(f"- Task ID: `{task_id}`")
-print(f"- Workflow ID: `{workflow_id}`")
-print(f"- Task status: `{task_status}`")
-print(f"- Submission mode: `{submission_mode}`")
-if submission_http_status:
-    print(f"- Submission HTTP status: `{submission_http_status}`")
-if submission_error:
-    print(f"- Submission error: `{markdown_cell(compact(submission_error))}`")
-print(f"- Timed out: `{str(timed_out).lower()}`")
-print(f"- Grade: `{grade}`")
-print()
-print("## Eval Bounds")
-print()
-print("| Field | Value |")
-print("|---|---|")
-print(f"| `wait_secs` | `{wait_secs}` |")
-print(f"| `max_rounds` | `{max_rounds}` |")
-print(f"| `max_turns` | `{max_turns}` |")
-print(f"| `max_budget_usd` | `{max_budget or 'not set'}` |")
-print(f"| `timeout_secs` | `{timeout_secs}` |")
-print()
-print("## Baseline vs Final")
-print()
-print("| Field | Baseline | Final |")
-print("|---|---|---|")
-print(f"| `headRefOid` | `{before['head']}` | `{after['head']}` |")
-print(f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |")
-print(f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |")
-print(f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |")
-print(f"| changed files | `{len(before['changed_files'])}` | `{len(after['changed_files'])}` |")
-print(f"| head changed | `false` | `{str(head_changed).lower()}` |")
-print()
-print("## Changed File Scope")
-print()
-print("| Field | Value |")
-print("|---|---|")
-print(f"| changed-file evidence | `{'collected' if after['files_collected'] else 'missing'}` |")
-print(f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |")
-print(f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |")
-print()
-print("## Final Changed Files")
-print()
-if after["changed_files"]:
-    print("| Path | Change | + | - |")
-    print("|---|---|---:|---:|")
-    for path, change_type, additions, deletions in file_rows(after["changed_files"]):
-        print(f"| `{markdown_cell(path)}` | `{markdown_cell(change_type)}` | `{additions}` | `{deletions}` |")
-else:
-    print("- None collected")
-print()
-print("## Blockers")
-print()
-if blockers:
-    for blocker in blockers:
-        print(f"- {blocker}")
-else:
-    print("- None")
-PY
+write_preflight_failure_artifacts() {
+  local error="$1"
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" write-preflight-failure \
+    --submission "$SUBMISSION_JSON" \
+    --task-detail "$TASK_DETAIL_JSON" \
+    --project-root "$PROJECT_ROOT" \
+    --server-url "$SERVER_URL" \
+    --error "$error"
 }
 
 BASELINE_JSON="$OUTPUT_DIR/baseline_pr.json"
@@ -680,6 +483,7 @@ TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
 PR_REPAIR_EVAL_INPUT_JSON="$OUTPUT_DIR/pr_repair_eval_input.json"
 QUALITY_SNAPSHOT_JSON="$OUTPUT_DIR/quality_snapshot.json"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
+PROJECTS_JSON="$OUTPUT_DIR/projects.json"
 
 write_quality_snapshot() {
   local baseline="$1"
@@ -720,7 +524,7 @@ snapshot_summary "$BASELINE_JSON"
 cp "$BASELINE_JSON" "$FINAL_JSON"
 FINAL_COLLECTED_AT="$BASELINE_COLLECTED_AT"
 write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
-write_collect_report "$BASELINE_JSON"
+write_collect_report "$BASELINE_JSON" "$QUALITY_SNAPSHOT_JSON"
 
 if [[ "$COLLECT_ONLY" -eq 1 ]]; then
   echo "Collect-only report: $OUTPUT_DIR/summary.md"
@@ -736,6 +540,20 @@ fi
 if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
   echo "Harness server is not reachable at $SERVER_URL; baseline was saved to $OUTPUT_DIR" >&2
   exit 3
+fi
+
+if ! preflight_error="$(preflight_project_registry "$PROJECTS_JSON" 2>&1)"; then
+  write_preflight_failure_artifacts "$preflight_error"
+  echo "$preflight_error" >&2
+  echo "Collecting final PR snapshot"
+  FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  collect_snapshot "$FINAL_JSON"
+  snapshot_summary "$FINAL_JSON"
+  write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0" "$QUALITY_SNAPSHOT_JSON"
+  echo "Evaluation report: $OUTPUT_DIR/summary.md"
+  echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
+  exit 4
 fi
 
 python3 - "$PROJECT_ROOT" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" <<'PY' > "$TASK_BODY_JSON"
@@ -780,7 +598,7 @@ if ! python3 "$SCRIPT_DIR/evaluate_pr_repair_submit.py" --server-url "$SERVER_UR
   collect_snapshot "$FINAL_JSON"
   snapshot_summary "$FINAL_JSON"
   write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
-  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0" "$QUALITY_SNAPSHOT_JSON"
   echo "Evaluation report: $OUTPUT_DIR/summary.md"
   echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
   exit 4
@@ -807,7 +625,7 @@ if [[ -z "$TASK_ID" ]]; then
   collect_snapshot "$FINAL_JSON"
   snapshot_summary "$FINAL_JSON"
   write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
-  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0"
+  write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0" "$QUALITY_SNAPSHOT_JSON"
   echo "Evaluation report: $OUTPUT_DIR/summary.md"
   echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
   exit 4
@@ -844,6 +662,6 @@ FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 collect_snapshot "$FINAL_JSON"
 snapshot_summary "$FINAL_JSON"
 write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
-write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out"
+write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out" "$QUALITY_SNAPSHOT_JSON"
 echo "Evaluation report: $OUTPUT_DIR/summary.md"
 echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"

--- a/scripts/evaluate_pr_repair_artifacts.py
+++ b/scripts/evaluate_pr_repair_artifacts.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Artifact helpers for PR repair live evaluations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from evaluate_pr_repair_submit import write_json
+
+
+JsonObject = dict[str, Any]
+
+
+def read_json(path: Path, *, required: bool = True) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        if required:
+            raise SystemExit(f"failed to read JSON artifact {path}: {exc}") from exc
+        return {}
+
+
+def normalized_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return str(Path(value).expanduser().resolve(strict=False))
+
+
+def project_registry_preflight(args: argparse.Namespace) -> int:
+    project_root = str(Path(args.project_root).expanduser().resolve(strict=False))
+    payload = read_json(args.projects_json)
+    if isinstance(payload, list):
+        projects = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("projects"), list):
+        projects = payload["projects"]
+    else:
+        print("project registry preflight failed: /projects response is not a project list")
+        return 2
+
+    matches = [
+        project
+        for project in projects
+        if isinstance(project, dict)
+        and (
+            normalized_path(project.get("root")) == project_root
+            or normalized_path(project.get("id")) == project_root
+        )
+    ]
+    active_matches = [project for project in matches if project.get("active", True)]
+    if active_matches:
+        return 0
+    if matches:
+        print(
+            "project registry preflight failed: "
+            f"project root is registered but inactive: {project_root}"
+        )
+    else:
+        print(f"project registry preflight failed: project root is not registered: {project_root}")
+    return 1
+
+
+def write_preflight_failure(args: argparse.Namespace) -> int:
+    submission = {
+        "error": args.error,
+        "eval_submission_mode": "prompt_task",
+        "http_status": "preflight",
+        "project_root": args.project_root,
+        "server_url": args.server_url,
+        "stage": "project_registry_preflight",
+        "status": "failed",
+    }
+    task_detail = {
+        "error": args.error,
+        "project_root": args.project_root,
+        "stage": "project_registry_preflight",
+        "status": "failed",
+    }
+    write_json(args.submission, submission)
+    write_json(args.task_detail, task_detail)
+    return 0
+
+
+def pr_facts(pr: JsonObject) -> JsonObject:
+    threads = (((pr.get("reviewThreads") or {}).get("nodes")) or [])
+    files = list(((pr.get("files") or {}).get("nodes")) or [])
+    active_threads = [
+        thread
+        for thread in threads
+        if not thread.get("isResolved", False) and not thread.get("isOutdated", False)
+    ]
+    return {
+        "head": pr.get("headRefOid"),
+        "merge": pr.get("mergeStateStatus") or "UNKNOWN",
+        "checks": (pr.get("statusCheckRollup") or {}).get("state") or "UNKNOWN",
+        "unresolved": len(active_threads),
+        "files_collected": "files" in pr,
+        "changed_files": files,
+        "changed_file_paths": sorted(
+            {
+                item.get("path")
+                for item in files
+                if isinstance(item, dict) and item.get("path")
+            }
+        ),
+    }
+
+
+def candidate_class(facts: JsonObject) -> str:
+    if facts["unresolved"] > 0:
+        return "review_feedback_repair"
+    if facts["checks"] != "SUCCESS":
+        return "ci_repair"
+    if facts["merge"] == "CLEAN" and facts["checks"] == "SUCCESS":
+        return "ready_noop"
+    return "mergeability_repair"
+
+
+def snapshot_summary(pr: JsonObject) -> str:
+    facts = pr_facts(pr)
+    files = (((pr.get("files") or {}).get("nodes")) or [])
+    return (
+        f"pr={pr.get('number')} head={facts['head']} merge={facts['merge']} "
+        f"checks={facts['checks']} unresolved_threads={facts['unresolved']} "
+        f"changed_files={len(files)}"
+    )
+
+
+def markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|")
+
+
+def compact(value: Any, limit: int = 240) -> str:
+    text = str(value).replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit - 3]}..."
+
+
+def limited_path_list(paths: list[str]) -> str:
+    if not paths:
+        return ""
+    shown = ", ".join(paths[:5])
+    if len(paths) > 5:
+        return f"{shown}, ... ({len(paths)} total)"
+    return shown
+
+
+def sorted_file_rows(files: list[JsonObject]) -> list[tuple[str, str, Any, Any]]:
+    rows = []
+    for item in sorted(files, key=lambda file: file.get("path") or ""):
+        rows.append(
+            (
+                item.get("path") or "UNKNOWN",
+                item.get("changeType") or "UNKNOWN",
+                item.get("additions", 0),
+                item.get("deletions", 0),
+            )
+        )
+    return rows
+
+
+def quality_fields(quality: JsonObject) -> tuple[Any, Any, Any, list[Any]]:
+    blockers = quality.get("blocker_summary")
+    if not isinstance(blockers, list):
+        blockers = []
+    return (
+        quality.get("final_grade", "unknown"),
+        quality.get("final_score", "unknown"),
+        quality.get("grade_cap") or "none",
+        blockers,
+    )
+
+
+def write_collect_report(args: argparse.Namespace) -> int:
+    baseline = read_json(args.baseline)
+    quality = read_json(args.quality)
+    grade, score, grade_cap, blockers = quality_fields(quality)
+    task_class = candidate_class(pr_facts(baseline))
+
+    lines = [
+        "# PR Repair Evaluation",
+        "",
+        f"- Run ID: `{args.run_id}`",
+        f"- Repo: `{args.repo}`",
+        f"- PR: `#{args.pr}`",
+        "- Mode: collect-only",
+        f"- Candidate class: `{task_class}`",
+        f"- Grade: `{grade}`",
+        f"- Score: `{score}`",
+        f"- Grade cap: `{grade_cap}`",
+        "",
+        "## Baseline",
+        "",
+        "```text",
+        snapshot_summary(baseline),
+        "```",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend([f"- {blocker}" for blocker in blockers] or ["- None"])
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return 0
+
+
+def write_final_report(args: argparse.Namespace) -> int:
+    baseline = read_json(args.baseline)
+    final = read_json(args.final)
+    submission = read_json(args.submission, required=False)
+    task_detail = read_json(args.task_detail, required=False)
+    quality = read_json(args.quality)
+
+    before = pr_facts(baseline)
+    after = pr_facts(final)
+    head_changed = before["head"] != after["head"]
+    new_changed_paths = sorted(set(after["changed_file_paths"]) - set(before["changed_file_paths"]))
+    removed_changed_paths = sorted(
+        set(before["changed_file_paths"]) - set(after["changed_file_paths"])
+    )
+    task_status = (
+        task_detail.get("status")
+        or (task_detail.get("workflow") or {}).get("state")
+        or submission.get("status")
+        or "unknown"
+    )
+    workflow_id = submission.get("workflow_id") or (task_detail.get("workflow") or {}).get("id")
+    task_id = submission.get("task_id") or task_detail.get("id")
+    submission_mode = submission.get("eval_submission_mode") or "unknown"
+    submission_http_status = submission.get("http_status") or task_detail.get("http_status")
+    submission_error = (
+        submission.get("error")
+        or submission.get("message")
+        or submission.get("detail")
+        or submission.get("raw_response")
+        or task_detail.get("error")
+    )
+    timed_out = args.timed_out == "1"
+    grade, score, grade_cap, blockers = quality_fields(quality)
+
+    lines = [
+        "# PR Repair Evaluation",
+        "",
+        f"- Run ID: `{args.run_id}`",
+        f"- Repo: `{args.repo}`",
+        f"- PR: `#{args.pr}`",
+        f"- Server URL: `{args.server_url}`",
+        f"- Candidate class: `{candidate_class(before)}`",
+        f"- Task ID: `{task_id}`",
+        f"- Workflow ID: `{workflow_id}`",
+        f"- Task status: `{task_status}`",
+        f"- Submission mode: `{submission_mode}`",
+    ]
+    if submission_http_status:
+        lines.append(f"- Submission HTTP status: `{submission_http_status}`")
+    if submission_error:
+        lines.append(f"- Submission error: `{markdown_cell(compact(submission_error))}`")
+    lines.extend(
+        [
+            f"- Timed out: `{str(timed_out).lower()}`",
+            f"- Grade: `{grade}`",
+            f"- Score: `{score}`",
+            f"- Grade cap: `{grade_cap}`",
+            "",
+            "## Eval Bounds",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| `wait_secs` | `{args.wait_secs}` |",
+            f"| `max_rounds` | `{args.max_rounds}` |",
+            f"| `max_turns` | `{args.max_turns}` |",
+            f"| `max_budget_usd` | `{args.max_budget_usd or 'not set'}` |",
+            f"| `timeout_secs` | `{args.timeout_secs}` |",
+            "",
+            "## Baseline vs Final",
+            "",
+            "| Field | Baseline | Final |",
+            "|---|---|---|",
+            f"| `headRefOid` | `{before['head']}` | `{after['head']}` |",
+            f"| `mergeStateStatus` | `{before['merge']}` | `{after['merge']}` |",
+            f"| `statusCheckRollup.state` | `{before['checks']}` | `{after['checks']}` |",
+            f"| active unresolved review threads | `{before['unresolved']}` | `{after['unresolved']}` |",
+            f"| changed files | `{len(before['changed_files'])}` | `{len(after['changed_files'])}` |",
+            f"| head changed | `false` | `{str(head_changed).lower()}` |",
+            "",
+            "## Changed File Scope",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| changed-file evidence | `{'collected' if after['files_collected'] else 'missing'}` |",
+            f"| new changed paths | `{limited_path_list(new_changed_paths) or 'none'}` |",
+            f"| removed changed paths | `{limited_path_list(removed_changed_paths) or 'none'}` |",
+            "",
+            "## Final Changed Files",
+            "",
+        ]
+    )
+
+    if after["changed_files"]:
+        lines.extend(["| Path | Change | + | - |", "|---|---|---:|---:|"])
+        for path, change_type, additions, deletions in sorted_file_rows(after["changed_files"]):
+            lines.append(
+                f"| `{markdown_cell(path)}` | `{markdown_cell(change_type)}` | "
+                f"`{additions}` | `{deletions}` |"
+            )
+    else:
+        lines.append("- None collected")
+
+    lines.extend(["", "## Blockers", ""])
+    lines.extend([f"- {blocker}" for blocker in blockers] or ["- None"])
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    preflight = sub.add_parser("preflight-project-registry")
+    preflight.add_argument("--project-root", required=True)
+    preflight.add_argument("--projects-json", type=Path, required=True)
+    preflight.set_defaults(func=project_registry_preflight)
+
+    failure = sub.add_parser("write-preflight-failure")
+    failure.add_argument("--submission", type=Path, required=True)
+    failure.add_argument("--task-detail", type=Path, required=True)
+    failure.add_argument("--project-root", required=True)
+    failure.add_argument("--server-url", required=True)
+    failure.add_argument("--error", required=True)
+    failure.set_defaults(func=write_preflight_failure)
+
+    collect = sub.add_parser("write-collect-report")
+    collect.add_argument("--baseline", type=Path, required=True)
+    collect.add_argument("--quality", type=Path, required=True)
+    collect.add_argument("--output", type=Path, required=True)
+    collect.add_argument("--run-id", required=True)
+    collect.add_argument("--repo", required=True)
+    collect.add_argument("--pr", required=True)
+    collect.set_defaults(func=write_collect_report)
+
+    final = sub.add_parser("write-final-report")
+    final.add_argument("--baseline", type=Path, required=True)
+    final.add_argument("--final", type=Path, required=True)
+    final.add_argument("--submission", type=Path, required=True)
+    final.add_argument("--task-detail", type=Path, required=True)
+    final.add_argument("--quality", type=Path, required=True)
+    final.add_argument("--output", type=Path, required=True)
+    final.add_argument("--run-id", required=True)
+    final.add_argument("--repo", required=True)
+    final.add_argument("--pr", required=True)
+    final.add_argument("--server-url", required=True)
+    final.add_argument("--timed-out", required=True)
+    final.add_argument("--wait-secs", required=True)
+    final.add_argument("--max-rounds", required=True)
+    final.add_argument("--max-turns", required=True)
+    final.add_argument("--max-budget-usd", default="")
+    final.add_argument("--timeout-secs", required=True)
+    final.set_defaults(func=write_final_report)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_evaluate_pr_repair_artifacts.py
+++ b/scripts/test_evaluate_pr_repair_artifacts.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Tests for PR repair eval artifact helpers."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("evaluate_pr_repair_artifacts.py")
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("evaluate_pr_repair_artifacts", SCRIPT_PATH)
+assert SPEC is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+from evaluate_pr_repair_submit import write_json as write_json_file
+
+
+def pr_snapshot(head: str = "abc123") -> dict[str, object]:
+    return {
+        "number": 7,
+        "headRefOid": head,
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": {"state": "SUCCESS"},
+        "reviewThreads": {"nodes": []},
+        "files": {"nodes": []},
+    }
+
+
+class ArtifactHelperTests(unittest.TestCase):
+    def test_project_registry_preflight_requires_registered_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            registered = tmp_path / "registered"
+            projects_json = tmp_path / "projects.json"
+            write_json_file(
+                projects_json,
+                [{"root": str(registered), "id": str(registered), "active": True}],
+            )
+
+            self.assertEqual(
+                MODULE.project_registry_preflight(
+                    argparse.Namespace(
+                        project_root=str(registered),
+                        projects_json=projects_json,
+                    )
+                ),
+                0,
+            )
+            self.assertEqual(
+                MODULE.project_registry_preflight(
+                    argparse.Namespace(
+                        project_root=str(tmp_path / "unregistered"),
+                        projects_json=projects_json,
+                    )
+                ),
+                1,
+            )
+
+    def test_preflight_failure_artifacts_are_structured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            submission = tmp_path / "submission.json"
+            task_detail = tmp_path / "task_detail_final.json"
+
+            MODULE.write_preflight_failure(
+                argparse.Namespace(
+                    submission=submission,
+                    task_detail=task_detail,
+                    project_root="/tmp/project",
+                    server_url="http://127.0.0.1:9800",
+                    error="project registry preflight failed",
+                )
+            )
+
+            self.assertEqual(json.loads(submission.read_text())["http_status"], "preflight")
+            self.assertEqual(
+                json.loads(task_detail.read_text())["stage"],
+                "project_registry_preflight",
+            )
+
+    def test_final_report_uses_quality_snapshot_grade_and_blockers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            baseline = tmp_path / "baseline.json"
+            final = tmp_path / "final.json"
+            quality = tmp_path / "quality_snapshot.json"
+            submission = tmp_path / "submission.json"
+            task_detail = tmp_path / "task_detail_final.json"
+            report = tmp_path / "summary.md"
+
+            write_json_file(baseline, pr_snapshot())
+            write_json_file(final, pr_snapshot())
+            write_json_file(
+                quality,
+                {
+                    "final_grade": "C",
+                    "final_score": 70,
+                    "grade_cap": "C",
+                    "blocker_summary": ["quality blocker"],
+                },
+            )
+            write_json_file(
+                submission,
+                {
+                    "status": "failed",
+                    "error": "project registry preflight failed",
+                    "eval_submission_mode": "prompt_task",
+                    "http_status": "preflight",
+                },
+            )
+            write_json_file(task_detail, {"status": "failed"})
+
+            MODULE.write_final_report(
+                argparse.Namespace(
+                    baseline=baseline,
+                    final=final,
+                    submission=submission,
+                    task_detail=task_detail,
+                    quality=quality,
+                    output=report,
+                    run_id="run-1",
+                    repo="owner/repo",
+                    pr="7",
+                    server_url="http://127.0.0.1:9800",
+                    timed_out="0",
+                    wait_secs="10",
+                    max_rounds="2",
+                    max_turns="6",
+                    max_budget_usd="",
+                    timeout_secs="7200",
+                )
+            )
+
+            text = report.read_text(encoding="utf-8")
+            self.assertIn("- Grade: `C`", text)
+            self.assertIn("- Score: `70`", text)
+            self.assertIn("- Grade cap: `C`", text)
+            self.assertIn("- Timed out: `false`", text)
+            self.assertIn("- quality blocker", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a live PR repair eval preflight that checks `GET /projects` before `POST /tasks` and fails fast when the requested project root is not registered.
- Preserve failure artifacts for preflight failures: `submission.json`, `task_detail_final.json`, `quality_snapshot.json`, and `summary.md`.
- Move PR repair report/preflight artifact logic into a focused Python helper so `summary.md` reports grade, score, grade cap, and blockers from `quality_snapshot.json`.

Closes #1257

## Validation

- `bash -n scripts/evaluate_pr_repair.sh`
- `python3 scripts/test_evaluate_pr_repair_artifacts.py`
- `python3 scripts/test_evaluate_pr_repair_submit.py`
- Python compile check for `scripts/evaluate_pr_repair_artifacts.py`, `scripts/evaluate_pr_repair_submit.py`, and tests
- Live preflight failure smoke against `http://127.0.0.1:9800`: expected exit `4`; emitted `submission.json`, `task_detail_final.json`, `quality_snapshot.json`, and `summary.md`; `submission.json` had `stage=project_registry_preflight` and `http_status=preflight`; `summary.md` reported grade `D`, score `54`, grade cap `C` from `quality_snapshot.json`
- `cargo test -p harness-eval -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
