### PR TITLE
feat(web): surface PR repair quality snapshots

### DIFF
--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -1,10 +1,13 @@
 import { workflowLabel } from "@/lib/format";
-import type { FullTask, TaskArtifact, TaskPrompt } from "@/types";
+import type { FullTask, QualitySnapshotRecord, TaskArtifact, TaskPrompt } from "@/types";
 
 interface Props {
   task: FullTask;
   prompts: TaskPrompt[] | undefined;
   artifacts: TaskArtifact[] | undefined;
+  qualitySnapshot?: QualitySnapshotRecord;
+  qualitySnapshotLoading?: boolean;
+  qualitySnapshotError?: boolean;
 }
 
 function reviewerVerdict(state: string): string {
@@ -26,7 +29,28 @@ function elapsedTime(createdAt: string | null, completedAt: string | undefined):
   return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
 }
 
-export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
+function formatLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function shortSha(value: string | null | undefined): string {
+  if (!value) return "N/A";
+  return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+export function ProofOfWorkCard({
+  task,
+  prompts,
+  artifacts,
+  qualitySnapshot,
+  qualitySnapshotLoading,
+  qualitySnapshotError,
+}: Props) {
+  const snapshot = qualitySnapshot?.snapshot;
+  const passedGates = snapshot?.hard_gates.filter((gate) => gate.status === "pass").length ?? 0;
+  const totalGates = snapshot?.hard_gates.length ?? 0;
+  const failedGates = snapshot?.hard_gates.filter((gate) => gate.status === "fail") ?? [];
+
   return (
     <div
       className="mt-4 border border-line bg-bg p-3 flex flex-col gap-3 font-mono text-[11px]"
@@ -54,6 +78,48 @@ export function ProofOfWorkCard({ task, prompts, artifacts }: Props) {
           <span className="text-ink-3">No PR</span>
         )}
       </section>
+
+      {task.pr_url && (
+        <section>
+          <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Quality Snapshot</div>
+          {qualitySnapshotLoading ? (
+            <span className="text-ink-3">Loading quality snapshot…</span>
+          ) : qualitySnapshotError ? (
+            <span className="text-rust">Failed to load quality snapshot</span>
+          ) : snapshot ? (
+            <div className="flex flex-col gap-2 text-ink">
+              <div className="flex flex-wrap gap-2">
+                <span className="border border-line bg-bg-1 px-1.5 py-[1px] text-[10px]">
+                  Grade {snapshot.final_grade}
+                </span>
+                <span>Score: {snapshot.final_score}/100</span>
+                <span>Run: {formatLabel(snapshot.run_mode)}</span>
+              </div>
+              <div className="flex flex-wrap gap-2 text-ink-2">
+                <span>Head: {shortSha(snapshot.final_pr?.head_oid)}</span>
+                <span>Gates: {passedGates}/{totalGates}</span>
+                <span>Recorded: {qualitySnapshot.created_at}</span>
+              </div>
+              {snapshot.blocker_summary.length > 0 && (
+                <div className="border border-line bg-bg-1 p-2 text-rust">
+                  {snapshot.blocker_summary[0]}
+                </div>
+              )}
+              {failedGates.length > 0 && (
+                <div className="flex flex-col gap-1 text-ink-2">
+                  {failedGates.slice(0, 3).map((gate) => (
+                    <div key={gate.name}>
+                      {formatLabel(gate.name)}: {gate.message}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <span className="text-ink-3">No quality snapshot recorded</span>
+          )}
+        </section>
+      )}
 
       <section>
         <div className="text-ink-3 mb-1 uppercase tracking-[0.08em]">Rounds / Elapsed</div>

--- a/web/src/components/TaskDetailSlideover.test.tsx
+++ b/web/src/components/TaskDetailSlideover.test.tsx
@@ -189,6 +189,9 @@ describe("TaskDetailSlideover", () => {
           { task_id: task.id, turn: 1, phase: "implement", prompt: "Write the fix", created_at: "2024-01-01T00:10:00Z" },
         ]);
       }
+      if (url.includes("/api/evals/pr/")) {
+        return Promise.resolve({ quality_snapshots: [] });
+      }
       return Promise.resolve([]);
     });
     wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
@@ -201,6 +204,102 @@ describe("TaskDetailSlideover", () => {
     expect(await screen.findByText(/implement/)).toBeInTheDocument();
     expect(card).toHaveTextContent("1 prompt recorded");
     expect(card).not.toHaveTextContent("Write the fix");
+    await waitFor(() => {
+      expect(card).toHaveTextContent("No quality snapshot recorded");
+    });
+    expect(mockApiJson).toHaveBeenCalledWith(
+      "/api/evals/pr/owner/repo/42?limit=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("renders the latest PR quality snapshot for terminal PR tasks", async () => {
+    const task = makeFullTask({
+      status: "done",
+      pr_url: "https://github.com/owner/repo/pull/42",
+      workflow: { state: "ready_to_merge", pr_number: 42 },
+      updated_at: "2024-01-01T01:00:00Z",
+    });
+    mockUseTaskDetail.mockReturnValue({ data: task, isLoading: false, isError: false });
+    mockApiJson.mockImplementation((url: string) => {
+      if (url.includes("/artifacts")) return Promise.resolve([]);
+      if (url.includes("/prompts")) return Promise.resolve([]);
+      if (url.includes("/api/evals/pr/")) {
+        return Promise.resolve({
+          quality_snapshots: [
+            {
+              id: "snapshot-1",
+              run_id: "run-1",
+              created_at: "2026-06-06T20:20:00Z",
+              snapshot: {
+                scenario: "pr_repair",
+                run_mode: "live_run",
+                target: {
+                  kind: "pull_request",
+                  repo: "owner/repo",
+                  pr_number: 42,
+                  base_ref: "main",
+                  head_ref: "fix/pr-42",
+                },
+                baseline_pr: null,
+                final_pr: {
+                  repo: "owner/repo",
+                  pr_number: 42,
+                  url: "https://github.com/owner/repo/pull/42",
+                  title: "Fix PR",
+                  base_ref: "main",
+                  head_ref: "fix/pr-42",
+                  head_oid: "abcdef1234567890",
+                  is_draft: false,
+                  merge_state: "clean",
+                  check_state: "passing",
+                  review_decision: "approved",
+                  active_unresolved_review_threads: [],
+                  review_threads_complete: true,
+                  changed_files: [],
+                  changed_files_complete: true,
+                  collected_at: "2026-06-06T20:19:00Z",
+                },
+                runtime: null,
+                hard_gates: [
+                  {
+                    name: "target_correctness",
+                    status: "pass",
+                    grade_cap: null,
+                    message: "Target matched",
+                  },
+                  {
+                    name: "review_thread_closure",
+                    status: "fail",
+                    grade_cap: "C",
+                    message: "One active thread remains",
+                  },
+                ],
+                final_score: 86,
+                final_grade: "B",
+                grade_cap: "C",
+                blocker_summary: ["One active thread remains"],
+              },
+            },
+          ],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    wrap(<TaskDetailSlideover taskId={task.id} onClose={vi.fn()} />);
+
+    const card = await screen.findByTestId("proof-of-work-card");
+    await waitFor(() => {
+      expect(card).toHaveTextContent("Quality Snapshot");
+      expect(card).toHaveTextContent("Grade B");
+      expect(card).toHaveTextContent("Score: 86/100");
+      expect(card).toHaveTextContent("Run: live run");
+      expect(card).toHaveTextContent("Head: abcdef123456");
+      expect(card).toHaveTextContent("Gates: 1/2");
+      expect(card).toHaveTextContent("One active thread remains");
+      expect(card).toHaveTextContent("review thread closure");
+    });
   });
 
   it("does not render proof-of-work card for non-terminal task", () => {

--- a/web/src/components/TaskDetailSlideover.tsx
+++ b/web/src/components/TaskDetailSlideover.tsx
@@ -4,7 +4,12 @@ import { useTaskDetail, useTaskStream } from "@/lib/queries";
 import { apiJson } from "@/lib/api";
 import { isTerminal } from "@/types/task";
 import { ProofOfWorkCard } from "./ProofOfWorkCard";
-import type { FullTask, TaskArtifact, TaskPrompt } from "@/types";
+import type {
+  EvalQualitySnapshotsResponse,
+  FullTask,
+  TaskArtifact,
+  TaskPrompt,
+} from "@/types";
 
 type Tab = "summary" | "output" | "prompts" | "artifacts";
 
@@ -52,6 +57,18 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
     queryKey: ["task-prompts", taskId],
     queryFn: ({ signal }) => apiJson<TaskPrompt[]>(`/tasks/${taskId}/prompts`, { signal }),
     enabled: !!taskId && (activeTab === "prompts" || isTaskTerminal),
+  });
+
+  const prQualityPath = qualitySnapshotPath(task?.pr_url ?? null);
+  const {
+    data: qualitySnapshots,
+    isFetching: isQualitySnapshotLoading,
+    isError: isQualitySnapshotError,
+  } = useQuery({
+    queryKey: ["pr-quality-snapshots", prQualityPath],
+    queryFn: ({ signal }) =>
+      apiJson<EvalQualitySnapshotsResponse>(prQualityPath!, { signal }),
+    enabled: isTaskTerminal && !!prQualityPath,
   });
 
   useEffect(() => {
@@ -133,6 +150,9 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
                   task={task}
                   prompts={prompts}
                   artifacts={artifacts}
+                  qualitySnapshot={qualitySnapshots?.quality_snapshots[0]}
+                  qualitySnapshotLoading={isQualitySnapshotLoading}
+                  qualitySnapshotError={isQualitySnapshotError}
                 />
               )}
             </>
@@ -159,6 +179,30 @@ export function TaskDetailSlideover({ taskId, onClose }: Props) {
       </div>
     </>
   );
+}
+
+function qualitySnapshotPath(prUrl: string | null): string | null {
+  const ref = parseGitHubPrUrl(prUrl);
+  if (!ref) return null;
+  return `/api/evals/pr/${encodeURIComponent(ref.owner)}/${encodeURIComponent(ref.repo)}/${ref.prNumber}?limit=1`;
+}
+
+function parseGitHubPrUrl(
+  prUrl: string | null,
+): { owner: string; repo: string; prNumber: number } | null {
+  if (!prUrl) return null;
+  let url: URL;
+  try {
+    url = new URL(prUrl);
+  } catch {
+    return null;
+  }
+  if (url.hostname !== "github.com") return null;
+  const [owner, repo, pull, number] = url.pathname.split("/").filter(Boolean);
+  if (!owner || !repo || pull !== "pull") return null;
+  const prNumber = Number.parseInt(number ?? "", 10);
+  if (!Number.isSafeInteger(prNumber) || prNumber <= 0) return null;
+  return { owner, repo, prNumber };
 }
 
 function formatFallbackLabel(value: string | null | undefined): string {

--- a/web/src/types/eval.ts
+++ b/web/src/types/eval.ts
@@ -1,0 +1,84 @@
+export interface EvalQualitySnapshotsResponse {
+  quality_snapshots: QualitySnapshotRecord[];
+}
+
+export interface QualitySnapshotRecord {
+  id: string;
+  run_id: string;
+  snapshot: QualitySnapshot;
+  created_at: string;
+}
+
+export interface QualitySnapshot {
+  scenario: string;
+  run_mode: string;
+  target: EvalTarget;
+  baseline_pr: PullRequestSnapshot | null;
+  final_pr: PullRequestSnapshot | null;
+  runtime: RuntimeSnapshot | null;
+  hard_gates: HardGateResult[];
+  final_score: number;
+  final_grade: string;
+  grade_cap: string | null;
+  blocker_summary: string[];
+}
+
+export type EvalTarget =
+  | {
+      kind: "pull_request";
+      repo: string;
+      pr_number: number;
+      base_ref: string | null;
+      head_ref: string | null;
+    }
+  | { kind: "issue"; repo: string; issue_number: number }
+  | { kind: "prompt_task"; task_id: string };
+
+export interface PullRequestSnapshot {
+  repo: string;
+  pr_number: number;
+  url: string | null;
+  title: string | null;
+  base_ref: string;
+  head_ref: string;
+  head_oid: string;
+  is_draft: boolean;
+  merge_state: string;
+  check_state: string;
+  review_decision: string | null;
+  active_unresolved_review_threads: ReviewThreadSnapshot[];
+  review_threads_complete: boolean;
+  changed_files: ChangedFileSnapshot[];
+  changed_files_complete: boolean;
+  collected_at: string;
+}
+
+export interface ReviewThreadSnapshot {
+  id: string;
+  path: string | null;
+  is_resolved: boolean;
+  is_outdated: boolean;
+}
+
+export interface ChangedFileSnapshot {
+  path: string;
+  additions: number;
+  deletions: number;
+  status: string;
+}
+
+export interface RuntimeSnapshot {
+  task_id: string | null;
+  workflow_id: string | null;
+  workflow_state: string | null;
+  latest_activity: string | null;
+  terminal_state: string | null;
+  collected_at: string;
+}
+
+export interface HardGateResult {
+  name: string;
+  status: string;
+  grade_cap: string | null;
+  message: string;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./dashboard";
+export * from "./eval";
 export * from "./operator_snapshot";
 export * from "./overview";
 export * from "./task";


### PR DESCRIPTION
## Summary
- Add typed frontend models for PR repair quality snapshots.
- Fetch the latest `/api/evals/pr/{owner}/{repo}/{pr_number}?limit=1` snapshot for terminal tasks with a GitHub PR URL.
- Render grade, score, run mode, final head, hard-gate status, failed gates, blockers, and loading/error/empty states in the proof-of-work card.

Closes #1272

## Verification
- `bun run typecheck`
- `bun run test -- TaskDetailSlideover.test.tsx`
- `bun run test`
- `bun run build`
- `cargo fmt --all`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test`
- `git diff --check`

Note: the web package does not define a `lint` script, so `bun run lint` is not available.