### PR TITLE
fix(server): guard task status classifications

### DIFF
--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -206,7 +206,16 @@ impl TaskSchedulerState {
             TaskStatus::Cancelled => SchedulerAuthorityState::Cancelled,
             TaskStatus::AwaitingDeps => SchedulerAuthorityState::AwaitingDependencies,
             TaskStatus::Pending => SchedulerAuthorityState::Queued,
-            _ => SchedulerAuthorityState::Running,
+            TaskStatus::Triaging
+            | TaskStatus::Planning
+            | TaskStatus::Implementing
+            | TaskStatus::ReviewGenerating
+            | TaskStatus::ReviewWaiting
+            | TaskStatus::PlannerGenerating
+            | TaskStatus::PlannerWaiting
+            | TaskStatus::AgentReview
+            | TaskStatus::Waiting
+            | TaskStatus::Reviewing => SchedulerAuthorityState::Running,
         };
     }
 

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -186,44 +186,44 @@ pub enum TaskFailureKind {
 }
 
 const TERMINAL_TASK_STATUSES: &[&str] = &[
-    task_status_tag(&TaskStatus::Done),
-    task_status_tag(&TaskStatus::Failed),
-    task_status_tag(&TaskStatus::Cancelled),
+    TaskStatus::Done.as_str(),
+    TaskStatus::Failed.as_str(),
+    TaskStatus::Cancelled.as_str(),
 ];
 const RESUMABLE_TASK_STATUSES: &[&str] = &[
-    task_status_tag(&TaskStatus::Triaging),
-    task_status_tag(&TaskStatus::Planning),
-    task_status_tag(&TaskStatus::Implementing),
-    task_status_tag(&TaskStatus::ReviewGenerating),
-    task_status_tag(&TaskStatus::ReviewWaiting),
-    task_status_tag(&TaskStatus::PlannerGenerating),
-    task_status_tag(&TaskStatus::PlannerWaiting),
-    task_status_tag(&TaskStatus::AgentReview),
-    task_status_tag(&TaskStatus::Waiting),
-    task_status_tag(&TaskStatus::Reviewing),
+    TaskStatus::Triaging.as_str(),
+    TaskStatus::Planning.as_str(),
+    TaskStatus::Implementing.as_str(),
+    TaskStatus::ReviewGenerating.as_str(),
+    TaskStatus::ReviewWaiting.as_str(),
+    TaskStatus::PlannerGenerating.as_str(),
+    TaskStatus::PlannerWaiting.as_str(),
+    TaskStatus::AgentReview.as_str(),
+    TaskStatus::Waiting.as_str(),
+    TaskStatus::Reviewing.as_str(),
 ];
 
-const fn task_status_tag(status: &TaskStatus) -> &'static str {
-    match status {
-        TaskStatus::Pending => "pending",
-        TaskStatus::AwaitingDeps => "awaiting_deps",
-        TaskStatus::Triaging => "triaging",
-        TaskStatus::Planning => "planning",
-        TaskStatus::Implementing => "implementing",
-        TaskStatus::ReviewGenerating => "review_generating",
-        TaskStatus::ReviewWaiting => "review_waiting",
-        TaskStatus::PlannerGenerating => "planner_generating",
-        TaskStatus::PlannerWaiting => "planner_waiting",
-        TaskStatus::AgentReview => "agent_review",
-        TaskStatus::Waiting => "waiting",
-        TaskStatus::Reviewing => "reviewing",
-        TaskStatus::Done => "done",
-        TaskStatus::Failed => "failed",
-        TaskStatus::Cancelled => "cancelled",
-    }
-}
-
 impl TaskStatus {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::AwaitingDeps => "awaiting_deps",
+            Self::Triaging => "triaging",
+            Self::Planning => "planning",
+            Self::Implementing => "implementing",
+            Self::ReviewGenerating => "review_generating",
+            Self::ReviewWaiting => "review_waiting",
+            Self::PlannerGenerating => "planner_generating",
+            Self::PlannerWaiting => "planner_waiting",
+            Self::AgentReview => "agent_review",
+            Self::Waiting => "waiting",
+            Self::Reviewing => "reviewing",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Done | Self::Failed | Self::Cancelled)
     }
