### PR TITLE
Ingest PR repair reviewer judgments in eval scoring

### DIFF
--- a/crates/harness-eval/src/bin/score_pr_repair.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair.rs
@@ -1,4 +1,6 @@
-use harness_eval::{pr_repair_eval_input_from_values, score_pr_repair_eval, PrRepairEvalIngest};
+use harness_eval::{
+    pr_repair_eval_input_from_values, score_pr_repair_eval, PrRepairEvalIngest, ReviewerJudgment,
+};
 use serde_json::Value;
 use std::env;
 use std::fs;
@@ -14,6 +16,7 @@ struct Args {
     task_detail: Option<PathBuf>,
     baseline_collected_at: String,
     final_collected_at: String,
+    reviewer_judgment: Option<PathBuf>,
     input_output: Option<PathBuf>,
     snapshot_output: PathBuf,
 }
@@ -31,6 +34,13 @@ fn run() -> Result<(), String> {
     let final_pr = read_json(&args.final_pr)?;
     let submission = args.submission.as_ref().map(read_json).transpose()?;
     let task_detail = args.task_detail.as_ref().map(read_json).transpose()?;
+    let reviewer_judgment = args
+        .reviewer_judgment
+        .as_ref()
+        .map(read_json)
+        .transpose()?
+        .map(parse_reviewer_judgment)
+        .transpose()?;
     let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
         repo: &args.repo,
         pr_number: args.pr_number,
@@ -40,6 +50,7 @@ fn run() -> Result<(), String> {
         final_pr: &final_pr,
         submission: submission.as_ref(),
         task_detail: task_detail.as_ref(),
+        reviewer_judgment,
     });
     let snapshot = score_pr_repair_eval(input.clone()).map_err(|err| err.to_string())?;
 
@@ -87,6 +98,12 @@ where
             "--final-collected-at" => {
                 parsed.final_collected_at = required_value(&mut args, "--final-collected-at")?;
             }
+            "--reviewer-judgment" => {
+                parsed.reviewer_judgment = Some(PathBuf::from(required_value(
+                    &mut args,
+                    "--reviewer-judgment",
+                )?));
+            }
             "--input-output" => {
                 parsed.input_output =
                     Some(PathBuf::from(required_value(&mut args, "--input-output")?));
@@ -131,6 +148,10 @@ fn read_json(path: &PathBuf) -> Result<Value, String> {
     serde_json::from_str(&body).map_err(|err| format!("failed to parse {}: {err}", path.display()))
 }
 
+fn parse_reviewer_judgment(value: Value) -> Result<ReviewerJudgment, String> {
+    serde_json::from_value(value).map_err(|err| format!("failed to parse reviewer judgment: {err}"))
+}
+
 fn write_json(path: &PathBuf, value: &Value) -> Result<(), String> {
     let body = serde_json::to_string_pretty(value).map_err(|err| err.to_string())?;
     fs::write(path, format!("{body}\n"))
@@ -138,5 +159,42 @@ fn write_json(path: &PathBuf, value: &Value) -> Result<(), String> {
 }
 
 fn usage() -> String {
-    "Usage: score_pr_repair --repo OWNER/REPO --pr N --baseline baseline_pr.json --final final_pr.json --baseline-collected-at RFC3339 --final-collected-at RFC3339 --snapshot-output quality_snapshot.json [--submission submission.json --task-detail task_detail_final.json --input-output pr_repair_eval_input.json]".to_string()
+    "Usage: score_pr_repair --repo OWNER/REPO --pr N --baseline baseline_pr.json --final final_pr.json --baseline-collected-at RFC3339 --final-collected-at RFC3339 --snapshot-output quality_snapshot.json [--submission submission.json --task-detail task_detail_final.json --reviewer-judgment reviewer_judgment.json --input-output pr_repair_eval_input.json]".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_accepts_reviewer_judgment_path() {
+        let args = parse_args(
+            [
+                "--repo",
+                "owner/repo",
+                "--pr",
+                "7",
+                "--baseline",
+                "baseline.json",
+                "--final",
+                "final.json",
+                "--baseline-collected-at",
+                "2026-06-06T00:00:00Z",
+                "--final-collected-at",
+                "2026-06-06T00:01:00Z",
+                "--snapshot-output",
+                "quality.json",
+                "--reviewer-judgment",
+                "reviewer_judgment.json",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        )
+        .unwrap_or_else(|err| panic!("args should parse: {err}"));
+
+        assert_eq!(
+            args.reviewer_judgment,
+            Some(PathBuf::from("reviewer_judgment.json"))
+        );
+    }
 }

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -1,6 +1,7 @@
 use crate::model::{
     ChangedFileSnapshot, CheckState, EvalScenario, EvalTarget, MergeState, PrRepairEvalInput,
-    PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, RuntimeJobSnapshot, RuntimeSnapshot,
+    PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, ReviewerJudgment,
+    RuntimeJobSnapshot, RuntimeSnapshot,
 };
 use serde_json::Value;
 
@@ -13,6 +14,7 @@ pub struct PrRepairEvalIngest<'a> {
     pub final_pr: &'a Value,
     pub submission: Option<&'a Value>,
     pub task_detail: Option<&'a Value>,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
 }
 
 pub fn github_pr_snapshot_from_value(
@@ -147,7 +149,7 @@ pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepa
         final_pr: final_pr_snapshot,
         runtime,
         usage: Vec::new(),
-        reviewer_judgment: None,
+        reviewer_judgment: input.reviewer_judgment,
         created_unrelated_pr: false,
         scope_violations: Vec::new(),
     }
@@ -372,6 +374,7 @@ mod tests {
             final_pr: &pr,
             submission: None,
             task_detail: None,
+            reviewer_judgment: None,
         });
 
         assert_eq!(input.scenario, EvalScenario::ReadyNoopControl);
@@ -404,9 +407,47 @@ mod tests {
             final_pr: &pr,
             submission: None,
             task_detail: None,
+            reviewer_judgment: None,
         });
 
         assert_eq!(input.scenario, EvalScenario::PrRepair);
