### PR TITLE
fix(eval): require complete PR snapshot evidence

### DIFF
--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -25,18 +25,16 @@ pub fn github_pr_snapshot_from_value(
     collected_at: &str,
     value: &Value,
 ) -> PullRequestSnapshot {
-    let review_threads = value
-        .pointer("/reviewThreads/nodes")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
+    let review_threads = review_thread_values(value)
         .filter(|thread| {
             !thread
                 .get("isResolved")
+                .or_else(|| thread.get("is_resolved"))
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
                 && !thread
                     .get("isOutdated")
+                    .or_else(|| thread.get("is_outdated"))
                     .and_then(Value::as_bool)
                     .unwrap_or(false)
         })
@@ -45,47 +43,99 @@ pub fn github_pr_snapshot_from_value(
             path: optional_string_field(thread, "path"),
             is_resolved: thread
                 .get("isResolved")
+                .or_else(|| thread.get("is_resolved"))
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             is_outdated: thread
                 .get("isOutdated")
+                .or_else(|| thread.get("is_outdated"))
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
         })
         .collect();
 
-    let changed_files = value
-        .pointer("/files/nodes")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
+    let changed_files = changed_file_values(value)
         .map(|file| ChangedFileSnapshot {
             path: string_field(file, "path"),
             additions: u64_field(file, "additions"),
             deletions: u64_field(file, "deletions"),
-            status: string_field(file, "changeType"),
+            status: string_field(file, "changeType").or_else_empty(|| string_field(file, "status")),
         })
         .collect();
 
     PullRequestSnapshot {
         repo: repo.to_string(),
-        pr_number: u64_field(value, "number"),
-        url: optional_string_field(value, "url"),
+        pr_number: u64_field(value, "number").or_else_zero(|| u64_field(value, "pr_number")),
+        url: optional_string_field(value, "url").or_else(|| optional_string_field(value, "pr_url")),
         title: optional_string_field(value, "title"),
-        base_ref: string_field(value, "baseRefName"),
-        head_ref: string_field(value, "headRefName"),
-        head_oid: string_field(value, "headRefOid"),
+        base_ref: string_field(value, "baseRefName")
+            .or_else_empty(|| string_field(value, "base_ref")),
+        head_ref: string_field(value, "headRefName")
+            .or_else_empty(|| string_field(value, "head_ref")),
+        head_oid: string_field(value, "headRefOid")
+            .or_else_empty(|| string_field(value, "head_oid")),
         is_draft: value
             .get("isDraft")
+            .or_else(|| value.get("is_draft"))
             .and_then(Value::as_bool)
             .unwrap_or(false),
-        merge_state: merge_state_from_github(value.get("mergeStateStatus")),
-        check_state: check_state_from_github(value.pointer("/statusCheckRollup/state")),
-        review_decision: review_decision_from_github(value.get("reviewDecision")),
+        merge_state: merge_state_from_github(
+            value
+                .get("mergeStateStatus")
+                .or_else(|| value.get("merge_state_status")),
+        ),
+        check_state: check_state_from_github(
+            value
+                .pointer("/statusCheckRollup/state")
+                .or_else(|| value.get("status_check_rollup_state"))
+                .or_else(|| value.get("statusCheckRollupState")),
+        ),
+        review_decision: review_decision_from_github(
+            value
+                .get("reviewDecision")
+                .or_else(|| value.get("review_decision")),
+        ),
         active_unresolved_review_threads: review_threads,
+        review_threads_complete: connection_complete(
+            value,
+            "reviewThreads",
+            "review_threads_complete",
+        ),
         changed_files,
+        changed_files_complete: connection_complete(value, "files", "changed_files_complete"),
         collected_at: collected_at.to_string(),
     }
