### PR TITLE
feat(eval): score repeated runtime failures

### DIFF
--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -274,6 +274,7 @@ fn runtime_jobs_from_value(value: &Value) -> Vec<RuntimeJobSnapshot> {
                 .or_else_empty(|| string_field(job, "runtimeJobId"))
                 .or_else_empty(|| string_field(job, "id")),
             state: string_field(job, "state").or_else_empty(|| string_field(job, "status")),
+            activity: optional_string_field(job, "activity"),
             artifact_count: job
                 .get("artifact_count")
                 .or_else(|| job.get("artifactCount"))
@@ -282,6 +283,11 @@ fn runtime_jobs_from_value(value: &Value) -> Vec<RuntimeJobSnapshot> {
             terminal_state: terminal_string_field(job, "terminal_state")
                 .or_else(|| terminal_string_field(job, "terminalState"))
                 .or_else(|| terminal_string_field(job, "status")),
+            error_kind: job
+                .get("error_kind")
+                .or_else(|| job.get("errorKind"))
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok()),
         })
         .collect()
 }

--- a/crates/harness-eval/src/model.rs
+++ b/crates/harness-eval/src/model.rs
@@ -102,8 +102,23 @@ pub struct PullRequestSnapshot {
 pub struct RuntimeJobSnapshot {
     pub runtime_job_id: String,
     pub state: String,
+    #[serde(default)]
+    pub activity: Option<String>,
     pub artifact_count: u64,
     pub terminal_state: Option<String>,
+    #[serde(default)]
+    pub error_kind: Option<RuntimeErrorKind>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeErrorKind {
+    Retryable,
+    Timeout,
+    Fatal,
+    Configuration,
+    ExternalDependency,
+    Unknown,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -201,17 +201,20 @@ fn runtime_has_failed_terminal_state(runtime: &RuntimeSnapshot) -> bool {
         .terminal_state
         .as_deref()
         .is_some_and(is_failed_runtime_terminal_state)
-        || runtime.runtime_jobs.iter().any(|job| {
-            job.terminal_state
-                .as_deref()
-                .is_some_and(is_failed_runtime_terminal_state)
-        })
+        || runtime.runtime_jobs.iter().any(runtime_job_failed)
 }
 
 fn is_failed_runtime_terminal_state(state: &str) -> bool {
     matches!(
         state.trim().to_ascii_lowercase().as_str(),
-        "failed" | "cancelled" | "canceled" | "timed_out" | "timeout" | "errored" | "error"
+        "failed"
+            | "cancelled"
+            | "canceled"
+            | "timed_out"
+            | "timeout"
+            | "errored"
+            | "error"
+            | "expired"
     )
 }
 
@@ -406,6 +409,7 @@ fn runtime_job_failed(job: &RuntimeJobSnapshot) -> bool {
     job.terminal_state
         .as_deref()
         .is_some_and(is_failed_runtime_terminal_state)
+        || is_failed_runtime_terminal_state(&job.state)
 }
 
 fn runtime_job_error_is_non_retryable(job: &RuntimeJobSnapshot) -> bool {

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -1,7 +1,7 @@
 use crate::model::{
     CheckState, Confidence, EvalGrade, EvalScenario, EvalTarget, GateStatus, HardGateName,
-    HardGateResult, MergeState, PrRepairEvalInput, QualitySnapshot, RuntimeSnapshot,
-    ScoreBreakdown, ScoreComponent, ScoreDimensionName,
+    HardGateResult, MergeState, PrRepairEvalInput, QualitySnapshot, RuntimeErrorKind,
+    RuntimeJobSnapshot, RuntimeSnapshot, ScoreBreakdown, ScoreComponent, ScoreDimensionName,
 };
 use std::{error::Error, fmt};
 
@@ -21,6 +21,7 @@ impl fmt::Display for ScoringError {
 }
 
 impl Error for ScoringError {}
+
 pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
     let target_matches = target_matches_pr(&input)?;
     let branch_safe = branch_safe(&input);
@@ -147,6 +148,7 @@ pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot,
         blocker_summary,
     })
 }
+
 fn target_matches_pr(input: &PrRepairEvalInput) -> Result<bool, ScoringError> {
     let EvalTarget::PullRequest {
         repo,
@@ -356,7 +358,7 @@ fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakd
         ),
         cost_and_time_efficiency: component(
             ScoreDimensionName::CostAndTimeEfficiency,
-            if has_usage { 8 } else { 4 },
+            cost_efficiency_points(input.runtime.as_ref(), has_usage),
             8,
         ),
         reporting_and_attribution_quality: component(
@@ -369,6 +371,48 @@ fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakd
             6,
         ),
     }
+}
+
+fn cost_efficiency_points(runtime: Option<&RuntimeSnapshot>, has_usage: bool) -> u8 {
+    let Some(runtime) = runtime else {
+        return if has_usage { 6 } else { 4 };
+    };
+    let failed_jobs = runtime
+        .runtime_jobs
+        .iter()
+        .filter(|job| runtime_job_failed(job))
+        .count();
+    let repeated_non_retryable = runtime
+        .runtime_jobs
+        .iter()
+        .filter(|job| runtime_job_failed(job) && runtime_job_error_is_non_retryable(job))
+        .count()
+        > 1;
+
+    if repeated_non_retryable {
+        0
+    } else if failed_jobs > 1 {
+        3
+    } else if failed_jobs == 1 {
+        6
+    } else if has_usage {
+        8
+    } else {
+        4
+    }
+}
+
+fn runtime_job_failed(job: &RuntimeJobSnapshot) -> bool {
+    job.terminal_state
+        .as_deref()
+        .is_some_and(is_failed_runtime_terminal_state)
+}
+
+fn runtime_job_error_is_non_retryable(job: &RuntimeJobSnapshot) -> bool {
+    matches!(
+        job.error_kind,
+        Some(RuntimeErrorKind::Fatal | RuntimeErrorKind::Configuration)
+    )
 }
 
 fn fix_correctness_points(input: &PrRepairEvalInput, changed_or_noop: bool) -> u8 {
@@ -399,402 +443,5 @@ fn component(name: ScoreDimensionName, points: u8, max_points: u8) -> ScoreCompo
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::model::{
-        ChangedFileSnapshot, MergeState, PullRequestSnapshot, ReviewerJudgment, ReviewerKind,
-        RuntimeJobSnapshot, UsageSnapshot,
-    };
-
-    #[test]
-    fn ready_noop_control_accepts_unchanged_head() {
-        let mut input = perfect_input();
-        input.scenario = EvalScenario::ReadyNoopControl;
-        input.baseline_pr.head_oid = "same-head".to_string();
-        input.final_pr.head_oid = "same-head".to_string();
-        input.final_pr.changed_files.clear();
-        input.final_evidence_head_oid = Some("same-head".to_string());
-        input.reviewer_judgment = Some(reviewer_judgment("same-head"));
-
-        let snapshot = score_pr_repair_eval(input).expect("score ready/no-op input");
-        let gate = find_gate(&snapshot, HardGateName::HeadChange);
-
-        assert_eq!(gate.status, GateStatus::Pass);
-        assert_eq!(gate.grade_cap, None);
-        assert_eq!(snapshot.grade_cap, None);
-    }
-
-    #[test]
-    fn ready_noop_control_changed_head_caps_and_penalizes() {
-        let mut input = perfect_input();
-        input.scenario = EvalScenario::ReadyNoopControl;
-        input.baseline_pr.head_oid = "base-head".to_string();
-        input.final_pr.head_oid = "changed-head".to_string();
-        input.final_evidence_head_oid = Some("changed-head".to_string());
-        input.reviewer_judgment = None;
-
-        let snapshot = match score_pr_repair_eval(input) {
-            Ok(snapshot) => snapshot,
-            Err(error) => panic!("score changed ready/no-op input failed: {error}"),
-        };
-        let gate = find_gate(&snapshot, HardGateName::HeadChange);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.final_grade, EvalGrade::C);
-        assert_eq!(snapshot.objective_score.fix_correctness_and_scope.points, 8);
-    }
-
-    #[test]
-    fn unresolved_active_review_threads_cap_and_fail() {
-        let mut input = perfect_input();
-        input
-            .final_pr
-            .active_unresolved_review_threads
-            .push(crate::model::ReviewThreadSnapshot {
-                id: "thread-1".to_string(),
-                path: Some("src/lib.rs".to_string()),
-                is_resolved: false,
-                is_outdated: false,
-            });
-
-        let snapshot = score_pr_repair_eval(input).expect("score input with unresolved thread");
-        let gate = find_gate(&snapshot, HardGateName::ReviewThreadClosure);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.final_grade, EvalGrade::C);
-    }
-
-    #[test]
-    fn non_clean_mergeability_caps_and_fails() {
-        let mut input = perfect_input();
-        input.final_pr.merge_state = MergeState::Blocked;
-
-        let snapshot = match score_pr_repair_eval(input) {
-            Ok(snapshot) => snapshot,
-            Err(error) => panic!("score non-clean mergeability input failed: {error}"),
-        };
-        let gate = find_gate(&snapshot, HardGateName::MergeabilityClean);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.final_grade, EvalGrade::C);
-        assert!(snapshot
-            .blocker_summary
-            .contains(&"final PR mergeability is not clean".to_string()));
-    }
-
-    #[test]
-    fn stale_final_evidence_caps_and_fails() {
-        let mut input = perfect_input();
-        input.final_evidence_head_oid = Some("old-head".to_string());
-
-        let snapshot = score_pr_repair_eval(input).expect("score stale final evidence");
-        let gate = find_gate(&snapshot, HardGateName::HeadFreshness);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.final_grade, EvalGrade::C);
-    }
-
-    #[test]
-    fn missing_runtime_artifact_caps_at_b() {
-        let mut input = perfect_input();
-        input.runtime = None;
-
-        let snapshot = score_pr_repair_eval(input).expect("score missing runtime input");
-        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.final_grade, EvalGrade::B);
-    }
-
-    #[test]
-    fn partial_runtime_artifact_without_workflow_identity_caps_at_b() {
-        let mut input = perfect_input();
-        input.runtime = Some(RuntimeSnapshot {
-            task_id: Some("task-1".to_string()),
-            workflow_id: None,
-            workflow_state: None,
-            runtime_jobs: Vec::new(),
-            latest_activity: None,
-            terminal_state: Some("succeeded".to_string()),
-            collected_at: "2026-06-05T00:10:00Z".to_string(),
-        });
-
-        let snapshot = match score_pr_repair_eval(input) {
-            Ok(snapshot) => snapshot,
-            Err(error) => panic!("score partial runtime input failed: {error}"),
-        };
-        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
-    }
-
-    #[test]
-    fn failed_runtime_terminal_states_cap_at_b() {
-        for state in [
-            "failed",
-            "cancelled",
-            "canceled",
-            "timed_out",
-            "timeout",
-            "errored",
-            "error",
-        ] {
-            let mut input = perfect_input();
-            let Some(runtime) = input.runtime.as_mut() else {
-                panic!("runtime should exist");
-            };
-            runtime.terminal_state = Some(state.to_string());
-            runtime.runtime_jobs[0].artifact_count = 1;
-            runtime.runtime_jobs[0].terminal_state = Some("succeeded".to_string());
-
-            let snapshot = match score_pr_repair_eval(input) {
-                Ok(snapshot) => snapshot,
-                Err(error) => panic!("score failed runtime input failed: {error}"),
-            };
-            let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
-
-            assert_eq!(gate.status, GateStatus::Fail);
-            assert_eq!(gate.grade_cap, Some(EvalGrade::B));
-            assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
-            assert_eq!(snapshot.final_grade, EvalGrade::B);
-        }
-    }
-
-    #[test]
-    fn failed_runtime_job_terminal_state_caps_at_b_even_with_artifacts() {
-        let mut input = perfect_input();
-        let Some(runtime) = input.runtime.as_mut() else {
-            panic!("runtime should exist");
-        };
-        runtime.terminal_state = Some("succeeded".to_string());
-        runtime.runtime_jobs[0].artifact_count = 1;
-        runtime.runtime_jobs[0].terminal_state = Some("failed".to_string());
-
-        let snapshot = match score_pr_repair_eval(input) {
-            Ok(snapshot) => snapshot,
-            Err(error) => panic!("score failed job runtime input failed: {error}"),
-        };
-        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
-    }
-
-    #[test]
-    fn auditable_runtime_terminal_states_count_as_runtime_evidence() {
-        for state in ["ready_to_merge", "blocked"] {
-            let mut input = perfect_input();
-            let Some(runtime) = input.runtime.as_mut() else {
-                panic!("runtime should exist");
-            };
-            runtime.terminal_state = Some(state.to_string());
-            runtime.runtime_jobs.clear();
-
-            let snapshot = match score_pr_repair_eval(input) {
-                Ok(snapshot) => snapshot,
-                Err(error) => panic!("score auditable runtime input failed: {error}"),
-            };
-            let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
-
-            assert_eq!(gate.status, GateStatus::Pass);
-            assert_eq!(gate.grade_cap, None);
-            assert_eq!(snapshot.grade_cap, None);
-        }
-    }
-
-    #[test]
-    fn stale_reviewer_judgment_caps_and_fails() {
-        let mut input = perfect_input();
-        input.reviewer_judgment = Some(reviewer_judgment("old-head"));
-
-        let snapshot = score_pr_repair_eval(input).expect("score stale reviewer input");
-        let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
-        assert_eq!(snapshot.final_grade, EvalGrade::C);
-        assert!(snapshot
-            .blocker_summary
-            .contains(&"reviewer judgment is stale for the final PR head".to_string()));
-    }
-
-    #[test]
-    fn missing_reviewer_judgment_caps_at_b() {
-        let mut input = perfect_input();
-        input.reviewer_judgment = None;
-
-        let snapshot = score_pr_repair_eval(input).expect("score missing reviewer input");
-        let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
-
-        assert_eq!(gate.status, GateStatus::NotApplicable);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
-        assert_eq!(snapshot.final_grade, EvalGrade::B);
-    }
-
-    #[test]
-    fn unrelated_pr_creation_caps_at_f() {
-        let mut input = perfect_input();
-        input.created_unrelated_pr = true;
-
-        let snapshot = score_pr_repair_eval(input).expect("score unrelated PR input");
-        let gate = find_gate(&snapshot, HardGateName::NoUnrelatedPrCreation);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::F));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
-        assert_eq!(snapshot.final_grade, EvalGrade::F);
-    }
-
-    #[test]
-    fn destructive_or_unrelated_scope_changes_cap_at_f() {
-        let mut input = perfect_input();
-        input
-            .scope_violations
-            .push("changed unrelated dashboard files".to_string());
-
-        let snapshot = score_pr_repair_eval(input).expect("score scope violation input");
-        let gate = find_gate(&snapshot, HardGateName::ScopeContainment);
-
-        assert_eq!(gate.status, GateStatus::Fail);
-        assert_eq!(gate.grade_cap, Some(EvalGrade::F));
-        assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
-        assert_eq!(snapshot.final_grade, EvalGrade::F);
-    }
-
-    #[test]
-    fn trajectory_score_contributes_to_fix_correctness() {
-        let mut input = perfect_input();
-        input.reviewer_judgment = Some(ReviewerJudgment {
-            code_quality_score: 100,
-            trajectory_score: 0,
-            ..reviewer_judgment("final-head")
-        });
-
-        let snapshot = score_pr_repair_eval(input).expect("score low trajectory input");
-
-        assert_eq!(
-            snapshot.objective_score.fix_correctness_and_scope.points,
-            17
-        );
-    }
-
-    #[test]
-    fn basic_score_breakdown_returns_deterministic_total() {
-        let snapshot = score_pr_repair_eval(perfect_input()).expect("score perfect input");
-
-        assert_eq!(snapshot.objective_score.max_total(), 100);
-        assert_eq!(snapshot.objective_score.total(), 100);
-        assert_eq!(snapshot.final_score, 100);
-        assert_eq!(snapshot.final_grade, EvalGrade::A);
-        assert_eq!(snapshot.grade_cap, None);
-    }
-
-    fn find_gate(snapshot: &QualitySnapshot, name: HardGateName) -> &HardGateResult {
-        snapshot
-            .hard_gates
-            .iter()
-            .find(|gate| gate.name == name)
-            .expect("gate should exist")
-    }
-    fn perfect_input() -> PrRepairEvalInput {
-        PrRepairEvalInput {
-            scenario: EvalScenario::PrRepair,
-            run_mode: crate::model::EvalRunMode::LiveRun,
-            target: EvalTarget::PullRequest {
-                repo: "owner/repo".to_string(),
-                pr_number: 42,
-                base_ref: Some("main".to_string()),
-                head_ref: Some("fix/pr-42".to_string()),
-            },
-            baseline_pr: pr_snapshot("base-head", Vec::new()),
-            final_pr: pr_snapshot(
-                "final-head",
-                vec![ChangedFileSnapshot {
-                    path: "src/lib.rs".to_string(),
-                    additions: 12,
-                    deletions: 3,
-                    status: "modified".to_string(),
-                }],
-            ),
-            final_evidence_head_oid: Some("final-head".to_string()),
-            runtime: Some(RuntimeSnapshot {
-                task_id: Some("task-1".to_string()),
-                workflow_id: Some("workflow-1".to_string()),
-                workflow_state: Some("completed".to_string()),
-                runtime_jobs: vec![RuntimeJobSnapshot {
-                    runtime_job_id: "job-1".to_string(),
-                    state: "completed".to_string(),
-                    artifact_count: 1,
-                    terminal_state: Some("succeeded".to_string()),
-                }],
-                latest_activity: Some("completed".to_string()),
-                terminal_state: Some("succeeded".to_string()),
-                collected_at: "2026-06-05T00:10:00Z".to_string(),
-            }),
-            usage: vec![UsageSnapshot {
-                agent_invocation_id: Some("invoke-1".to_string()),
-                runtime_job_id: Some("job-1".to_string()),
-                workflow_id: Some("workflow-1".to_string()),
-                model: Some("codex".to_string()),
-                reasoning_effort: Some("medium".to_string()),
-                input_tokens: Some(1000),
-                output_tokens: Some(200),
-                cached_input_tokens: Some(100),
-                total_tokens: Some(1200),
-                cost_usd_micros: Some(120_000),
-                token_confidence: Confidence::Exact,
-                cost_confidence: Confidence::Estimated,
-            }],
-            reviewer_judgment: Some(reviewer_judgment("final-head")),
-            created_unrelated_pr: false,
-            scope_violations: Vec::new(),
-        }
-    }
-
-    fn pr_snapshot(head_oid: &str, changed_files: Vec<ChangedFileSnapshot>) -> PullRequestSnapshot {
-        PullRequestSnapshot {
-            repo: "owner/repo".to_string(),
-            pr_number: 42,
-            url: Some("https://github.com/owner/repo/pull/42".to_string()),
-            title: Some("Fix issue".to_string()),
-            base_ref: "main".to_string(),
-            head_ref: "fix/pr-42".to_string(),
-            head_oid: head_oid.to_string(),
-            is_draft: false,
-            merge_state: MergeState::Clean,
-            check_state: CheckState::Passing,
-            review_decision: Some(crate::model::ReviewDecision::Approved),
-            active_unresolved_review_threads: Vec::new(),
-            review_threads_complete: true,
-            changed_files,
-            changed_files_complete: true,
-            collected_at: "2026-06-05T00:00:00Z".to_string(),
-        }
-    }
-
-    fn reviewer_judgment(head_oid: &str) -> ReviewerJudgment {
-        ReviewerJudgment {
-            reviewer_kind: ReviewerKind::Human,
-            judged_head_oid: head_oid.to_string(),
-            code_quality_score: 100,
-            trajectory_score: 100,
-            findings: Vec::new(),
-            residual_risks: Vec::new(),
-        }
-    }
-}
+#[path = "scoring_tests.rs"]
+mod tests;

