### PR TITLE
fix(eval): isolate PR repair eval runs

### DIFF
--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -483,6 +483,12 @@ PR_REPAIR_EVAL_INPUT_JSON="$OUTPUT_DIR/pr_repair_eval_input.json"
 QUALITY_SNAPSHOT_JSON="$OUTPUT_DIR/quality_snapshot.json"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
 PROJECTS_JSON="$OUTPUT_DIR/projects.json"
+TASKS_PREFLIGHT_JSON="$OUTPUT_DIR/tasks_preflight.json"
+TASKS_PREFLIGHT_ERROR="$OUTPUT_DIR/tasks_preflight_error.txt"
+RUNTIME_TREE_FINAL_JSON="$OUTPUT_DIR/runtime_tree_final.json"
+RUNTIME_TREE_FINAL_ERROR="$OUTPUT_DIR/runtime_tree_final_error.txt"
+EVAL_TARGET_ID="pr-repair-eval:$REPO#$PR"
+EVAL_EXTERNAL_ID="$EVAL_TARGET_ID:run:$RUN_ID"
 
 write_quality_snapshot() {
   local baseline="$1"
@@ -514,6 +520,29 @@ write_quality_snapshot() {
     args+=(--task-detail "$task_detail")
   fi
   cargo "${args[@]}"
+}
+
+collect_runtime_tree_artifact() {
+  local project_root="$1"
+  local workflow_id="$2"
+  local task_id="$3"
+  if [[ -z "$project_root" || -z "$workflow_id" ]]; then
+    return 0
+  fi
+  if curl "${curl_args[@]}" --get \
+    --data-urlencode "project_id=$project_root" \
+    --data-urlencode "limit=100" \
+    --data-urlencode "job_limit=5" \
+    "$SERVER_URL/api/workflows/runtime/tree" \
+    > "$RUNTIME_TREE_FINAL_JSON" 2>"$RUNTIME_TREE_FINAL_ERROR"; then
+    python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" merge-runtime-tree \
+      --task-detail "$TASK_DETAIL_JSON" \
+      --runtime-tree "$RUNTIME_TREE_FINAL_JSON" \
+      --workflow-id "$workflow_id" \
+      --task-id "$task_id"
+  else
+    echo "Runtime tree collection failed; see $RUNTIME_TREE_FINAL_ERROR" >&2
+  fi
 }
 
 echo "Collecting baseline for $REPO#$PR"
@@ -560,11 +589,29 @@ if ! registered_project="$(python3 "$SCRIPT_DIR/evaluate_pr_repair_preflight.py"
 fi
 echo "Registered project: $registered_project"
 
-python3 - "$registered_project" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" <<'PY' > "$TASK_BODY_JSON"
+echo "Checking for active duplicate PR repair eval tasks"
+if ! curl "${curl_args[@]}" --get \
+  --data-urlencode "source=pr_repair_eval" \
+  --data-urlencode "kind=prompt" \
+  --data-urlencode "limit=500" \
+  "$SERVER_URL/tasks" > "$TASKS_PREFLIGHT_JSON" 2>"$TASKS_PREFLIGHT_ERROR"; then
+  write_live_preflight_failure_report \
+    "Harness task list is not reachable at $SERVER_URL/tasks; see $TASKS_PREFLIGHT_ERROR" \
+    5
+fi
+if ! duplicate_error="$(python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" check-conflicts \
+  --tasks-json "$TASKS_PREFLIGHT_JSON" \
+  --project-root "$registered_project" \
+  --external-id "$EVAL_EXTERNAL_ID" \
+  --target-prefix "$EVAL_TARGET_ID" 2>&1)"; then
+  write_live_preflight_failure_report "$duplicate_error" 5
+fi
+
+python3 - "$registered_project" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" "$EVAL_EXTERNAL_ID" <<'PY' > "$TASK_BODY_JSON"
 import json
 import sys
 
-project_root, repo, pr, wait_secs, max_rounds, max_turns, max_budget = sys.argv[1:]
+project_root, repo, pr, wait_secs, max_rounds, max_turns, max_budget, external_id = sys.argv[1:]
 wait_secs_value = int(wait_secs)
 max_rounds_value = int(max_rounds)
 max_turns_value = int(max_turns)
