### PR TITLE
feat(eval): ingest PR repair usage snapshots

### DIFF
--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -5,6 +5,9 @@ use crate::model::{
 };
 use serde_json::Value;
 
+mod usage_ingest;
+use usage_ingest::usage_snapshots_from_values;
+
 pub struct PrRepairEvalIngest<'a> {
     pub repo: &'a str,
     pub pr_number: u64,
@@ -94,6 +97,8 @@ pub fn runtime_snapshot_from_values(
         .or_else(|| optional_string_field(submission, "submission_id"))
         .or_else(|| optional_string_field(task_detail, "id"));
     let workflow_id = optional_string_field(submission, "workflow_id")
+        .or_else(|| optional_string_field(submission, "workflowId"))
+        .or_else(|| task_detail_workflow_id(task_detail))
         .or_else(|| optional_string_at_pointer(task_detail, "/workflow/id"));
     let terminal_state = terminal_string_field(task_detail, "status")
         .or_else(|| terminal_string_at_pointer(task_detail, "/workflow/state"))
@@ -135,6 +140,26 @@ pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepa
         }
         _ => None,
     };
+    let usage_workflow_id = runtime
+        .as_ref()
+        .and_then(|runtime| runtime.workflow_id.clone())
+        .or_else(|| {
+            input.submission.and_then(|submission| {
+                optional_string_field(submission, "workflow_id")
+                    .or_else(|| optional_string_field(submission, "workflowId"))
+            })
+        })
+        .or_else(|| input.task_detail.and_then(task_detail_workflow_id))
+        .or_else(|| {
+            input
+                .task_detail
+                .and_then(|task_detail| optional_string_at_pointer(task_detail, "/workflow/id"))
+        });
+    let usage = usage_snapshots_from_values(
+        input.submission,
+        input.task_detail,
+        usage_workflow_id.as_deref(),
+    );
 
     PrRepairEvalInput {
         scenario,
@@ -148,11 +173,16 @@ pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepa
         baseline_pr,
         final_pr: final_pr_snapshot,
         runtime,
-        usage: Vec::new(),
+        usage,
         reviewer_judgment: input.reviewer_judgment,
         created_unrelated_pr: false,
         scope_violations: Vec::new(),
     }
+}
+
+fn task_detail_workflow_id(task_detail: &Value) -> Option<String> {
+    optional_string_field(task_detail, "workflow_id")
+        .or_else(|| optional_string_field(task_detail, "workflowId"))
 }
 
 fn scenario_from_baseline(snapshot: &PullRequestSnapshot) -> EvalScenario {
@@ -448,6 +478,92 @@ mod tests {
         });
 
         assert_eq!(input.reviewer_judgment, Some(judgment));