--- a/crates/harness-eval/src/scoring_tests.rs
+++ b/crates/harness-eval/src/scoring_tests.rs
@@ -148,6 +148,7 @@ fn failed_runtime_terminal_states_cap_at_b() {
         "timeout",
         "errored",
         "error",
+        "expired",
     ] {
         let mut input = perfect_input();
         let Some(runtime) = input.runtime.as_mut() else {
@@ -183,6 +184,28 @@ fn failed_runtime_job_terminal_state_caps_at_b_even_with_artifacts() {
     let snapshot = match score_pr_repair_eval(input) {
         Ok(snapshot) => snapshot,
         Err(error) => panic!("score failed job runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn expired_runtime_job_state_caps_at_b_when_terminal_state_is_missing() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.terminal_state = Some("succeeded".to_string());
+    runtime.runtime_jobs[0].artifact_count = 1;
+    runtime.runtime_jobs[0].state = "expired".to_string();
+    runtime.runtime_jobs[0].terminal_state = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score expired job runtime input failed: {error}"),
     };
     let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
 
@@ -238,6 +261,23 @@ fn single_failed_runtime_job_partially_penalizes_cost_efficiency() {
     runtime.runtime_jobs = vec![failed_job("job-1", RuntimeErrorKind::Timeout)];
 
     let snapshot = score_pr_repair_eval(input).expect("score single failed runtime job");
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 6);
+}
+
+#[test]
+fn expired_runtime_job_state_partially_penalizes_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs[0].state = "expired".to_string();
+    runtime.runtime_jobs[0].terminal_state = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score expired runtime job failed: {error}"),
+    };
 
     assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 6);
 }