@@ -271,7 +271,7 @@ impl TaskStatus {
 
 impl AsRef<str> for TaskStatus {
     fn as_ref(&self) -> &str {
-        task_status_tag(self)
+        self.as_str()
     }
 }
 

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -185,19 +185,43 @@ pub enum TaskFailureKind {
     WorkspaceLifecycle,
 }
 
-const TERMINAL_TASK_STATUSES: &[&str] = &["done", "failed", "cancelled"];
-const RESUMABLE_TASK_STATUSES: &[&str] = &[
-    "triaging",
-    "planning",
-    "implementing",
-    "review_generating",
-    "review_waiting",
-    "planner_generating",
-    "planner_waiting",
-    "agent_review",
-    "waiting",
-    "reviewing",
+const TERMINAL_TASK_STATUSES: &[&str] = &[
+    task_status_tag(&TaskStatus::Done),
+    task_status_tag(&TaskStatus::Failed),
+    task_status_tag(&TaskStatus::Cancelled),
 ];
+const RESUMABLE_TASK_STATUSES: &[&str] = &[
+    task_status_tag(&TaskStatus::Triaging),
+    task_status_tag(&TaskStatus::Planning),
+    task_status_tag(&TaskStatus::Implementing),
+    task_status_tag(&TaskStatus::ReviewGenerating),
+    task_status_tag(&TaskStatus::ReviewWaiting),
+    task_status_tag(&TaskStatus::PlannerGenerating),
+    task_status_tag(&TaskStatus::PlannerWaiting),
+    task_status_tag(&TaskStatus::AgentReview),
+    task_status_tag(&TaskStatus::Waiting),
+    task_status_tag(&TaskStatus::Reviewing),
+];
+
+const fn task_status_tag(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Pending => "pending",
+        TaskStatus::AwaitingDeps => "awaiting_deps",
+        TaskStatus::Triaging => "triaging",
+        TaskStatus::Planning => "planning",
+        TaskStatus::Implementing => "implementing",
+        TaskStatus::ReviewGenerating => "review_generating",
+        TaskStatus::ReviewWaiting => "review_waiting",
+        TaskStatus::PlannerGenerating => "planner_generating",
+        TaskStatus::PlannerWaiting => "planner_waiting",
+        TaskStatus::AgentReview => "agent_review",
+        TaskStatus::Waiting => "waiting",
+        TaskStatus::Reviewing => "reviewing",
+        TaskStatus::Done => "done",
+        TaskStatus::Failed => "failed",
+        TaskStatus::Cancelled => "cancelled",
+    }
+}
 
 impl TaskStatus {
     pub fn is_terminal(&self) -> bool {
@@ -247,23 +271,7 @@ impl TaskStatus {
 
 impl AsRef<str> for TaskStatus {
     fn as_ref(&self) -> &str {
-        match self {
-            TaskStatus::Pending => "pending",
-            TaskStatus::AwaitingDeps => "awaiting_deps",
-            TaskStatus::Triaging => "triaging",
-            TaskStatus::Planning => "planning",
-            TaskStatus::Implementing => "implementing",
-            TaskStatus::ReviewGenerating => "review_generating",
-            TaskStatus::ReviewWaiting => "review_waiting",
-            TaskStatus::PlannerGenerating => "planner_generating",
-            TaskStatus::PlannerWaiting => "planner_waiting",
-            TaskStatus::AgentReview => "agent_review",
-            TaskStatus::Waiting => "waiting",
-            TaskStatus::Reviewing => "reviewing",
-            TaskStatus::Done => "done",
-            TaskStatus::Failed => "failed",
-            TaskStatus::Cancelled => "cancelled",
-        }
+        task_status_tag(self)
     }
 }
 

--- a/crates/harness-server/tests/state_invariants.rs
+++ b/crates/harness-server/tests/state_invariants.rs
@@ -289,3 +289,28 @@ fn task_status_is_terminal_helper_matches_local_classification() {
         );
     }
 }
+
+#[test]
+fn task_status_sql_filters_match_restart_classification() {
+    let expected_terminal: Vec<&str> = all_task_statuses()
+        .iter()
+        .filter(|status| task_is_terminal(status))
+        .map(task_status_tag)
+        .collect();
+    assert_eq!(
+        TaskStatus::terminal_statuses(),
+        expected_terminal.as_slice(),
+        "TaskStatus::terminal_statuses must be derived from the terminal classification",
+    );
+
+    let expected_resumable: Vec<&str> = all_task_statuses()
+        .iter()
+        .filter(|status| status.is_resumable_after_restart())
+        .map(task_status_tag)
+        .collect();
+    assert_eq!(
+        TaskStatus::resumable_statuses(),
+        expected_resumable.as_slice(),
+        "TaskStatus::resumable_statuses must be derived from the restart classification",
+    );
+}


### PR DESCRIPTION
## Summary
- derive task status SQL filter strings from the canonical TaskStatus tag helper
- make TaskSchedulerState::mark_terminal exhaustive instead of using a wildcard
- add an invariant test tying terminal/resumable SQL filters to TaskStatus classification

Closes #1298

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server --test state_invariants
- cargo check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Note: full cargo test was run and reached 1376 passed / 2 failed in harness-server. The failures were periodic_retry::tests::retry_tick_cleans_workspace_before_reenqueue and router::tests::gc_adopt_schedule_changes_with_gc_config; the latter passed when rerun individually, while the retry test remained tied to external test runtime/DB state and is outside this task-status change surface.