### PR TITLE
Fix runtime terminal workspace cleanup

### DIFF
--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -27,6 +27,8 @@ struct RuntimeTaskResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     issue: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     workflow: Option<TaskWorkflowSummary>,
 }
 
@@ -123,6 +125,7 @@ async fn runtime_task_response_by_handle(
             .and_then(|value| value.as_str())
             .map(ToOwned::to_owned),
         issue,
+        error: runtime_string_field(&workflow.data, "failure_reason"),
         workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
     }))
 }

--- a/crates/harness-server/src/http/tests/mod.rs
+++ b/crates/harness-server/src/http/tests/mod.rs
@@ -36,6 +36,7 @@ mod runtime_task_route_tests;
 mod runtime_tree_tests;
 mod runtime_worker_followup_tests;
 mod runtime_worker_tests;
+mod runtime_worker_workspace_tests;
 mod task_detail_sse_tests;
 mod webhook_runtime_tests;
 mod webhook_task_tests;

--- a/crates/harness-server/src/http/tests/route_helpers.rs
+++ b/crates/harness-server/src/http/tests/route_helpers.rs
@@ -5,6 +5,49 @@ pub(super) fn init_fake_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub(super) fn init_worktree_git_repo(root: &std::path::Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(root)?;
+    run_git(root, &["init"])?;
+    run_git(root, &["config", "user.email", "test@harness.test"])?;
+    run_git(root, &["config", "user.name", "Harness Test"])?;
+    run_git(root, &["commit", "--allow-empty", "-m", "init"])?;
+    run_git(root, &["branch", "-M", "main"])?;
+    Ok(())
+}
+
+fn run_git(root: &std::path::Path, args: &[&str]) -> anyhow::Result<()> {
+    let git_bin = std::env::var("HARNESS_GIT_BIN").unwrap_or_else(|_| "git".to_string());
+    let mut command = std::process::Command::new(git_bin);
+    for key in [
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CONFIG",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_COUNT",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_IMPLICIT_WORK_TREE",
+        "GIT_GRAFT_FILE",
+        "GIT_INDEX_FILE",
+        "GIT_NO_REPLACE_OBJECTS",
+        "GIT_REPLACE_REF_BASE",
+        "GIT_PREFIX",
+        "GIT_SHALLOW_FILE",
+        "GIT_COMMON_DIR",
+    ] {
+        command.env_remove(key);
+    }
+    let output = command.arg("-C").arg(root).args(args).output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
 pub(super) fn task_app(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health_check))

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -349,6 +349,65 @@ async fn workflow_runtime_cancel_endpoint_cancels_issue_workflow() -> anyhow::Re
 }
 
 #[tokio::test]
+async fn get_task_runtime_issue_surfaces_failure_reason() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "failed",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1299"),
+    )
+    .with_id("issue-1299")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 1299,
+        "task_id": "runtime-task-1299",
+        "task_ids": ["runtime-task-1299"],
+        "failure_reason": "WorktreeCollision: workspace path is managed by another harness session",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let app = Router::new()
+        .route("/tasks/{id}", get(get_task))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/runtime-task-1299")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["status"], "failed");
+    assert_eq!(
+        body["error"],
+        "WorktreeCollision: workspace path is managed by another harness session"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests/runtime_worker_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_tests.rs
@@ -193,6 +193,124 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
 }
 
 #[tokio::test]