+    }
+
+    #[test]
+    fn preserves_reviewer_judgment_from_ingest() {
+        let pr = json!({
+            "number": 7,
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+        let judgment = ReviewerJudgment {
+            reviewer_kind: crate::model::ReviewerKind::Llm,
+            judged_head_oid: "abc123".to_string(),
+            code_quality_score: 92,
+            trajectory_score: 88,
+            findings: Vec::new(),
+            residual_risks: Vec::new(),
+        };
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: None,
+            reviewer_judgment: Some(judgment.clone()),
+        });
+
+        assert_eq!(input.reviewer_judgment, Some(judgment));
     }
 
     #[test]
@@ -435,6 +476,7 @@ mod tests {
             final_pr: &pr,
             submission: None,
             task_detail: None,
+            reviewer_judgment: None,
         });
 
         assert_eq!(input.scenario, EvalScenario::PrRepair);

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -17,6 +17,8 @@ Options:
   --max-rounds N          Structured Harness round bound and task prompt guidance. Default: 2
   --max-turns N           Structured Harness turn bound and task prompt guidance. Default: 6
   --max-budget-usd N      Optional Harness max budget in USD.
+  --reviewer-judgment PATH
+                          Optional ReviewerJudgment JSON for the final PR head.
   --poll-secs N           Poll interval for GET /tasks/{id}. Default: 30
   --timeout-secs N        Overall task poll timeout. Default: 7200
   -h, --help              Show this help.
@@ -46,6 +48,7 @@ WAIT_SECS=10
 MAX_ROUNDS=2
 MAX_TURNS=6
 MAX_BUDGET_USD=""
+REVIEWER_JUDGMENT_JSON=""
 POLL_SECS=30
 TIMEOUT_SECS=7200
 
@@ -89,6 +92,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-budget-usd)
       MAX_BUDGET_USD="${2:-}"
+      shift 2
+      ;;
+    --reviewer-judgment)
+      REVIEWER_JUDGMENT_JSON="${2:-}"
       shift 2
       ;;
     --poll-secs)
@@ -518,6 +525,9 @@ write_quality_snapshot() {
   fi
   if [[ -s "$task_detail" ]]; then
     args+=(--task-detail "$task_detail")
+  fi
+  if [[ -n "$REVIEWER_JUDGMENT_JSON" ]]; then
+    args+=(--reviewer-judgment "$REVIEWER_JUDGMENT_JSON")
   fi
   cargo "${args[@]}"
 }

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -95,7 +95,15 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --reviewer-judgment)
-      REVIEWER_JUDGMENT_JSON="${2:-}"
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "Error: --reviewer-judgment requires a file path" >&2
+        exit 2
+      fi
+      if [[ ! -f "$2" ]]; then
+        echo "Error: reviewer judgment file does not exist: $2" >&2
+        exit 2
+      fi
+      REVIEWER_JUDGMENT_JSON="$2"
       shift 2
       ;;
     --poll-secs)


### PR DESCRIPTION
## Summary
- Add optional ReviewerJudgment ingestion to the PR repair eval scorer.
- Wire --reviewer-judgment through score_pr_repair and scripts/evaluate_pr_repair.sh.
- Preserve reviewer judgment artifacts in PrRepairEvalInput without synthesizing code-quality scores from CI or mergeability.

## Evaluation
- Replayed PR #1259 eval artifacts with a fresh LLM reviewer judgment for head 7cf3c60c4ff55103f7f315df4b7f26b8e25fccc0.
- Score moved from B / 83 with the reviewer gate capped to A / 91 with reviewer_judgment_freshness passing.

## Validation
- bash -n scripts/evaluate_pr_repair.sh
- python3 -m unittest scripts/test_evaluate_pr_repair_submit.py scripts/test_evaluate_pr_repair_helpers.py scripts/test_evaluate_pr_repair_artifacts.py
- cargo test -p harness-eval
- cargo check
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

Refs #1262