### PR TITLE
fix(eval): preflight eval API before live repair

### DIFF
--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -60,11 +60,14 @@ does not accept common false positives.
 `QualitySnapshot` records a `run_mode`. Collect-only snapshots must use
 `collect_only`; live Harness repair runs use `live_run` only after Harness
 returns a non-empty `task_id` from `POST /tasks`. Server health failures, project
-registry failures, duplicate-task preflight failures, POST failures, and missing
-task IDs are still diagnostic reports, but they are tagged `collect_only`
-because no Harness repair attempt exists. Benchmark inputs must include an
-explicit `run_mode=live_run`; missing `run_mode` is rejected because older
-collect-only artifacts did not have this field.
+registry failures, eval API preflight failures, duplicate-task preflight
+failures, POST failures, and missing task IDs are still diagnostic reports, but
+they are tagged `collect_only` because no Harness repair attempt exists. The
+eval API preflight must happen before `POST /tasks`; a server that is too old to
+serve `/api/evals/runs` can otherwise spend agent tokens without producing a
+dashboard quality record. Benchmark inputs must include an explicit
+`run_mode=live_run`; missing `run_mode` is rejected because older collect-only
+artifacts did not have this field.
 
 The `score_pr_repair` CLI must be invoked with an explicit
 `--run-mode live_run|collect_only` whenever it writes a new `QualitySnapshot`.

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -465,22 +465,25 @@ write_final_report() {
 
 write_preflight_failure_artifacts() {
   local error="$1"
+  local stage="${2:-project_registry_preflight}"
   python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" write-preflight-failure \
     --submission "$SUBMISSION_JSON" \
     --task-detail "$TASK_DETAIL_JSON" \
     --project-root "$PROJECT_ROOT" \
     --server-url "$SERVER_URL" \
-    --error "$error"
+    --error "$error" \
+    --stage "$stage"
 }
 
 write_live_preflight_failure_report() {
   local reason="$1"
   local exit_code="$2"
-  write_preflight_failure_artifacts "$reason"
+  local stage="${3:-project_registry_preflight}"
+  write_preflight_failure_artifacts "$reason" "$stage"
   echo "$reason" >&2
-  echo "Collecting final PR snapshot"
-  FINAL_COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  collect_snapshot "$FINAL_JSON"
+  echo "Using baseline PR snapshot as final snapshot because no Harness task was submitted"
+  cp "$BASELINE_JSON" "$FINAL_JSON"
+  FINAL_COLLECTED_AT="$BASELINE_COLLECTED_AT"
   snapshot_summary "$FINAL_JSON"
   write_quality_snapshot "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "$BASELINE_COLLECTED_AT" "$FINAL_COLLECTED_AT"
   write_final_report "$BASELINE_JSON" "$FINAL_JSON" "$SUBMISSION_JSON" "$TASK_DETAIL_JSON" "0" "$QUALITY_SNAPSHOT_JSON"
@@ -503,6 +506,8 @@ HEALTH_JSON="$OUTPUT_DIR/health.json"
 PROJECTS_JSON="$OUTPUT_DIR/projects.json"
 TASKS_PREFLIGHT_JSON="$OUTPUT_DIR/tasks_preflight.json"
 TASKS_PREFLIGHT_ERROR="$OUTPUT_DIR/tasks_preflight_error.txt"
+EVAL_API_PREFLIGHT_JSON="$OUTPUT_DIR/eval_api_preflight.json"
+EVAL_API_PREFLIGHT_ERROR="$OUTPUT_DIR/eval_api_preflight_error.txt"
 RUNTIME_TREE_FINAL_JSON="$OUTPUT_DIR/runtime_tree_final.json"
 RUNTIME_TREE_FINAL_ERROR="$OUTPUT_DIR/runtime_tree_final_error.txt"
 EVAL_TARGET_ID="pr-repair-eval:$REPO#$PR"
@@ -632,14 +637,23 @@ fi
 if ! curl "${curl_args[@]}" "$SERVER_URL/health" > "$HEALTH_JSON"; then
   write_live_preflight_failure_report \
     "Harness server is not reachable at $SERVER_URL/health" \
-    3
+    3 \
+    "server_health_preflight"
+fi
+
+if ! curl "${curl_args[@]}" "$SERVER_URL/api/evals/runs?limit=1" > "$EVAL_API_PREFLIGHT_JSON" 2>"$EVAL_API_PREFLIGHT_ERROR"; then
+  write_live_preflight_failure_report \
+    "Harness eval API is not reachable at $SERVER_URL/api/evals/runs?limit=1; see $EVAL_API_PREFLIGHT_ERROR" \
+    5 \
+    "eval_api_preflight"
 fi
 
 echo "Checking Harness project registry for $PROJECT_ROOT"
 if ! curl "${curl_args[@]}" "$SERVER_URL/projects" > "$PROJECTS_JSON"; then
   write_live_preflight_failure_report \
     "Harness project registry is not reachable at $SERVER_URL/projects" \
-    5
+    5 \
+    "project_registry_preflight"
 fi
 
 PREFLIGHT_ERROR="$OUTPUT_DIR/project_preflight_error.txt"
@@ -649,7 +663,7 @@ if ! registered_project="$(python3 "$SCRIPT_DIR/evaluate_pr_repair_preflight.py"
     reason="Harness project root is not registered for live eval: $PROJECT_ROOT"
   fi
   echo "Register the project with POST /projects or pass a registered --project-root." >&2
-  write_live_preflight_failure_report "$reason" 5
+  write_live_preflight_failure_report "$reason" 5 "project_registry_preflight"
 fi
 echo "Registered project: $registered_project"
 
@@ -661,14 +675,15 @@ if ! curl "${curl_args[@]}" --get \
   "$SERVER_URL/tasks" > "$TASKS_PREFLIGHT_JSON" 2>"$TASKS_PREFLIGHT_ERROR"; then
   write_live_preflight_failure_report \
     "Harness task list is not reachable at $SERVER_URL/tasks; see $TASKS_PREFLIGHT_ERROR" \
-    5
+    5 \
+    "duplicate_task_preflight"
 fi
 if ! duplicate_error="$(python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" check-conflicts \
   --tasks-json "$TASKS_PREFLIGHT_JSON" \
   --project-root "$registered_project" \
   --external-id "$EVAL_EXTERNAL_ID" \
   --target-prefix "$EVAL_TARGET_ID" 2>&1)"; then
-  write_live_preflight_failure_report "$duplicate_error" 5
+  write_live_preflight_failure_report "$duplicate_error" 5 "duplicate_task_preflight"
 fi
 
 python3 - "$registered_project" "$REPO" "$PR" "$WAIT_SECS" "$MAX_ROUNDS" "$MAX_TURNS" "$MAX_BUDGET_USD" "$EVAL_EXTERNAL_ID" <<'PY' > "$TASK_BODY_JSON"

--- a/scripts/evaluate_pr_repair_artifacts.py
+++ b/scripts/evaluate_pr_repair_artifacts.py
@@ -84,19 +84,20 @@ def project_registry_preflight(args: argparse.Namespace) -> int:
 
 
 def write_preflight_failure(args: argparse.Namespace) -> int:
+    stage = args.stage or "project_registry_preflight"
     submission = {
         "error": args.error,
         "eval_submission_mode": "prompt_task",
         "http_status": "preflight",
         "project_root": args.project_root,
         "server_url": args.server_url,
-        "stage": "project_registry_preflight",
+        "stage": stage,
         "status": "failed",
     }
     task_detail = {
         "error": args.error,
         "project_root": args.project_root,
-        "stage": "project_registry_preflight",
+        "stage": stage,
         "status": "failed",
     }
     write_json(str(args.submission), submission)
@@ -635,6 +636,7 @@ def build_parser() -> argparse.ArgumentParser:
     failure.add_argument("--project-root", required=True)
     failure.add_argument("--server-url", required=True)
     failure.add_argument("--error", required=True)
+    failure.add_argument("--stage", default="project_registry_preflight")
     failure.set_defaults(func=write_preflight_failure)
 
     conflicts = sub.add_parser("check-conflicts")

--- a/scripts/test_evaluate_pr_repair_artifacts.py
+++ b/scripts/test_evaluate_pr_repair_artifacts.py
@@ -77,6 +77,7 @@ class ArtifactHelperTests(unittest.TestCase):
                     project_root="/tmp/project",
                     server_url="http://127.0.0.1:9800",
                     error="project registry preflight failed",
+                    stage="project_registry_preflight",
                 )
             )
 