@@ -572,7 +619,7 @@ body = {
     "project": project_root,
     "repo": repo,
     "source": "pr_repair_eval",
-    "external_id": f"pr-repair-eval:{repo}#{pr}",
+    "external_id": external_id,
     "wait_secs": wait_secs_value,
     "max_rounds": max_rounds_value,
     "max_turns": max_turns_value,
@@ -615,7 +662,7 @@ import sys
 try:
     with open(sys.argv[1], "r", encoding="utf-8") as fh:
         data = json.load(fh)
-except json.JSONDecodeError:
+except (OSError, json.JSONDecodeError):
     data = {}
 
 print(data.get("task_id") or data.get("submission_id") or "")
@@ -636,6 +683,19 @@ if [[ -z "$TASK_ID" ]]; then
 fi
 
 echo "Submitted task_id=$TASK_ID"
+WORKFLOW_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    data = {}
+
+print(data.get("workflow_id") or "")
+PY
+)"
 ENCODED_TASK_ID="$(url_encode_path_segment "$TASK_ID")"
 deadline=$(( $(date +%s) + TIMEOUT_SECS ))
 status="unknown"
@@ -665,6 +725,25 @@ echo "Collecting final PR snapshot"
 FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 collect_snapshot "$FINAL_JSON"
 snapshot_summary "$FINAL_JSON"
+if [[ -z "$WORKFLOW_ID" ]]; then
+  WORKFLOW_ID="$(python3 - "$TASK_DETAIL_JSON" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    data = {}
+
+workflow = data.get("workflow") if isinstance(data, dict) else {}
+if not isinstance(workflow, dict):
+    workflow = {}
+print(workflow.get("id") or data.get("workflow_id") or "")
+PY
+)"
+fi
+collect_runtime_tree_artifact "$registered_project" "$WORKFLOW_ID" "$TASK_ID"
 write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
 write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out" "$QUALITY_SNAPSHOT_JSON"
 echo "Evaluation report: $OUTPUT_DIR/summary.md"

--- a/scripts/evaluate_pr_repair_artifacts.py
+++ b/scripts/evaluate_pr_repair_artifacts.py
@@ -13,6 +13,26 @@ from evaluate_pr_repair_submit import write_json
 
 JsonObject = dict[str, Any]
 
+TERMINAL_TASK_STATES = {
+    "blocked",
+    "cancelled",
+    "canceled",
+    "done",
+    "failed",
+    "passed",
+    "ready_to_merge",
+    "success",
+    "succeeded",
+}
+
+ACTIVE_SCHEDULER_STATES = {
+    "awaiting_dependencies",
+    "dispatching",
+    "pending",
+    "queued",
+    "running",
+}
+
 
 def read_json(path: Path, *, required: bool = True) -> Any:
     try:
@@ -81,6 +101,119 @@ def write_preflight_failure(args: argparse.Namespace) -> int:
     }
     write_json(str(args.submission), submission)
     write_json(str(args.task_detail), task_detail)
