### PR TITLE
feat(eval): persist live PR repair scores

### DIFF
--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -232,13 +232,21 @@ Each run must also write machine-readable eval artifacts:
   `harness-eval` and `/api/evals/runs/{run_id}/score`.
 - `quality_snapshot.json`: deterministic `QualitySnapshot` with hard gates,
   score breakdown, grade caps, blocker summary, runtime evidence, and PR facts.
+- `eval_run.json`: the server eval run created for a successfully submitted
+  live Harness repair task.
+- `eval_artifact_pr_repair_input.json`: the server artifact upload response for
+  the final canonical input.
+- `eval_score.json`: the server-side scoring response that links the eval run
+  to the stored `quality_snapshot`.
 
-Both artifacts include `run_mode`. Operators may archive collect-only artifacts
-next to live-run artifacts, but only `live_run` snapshots are valid inputs for
-the capability benchmark. A snapshot is `live_run` only after a Harness task was
-successfully submitted for the target PR; live-mode preflight failures remain
-`collect_only`. The benchmark CLI rejects missing `run_mode` rather than
-defaulting old snapshots to live runs.
+The canonical input and local quality snapshot include `run_mode`. Operators
+may archive collect-only artifacts next to live-run artifacts, but only
+`live_run` snapshots are valid inputs for the capability benchmark. A snapshot
+is `live_run` only after a Harness task was successfully submitted for the
+target PR; live-mode preflight failures remain `collect_only`. The benchmark CLI
+rejects missing `run_mode` rather than defaulting old snapshots to live runs.
+Collect-only runs and live preflight failures are local-only; the script
+persists to `/api/evals` only after the live Harness task has a `task_id`.
 
 The Markdown summary is an operator convenience layer. It must not be the source
 of truth for eval scoring, dashboards, or merge readiness.

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -26,8 +26,8 @@ Options:
 Environment:
   HARNESS_API_TOKEN       Optional Bearer token for Harness HTTP routes.
 
-The script never starts `harness serve`; start the server from a standalone
-terminal before a live evaluation.
+The script never starts `harness serve`; start the server before a live
+evaluation. Live evaluations persist the final score through `/api/evals`.
 EOF
 }
 
@@ -496,6 +496,9 @@ TASK_DETAIL_JSON="$OUTPUT_DIR/task_detail_final.json"
 TASK_BODY_JSON="$OUTPUT_DIR/task_body.json"
 PR_REPAIR_EVAL_INPUT_JSON="$OUTPUT_DIR/pr_repair_eval_input.json"
 QUALITY_SNAPSHOT_JSON="$OUTPUT_DIR/quality_snapshot.json"
+EVAL_RUN_JSON="$OUTPUT_DIR/eval_run.json"
+EVAL_ARTIFACT_JSON="$OUTPUT_DIR/eval_artifact_pr_repair_input.json"
+EVAL_SCORE_JSON="$OUTPUT_DIR/eval_score.json"
 HEALTH_JSON="$OUTPUT_DIR/health.json"
 PROJECTS_JSON="$OUTPUT_DIR/projects.json"
 TASKS_PREFLIGHT_JSON="$OUTPUT_DIR/tasks_preflight.json"
@@ -505,6 +508,7 @@ RUNTIME_TREE_FINAL_ERROR="$OUTPUT_DIR/runtime_tree_final_error.txt"
 EVAL_TARGET_ID="pr-repair-eval:$REPO#$PR"
 EVAL_EXTERNAL_ID="$EVAL_TARGET_ID:run:$RUN_ID"
 QUALITY_RUN_MODE="collect_only"