@@ -85,6 +86,26 @@ class ArtifactHelperTests(unittest.TestCase):
                 json.loads(task_detail.read_text())["stage"],
                 "project_registry_preflight",
             )
+
+    def test_preflight_failure_artifacts_record_custom_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            submission = tmp_path / "submission.json"
+            task_detail = tmp_path / "task_detail_final.json"
+
+            MODULE.write_preflight_failure(
+                argparse.Namespace(
+                    submission=submission,
+                    task_detail=task_detail,
+                    project_root="/tmp/project",
+                    server_url="http://127.0.0.1:9800",
+                    error="eval API unavailable",
+                    stage="eval_api_preflight",
+                )
+            )
+
+            self.assertEqual(json.loads(submission.read_text())["stage"], "eval_api_preflight")
+            self.assertEqual(json.loads(task_detail.read_text())["stage"], "eval_api_preflight")
 
     def test_conflicting_eval_tasks_only_flags_active_matching_external_id(self) -> None:
         response = {


### PR DESCRIPTION
## Summary

- add a live eval API preflight before `POST /tasks` in `evaluate_pr_repair.sh`
- record the exact failing preflight stage in diagnostic artifacts
- reuse the baseline PR snapshot as the final snapshot when no Harness repair task was submitted

Closes #1280

## Validation

- `python3 -B -m unittest scripts/test_evaluate_pr_repair_artifacts.py scripts/test_evaluate_pr_repair_persist.py scripts/test_evaluate_pr_repair_submit.py scripts/test_evaluate_pr_repair_helpers.py`
- `bash -n scripts/evaluate_pr_repair.sh`
- live smoke against a stale server without `/api/evals/runs`: exited before task submission with `stage=eval_api_preflight`
- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`