+    return 0
+
+
+def normalized_state(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def terminal_state_from_task(task: JsonObject) -> str:
+    workflow = task.get("workflow")
+    workflow_state = ""
+    if isinstance(workflow, dict):
+        workflow_state = normalized_state(workflow.get("state") or workflow.get("status"))
+    candidates = [
+        workflow_state,
+        normalized_state(task.get("workflow_state")),
+        normalized_state(task.get("workflowStatus")),
+        normalized_state(task.get("status")),
+        normalized_state(task.get("state")),
+    ]
+    for candidate in candidates:
+        if candidate in TERMINAL_TASK_STATES:
+            return candidate
+    if normalized_state(task.get("phase")) == "terminal":
+        return "terminal"
+    return ""
+
+
+def task_is_active(task: JsonObject) -> bool:
+    if terminal_state_from_task(task):
+        return False
+
+    scheduler = task.get("scheduler")
+    scheduler_state = ""
+    if isinstance(scheduler, dict):
+        scheduler_state = normalized_state(scheduler.get("authority_state"))
+    if scheduler_state in ACTIVE_SCHEDULER_STATES:
+        return True
+    if scheduler_state in TERMINAL_TASK_STATES:
+        return False
+
+    phase = normalized_state(task.get("phase"))
+    return phase != "terminal"
+
+
+def conflicting_eval_tasks(
+    tasks_response: Any,
+    *,
+    external_id: str,
+    target_prefix: str | None = None,
+    task_id: str | None = None,
+    workflow_id: str | None = None,
+) -> list[JsonObject]:
+    tasks = tasks_response.get("data") if isinstance(tasks_response, dict) else None
+    if not isinstance(tasks, list):
+        raise SystemExit("Harness task list response is missing a data array")
+
+    conflicts = []
+    for item in tasks:
+        if not isinstance(item, dict):
+            continue
+        item_external_id = item.get("external_id")
+        target_matches = item_external_id == external_id
+        if target_prefix:
+            target_matches = target_matches or item_external_id == target_prefix
+            target_matches = target_matches or (
+                isinstance(item_external_id, str)
+                and item_external_id.startswith(f"{target_prefix}:")
+            )
+        if not target_matches:
+            continue
+        if task_id and item.get("id") == task_id:
+            continue
+        if workflow_id and item.get("workflow_id") == workflow_id:
+            continue
+        if task_is_active(item):
+            conflicts.append(item)
+    return conflicts
+
+
+def conflict_message(conflicts: list[JsonObject], project_root: str, external_id: str) -> str:
+    rows = []
+    for task in conflicts[:8]:
+        scheduler = task.get("scheduler")
+        scheduler_state = (
+            scheduler.get("authority_state") if isinstance(scheduler, dict) else "<unknown>"
+        )
+        rows.append(
+            "task_id={task_id} project={project} status={status} scheduler={scheduler} workflow={workflow}".format(
+                task_id=task.get("id") or task.get("task_id") or "<unknown>",
+                project=task.get("project") or "<unknown>",
+                status=task.get("status") or "<unknown>",
+                scheduler=scheduler_state,
+                workflow=task.get("workflow_id") or "<unknown>",
+            )
+        )
+    suffix = "; ".join(rows)
+    return (
+        f"Conflicting active PR repair eval already exists for {external_id}; "
+        f"target project={project_root}; conflicts: {suffix}"
+    )
+
+
+def check_conflicts(args: argparse.Namespace) -> int:
+    conflicts = conflicting_eval_tasks(
+        read_json(args.tasks_json),
+        external_id=args.external_id,
+        target_prefix=args.target_prefix or None,
+    )
+    if conflicts:
+        print(conflict_message(conflicts, args.project_root, args.external_id))
+        return 1
     return 0
 
 
@@ -340,6 +473,153 @@ def write_final_report(args: argparse.Namespace) -> int:
     return 0
 
 
+def iter_workflow_nodes(node: Any):
+    if not isinstance(node, dict):
+        return
+    yield node
+    children = node.get("children")
+    if isinstance(children, list):
+        for child in children:
+            yield from iter_workflow_nodes(child)
+
+
+def find_workflow_node(
+    runtime_tree: Any,
+    workflow_id: str | None,
+    task_id: str | None,
+) -> JsonObject | None:
+    workflows = runtime_tree.get("workflows") if isinstance(runtime_tree, dict) else None
+    if not isinstance(workflows, list):
+        return None
+    for root in workflows:
+        for node in iter_workflow_nodes(root):
+            workflow = node.get("workflow")
+            if not isinstance(workflow, dict):
+                continue
+            workflow_data = workflow.get("data") if isinstance(workflow.get("data"), dict) else {}
+            task_ids = (
+                workflow_data.get("task_ids")
+                if isinstance(workflow_data.get("task_ids"), list)
+                else []
+            )
+            if workflow_id and workflow.get("id") == workflow_id:
+                return node
+            if task_id and (
+                workflow_data.get("task_id") == task_id
+                or workflow_data.get("submission_id") == task_id
+                or task_id in task_ids
+            ):
+                return node
+    return None
+
+
+def artifact_count(job: JsonObject) -> int:
+    output = job.get("output")
+    if isinstance(output, dict):
+        artifacts = output.get("artifacts")
+        if isinstance(artifacts, list):
+            return len(artifacts)
+    return 0
+
+
+def activity_from_job(job: JsonObject) -> str | None:
+    output = job.get("output")
+    if isinstance(output, dict) and isinstance(output.get("activity"), str):
+        return output["activity"]
+    input_value = job.get("input")
+    if isinstance(input_value, dict) and isinstance(input_value.get("activity"), str):
+        return input_value["activity"]
+    return None
+
+
+def runtime_jobs_from_node(node: JsonObject) -> tuple[list[JsonObject], str | None]:
+    jobs = []
+    latest_activity = None
+    commands = node.get("commands")
+    if not isinstance(commands, list):
+        return jobs, latest_activity
+    for command in commands:
+        if not isinstance(command, dict):
+            continue
+        runtime_jobs = command.get("runtime_jobs")
+        if not isinstance(runtime_jobs, list):
+            continue
+        for job in runtime_jobs:
+            if not isinstance(job, dict):
+                continue
+            latest_activity = activity_from_job(job) or latest_activity
+            status = job.get("status") if isinstance(job.get("status"), str) else ""
+            jobs.append(
+                {
+                    "artifact_count": artifact_count(job),
+                    "id": job.get("id") or "",
+                    "runtime_job_id": job.get("id") or "",
+                    "state": status,
+                    "status": status,
+                    "terminal_state": (
+                        status if normalized_state(status) in TERMINAL_TASK_STATES else None
+                    ),
+                }
+            )
+    return jobs, latest_activity
+
+
+def merge_runtime_tree_data(
+    task_detail: JsonObject,
+    runtime_tree: Any,
+    *,
+    workflow_id: str | None,
+    task_id: str | None,
+) -> JsonObject:
+    node = find_workflow_node(runtime_tree, workflow_id, task_id)
+    artifact = {
+        "source": "workflow_runtime_tree",
+        "workflow_id": workflow_id,
+        "task_id": task_id,
+        "status": "workflow_not_found",
+        "runtime_job_count": 0,
+    }
+    if node is None:
+        task_detail["runtime_tree_artifact"] = artifact
+        return task_detail
+
+    workflow = node.get("workflow") if isinstance(node.get("workflow"), dict) else {}
+    jobs, latest_activity = runtime_jobs_from_node(node)
+    artifact["status"] = "matched"
+    artifact["runtime_job_count"] = len(jobs)
+    task_detail["runtime_tree_artifact"] = artifact
+    task_detail["runtime_jobs"] = jobs
+    if latest_activity and not task_detail.get("latest_activity"):
+        task_detail["latest_activity"] = latest_activity
+
+    detail_workflow = task_detail.get("workflow")
+    if not isinstance(detail_workflow, dict):
+        detail_workflow = {}
+    if workflow.get("id") and not detail_workflow.get("id"):
+        detail_workflow["id"] = workflow.get("id")
+    if workflow.get("state") and not detail_workflow.get("state"):
+        detail_workflow["state"] = workflow.get("state")
+    if workflow.get("project_id") and not detail_workflow.get("project_id"):
+        detail_workflow["project_id"] = workflow.get("project_id")
+    if detail_workflow:
+        task_detail["workflow"] = detail_workflow
+    return task_detail
+
+
+def merge_runtime_tree(args: argparse.Namespace) -> int:
+    raw_task_detail = read_json(args.task_detail, required=False)
+    task_detail = raw_task_detail if isinstance(raw_task_detail, dict) else {}
+    runtime_tree = read_json(args.runtime_tree)
+    merged = merge_runtime_tree_data(
+        task_detail,
+        runtime_tree,
+        workflow_id=args.workflow_id or None,
+        task_id=args.task_id or None,
+    )
+    write_json(str(args.task_detail), merged)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
@@ -356,6 +636,20 @@ def build_parser() -> argparse.ArgumentParser:
     failure.add_argument("--server-url", required=True)
     failure.add_argument("--error", required=True)
     failure.set_defaults(func=write_preflight_failure)
+
+    conflicts = sub.add_parser("check-conflicts")
+    conflicts.add_argument("--tasks-json", required=True, type=Path)
+    conflicts.add_argument("--project-root", required=True)
+    conflicts.add_argument("--external-id", required=True)
+    conflicts.add_argument("--target-prefix", default="")
+    conflicts.set_defaults(func=check_conflicts)
+
+    runtime_tree = sub.add_parser("merge-runtime-tree")
+    runtime_tree.add_argument("--task-detail", required=True, type=Path)
+    runtime_tree.add_argument("--runtime-tree", required=True, type=Path)
+    runtime_tree.add_argument("--workflow-id", default="")
+    runtime_tree.add_argument("--task-id", default="")
+    runtime_tree.set_defaults(func=merge_runtime_tree)
 
     collect = sub.add_parser("write-collect-report")
     collect.add_argument("--baseline", type=Path, required=True)

--- a/scripts/test_evaluate_pr_repair_artifacts.py
+++ b/scripts/test_evaluate_pr_repair_artifacts.py
@@ -86,6 +86,105 @@ class ArtifactHelperTests(unittest.TestCase):
                 "project_registry_preflight",
             )
 
