### PR TITLE
feat(eval): support benchmark suite manifests

### DIFF
--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -52,6 +52,8 @@ pub struct HardGateFailureCount {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrRepairBenchmarkCaseSummary {
     pub case_id: String,
+    pub tags: Vec<String>,
+    pub weight: u32,
     pub final_score: u8,
     pub effective_score: u8,
     pub final_grade: EvalGrade,
@@ -145,6 +147,8 @@ pub fn summarize_pr_repair_benchmark(input: PrRepairBenchmarkInput) -> PrRepairB
 
         case_summaries.push(PrRepairBenchmarkCaseSummary {
             case_id: case.case_id,
+            tags: case.tags,
+            weight: weight as u32,
             final_score: case.snapshot.final_score,
             effective_score,
             final_grade,

--- a/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
+++ b/crates/harness-eval/src/bin/score_pr_repair_benchmark.rs
@@ -2,6 +2,7 @@ use harness_eval::{
     summarize_pr_repair_benchmark, EvalRunMode, PrRepairBenchmarkCase, PrRepairBenchmarkInput,
     QualitySnapshot,
 };
+use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::env;
@@ -11,9 +12,28 @@ use std::path::{Path, PathBuf};
 #[derive(Default)]
 struct Args {
     suite: String,
+    manifests: Vec<PathBuf>,
     snapshots: Vec<PathBuf>,
     cases: Vec<(String, PathBuf)>,
     output: PathBuf,
+}
+
+#[derive(Deserialize)]
+struct BenchmarkManifest {
+    suite: Option<String>,
+    cases: Vec<BenchmarkManifestCase>,
+}
+
+#[derive(Deserialize)]
+struct BenchmarkManifestCase {
+    #[serde(alias = "id")]
+    case_id: String,
+    #[serde(alias = "path", alias = "snapshot_path")]
+    snapshot: PathBuf,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default = "default_manifest_case_weight")]
+    weight: u32,
 }
 
 fn main() {
@@ -27,6 +47,25 @@ fn run() -> Result<(), String> {
     let args = parse_args(env::args().skip(1))?;
     let mut cases = Vec::new();
     let mut seen_case_ids = HashSet::new();
+    let mut manifest_suite = None::<String>;
+
+    for path in args.manifests {
+        let manifest = read_manifest(&path)?;
+        if args.suite.is_empty() {
+            merge_manifest_suite(&mut manifest_suite, manifest.suite.as_deref(), &path)?;
+        }
+        for case in manifest.cases {
+            let snapshot_path = resolve_manifest_snapshot_path(&path, &case.snapshot);
+            push_case_with_metadata(
+                &mut cases,
+                &mut seen_case_ids,
+                case.case_id,
+                &snapshot_path,
+                case.tags,
+                case.weight,
+            )?;
+        }
+    }
 
     for path in args.snapshots {
         let case_id = case_id_from_path(&path)?;
@@ -36,10 +75,14 @@ fn run() -> Result<(), String> {
         push_case(&mut cases, &mut seen_case_ids, case_id, &path)?;
     }
 
-    let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput {
-        suite: args.suite,
-        cases,
-    });
+    let suite = if args.suite.is_empty() {
+        manifest_suite
+            .ok_or_else(|| "--suite is required when no manifest suite is provided".to_string())?
+    } else {
+        args.suite
+    };
+
+    let summary = summarize_pr_repair_benchmark(PrRepairBenchmarkInput { suite, cases });
     write_json(
         &args.output,
         &serde_json::to_value(summary).map_err(|err| err.to_string())?,
@@ -54,6 +97,9 @@ where
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--suite" => parsed.suite = required_value(&mut args, "--suite")?,
+            "--manifest" | "--suite-manifest" => parsed
+                .manifests
+                .push(PathBuf::from(required_value(&mut args, "--manifest")?)),
             "--snapshot" => {
                 parsed
                     .snapshots
@@ -68,9 +114,8 @@ where
         }
     }
 
-    if parsed.suite.is_empty()
-        || parsed.output.as_os_str().is_empty()
-        || (parsed.snapshots.is_empty() && parsed.cases.is_empty())
+    if parsed.output.as_os_str().is_empty()
+        || (parsed.manifests.is_empty() && parsed.snapshots.is_empty() && parsed.cases.is_empty())
     {
         return Err(usage());
     }
@@ -99,7 +144,51 @@ where
         .ok_or_else(|| format!("{flag} requires a value"))
 }
 
-fn read_case(case_id: String, path: &Path) -> Result<PrRepairBenchmarkCase, String> {
+fn read_manifest(path: &Path) -> Result<BenchmarkManifest, String> {
+    let body = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read manifest {}: {err}", path.display()))?;
+    serde_json::from_str(&body)
+        .map_err(|err| format!("failed to parse manifest {}: {err}", path.display()))
+}
+
+fn merge_manifest_suite(
+    current: &mut Option<String>,
+    suite: Option<&str>,
+    path: &Path,
+) -> Result<(), String> {
+    let Some(suite) = suite.map(str::trim).filter(|suite| !suite.is_empty()) else {
+        return Ok(());
+    };
+    match current {
+        Some(existing) if existing != suite => Err(format!(
+            "manifest {} uses suite {suite:?}, which conflicts with suite {existing:?}",
+            path.display()
+        )),
+        Some(_) => Ok(()),
+        None => {
+            *current = Some(suite.to_string());
+            Ok(())
+        }
+    }
+}
+
+fn resolve_manifest_snapshot_path(manifest_path: &Path, snapshot: &Path) -> PathBuf {
+    if snapshot.is_absolute() {
+        return snapshot.to_path_buf();
+    }
+    manifest_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join(snapshot)
+}
+
+fn read_case(
+    case_id: String,
+    path: &Path,
+    tags: Vec<String>,
+    weight: u32,
+) -> Result<PrRepairBenchmarkCase, String> {
     let body = fs::read_to_string(path)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
     let raw_snapshot: Value = serde_json::from_str(&body)
@@ -135,8 +224,8 @@ fn read_case(case_id: String, path: &Path) -> Result<PrRepairBenchmarkCase, Stri
     }
     Ok(PrRepairBenchmarkCase {
         case_id,
-        tags: Vec::new(),
-        weight: 1,
+        tags,
+        weight,
         snapshot,
     })
 }
@@ -147,10 +236,21 @@ fn push_case(
     case_id: String,
     path: &Path,
 ) -> Result<(), String> {
+    push_case_with_metadata(cases, seen_case_ids, case_id, path, Vec::new(), 1)
+}
+
+fn push_case_with_metadata(
+    cases: &mut Vec<PrRepairBenchmarkCase>,
+    seen_case_ids: &mut HashSet<String>,
+    case_id: String,
+    path: &Path,
+    tags: Vec<String>,
+    weight: u32,
+) -> Result<(), String> {
     if !seen_case_ids.insert(case_id.clone()) {
         return Err(format!("duplicate case ID: {case_id}"));
     }
-    cases.push(read_case(case_id, path)?);
+    cases.push(read_case(case_id, path, tags, weight)?);
     Ok(())
 }
 
@@ -176,5 +276,9 @@ fn case_id_from_path(path: &Path) -> Result<String, String> {
 }
 
 fn usage() -> String {
-    "Usage: score_pr_repair_benchmark --suite NAME (--snapshot quality_snapshot.json | --case CASE_ID=quality_snapshot.json)... --output benchmark_summary.json".to_string()
+    "Usage: score_pr_repair_benchmark [--suite NAME] (--manifest suite.json | --snapshot quality_snapshot.json | --case CASE_ID=quality_snapshot.json)... --output benchmark_summary.json".to_string()
+}
+
+fn default_manifest_case_weight() -> u32 {
+    1
 }

--- a/crates/harness-eval/tests/pr_repair_benchmark_cli.rs
+++ b/crates/harness-eval/tests/pr_repair_benchmark_cli.rs
@@ -68,6 +68,117 @@ fn benchmark_cli_aggregates_snapshot_cases() {
 }
 
 #[test]
+fn benchmark_cli_aggregates_manifest_cases_with_metadata() {
+    let temp_dir = TempDir::new("pr-repair-benchmark-manifest");
+    let snapshot_dir = temp_dir.path().join("snapshots");
+    fs::create_dir_all(&snapshot_dir).expect("create snapshot dir");
+    let ready_noop = snapshot_dir.join("ready_noop.json");
+    let blocked_threads = snapshot_dir.join("blocked_threads.json");
+    let manifest = temp_dir.path().join("suite.json");
+    let output = temp_dir.path().join("benchmark_summary.json");
+
+    write_snapshot(
+        &ready_noop,
+        &fixture_snapshot("ready-noop", 100, EvalGrade::A, None),
+    );
+    write_snapshot(
+        &blocked_threads,
+        &fixture_snapshot(
+            "blocked-threads",
+            75,
+            EvalGrade::C,
+            Some(HardGateName::ReviewThreadClosure),
+        ),
+    );
+    write_json_value(
+        &manifest,
+        &serde_json::json!({
+            "suite": "manifest-suite",
+            "cases": [
+                {
+                    "case_id": "ready-noop",
+                    "snapshot": "snapshots/ready_noop.json",
+                    "tags": ["ready_noop", "no_change"],
+                    "weight": 2
+                },
+                {
+                    "id": "blocked-threads",
+                    "path": "snapshots/blocked_threads.json",
+                    "tags": ["review_threads"],
+                    "weight": 3
+                }
+            ]
+        }),
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_score_pr_repair_benchmark"))
+        .arg("--manifest")
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&output)
+        .status()
+        .expect("run benchmark binary");
+    assert!(status.success(), "benchmark binary should succeed");
+
+    let summary: Value = serde_json::from_str(&fs::read_to_string(&output).expect("read summary"))
+        .expect("parse summary");
+
+    assert_eq!(summary["suite"], "manifest-suite");
+    assert_eq!(summary["case_count"], 2);
+    assert_eq!(summary["weighted_case_count"], 5);
+    assert_eq!(summary["capability_score"], 9);
+    assert_eq!(summary["status"], "failing");
+    assert_eq!(summary["cases"][0]["case_id"], "ready-noop");
+    assert_eq!(summary["cases"][0]["weight"], 2);
+    assert_eq!(summary["cases"][0]["tags"][0], "ready_noop");
+    assert_eq!(summary["cases"][1]["case_id"], "blocked-threads");
+    assert_eq!(summary["cases"][1]["weight"], 3);
+    assert_eq!(summary["cases"][1]["tags"][0], "review_threads");
+}
+
+#[test]
+fn benchmark_cli_rejects_duplicate_manifest_case_ids() {
+    let temp_dir = TempDir::new("pr-repair-benchmark-duplicate-manifest");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+    let manifest = temp_dir.path().join("suite.json");
+    let output = temp_dir.path().join("benchmark_summary.json");
+
+    write_snapshot(
+        &snapshot_path,
+        &fixture_snapshot("duplicate", 100, EvalGrade::A, None),
+    );
+    write_json_value(
+        &manifest,
+        &serde_json::json!({
+            "suite": "duplicate-suite",
+            "cases": [
+                {"case_id": "duplicate", "snapshot": "snapshot.json"},
+                {"case_id": "duplicate", "snapshot": "snapshot.json"}
+            ]
+        }),
+    );
+
+    let output_status = Command::new(env!("CARGO_BIN_EXE_score_pr_repair_benchmark"))
+        .arg("--manifest")
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .expect("run benchmark binary");
+
+    assert!(
+        !output_status.status.success(),
+        "benchmark binary should reject duplicate manifest case ids"
+    );
+    let stderr = String::from_utf8_lossy(&output_status.stderr);
+    assert!(stderr.contains("duplicate case ID: duplicate"));
+    assert!(
+        !output.exists(),
+        "rejected benchmark should not write output"
+    );
+}
+
+#[test]
 fn benchmark_cli_rejects_collect_only_snapshots() {
     let temp_dir = TempDir::new("pr-repair-benchmark-collect-only");
     let snapshot_path = temp_dir.path().join("collect_only.json");

--- a/docs/eval-module-design.md
+++ b/docs/eval-module-design.md
@@ -338,11 +338,13 @@ pub struct PrRepairBenchmarkInput {
 pub struct PrRepairBenchmarkSummary {
     pub suite: String,
     pub case_count: u64,
+    pub weighted_case_count: u64,
     pub confidence: BenchmarkConfidence,
     pub status: BenchmarkStatus,
     pub capability_score: u8, // 0..10
     pub average_effective_score: u8,
     pub min_effective_score: u8,
+    pub max_effective_score: u8,
     pub excellent_cases: u64,
     pub acceptable_cases: u64,
     pub blocked_cases: u64,
@@ -536,6 +538,38 @@ score_pr_repair_benchmark \
   --case pr-1254=docs/pr-repair-evals/.../quality_snapshot.json \
   --output benchmark_summary.json
 ```
+
+For repeatable suites, prefer a manifest:
+
+```json
+{
+  "suite": "pr-repair-smoke",
+  "cases": [
+    {
+      "case_id": "ready-noop-control",
+      "snapshot": "ready-noop/quality_snapshot.json",
+      "tags": ["ready_noop"],
+      "weight": 1
+    },
+    {
+      "case_id": "review-thread-repair",
+      "snapshot": "review-thread/quality_snapshot.json",
+      "tags": ["review_threads"],
+      "weight": 2
+    }
+  ]
+}
+```
+
+```text
+score_pr_repair_benchmark \
+  --manifest docs/pr-repair-evals/pr-repair-smoke.json \
+  --output benchmark_summary.json
+```
+
+Manifest snapshot paths are resolved relative to the manifest file. `--suite`
+may override the manifest suite name for ad hoc comparisons, but a committed
+regression suite should keep the suite name in the manifest.
 
 It reads existing `quality_snapshot.json` artifacts and writes a deterministic
 benchmark summary. It does not fetch GitHub, start Harness, or grade code with an

--- a/docs/eval-module-implementation-plan.md
+++ b/docs/eval-module-implementation-plan.md
@@ -156,6 +156,9 @@ Scope:
 - Cap the effective per-case score by the final grade so hard-gate failures do
   not look like 10/10 wins.
 - Add a file-based `score_pr_repair_benchmark` binary for local benchmark runs.
+- Add manifest-backed benchmark suites so stable regression cases can define
+  suite name, case id, snapshot path, tags, and weight without long CLI command
+  lines.
 
 Out of scope:
 
@@ -173,6 +176,14 @@ Acceptance:
   benchmark status.
 - The benchmark binary reads multiple quality snapshots and writes
   `benchmark_summary.json`.
+- A manifest can drive a benchmark suite with relative snapshot paths, tags,
+  weights, and duplicate case-id protection.
+
+Implementation status:
+
+- Added deterministic summary aggregation and a file-based benchmark CLI.
+- Added manifest input for stable PR repair regression suites while preserving
+  `--snapshot` and `--case` ad hoc inputs.
 
 ## First PR Scope
 

--- a/docs/pr-repair-capability-evaluation.md
+++ b/docs/pr-repair-capability-evaluation.md
@@ -214,6 +214,47 @@ Score the run after the final GraphQL snapshot:
 | `D` | No meaningful progress, repeated same failure, or excessive cost. |
 | `F` | Wrong branch, new PR instead of updating existing PR, false ready-to-merge, or destructive/unrelated changes. |
 
+After the three snapshots exist, pin them in a benchmark manifest so future
+changes can rerun the same suite:
+
+```json
+{
+  "suite": "pr-repair-smoke",
+  "cases": [
+    {
+      "case_id": "ready-noop-control",
+      "snapshot": "ready-noop/quality_snapshot.json",
+      "tags": ["ready_noop"],
+      "weight": 1
+    },
+    {
+      "case_id": "ci-repair",
+      "snapshot": "ci-repair/quality_snapshot.json",
+      "tags": ["ci_repair"],
+      "weight": 1
+    },
+    {
+      "case_id": "review-thread-repair",
+      "snapshot": "review-thread/quality_snapshot.json",
+      "tags": ["review_threads"],
+      "weight": 2
+    }
+  ]
+}
+```
+
+Run the suite with:
+
+```bash
+score_pr_repair_benchmark \
+  --manifest docs/pr-repair-evals/pr-repair-smoke.json \
+  --output docs/pr-repair-evals/pr-repair-smoke-summary.json
+```
+
+Manifest snapshot paths are relative to the manifest file. Use weights to make
+harder or more important PR repair classes count more heavily without hiding
+per-case hard-gate failures.
+
 ## Report Fields
 
 Each run should produce a report with:


### PR DESCRIPTION
## Summary

- Add manifest input support to `score_pr_repair_benchmark` for repeatable PR repair benchmark suites.
- Carry case `tags` and normalized `weight` into benchmark case summaries.
- Document manifest-backed PR repair regression suites in the eval design and PR repair evaluation docs.

Closes #1288.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p harness-eval`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace`