--- a/crates/harness-eval/src/scoring_tests.rs
+++ b/crates/harness-eval/src/scoring_tests.rs
@@ -1,0 +1,440 @@
+use super::*;
+use crate::model::{
+    ChangedFileSnapshot, MergeState, PullRequestSnapshot, ReviewerJudgment, ReviewerKind,
+    RuntimeErrorKind, RuntimeJobSnapshot, UsageSnapshot,
+};
+
+#[test]
+fn ready_noop_control_accepts_unchanged_head() {
+    let mut input = perfect_input();
+    input.scenario = EvalScenario::ReadyNoopControl;
+    input.baseline_pr.head_oid = "same-head".to_string();
+    input.final_pr.head_oid = "same-head".to_string();
+    input.final_pr.changed_files.clear();
+    input.final_evidence_head_oid = Some("same-head".to_string());
+    input.reviewer_judgment = Some(reviewer_judgment("same-head"));
+
+    let snapshot = score_pr_repair_eval(input).expect("score ready/no-op input");
+    let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+    assert_eq!(gate.status, GateStatus::Pass);
+    assert_eq!(gate.grade_cap, None);
+    assert_eq!(snapshot.grade_cap, None);
+}
+
+#[test]
+fn ready_noop_control_changed_head_caps_and_penalizes() {
+    let mut input = perfect_input();
+    input.scenario = EvalScenario::ReadyNoopControl;
+    input.baseline_pr.head_oid = "base-head".to_string();
+    input.final_pr.head_oid = "changed-head".to_string();
+    input.final_evidence_head_oid = Some("changed-head".to_string());
+    input.reviewer_judgment = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score changed ready/no-op input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert_eq!(snapshot.objective_score.fix_correctness_and_scope.points, 8);
+}
+
+#[test]
+fn unresolved_active_review_threads_cap_and_fail() {
+    let mut input = perfect_input();
+    input
+        .final_pr
+        .active_unresolved_review_threads
+        .push(crate::model::ReviewThreadSnapshot {
+            id: "thread-1".to_string(),
+            path: Some("src/lib.rs".to_string()),
+            is_resolved: false,
+            is_outdated: false,
+        });
+
+    let snapshot = score_pr_repair_eval(input).expect("score input with unresolved thread");
+    let gate = find_gate(&snapshot, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+}
+
+#[test]
+fn non_clean_mergeability_caps_and_fails() {
+    let mut input = perfect_input();
+    input.final_pr.merge_state = MergeState::Blocked;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score non-clean mergeability input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::MergeabilityClean);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert!(snapshot
+        .blocker_summary
+        .contains(&"final PR mergeability is not clean".to_string()));
+}
+
+#[test]
+fn stale_final_evidence_caps_and_fails() {
+    let mut input = perfect_input();
+    input.final_evidence_head_oid = Some("old-head".to_string());
+
+    let snapshot = score_pr_repair_eval(input).expect("score stale final evidence");
+    let gate = find_gate(&snapshot, HardGateName::HeadFreshness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+}
+
+#[test]
+fn missing_runtime_artifact_caps_at_b() {
+    let mut input = perfect_input();
+    input.runtime = None;
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing runtime input");
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.final_grade, EvalGrade::B);
+}
+
+#[test]
+fn partial_runtime_artifact_without_workflow_identity_caps_at_b() {
+    let mut input = perfect_input();
+    input.runtime = Some(RuntimeSnapshot {
+        task_id: Some("task-1".to_string()),
+        workflow_id: None,
+        workflow_state: None,
+        runtime_jobs: Vec::new(),
+        latest_activity: None,
+        terminal_state: Some("succeeded".to_string()),
+        collected_at: "2026-06-05T00:10:00Z".to_string(),
+    });
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score partial runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn failed_runtime_terminal_states_cap_at_b() {
+    for state in [
+        "failed",
+        "cancelled",
+        "canceled",
+        "timed_out",
+        "timeout",
+        "errored",
+        "error",
+    ] {
+        let mut input = perfect_input();
+        let Some(runtime) = input.runtime.as_mut() else {
+            panic!("runtime should exist");
+        };
+        runtime.terminal_state = Some(state.to_string());
+        runtime.runtime_jobs[0].artifact_count = 1;
+        runtime.runtime_jobs[0].terminal_state = Some("succeeded".to_string());
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score failed runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.final_grade, EvalGrade::B);
+    }
+}
+
+#[test]
+fn failed_runtime_job_terminal_state_caps_at_b_even_with_artifacts() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.terminal_state = Some("succeeded".to_string());
+    runtime.runtime_jobs[0].artifact_count = 1;
+    runtime.runtime_jobs[0].terminal_state = Some("failed".to_string());
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score failed job runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn auditable_runtime_terminal_states_count_as_runtime_evidence() {
+    for state in ["ready_to_merge", "blocked"] {
+        let mut input = perfect_input();
+        let Some(runtime) = input.runtime.as_mut() else {
+            panic!("runtime should exist");
+        };
+        runtime.terminal_state = Some(state.to_string());
+        runtime.runtime_jobs.clear();
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score auditable runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Pass);
+        assert_eq!(gate.grade_cap, None);
+        assert_eq!(snapshot.grade_cap, None);
+    }
+}
+
+#[test]
+fn repeated_non_retryable_runtime_failures_zero_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs = vec![
+        failed_job("job-1", RuntimeErrorKind::Configuration),
+        failed_job("job-2", RuntimeErrorKind::Configuration),
+    ];
+
+    let snapshot = score_pr_repair_eval(input).expect("score repeated configuration failures");
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 0);
+}
+
+#[test]
+fn single_failed_runtime_job_partially_penalizes_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs = vec![failed_job("job-1", RuntimeErrorKind::Timeout)];
+
+    let snapshot = score_pr_repair_eval(input).expect("score single failed runtime job");
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 6);
+}
+
+#[test]
+fn stale_reviewer_judgment_caps_and_fails() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = Some(reviewer_judgment("old-head"));
+
+    let snapshot = score_pr_repair_eval(input).expect("score stale reviewer input");
+    let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert!(snapshot
+        .blocker_summary
+        .contains(&"reviewer judgment is stale for the final PR head".to_string()));
+}
+
+#[test]
+fn missing_reviewer_judgment_caps_at_b() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = None;
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing reviewer input");
+    let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+    assert_eq!(gate.status, GateStatus::NotApplicable);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.final_grade, EvalGrade::B);
+}
+
+#[test]
+fn unrelated_pr_creation_caps_at_f() {
+    let mut input = perfect_input();
+    input.created_unrelated_pr = true;
+
+    let snapshot = score_pr_repair_eval(input).expect("score unrelated PR input");
+    let gate = find_gate(&snapshot, HardGateName::NoUnrelatedPrCreation);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.final_grade, EvalGrade::F);
+}
+
+#[test]
+fn destructive_or_unrelated_scope_changes_cap_at_f() {
+    let mut input = perfect_input();
+    input
+        .scope_violations
+        .push("changed unrelated dashboard files".to_string());
+
+    let snapshot = score_pr_repair_eval(input).expect("score scope violation input");
+    let gate = find_gate(&snapshot, HardGateName::ScopeContainment);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.final_grade, EvalGrade::F);
+}
+
+#[test]
+fn trajectory_score_contributes_to_fix_correctness() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = Some(ReviewerJudgment {
+        code_quality_score: 100,
+        trajectory_score: 0,
+        ..reviewer_judgment("final-head")
+    });
+
+    let snapshot = score_pr_repair_eval(input).expect("score low trajectory input");
+
+    assert_eq!(
+        snapshot.objective_score.fix_correctness_and_scope.points,
+        17
+    );
+}
+
+#[test]
+fn basic_score_breakdown_returns_deterministic_total() {
+    let snapshot = score_pr_repair_eval(perfect_input()).expect("score perfect input");
+
+    assert_eq!(snapshot.objective_score.max_total(), 100);
+    assert_eq!(snapshot.objective_score.total(), 100);
+    assert_eq!(snapshot.final_score, 100);
+    assert_eq!(snapshot.final_grade, EvalGrade::A);
+    assert_eq!(snapshot.grade_cap, None);
+}
+
+fn find_gate(snapshot: &QualitySnapshot, name: HardGateName) -> &HardGateResult {
+    snapshot
+        .hard_gates
+        .iter()
+        .find(|gate| gate.name == name)
+        .expect("gate should exist")
+}
+
+fn perfect_input() -> PrRepairEvalInput {
+    PrRepairEvalInput {
+        scenario: EvalScenario::PrRepair,
+        run_mode: crate::model::EvalRunMode::LiveRun,
+        target: EvalTarget::PullRequest {
+            repo: "owner/repo".to_string(),
+            pr_number: 42,
+            base_ref: Some("main".to_string()),
+            head_ref: Some("fix/pr-42".to_string()),
+        },
+        baseline_pr: pr_snapshot("base-head", Vec::new()),
+        final_pr: pr_snapshot(
+            "final-head",
+            vec![ChangedFileSnapshot {
+                path: "src/lib.rs".to_string(),
+                additions: 12,
+                deletions: 3,
+                status: "modified".to_string(),
+            }],
+        ),
+        final_evidence_head_oid: Some("final-head".to_string()),
+        runtime: Some(RuntimeSnapshot {
+            task_id: Some("task-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            workflow_state: Some("completed".to_string()),
+            runtime_jobs: vec![RuntimeJobSnapshot {
+                runtime_job_id: "job-1".to_string(),
+                state: "completed".to_string(),
+                activity: Some("implement_issue".to_string()),
+                artifact_count: 1,
+                terminal_state: Some("succeeded".to_string()),
+                error_kind: None,
+            }],
+            latest_activity: Some("completed".to_string()),
+            terminal_state: Some("succeeded".to_string()),
+            collected_at: "2026-06-05T00:10:00Z".to_string(),
+        }),
+        usage: vec![UsageSnapshot {
+            agent_invocation_id: Some("invoke-1".to_string()),
+            runtime_job_id: Some("job-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            model: Some("codex".to_string()),
+            reasoning_effort: Some("medium".to_string()),
+            input_tokens: Some(1000),
+            output_tokens: Some(200),
+            cached_input_tokens: Some(100),
+            total_tokens: Some(1200),
+            cost_usd_micros: Some(120_000),
+            token_confidence: Confidence::Exact,
+            cost_confidence: Confidence::Estimated,
+        }],
+        reviewer_judgment: Some(reviewer_judgment("final-head")),
+        created_unrelated_pr: false,
+        scope_violations: Vec::new(),
+    }
+}
+
+fn failed_job(id: &str, error_kind: RuntimeErrorKind) -> RuntimeJobSnapshot {
+    RuntimeJobSnapshot {
+        runtime_job_id: id.to_string(),
+        state: "failed".to_string(),
+        activity: Some("implement_issue".to_string()),
+        artifact_count: 1,
+        terminal_state: Some("failed".to_string()),
+        error_kind: Some(error_kind),
+    }
+}
+
+fn pr_snapshot(head_oid: &str, changed_files: Vec<ChangedFileSnapshot>) -> PullRequestSnapshot {
+    PullRequestSnapshot {
+        repo: "owner/repo".to_string(),
+        pr_number: 42,
+        url: Some("https://github.com/owner/repo/pull/42".to_string()),
+        title: Some("Fix issue".to_string()),
+        base_ref: "main".to_string(),
+        head_ref: "fix/pr-42".to_string(),
+        head_oid: head_oid.to_string(),
+        is_draft: false,
+        merge_state: MergeState::Clean,
+        check_state: CheckState::Passing,
+        review_decision: Some(crate::model::ReviewDecision::Approved),
+        active_unresolved_review_threads: Vec::new(),
+        review_threads_complete: true,
+        changed_files,
+        changed_files_complete: true,
+        collected_at: "2026-06-05T00:00:00Z".to_string(),
+    }
+}
+
+fn reviewer_judgment(head_oid: &str) -> ReviewerJudgment {
+    ReviewerJudgment {
+        reviewer_kind: ReviewerKind::Human,
+        judged_head_oid: head_oid.to_string(),
+        code_quality_score: 100,
+        trajectory_score: 100,
+        findings: Vec::new(),
+        residual_risks: Vec::new(),
+    }
+}

--- a/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
+++ b/crates/harness-eval/tests/pr_repair_snapshot_completeness.rs
@@ -321,8 +321,10 @@ fn eval_input(
             runtime_jobs: vec![RuntimeJobSnapshot {
                 runtime_job_id: "job-1".to_string(),
                 state: "completed".to_string(),
+                activity: Some("implement_issue".to_string()),
                 artifact_count: 1,
                 terminal_state: Some("succeeded".to_string()),
+                error_kind: None,
             }],
             latest_activity: Some("completed".to_string()),
             terminal_state: Some("succeeded".to_string()),

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -107,7 +107,7 @@ Use the hard gates first, then score the successful run with this rubric:
 | Fix correctness and scope | 22 | Produces the smallest correct fix, preserves product behavior, avoids silent degradation, and does not introduce regression risk. |
 | Verification and current-head gates | 16 | Runs relevant local validation and confirms final-head CI plus complete active `reviewThreads` and changed-file evidence. |
 | Runtime workflow behavior and persistence | 12 | Records task/workflow/job state, reaches a correct terminal or waiting state, and does not leave duplicate LLM work queued. |
-| Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class, exposes usage attribution, and avoids repeated failed runtime jobs. Repeated non-retryable runtime failures such as `configuration` or `fatal` errors receive zero points for this dimension. |
+| Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class, exposes usage attribution, and avoids repeated failed runtime jobs, including `expired` jobs. Repeated non-retryable runtime failures such as `configuration` or `fatal` errors receive zero points for this dimension. |
 | Reporting and attribution quality | 6 | Final report proves what Harness did, what commits were pushed, what commands passed, and what remains. |
 
 ### Code Quality Subscore

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -107,7 +107,7 @@ Use the hard gates first, then score the successful run with this rubric:
 | Fix correctness and scope | 22 | Produces the smallest correct fix, preserves product behavior, avoids silent degradation, and does not introduce regression risk. |
 | Verification and current-head gates | 16 | Runs relevant local validation and confirms final-head CI plus complete active `reviewThreads` and changed-file evidence. |
 | Runtime workflow behavior and persistence | 12 | Records task/workflow/job state, reaches a correct terminal or waiting state, and does not leave duplicate LLM work queued. |
-| Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class and exposes usage attribution. |
+| Cost and time efficiency | 8 | Completes within the expected turn/time envelope for the task class, exposes usage attribution, and avoids repeated failed runtime jobs. Repeated non-retryable runtime failures such as `configuration` or `fatal` errors receive zero points for this dimension. |
 | Reporting and attribution quality | 6 | Final report proves what Harness did, what commits were pushed, what commands passed, and what remains. |
 
 ### Code Quality Subscore
@@ -224,6 +224,7 @@ Each run should produce a report with:
 - baseline and final `statusCheckRollup.state`
 - baseline and final active unresolved review-thread count
 - Harness `task_id`, `workflow_id`, and terminal state when available
+- Runtime job `activity`, terminal state, artifact count, and `error_kind` when available
 - elapsed time and configured turn/budget limits
 - changed files from the final PR diff
 - validation commands observed in task rounds or PR comments

--- a/scripts/evaluate_pr_repair_artifacts.py
+++ b/scripts/evaluate_pr_repair_artifacts.py
@@ -533,6 +533,25 @@ def activity_from_job(job: JsonObject) -> str | None:
     return None
 
 
+def error_kind_from_job(job: JsonObject) -> str | None:
+    for key in ("error_kind", "errorKind"):
+        value = job.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    output = job.get("output")
+    if isinstance(output, dict):
+        value = output.get("error_kind") or output.get("errorKind")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    envelope = job.get("activity_result_envelope")
+    final_result = envelope.get("final_result") if isinstance(envelope, dict) else None
+    if isinstance(final_result, dict):
+        value = final_result.get("error_kind") or final_result.get("errorKind")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def runtime_jobs_from_node(node: JsonObject) -> tuple[list[JsonObject], str | None]:
     jobs = []
     latest_activity = None
@@ -548,11 +567,14 @@ def runtime_jobs_from_node(node: JsonObject) -> tuple[list[JsonObject], str | No
         for job in runtime_jobs:
             if not isinstance(job, dict):
                 continue
-            latest_activity = activity_from_job(job) or latest_activity
+            activity = activity_from_job(job)
+            latest_activity = activity or latest_activity
             status = job.get("status") if isinstance(job.get("status"), str) else ""
             jobs.append(
                 {
+                    "activity": activity,
                     "artifact_count": artifact_count(job),
+                    "error_kind": error_kind_from_job(job),
                     "id": job.get("id") or "",
                     "runtime_job_id": job.get("id") or "",
                     "state": status,

--- a/scripts/evaluate_pr_repair_artifacts.py
+++ b/scripts/evaluate_pr_repair_artifacts.py
@@ -18,6 +18,7 @@ TERMINAL_TASK_STATES = {
     "cancelled",
     "canceled",
     "done",
+    "expired",
     "failed",
     "passed",
     "ready_to_merge",

--- a/scripts/test_evaluate_pr_repair_artifacts.py
+++ b/scripts/test_evaluate_pr_repair_artifacts.py
@@ -187,6 +187,10 @@ class ArtifactHelperTests(unittest.TestCase):
                                         "activity": "implement_prompt",
                                         "artifacts": [{"artifact_type": "runtime_turn"}],
                                     },
+                                },
+                                {
+                                    "id": "job-2",
+                                    "status": "expired",
                                 }
                             ]
                         }
@@ -209,6 +213,8 @@ class ArtifactHelperTests(unittest.TestCase):
         self.assertEqual(merged["runtime_jobs"][0]["artifact_count"], 1)
         self.assertEqual(merged["runtime_jobs"][0]["error_kind"], "configuration")
         self.assertEqual(merged["runtime_jobs"][0]["terminal_state"], "succeeded")
+        self.assertEqual(merged["runtime_jobs"][1]["runtime_job_id"], "job-2")
+        self.assertEqual(merged["runtime_jobs"][1]["terminal_state"], "expired")
         self.assertEqual(merged["latest_activity"], "implement_prompt")
 
     def test_final_report_uses_quality_snapshot_grade_and_blockers(self) -> None:

--- a/scripts/test_evaluate_pr_repair_artifacts.py
+++ b/scripts/test_evaluate_pr_repair_artifacts.py
@@ -180,6 +180,9 @@ class ArtifactHelperTests(unittest.TestCase):
                                 {
                                     "id": "job-1",
                                     "status": "succeeded",
+                                    "activity_result_envelope": {
+                                        "final_result": {"error_kind": "configuration"}
+                                    },
                                     "output": {
                                         "activity": "implement_prompt",
                                         "artifacts": [{"artifact_type": "runtime_turn"}],
@@ -202,7 +205,9 @@ class ArtifactHelperTests(unittest.TestCase):
 
         self.assertEqual(merged["runtime_tree_artifact"]["status"], "matched")
         self.assertEqual(merged["runtime_jobs"][0]["runtime_job_id"], "job-1")
+        self.assertEqual(merged["runtime_jobs"][0]["activity"], "implement_prompt")
         self.assertEqual(merged["runtime_jobs"][0]["artifact_count"], 1)
+        self.assertEqual(merged["runtime_jobs"][0]["error_kind"], "configuration")
         self.assertEqual(merged["runtime_jobs"][0]["terminal_state"], "succeeded")
         self.assertEqual(merged["latest_activity"], "implement_prompt")
 


### PR DESCRIPTION
## Summary
- Add optional `activity` and `error_kind` fields to PR repair eval runtime job snapshots while keeping older artifacts compatible.
- Extract runtime job `error_kind` from `/api/workflow-runtime/tree` activity result envelopes in `scripts/evaluate_pr_repair.sh` artifacts.
- Penalize failed runtime jobs in the cost/time efficiency score, with repeated non-retryable `configuration` or `fatal` failures receiving zero points for that dimension.
- Move scoring tests into `scoring_tests.rs` to keep the scorer source below the file-size limit.

## Why
The live PR repair eval exposed repeated agent-limit/runtime failures. The scorer had a cost-efficiency dimension, but it did not preserve enough per-job failure data to explain or penalize repeated non-retryable failures deterministically.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p harness-eval`
- `python3 scripts/test_evaluate_pr_repair_artifacts.py`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`

Closes #1286