+EVAL_PERSIST_FAILED=0
 
 write_quality_snapshot() {
   local baseline="$1"
@@ -544,6 +548,42 @@ write_quality_snapshot() {
     args+=(--reviewer-judgment "$REVIEWER_JUDGMENT_JSON")
   fi
   cargo "${args[@]}"
+}
+
+ensure_eval_run_record() {
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_persist.py" ensure-run \
+    --server-url "$SERVER_URL" \
+    --input "$PR_REPAIR_EVAL_INPUT_JSON" \
+    --source-task-id "$TASK_ID" \
+    --output "$EVAL_RUN_JSON"
+}
+
+persist_eval_score_record() {
+  python3 "$SCRIPT_DIR/evaluate_pr_repair_persist.py" persist-score \
+    --server-url "$SERVER_URL" \
+    --input "$PR_REPAIR_EVAL_INPUT_JSON" \
+    --run "$EVAL_RUN_JSON" \
+    --artifact-output "$EVAL_ARTIFACT_JSON" \
+    --score-output "$EVAL_SCORE_JSON"
+}
+
+score_snapshot_id() {
+  python3 - "$EVAL_SCORE_JSON" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    data = {}
+
+snapshot = data.get("quality_snapshot") if isinstance(data, dict) else {}
+if isinstance(snapshot, dict):
+    print(snapshot.get("id") or "")
+else:
+    print("")
+PY
 }
 
 collect_runtime_tree_artifact() {
@@ -708,6 +748,11 @@ fi
 
 QUALITY_RUN_MODE="live_run"
 echo "Submitted task_id=$TASK_ID"
+if eval_run_id="$(ensure_eval_run_record)"; then
+  echo "Eval run: $eval_run_id"
+else
+  echo "Eval run persistence will be retried after final snapshot; see $EVAL_RUN_JSON" >&2
+fi
 WORKFLOW_ID="$(python3 - "$SUBMISSION_JSON" <<'PY'
 import json
 import sys
@@ -771,5 +816,18 @@ fi
 collect_runtime_tree_artifact "$registered_project" "$WORKFLOW_ID" "$TASK_ID"
 write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
 write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$timed_out" "$QUALITY_SNAPSHOT_JSON"
+if eval_run_id="$(ensure_eval_run_record)" && persist_eval_score_record; then
+  echo "Server eval run: $eval_run_id"
+  snapshot_id="$(score_snapshot_id)"
+  if [[ -n "$snapshot_id" ]]; then
+    echo "Server quality snapshot: $snapshot_id"
+  fi
+else
+  EVAL_PERSIST_FAILED=1
+  echo "Eval persistence failed; local artifacts are still available in $OUTPUT_DIR" >&2
+fi
 echo "Evaluation report: $OUTPUT_DIR/summary.md"
 echo "Quality snapshot: $QUALITY_SNAPSHOT_JSON"
+if [[ "$EVAL_PERSIST_FAILED" -eq 1 ]]; then
+  exit 6
+fi

--- a/scripts/evaluate_pr_repair_persist.py
+++ b/scripts/evaluate_pr_repair_persist.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Persist PR repair eval artifacts through the Harness eval API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from evaluate_pr_repair_artifacts import read_json
+from evaluate_pr_repair_submit import load_response, write_json
+
+
+JsonObject = dict[str, Any]
+
+
+def http_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("HARNESS_API_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def post_json(server_url: str, path: str, body: JsonObject | None) -> tuple[int, JsonObject]:
+    data = b"" if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        f"{server_url.rstrip('/')}{path}",
+        data=data,
+        headers=http_headers(),
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        status = exc.code
+    except (urllib.error.URLError, OSError) as exc:
+        reason = getattr(exc, "reason", exc)
+        return 0, {
+            "error": str(reason),
+            "http_status": "000",
+            "status": "failed",
+        }
+
+    payload = load_response(raw)
+    payload["http_status"] = str(status)
+    if status < 200 or status >= 300:
+        payload.setdefault("status", "failed")
+    return status, payload
+
+
+def eval_run_id(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    run = payload.get("run")
+    if not isinstance(run, dict):
+        return None
+    run_id = run.get("id")
+    if isinstance(run_id, str) and run_id.strip():
+        return run_id
+    return None
+
+
+def eval_run_create_body(input_path: Path, source_task_id: str | None) -> JsonObject:
+    eval_input = read_json(input_path)
+    if not isinstance(eval_input, dict):
+        raise SystemExit(f"eval input artifact must be a JSON object: {input_path}")
+    scenario = eval_input.get("scenario")
+    target = eval_input.get("target")
+    if not isinstance(scenario, str) or not scenario.strip():
+        raise SystemExit(f"eval input artifact is missing scenario: {input_path}")
+    if not isinstance(target, dict):
+        raise SystemExit(f"eval input artifact is missing target object: {input_path}")
+
+    body: JsonObject = {
+        "scenario": scenario,
+        "target": target,
+    }
+    if source_task_id:
+        body["source_task_id"] = source_task_id
+    return body
+
+
+def ensure_eval_run(args: argparse.Namespace) -> int:
+    existing = read_json(args.output, required=False)
+    existing_id = eval_run_id(existing)
+    if existing_id:
+        sys.stdout.write(f"{existing_id}\n")
+        return 0
+
+    status, payload = post_json(
+        args.server_url,
+        "/api/evals/runs",
+        eval_run_create_body(args.input, args.source_task_id or None),
+    )
+    write_json(str(args.output), payload)
+    run_id = eval_run_id(payload)
+    if status < 200 or status >= 300 or not run_id:
+        sys.stderr.write(f"failed to create eval run; see {args.output}\n")
+        return 22
+    sys.stdout.write(f"{run_id}\n")
+    return 0
+
+
+def persist_eval_score(args: argparse.Namespace) -> int:
+    run_payload = read_json(args.run)
+    run_id = eval_run_id(run_payload)
+    if not run_id:
+        sys.stderr.write(f"eval run artifact is missing run.id: {args.run}\n")
+        return 2
+
+    try:
+        input_body = args.input.read_text(encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(f"failed to read eval input artifact {args.input}: {exc}\n")
+        return 2
+    if not input_body.strip():
+        sys.stderr.write(f"eval input artifact is empty: {args.input}\n")
+        return 2
+
+    encoded_run_id = urllib.parse.quote(run_id, safe="")
+    artifact_status, artifact_payload = post_json(
+        args.server_url,
+        f"/api/evals/runs/{encoded_run_id}/artifacts",
+        {
+            "artifact_type": "pr_repair_eval_input",
+            "label": "canonical PR repair eval input",
+            "content_type": "application/json",
+            "body": input_body,
+        },
+    )
+    write_json(str(args.artifact_output), artifact_payload)
+    if artifact_status < 200 or artifact_status >= 300:
+        sys.stderr.write(f"failed to upload eval input artifact; see {args.artifact_output}\n")
+        return 22
+
+    score_status, score_payload = post_json(
+        args.server_url,
+        f"/api/evals/runs/{encoded_run_id}/score",
+        None,
+    )
+    write_json(str(args.score_output), score_payload)
+    if score_status < 200 or score_status >= 300:
+        sys.stderr.write(f"failed to score eval run; see {args.score_output}\n")
+        return 22
+    return 0
+
+
+def build_persist_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    ensure_run = sub.add_parser("ensure-run")
+    ensure_run.add_argument("--server-url", required=True)
+    ensure_run.add_argument("--input", type=Path, required=True)
+    ensure_run.add_argument("--source-task-id", default="")
+    ensure_run.add_argument("--output", type=Path, required=True)
+    ensure_run.set_defaults(func=ensure_eval_run)
+
+    persist_score = sub.add_parser("persist-score")
+    persist_score.add_argument("--server-url", required=True)
+    persist_score.add_argument("--input", type=Path, required=True)
+    persist_score.add_argument("--run", type=Path, required=True)
+    persist_score.add_argument("--artifact-output", type=Path, required=True)
+    persist_score.add_argument("--score-output", type=Path, required=True)
+    persist_score.set_defaults(func=persist_eval_score)
+
+    return parser
+
+
+def main() -> int:
+    args = build_persist_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_evaluate_pr_repair_persist.py
+++ b/scripts/test_evaluate_pr_repair_persist.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for persisting PR repair eval results through the Harness eval API."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("evaluate_pr_repair_persist.py")
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("evaluate_pr_repair_persist", SCRIPT_PATH)
+assert SPEC is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class EvalApiResponseStub:
+    def __init__(self, status: int, body: dict[str, object]) -> None:
+        self.status = status
+        self._body = json.dumps(body).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "EvalApiResponseStub":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+def eval_input() -> dict[str, object]:
+    return {
+        "scenario": "pr_repair",
+        "run_mode": "live_run",
+        "target": {
+            "kind": "pull_request",
+            "repo": "owner/repo",
+            "pr_number": 7,
+            "base_ref": "main",
+            "head_ref": "fix/review",
+        },
+    }
+
+
+class PersistHelperTests(unittest.TestCase):
+    def test_ensure_eval_run_creates_run_from_canonical_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "pr_repair_eval_input.json"
+            output_path = tmp_path / "eval_run.json"
+            input_path.write_text(json.dumps(eval_input()), encoding="utf-8")
+            calls: list[dict[str, object]] = []
+
+            def eval_run_urlopen_stub(request: object, timeout: int) -> EvalApiResponseStub:
+                calls.append(
+                    {
+                        "url": request.full_url,
+                        "body": json.loads(request.data.decode("utf-8")),
+                        "timeout": timeout,
+                    }
+                )
+                return EvalApiResponseStub(201, {"run": {"id": "run-1"}})
+
+            with mock.patch.object(
+                MODULE.urllib.request,
+                "urlopen",
+                side_effect=eval_run_urlopen_stub,
+            ):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    status = MODULE.ensure_eval_run(
+                        argparse.Namespace(
+                            server_url="http://127.0.0.1:9800",
+                            input=input_path,
+                            source_task_id="task-1",
+                            output=output_path,
+                        )
+                    )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(output_path.read_text())["run"]["id"], "run-1")
+            self.assertEqual(calls[0]["url"], "http://127.0.0.1:9800/api/evals/runs")
+            self.assertEqual(calls[0]["timeout"], 5)
+            self.assertEqual(
+                calls[0]["body"],
+                {
+                    "scenario": "pr_repair",
+                    "target": eval_input()["target"],
+                    "source_task_id": "task-1",
+                },
+            )
+
+    def test_persist_eval_score_uploads_input_then_scores_from_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "pr_repair_eval_input.json"
+            run_path = tmp_path / "eval_run.json"
+            artifact_output = tmp_path / "eval_artifact.json"
+            score_output = tmp_path / "eval_score.json"
+            input_body = json.dumps(eval_input(), indent=2) + "\n"
+            input_path.write_text(input_body, encoding="utf-8")
+            run_path.write_text(json.dumps({"run": {"id": "run/needs encoding"}}), encoding="utf-8")
+            calls: list[dict[str, object]] = []
+
+            def eval_score_urlopen_stub(request: object, timeout: int) -> EvalApiResponseStub:
+                body = request.data.decode("utf-8")
+                calls.append(
+                    {
+                        "url": request.full_url,
+                        "body": json.loads(body) if body else None,
+                        "timeout": timeout,
+                    }
+                )
+                if request.full_url.endswith("/artifacts"):
+                    return EvalApiResponseStub(201, {"artifact": {"id": "artifact-1"}})
+                return EvalApiResponseStub(
+                    200,
+                    {
+                        "run": {"id": "run/needs encoding", "status": "scored"},
+                        "quality_snapshot": {"id": "snapshot-1"},
+                    },
+                )
+
+            with mock.patch.object(
+                MODULE.urllib.request,
+                "urlopen",
+                side_effect=eval_score_urlopen_stub,
+            ):
+                status = MODULE.persist_eval_score(
+                    argparse.Namespace(
+                        server_url="http://127.0.0.1:9800",
+                        input=input_path,
+                        run=run_path,
+                        artifact_output=artifact_output,
+                        score_output=score_output,
+                    )
+                )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(
+                calls[0]["url"],
+                "http://127.0.0.1:9800/api/evals/runs/run%2Fneeds%20encoding/artifacts",
+            )
+            self.assertEqual(calls[0]["body"]["artifact_type"], "pr_repair_eval_input")
+            self.assertEqual(calls[0]["body"]["body"], input_body)
+            self.assertEqual(
+                calls[1]["url"],
+                "http://127.0.0.1:9800/api/evals/runs/run%2Fneeds%20encoding/score",
+            )
+            self.assertIsNone(calls[1]["body"])
+            self.assertEqual(json.loads(score_output.read_text())["quality_snapshot"]["id"], "snapshot-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Create a server eval run for live PR repair evaluations after Harness returns a task id.
- Upload the final canonical `pr_repair_eval_input` artifact and request deterministic server-side scoring through `/api/evals/runs/{run_id}/score`.
- Keep collect-only and live preflight failures local-only, while making live eval API persistence failures return a non-zero exit after local reports are written.
- Document the new server persistence artifacts.

Closes #1278

## Validation

- `python3 -m unittest scripts/test_evaluate_pr_repair_persist.py scripts/test_evaluate_pr_repair_artifacts.py scripts/test_evaluate_pr_repair_submit.py scripts/test_evaluate_pr_repair_helpers.py`
- `bash -n scripts/evaluate_pr_repair.sh`
- `cargo test -p harness-eval`
- `cargo test -p harness-server evals_api_tests`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `git diff --check`
- `cargo test --workspace`