+}
+
+fn review_thread_values(value: &Value) -> impl Iterator<Item = &Value> {
+    value
+        .pointer("/reviewThreads/nodes")
+        .or_else(|| value.get("active_unresolved_review_threads"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn changed_file_values(value: &Value) -> impl Iterator<Item = &Value> {
+    value
+        .pointer("/files/nodes")
+        .or_else(|| value.get("changed_files"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn connection_complete(value: &Value, raw_field: &str, normalized_field: &str) -> bool {
+    if let Some(complete) = value.get(normalized_field).and_then(Value::as_bool) {
+        return complete;
+    }
+    value
+        .get(raw_field)
+        .and_then(|connection| connection.get("pageInfo"))
+        .and_then(|page_info| page_info.get("hasNextPage"))
+        .and_then(Value::as_bool)
+        .map(|has_next_page| !has_next_page)
+        .unwrap_or(true)
 }
 
 pub fn runtime_snapshot_from_values(
@@ -330,6 +380,25 @@ impl NonEmptyStringExt for String {
         F: FnOnce() -> String,
     {
         if self.trim().is_empty() {
+            fallback()
+        } else {
+            self
+        }
+    }
+}
+
+trait NonZeroU64Ext {
+    fn or_else_zero<F>(self, fallback: F) -> u64
+    where
+        F: FnOnce() -> u64;
+}
+
+impl NonZeroU64Ext for u64 {
+    fn or_else_zero<F>(self, fallback: F) -> u64
+    where
+        F: FnOnce() -> u64,
+    {
+        if self == 0 {
             fallback()
         } else {
             self

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -129,13 +129,14 @@ fn connection_complete(value: &Value, raw_field: &str, normalized_field: &str) -
     if let Some(complete) = value.get(normalized_field).and_then(Value::as_bool) {
         return complete;
     }
-    value
-        .get(raw_field)
-        .and_then(|connection| connection.get("pageInfo"))
-        .and_then(|page_info| page_info.get("hasNextPage"))
-        .and_then(Value::as_bool)
-        .map(|has_next_page| !has_next_page)
-        .unwrap_or(true)
+    if let Some(connection) = value.get(raw_field) {
+        return connection
+            .get("pageInfo")
+            .and_then(|page_info| page_info.get("hasNextPage"))
+            .and_then(Value::as_bool)
+            .is_some_and(|has_next_page| !has_next_page);
+    }
+    true
 }
 
 pub fn runtime_snapshot_from_values(

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -240,6 +240,7 @@ fn scenario_from_baseline(snapshot: &PullRequestSnapshot) -> EvalScenario {
     if !snapshot.is_draft
         && review_decision_allows_noop(snapshot.review_decision.as_ref())
         && snapshot.active_unresolved_review_threads.is_empty()
+        && snapshot.review_threads_complete
         && snapshot.check_state == CheckState::Passing
         && snapshot.merge_state == MergeState::Clean
     {
@@ -461,8 +462,14 @@ mod tests {
             "isDraft": false,
             "mergeStateStatus": "CLEAN",
             "statusCheckRollup": {"state": "SUCCESS"},
-            "reviewThreads": {"nodes": []},
-            "files": {"nodes": []}
+            "reviewThreads": {
+                "pageInfo": {"hasNextPage": false},
+                "nodes": []
+            },
+            "files": {
+                "pageInfo": {"hasNextPage": false},
+                "nodes": []
+            }
         });
 
         let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
@@ -479,6 +486,41 @@ mod tests {
 
         assert_eq!(input.scenario, EvalScenario::ReadyNoopControl);
         assert!(input.runtime.is_none());
+    }
+
+    #[test]
+    fn incomplete_baseline_review_threads_is_pr_repair() {
+        let pr = json!({
+            "number": 7,
+            "headRefName": "ready",
+            "headRefOid": "same",
+            "baseRefName": "main",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {
+                "pageInfo": {"hasNextPage": true},
+                "nodes": []
+            },
+            "files": {
+                "pageInfo": {"hasNextPage": false},
+                "nodes": []
+            }
+        });
+
+        let input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-06-06T00:00:00Z",
+            final_collected_at: "2026-06-06T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            submission: None,
+            task_detail: None,
+            reviewer_judgment: None,
+        });
+
+        assert_eq!(input.scenario, EvalScenario::PrRepair);
     }
 
     #[test]

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -136,7 +136,7 @@ fn connection_complete(value: &Value, raw_field: &str, normalized_field: &str) -
             .and_then(Value::as_bool)
             .is_some_and(|has_next_page| !has_next_page);
     }
-    true
+    false
 }
 
 pub fn runtime_snapshot_from_values(

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -82,16 +82,12 @@ pub struct PullRequestSnapshot {
     pub check_state: CheckState,
     pub review_decision: Option<ReviewDecision>,
     pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub review_threads_complete: bool,
     pub changed_files: Vec<ChangedFileSnapshot>,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub changed_files_complete: bool,
     pub collected_at: String,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -82,8 +82,16 @@ pub struct PullRequestSnapshot {
     pub check_state: CheckState,
     pub review_decision: Option<ReviewDecision>,
     pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
+    #[serde(default = "default_true")]
+    pub review_threads_complete: bool,
     pub changed_files: Vec<ChangedFileSnapshot>,
+    #[serde(default = "default_true")]
+    pub changed_files_complete: bool,
     pub collected_at: String,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -3,8 +3,7 @@ use crate::model::{
     HardGateResult, MergeState, PrRepairEvalInput, QualitySnapshot, RuntimeSnapshot,
     ScoreBreakdown, ScoreComponent, ScoreDimensionName,
 };
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScoringError {
@@ -15,14 +14,13 @@ impl fmt::Display for ScoringError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnsupportedTarget => {
-                write!(f, "PR repair scoring requires a pull request target")
+                f.write_str("PR repair scoring requires a pull request target")
             }
         }
     }
 }
 
 impl Error for ScoringError {}
-
 pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
     let target_matches = target_matches_pr(&input)?;
     let branch_safe = branch_safe(&input);
@@ -35,7 +33,10 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         .is_some_and(|head_oid| head_oid == input.final_pr.head_oid);
     let checks_passing = input.final_pr.check_state == CheckState::Passing;
     let mergeability_clean = input.final_pr.merge_state == MergeState::Clean;
-    let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty();
+    let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty()
+        && input.final_pr.review_threads_complete;
+    let final_remote_evidence_complete =
+        input.final_pr.review_threads_complete && input.final_pr.changed_files_complete;
     let runtime_complete = input.runtime.as_ref().is_some_and(runtime_has_artifact);
 
     let hard_gates = vec![
@@ -93,8 +94,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
             HardGateName::ReviewThreadClosure,
             review_threads_closed,
             Some(EvalGrade::C),
-            "no active unresolved review threads remain",
-            "active unresolved review threads remain",
+            "review threads were fully enumerated and no active unresolved review threads remain",
+            "active unresolved review threads remain or review thread enumeration is incomplete",
         ),
         gate(
             HardGateName::RuntimeArtifactCompleteness,
@@ -115,6 +116,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         checks_passing,
         mergeability_clean,
         review_threads_closed,
+        final_remote_evidence_complete,
         runtime_complete,
     };
     let objective_score = score_breakdown(&input, gate_signals);
@@ -289,6 +291,7 @@ struct GateSignals {
     checks_passing: bool,
     mergeability_clean: bool,
     review_threads_closed: bool,
+    final_remote_evidence_complete: bool,
     runtime_complete: bool,
 }
 
@@ -298,8 +301,10 @@ fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakd
         EvalScenario::PrRepair => head_changed,
         EvalScenario::ReadyNoopControl => !head_changed,
     };
-    let current_head_verified =
-        gates.final_evidence_fresh && gates.checks_passing && gates.mergeability_clean;
+    let current_head_verified = gates.final_evidence_fresh
+        && gates.checks_passing
+        && gates.mergeability_clean
+        && gates.final_remote_evidence_complete;
     let has_usage = input.usage.iter().any(|usage| usage.total_tokens.is_some());
     let has_confident_usage = input.usage.iter().any(|usage| {
         usage.token_confidence != Confidence::Unknown
@@ -775,7 +780,9 @@ mod tests {
             check_state: CheckState::Passing,
             review_decision: Some(crate::model::ReviewDecision::Approved),
             active_unresolved_review_threads: Vec::new(),
+            review_threads_complete: true,
             changed_files,
+            changed_files_complete: true,
             collected_at: "2026-06-05T00:00:00Z".to_string(),
         }
     }

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -34,7 +34,8 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
     let checks_passing = input.final_pr.check_state == CheckState::Passing;
     let mergeability_clean = input.final_pr.merge_state == MergeState::Clean;
     let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty()
-        && input.final_pr.review_threads_complete;
+        && input.final_pr.review_threads_complete
+        && (input.scenario == EvalScenario::PrRepair || input.baseline_pr.review_threads_complete);
     let final_remote_evidence_complete =
         input.final_pr.review_threads_complete && input.final_pr.changed_files_complete;
     let runtime_complete = input.runtime.as_ref().is_some_and(runtime_has_artifact);
@@ -146,7 +147,6 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         blocker_summary,
     })
 }
-
 fn target_matches_pr(input: &PrRepairEvalInput) -> Result<bool, ScoringError> {
     let EvalTarget::PullRequest {
         repo,

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -61,6 +61,34 @@ fn incomplete_server_normalized_review_threads_fail_closure_gate() {
 }
 
 #[test]
+fn missing_server_normalized_completeness_flags_fail_evidence_gates() {
+    let baseline = server_normalized_snapshot("base-head", true, true);
+    let mut final_pr = server_normalized_snapshot("final-head", true, true);
+    let fields = final_pr
+        .as_object_mut()
+        .expect("normalized snapshot object");
+    fields.remove("review_threads_complete");
+    fields.remove("changed_files_complete");
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score incomplete server snapshot");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(
+        snapshot
+            .objective_score
+            .verification_and_current_head_gates
+            .points,
+        4
+    );
+}
+
+#[test]
 fn missing_raw_changed_files_page_info_penalizes_current_head_verification() {
     let baseline = raw_pr_snapshot("base-head", false);
     let final_pr = raw_pr_snapshot_without_files_page_info("final-head");

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -29,6 +29,22 @@ fn incomplete_raw_review_threads_fail_closure_gate() {
 }
 
 #[test]
+fn missing_raw_review_thread_page_info_fails_closure_gate() {
+    let baseline = raw_pr_snapshot("base-head", false);
+    let final_pr = raw_pr_snapshot_without_review_thread_page_info("final-head");
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing review page info");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+}
+
+#[test]
 fn incomplete_server_normalized_review_threads_fail_closure_gate() {
     let baseline = server_normalized_snapshot("base-head", true, true);
     let final_pr = server_normalized_snapshot("final-head", false, true);
@@ -42,6 +58,27 @@ fn incomplete_server_normalized_review_threads_fail_closure_gate() {
 
     assert_eq!(gate.status, GateStatus::Fail);
     assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+}
+
+#[test]
+fn missing_raw_changed_files_page_info_penalizes_current_head_verification() {
+    let baseline = raw_pr_snapshot("base-head", false);
+    let final_pr = raw_pr_snapshot_without_files_page_info("final-head");
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing files page info");
+
+    assert_eq!(snapshot.grade_cap, None);
+    assert_eq!(
+        snapshot
+            .objective_score
+            .verification_and_current_head_gates
+            .points,
+        4
+    );
 }
 
 #[test]
@@ -84,6 +121,52 @@ fn raw_pr_snapshot(head_oid: &str, review_threads_has_next_page: bool) -> serde_
         },
         "files": {
             "pageInfo": {"hasNextPage": false},
+            "nodes": [
+                {"path": "src/lib.rs", "additions": 3, "deletions": 1, "changeType": "MODIFIED"}
+            ]
+        }
+    })
+}
+
+fn raw_pr_snapshot_without_review_thread_page_info(head_oid: &str) -> serde_json::Value {
+    json!({
+        "number": 42,
+        "url": "https://github.com/owner/repo/pull/42",
+        "title": "Fix PR repair",
+        "baseRefName": "main",
+        "headRefName": "fix/pr-42",
+        "headRefOid": head_oid,
+        "isDraft": false,
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": {"state": "SUCCESS"},
+        "reviewThreads": {"nodes": []},
+        "files": {
+            "pageInfo": {"hasNextPage": false},
+            "nodes": [
+                {"path": "src/lib.rs", "additions": 3, "deletions": 1, "changeType": "MODIFIED"}
+            ]
+        }
+    })
+}
+
+fn raw_pr_snapshot_without_files_page_info(head_oid: &str) -> serde_json::Value {
+    json!({
+        "number": 42,
+        "url": "https://github.com/owner/repo/pull/42",
+        "title": "Fix PR repair",
+        "baseRefName": "main",
+        "headRefName": "fix/pr-42",
+        "headRefOid": head_oid,
+        "isDraft": false,
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": {"state": "SUCCESS"},
+        "reviewThreads": {
+            "pageInfo": {"hasNextPage": false},
+            "nodes": []
+        },
+        "files": {
             "nodes": [
                 {"path": "src/lib.rs", "additions": 3, "deletions": 1, "changeType": "MODIFIED"}
             ]

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -124,6 +124,41 @@ fn direct_eval_input_missing_completeness_flags_fail_evidence_gates() {
 }
 
 #[test]
+fn ready_noop_missing_baseline_completeness_fails_closure_gate() {
+    let baseline = github_pr_snapshot_from_value(
+        "owner/repo",
+        "2026-06-06T00:00:00Z",
+        &server_normalized_snapshot("same-head", true, true),
+    );
+    let final_pr = github_pr_snapshot_from_value(
+        "owner/repo",
+        "2026-06-06T00:01:00Z",
+        &server_normalized_snapshot("same-head", true, true),
+    );
+    let mut input = serde_json::to_value(eval_input(baseline, final_pr)).expect("serialize input");
+    input["scenario"] = json!("ready_noop_control");
+    let baseline_pr = input
+        .get_mut("baseline_pr")
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("baseline PR object");
+    baseline_pr.remove("review_threads_complete");
+    let input: PrRepairEvalInput = serde_json::from_value(input).expect("deserialize input");
+
+    let snapshot = score_pr_repair_eval(input).expect("score ready/no-op incomplete baseline");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(
+        snapshot
+            .objective_score
+            .feedback_discovery_and_prioritization
+            .points,
+        4
+    );
+}
+
+#[test]
 fn missing_raw_changed_files_page_info_penalizes_current_head_verification() {
     let baseline = raw_pr_snapshot("base-head", false);
     let final_pr = raw_pr_snapshot_without_files_page_info("final-head");

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -1,0 +1,184 @@
+use harness_eval::{
+    github_pr_snapshot_from_value, score_pr_repair_eval, Confidence, EvalGrade, EvalScenario,
+    EvalTarget, GateStatus, HardGateName, PrRepairEvalInput, PullRequestSnapshot, ReviewerJudgment,
+    ReviewerKind, RuntimeJobSnapshot, RuntimeSnapshot, UsageSnapshot,
+};
+use serde_json::json;
+
+#[test]
+fn incomplete_raw_review_threads_fail_closure_gate() {
+    let baseline = raw_pr_snapshot("base-head", false);
+    let final_pr = raw_pr_snapshot("final-head", true);
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score incomplete raw snapshot");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(
+        snapshot
+            .objective_score
+            .feedback_discovery_and_prioritization
+            .points,
+        4
+    );
+}
+
+#[test]
+fn incomplete_server_normalized_review_threads_fail_closure_gate() {
+    let baseline = server_normalized_snapshot("base-head", true, true);
+    let final_pr = server_normalized_snapshot("final-head", false, true);
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score incomplete server snapshot");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+}
+
+#[test]
+fn incomplete_changed_files_penalize_current_head_verification() {
+    let baseline = server_normalized_snapshot("base-head", true, true);
+    let final_pr = server_normalized_snapshot("final-head", true, false);
+    let input = eval_input(
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:00:00Z", &baseline),
+        github_pr_snapshot_from_value("owner/repo", "2026-06-06T00:01:00Z", &final_pr),
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score incomplete files snapshot");
+
+    assert_eq!(snapshot.grade_cap, None);
+    assert_eq!(
+        snapshot
+            .objective_score
+            .verification_and_current_head_gates
+            .points,
+        4
+    );
+    assert_eq!(snapshot.final_score, 88);
+}
+
+fn raw_pr_snapshot(head_oid: &str, review_threads_has_next_page: bool) -> serde_json::Value {
+    json!({
+        "number": 42,
+        "url": "https://github.com/owner/repo/pull/42",
+        "title": "Fix PR repair",
+        "baseRefName": "main",
+        "headRefName": "fix/pr-42",
+        "headRefOid": head_oid,
+        "isDraft": false,
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": {"state": "SUCCESS"},
+        "reviewThreads": {
+            "pageInfo": {"hasNextPage": review_threads_has_next_page},
+            "nodes": []
+        },
+        "files": {
+            "pageInfo": {"hasNextPage": false},
+            "nodes": [
+                {"path": "src/lib.rs", "additions": 3, "deletions": 1, "changeType": "MODIFIED"}
+            ]
+        }
+    })
+}
+
+fn server_normalized_snapshot(
+    head_oid: &str,
+    review_threads_complete: bool,
+    changed_files_complete: bool,
+) -> serde_json::Value {
+    json!({
+        "pr_number": 42,
+        "pr_url": "https://github.com/owner/repo/pull/42",
+        "title": "Fix PR repair",
+        "base_ref": "main",
+        "head_ref": "fix/pr-42",
+        "head_oid": head_oid,
+        "is_draft": false,
+        "merge_state_status": "CLEAN",
+        "review_decision": "APPROVED",
+        "status_check_rollup_state": "SUCCESS",
+        "active_unresolved_review_threads": [],
+        "review_threads_complete": review_threads_complete,
+        "changed_files": [
+            {"path": "src/lib.rs", "additions": 3, "deletions": 1, "status": "MODIFIED"}
+        ],
+        "changed_files_complete": changed_files_complete
+    })
+}
+
+fn eval_input(
+    baseline_pr: PullRequestSnapshot,
+    final_pr: PullRequestSnapshot,
+) -> PrRepairEvalInput {
+    let final_head_oid = final_pr.head_oid.clone();
+    PrRepairEvalInput {
+        scenario: EvalScenario::PrRepair,
+        target: EvalTarget::PullRequest {
+            repo: "owner/repo".to_string(),
+            pr_number: 42,
+            base_ref: Some("main".to_string()),
+            head_ref: Some("fix/pr-42".to_string()),
+        },
+        final_evidence_head_oid: Some(final_head_oid.clone()),
+        baseline_pr,
+        final_pr,
+        runtime: Some(RuntimeSnapshot {
+            task_id: Some("task-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            workflow_state: Some("completed".to_string()),
+            runtime_jobs: vec![RuntimeJobSnapshot {
+                runtime_job_id: "job-1".to_string(),
+                state: "completed".to_string(),
+                artifact_count: 1,
+                terminal_state: Some("succeeded".to_string()),
+            }],
+            latest_activity: Some("completed".to_string()),
+            terminal_state: Some("succeeded".to_string()),
+            collected_at: "2026-06-06T00:01:00Z".to_string(),
+        }),
+        usage: vec![UsageSnapshot {
+            agent_invocation_id: Some("invoke-1".to_string()),
+            runtime_job_id: Some("job-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            model: Some("codex".to_string()),
+            reasoning_effort: Some("medium".to_string()),
+            input_tokens: Some(1000),
+            output_tokens: Some(200),
+            cached_input_tokens: Some(100),
+            total_tokens: Some(1200),
+            cost_usd_micros: Some(120_000),
+            token_confidence: Confidence::Exact,
+            cost_confidence: Confidence::Estimated,
+        }],
+        reviewer_judgment: Some(ReviewerJudgment {
+            reviewer_kind: ReviewerKind::Human,
+            judged_head_oid: final_head_oid,
+            code_quality_score: 100,
+            trajectory_score: 100,
+            findings: Vec::new(),
+            residual_risks: Vec::new(),
+        }),
+        created_unrelated_pr: false,
+        scope_violations: Vec::new(),
+    }
+}
+
+fn snapshot_gate(
+    gates: &[harness_eval::HardGateResult],
+    name: HardGateName,
+) -> &harness_eval::HardGateResult {
+    gates
+        .iter()
+        .find(|gate| gate.name == name)
+        .expect("gate should exist")
+}

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -89,6 +89,41 @@ fn missing_server_normalized_completeness_flags_fail_evidence_gates() {
 }
 
 #[test]
+fn direct_eval_input_missing_completeness_flags_fail_evidence_gates() {
+    let baseline = github_pr_snapshot_from_value(
+        "owner/repo",
+        "2026-06-06T00:00:00Z",
+        &server_normalized_snapshot("base-head", true, true),
+    );
+    let final_pr = github_pr_snapshot_from_value(
+        "owner/repo",
+        "2026-06-06T00:01:00Z",
+        &server_normalized_snapshot("final-head", true, true),
+    );
+    let mut input = serde_json::to_value(eval_input(baseline, final_pr)).expect("serialize input");
+    let final_pr = input
+        .get_mut("final_pr")
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("final PR object");
+    final_pr.remove("review_threads_complete");
+    final_pr.remove("changed_files_complete");
+    let input: PrRepairEvalInput = serde_json::from_value(input).expect("deserialize input");
+
+    let snapshot = score_pr_repair_eval(input).expect("score direct incomplete input");
+    let gate = snapshot_gate(&snapshot.hard_gates, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(
+        snapshot
+            .objective_score
+            .verification_and_current_head_gates
+            .points,
+        4
+    );
+}
+
+#[test]
 fn missing_raw_changed_files_page_info_penalizes_current_head_verification() {
     let baseline = raw_pr_snapshot("base-head", false);
     let final_pr = raw_pr_snapshot_without_files_page_info("final-head");

--- a/crates/harness-server/src/http/tests/evals_api_tests.rs
+++ b/crates/harness-server/src/http/tests/evals_api_tests.rs
@@ -367,12 +367,14 @@ fn pr_snapshot_json(
         "check_state": check_state,
         "review_decision": "approved",
         "active_unresolved_review_threads": active_unresolved_review_threads,
+        "review_threads_complete": true,
         "changed_files": [{
             "path": "src/lib.rs",
             "additions": 4,
             "deletions": 1,
             "status": "modified"
         }],
+        "changed_files_complete": true,
         "collected_at": "2026-06-05T00:00:00Z"
     })
 }

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -148,8 +148,10 @@ pub enum EvalScenario {
 }
 ```
 
-`PrRepair` is the first scenario to implement. The other variants reserve the
-schema for future benchmark suites.
+`PrRepair` is the first scenario to implement. `ReadyNoopControl` requires a
+complete baseline `reviewThreads` enumeration; incomplete baseline review
+pagination is treated as repair work, not as a clean no-op control. The other
+variants reserve the schema for future benchmark suites.
 
 ### `EvalTarget`
 

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -201,7 +201,10 @@ pub struct PullRequestSnapshot {
 `reviewThreads` must come from GraphQL or an equivalent API surface that can
 distinguish active unresolved threads from outdated or resolved threads. The
 snapshot must also record whether `reviewThreads` and changed-file enumeration
-was complete; incomplete pagination is not valid merge-readiness evidence.
+was complete. Raw GitHub evidence proves completeness with
+`pageInfo.hasNextPage=false`; server-normalized evidence must carry explicit
+`review_threads_complete=true` and `changed_files_complete=true`. Incomplete or
+missing completeness evidence is not valid merge-readiness evidence.
 
 ### `RuntimeSnapshot`
 

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -204,7 +204,9 @@ snapshot must also record whether `reviewThreads` and changed-file enumeration
 was complete. Raw GitHub evidence proves completeness with
 `pageInfo.hasNextPage=false`; server-normalized evidence must carry explicit
 `review_threads_complete=true` and `changed_files_complete=true`. Incomplete or
-missing completeness evidence is not valid merge-readiness evidence.
+missing completeness evidence is not valid merge-readiness evidence. Direct
+`PrRepairEvalInput` artifacts that omit the completeness fields are treated as
+incomplete, not as legacy-complete evidence.
 
 ### `RuntimeSnapshot`
 

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -282,7 +282,7 @@ grade is capped even when other score dimensions look strong.
 | Head freshness | final evidence head vs final PR head | `C` |
 | Required checks | final check state for final head | `C` |
 | Mergeability clean | final merge state for final head | `C` |
-| Review-thread closure | final active unresolved threads | `C` |
+| Review-thread closure | final active unresolved threads plus required thread enumeration completeness | `C` |
 | Runtime artifact completeness | task/workflow/job snapshots | `B` |
 | Reviewer judgment freshness | reviewer head vs final PR head | `C`, or `B` when absent |
 | No destructive/unrelated scope | changed files and risk scanner | `F` |
@@ -578,6 +578,7 @@ Every failed or weak run should classify the first meaningful failure:
 `harness-eval` should have fixture-based unit tests:
 
 - score ready/no-op control without requiring a head change
+- fail ready/no-op control when baseline review-thread completeness is missing
 - fail wrong-target final snapshot
 - cap grade at `C` for unresolved active review threads
 - cap grade at `C` for stale-head validation

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -189,13 +189,17 @@ pub struct PullRequestSnapshot {
     pub check_state: CheckState,
     pub review_decision: Option<ReviewDecision>,
     pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
+    pub review_threads_complete: bool,
     pub changed_files: Vec<ChangedFileSnapshot>,
+    pub changed_files_complete: bool,
     pub collected_at: DateTime<Utc>,
 }
 ```
 
 `reviewThreads` must come from GraphQL or an equivalent API surface that can
-distinguish active unresolved threads from outdated or resolved threads.
+distinguish active unresolved threads from outdated or resolved threads. The
+snapshot must also record whether `reviewThreads` and changed-file enumeration
+was complete; incomplete pagination is not valid merge-readiness evidence.
 
 ### `RuntimeSnapshot`
 

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -67,7 +67,7 @@ some useful work.
 |---|---|---|
 | Current PR targeting | The run updates or reports on the requested PR only. | Wrong PR, new PR, or unrelated branch. |
 | Head freshness | Final validation, review, and merge-readiness evidence names the final `headRefOid`. | Stale approval or stale CI was reused. |
-| Blocking feedback | Final active, non-outdated unresolved `reviewThreads` count is zero, or every remaining thread has an explicit justified rejection. | The original blocker remains. |
+| Blocking feedback | Final `reviewThreads` enumeration is complete and active, non-outdated unresolved thread count is zero, or every remaining thread has an explicit justified rejection. | The original blocker remains, or the evaluator did not inspect every review thread. |
 | Required checks | Final required checks are `SUCCESS` for the final head SHA, unless the case is explicitly collect-only. | CI still blocks merge. |
 | Branch safety | The existing PR branch is used and no unrelated files are changed. | Cross-branch mutation, broad cleanup, or dirty-state dependence. |
 | No unrelated PR creation | The run updates the existing PR branch and does not open or report a different PR. | The evaluation target was replaced by a new PR. |
@@ -88,7 +88,7 @@ Use the hard gates first, then score the successful run with this rubric:
 | Feedback discovery and prioritization | 14 | Finds actionable feedback, distinguishes stale or false-positive comments, and focuses on the blocker. |
 | Branch and PR safety | 10 | Uses the existing PR branch, no new PR, no wrong worktree, and no unrelated local changes. |
 | Fix correctness and scope | 22 | Produces the smallest correct fix, preserves product behavior, avoids silent degradation, and does not introduce regression risk. |
-| Verification and current-head gates | 16 | Runs relevant local validation and confirms final-head CI plus active `reviewThreads`. |
+| Verification and current-head gates | 16 | Runs relevant local validation and confirms final-head CI plus complete active `reviewThreads` and changed-file evidence. |
 | Runtime workflow behavior and persistence | 12 | Records task/workflow/job state, reaches a correct terminal or waiting state, and does not leave duplicate LLM work queued. |
 | Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class and exposes usage attribution. |
 | Reporting and attribution quality | 6 | Final report proves what Harness did, what commits were pushed, what commands passed, and what remains. |


### PR DESCRIPTION
## Summary
- Add PR snapshot completeness flags for review thread and changed-file pagination.
- Parse both raw GitHub GraphQL connections and server-normalized snapshot fields.
- Fail PR repair review-thread closure evidence when review threads were not fully enumerated, and penalize current-head verification when final remote evidence is incomplete.
- Document the completeness requirement and cover raw plus normalized snapshot cases.

## Validation
- cargo fmt --all
- cargo test -p harness-eval
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test

Closes #1268