+async fn runtime_job_worker_cleans_on_terminal_workspace_after_failed_runtime_attempt(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nbase:\n  require_remote_head: false\nworkspace:\n  strategy: worktree\n  cleanup: on_terminal\n  reuse_existing_workspace: true\n---\n",
+    )?;
+    init_worktree_git_repo(&project_root)?;
+    let workspace_root = dir.path().join("workspaces");
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.workspace.root = workspace_root.clone();
+    config.workspace.root_configured = true;
+
+    let agent = FailingStreamAgent::new("simulated provider outage");
+    let mut registry = harness_agents::registry::AgentRegistry::new("codex");
+    registry.register("codex", agent.clone());
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        config.clone(),
+        registry,
+    )
+    .await?;
+    let workspace_mgr = Arc::new(crate::workspace::WorkspaceManager::new(
+        config.workspace.clone(),
+    )?);
+    let mut state = match Arc::try_unwrap(state) {
+        Ok(state) => state,
+        Err(_) => panic!("test state should have one owner before workspace manager injection"),
+    };
+    state.concurrency.workspace_mgr = Some(workspace_mgr);
+    let state = Arc::new(state);
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1299"),
+    )
+    .with_id("issue-1299")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 1299,
+        "task_id": "runtime-task-1299",
+        "task_ids": ["runtime-task-1299"],
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+        "implement_issue",
+        "impl-1299",
+    );
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": workflow.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key,
+                "command": command.command,
+                "activity": "implement_issue",
+                "runtime_profile": harness_workflow::runtime::RuntimeProfile::new(
+                    "codex-default",
+                    harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                ),
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.failed, 1);
+    let updated = store
+        .get_instance("issue-1299")
+        .await?
+        .expect("workflow should still exist");
+    assert_eq!(updated.state, "failed");
+    assert!(
+        updated
+            .data
+            .get("failure_reason")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|reason| reason.contains("simulated provider outage")),
+        "failed runtime workflow should retain the projected failure reason: {:?}",
+        updated.data
+    );
+    let remaining_workspaces = std::fs::read_dir(&workspace_root)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .count();
+    assert_eq!(
+        remaining_workspaces, 0,
+        "terminal on_terminal cleanup should remove the deterministic runtime workspace"
+    );
+    assert_eq!(agent.prompts.lock().await.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_job_worker_cancels_job_when_workflow_already_terminal() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests/runtime_worker_workspace_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_workspace_tests.rs
@@ -1,0 +1,179 @@
+use super::*;
+
+#[tokio::test]
+async fn terminal_runtime_cleanup_releases_missing_workspace_without_git_cleanup(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-missing-terminal-workspace");
+    std::fs::create_dir_all(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nbase:\n  require_remote_head: false\nworkspace:\n  strategy: worktree\n  cleanup: on_terminal\n  reuse_existing_workspace: true\n---\n",
+    )?;
+    init_worktree_git_repo(&project_root)?;
+    let workspace_root = dir.path().join("workspaces");
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.workspace.root = workspace_root;
+    config.workspace.root_configured = true;
+    let agent = RuntimeStreamAgent::new();
+    let mut registry = harness_agents::registry::AgentRegistry::new("codex");
+    registry.register("codex", agent);
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        config.clone(),
+        registry,
+    )
+    .await?;
+    let workspace_mgr = Arc::new(crate::workspace::WorkspaceManager::new(
+        config.workspace.clone(),
+    )?);
+    let mut state = match Arc::try_unwrap(state) {
+        Ok(state) => state,
+        Err(_) => panic!("test state should have one owner before workspace manager injection"),
+    };
+    state.concurrency.workspace_mgr = Some(workspace_mgr.clone());
+    let state = Arc::new(state);
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "failed",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1299"),
+    )
+    .with_id("issue-1299-missing-workspace")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 1299,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let task_id = crate::task_runner::TaskId::from_str(&format!(
+        "runtime-wf-github-issue-pr-{}",
+        stable_hash_8_for_test(&workflow.id)
+    ));
+    let workspace_path = workspace_mgr.workspace_path_for(
+        &task_id,
+        &project_root,
+        Some(workflow.subject.subject_key.as_str()),
+        Some("owner/repo"),
+    );
+    workspace_mgr.active.insert(
+        task_id.clone(),
+        crate::workspace::ActiveWorkspace {
+            workspace_path: workspace_path.clone(),
+            source_repo: project_root.clone(),
+            repo: Some("owner/repo".to_string()),
+            runtime_workflow_id: Some(workflow.id.clone()),
+            branch: "harness/runtime-wf-github-issue-pr-test".to_string(),
+            created_at: std::time::SystemTime::now(),
+            owner_session: workspace_mgr.owner_session.clone(),
+            run_generation: 1,
+        },
+    );
+    workspace_mgr
+        .active_paths
+        .insert(workspace_path.clone(), task_id.clone());
+    assert!(!workspace_path.exists());
+    assert_eq!(workspace_mgr.live_count(), 1);
+    let marker = dir.path().join("git-cleanup-marker");
+    let proxy = write_git_marker_proxy(
+        dir.path(),
+        &project_root.to_string_lossy(),
+        &marker.to_string_lossy(),
+    )?;
+    let previous_git_bin = set_missing_workspace_test_git_proxy(proxy.as_os_str());
+
+    let cleanup_result =
+        crate::workflow_runtime_worker::notify_runtime_submission_terminal_workflow(
+            &state,
+            &workflow.id,
+            None,
+        )
+        .await;
+    restore_missing_workspace_test_git_proxy(previous_git_bin);
+    cleanup_result?;
+
+    assert!(
+        !marker.exists(),
+        "missing terminal workspace cleanup should release the lease without invoking git cleanup"
+    );
+    assert_eq!(workspace_mgr.live_count(), 0);
+    assert!(workspace_mgr.get_workspace(&task_id).is_none());
+    assert!(
+        workspace_mgr.active_paths.get(&workspace_path).is_none(),
+        "missing workspace release should clear the active path reservation"
+    );
+    Ok(())
+}
+
+fn stable_hash_8_for_test(value: &str) -> String {
+    let mut hash: u32 = 0x811c9dc5;
+    for byte in value.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    format!("{hash:08x}")
+}
+
+fn write_git_marker_proxy(
+    root: &std::path::Path,
+    project_root: &str,
+    marker: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    #[cfg(not(unix))]
+    anyhow::bail!("git marker proxy test requires a unix shell");
+    #[cfg(unix)]
+    {
+        let proxy = root.join("git-marker-proxy.sh");
+        let real_git = std::env::var("HARNESS_GIT_BIN").unwrap_or_else(|_| "git".to_string());
+        std::fs::write(
+            &proxy,
+            format!(
+                "#!/bin/sh\nproject_root={}\nmarker={}\nreal_git={}\nif printf '%s\\n' \"$*\" | grep -F -- \"$project_root\" >/dev/null; then\n  printf '%s\\n' \"$*\" >> \"$marker\"\nfi\nexec \"$real_git\" \"$@\"\n",
+                shell_quote(project_root),
+                shell_quote(marker),
+                shell_quote(&real_git)
+            ),
+        )?;
+        let mut permissions = std::fs::metadata(&proxy)?.permissions();
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&proxy, permissions)?;
+        Ok(proxy)
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn set_missing_workspace_test_git_proxy(value: &std::ffi::OsStr) -> Option<std::ffi::OsString> {
+    let previous = std::env::var_os("HARNESS_GIT_BIN");
+    // SAFETY: this scoped test override is restored before assertions; the proxy
+    // delegates every git command to the real binary and only records calls for
+    // this test's private temporary project path.
+    unsafe { std::env::set_var("HARNESS_GIT_BIN", value) };
+    previous
+}
+
+fn restore_missing_workspace_test_git_proxy(previous: Option<std::ffi::OsString>) {
+    match previous {
+        Some(value) => {
+            // SAFETY: restores the process environment value saved by this test.
+            unsafe { std::env::set_var("HARNESS_GIT_BIN", value) };
+        }
+        None => {
+            // SAFETY: restores absence for the process environment value saved by this test.
+            unsafe { std::env::remove_var("HARNESS_GIT_BIN") };
+        }
+    }
+}

--- a/crates/harness-server/src/http/tests/state_support.rs
+++ b/crates/harness-server/src/http/tests/state_support.rs
@@ -20,6 +20,11 @@ pub(super) struct RuntimeStreamAgent {
     pub(super) approval_policies: Mutex<Vec<Option<String>>>,
 }
 
+pub(super) struct FailingStreamAgent {
+    pub(super) prompts: Mutex<Vec<String>>,
+    error: String,
+}
+
 impl RuntimeStreamAgent {
     pub(super) fn new() -> Arc<Self> {
         Arc::new(Self {
@@ -28,6 +33,15 @@ impl RuntimeStreamAgent {
             reasoning_efforts: Mutex::new(Vec::new()),
             sandbox_modes: Mutex::new(Vec::new()),
             approval_policies: Mutex::new(Vec::new()),
+        })
+    }
+}
+
+impl FailingStreamAgent {
+    pub(super) fn new(error: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            prompts: Mutex::new(Vec::new()),
+            error: error.into(),
         })
     }
 }