+    def test_conflicting_eval_tasks_only_flags_active_matching_external_id(self) -> None:
+        response = {
+            "data": [
+                {
+                    "id": "active-other",
+                    "external_id": "pr-repair-eval:owner/repo#7:run:20260606T000000Z",
+                    "project": "/repo-a",
+                    "status": "waiting",
+                    "phase": "plan",
+                    "scheduler": {"authority_state": "queued"},
+                },
+                {
+                    "id": "terminal-same",
+                    "external_id": "pr-repair-eval:owner/repo#7:run:20260606T000100Z",
+                    "project": "/repo-b",
+                    "status": "cancelled",
+                    "phase": "terminal",
+                    "scheduler": {"authority_state": "cancelled"},
+                },
+                {
+                    "id": "terminal-workflow-same",
+                    "external_id": "pr-repair-eval:owner/repo#7:run:20260606T000150Z",
+                    "project": "/repo-b",
+                    "status": "waiting",
+                    "phase": "implement",
+                    "workflow": {"state": "ready_to_merge"},
+                    "scheduler": {"authority_state": "queued"},
+                },
+                {
+                    "id": "active-different",
+                    "external_id": "pr-repair-eval:owner/repo#8",
+                    "project": "/repo-c",
+                    "status": "waiting",
+                    "phase": "plan",
+                    "scheduler": {"authority_state": "queued"},
+                },
+            ]
+        }
+
+        conflicts = MODULE.conflicting_eval_tasks(
+            response,
+            external_id="pr-repair-eval:owner/repo#7:run:20260606T000200Z",
+            target_prefix="pr-repair-eval:owner/repo#7",
+        )
+
+        self.assertEqual([task["id"] for task in conflicts], ["active-other"])
+
+    def test_merge_runtime_tree_adds_runtime_jobs_to_task_detail(self) -> None:
+        task_detail = {
+            "id": "task-1",
+            "status": "done",
+            "workflow": {"id": "workflow-1", "state": "done"},
+        }
+        runtime_tree = {
+            "workflows": [
+                {
+                    "workflow": {
+                        "id": "workflow-1",
+                        "state": "done",
+                        "project_id": "/repo",
+                        "data": {"task_id": "task-1", "task_ids": ["task-1"]},
+                    },
+                    "commands": [
+                        {
+                            "runtime_jobs": {
+                                "id": "malformed-job-container",
+                            }
+                        },
+                        {
+                            "runtime_jobs": [
+                                {
+                                    "id": "job-1",
+                                    "status": "succeeded",
+                                    "output": {
+                                        "activity": "implement_prompt",
+                                        "artifacts": [{"artifact_type": "runtime_turn"}],
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                    "children": [],
+                }
+            ]
+        }
+
+        merged = MODULE.merge_runtime_tree_data(
+            task_detail,
+            runtime_tree,
+            workflow_id="workflow-1",
+            task_id="task-1",
+        )
+
+        self.assertEqual(merged["runtime_tree_artifact"]["status"], "matched")
+        self.assertEqual(merged["runtime_jobs"][0]["runtime_job_id"], "job-1")
+        self.assertEqual(merged["runtime_jobs"][0]["artifact_count"], 1)
+        self.assertEqual(merged["runtime_jobs"][0]["terminal_state"], "succeeded")
+        self.assertEqual(merged["latest_activity"], "implement_prompt")
+
     def test_final_report_uses_quality_snapshot_grade_and_blockers(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary

- give each live PR repair eval a per-run external_id while keeping a stable target prefix for active duplicate detection
- collect workflow runtime tree evidence with project_id after the run and merge terminal runtime job metadata into task_detail_final.json
- add artifact helper coverage for active duplicate filtering and runtime tree evidence normalization

Closes #1260

## Live eval evidence

A live eval against PR #1259 improved from the earlier missing-runtime-evidence failure mode to a B/83 result after these local changes: task d4a22980-cf3d-496e-8988-db0a1ba77024 reached done, runtime job 566e1c30-727d-4572-a782-54084ae61ab1 was captured as succeeded, final mergeStateStatus was CLEAN, statusCheckRollup was SUCCESS, and active unresolved reviewThreads was 0. This does not claim a perfect score; the remaining cap is reviewer judgment / cost attribution, which should be handled in a follow-up slice.

## Validation

- bash -n scripts/evaluate_pr_repair.sh
- python3 -m unittest scripts/test_evaluate_pr_repair_submit.py scripts/test_evaluate_pr_repair_helpers.py scripts/test_evaluate_pr_repair_artifacts.py
- cargo check
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
