### PR TITLE
fix(runtime): stop retrying Codex quota failures

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -224,6 +224,53 @@ fn codex_spawn_failure_message(
     )
 }
 
+fn codex_structured_error_from_stdout(stdout: &str) -> Option<String> {
+    parse_codex_exec_output(stdout).ok()?.structured_error
+}
+
+fn codex_structured_error(message: impl Into<String>) -> harness_core::error::HarnessError {
+    let message = format!("codex structured error: {}", message.into());
+    if harness_core::error::is_billing_failure_message(&message) {
+        return harness_core::error::HarnessError::BillingFailed(message);
+    }
+    if harness_core::error::is_quota_failure_message(&message) {
+        return harness_core::error::HarnessError::QuotaExhausted(message);
+    }
+    harness_core::error::HarnessError::AgentExecution(message)
+}
+
+fn codex_nonzero_exit_error(
+    status: std::process::ExitStatus,
+    stderr: &str,
+    structured_error: Option<&str>,
+) -> harness_core::error::HarnessError {
+    if let Some(message) = structured_error {
+        let mut error = codex_structured_error(format!("exit {status}: {message}"));
+        if matches!(error, harness_core::error::HarnessError::AgentExecution(_))
+            && !stderr.trim().is_empty()
+        {
+            error = harness_core::error::HarnessError::AgentExecution(format!(
+                "{error}; stderr=[{stderr}]"
+            ));
+        }
+        return error;
+    }
+
+    if harness_core::error::is_billing_failure_message(stderr) {
+        return harness_core::error::HarnessError::BillingFailed(format!(
+            "codex billing failure (exit {status}): {stderr}"
+        ));
+    }
+    if harness_core::error::is_quota_failure_message(stderr) {
+        return harness_core::error::HarnessError::QuotaExhausted(format!(
+            "codex quota exhausted (exit {status}): {stderr}"
+        ));
+    }
+    harness_core::error::HarnessError::AgentExecution(format!(
+        "codex exited with {status}: {stderr}"
+    ))
+}
+
 #[async_trait]
 impl CodeAgent for CodexAgent {
     fn name(&self) -> &str {
@@ -313,27 +360,17 @@ impl CodeAgent for CodexAgent {
         log_captured_stderr_diagnostics(&stderr, self.name());
 
         if !output.status.success() {
-            if harness_core::error::is_billing_failure_message(&stderr) {
-                return Err(harness_core::error::HarnessError::BillingFailed(format!(
-                    "codex billing failure (exit {}): {stderr}",
-                    output.status
-                )));
-            }
-            if harness_core::error::is_quota_failure_message(&stderr) {
-                return Err(harness_core::error::HarnessError::QuotaExhausted(format!(
-                    "codex quota exhausted (exit {}): {stderr}",
-                    output.status
-                )));
-            }
-            return Err(harness_core::error::HarnessError::AgentExecution(format!(
-                "codex exited with {}: {stderr}",
-                output.status
-            )));
+            let structured_error = codex_structured_error_from_stdout(&stdout);
+            return Err(codex_nonzero_exit_error(
+                output.status,
+                &stderr,
+                structured_error.as_deref(),
+            ));
         }
 
         let parsed = parse_codex_exec_output(&stdout)?;
         if let Some(message) = parsed.structured_error {
-            return Err(harness_core::error::HarnessError::AgentExecution(message));
+            return Err(codex_structured_error(message));
         }
         for warning in &parsed.warnings {
             tracing::warn!(agent = self.name(), "{warning}");
@@ -479,27 +516,14 @@ impl CodeAgent for CodexAgent {
         })?;
         if !status.success() {
             let stderr = captured_stderr_tail(&stderr_capture);
-            if !stderr.is_empty() {
-                if harness_core::error::is_billing_failure_message(&stderr) {
-                    return Err(harness_core::error::HarnessError::BillingFailed(format!(
-                        "codex billing failure (streamed exit): {stderr}"
-                    )));
-                }
-                if harness_core::error::is_quota_failure_message(&stderr) {
-                    return Err(harness_core::error::HarnessError::QuotaExhausted(format!(
-                        "codex quota exhausted (streamed exit): {stderr}"
-                    )));
-                }
-            }
-            return Err(enrich_stream_exit_error(
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "codex exited with {status}"
-                )),
+            return Err(codex_nonzero_exit_error(
+                status,
                 &stderr,
+                parsed.structured_error.as_deref(),
             ));
         }
         if let Some(message) = parsed.structured_error {
-            return Err(harness_core::error::HarnessError::AgentExecution(message));
+            return Err(codex_structured_error(message));
         }
         send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;
         Ok(())
@@ -587,3 +611,7 @@ mod approval_policy_arg_tests {
 #[cfg(test)]
 #[path = "codex_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "codex_failure_tests.rs"]
+mod failure_tests;

--- a/crates/harness-agents/src/codex_failure_tests.rs
+++ b/crates/harness-agents/src/codex_failure_tests.rs
@@ -1,0 +1,68 @@
+use super::tests::write_executable_script;
+use super::*;
+
+#[tokio::test]
+async fn execute_classifies_quota_failure_from_stdout_json_error() {
+    let (dir, script) = write_executable_script(
+        r#"
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-1"}'
+printf '%s\n' '{"type":"error","message":"usage limit reached; try again later"}'
+echo 'Reading additional input from stdin...' >&2
+exit 1
+"#,
+    );
+    let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let err = agent
+        .execute(request)
+        .await
+        .expect_err("execution should fail");
+
+    assert!(
+        matches!(err, harness_core::error::HarnessError::QuotaExhausted(_)),
+        "expected codex stdout JSON error to preserve quota classification, got: {err}"
+    );
+    assert_eq!(
+        err.turn_failure().expect("turn failure").kind,
+        harness_core::types::TurnFailureKind::Quota
+    );
+}
+
+#[tokio::test]
+async fn execute_stream_classifies_quota_failure_from_stdout_json_error() {
+    let (dir, script) = write_executable_script(
+        r#"
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-1"}'
+printf '%s\n' '{"type":"turn.started"}'
+printf '%s\n' '{"type":"error","message":"usage limit reached; try again later"}'
+echo 'Reading additional input from stdin...' >&2
+exit 1
+"#,
+    );
+    let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    let err = agent
+        .execute_stream(request, tx)
+        .await
+        .expect_err("stream execution should fail");
+
+    assert!(
+        matches!(err, harness_core::error::HarnessError::QuotaExhausted(_)),
+        "expected streamed codex stdout JSON error to preserve quota classification, got: {err}"
+    );
+    assert_eq!(
+        err.turn_failure().expect("turn failure").kind,
+        harness_core::types::TurnFailureKind::Quota
+    );
+}

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -53,7 +53,7 @@ impl Drop for ScopedEnvVar {
     }
 }
 
-fn write_executable_script(script_body: &str) -> (tempfile::TempDir, PathBuf) {
+pub(super) fn write_executable_script(script_body: &str) -> (tempfile::TempDir, PathBuf) {
     let dir = tempfile::tempdir().expect("create tempdir");
     let path = dir.path().join("mock-codex.sh");
     let script = format!("#!/bin/sh\nset -eu\n{script_body}\n");

--- a/crates/harness-core/src/error.rs
+++ b/crates/harness-core/src/error.rs
@@ -242,6 +242,7 @@ pub fn is_quota_failure_message(message: &str) -> bool {
     let lower = message.to_lowercase();
     lower.contains("quota exhausted")
         || lower.contains("hit your limit")
+        || lower.contains("usage limit")
         || lower.contains("rate limit exceeded")
         || lower.contains("rate_limit_exceeded")
         || lower.contains("too many requests")

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -180,6 +180,8 @@ impl ActivityResultEnvelope {
         let mut result = ActivityResult::failed(activity, summary, error.clone());
         if turn_error_is_timeout(&error) {
             result = result.with_error_kind(ActivityErrorKind::Timeout);
+        } else if turn_error_is_non_retryable_agent_limit(&error) {
+            result = result.with_error_kind(ActivityErrorKind::Configuration);
         }
         Self {
             extraction_strategy: ActivityResultExtractionStrategy::NotAttempted,
@@ -256,6 +258,11 @@ fn activity_result_envelope_from_turn(
 fn turn_error_is_timeout(error: &str) -> bool {
     let normalized = error.to_ascii_lowercase();
     normalized.contains("timed out") || normalized.contains("timeout reached")
+}
+
+fn turn_error_is_non_retryable_agent_limit(error: &str) -> bool {
+    harness_core::error::is_quota_failure_message(error)
+        || harness_core::error::is_billing_failure_message(error)
 }
 
 enum StructuredActivityResult {
@@ -770,3 +777,7 @@ Final result:
             .artifact
     }
 }
+
+#[cfg(test)]
+#[path = "activity_result_limit_tests.rs"]
+mod limit_tests;

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+use harness_workflow::runtime::{ActivityStatus, RuntimeKind};
+
+#[test]
+fn activity_result_from_turn_marks_quota_failure_non_retryable() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_prompt"
+        }),
+    );
+    let items = vec![Item::Error {
+        code: -1,
+        message: "agent quota exhausted: codex structured error: usage limit reached".to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_prompt");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+    assert_eq!(
+        result.error.as_deref(),
+        Some("agent quota exhausted: codex structured error: usage limit reached")
+    );
+}


### PR DESCRIPTION
## Summary
- Parse Codex exec stdout JSONL structured `error.message` values on non-zero exits before falling back to stderr.
- Classify Codex `usage limit` failures as quota failures for both non-streaming and streaming adapters.
- Mark quota/billing turn failures as non-retryable activity failures so workflow runtime does not keep retrying agent-limit failures.

## Evidence
- Live PR repair eval against #1234 stalled because Codex emitted a stdout JSONL error: `You've hit your usage limit...`, while stderr only contained the harmless stdin notice.
- The previous path treated that as a generic retryable agent execution failure, causing repeated runtime attempts and token/time waste.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p harness-agents execute_classifies_quota_failure_from_stdout_json_error -- --nocapture`
- `cargo test -p harness-agents execute_stream_classifies_quota_failure_from_stdout_json_error -- --nocapture`
- `cargo test -p harness-server activity_result_from_turn_marks_quota_failure_non_retryable -- --nocapture`
- `cargo test -p harness-agents`
- `cargo test -p harness-server activity_result_from_turn -- --nocapture`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`

Closes #1284