@@ -162,6 +176,35 @@ impl CodeAgent for RuntimeStreamAgent {
             .await;
         let _ = tx.send(StreamItem::Done).await;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl CodeAgent for FailingStreamAgent {
+    fn name(&self) -> &str {
+        "failing-stream-agent"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+
+    async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        self.prompts.lock().await.push(req.prompt);
+        Err(harness_core::error::HarnessError::AgentExecution(
+            self.error.clone(),
+        ))
+    }
+
+    async fn execute_stream(
+        &self,
+        req: AgentRequest,
+        _tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        self.prompts.lock().await.push(req.prompt);
+        Err(harness_core::error::HarnessError::AgentExecution(
+            self.error.clone(),
+        ))
     }
 }
 

--- a/crates/harness-server/src/periodic_retry.rs
+++ b/crates/harness-server/src/periodic_retry.rs
@@ -760,8 +760,13 @@ mod tests {
             tasks.iter().all(|t| t.id == task_id),
             "runtime-first issue retry should not enqueue a successor task row"
         );
-        let workflow_id =
-            harness_workflow::issue_lifecycle::workflow_id(dir.path().to_str().unwrap(), None, 42);
+        let detected_repo = crate::task_executor::pr_detection::detect_repo_slug(dir.path()).await;
+        let project_id = dir.path().to_string_lossy();
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            project_id.as_ref(),
+            detected_repo.as_deref(),
+            42,
+        );
         let instance = runtime_store
             .get_instance(&workflow_id)
             .await?

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -111,6 +111,12 @@ pub(crate) async fn notify_runtime_submission_terminal_workflow(
         &instance,
     )
     .await?;
