### PR TITLE
fix(server): retry PR lifecycle runtime persistence

### DIFF
--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -15,6 +15,15 @@ use std::path::Path;
 
 const DEFAULT_PR_FEEDBACK_FAILED_CHILD_SUPPRESSION_SECS: u64 = 24 * 60 * 60;
 
+mod pr_lifecycle_persist;
+use pr_lifecycle_persist::{
+    issue_workflow_id, persist_pr_lifecycle_with_retry, pr_lifecycle_workflow_id,
+};
+#[cfg(test)]
+use pr_lifecycle_persist::{
+    set_pr_lifecycle_persist_test_failures, PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS,
+};
+
 pub(crate) struct PrDetectedRuntimeContext<'a> {
     pub project_root: &'a Path,
     pub repo: Option<&'a str>,
@@ -142,14 +151,39 @@ pub(crate) async fn record_pr_detected(
     ctx: PrDetectedRuntimeContext<'_>,
 ) {
     let Some(store) = store else {
-        return;
-    };
-    if let Err(error) = persist_pr_detected(store, &ctx).await {
-        tracing::warn!(
+        tracing::error!(
             issue = ctx.issue_number,
             pr = ctx.pr_number,
             task_id = %ctx.task_id.0,
-            "workflow runtime PR detection write failed: {error}"
+            "workflow runtime PR detection write skipped because the runtime store is unavailable"
+        );
+        return;
+    };
+    let workflow_id = issue_workflow_id(ctx.project_root, ctx.repo, ctx.issue_number);
+    let failure_payload = json!({
+        "issue_number": ctx.issue_number,
+        "repo": ctx.repo,
+        "task_id": ctx.task_id.as_str(),
+        "pr_number": ctx.pr_number,
+        "pr_url": ctx.pr_url,
+    });
+    if let Err(error) = persist_pr_lifecycle_with_retry(
+        store,
+        &workflow_id,
+        "record_pr_detected",
+        ctx.task_id,
+        ctx.pr_number,
+        failure_payload,
+        || persist_pr_detected(store, &ctx),
+    )
+    .await
+    {
+        tracing::error!(
+            workflow_id = %workflow_id,
+            issue = ctx.issue_number,
+            pr = ctx.pr_number,
+            task_id = %ctx.task_id.0,
+            "workflow runtime PR detection write failed after retries: {error}"
         );
     }
 }
@@ -159,13 +193,42 @@ pub(crate) async fn record_pr_feedback(
     ctx: PrFeedbackRuntimeContext<'_>,
 ) {
     let Some(store) = store else {
-        return;
-    };
-    if let Err(error) = persist_pr_feedback(store, &ctx).await {
-        tracing::warn!(
+        tracing::error!(
+            issue = ?ctx.issue_number,
             pr = ctx.pr_number,
             task_id = %ctx.task_id.0,
-            "workflow runtime PR feedback write failed: {error}"
+            "workflow runtime PR feedback write skipped because the runtime store is unavailable"
+        );
+        return;
+    };
+    let workflow_id =
+        pr_lifecycle_workflow_id(ctx.project_root, ctx.repo, ctx.issue_number, ctx.pr_number);
+    let failure_payload = json!({
+        "issue_number": ctx.issue_number,
+        "repo": ctx.repo,
+        "task_id": ctx.task_id.as_str(),
+        "pr_number": ctx.pr_number,
+        "pr_url": ctx.pr_url,
+        "outcome": outcome_label(ctx.outcome),
+        "summary": ctx.summary,
+    });
+    if let Err(error) = persist_pr_lifecycle_with_retry(
+        store,
+        &workflow_id,
+        "record_pr_feedback",
+        ctx.task_id,
+        ctx.pr_number,
+        failure_payload,
+        || persist_pr_feedback(store, &ctx),
+    )
+    .await
+    {
+        tracing::error!(
+            workflow_id = %workflow_id,
+            issue = ?ctx.issue_number,
+            pr = ctx.pr_number,
+            task_id = %ctx.task_id.0,
+            "workflow runtime PR feedback write failed after retries: {error}"
         );
     }
 }
@@ -191,13 +254,41 @@ pub(crate) async fn record_pr_merged(
     ctx: PrMergedRuntimeContext<'_>,
 ) {
     let Some(store) = store else {
-        return;
-    };
-    if let Err(error) = persist_pr_merged(store, &ctx).await {
-        tracing::warn!(
+        tracing::error!(
+            issue = ?ctx.issue_number,
             pr = ctx.pr_number,
             task_id = %ctx.task_id.0,
-            "workflow runtime PR merge write failed: {error}"
+            "workflow runtime PR merge write skipped because the runtime store is unavailable"
+        );
+        return;
+    };
+    let workflow_id =
+        pr_lifecycle_workflow_id(ctx.project_root, ctx.repo, ctx.issue_number, ctx.pr_number);
+    let failure_payload = json!({
+        "issue_number": ctx.issue_number,
+        "repo": ctx.repo,
+        "task_id": ctx.task_id.as_str(),
+        "pr_number": ctx.pr_number,
+        "pr_url": ctx.pr_url,
+        "summary": ctx.summary,
+    });
+    if let Err(error) = persist_pr_lifecycle_with_retry(
+        store,
+        &workflow_id,
+        "record_pr_merged",
+        ctx.task_id,
+        ctx.pr_number,
+        failure_payload,
+        || persist_pr_merged(store, &ctx),
+    )
+    .await
+    {
+        tracing::error!(
+            workflow_id = %workflow_id,
+            issue = ?ctx.issue_number,
+            pr = ctx.pr_number,
+            task_id = %ctx.task_id.0,
+            "workflow runtime PR merge write failed after retries: {error}"
         );
     }
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
@@ -45,7 +45,8 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = anyhow::Result<()>>,
 {
-    for attempt in 1..=PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS {
+    let mut attempt = 1;
+    loop {
         let result = match maybe_inject_pr_lifecycle_persist_failure_for_test(task_id) {
             Ok(()) => persist().await,
             Err(error) => Err(error),
@@ -75,6 +76,7 @@ where
                     "workflow runtime PR lifecycle write failed; retrying: {error}"
                 );
                 tokio::time::sleep(PR_LIFECYCLE_PERSIST_RETRY_BACKOFF).await;
+                attempt += 1;
             }
             Err(error) => {
                 record_pr_lifecycle_persist_failure(
@@ -92,7 +94,6 @@ where
             }
         }
     }
-    anyhow::bail!("workflow runtime PR lifecycle write exhausted retry attempts")
 }
 
 async fn record_pr_lifecycle_persist_failure(
@@ -135,14 +136,37 @@ static PR_LIFECYCLE_PERSIST_TEST_FAILURES: std::sync::Mutex<
 > = std::sync::Mutex::new(std::collections::BTreeMap::new());
 
 #[cfg(test)]
-pub(super) fn set_pr_lifecycle_persist_test_failures(task_id: &str, failures: usize) {
+pub(super) struct PrLifecyclePersistTestFailuresGuard {
+    task_id: String,
+}
+
+#[cfg(test)]
+impl Drop for PrLifecyclePersistTestFailuresGuard {
+    fn drop(&mut self) {
+        if let Ok(mut plans) = PR_LIFECYCLE_PERSIST_TEST_FAILURES.lock() {
+            plans.remove(&self.task_id);
+        }
+    }
+}
+
+#[cfg(test)]
+#[must_use]
+pub(super) fn set_pr_lifecycle_persist_test_failures(
+    task_id: &str,
+    failures: usize,
+) -> PrLifecyclePersistTestFailuresGuard {
     let Ok(mut plans) = PR_LIFECYCLE_PERSIST_TEST_FAILURES.lock() else {
-        return;
+        return PrLifecyclePersistTestFailuresGuard {
+            task_id: task_id.to_string(),
+        };
     };
     if failures == 0 {
         plans.remove(task_id);
     } else {
         plans.insert(task_id.to_string(), failures);
+    }
+    PrLifecyclePersistTestFailuresGuard {
+        task_id: task_id.to_string(),
     }
 }
 

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
@@ -1,0 +1,174 @@
+use super::pr_workflow_id;
+use crate::task_runner::TaskId;
+use harness_workflow::runtime::WorkflowRuntimeStore;
+use serde_json::json;
+use std::{future::Future, path::Path, time::Duration};
+
+pub(super) const PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS: usize = 3;
+const PR_LIFECYCLE_PERSIST_RETRY_BACKOFF: Duration = Duration::from_millis(50);
+const PR_LIFECYCLE_PERSIST_FAILURE_EVENT: &str = "PrLifecyclePersistenceFailed";
+const PR_LIFECYCLE_PERSIST_FAILURE_SOURCE: &str = "workflow_runtime_pr_feedback";
+
+pub(super) fn issue_workflow_id(
+    project_root: &Path,
+    repo: Option<&str>,
+    issue_number: u64,
+) -> String {
+    let project_id = project_root.to_string_lossy();
+    harness_workflow::issue_lifecycle::workflow_id(&project_id, repo, issue_number)
+}
+
+pub(super) fn pr_lifecycle_workflow_id(
+    project_root: &Path,
+    repo: Option<&str>,
+    issue_number: Option<u64>,
+    pr_number: u64,
+) -> String {
+    if let Some(issue_number) = issue_number {
+        issue_workflow_id(project_root, repo, issue_number)
+    } else {
+        let project_id = project_root.to_string_lossy();
+        pr_workflow_id(&project_id, repo, pr_number)
+    }
+}
+
+pub(super) async fn persist_pr_lifecycle_with_retry<F, Fut>(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    operation: &'static str,
+    task_id: &TaskId,
+    pr_number: u64,
+    failure_payload: serde_json::Value,
+    mut persist: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    for attempt in 1..=PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS {
+        let result = match maybe_inject_pr_lifecycle_persist_failure_for_test(task_id) {
+            Ok(()) => persist().await,
+            Err(error) => Err(error),
+        };
+        match result {
+            Ok(()) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        workflow_id,
+                        operation,
+                        pr = pr_number,
+                        task_id = %task_id.0,
+                        attempt,
+                        "workflow runtime PR lifecycle write succeeded after retry"
+                    );
+                }
+                return Ok(());
+            }
+            Err(error) if attempt < PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS => {
+                tracing::warn!(
+                    workflow_id,
+                    operation,
+                    pr = pr_number,
+                    task_id = %task_id.0,
+                    attempt,
+                    max_attempts = PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS,
+                    "workflow runtime PR lifecycle write failed; retrying: {error}"
+                );
+                tokio::time::sleep(PR_LIFECYCLE_PERSIST_RETRY_BACKOFF).await;
+            }
+            Err(error) => {
+                record_pr_lifecycle_persist_failure(
+                    store,
+                    workflow_id,
+                    operation,
+                    task_id,
+                    pr_number,
+                    failure_payload,
+                    &error,
+                    attempt,
+                )
+                .await;
+                return Err(error);
+            }
+        }
+    }
+    anyhow::bail!("workflow runtime PR lifecycle write exhausted retry attempts")
+}
+
+async fn record_pr_lifecycle_persist_failure(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    operation: &'static str,
+    task_id: &TaskId,
+    pr_number: u64,
+    mut payload: serde_json::Value,
+    error: &anyhow::Error,
+    attempts: usize,
+) {
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("operation".to_string(), json!(operation));
+        object.insert("attempts".to_string(), json!(attempts));
+        object.insert("error".to_string(), json!(error.to_string()));
+    }
+    if let Err(event_error) = store
+        .append_event(
+            workflow_id,
+            PR_LIFECYCLE_PERSIST_FAILURE_EVENT,
+            PR_LIFECYCLE_PERSIST_FAILURE_SOURCE,
+            payload,
+        )
+        .await
+    {
+        tracing::error!(
+            workflow_id,
+            operation,
+            pr = pr_number,
+            task_id = %task_id.0,
+            "workflow runtime PR lifecycle failure event write failed: {event_error}"
+        );
+    }
+}
+
+#[cfg(test)]
+static PR_LIFECYCLE_PERSIST_TEST_FAILURES: std::sync::Mutex<
+    std::collections::BTreeMap<String, usize>,
+> = std::sync::Mutex::new(std::collections::BTreeMap::new());
+
+#[cfg(test)]
+pub(super) fn set_pr_lifecycle_persist_test_failures(task_id: &str, failures: usize) {
+    let Ok(mut plans) = PR_LIFECYCLE_PERSIST_TEST_FAILURES.lock() else {
+        return;
+    };
+    if failures == 0 {
+        plans.remove(task_id);
+    } else {
+        plans.insert(task_id.to_string(), failures);
+    }
+}
+
+#[cfg(test)]
+fn maybe_inject_pr_lifecycle_persist_failure_for_test(task_id: &TaskId) -> anyhow::Result<()> {
+    let mut plans = PR_LIFECYCLE_PERSIST_TEST_FAILURES
+        .lock()
+        .map_err(|_| anyhow::anyhow!("PR lifecycle persist test failure mutex poisoned"))?;
+    let Some(remaining) = plans.get_mut(task_id.as_str()) else {
+        return Ok(());
+    };
+    if *remaining == 0 {
+        plans.remove(task_id.as_str());
+        return Ok(());
+    }
+    *remaining -= 1;
+    if *remaining == 0 {
+        plans.remove(task_id.as_str());
+    }
+    anyhow::bail!(
+        "injected PR lifecycle persist failure for {}",
+        task_id.as_str()
+    )
+}
+
+#[cfg(not(test))]
+fn maybe_inject_pr_lifecycle_persist_failure_for_test(_task_id: &TaskId) -> anyhow::Result<()> {
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -60,7 +60,7 @@ async fn transient_pr_lifecycle_persist_failure_is_retried_and_converges() -> an
     let project_root = dir.path().join("project");
     std::fs::create_dir(&project_root)?;
     let task_id = TaskId::from_str("transient-pr-lifecycle-persist-failure");
-    set_pr_lifecycle_persist_test_failures(task_id.as_str(), 2);
+    let _guard = set_pr_lifecycle_persist_test_failures(task_id.as_str(), 2);
 
     record_pr_detected(
         Some(&store),
@@ -107,7 +107,8 @@ async fn persistent_pr_lifecycle_persist_failure_records_operator_event() -> any
     let project_root = dir.path().join("project");
     std::fs::create_dir(&project_root)?;
     let task_id = TaskId::from_str("persistent-pr-lifecycle-persist-failure");
-    set_pr_lifecycle_persist_test_failures(task_id.as_str(), PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS);
+    let _guard =
+        set_pr_lifecycle_persist_test_failures(task_id.as_str(), PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS);
 
     record_pr_detected(
         Some(&store),

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -47,6 +47,109 @@ async fn pr_detected_persists_pr_open_state() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn transient_pr_lifecycle_persist_failure_is_retried_and_converges() -> anyhow::Result<()> {
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let store =
+        match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await {
+            Ok(store) => store,
+            Err(_) => return Ok(()),
+        };
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("transient-pr-lifecycle-persist-failure");
+    set_pr_lifecycle_persist_test_failures(task_id.as_str(), 2);
+
+    record_pr_detected(
+        Some(&store),
+        PrDetectedRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 123,
+            task_id: &task_id,
+            pr_number: 77,
+            pr_url: "https://github.com/owner/repo/pull/77",
+        },
+    )
+    .await;
+
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_root.to_string_lossy(),
+        Some("owner/repo"),
+        123,
+    );
+    let instance = store.get_instance(&workflow_id).await?;
+    let Some(instance) = instance else {
+        anyhow::bail!("workflow instance should be persisted after retry");
+    };
+    assert_eq!(instance.state, "pr_open");
+    let events = store.events_for(&workflow_id).await?;
+    assert!(events.iter().any(|event| event.event_type == "PrDetected"));
+    assert!(!events
+        .iter()
+        .any(|event| event.event_type == "PrLifecyclePersistenceFailed"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn persistent_pr_lifecycle_persist_failure_records_operator_event() -> anyhow::Result<()> {
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let store =
+        match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await {
+            Ok(store) => store,
+            Err(_) => return Ok(()),
+        };
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("persistent-pr-lifecycle-persist-failure");
+    set_pr_lifecycle_persist_test_failures(task_id.as_str(), PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS);
+
+    record_pr_detected(
+        Some(&store),
+        PrDetectedRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 123,
+            task_id: &task_id,
+            pr_number: 77,
+            pr_url: "https://github.com/owner/repo/pull/77",
+        },
+    )
+    .await;
+
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_root.to_string_lossy(),
+        Some("owner/repo"),
+        123,
+    );
+    assert!(store.get_instance(&workflow_id).await?.is_none());
+    let events = store.events_for(&workflow_id).await?;
+    let failure_event = events
+        .iter()
+        .find(|event| event.event_type == "PrLifecyclePersistenceFailed");
+    let Some(failure_event) = failure_event else {
+        anyhow::bail!("persistent failure should create an operator-visible workflow event");
+    };
+    assert_eq!(failure_event.event["operation"], "record_pr_detected");
+    assert_eq!(
+        failure_event.event["attempts"],
+        serde_json::json!(PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS)
+    );
+    assert_eq!(failure_event.event["issue_number"], 123);
+    assert_eq!(failure_event.event["pr_number"], 77);
+    assert_eq!(failure_event.event["task_id"], task_id.as_str());
+    assert!(failure_event.event["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("injected PR lifecycle persist failure")));
+    Ok(())
+}
+
+#[tokio::test]
 async fn rejected_new_runtime_decision_persists_initial_instance() -> anyhow::Result<()> {
     let Ok(database_url) = resolve_database_url(None) else {
         return Ok(());


### PR DESCRIPTION
## Summary
- Retry PR detected/feedback/merged workflow-runtime persistence writes before giving up.
- Log missing-store/final persistence failures at error level with workflow/task/PR context.
- Record a PrLifecyclePersistenceFailed workflow event on persistent failure so operators can see stranded external PR facts.
- Add regression tests for transient retry convergence and persistent failure event recording.

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server workflow_runtime_pr_feedback::tests::
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test (failed in full-suite run: router::tests::gc_adopt_schedule_changes_with_gc_config and task_runner::spawn::tests::spawn_skills_tests::validation_phase_is_set_on_review_loop_turns; both passed when rerun directly)
- cargo test -p harness-server router::tests::gc_adopt_schedule_changes_with_gc_config
- cargo test -p harness-server task_runner::spawn::tests::spawn_skills_tests::validation_phase_is_set_on_review_loop_turns

Fixes #1294