### PR TITLE
feat(runtime): gate PR readiness through quality gate

### DIFF
--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -689,9 +689,12 @@ pub(super) fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
         "scheduled" | "discovered" => TaskStatus::Pending,
         "planning" => TaskStatus::Planning,
         "implementing" | "replanning" | "addressing_feedback" => TaskStatus::Implementing,
-        "pr_open" | "local_review_gate" | "awaiting_feedback" | "ready_to_merge" | "blocked" => {
-            TaskStatus::Waiting
-        }
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge"
+        | "blocked" => TaskStatus::Waiting,
         "done" | "passed" => TaskStatus::Done,
         "failed" => TaskStatus::Failed,
         "cancelled" => TaskStatus::Cancelled,
@@ -702,9 +705,11 @@ pub(super) fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
 fn runtime_workflow_state_to_task_phase(state: &str) -> TaskPhase {
     match state {
         "done" | "passed" | "failed" | "cancelled" => TaskPhase::Terminal,
-        "pr_open" | "local_review_gate" | "awaiting_feedback" | "ready_to_merge" => {
-            TaskPhase::Review
-        }
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge" => TaskPhase::Review,
         "planning" | "replanning" | "blocked" => TaskPhase::Plan,
         _ => TaskPhase::Implement,
     }
@@ -726,9 +731,12 @@ fn runtime_workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSch
             scheduler.mark_terminal(status);
             scheduler
         }
-        "pr_open" | "local_review_gate" | "awaiting_feedback" | "ready_to_merge" | "blocked" => {
-            TaskSchedulerState::queued()
-        }
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge"
+        | "blocked" => TaskSchedulerState::queued(),
         _ => match status {
             TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
             TaskStatus::Pending => TaskSchedulerState::queued(),

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -317,7 +317,11 @@ pub(crate) fn proof_from_runtime_workflow(
     }) || accepted_decisions.iter().any(|record| {
         matches!(
             record.decision.decision.as_str(),
-            "mark_ready_to_merge" | "approve_merge" | "record_pr_merged" | "quality_passed"
+            "mark_ready_to_merge"
+                | "quality_gate_passed"
+                | "approve_merge"
+                | "record_pr_merged"
+                | "quality_passed"
         )
     }) || workflow.state == "passed";
     let changes_requested = events
@@ -361,6 +365,8 @@ pub(crate) fn proof_from_runtime_workflow(
                 "address_pr_feedback"
                     | "wait_for_pr_feedback"
                     | "mark_ready_to_merge"
+                    | "start_quality_gate"
+                    | "quality_gate_passed"
                     | "quality_passed"
             )
         })