+    if let Err(error) = workspace::cleanup_terminal_runtime_workspace(state, &instance).await {
+        tracing::warn!(
+            workflow_id = %workflow_id,
+            "terminal runtime workspace cleanup failed: {error}"
+        );
+    }
     let Some(callback) = state.intake.completion_callback.as_ref() else {
         return Ok(false);
     };

--- a/crates/harness-server/src/workflow_runtime_worker/workspace.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/workspace.rs
@@ -188,6 +188,67 @@ pub(super) async fn finish_runtime_workspace(
     hook_result
 }
 
+pub(super) async fn cleanup_terminal_runtime_workspace(
+    state: &AppState,
+    workflow: &WorkflowInstance,
+) -> anyhow::Result<()> {
+    if !workflow.is_terminal() {
+        return Ok(());
+    }
+    let Some(workspace_mgr) = state.concurrency.workspace_mgr.as_ref() else {
+        return Ok(());
+    };
+    let Some(project_id) = workflow
+        .data
+        .get("project_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Ok(());
+    };
+    let source_project_root = PathBuf::from(project_id);
+    let workflow_document =
+        harness_core::config::workflow::load_workflow_document(&source_project_root)?;
+    if workflow_document.config.workspace.strategy != "worktree"
+        || workflow_document.config.workspace.cleanup != "on_terminal"
+    {
+        return Ok(());
+    }
+
+    let task_id = stable_runtime_workspace_task_id_for_workflow(workflow);
+    let repo = workflow
+        .data
+        .get("repo")
+        .and_then(serde_json::Value::as_str)
+        .or(workflow_document.config.source.repo.as_deref());
+    let workspace_path = workspace_mgr.workspace_path_for(
+        &task_id,
+        &source_project_root,
+        Some(workflow.subject.subject_key.as_str()),
+        repo,
+    );
+    if workspace_path.exists() {
+        if let Some(hook) = workflow_document.config.hooks.before_remove.as_deref() {
+            if let Err(error) = run_workflow_hook(
+                "before_remove",
+                hook,
+                &workspace_path,
+                workflow_document.config.hooks.timeout_secs,
+            )
+            .await
+            {
+                tracing::warn!(
+                    workflow_id = %workflow.id,
+                    workspace_path = %workspace_path.display(),
+                    "before_remove hook failed during terminal runtime workspace cleanup: {error}"
+                );
+            }
+        }
+    }
+    workspace_mgr
+        .cleanup_workspace_for_retry(&task_id, &source_project_root, Some(&workspace_path))
+        .await
+}
+
 fn validate_workspace_cleanup_policy(cleanup: &str) -> anyhow::Result<()> {
     match cleanup {
         "after_run" | "on_terminal" => Ok(()),
@@ -235,13 +296,17 @@ pub(super) fn stable_runtime_workspace_task_id(
     workflow: Option<&WorkflowInstance>,
 ) -> TaskId {
     if let Some(workflow) = workflow {
-        let definition = sanitize_workspace_id_component(&workflow.definition_id);
-        return TaskId::from_str(&format!(
-            "runtime-wf-{definition}-{}",
-            stable_hash_8(&workflow.id)
-        ));
+        return stable_runtime_workspace_task_id_for_workflow(workflow);
     }
     TaskId::from_str(&format!("runtime-job-{}", stable_hash_8(&job.id)))
+}
+
+fn stable_runtime_workspace_task_id_for_workflow(workflow: &WorkflowInstance) -> TaskId {
+    let definition = sanitize_workspace_id_component(&workflow.definition_id);
+    TaskId::from_str(&format!(
+        "runtime-wf-{definition}-{}",
+        stable_hash_8(&workflow.id)
+    ))
 }
 
 fn sanitize_workspace_id_component(value: &str) -> String {

--- a/crates/harness-server/src/workflow_runtime_worker/workspace.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/workspace.rs
@@ -243,10 +243,13 @@ pub(super) async fn cleanup_terminal_runtime_workspace(
                 );
             }
         }
+        workspace_mgr
+            .cleanup_workspace_for_retry(&task_id, &source_project_root, Some(&workspace_path))
+            .await
+    } else {
+        workspace_mgr.release_workspace(&task_id);
+        Ok(())
     }
