### PR TITLE
fix(eval): tag collect-only repair snapshots

### DIFF
--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -378,6 +378,7 @@ mod tests {
     ) -> QualitySnapshot {
         QualitySnapshot {
             scenario: EvalScenario::PrRepair,
+            run_mode: crate::model::EvalRunMode::LiveRun,
             target: EvalTarget::PullRequest {
                 repo: "owner/repo".to_string(),
                 pr_number: 7,

--- a/crates/harness-eval/src/bin/score_pr_repair.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair.rs
@@ -1,12 +1,13 @@
 use harness_eval::{
-    pr_repair_eval_input_from_values, score_pr_repair_eval, PrRepairEvalIngest, ReviewerJudgment,
+    pr_repair_eval_input_from_values, score_pr_repair_eval, EvalRunMode, PrRepairEvalIngest,
+    ReviewerJudgment,
 };
 use serde_json::Value;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct Args {
     repo: String,
     pr_number: u64,
@@ -16,6 +17,7 @@ struct Args {
     task_detail: Option<PathBuf>,
     baseline_collected_at: String,
     final_collected_at: String,
+    run_mode: Option<EvalRunMode>,
     reviewer_judgment: Option<PathBuf>,
     input_output: Option<PathBuf>,
     snapshot_output: PathBuf,
@@ -48,6 +50,9 @@ fn run() -> Result<(), String> {
         final_collected_at: &args.final_collected_at,
         baseline: &baseline,
         final_pr: &final_pr,
+        run_mode: args
+            .run_mode
+            .ok_or_else(|| "--run-mode is required".to_string())?,
         submission: submission.as_ref(),
         task_detail: task_detail.as_ref(),
         reviewer_judgment,
@@ -98,6 +103,9 @@ where
             "--final-collected-at" => {
                 parsed.final_collected_at = required_value(&mut args, "--final-collected-at")?;
             }
+            "--run-mode" => {
+                parsed.run_mode = Some(parse_run_mode(&required_value(&mut args, "--run-mode")?)?);
+            }
             "--reviewer-judgment" => {
                 parsed.reviewer_judgment = Some(PathBuf::from(required_value(
                     &mut args,
@@ -125,12 +133,21 @@ where
         || parsed.final_pr.as_os_str().is_empty()
         || parsed.baseline_collected_at.is_empty()
         || parsed.final_collected_at.is_empty()
+        || parsed.run_mode.is_none()
         || parsed.snapshot_output.as_os_str().is_empty()
     {
         return Err(usage());
     }
 
     Ok(parsed)
+}
+
+fn parse_run_mode(value: &str) -> Result<EvalRunMode, String> {
+    match value {
+        "live_run" => Ok(EvalRunMode::LiveRun),
+        "collect_only" => Ok(EvalRunMode::CollectOnly),
+        _ => Err("--run-mode must be live_run or collect_only".to_string()),
+    }
 }
 
 fn required_value<I>(args: &mut I, flag: &str) -> Result<String, String>
@@ -159,7 +176,7 @@ fn write_json(path: &PathBuf, value: &Value) -> Result<(), String> {
 }
 
 fn usage() -> String {
-    "Usage: score_pr_repair --repo OWNER/REPO --pr N --baseline baseline_pr.json --final final_pr.json --baseline-collected-at RFC3339 --final-collected-at RFC3339 --snapshot-output quality_snapshot.json [--submission submission.json --task-detail task_detail_final.json --reviewer-judgment reviewer_judgment.json --input-output pr_repair_eval_input.json]".to_string()
+    "Usage: score_pr_repair --repo OWNER/REPO --pr N --baseline baseline_pr.json --final final_pr.json --baseline-collected-at RFC3339 --final-collected-at RFC3339 --run-mode live_run|collect_only --snapshot-output quality_snapshot.json [--submission submission.json --task-detail task_detail_final.json --reviewer-judgment reviewer_judgment.json --input-output pr_repair_eval_input.json]".to_string()
 }
 
 #[cfg(test)]
@@ -182,6 +199,8 @@ mod tests {
                 "2026-06-06T00:00:00Z",
                 "--final-collected-at",
                 "2026-06-06T00:01:00Z",
+                "--run-mode",
+                "live_run",
                 "--snapshot-output",
                 "quality.json",
                 "--reviewer-judgment",
@@ -196,5 +215,33 @@ mod tests {
             args.reviewer_judgment,
             Some(PathBuf::from("reviewer_judgment.json"))
         );
+        assert_eq!(args.run_mode, Some(EvalRunMode::LiveRun));
+    }
+
+    #[test]
+    fn parse_args_requires_run_mode() {
+        let err = parse_args(
+            [
+                "--repo",
+                "owner/repo",
+                "--pr",
+                "7",
+                "--baseline",
+                "baseline.json",
+                "--final",
+                "final.json",
+                "--baseline-collected-at",
+                "2026-06-06T00:00:00Z",
+                "--final-collected-at",
+                "2026-06-06T00:01:00Z",
+                "--snapshot-output",
+                "quality.json",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        )
+        .expect_err("args without --run-mode should fail");
+
+        assert!(err.contains("--run-mode live_run|collect_only"));
     }
 }

--- a/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
@@ -1,5 +1,6 @@
 use harness_eval::{
-    summarize_pr_repair_benchmark, PrRepairBenchmarkCase, PrRepairBenchmarkInput, QualitySnapshot,
+    summarize_pr_repair_benchmark, EvalRunMode, PrRepairBenchmarkCase, PrRepairBenchmarkInput,
+    QualitySnapshot,
 };
 use serde_json::Value;
 use std::collections::HashSet;
@@ -101,8 +102,37 @@ where
 fn read_case(case_id: String, path: &Path) -> Result<PrRepairBenchmarkCase, String> {
     let body = fs::read_to_string(path)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    let snapshot: QualitySnapshot = serde_json::from_str(&body)
+    let raw_snapshot: Value = serde_json::from_str(&body)
         .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+    match raw_snapshot.get("run_mode").and_then(Value::as_str) {
+        Some("live_run") => {}
+        Some("collect_only") => {
+            return Err(format!(
+                "collect-only snapshot {} cannot be used as a live PR repair benchmark case",
+                path.display()
+            ));
+        }
+        Some(value) => {
+            return Err(format!(
+                "snapshot {} has unsupported run_mode {value:?}; expected live_run",
+                path.display()
+            ));
+        }
+        None => {
+            return Err(format!(
+                "snapshot {} must include explicit run_mode=\"live_run\" for live PR repair benchmarks",
+                path.display()
+            ));
+        }
+    }
+    let snapshot: QualitySnapshot = serde_json::from_value(raw_snapshot)
+        .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+    if snapshot.run_mode != EvalRunMode::LiveRun {
+        return Err(format!(
+            "snapshot {} must use run_mode=\"live_run\" for live PR repair benchmarks",
+            path.display()
+        ));
+    }
     Ok(PrRepairBenchmarkCase {
         case_id,
         tags: Vec::new(),

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -1,6 +1,6 @@
 use crate::model::{
-    ChangedFileSnapshot, CheckState, EvalScenario, EvalTarget, MergeState, PrRepairEvalInput,
-    PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, ReviewerJudgment,
+    ChangedFileSnapshot, CheckState, EvalRunMode, EvalScenario, EvalTarget, MergeState,
+    PrRepairEvalInput, PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, ReviewerJudgment,
     RuntimeJobSnapshot, RuntimeSnapshot,
 };
 use serde_json::Value;
@@ -15,6 +15,7 @@ pub struct PrRepairEvalIngest<'a> {
     pub final_collected_at: &'a str,
     pub baseline: &'a Value,
     pub final_pr: &'a Value,
+    pub run_mode: EvalRunMode,
     pub submission: Option<&'a Value>,
     pub task_detail: Option<&'a Value>,
     pub reviewer_judgment: Option<ReviewerJudgment>,
@@ -214,6 +215,7 @@ pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepa
 
     PrRepairEvalInput {
         scenario,
+        run_mode: input.run_mode,
         target: EvalTarget::PullRequest {
             repo: input.repo.to_string(),
             pr_number: input.pr_number,
@@ -479,6 +481,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: None,
             reviewer_judgment: None,
@@ -515,6 +518,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: None,
             reviewer_judgment: None,
@@ -547,6 +551,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: None,
             reviewer_judgment: None,
@@ -584,6 +589,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: None,
             reviewer_judgment: Some(judgment.clone()),
@@ -624,6 +630,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: Some(&submission),
             task_detail: Some(&task_detail),
             reviewer_judgment: None,
@@ -666,6 +673,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: Some(&task_detail),
             reviewer_judgment: None,
@@ -702,6 +710,7 @@ mod tests {
             final_collected_at: "2026-06-06T00:01:00Z",
             baseline: &pr,
             final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
             submission: None,
             task_detail: None,
             reviewer_judgment: None,

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -7,6 +7,14 @@ pub enum EvalScenario {
     ReadyNoopControl,
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalRunMode {
+    #[default]
+    LiveRun,
+    CollectOnly,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EvalTarget {
@@ -171,6 +179,7 @@ pub struct ReviewerJudgment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PrRepairEvalInput {
     pub scenario: EvalScenario,
+    pub run_mode: EvalRunMode,
     pub target: EvalTarget,
     pub baseline_pr: PullRequestSnapshot,
     pub final_pr: PullRequestSnapshot,
@@ -312,6 +321,8 @@ impl ScoreBreakdown {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QualitySnapshot {
     pub scenario: EvalScenario,
+    #[serde(default)]
+    pub run_mode: EvalRunMode,
     pub target: EvalTarget,
     pub baseline_pr: Option<PullRequestSnapshot>,
     pub final_pr: Option<PullRequestSnapshot>,

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -107,7 +107,6 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         ),
         reviewer_gate(&input),
     ];
-
     let gate_signals = GateSignals {
         target_matches,
         branch_safe,
@@ -133,6 +132,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
 
     Ok(QualitySnapshot {
         scenario: input.scenario,
+        run_mode: input.run_mode,
         target: input.target,
         baseline_pr: Some(input.baseline_pr),
         final_pr: Some(input.final_pr),
@@ -711,10 +711,10 @@ mod tests {
             .find(|gate| gate.name == name)
             .expect("gate should exist")
     }
-
     fn perfect_input() -> PrRepairEvalInput {
         PrRepairEvalInput {
             scenario: EvalScenario::PrRepair,
+            run_mode: crate::model::EvalRunMode::LiveRun,
             target: EvalTarget::PullRequest {
                 repo: "owner/repo".to_string(),
                 pr_number: 42,

--- a/crates/harness-eval/tests/pr_repair_benchmark_cli.rs
+++ b/crates/harness-eval/tests/pr_repair_benchmark_cli.rs
@@ -1,6 +1,6 @@
 use harness_eval::{
-    EvalGrade, EvalScenario, EvalTarget, GateStatus, HardGateName, HardGateResult, QualitySnapshot,
-    ScoreBreakdown, ScoreComponent, ScoreDimensionName,
+    EvalGrade, EvalRunMode, EvalScenario, EvalTarget, GateStatus, HardGateName, HardGateResult,
+    QualitySnapshot, ScoreBreakdown, ScoreComponent, ScoreDimensionName,
 };
 use serde_json::Value;
 use std::ffi::OsString;
@@ -67,6 +67,77 @@ fn benchmark_cli_aggregates_snapshot_cases() {
     assert_eq!(summary["hard_gate_failures"][0]["count"], 1);
 }
 
+#[test]
+fn benchmark_cli_rejects_collect_only_snapshots() {
+    let temp_dir = TempDir::new("pr-repair-benchmark-collect-only");
+    let snapshot_path = temp_dir.path().join("collect_only.json");
+    let output = temp_dir.path().join("benchmark_summary.json");
+    let mut snapshot = fixture_snapshot("collect-only", 100, EvalGrade::A, None);
+    snapshot.run_mode = EvalRunMode::CollectOnly;
+    write_snapshot(&snapshot_path, &snapshot);
+
+    let output_status = Command::new(env!("CARGO_BIN_EXE_score_pr_repair_benchmark"))
+        .arg("--suite")
+        .arg("collect-only")
+        .arg("--snapshot")
+        .arg(&snapshot_path)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .expect("run benchmark binary");
+
+    assert!(
+        !output_status.status.success(),
+        "benchmark binary should reject collect-only snapshots"
+    );
+    let stderr = String::from_utf8_lossy(&output_status.stderr);
+    assert!(stderr.contains("collect-only snapshot"));
+    assert!(
+        !output.exists(),
+        "rejected benchmark should not write output"
+    );
+}
+
+#[test]
+fn benchmark_cli_rejects_missing_run_mode_snapshots() {
+    let temp_dir = TempDir::new("pr-repair-benchmark-missing-run-mode");
+    let snapshot_path = temp_dir.path().join("missing_run_mode.json");
+    let output = temp_dir.path().join("benchmark_summary.json");
+    let mut snapshot = serde_json::to_value(fixture_snapshot(
+        "missing-run-mode",
+        100,
+        EvalGrade::A,
+        None,
+    ))
+    .expect("serialize snapshot");
+    snapshot
+        .as_object_mut()
+        .expect("snapshot should be an object")
+        .remove("run_mode");
+    write_json_value(&snapshot_path, &snapshot);
+
+    let output_status = Command::new(env!("CARGO_BIN_EXE_score_pr_repair_benchmark"))
+        .arg("--suite")
+        .arg("missing-run-mode")
+        .arg("--snapshot")
+        .arg(&snapshot_path)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .expect("run benchmark binary");
+
+    assert!(
+        !output_status.status.success(),
+        "benchmark binary should reject missing run_mode snapshots"
+    );
+    let stderr = String::from_utf8_lossy(&output_status.stderr);
+    assert!(stderr.contains("must include explicit run_mode"));
+    assert!(
+        !output.exists(),
+        "rejected benchmark should not write output"
+    );
+}
+
 struct TempDir {
     path: PathBuf,
 }
@@ -105,7 +176,12 @@ fn case_arg(case_id: &str, path: &Path) -> OsString {
 }
 
 fn write_snapshot(path: &Path, snapshot: &QualitySnapshot) {
-    let body = serde_json::to_string_pretty(snapshot).expect("serialize snapshot");
+    let value = serde_json::to_value(snapshot).expect("serialize snapshot");
+    write_json_value(path, &value);
+}
+
+fn write_json_value(path: &Path, value: &Value) {
+    let body = serde_json::to_string_pretty(value).expect("serialize snapshot");
     fs::write(path, format!("{body}\n")).expect("write snapshot");
 }
 
@@ -117,6 +193,7 @@ fn fixture_snapshot(
 ) -> QualitySnapshot {
     QualitySnapshot {
         scenario: EvalScenario::PrRepair,
+        run_mode: EvalRunMode::LiveRun,
         target: EvalTarget::PullRequest {
             repo: "owner/repo".to_string(),
             pr_number: 42,

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -304,6 +304,7 @@ fn eval_input(
     let final_head_oid = final_pr.head_oid.clone();
     PrRepairEvalInput {
         scenario: EvalScenario::PrRepair,
+        run_mode: harness_eval::EvalRunMode::LiveRun,
         target: EvalTarget::PullRequest {
             repo: "owner/repo".to_string(),
             pr_number: 42,

--- a/crates/harness-server/src/handlers/evals.rs
+++ b/crates/harness-server/src/handlers/evals.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use axum::{
     body::Bytes,
     extract::{Path, Query, State},
@@ -265,8 +264,9 @@ async fn load_input_artifact(
     else {
         return Ok(None);
     };
-    let input = serde_json::from_str(&artifact.body)
-        .with_context(|| "failed to parse pr_repair_eval_input artifact")?;
+    let input = serde_json::from_str(&artifact.body).map_err(|error| {
+        anyhow::anyhow!("failed to parse pr_repair_eval_input artifact: {error}")
+    })?;
     Ok(Some(input))
 }
 

--- a/crates/harness-server/src/http/tests/evals_api_tests.rs
+++ b/crates/harness-server/src/http/tests/evals_api_tests.rs
@@ -255,6 +255,105 @@ async fn score_accepts_unwrapped_eval_input_body() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn score_rejects_unwrapped_eval_input_without_run_mode() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.data_dir = dir.path().to_path_buf();
+    let state = make_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = evals_app(state);
+    let run_id = create_pr_repair_run(app.clone()).await?;
+    let mut input = pr_repair_input();
+    input
+        .as_object_mut()
+        .expect("PR repair input object")
+        .remove("run_mode");
+
+    let score = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/evals/runs/{run_id}/score"))
+                .header("content-type", "application/json")
+                .body(Body::from(input.to_string()))?,
+        )
+        .await?;
+    assert_eq!(score.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body = response_json(score).await?;
+    assert!(body["error"]
+        .as_str()
+        .expect("error message")
+        .contains("run_mode"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn score_rejects_eval_input_artifact_without_run_mode() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.data_dir = dir.path().to_path_buf();
+    let state = make_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = evals_app(state);
+    let run_id = create_pr_repair_run(app.clone()).await?;
+    let mut input = pr_repair_input();
+    input
+        .as_object_mut()
+        .expect("PR repair input object")
+        .remove("run_mode");
+
+    let artifact_body = serde_json::json!({
+        "artifact_type": "pr_repair_eval_input",
+        "label": "missing run mode",
+        "content_type": "application/json",
+        "body": input.to_string()
+    });
+    let artifact = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/evals/runs/{run_id}/artifacts"))
+                .header("content-type", "application/json")
+                .body(Body::from(artifact_body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(artifact.status(), axum::http::StatusCode::CREATED);
+
+    let score = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/evals/runs/{run_id}/score"))
+                .header("content-type", "application/json")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(score.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body = response_json(score).await?;
+    let message = body["error"].as_str().expect("error message");
+    assert!(message.contains("failed to parse pr_repair_eval_input artifact"));
+    assert!(message.contains("run_mode"));
+    Ok(())
+}
+
 async fn create_pr_repair_run(app: Router) -> anyhow::Result<String> {
     let create = app
         .oneshot(
@@ -287,6 +386,7 @@ fn pr_repair_run_body() -> serde_json::Value {
 fn pr_repair_input() -> serde_json::Value {
     serde_json::json!({
         "scenario": "pr_repair",
+        "run_mode": "live_run",
         "target": {
             "kind": "pull_request",
             "repo": "owner/repo",

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -125,6 +125,7 @@ One invocation of an evaluation scenario.
 pub struct EvalRun {
     pub run_id: EvalRunId,
     pub scenario: EvalScenario,
+    pub run_mode: EvalRunMode,
     pub target: EvalTarget,
     pub status: EvalRunStatus,
     pub started_at: DateTime<Utc>,
@@ -136,6 +137,17 @@ pub struct EvalRun {
     pub artifacts: Vec<EvalArtifactRef>,
 }
 ```
+
+```rust
+pub enum EvalRunMode {
+    LiveRun,
+    CollectOnly,
+}
+```
+
+`CollectOnly` means the evaluator only collected GitHub truth and did not submit
+or observe a Harness repair task. These artifacts are useful baselines, but they
+are not live capability benchmark cases.
 
 ### `EvalScenario`
 
@@ -255,6 +267,7 @@ The final persisted report for a run.
 ```rust
 pub struct QualitySnapshot {
     pub run: EvalRun,
+    pub run_mode: EvalRunMode,
     pub baseline_pr: Option<PullRequestSnapshot>,
     pub final_pr: Option<PullRequestSnapshot>,
     pub runtime: RuntimeSnapshot,
@@ -488,9 +501,19 @@ running Harness server before submitting `POST /tasks`. An unregistered local
 worktree can otherwise produce a workflow handle that no runtime worker will
 execute, which creates false-negative quality data. When that preflight fails,
 the collector should fail fast but still emit `submission.json`,
-`task_detail_final.json`, `quality_snapshot.json`, and `summary.md`. The Markdown
-report must render grade, score, grade cap, hard gates, and blockers from
-`quality_snapshot.json`; it must not maintain an independent grading heuristic.
+`task_detail_final.json`, `quality_snapshot.json`, and `summary.md` with
+`run_mode=collect_only` because no Harness repair task exists yet. After
+`POST /tasks` returns a non-empty `task_id`, subsequent snapshots are tagged
+`run_mode=live_run` even if the task later fails, blocks, or times out. The
+`score_pr_repair` CLI requires explicit `--run-mode live_run|collect_only` for
+every invocation that writes a new snapshot; compatibility defaults are reserved
+for deserializing older stored artifacts, not for producing new live evidence.
+The server `/api/evals/runs/{run_id}/score` input contract also requires
+explicit `run_mode` for direct request bodies and `pr_repair_eval_input`
+artifacts.
+The Markdown report must render grade, score, grade cap, hard gates, and blockers
+from `quality_snapshot.json`; it must not maintain an independent grading
+heuristic.
 
 Later, add a CLI wrapper:
 
@@ -516,7 +539,11 @@ score_pr_repair_benchmark \
 
 It reads existing `quality_snapshot.json` artifacts and writes a deterministic
 benchmark summary. It does not fetch GitHub, start Harness, or grade code with an
-LLM.
+LLM. It accepts only snapshots with explicit `run_mode=live_run`; it rejects
+`collect_only` and missing `run_mode` snapshots so baseline collection cannot be
+misreported as live repair capability. Live-mode preflight failures are also
+tagged `collect_only`; only snapshots for successfully submitted Harness tasks
+are benchmarkable live cases.
 
 ## Dashboard Design
 
@@ -602,6 +629,7 @@ The script should have shell or integration tests for:
 
 - URL-encoding task IDs that contain `/`
 - collect-only baseline mode
+- live-mode preflight failures remaining `collect_only`
 - final snapshot generation after task polling resumes
 
 ## Rollout Plan

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -57,6 +57,20 @@ This checks existing local-review completion gates:
 Level 0 does not prove an agent can fix a real PR. It proves that the local gate
 does not accept common false positives.
 
+`QualitySnapshot` records a `run_mode`. Collect-only snapshots must use
+`collect_only`; live Harness repair runs use `live_run` only after Harness
+returns a non-empty `task_id` from `POST /tasks`. Server health failures, project
+registry failures, duplicate-task preflight failures, POST failures, and missing
+task IDs are still diagnostic reports, but they are tagged `collect_only`
+because no Harness repair attempt exists. Benchmark inputs must include an
+explicit `run_mode=live_run`; missing `run_mode` is rejected because older
+collect-only artifacts did not have this field.
+
+The `score_pr_repair` CLI must be invoked with an explicit
+`--run-mode live_run|collect_only` whenever it writes a new `QualitySnapshot`.
+Server scoring input for `/api/evals/runs/{run_id}/score` must also include
+`run_mode`. Neither path may default direct/manual scoring to `live_run`.
+
 ## Hard Gates
 
 A run must pass every hard gate before the numeric score can be interpreted as a
@@ -140,6 +154,16 @@ This records the PR `headRefOid`, `mergeStateStatus`, `statusCheckRollup`,
 `reviewDecision`, active unresolved `reviewThreads`, and a recommended task
 class. Use this before every live repair run.
 
+Collect-only reports still write `pr_repair_eval_input.json` and
+`quality_snapshot.json`, but those snapshots are tagged `run_mode=collect_only`.
+The benchmark CLI rejects them because no Harness repair, runtime artifact, or
+usage attribution exists yet.
+
+Live-mode preflight failures use the same `collect_only` tag until the script
+successfully submits a Harness task and records its `task_id`. This keeps
+environment/setup failures out of the live repair capability benchmark while
+still preserving enough evidence to debug why no repair attempt started.
+
 ### Level 2: Harness Live PR Repair
 
 Start Harness from a standalone terminal, not from a Codex session:
@@ -208,6 +232,13 @@ Each run must also write machine-readable eval artifacts:
   `harness-eval` and `/api/evals/runs/{run_id}/score`.
 - `quality_snapshot.json`: deterministic `QualitySnapshot` with hard gates,
   score breakdown, grade caps, blocker summary, runtime evidence, and PR facts.
+
+Both artifacts include `run_mode`. Operators may archive collect-only artifacts
+next to live-run artifacts, but only `live_run` snapshots are valid inputs for
+the capability benchmark. A snapshot is `live_run` only after a Harness task was
+successfully submitted for the target PR; live-mode preflight failures remain
+`collect_only`. The benchmark CLI rejects missing `run_mode` rather than
+defaulting old snapshots to live runs.
 
 The Markdown summary is an operator convenience layer. It must not be the source
 of truth for eval scoring, dashboards, or merge readiness.

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -504,6 +504,7 @@ RUNTIME_TREE_FINAL_JSON="$OUTPUT_DIR/runtime_tree_final.json"
 RUNTIME_TREE_FINAL_ERROR="$OUTPUT_DIR/runtime_tree_final_error.txt"
 EVAL_TARGET_ID="pr-repair-eval:$REPO#$PR"
 EVAL_EXTERNAL_ID="$EVAL_TARGET_ID:run:$RUN_ID"
+QUALITY_RUN_MODE="collect_only"
 
 write_quality_snapshot() {
   local baseline="$1"
@@ -528,6 +529,11 @@ write_quality_snapshot() {
     --input-output "$PR_REPAIR_EVAL_INPUT_JSON"
     --snapshot-output "$QUALITY_SNAPSHOT_JSON"
   )
+  if [[ "$COLLECT_ONLY" -eq 1 || "$QUALITY_RUN_MODE" == "collect_only" ]]; then
+    args+=(--run-mode collect_only)
+  else
+    args+=(--run-mode live_run)
+  fi
   if [[ -s "$submission" ]]; then
     args+=(--submission "$submission")
   fi
@@ -700,6 +706,7 @@ if [[ -z "$TASK_ID" ]]; then
   exit 4
 fi
 
+QUALITY_RUN_MODE="live_run"
 echo "Submitted task_id=$TASK_ID"
 WORKFLOW_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
 import json


### PR DESCRIPTION
## Summary
- Add explicit `EvalRunMode` metadata to PR repair eval inputs and quality snapshots.
- Mark `evaluate_pr_repair.sh --collect-only` snapshots as `collect_only`.
- Reject collect-only snapshots in `score_pr_repair_benchmark` so baseline collection cannot be scored as live repair capability.
- Document the collect-only versus live-run boundary.

Closes #1270

## Validation
- `bash -n scripts/evaluate_pr_repair.sh`
- collect-only smoke run for PR #1232 wrote `run_mode=collect_only` and `score_pr_repair_benchmark` rejected that snapshot
- `cargo test -p harness-eval`
- `cargo test -p harness-server evals_api_tests`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test`

## Not Run
- `python3 -m pytest scripts/test_evaluate_pr_repair_helpers.py scripts/test_evaluate_pr_repair_artifacts.py scripts/test_evaluate_pr_repair_submit.py` because pytest is not installed in the active Python environment.