+    }
+
+    #[test]
+    fn preserves_usage_from_ingest_artifacts() {
+        let pr = json!({
+            "number": 7,
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+        let submission = json!({"task_id": "task-1", "workflow_id": "workflow-1"});
+        let task_detail = json!({
+            "id": "task-1",
+            "status": "done",
+            "usage": [{
+                "runtime_job_id": "job-1",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "token_confidence": "exact"
+            }]
+        });
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: Some(&submission),
+            task_detail: Some(&task_detail),
+            reviewer_judgment: None,
+        });
+
+        assert_eq!(input.usage.len(), 1);
+        assert_eq!(input.usage[0].runtime_job_id.as_deref(), Some("job-1"));
+        assert_eq!(input.usage[0].workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(input.usage[0].total_tokens, Some(150));
+    }
+
+    #[test]
+    fn uses_task_detail_workflow_id_as_usage_fallback() {
+        let pr = json!({
+            "number": 7,
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+        let task_detail = json!({
+            "id": "task-1",
+            "workflow_id": "workflow-from-task-detail",
+            "status": "done",
+            "usage": [{
+                "runtime_job_id": "job-1",
+                "input_tokens": 20,
+                "output_tokens": 5
+            }]
+        });
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: Some(&task_detail),
+            reviewer_judgment: None,
+        });
+
+        assert_eq!(input.usage.len(), 1);
+        assert_eq!(
+            input.usage[0].workflow_id.as_deref(),
+            Some("workflow-from-task-detail")
+        );
     }
 
     #[test]

--- a/crates/harness-eval/src/ingest/usage_ingest.rs
+++ b/crates/harness-eval/src/ingest/usage_ingest.rs
@@ -1,0 +1,454 @@
+use crate::model::{Confidence, UsageSnapshot};
+use serde_json::Value;
+
+use super::{json_u64, optional_string_field};
+
+pub(super) fn usage_snapshots_from_values(
+    submission: Option<&Value>,
+    task_detail: Option<&Value>,
+    fallback_workflow_id: Option<&str>,
+) -> Vec<UsageSnapshot> {
+    let mut snapshots = Vec::new();
+    for value in task_detail.into_iter().chain(submission) {
+        for usage in usage_snapshots_from_value(value, fallback_workflow_id) {
+            if !snapshots.contains(&usage) {
+                snapshots.push(usage);
+            }
+        }
+    }
+    snapshots
+}
+
+fn usage_snapshots_from_value(
+    value: &Value,
+    fallback_workflow_id: Option<&str>,
+) -> Vec<UsageSnapshot> {
+    usage_arrays(value)
+        .into_iter()
+        .flat_map(|array| array.iter())
+        .filter_map(|record| usage_snapshot_from_record(record, fallback_workflow_id))
+        .collect()
+}
+
+fn usage_arrays(value: &Value) -> Vec<&Vec<Value>> {
+    [
+        "usage",
+        "usage_snapshots",
+        "usageSnapshots",
+        "llm_usage",
+        "llmUsage",
+        "llm_usage_events",
+        "llmUsageEvents",
+    ]
+    .into_iter()
+    .filter_map(|field| value.get(field).and_then(Value::as_array))
+    .collect()
+}
+
+fn usage_snapshot_from_record(
+    record: &Value,
+    fallback_workflow_id: Option<&str>,
+) -> Option<UsageSnapshot> {
+    let parsed_content = record.get("content").and_then(|content| {
+        content
+            .as_str()
+            .and_then(|content| serde_json::from_str::<Value>(content).ok())
+            .or_else(|| {
+                if content.is_object() {
+                    Some(content.clone())
+                } else {
+                    None
+                }
+            })
+    });
+    let payload = parsed_content
+        .as_ref()
+        .map(payload_value)
+        .or_else(|| record.get("payload").map(payload_value))
+        .or_else(|| record.get("usage").map(payload_value))
+        .unwrap_or(record);
+    let mut token_sources = vec![payload, record];
+    let mut metadata_sources = vec![record];
+    if let Some(content) = parsed_content.as_ref() {
+        token_sources.push(content);
+        metadata_sources.push(content);
+    }
+    metadata_sources.push(payload);
+
+    let input_tokens = optional_u64_from_sources(&token_sources, &["input_tokens", "inputTokens"]);
+    let output_tokens =
+        optional_u64_from_sources(&token_sources, &["output_tokens", "outputTokens"]);
+    let additive_cache_tokens = token_sources
+        .iter()
+        .find_map(|source| additive_cache_token_sum(source));
+    let cached_input_tokens = optional_u64_from_sources(
+        &token_sources,
+        &["cached_input_tokens", "cachedInputTokens"],
+    )
+    .or(additive_cache_tokens);
+    let component_total = component_token_total(input_tokens, output_tokens, additive_cache_tokens);
+    let reported_total_tokens = optional_u64_from_sources(
+        &token_sources,
+        &[
+            "total_tokens",
+            "totalTokens",
+            "reported_total_tokens",
+            "reportedTotalTokens",
+        ],
+    );
+    let total_tokens = max_token_total(reported_total_tokens, component_total);
+    let cost_usd_micros = optional_u64_from_sources(
+        &token_sources,
+        &["cost_usd_micros", "estimated_cost_usd_micros"],
+    );
+
+    if input_tokens.is_none()
+        && output_tokens.is_none()
+        && cached_input_tokens.is_none()
+        && total_tokens.is_none()
+        && cost_usd_micros.is_none()
+    {
+        return None;
+    }
+
+    Some(UsageSnapshot {
+        agent_invocation_id: optional_string_from_sources(
+            &metadata_sources,
+            &["agent_invocation_id", "agentInvocationId"],
+        ),
+        runtime_job_id: optional_string_from_sources(
+            &metadata_sources,
+            &["runtime_job_id", "runtimeJobId"],
+        ),
+        workflow_id: optional_string_from_sources(
+            &metadata_sources,
+            &["workflow_id", "workflowId"],
+        )
+        .or_else(|| fallback_workflow_id.map(ToString::to_string)),
+        model: optional_string_from_sources(&metadata_sources, &["model"]),
+        reasoning_effort: optional_string_from_sources(
+            &metadata_sources,
+            &["reasoning_effort", "reasoningEffort"],
+        ),
+        input_tokens,
+        output_tokens,
+        cached_input_tokens,
+        total_tokens,
+        cost_usd_micros,
+        token_confidence: confidence_from_sources(
+            &metadata_sources,
+            &["token_confidence", "tokenConfidence"],
+        )
+        .unwrap_or_else(|| {
+            if total_tokens.is_some() {
+                Confidence::Exact
+            } else {
+                Confidence::Unknown
+            }
+        }),
+        cost_confidence: confidence_from_sources(
+            &metadata_sources,
+            &["cost_confidence", "costConfidence"],
+        )
+        .unwrap_or(Confidence::Unknown),
+    })
+}
+
+fn additive_cache_token_sum(value: &Value) -> Option<u64> {
+    let read = optional_u64_from_sources(
+        &[value],
+        &["cache_read_input_tokens", "cacheReadInputTokens"],
+    )
+    .unwrap_or(0);
+    let create = optional_u64_from_sources(
+        &[value],
+        &["cache_creation_input_tokens", "cacheCreationInputTokens"],
+    )
+    .unwrap_or(0);
+    if read > 0 || create > 0 {
+        Some(read.saturating_add(create))
+    } else {
+        None
+    }
+}
+
+fn payload_value(value: &Value) -> &Value {
+    value
+        .get("payload")
+        .or_else(|| value.get("usage"))
+        .unwrap_or(value)
+}
+
+fn component_token_total(
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    additive_cache_tokens: Option<u64>,
+) -> Option<u64> {
+    let input_tokens = input_tokens?;
+    let output_tokens = output_tokens?;
+    Some(
+        input_tokens
+            .saturating_add(output_tokens)
+            .saturating_add(additive_cache_tokens.unwrap_or(0)),
+    )
+}
+
+fn max_token_total(reported: Option<u64>, component: Option<u64>) -> Option<u64> {
+    match (reported, component) {
+        (Some(reported), Some(component)) => Some(reported.max(component)),
+        (Some(reported), None) => Some(reported),
+        (None, Some(component)) => Some(component),
+        (None, None) => None,
+    }
+}
+
+fn optional_u64_field(value: &Value, field: &str) -> Option<u64> {
+    value.get(field).and_then(json_u64)
+}
+
+fn optional_u64_from_sources(sources: &[&Value], fields: &[&str]) -> Option<u64> {
+    sources.iter().find_map(|source| {
+        fields
+            .iter()
+            .find_map(|field| optional_u64_field(source, field))
+    })
+}
+
+fn optional_string_from_sources(sources: &[&Value], fields: &[&str]) -> Option<String> {
+    sources.iter().find_map(|source| {
+        fields
+            .iter()
+            .find_map(|field| optional_string_field(source, field))
+    })
+}
+
+fn confidence_field(value: &Value, field: &str) -> Option<Confidence> {
+    match value
+        .get(field)
+        .and_then(Value::as_str)?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "exact" => Some(Confidence::Exact),
+        "estimated" => Some(Confidence::Estimated),
+        "observed" => Some(Confidence::Observed),
+        "unknown" => Some(Confidence::Unknown),
+        _ => None,
+    }
+}
+
+fn confidence_from_sources(sources: &[&Value], fields: &[&str]) -> Option<Confidence> {
+    sources.iter().find_map(|source| {
+        fields
+            .iter()
+            .find_map(|field| confidence_field(source, field))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn preserves_canonical_usage_from_task_detail() {
+        let task_detail = json!({
+            "usage": [{
+                "agent_invocation_id": "agent-1",
+                "runtime_job_id": "job-1",
+                "workflow_id": "workflow-1",
+                "model": "codex-test",
+                "reasoning_effort": "medium",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cached_input_tokens": 10,
+                "total_tokens": 160,
+                "cost_usd_micros": 123,
+                "token_confidence": "exact",
+                "cost_confidence": "estimated"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), None);
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].agent_invocation_id.as_deref(), Some("agent-1"));
+        assert_eq!(usage[0].runtime_job_id.as_deref(), Some("job-1"));
+        assert_eq!(usage[0].workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(usage[0].total_tokens, Some(160));
+        assert_eq!(usage[0].cost_usd_micros, Some(123));
+        assert_eq!(usage[0].token_confidence, Confidence::Exact);
+        assert_eq!(usage[0].cost_confidence, Confidence::Estimated);
+    }
+
+    #[test]
+    fn maps_llm_usage_event_payloads_to_usage() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": "{\"agent\":\"codex\",\"model\":\"gpt-test\",\"input_tokens\":40,\"output_tokens\":5,\"cache_read_input_tokens\":3,\"cache_creation_input_tokens\":2,\"reported_total_tokens\":50}"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(usage[0].model.as_deref(), Some("gpt-test"));
+        assert_eq!(usage[0].input_tokens, Some(40));
+        assert_eq!(usage[0].output_tokens, Some(5));
+        assert_eq!(usage[0].cached_input_tokens, Some(5));
+        assert_eq!(usage[0].total_tokens, Some(50));
+        assert_eq!(usage[0].cost_usd_micros, None);
+        assert_eq!(usage[0].token_confidence, Confidence::Exact);
+        assert_eq!(usage[0].cost_confidence, Confidence::Unknown);
+    }
+
+    #[test]
+    fn maps_nested_usage_event_content_to_usage() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": "{\"usage\":{\"input_tokens\":10,\"output_tokens\":2,\"total_tokens\":12}}"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].output_tokens, Some(2));
+        assert_eq!(usage[0].total_tokens, Some(12));
+    }
+
+    #[test]
+    fn preserves_metadata_from_content_envelope_with_nested_usage() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": "{\"workflow_id\":\"workflow-from-content\",\"runtime_job_id\":\"job-from-content\",\"model\":\"gpt-test\",\"reasoning_effort\":\"medium\",\"usage\":{\"input_tokens\":10,\"output_tokens\":2,\"total_tokens\":12}}"
+            }]
+        });
+
+        let usage =
+            usage_snapshots_from_values(None, Some(&task_detail), Some("fallback-workflow"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(
+            usage[0].workflow_id.as_deref(),
+            Some("workflow-from-content")
+        );
+        assert_eq!(usage[0].runtime_job_id.as_deref(), Some("job-from-content"));
+        assert_eq!(usage[0].model.as_deref(), Some("gpt-test"));
+        assert_eq!(usage[0].reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].output_tokens, Some(2));
+        assert_eq!(usage[0].total_tokens, Some(12));
+    }
+
+    #[test]
+    fn maps_camel_case_codex_usage_payload() {
+        let task_detail = json!({
+            "usage": [{
+                "inputTokens": 10,
+                "cachedInputTokens": 4,
+                "outputTokens": 3,
+                "totalTokens": 13
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), None);
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].output_tokens, Some(3));
+        assert_eq!(usage[0].cached_input_tokens, Some(4));
+        assert_eq!(usage[0].total_tokens, Some(13));
+    }
+
+    #[test]
+    fn maps_object_usage_event_content_to_usage() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": {
+                    "payload": {
+                        "input_tokens": 11,
+                        "output_tokens": 3,
+                        "total_tokens": 14
+                    }
+                }
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].workflow_id.as_deref(), Some("workflow-1"));
+        assert_eq!(usage[0].input_tokens, Some(11));
+        assert_eq!(usage[0].output_tokens, Some(3));
+        assert_eq!(usage[0].total_tokens, Some(14));
+    }
+
+    #[test]
+    fn codex_cached_input_tokens_are_not_double_counted() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": "{\"input_tokens\":10,\"cached_input_tokens\":4,\"output_tokens\":3}"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].cached_input_tokens, Some(4));
+        assert_eq!(usage[0].output_tokens, Some(3));
+        assert_eq!(usage[0].total_tokens, Some(13));
+    }
+
+    #[test]
+    fn reported_total_uses_larger_additive_component_total() {
+        let task_detail = json!({
+            "llm_usage_events": [{
+                "content": "{\"input_tokens\":10,\"output_tokens\":3,\"cache_read_input_tokens\":4,\"reported_total_tokens\":13}"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].output_tokens, Some(3));
+        assert_eq!(usage[0].cached_input_tokens, Some(4));
+        assert_eq!(usage[0].total_tokens, Some(17));
+    }
+
+    #[test]
+    fn partial_token_components_do_not_derive_exact_total() {
+        let task_detail = json!({
+            "usage": [{
+                "input_tokens": 10
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].input_tokens, Some(10));
+        assert_eq!(usage[0].output_tokens, None);
+        assert_eq!(usage[0].total_tokens, None);
+        assert_eq!(usage[0].token_confidence, Confidence::Unknown);
+    }
+
+    #[test]
+    fn ignores_records_without_token_or_cost_data() {
+        let task_detail = json!({
+            "usage": [{
+                "model": "codex-test"
+            }]
+        });
+
+        let usage = usage_snapshots_from_values(None, Some(&task_detail), Some("workflow-1"));
+
+        assert!(usage.is_empty());
+    }
+}

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -114,6 +114,15 @@ Acceptance:
 - Eval snapshots show exact, estimated, observed, or unknown confidence.
 - Missing price catalog leaves cost fields null with diagnostics.
 
+Implementation status:
+
+- Added `harness-eval` ingestion for canonical `usage` / `usage_snapshots`
+  arrays and Harness `llm_usage` event-style payload arrays.
+- The pure eval crate still does not load prices or call server APIs; it only
+  preserves token/cost fields and confidence labels supplied by artifacts.
+- Remaining work: collect and attach usage artifacts from server-side event
+  storage or external evaluator scripts.
+
 ### Issue 5: Add the dashboard eval view
 
 Scope:


### PR DESCRIPTION
## Summary
- Parse canonical `usage` / `usage_snapshots` arrays from PR repair eval submission and task detail artifacts into `PrRepairEvalInput.usage`.
- Parse Harness `llm_usage` event-style payload arrays, including JSON string `content`, without loading price catalogs or hardcoding model prices.
- Preserve supplied token/cost confidence and keep missing cost as unknown/null.
- Update the eval implementation plan with the current status and remaining server-side artifact collection gap.

## Validation
- `cargo test -p harness-eval`
- `cargo run --quiet --manifest-path Cargo.toml -p harness-eval --bin score_pr_repair -- --submission /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/submission.json --task-detail /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/task_detail_final_with_usage.json --baseline /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/baseline_pr.json --final /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/final_pr.json --repo majiayu000/harness --pr-number 1259 --reviewer-judgment /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/reviewer_judgment.json --output /tmp/harness-pr-repair-evals/pr1259-live-20260606T100059Z/quality_snapshot_with_usage.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Replay score with injected usage artifact: A/99, cost_and_time_efficiency 8/8, reporting_and_attribution_quality 6/6.

Closes #1264