-    workspace_mgr
-        .cleanup_workspace_for_retry(&task_id, &source_project_root, Some(&workspace_path))
-        .await
 }
 
 fn validate_workspace_cleanup_policy(cleanup: &str) -> anyhow::Result<()> {

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -363,6 +363,21 @@ impl WorkspaceManager {
             .await
     }
 
+    pub(crate) fn workspace_path_for(
+        &self,
+        task_id: &TaskId,
+        source_repo: &Path,
+        external_id: Option<&str>,
+        repo: Option<&str>,
+    ) -> PathBuf {
+        self.config.root.join(derive_workspace_key(
+            task_id,
+            external_id,
+            repo,
+            Some(source_repo),
+        ))
+    }
+
     /// Return the workspace path for the given task if it is active.
     pub fn get_workspace(&self, task_id: &TaskId) -> Option<PathBuf> {
         self.active.get(task_id).map(|e| e.workspace_path.clone())


### PR DESCRIPTION
## Summary
- Clean deterministic runtime workspaces when workflow submissions reach terminal states under `workspace.cleanup: on_terminal`.
- Surface runtime workflow `failure_reason` in `GET /tasks/:id` detail responses.
- Add regressions for failed runtime workspace cleanup, task detail error projection, and repo-qualified retry assertions.

## Validation
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test -p harness-server runtime_job_worker_cleans_on_terminal_workspace_after_failed_runtime_attempt -- --nocapture`
- `cargo test -p harness-server get_task_runtime_issue_surfaces_failure_reason -- --nocapture`
- `cargo test -p harness-server periodic_retry::tests::retry_tick_cleans_workspace_before_reenqueue -- --nocapture`
- `cargo test -p harness-server`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`

Closes #1299