### PR TITLE
feat(web): add eval dashboard view

### DIFF
--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -136,6 +136,15 @@ Acceptance:
 - Operators can tell whether a PR repair succeeded, why it failed, and what it
   cost without reading raw logs.
 
+Implementation status:
+
+- Added a dashboard `Evals` tab backed by `/api/evals/runs` and
+  `/api/evals/quality-snapshots/{snapshot_id}`.
+- The view shows run status, scenario, target PR, score, grade, hard-gate pass
+  count, blockers, and usage totals when a quality snapshot exists.
+- Remaining work: add benchmark summary history and richer trend charts once
+  enough live-run samples exist.
+
 ### Issue 6: Add PR repair benchmark summaries
 
 Scope:

--- a/web/src/components/ProofOfWorkCard.tsx
+++ b/web/src/components/ProofOfWorkCard.tsx
@@ -1,4 +1,4 @@
-import { workflowLabel } from "@/lib/format";
+import { formatSnakeLabel, shortSha, workflowLabel } from "@/lib/format";
 import type { FullTask, QualitySnapshotRecord, TaskArtifact, TaskPrompt } from "@/types";
 
 interface Props {
@@ -27,15 +27,6 @@ function elapsedTime(createdAt: string | null, completedAt: string | undefined):
   if (s < 60) return `${s}s`;
   if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
   return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
-}
-
-function formatLabel(value: string): string {
-  return value.replaceAll("_", " ");
-}
-
-function shortSha(value: string | null | undefined): string {
-  if (!value) return "N/A";
-  return value.length > 12 ? value.slice(0, 12) : value;
 }
 
 export function ProofOfWorkCard({
@@ -93,7 +84,7 @@ export function ProofOfWorkCard({
                   Grade {snapshot.final_grade}
                 </span>
                 <span>Score: {snapshot.final_score}/100</span>
-                <span>Run: {formatLabel(snapshot.run_mode)}</span>
+                <span>Run: {formatSnakeLabel(snapshot.run_mode)}</span>
               </div>
               <div className="flex flex-wrap gap-2 text-ink-2">
                 <span>Head: {shortSha(snapshot.final_pr?.head_oid)}</span>
@@ -109,7 +100,7 @@ export function ProofOfWorkCard({
                 <div className="flex flex-col gap-1 text-ink-2">
                   {failedGates.slice(0, 3).map((gate) => (
                     <div key={gate.name}>
-                      {formatLabel(gate.name)}: {gate.message}
+                      {formatSnakeLabel(gate.name)}: {gate.message}
                     </div>
                   ))}
                 </div>

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -25,6 +25,16 @@ export function workflowLabel(state: string): string {
   }
 }
 
+export function formatSnakeLabel(value: string | null | undefined): string {
+  if (!value) return "N/A";
+  return value.replaceAll("_", " ");
+}
+
+export function shortSha(value: string | null | undefined): string {
+  if (!value) return "N/A";
+  return value.length > 12 ? value.slice(0, 12) : value;
+}
+
 function isFiniteNumber(n: unknown): n is number {
   return typeof n === "number" && Number.isFinite(n);
 }

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -3,6 +3,9 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiJson, apiFetch } from "./api";
 import type {
   DashboardPayload,
+  EvalDashboardResponse,
+  EvalQualitySnapshotResponse,
+  EvalRunsResponse,
   FullTask,
   OperatorSnapshotPayload,
   OverviewPayload,
@@ -39,6 +42,45 @@ export function useUsageMonitor() {
     queryKey: ["usage-monitor"],
     queryFn: ({ signal }) => apiJson<UsageMonitorPayload>("/api/usage-monitor", { signal }),
     refetchInterval: 5_000,
+  });
+}
+
+export function useEvalDashboard(limit = 50) {
+  return useQuery<EvalDashboardResponse, Error>({
+    queryKey: ["eval-dashboard", limit],
+    queryFn: async ({ signal }) => {
+      const runs = await apiJson<EvalRunsResponse>(`/api/evals/runs?limit=${limit}`, { signal });
+      const rows = await Promise.all(
+        runs.runs.map(async (run) => {
+          if (!run.quality_snapshot_id) {
+            return {
+              run,
+              quality_snapshot: null,
+              quality_snapshot_error: null,
+            };
+          }
+          try {
+            const snapshot = await apiJson<EvalQualitySnapshotResponse>(
+              `/api/evals/quality-snapshots/${encodeURIComponent(run.quality_snapshot_id)}`,
+              { signal },
+            );
+            return {
+              run,
+              quality_snapshot: snapshot.quality_snapshot,
+              quality_snapshot_error: null,
+            };
+          } catch (error) {
+            return {
+              run,
+              quality_snapshot: null,
+              quality_snapshot_error: error instanceof Error ? error.message : "snapshot unavailable",
+            };
+          }
+        }),
+      );
+      return { rows };
+    },
+    refetchInterval: 30_000,
   });
 }
 

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -7,12 +7,19 @@ import { Active } from "./dashboard/Active";
 import { History } from "./dashboard/History";
 import { Channels } from "./dashboard/Channels";
 import { Submit } from "./dashboard/Submit";
+import { Evals } from "./dashboard/Evals";
 import { useDashboard } from "@/lib/queries";
 
-type Tab = "board" | "history" | "channels" | "submit";
+type Tab = "board" | "history" | "channels" | "evals" | "submit";
 
 function parseTab(value: string | null): Tab | null {
-  if (value === "board" || value === "history" || value === "channels" || value === "submit") {
+  if (
+    value === "board" ||
+    value === "history" ||
+    value === "channels" ||
+    value === "evals" ||
+    value === "submit"
+  ) {
     return value;
   }
   return null;
@@ -41,6 +48,7 @@ export function Dashboard() {
         { id: "board", label: "Active", active: tab === "board" },
         { id: "history", label: "History", active: tab === "history" },
         { id: "channels", label: "Channels", active: tab === "channels" },
+        { id: "evals", label: "Evals", active: tab === "evals" },
         { id: "submit", label: "Submit", active: tab === "submit" },
       ],
     },
@@ -74,6 +82,7 @@ export function Dashboard() {
           {tab === "board" && <Active projectFilter={projectFilter} />}
           {tab === "history" && <History projectFilter={projectFilter} />}
           {tab === "channels" && <Channels projectFilter={projectFilter} />}
+          {tab === "evals" && <Evals />}
           {tab === "submit" && <Submit projectFilter={projectFilter} />}
         </div>
       </main>

--- a/web/src/routes/dashboard/Evals.test.tsx
+++ b/web/src/routes/dashboard/Evals.test.tsx
@@ -101,7 +101,7 @@ function row(id: string, quality: QualitySnapshot | null, error: string | null =
           head_ref: "fix/review",
         },
       source_task_id: "task-7",
-      status: quality ? "scored" : "created",
+      status: quality ? "Scored" : "Created",
       quality_snapshot_id: quality ? `snapshot-${id}` : null,
       created_at: "2026-06-06T00:00:00Z",
       updated_at: "2026-06-06T00:02:00Z",

--- a/web/src/routes/dashboard/Evals.test.tsx
+++ b/web/src/routes/dashboard/Evals.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Evals } from "./Evals";
+import type { EvalDashboardRow, QualitySnapshot } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useEvalDashboard: vi.fn(),
+}));
+
+import { useEvalDashboard } from "@/lib/queries";
+
+const mockUseEvalDashboard = useEvalDashboard as ReturnType<typeof vi.fn>;
+
+function snapshot(overrides: Partial<QualitySnapshot> = {}): QualitySnapshot {
+  return {
+    scenario: "pr_repair",
+    run_mode: "live_run",
+    target: {
+      kind: "pull_request",
+      repo: "owner/repo",
+      pr_number: 7,
+      base_ref: "main",
+      head_ref: "fix/review",
+    },
+    baseline_pr: null,
+    final_pr: {
+      repo: "owner/repo",
+      pr_number: 7,
+      url: "https://github.com/owner/repo/pull/7",
+      title: "Fix review",
+      base_ref: "main",
+      head_ref: "fix/review",
+      head_oid: "abcdef1234567890",
+      is_draft: false,
+      merge_state: "clean",
+      check_state: "passing",
+      review_decision: "approved",
+      active_unresolved_review_threads: [],
+      review_threads_complete: true,
+      changed_files: [],
+      changed_files_complete: true,
+      collected_at: "2026-06-06T00:01:00Z",
+    },
+    runtime: {
+      task_id: "task-7",
+      workflow_id: "workflow-7",
+      workflow_state: "ready_to_merge",
+      latest_activity: "quality_gate",
+      terminal_state: "ready_to_merge",
+      collected_at: "2026-06-06T00:01:00Z",
+    },
+    hard_gates: [
+      {
+        name: "target_correctness",
+        status: "pass",
+        grade_cap: null,
+        message: "final PR matches the requested target",
+      },
+      {
+        name: "review_thread_closure",
+        status: "pass",
+        grade_cap: null,
+        message: "review threads were closed",
+      },
+    ],
+    final_score: 96,
+    final_grade: "A",
+    grade_cap: null,
+    blocker_summary: [],
+    usage: [
+      {
+        agent_invocation_id: "agent-7",
+        runtime_job_id: "job-7",
+        workflow_id: "workflow-7",
+        model: "codex-test",
+        reasoning_effort: "medium",
+        input_tokens: 1000,
+        output_tokens: 500,
+        cached_input_tokens: 0,
+        total_tokens: 1500,
+        cost_usd_micros: 1234,
+        token_confidence: "exact",
+        cost_confidence: "estimated",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function row(id: string, quality: QualitySnapshot | null, error: string | null = null): EvalDashboardRow {
+  return {
+    run: {
+      id,
+      scenario: quality?.scenario ?? "pr_repair",
+      target:
+        quality?.target ?? {
+          kind: "pull_request",
+          repo: "owner/repo",
+          pr_number: 7,
+          base_ref: "main",
+          head_ref: "fix/review",
+        },
+      source_task_id: "task-7",
+      status: quality ? "scored" : "created",
+      quality_snapshot_id: quality ? `snapshot-${id}` : null,
+      created_at: "2026-06-06T00:00:00Z",
+      updated_at: "2026-06-06T00:02:00Z",
+      completed_at: quality ? "2026-06-06T00:02:00Z" : null,
+    },
+    quality_snapshot: quality
+      ? {
+          id: `snapshot-${id}`,
+          run_id: id,
+          snapshot: quality,
+          created_at: "2026-06-06T00:02:00Z",
+        }
+      : null,
+    quality_snapshot_error: error,
+  };
+}
+
+describe("<Evals>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders scored eval rows with score, gates, usage, and PR target", () => {
+    mockUseEvalDashboard.mockReturnValue({
+      data: { rows: [row("run-1", snapshot())] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<Evals />);
+
+    expect(mockUseEvalDashboard).toHaveBeenCalledWith(50);
+    expect(screen.getByText("1 eval runs")).toBeInTheDocument();
+    expect(screen.getByText("owner/repo#7")).toHaveAttribute(
+      "href",
+      "https://github.com/owner/repo/pull/7",
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("96/100")).toBeInTheDocument();
+    expect(screen.getByText("2/2")).toBeInTheDocument();
+    expect(screen.getByText("1,500 tokens")).toBeInTheDocument();
+    expect(screen.getByText("$0.0012")).toBeInTheDocument();
+  });
+
+  it("filters blocked runs from failed hard gates and snapshot errors", () => {
+    const blocked = snapshot({
+      final_score: 74,
+      final_grade: "C",
+      blocker_summary: ["active unresolved review threads remain"],
+      hard_gates: [
+        {
+          name: "review_thread_closure",
+          status: "fail",
+          grade_cap: "C",
+          message: "active unresolved review threads remain",
+        },
+      ],
+    });
+    mockUseEvalDashboard.mockReturnValue({
+      data: {
+        rows: [
+          row("run-pass", snapshot()),
+          row("run-blocked", blocked),
+          row("run-error", null, "snapshot unavailable"),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<Evals />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "blocked" } });
+
+    expect(screen.queryByText("run-pass")).not.toBeInTheDocument();
+    expect(screen.getByText("run-blocked")).toBeInTheDocument();
+    expect(screen.getByText("snapshot unavailable")).toBeInTheDocument();
+    expect(screen.getAllByText("blocked").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows empty state when no eval rows match search", () => {
+    mockUseEvalDashboard.mockReturnValue({
+      data: { rows: [row("run-1", snapshot())] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<Evals />);
+    fireEvent.change(screen.getByPlaceholderText("Search evals…"), {
+      target: { value: "missing" },
+    });
+
+    expect(screen.getByText("No eval runs found.")).toBeInTheDocument();
+    const metrics = screen.getByText("Runs").parentElement;
+    if (!metrics) throw new Error("missing metrics");
+    expect(within(metrics).getByText("1")).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/dashboard/Evals.tsx
+++ b/web/src/routes/dashboard/Evals.tsx
@@ -64,6 +64,7 @@ function rowMatchesQuery(row: EvalDashboardRow, query: string): boolean {
     row.run.id,
     row.run.scenario,
     row.run.status,
+    normalizedStatus(row.run.status),
     row.run.source_task_id,
     targetLabel(row.run.target),
     snapshot?.final_grade,
@@ -81,8 +82,20 @@ function gradeClass(grade: string | null | undefined): string {
 
 function evalStatusClass(run: EvalRun, blocked: boolean): string {
   if (blocked) return "border-rust/40 bg-rust/10 text-rust";
-  if (run.status === "scored") return "border-ok/40 bg-ok/10 text-ok";
+  if (runIsScored(run)) return "border-ok/40 bg-ok/10 text-ok";
   return "border-line bg-bg text-ink-3";
+}
+
+function normalizedStatus(status: string): string {
+  return status
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+function runIsScored(run: EvalRun): boolean {
+  return normalizedStatus(run.status) === "scored";
 }
 
 function usageTotals(usage: UsageSnapshot[] | undefined): { tokens: number | null; micros: number | null } {
@@ -128,7 +141,7 @@ export function Evals() {
     );
   }, [data?.rows, filter, query]);
 
-  const scored = (data?.rows ?? []).filter((row) => row.run.status === "scored").length;
+  const scored = (data?.rows ?? []).filter((row) => runIsScored(row.run)).length;
   const blocked = (data?.rows ?? []).filter((row) => blockerCount(row) > 0 || row.quality_snapshot_error).length;
   const live = (data?.rows ?? []).filter((row) => rowRunMode(row) === "live_run").length;
   const visibleSnapshots = rows
@@ -261,7 +274,7 @@ function EvalRow({ row }: { row: EvalDashboardRow }) {
       </td>
       <td className="px-3 py-2">
         <span className={`inline-block border px-1.5 py-[1px] font-mono text-[10px] ${evalStatusClass(row.run, blocked)}`}>
-          {blocked ? "blocked" : formatSnakeLabel(row.run.status)}
+          {blocked ? "blocked" : formatSnakeLabel(normalizedStatus(row.run.status))}
         </span>
         {row.run.source_task_id ? (
           <div className="mt-1 truncate font-mono text-[10px] text-ink-4" title={row.run.source_task_id}>

--- a/web/src/routes/dashboard/Evals.tsx
+++ b/web/src/routes/dashboard/Evals.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useState } from "react";
+import { fmtInt, formatSnakeLabel, relativeAgo, shortSha } from "@/lib/format";
+import { useEvalDashboard } from "@/lib/queries";
+import type {
+  EvalDashboardRow,
+  EvalRun,
+  EvalTarget,
+  HardGateResult,
+  QualitySnapshot,
+  UsageSnapshot,
+} from "@/types";
+
+type Filter = "all" | "live" | "collect" | "blocked";
+
+function targetLabel(target: EvalTarget): string {
+  switch (target.kind) {
+    case "pull_request":
+      return `${target.repo}#${target.pr_number}`;
+    case "issue":
+      return `${target.repo}#${target.issue_number}`;
+    case "prompt_task":
+      return target.task_id;
+  }
+}
+
+function targetHref(target: EvalTarget, snapshot: QualitySnapshot | null): string | null {
+  if (target.kind !== "pull_request") return null;
+  return snapshot?.final_pr?.url ?? snapshot?.baseline_pr?.url ?? null;
+}
+
+function failedGates(snapshot: QualitySnapshot | null): HardGateResult[] {
+  return snapshot?.hard_gates.filter((gate) => gate.status === "fail") ?? [];
+}
+
+function gateLabel(snapshot: QualitySnapshot | null): string {
+  if (!snapshot) return "N/A";
+  const passed = snapshot.hard_gates.filter((gate) => gate.status === "pass").length;
+  return `${passed}/${snapshot.hard_gates.length}`;
+}
+
+function blockerCount(row: EvalDashboardRow): number {
+  const snapshot = row.quality_snapshot?.snapshot ?? null;
+  return failedGates(snapshot).length + (snapshot?.blocker_summary.length ?? 0);
+}
+
+function rowRunMode(row: EvalDashboardRow): string | null {
+  return row.quality_snapshot?.snapshot.run_mode ?? null;
+}
+
+function rowMatchesFilter(row: EvalDashboardRow, filter: Filter): boolean {
+  if (filter === "all") return true;
+  if (filter === "blocked") return blockerCount(row) > 0 || !!row.quality_snapshot_error;
+  const mode = rowRunMode(row);
+  if (filter === "live") return mode === "live_run";
+  if (filter === "collect") return mode === "collect_only";
+  return true;
+}
+
+function rowMatchesQuery(row: EvalDashboardRow, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const snapshot = row.quality_snapshot?.snapshot;
+  return [
+    row.run.id,
+    row.run.scenario,
+    row.run.status,
+    row.run.source_task_id,
+    targetLabel(row.run.target),
+    snapshot?.final_grade,
+    snapshot?.final_pr?.head_oid,
+  ].some((value) => value?.toLowerCase().includes(q));
+}
+
+function gradeClass(grade: string | null | undefined): string {
+  if (grade === "A") return "border-ok/40 bg-ok/10 text-ok";
+  if (grade === "B") return "border-sky/40 bg-sky/10 text-sky";
+  if (grade === "C") return "border-warn/40 bg-warn/10 text-warn";
+  if (grade === "D" || grade === "F") return "border-rust/40 bg-rust/10 text-rust";
+  return "border-line bg-bg text-ink-3";
+}
+
+function evalStatusClass(run: EvalRun, blocked: boolean): string {
+  if (blocked) return "border-rust/40 bg-rust/10 text-rust";
+  if (run.status === "scored") return "border-ok/40 bg-ok/10 text-ok";
+  return "border-line bg-bg text-ink-3";
+}
+
+function usageTotals(usage: UsageSnapshot[] | undefined): { tokens: number | null; micros: number | null } {
+  if (!usage || usage.length === 0) return { tokens: null, micros: null };
+  let hasTokens = false;
+  let tokens = 0;
+  let hasCost = false;
+  let micros = 0;
+  for (const item of usage) {
+    if (typeof item.total_tokens === "number") {
+      hasTokens = true;
+      tokens += item.total_tokens;
+    }
+    if (typeof item.cost_usd_micros === "number") {
+      hasCost = true;
+      micros += item.cost_usd_micros;
+    }
+  }
+  return { tokens: hasTokens ? tokens : null, micros: hasCost ? micros : null };
+}
+
+function formatCost(micros: number | null): string {
+  if (micros === null) return "N/A";
+  return `$${(micros / 1_000_000).toFixed(4)}`;
+}
+
+function sortRows(rows: EvalDashboardRow[]): EvalDashboardRow[] {
+  return [...rows].sort((a, b) => {
+    const aTime = Date.parse(a.run.updated_at);
+    const bTime = Date.parse(b.run.updated_at);
+    return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
+  });
+}
+
+export function Evals() {
+  const [filter, setFilter] = useState<Filter>("all");
+  const [query, setQuery] = useState("");
+  const { data, isLoading, isError } = useEvalDashboard(50);
+
+  const rows = useMemo(() => {
+    return sortRows(data?.rows ?? []).filter(
+      (row) => rowMatchesFilter(row, filter) && rowMatchesQuery(row, query),
+    );
+  }, [data?.rows, filter, query]);
+
+  const scored = (data?.rows ?? []).filter((row) => row.run.status === "scored").length;
+  const blocked = (data?.rows ?? []).filter((row) => blockerCount(row) > 0 || row.quality_snapshot_error).length;
+  const live = (data?.rows ?? []).filter((row) => rowRunMode(row) === "live_run").length;
+  const visibleSnapshots = rows
+    .map((row) => row.quality_snapshot?.snapshot)
+    .filter((snapshot): snapshot is QualitySnapshot => !!snapshot);
+  const averageScore =
+    visibleSnapshots.length === 0
+      ? null
+      : Math.round(
+          visibleSnapshots.reduce((sum, snapshot) => sum + snapshot.final_score, 0) /
+            visibleSnapshots.length,
+        );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-4 gap-3">
+        <Metric label="Runs" value={fmtInt(data?.rows.length ?? 0)} />
+        <Metric label="Scored" value={fmtInt(scored)} />
+        <Metric label="Live" value={fmtInt(live)} />
+        <Metric label="Blocked" value={fmtInt(blocked)} tone={blocked > 0 ? "bad" : "ok"} />
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search evals…"
+          className="flex-1 h-[30px] bg-bg-1 border border-line-2 px-2.5 text-ink font-mono text-[12px] rounded-[3px]"
+        />
+        <select
+          value={filter}
+          onChange={(event) => setFilter(event.target.value as Filter)}
+          className="h-[30px] bg-bg-1 border border-line-2 text-ink font-mono text-[12px] px-2 rounded-[3px]"
+        >
+          <option value="all">All</option>
+          <option value="live">Live</option>
+          <option value="collect">Collect-only</option>
+          <option value="blocked">Blocked</option>
+        </select>
+      </div>
+
+      <div className="border border-line bg-bg-1">
+        <div className="flex items-center justify-between border-b border-line px-3 py-2 font-mono text-[11px] text-ink-3">
+          <span>{rows.length} eval runs</span>
+          <span>avg score {averageScore === null ? "N/A" : `${averageScore}/100`}</span>
+        </div>
+
+        {isLoading ? (
+          <div className="px-3 py-8 text-center font-mono text-[12px] text-ink-3">Loading evals…</div>
+        ) : isError ? (
+          <div className="px-3 py-8 text-center font-mono text-[12px] text-rust">Evals unavailable</div>
+        ) : rows.length === 0 ? (
+          <div className="px-3 py-10 text-center font-mono text-[12px] text-ink-3">No eval runs found.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[980px] border-collapse text-left">
+              <thead className="border-b border-line bg-bg">
+                <tr className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-4">
+                  <th className="w-[90px] px-3 py-2 font-normal">Updated</th>
+                  <th className="px-3 py-2 font-normal">Target</th>
+                  <th className="w-[120px] px-3 py-2 font-normal">Scenario</th>
+                  <th className="w-[120px] px-3 py-2 font-normal">Status</th>
+                  <th className="w-[110px] px-3 py-2 font-normal">Score</th>
+                  <th className="w-[90px] px-3 py-2 font-normal">Gates</th>
+                  <th className="w-[130px] px-3 py-2 font-normal">Usage</th>
+                  <th className="w-[220px] px-3 py-2 font-normal">Blocker</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <EvalRow key={row.run.id} row={row} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone?: "ok" | "bad" }) {
+  const toneClass = tone === "bad" ? "text-rust" : tone === "ok" ? "text-ok" : "text-ink";
+  return (
+    <div className="border border-line bg-bg-1 px-3 py-2">
+      <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-4">{label}</div>
+      <div className={`mt-1 font-mono text-[20px] leading-none ${toneClass}`}>{value}</div>
+    </div>
+  );
+}
+
+function EvalRow({ row }: { row: EvalDashboardRow }) {
+  const snapshot = row.quality_snapshot?.snapshot ?? null;
+  const target = targetLabel(row.run.target);
+  const href = targetHref(row.run.target, snapshot);
+  const blockers = [
+    ...(snapshot?.blocker_summary ?? []),
+        ...failedGates(snapshot).map((gate) => `${formatSnakeLabel(gate.name)}: ${gate.message}`),
+  ];
+  const totals = usageTotals(snapshot?.usage);
+  const blocked = blockers.length > 0 || !!row.quality_snapshot_error;
+
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+        {row.run.updated_at ? relativeAgo(row.run.updated_at) : "N/A"}
+      </td>
+      <td className="px-3 py-2">
+        <div className="min-w-0">
+          {href ? (
+            <a href={href} target="_blank" rel="noreferrer" className="font-mono text-[11px] text-rust hover:underline">
+              {target}
+            </a>
+          ) : (
+            <span className="font-mono text-[11px] text-ink">{target}</span>
+          )}
+          <div className="mt-1 truncate font-mono text-[10px] text-ink-4" title={row.run.id}>
+            {row.run.id}
+          </div>
+          {snapshot?.final_pr?.head_oid ? (
+            <div className="mt-1 font-mono text-[10px] text-ink-3">
+              head {shortSha(snapshot.final_pr.head_oid)}
+            </div>
+          ) : null}
+        </div>
+      </td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+        <div>{formatSnakeLabel(row.run.scenario)}</div>
+        <div className="mt-1 text-[10px] text-ink-4">{formatSnakeLabel(snapshot?.run_mode)}</div>
+      </td>
+      <td className="px-3 py-2">
+        <span className={`inline-block border px-1.5 py-[1px] font-mono text-[10px] ${evalStatusClass(row.run, blocked)}`}>
+          {blocked ? "blocked" : formatSnakeLabel(row.run.status)}
+        </span>
+        {row.run.source_task_id ? (
+          <div className="mt-1 truncate font-mono text-[10px] text-ink-4" title={row.run.source_task_id}>
+            task {row.run.source_task_id}
+          </div>
+        ) : null}
+      </td>
+      <td className="px-3 py-2">
+        {snapshot ? (
+          <div className="flex items-center gap-2 font-mono text-[11px]">
+            <span className={`border px-1.5 py-[1px] text-[10px] ${gradeClass(snapshot.final_grade)}`}>
+              {snapshot.final_grade}
+            </span>
+            <span className="text-ink">{snapshot.final_score}/100</span>
+          </div>
+        ) : (
+          <span className="font-mono text-[11px] text-ink-4">N/A</span>
+        )}
+      </td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{gateLabel(snapshot)}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+        <div>{fmtInt(totals.tokens)} tokens</div>
+        <div className="mt-1 text-[10px] text-ink-4">{formatCost(totals.micros)}</div>
+      </td>
+      <td className="px-3 py-2">
+        {row.quality_snapshot_error ? (
+          <div className="line-clamp-2 text-[11px] leading-snug text-rust" title={row.quality_snapshot_error}>
+            {row.quality_snapshot_error}
+          </div>
+        ) : blockers.length > 0 ? (
+          <div className="line-clamp-2 text-[11px] leading-snug text-rust" title={blockers[0]}>
+            {blockers[0]}
+          </div>
+        ) : (
+          <span className="font-mono text-[11px] text-ink-4">None</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/web/src/types/eval.ts
+++ b/web/src/types/eval.ts
@@ -2,6 +2,36 @@ export interface EvalQualitySnapshotsResponse {
   quality_snapshots: QualitySnapshotRecord[];
 }
 
+export interface EvalQualitySnapshotResponse {
+  quality_snapshot: QualitySnapshotRecord;
+}
+
+export interface EvalRunsResponse {
+  runs: EvalRun[];
+}
+
+export interface EvalDashboardResponse {
+  rows: EvalDashboardRow[];
+}
+
+export interface EvalDashboardRow {
+  run: EvalRun;
+  quality_snapshot: QualitySnapshotRecord | null;
+  quality_snapshot_error: string | null;
+}
+
+export interface EvalRun {
+  id: string;
+  scenario: string;
+  target: EvalTarget;
+  source_task_id: string | null;
+  status: string;
+  quality_snapshot_id: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
 export interface QualitySnapshotRecord {
   id: string;
   run_id: string;
@@ -21,6 +51,7 @@ export interface QualitySnapshot {
   final_grade: string;
   grade_cap: string | null;
   blocker_summary: string[];
+  usage?: UsageSnapshot[];
 }
 
 export type EvalTarget =
@@ -74,6 +105,21 @@ export interface RuntimeSnapshot {
   latest_activity: string | null;
   terminal_state: string | null;
   collected_at: string;
+}
+
+export interface UsageSnapshot {
+  agent_invocation_id: string | null;
+  runtime_job_id: string | null;
+  workflow_id: string | null;
+  model: string | null;
+  reasoning_effort: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cached_input_tokens: number | null;
+  total_tokens: number | null;
+  cost_usd_micros: number | null;
+  token_confidence: string;
+  cost_confidence: string;
 }
 
 export interface HardGateResult {


### PR DESCRIPTION
## Summary

- Add a dashboard Evals tab that lists recent eval runs and their quality snapshots.
- Fetch scored run snapshots from /api/evals/quality-snapshots/{snapshot_id} and show score, grade, hard gates, blockers, target PR, run mode, and usage totals.
- Reuse shared formatting helpers for snake_case labels and short SHAs.
- Update the eval implementation plan with the dashboard view status.

Closes #1276

## Verification

- bun run test
- bun run build
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- git diff --check
- cargo test --workspace
- curl -fsS 'http://127.0.0.1:5174/dashboard?tab=evals'

## Notes

- Local Vite smoke page loaded successfully. Automated screenshot capture was not available because the local Node REPL did not have Playwright installed and Computer Use could not attach to the Chrome window.