--- a/crates/harness-server/src/http/tests/runtime_worker_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_tests.rs
@@ -599,3 +599,106 @@ async fn runtime_job_worker_starts_pr_feedback_child_workflow_without_agent_turn
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn runtime_job_worker_starts_quality_gate_child_workflow_without_agent_turn(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-quality-gate-child");
+    std::fs::create_dir_all(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let parent = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "quality_gate_pending",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:227"),
+    )
+    .with_id("issue-quality-gate-parent")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "repo": "owner/repo",
+        "issue_number": 227,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+        "task_id": "runtime-task-227",
+    }));
+    store.upsert_instance(&parent).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow,
+        "quality-gate:issue-227:77",
+        serde_json::json!({
+            "definition_id": harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID,
+            "subject_key": "pr:77",
+            "child_activity": harness_workflow::runtime::QUALITY_GATE_ACTIVITY,
+            "repo": "owner/repo",
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "validation_commands": ["cargo check"],
+        }),
+    );
+    let command_id = store.enqueue_command(&parent.id, None, &command).await?;
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": parent.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key.clone(),
+                "activity": command.runtime_activity_key(),
+                "command": command.command.clone(),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.succeeded, 1);
+    assert_eq!(
+        store
+            .runtime_turns_started_for_workflow(&parent.id, None)
+            .await?,
+        0
+    );
+    let children = store
+        .list_instances_by_definition(
+            harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID,
+            Some(&project_id),
+            None,
+        )
+        .await?;
+    assert_eq!(children.len(), 1);
+    let child = &children[0];
+    assert_eq!(child.state, "checking");
+    assert_eq!(
+        child.parent_workflow_id.as_deref(),
+        Some("issue-quality-gate-parent")
+    );
+    assert_eq!(child.data["pr_number"], 77);
+    assert_eq!(child.data["started_by_runtime_job_id"], runtime_job.id);
+    assert_eq!(child.data["validation_commands"][0], "cargo check");
+    let child_commands = store.commands_for(&child.id).await?;
+    assert_eq!(child_commands.len(), 1);
+    assert_eq!(
+        child_commands[0].command.activity_name(),
+        Some(harness_workflow::runtime::QUALITY_GATE_ACTIVITY)
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/task_executor/local_review_completion_tests.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion_tests.rs
@@ -292,7 +292,7 @@ async fn hosted_bot_disabled_completion_records_ready_to_merge_feedback() -> any
         .get_instance(&workflow_id)
         .await?
         .expect("workflow instance should be recorded");
-    assert_eq!(instance.state, "ready_to_merge");
+    assert_eq!(instance.state, "quality_gate_pending");
     let events = runtime_store.events_for(&workflow_id).await?;
     assert!(events
         .iter()

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -183,11 +183,18 @@ async fn pr_feedback_ready_to_merge_updates_parent_workflow_after_local_review(
         .get_instance(&workflow_id)
         .await?
         .expect("workflow instance should be persisted");
-    assert_eq!(instance.state, "ready_to_merge");
+    assert_eq!(instance.state, "quality_gate_pending");
     let events = store.events_for(&workflow_id).await?;
     assert!(events
         .iter()
         .any(|event| event.event_type == "PrReadyToMerge"));
+    let commands = store.commands_for(&workflow_id).await?;
+    assert!(commands.iter().any(|command| {
+        command.command.command_type
+            == harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
+            && command.command.command["definition_id"]
+                == harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID
+    }));
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -1,10 +1,11 @@
 use crate::http::AppState;
 use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
-    build_pr_feedback_inspect_decision, ActivityArtifact, ActivityErrorKind, ActivityResult,
-    DecisionValidator, PrFeedbackInspectDecisionInput, RuntimeJob, WorkflowDecisionRecord,
-    WorkflowDefinition, WorkflowInstance, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
-    PR_FEEDBACK_DEFINITION_ID,
+    build_pr_feedback_inspect_decision, build_quality_gate_run_decision, ActivityArtifact,
+    ActivityErrorKind, ActivityResult, DecisionValidator, PrFeedbackInspectDecisionInput,
+    QualityGateDecisionInput, RuntimeJob, WorkflowDecisionRecord, WorkflowDefinition,
+    WorkflowInstance, WorkflowSubject, PROMPT_TASK_DEFINITION_ID, PR_FEEDBACK_DEFINITION_ID,
+    QUALITY_GATE_DEFINITION_ID,
 };
 use serde_json::{json, Value};
 use std::path::Path;
@@ -38,6 +39,10 @@ pub(super) async fn execute_start_child_workflow(
     }
     if definition_id == PROMPT_TASK_DEFINITION_ID {
         return execute_start_prompt_task_child_workflow(state, job, parent, command, subject_key)
+            .await;
+    }
+    if definition_id == QUALITY_GATE_DEFINITION_ID {
+        return execute_start_quality_gate_child_workflow(state, job, parent, command, subject_key)
             .await;
     }
     if definition_id != "github_issue_pr" {
@@ -262,6 +267,175 @@ async fn execute_start_prompt_task_child_workflow(
             "decision_id": submission.decision_id,
             "command_ids": submission.command_ids,
             "rejection_reason": submission.rejection_reason,
+        }),
+    )))
+}
+
+async fn execute_start_quality_gate_child_workflow(
+    state: &Arc<AppState>,
+    job: &RuntimeJob,
+    parent: Option<&WorkflowInstance>,
+    command: &Value,
+    subject_key: &str,
+) -> anyhow::Result<ActivityResult> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        anyhow::bail!("workflow runtime store is unavailable");
+    };
+    let parent =
+        parent.ok_or_else(|| anyhow::anyhow!("quality_gate child workflow requires a parent"))?;
+    let project_id = parent
+        .data
+        .get("project_id")
+        .and_then(Value::as_str)
+        .or_else(|| job.input.get("project_id").and_then(Value::as_str))
+        .ok_or_else(|| anyhow::anyhow!("quality_gate child workflow project_id is missing"))?;
+    let repo = command
+        .get("repo")
+        .and_then(Value::as_str)
+        .or_else(|| parent.data.get("repo").and_then(Value::as_str));
+    let pr_number = command
+        .get("pr_number")
+        .and_then(Value::as_u64)
+        .or_else(|| parent.data.get("pr_number").and_then(Value::as_u64));
+    let pr_url = optional_string(command, "pr_url").or_else(|| {
+        parent
+            .data
+            .get("pr_url")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    });
+    let validation_commands = string_vec(command, "validation_commands");
+    let child_id = format!("{}::quality-gate:{}", parent.id, job.command_id);
+    store
+        .upsert_definition(&WorkflowDefinition::new(
+            QUALITY_GATE_DEFINITION_ID,
+            1,
+            "Quality gate workflow",
+        ))
+        .await?;
+    let mut child = match store.get_instance(&child_id).await? {
+        Some(instance) => instance,
+        None => WorkflowInstance::new(
+            QUALITY_GATE_DEFINITION_ID,
+            1,
+            "pending",
+            WorkflowSubject::new("quality_gate", subject_key),
+        )
+        .with_id(child_id.clone()),
+    };
+    if child.parent_workflow_id.is_none() {
+        child.parent_workflow_id = Some(parent.id.clone());
+    }
+    merge_json_object(
+        &mut child.data,
+        json!({
+            "project_id": project_id,
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_url": pr_url.clone(),
+            "parent_workflow_id": parent.id.as_str(),
+            "runtime_job_id": job.id.as_str(),
+            "command_id": job.command_id.as_str(),
+            "started_by_runtime_job_id": job.id.as_str(),
+            "started_by_command_id": job.command_id.as_str(),
+            "validation_commands": validation_commands.clone(),
+        }),
+    );
+    store.upsert_instance(&child).await?;
+    store
+        .append_event(
+            &child.id,
+            "ChildWorkflowStarted",
+            "workflow_runtime_worker",
+            json!({
+                "parent_workflow_id": parent.id.as_str(),
+                "runtime_job_id": job.id.as_str(),
+                "command_id": job.command_id.as_str(),
+                "definition_id": QUALITY_GATE_DEFINITION_ID,
+                "subject_key": subject_key,
+            }),
+        )
+        .await?;
+
+    let child_command_ids = if child.state == "pending" {
+        let event = store
+            .append_event(
+                &child.id,
+                "QualityGateRequested",
+                "workflow_runtime_worker",
+                json!({
+                    "parent_workflow_id": parent.id.as_str(),
+                    "pr_number": pr_number,
+                    "pr_url": pr_url.clone(),
+                    "repo": repo,
+                }),
+            )
+            .await?;
+        let output = build_quality_gate_run_decision(
+            &child,
+            QualityGateDecisionInput {
+                reason: "Parent PR workflow requested a quality gate before ready_to_merge.",
+                validation_commands: &validation_commands,
+            },
+        );
+        let validation = DecisionValidator::quality_gate().validate(
+            &child,
+            &output.decision,
+            &harness_workflow::runtime::ValidationContext::new(
+                "workflow_runtime_worker",
+                chrono::Utc::now(),
+            ),
+        );
+        let record = match validation {
+            Ok(()) => WorkflowDecisionRecord::accepted(output.decision.clone(), Some(event.id)),
+            Err(error) => {
+                let record = WorkflowDecisionRecord::rejected(
+                    output.decision,
+                    Some(event.id),
+                    error.to_string(),
+                );
+                store.record_decision(&record).await?;
+                return Ok(ActivityResult::failed(
+                    activity_name(job),
+                    "Quality gate child workflow request was rejected.",
+                    error.to_string(),
+                )
+                .with_error_kind(ActivityErrorKind::Configuration));
+            }
+        };
+        store.record_decision(&record).await?;
+        let mut command_ids = Vec::new();
+        for command in &output.decision.commands {
+            let command_id = store
+                .enqueue_command(&child.id, Some(&record.id), command)
+                .await?;
+            command_ids.push(command_id);
+        }
+        child.state = output.decision.next_state;
+        child.version = child.version.saturating_add(1);
+        store.upsert_instance(&child).await?;
+        command_ids
+    } else {
+        Vec::new()
+    };
+
+    Ok(ActivityResult::succeeded(
+        activity_name(job),
+        format!("Quality gate child workflow `{}` started.", child.id),
+    )
+    .with_artifact(ActivityArtifact::new(
+        "child_workflow",
+        json!({
+            "workflow_id": child.id,
+            "definition_id": child.definition_id,
+            "state": child.state,
+            "subject_key": child.subject.subject_key,
+        }),
+    ))
+    .with_artifact(ActivityArtifact::new(
+        "child_commands",
+        json!({
+            "command_ids": child_command_ids,
         }),
     )))
 }

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -357,15 +357,15 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         ("github_issue_pr", "sweep_pr_feedback")
         | ("github_issue_pr", PR_FEEDBACK_INSPECT_ACTIVITY) => json!({
             "on_succeeded": {
-                "reducer_next_state": "derived_from_structured_decision_or_signals",
+                "reducer_next_state": "derived_from_structured_decision_or_signals; ready evidence starts quality_gate before ready_to_merge",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
                 "accepted_artifacts": ["workflow_decision", SERVER_PR_SNAPSHOT_ARTIFACT, PR_FEEDBACK_SNAPSHOT_ARTIFACT],
-                "success_requires": "PrReadyToMerge or mark_ready_to_merge requires server_pr_snapshot collected by Harness with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, complete reviewThreads, and zero active unresolved review threads.",
+                "success_requires": "PrReadyToMerge requires server_pr_snapshot collected by Harness with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, complete reviewThreads, and zero active unresolved review threads; the parent then starts a quality_gate before ready_to_merge.",
                 "required_summary": "Describe inspected PR feedback, review state, checks, mergeability, draft state, unresolved review threads, snapshot source, and next action."
             },
             "structured_decision": {
                 "preferred": true,
-                "description": "Return a workflow_decision artifact for address_pr_feedback, wait_for_pr_feedback, or mark_ready_to_merge."
+                "description": "Return a workflow_decision artifact for address_pr_feedback or wait_for_pr_feedback. Prefer the PrReadyToMerge signal plus server_pr_snapshot for readiness; the reducer starts quality_gate."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -374,15 +374,15 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         }),
         (PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => json!({
             "on_succeeded": {
-                "reducer_next_state": "feedback_found_or_no_actionable_feedback_or_ready_to_merge_from_signals",
+                "reducer_next_state": "feedback_found_or_no_actionable_feedback_or_ready_to_merge_from_signals; parent ready evidence starts quality_gate first",
                 "accepted_signals": ["FeedbackFound", "NoFeedbackFound", "PrReadyToMerge", "ChangesRequested", "ChecksFailed"],
                 "accepted_artifacts": ["workflow_decision", SERVER_PR_SNAPSHOT_ARTIFACT, PR_FEEDBACK_SNAPSHOT_ARTIFACT],
-                "success_requires": "PrReadyToMerge or any workflow_decision with next_state=ready_to_merge requires server_pr_snapshot collected by Harness with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, complete reviewThreads, and zero active unresolved review threads.",
-                "parent_propagation": "The same activity result is propagated to the parent github_issue_pr workflow."
+                "success_requires": "PrReadyToMerge or any child workflow_decision with next_state=ready_to_merge requires server_pr_snapshot collected by Harness with final head, observed_at, APPROVED reviewDecision, isDraft=false, SUCCESS checks, CLEAN mergeStateStatus, complete reviewThreads, and zero active unresolved review threads.",
+                "parent_propagation": "The same activity result is propagated to the parent github_issue_pr workflow; the parent starts quality_gate before ready_to_merge."
             },
             "structured_decision": {
                 "optional": true,
-                "description": "A workflow_decision artifact may update the pr_feedback child workflow, but ready_to_merge workflow_decisions still require the same server_pr_snapshot evidence as PrReadyToMerge signals."
+                "description": "A workflow_decision artifact may update the pr_feedback child workflow, but ready_to_merge workflow_decisions still require the same server_pr_snapshot evidence as PrReadyToMerge signals; parent readiness goes through quality_gate."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -572,10 +572,10 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "artifacts": {
                 "workflow_decision": {
                     "optional": true,
-                    "allowed_decisions": ["address_pr_feedback", "wait_for_pr_feedback", "mark_ready_to_merge"]
+                    "allowed_decisions": ["address_pr_feedback", "wait_for_pr_feedback"]
                 },
                 "server_pr_snapshot": {
-                    "required_when": "Using PrReadyToMerge or mark_ready_to_merge.",
+                    "required_when": "Using PrReadyToMerge.",
                     "source": "Harness server GitHub GraphQL collector",
                     "fields": ["schema", "snapshot_source", "pr_number", "pr_url", "head_oid", "observed_at", "active_unresolved_review_threads", "active_unresolved_review_threads_count", "review_threads_complete", "status_check_rollup_state", "merge_state_status", "review_decision", "is_draft", "changed_files"]
                 },

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -373,7 +373,7 @@ fn activity_result_schema_describes_pr_feedback_child_contract() {
     );
     assert_eq!(
         schema["transition_contract"]["on_succeeded"]["parent_propagation"],
-        "The same activity result is propagated to the parent github_issue_pr workflow."
+        "The same activity result is propagated to the parent github_issue_pr workflow; the parent starts quality_gate before ready_to_merge."
     );
     assert!(
         schema["transition_contract"]["on_succeeded"]["success_requires"]
@@ -395,7 +395,7 @@ fn activity_result_schema_describes_pr_feedback_child_contract() {
     );
     assert_eq!(
         schema["agent_summary_contract"]["artifacts"]["server_pr_snapshot"]["required_when"],
-        "Using PrReadyToMerge or mark_ready_to_merge."
+        "Using PrReadyToMerge."
     );
     assert_eq!(schema["agent_summary_contract"]["server_owned"], true);
     assert_eq!(

--- a/crates/harness-workflow/src/runtime/pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/pr_feedback.rs
@@ -1,6 +1,7 @@
 use super::model::{
     WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
 };
+use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
 
 pub const PR_FEEDBACK_DEFINITION_ID: &str = "pr_feedback";
 pub const PR_FEEDBACK_INSPECT_ACTIVITY: &str = "inspect_pr_feedback";
@@ -23,6 +24,7 @@ pub enum PrFeedbackWorkflowAction {
     InspectFeedback,
     AddressFeedback,
     AwaitFeedback,
+    RequestQualityGate,
     ReadyToMerge,
 }
 
@@ -173,14 +175,26 @@ pub fn build_pr_feedback_decision(
             let decision = WorkflowDecision::new(
                 &instance.id,
                 &instance.state,
-                "mark_ready_to_merge",
-                "ready_to_merge",
+                "start_quality_gate",
+                "quality_gate_pending",
                 input.summary,
             )
+            .with_command(WorkflowCommand::new(
+                super::model::WorkflowCommandType::StartChildWorkflow,
+                format!("quality-gate:{}:{}:run", input.task_id, input.pr_number),
+                serde_json::json!({
+                    "definition_id": QUALITY_GATE_DEFINITION_ID,
+                    "subject_key": format!("pr:{}", input.pr_number),
+                    "child_activity": QUALITY_GATE_ACTIVITY,
+                    "pr_number": input.pr_number,
+                    "pr_url": input.pr_url,
+                    "validation_commands": [],
+                }),
+            ))
             .with_evidence(feedback_evidence(input))
             .high_confidence();
             PrFeedbackDecisionOutput {
-                action: PrFeedbackWorkflowAction::ReadyToMerge,
+                action: PrFeedbackWorkflowAction::RequestQualityGate,
                 decision,
             }
         }

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -20,8 +20,8 @@ use self::pr_feedback_completion::{
     pr_feedback_sweep_decision_from_activity_result,
 };
 use self::quality_gate_completion::{
-    quality_gate_activity_matches, quality_gate_success_contract_error,
-    quality_gate_success_decision,
+    parent_quality_gate_pass_decision, quality_gate_activity_matches,
+    quality_gate_success_contract_error, quality_gate_success_decision,
 };
 use self::repo_backlog_completion::{
     repo_backlog_child_dispatch_still_active, repo_backlog_invalid_success_decision,
@@ -125,6 +125,10 @@ fn reduce_success(
         .filter(|decision| structured_decision_validates(instance, event, result, decision))
         .cloned()
     {
+        return Some(decision);
+    }
+
+    if let Some(decision) = parent_quality_gate_pass_decision(instance, event, result) {
         return Some(decision);
     }
 

--- a/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
@@ -102,7 +102,12 @@ pub(super) fn github_issue_closed_decision(
 fn github_issue_state_can_finish_closed(state: &str) -> bool {
     matches!(
         state,
-        "implementing" | "pr_open" | "awaiting_feedback" | "addressing_feedback" | "ready_to_merge"
+        "implementing"
+            | "pr_open"
+            | "awaiting_feedback"
+            | "addressing_feedback"
+            | "quality_gate_pending"
+            | "ready_to_merge"
     )
 }
 

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -81,7 +81,16 @@ pub(super) fn pr_feedback_success_contract_error(
         if pr_feedback_outcome_from_signals(result) == Some(PrFeedbackOutcome::BlockingFeedback) {
             return None;
         }
-        if ready_snapshot_proves_pr_ready(instance, result) {
+        let ready_snapshot = ready_snapshot_proves_pr_ready(instance, result);
+        if structured_decision.is_some_and(structured_ready_decision)
+            && !has_signal(result, "PrReadyToMerge")
+            && ready_snapshot
+        {
+            return Some(
+                "PR readiness workflow_decision is no longer accepted directly: emit PrReadyToMerge with a current server_pr_snapshot so the parent workflow starts quality_gate before ready_to_merge".to_string(),
+            );
+        }
+        if ready_snapshot {
             return None;
         }
         return Some(

--- a/crates/harness-workflow/src/runtime/reducer/quality_gate_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/quality_gate_completion.rs
@@ -36,6 +36,42 @@ pub(super) fn quality_gate_success_decision(
     ))
 }
 
+pub(super) fn parent_quality_gate_pass_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        super::GITHUB_ISSUE_PR_DEFINITION_ID,
+        "quality_gate_pending",
+        QUALITY_GATE_ACTIVITY,
+    ) {
+        return None;
+    }
+
+    if let Some(reason) = quality_gate_success_contract_error(result) {
+        return Some(invalid_agent_output_blocked_decision(
+            instance, event, result, reason,
+        ));
+    }
+
+    Some(
+        WorkflowDecision::new(
+            &instance.id,
+            &instance.state,
+            "quality_gate_passed",
+            "ready_to_merge",
+            "quality gate passed; PR is ready to merge",
+        )
+        .with_evidence(runtime_completion_evidence(event, result))
+        .high_confidence(),
+    )
+}
+
 pub(super) fn quality_gate_activity_matches(
     instance: &WorkflowInstance,
     result: &ActivityResult,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -675,7 +675,7 @@ fn pr_feedback_decision_waits_when_no_actionable_feedback_exists() {
 }
 
 #[test]
-fn pr_feedback_decision_marks_ready_to_merge() {
+fn pr_feedback_decision_starts_quality_gate_before_ready_to_merge() {
     let instance = issue_instance("awaiting_feedback");
     let output = build_pr_feedback_decision(
         &instance,
@@ -688,16 +688,25 @@ fn pr_feedback_decision_marks_ready_to_merge() {
         },
     );
 
-    assert_eq!(output.action, PrFeedbackWorkflowAction::ReadyToMerge);
-    assert_eq!(output.decision.decision, "mark_ready_to_merge");
-    assert_eq!(output.decision.next_state, "ready_to_merge");
+    assert_eq!(output.action, PrFeedbackWorkflowAction::RequestQualityGate);
+    assert_eq!(output.decision.decision, "start_quality_gate");
+    assert_eq!(output.decision.next_state, "quality_gate_pending");
+    assert_eq!(
+        output.decision.commands[0].command_type,
+        WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(
+        output.decision.commands[0].command["definition_id"],
+        QUALITY_GATE_DEFINITION_ID
+    );
+    assert_eq!(output.decision.commands[0].command["subject_key"], "pr:77");
     DecisionValidator::github_issue_pr()
         .validate(
             &instance,
             &output.decision,
             &ValidationContext::new("workflow-policy", Utc::now()),
         )
-        .expect("ready-to-merge decision should validate");
+        .expect("quality gate request decision should validate");
 }
 
 #[test]
@@ -915,6 +924,47 @@ fn runtime_completion_reducer_finishes_closed_issue_signal_without_pr() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("closed issue completion should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_finishes_closed_issue_during_quality_gate() {
+    let instance = issue_instance("quality_gate_pending");
+    let result = ActivityResult::succeeded(
+        QUALITY_GATE_ACTIVITY,
+        "Issue was closed before quality gate completed.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "issue_state",
+        json!({
+            "issue_number": 123,
+            "state": "closed"
+        }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("closed issue artifact should finish the workflow");
+
+    assert_eq!(decision.decision, "finish_closed_issue");
+    assert_eq!(decision.next_state, "done");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("closed issue quality gate completion should validate");
 }
 
 #[test]
@@ -3040,6 +3090,76 @@ fn runtime_completion_reducer_passes_quality_gate_after_success() {
 }
 
 #[test]
+fn runtime_completion_reducer_marks_issue_pr_ready_after_quality_gate_pass() {
+    let instance = issue_instance("quality_gate_pending");
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ))
+        .with_validation(ValidationRecord::new("cargo check", "passed"));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("quality gate completion should mark parent ready");
+
+    assert_eq!(decision.decision, "quality_gate_passed");
+    assert_eq!(decision.next_state, "ready_to_merge");
+    assert!(decision.commands.is_empty());
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("parent quality gate pass transition should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_issue_pr_quality_gate_without_validation() {
+    let instance = issue_instance("quality_gate_pending");
+    let result = ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation was claimed.")
+        .with_signal(ActivitySignal::new(
+            QUALITY_PASSED_SIGNAL,
+            json!({
+                "validation": "passed"
+            }),
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("missing validation evidence should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("validation evidence"));
+}
+
+#[test]
 fn runtime_completion_reducer_blocks_quality_gate_success_without_status_signal() {
     let instance = quality_gate_instance("checking");
     let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate:run");
@@ -4801,6 +4921,156 @@ async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> a
         .expect("activity artifacts should be an array")
         .iter()
         .all(|artifact| artifact["artifact_type"] != "workflow_decision"));
+    Ok(())
+}
+
+async fn seed_quality_gate_child_job(
+    store: &WorkflowRuntimeStore,
+    parent_id: &str,
+    child_id: &str,
+) -> anyhow::Result<RuntimeJob> {
+    let parent = issue_instance("quality_gate_pending").with_id(parent_id);
+    store.upsert_instance(&parent).await?;
+    let child = WorkflowInstance::new(
+        QUALITY_GATE_DEFINITION_ID,
+        1,
+        "checking",
+        WorkflowSubject::new("quality_gate", "pr:77"),
+    )
+    .with_id(child_id)
+    .with_parent(parent.id.clone());
+    store.upsert_instance(&child).await?;
+    let command = WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-gate-77");
+    let command_id = store.enqueue_command(&child.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": QUALITY_GATE_ACTIVITY }),
+        )
+        .await
+}
+
+#[tokio::test]
+async fn runtime_worker_propagates_quality_gate_child_pass_to_parent() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let job = seed_quality_gate_child_job(&store, "issue-parent", "quality-gate-child").await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation passed.")
+            .with_signal(ActivitySignal::new(
+                QUALITY_PASSED_SIGNAL,
+                json!({ "validation": "passed" }),
+            ))
+            .with_validation(ValidationRecord::new("cargo check", "passed")),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance("quality-gate-child")
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "passed");
+    let parent_after = store
+        .get_instance("issue-parent")
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "ready_to_merge");
+    let parent_events = store.events_for("issue-parent").await?;
+    assert!(parent_events.iter().any(|event| {
+        event.event_type == "RuntimeJobCompleted"
+            && event.event["child_workflow_id"] == "quality-gate-child"
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_propagates_quality_gate_child_block_to_parent() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let job =
+        seed_quality_gate_child_job(&store, "issue-parent-blocked", "quality-gate-child-blocked")
+            .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "Validation was claimed.")
+            .with_signal(ActivitySignal::new(
+                QUALITY_PASSED_SIGNAL,
+                json!({ "validation": "passed" }),
+            )),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance("quality-gate-child-blocked")
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "blocked");
+    let parent_after = store
+        .get_instance("issue-parent-blocked")
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "blocked");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_worker_propagates_quality_gate_child_failure_to_parent() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let job =
+        seed_quality_gate_child_job(&store, "issue-parent-failed", "quality-gate-child-failed")
+            .await?;
+    let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
+    let executor = StaticRuntimeExecutor {
+        result: ActivityResult::failed(
+            QUALITY_GATE_ACTIVITY,
+            "Quality gate execution failed.",
+            "validation command failed",
+        )
+        .with_error_kind(ActivityErrorKind::Fatal),
+    };
+
+    let completed = worker
+        .run_once(&executor)
+        .await?
+        .expect("worker should claim and complete one job");
+
+    assert_eq!(completed.id, job.id);
+    let child_after = store
+        .get_instance("quality-gate-child-failed")
+        .await?
+        .expect("child workflow should exist");
+    assert_eq!(child_after.state, "failed");
+    let parent_after = store
+        .get_instance("issue-parent-failed")
+        .await?
+        .expect("parent workflow should exist");
+    assert_eq!(parent_after.state, "failed");
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -143,6 +143,37 @@ fn structured_ready_decision_without_current_pr_snapshot_blocks() {
 }
 
 #[test]
+fn structured_ready_decision_with_snapshot_without_ready_signal_blocks_quality_gate_bypass() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let proposed_decision = WorkflowDecision::new(
+        &instance.id,
+        "awaiting_feedback",
+        "mark_ready_to_merge",
+        "ready_to_merge",
+        "Agent reported the PR is ready.",
+    )
+    .high_confidence();
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime agent emitted a direct ready workflow decision.",
+    )
+    .with_artifact(ActivityArtifact::new(
+        "workflow_decision",
+        serde_json::to_value(&proposed_decision).expect("decision should serialize"),
+    ))
+    .with_artifact(ready_snapshot_artifact());
+    let event = event_for_result(result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("direct ready decision should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("quality_gate"));
+}
+
+#[test]
 fn structured_ready_decision_with_blocking_signal_uses_blocking_feedback() {
     let instance = pr_workflow_state("awaiting_feedback");
     let proposed_decision = WorkflowDecision::new(
@@ -369,7 +400,7 @@ fn address_pr_feedback_snapshot_for_different_pr_blocks() {
 }
 
 #[test]
-fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
+fn ready_to_merge_signal_with_current_pr_snapshot_starts_quality_gate() {
     let instance = pr_workflow_state("awaiting_feedback");
     let result = ActivityResult::succeeded(
         PR_FEEDBACK_INSPECT_ACTIVITY,
@@ -386,15 +417,25 @@ fn ready_to_merge_signal_with_current_pr_snapshot_can_mark_ready() {
         .expect("event should parse")
         .expect("valid snapshot should reduce");
 
-    assert_eq!(decision.decision, "mark_ready_to_merge");
-    assert_eq!(decision.next_state, "ready_to_merge");
+    assert_eq!(decision.decision, "start_quality_gate");
+    assert_eq!(decision.next_state, "quality_gate_pending");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::StartChildWorkflow
+    );
+    assert_eq!(
+        decision.commands[0].command["definition_id"],
+        QUALITY_GATE_DEFINITION_ID
+    );
+    assert_eq!(decision.commands[0].command["subject_key"], "pr:77");
     DecisionValidator::github_issue_pr()
         .validate(
             &instance,
             &decision,
             &ValidationContext::new("runtime-1", Utc::now()),
         )
-        .expect("ready snapshot decision should validate");
+        .expect("ready snapshot quality gate decision should validate");
 }
 
 #[test]
@@ -476,8 +517,8 @@ fn ready_to_merge_snapshot_accepts_quoted_pr_number() {
         .expect("event should parse")
         .expect("quoted snapshot PR number should reduce");
 
-    assert_eq!(decision.decision, "mark_ready_to_merge");
-    assert_eq!(decision.next_state, "ready_to_merge");
+    assert_eq!(decision.decision, "start_quality_gate");
+    assert_eq!(decision.next_state, "quality_gate_pending");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -198,11 +198,18 @@ impl TransitionAllowlist {
             )
             .allow(
                 "awaiting_feedback",
+                "quality_gate_pending",
+                [StartChildWorkflow, Wait],
+            )
+            .allow(
+                "quality_gate_pending",
                 "ready_to_merge",
-                [EnqueueActivity, StartChildWorkflow, Wait],
+                std::iter::empty::<WorkflowCommandType>(),
             )
             .allow("awaiting_feedback", "done", [MarkDone])
             .allow("addressing_feedback", "done", [MarkDone])
+            .allow("quality_gate_pending", "done", [MarkDone])
+            .allow("quality_gate_pending", "quality_gate_pending", [Wait])
             .allow("ready_to_merge", "ready_to_merge", [Wait])
             .allow("ready_to_merge", "done", [MarkDone])
             .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -134,6 +134,8 @@ impl<'a> RuntimeWorker<'a> {
         if let Some(event) = completion.workflow_event.as_ref() {
             self.propagate_pr_feedback_child_completion(&event.workflow_id, event)
                 .await?;
+            self.propagate_quality_gate_child_completion(&event.workflow_id, event)
+                .await?;
         }
         Ok(Some(completion.runtime_job))
     }
@@ -232,6 +234,39 @@ impl<'a> RuntimeWorker<'a> {
             return Ok(());
         }
         if matches!(child.state.as_str(), "pending" | "inspecting") {
+            return Ok(());
+        }
+        let Some(parent_workflow_id) = child.parent_workflow_id.as_deref() else {
+            return Ok(());
+        };
+        let parent_event = self
+            .store
+            .append_event(
+                parent_workflow_id,
+                "RuntimeJobCompleted",
+                &self.owner,
+                merge_child_completion_payload(event, &child.id),
+            )
+            .await?;
+        self.apply_runtime_completion_reducer(parent_workflow_id, &parent_event)
+            .await
+    }
+
+    async fn propagate_quality_gate_child_completion(
+        &self,
+        workflow_id: &str,
+        event: &super::model::WorkflowEvent,
+    ) -> anyhow::Result<()> {
+        let Some(child) = self.store.get_instance(workflow_id).await? else {
+            return Ok(());
+        };
+        if child.definition_id != super::quality_gate::QUALITY_GATE_DEFINITION_ID {
+            return Ok(());
+        }
+        if !matches!(
+            child.state.as_str(),
+            "passed" | "blocked" | "failed" | "cancelled"
+        ) {
             return Ok(());
         }
         let Some(parent_workflow_id) = child.parent_workflow_id.as_deref() else {


### PR DESCRIPTION
## Summary
- route ready PR feedback through `quality_gate_pending` instead of moving `github_issue_pr` directly to `ready_to_merge`
- start a `quality_gate` child workflow from current server-owned PR readiness evidence and propagate pass/block/failure/cancel back to the parent workflow
- block direct ready-to-merge workflow decision bypasses, update task projections, and refresh prompt contracts/tests for the new readiness path

Closes #1274.

## Verification
- `cargo fmt --all`
- `cargo test -p harness-workflow`
- `cargo test -p harness-server workflow_runtime_worker`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`