### PR TITLE
Fix ready-to-merge reconciliation

### DIFF
--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -29,11 +29,12 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
 
     if dry_run {
         println!(
-            "Reconciliation dry-run: {} candidate(s), {} terminal skipped, {} task transition(s), {} workflow transition(s)",
+            "Reconciliation dry-run: {} candidate(s), {} terminal skipped, {} task transition(s), {} workflow transition(s), {} workflow alert(s)",
             report.candidates,
             report.skipped_terminal,
             report.transitions.len(),
-            report.workflow_transitions.len()
+            report.workflow_transitions.len(),
+            report.workflow_alerts.len()
         );
     } else {
         let applied = report.transitions.iter().filter(|t| t.applied).count()
@@ -43,8 +44,11 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
                 .filter(|t| t.applied)
                 .count();
         println!(
-            "Reconciliation: {} candidate(s), {} terminal skipped, {} transition(s) applied",
-            report.candidates, report.skipped_terminal, applied
+            "Reconciliation: {} candidate(s), {} terminal skipped, {} transition(s) applied, {} workflow alert(s)",
+            report.candidates,
+            report.skipped_terminal,
+            applied,
+            report.workflow_alerts.len()
         );
     }
 
@@ -59,6 +63,27 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
         println!(
             "  workflow {} {}#{}: {} → {} ({}) [{}]",
             t.workflow_id, repo, t.pr_number, t.from, t.to, t.reason, applied
+        );
+    }
+
+    for alert in &report.workflow_alerts {
+        let repo = alert.repo.as_deref().unwrap_or("<unknown>");
+        let issue_number = alert
+            .issue_number
+            .map(|number| number.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let pr_url = alert.pr_url.as_deref().unwrap_or("<unknown>");
+        println!(
+            "  workflow alert {} repo={} issue=#{} pr=#{} state={} age_secs={} ttl_secs={} reason={} url={}",
+            alert.workflow_id,
+            repo,
+            issue_number,
+            alert.pr_number,
+            alert.state,
+            alert.age_secs,
+            alert.ttl_secs,
+            alert.reason,
+            pr_url
         );
     }
 

--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -17,11 +17,11 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
     let store = harness_server::task_runner::TaskStore::open(&db_path).await?;
     let (runtime_store, issue_workflow_store) = open_workflow_stores(config).await;
 
-    let report = harness_server::reconciliation::run_once_with_runtime_token(
+    let report = harness_server::reconciliation::run_once_with_runtime_config(
         &store,
         runtime_store.as_ref(),
         issue_workflow_store.as_ref(),
-        config.reconciliation.max_gh_calls_per_minute,
+        &config.reconciliation,
         dry_run,
         config.server.github_token.as_deref(),
     )

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod dirs;
 pub mod intake;
+pub mod maintenance;
 pub mod misc;
 pub mod project;
 pub mod resolve;
@@ -10,6 +11,7 @@ pub mod workflow;
 
 use self::agents::*;
 use self::intake::*;
+use self::maintenance::*;
 use self::misc::*;
 use self::server::*;
 use serde::{Deserialize, Deserializer, Serialize};

--- a/crates/harness-core/src/config/maintenance.rs
+++ b/crates/harness-core/src/config/maintenance.rs
@@ -1,0 +1,261 @@
+use chrono::{DateTime, Duration, NaiveTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Daily maintenance window configuration for scheduled restarts and self-updates.
+///
+/// When enabled, no new tasks are dispatched during the configured time window.
+/// In-flight tasks continue to completion. The window boundary logic handles
+/// cross-midnight ranges (e.g. 23:00-02:00) and DST transitions via `chrono-tz`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintenanceWindowConfig {
+    /// When false (default), this feature is completely disabled. No behaviour change.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Start of the quiet window in local time (inclusive). Format: "HH:MM:SS".
+    #[serde(default = "default_quiet_window_start")]
+    pub quiet_window_start: NaiveTime,
+    /// End of the quiet window in local time (exclusive). Format: "HH:MM:SS".
+    /// If `quiet_window_end < quiet_window_start`, the window crosses midnight.
+    #[serde(default = "default_quiet_window_end")]
+    pub quiet_window_end: NaiveTime,
+    /// IANA timezone name (e.g. "America/New_York"). Defaults to "UTC".
+    #[serde(default = "default_maintenance_timezone")]
+    pub timezone: String,
+    /// Maximum seconds to wait for in-flight tasks to drain before external restart.
+    #[serde(default = "default_drain_timeout_secs")]
+    pub drain_timeout_secs: u64,
+}
+
+fn default_quiet_window_start() -> NaiveTime {
+    // 06:00:00 is always valid; fallback to midnight if chrono invariants change.
+    NaiveTime::from_hms_opt(6, 0, 0).unwrap_or(NaiveTime::MIN)
+}
+
+fn default_quiet_window_end() -> NaiveTime {
+    // 08:00:00 is always valid; fallback to midnight if chrono invariants change.
+    NaiveTime::from_hms_opt(8, 0, 0).unwrap_or(NaiveTime::MIN)
+}
+
+fn default_maintenance_timezone() -> String {
+    "UTC".to_string()
+}
+
+fn default_drain_timeout_secs() -> u64 {
+    3600
+}
+
+impl Default for MaintenanceWindowConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            quiet_window_start: default_quiet_window_start(),
+            quiet_window_end: default_quiet_window_end(),
+            timezone: default_maintenance_timezone(),
+            drain_timeout_secs: default_drain_timeout_secs(),
+        }
+    }
+}
+
+impl MaintenanceWindowConfig {
+    /// Returns `true` when `now` falls inside the configured quiet window.
+    ///
+    /// Always returns `false` when `enabled = false`.
+    /// Handles cross-midnight windows: if `quiet_window_end < quiet_window_start`,
+    /// the window spans midnight and is active when `time >= start || time < end`.
+    /// Equal start and end produce a zero-length window (always returns `false`).
+    /// Falls back to UTC if the timezone string cannot be parsed.
+    pub fn in_quiet_window(&self, now: DateTime<Utc>) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let tz = self
+            .timezone
+            .parse::<chrono_tz::Tz>()
+            .unwrap_or(chrono_tz::UTC);
+        let local = now.with_timezone(&tz);
+        let t = local.time();
+        let start = self.quiet_window_start;
+        let end = self.quiet_window_end;
+        if end < start {
+            // Cross-midnight: active from start to midnight, and midnight to end.
+            t >= start || t < end
+        } else {
+            t >= start && t < end
+        }
+    }
+
+    /// Returns the number of seconds until the quiet window ends.
+    ///
+    /// Uses timezone-aware `DateTime` arithmetic so the result is correct on
+    /// DST transition days. Returns 0 when `enabled = false`.
+    pub fn secs_until_window_end(&self, now: DateTime<Utc>) -> u64 {
+        if !self.enabled {
+            return 0;
+        }
+        let tz = self
+            .timezone
+            .parse::<chrono_tz::Tz>()
+            .unwrap_or(chrono_tz::UTC);
+        let local: chrono::DateTime<chrono_tz::Tz> = now.with_timezone(&tz);
+        let today = local.date_naive();
+        let end_naive = today.and_time(self.quiet_window_end);
+        // earliest() resolves DST ambiguity (fall-back); returns None on spring-forward
+        // gaps, which we treat as "window end has passed".
+        let diff_secs = match tz.from_local_datetime(&end_naive).earliest() {
+            Some(end_dt) => end_dt.signed_duration_since(local).num_seconds(),
+            None => 0,
+        };
+        if diff_secs > 0 {
+            diff_secs as u64
+        } else {
+            // End time has already passed today; for cross-midnight windows the end
+            // falls tomorrow, so compute against tomorrow's wall-clock end time.
+            let tomorrow = today + Duration::days(1);
+            let end_tomorrow_naive = tomorrow.and_time(self.quiet_window_end);
+            tz.from_local_datetime(&end_tomorrow_naive)
+                .earliest()
+                .map(|end_dt| end_dt.signed_duration_since(local).num_seconds().max(0) as u64)
+                .unwrap_or(0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utc_at(hour: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 3, 15, hour, min, 0)
+            .single()
+            .expect("valid datetime")
+    }
+
+    fn window(start_h: u32, start_m: u32, end_h: u32, end_m: u32) -> MaintenanceWindowConfig {
+        MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(start_h, start_m, 0).unwrap(),
+            quiet_window_end: NaiveTime::from_hms_opt(end_h, end_m, 0).unwrap(),
+            timezone: "UTC".to_string(),
+            drain_timeout_secs: 3600,
+        }
+    }
+
+    #[test]
+    fn disabled_always_false() {
+        let mut cfg = window(6, 0, 8, 0);
+        cfg.enabled = false;
+        assert!(!cfg.in_quiet_window(utc_at(7, 0)));
+        assert!(!cfg.in_quiet_window(utc_at(6, 0)));
+    }
+
+    #[test]
+    fn inside_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(cfg.in_quiet_window(utc_at(7, 0)));
+    }
+
+    #[test]
+    fn before_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(5, 59)));
+    }
+
+    #[test]
+    fn after_window() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(8, 1)));
+    }
+
+    #[test]
+    fn boundary_start_inclusive() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(cfg.in_quiet_window(utc_at(6, 0)));
+    }
+
+    #[test]
+    fn boundary_end_exclusive() {
+        let cfg = window(6, 0, 8, 0);
+        assert!(!cfg.in_quiet_window(utc_at(8, 0)));
+    }
+
+    #[test]
+    fn cross_midnight_inside() {
+        let cfg = window(23, 0, 2, 0);
+        assert!(cfg.in_quiet_window(utc_at(0, 30)));
+    }
+
+    #[test]
+    fn cross_midnight_outside() {
+        let cfg = window(23, 0, 2, 0);
+        assert!(!cfg.in_quiet_window(utc_at(12, 0)));
+    }
+
+    #[test]
+    fn dst_spring_forward_no_panic() {
+        let cfg = MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(2, 0, 0).unwrap(),
+            quiet_window_end: NaiveTime::from_hms_opt(4, 0, 0).unwrap(),
+            timezone: "America/New_York".to_string(),
+            drain_timeout_secs: 3600,
+        };
+        let now = Utc
+            .with_ymd_and_hms(2024, 3, 10, 7, 30, 0)
+            .single()
+            .unwrap();
+        cfg.in_quiet_window(now);
+    }
+
+    #[test]
+    fn dst_fall_back_no_panic() {
+        let cfg = MaintenanceWindowConfig {
+            enabled: true,
+            quiet_window_start: NaiveTime::from_hms_opt(1, 0, 0).unwrap_or(NaiveTime::MIN),
+            quiet_window_end: NaiveTime::from_hms_opt(3, 0, 0).unwrap_or(NaiveTime::MIN),
+            timezone: "America/New_York".to_string(),
+            drain_timeout_secs: 3600,
+        };
+        let now = Utc
+            .with_ymd_and_hms(2024, 11, 3, 6, 30, 0)
+            .single()
+            .unwrap();
+        cfg.in_quiet_window(now);
+    }
+
+    #[test]
+    fn secs_until_end_normal() {
+        let cfg = window(6, 0, 8, 0);
+        let secs = cfg.secs_until_window_end(utc_at(7, 0));
+        assert_eq!(secs, 3600);
+    }
+
+    #[test]
+    fn secs_until_end_cross_midnight() {
+        let cfg = window(23, 0, 2, 0);
+        let secs = cfg.secs_until_window_end(utc_at(23, 30));
+        assert_eq!(secs, 9000);
+    }
+
+    #[test]
+    fn maintenance_window_config_default_disabled() {
+        let cfg = MaintenanceWindowConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.timezone, "UTC");
+        assert_eq!(cfg.drain_timeout_secs, 3600);
+    }
+
+    #[test]
+    fn maintenance_window_config_toml_roundtrip() {
+        let toml = r#"
+            enabled = true
+            quiet_window_start = "06:00:00"
+            quiet_window_end = "08:00:00"
+            timezone = "America/New_York"
+            drain_timeout_secs = 7200
+        "#;
+        let cfg: MaintenanceWindowConfig = toml::from_str(toml).expect("toml parse failed");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.timezone, "America/New_York");
+        assert_eq!(cfg.drain_timeout_secs, 7200);
+    }
+}

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -1,5 +1,4 @@
 use crate::types::Grade;
-use chrono::{DateTime, Duration, NaiveTime, TimeZone, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -596,7 +595,7 @@ impl Default for RetrySchedulerConfig {
 ///
 /// The loop enumerates every non-terminal task that has a `pr_url` or an
 /// `external_id` like `issue:N` / `pr:N`, fetches the current GitHub state
-/// via `gh`, and applies the appropriate task-status transition.
+/// via the GitHub API, and applies the appropriate task-status transition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconciliationConfig {
     /// Whether the reconciliation loop is enabled. Default: true.
@@ -605,9 +604,17 @@ pub struct ReconciliationConfig {
     /// Seconds between reconciliation ticks. Default: 300 (5 minutes).
     #[serde(default = "default_reconciliation_interval_secs")]
     pub interval_secs: u64,
-    /// Maximum `gh` CLI calls per minute across all candidates. Default: 20.
+    /// Maximum GitHub API calls per minute across all candidates. Default: 20.
     #[serde(default = "default_reconciliation_max_gh_calls_per_minute")]
     pub max_gh_calls_per_minute: u32,
+    /// Minimum age, in seconds, before a `github_issue_pr` workflow in
+    /// `ready_to_merge` is reconciled against GitHub. Default: 300.
+    #[serde(default = "default_ready_to_merge_min_age_secs")]
+    pub ready_to_merge_min_age_secs: u64,
+    /// Age, in seconds, after which a still-open `ready_to_merge` PR is
+    /// reported as stale during reconciliation. Default: 3600.
+    #[serde(default = "default_ready_to_merge_alert_ttl_secs")]
+    pub ready_to_merge_alert_ttl_secs: u64,
 }
 
 fn default_reconciliation_enabled() -> bool {
@@ -622,131 +629,22 @@ fn default_reconciliation_max_gh_calls_per_minute() -> u32 {
     20
 }
 
+fn default_ready_to_merge_min_age_secs() -> u64 {
+    300
+}
+
+fn default_ready_to_merge_alert_ttl_secs() -> u64 {
+    3600
+}
+
 impl Default for ReconciliationConfig {
     fn default() -> Self {
         Self {
             enabled: default_reconciliation_enabled(),
             interval_secs: default_reconciliation_interval_secs(),
             max_gh_calls_per_minute: default_reconciliation_max_gh_calls_per_minute(),
-        }
-    }
-}
-
-/// Daily maintenance window configuration for scheduled restarts and self-updates.
-///
-/// When enabled, no new tasks are dispatched during the configured time window.
-/// In-flight tasks continue to completion. The window boundary logic handles
-/// cross-midnight ranges (e.g. 23:00–02:00) and DST transitions via `chrono-tz`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MaintenanceWindowConfig {
-    /// When false (default), this feature is completely disabled. No behaviour change.
-    #[serde(default)]
-    pub enabled: bool,
-    /// Start of the quiet window in local time (inclusive). Format: "HH:MM:SS".
-    #[serde(default = "default_quiet_window_start")]
-    pub quiet_window_start: NaiveTime,
-    /// End of the quiet window in local time (exclusive). Format: "HH:MM:SS".
-    /// If `quiet_window_end < quiet_window_start`, the window crosses midnight.
-    #[serde(default = "default_quiet_window_end")]
-    pub quiet_window_end: NaiveTime,
-    /// IANA timezone name (e.g. "America/New_York"). Defaults to "UTC".
-    #[serde(default = "default_maintenance_timezone")]
-    pub timezone: String,
-    /// Maximum seconds to wait for in-flight tasks to drain before external restart.
-    #[serde(default = "default_drain_timeout_secs")]
-    pub drain_timeout_secs: u64,
-}
-
-fn default_quiet_window_start() -> NaiveTime {
-    // 06:00:00 — always valid; fallback to midnight if chrono invariants change.
-    NaiveTime::from_hms_opt(6, 0, 0).unwrap_or(NaiveTime::MIN)
-}
-
-fn default_quiet_window_end() -> NaiveTime {
-    // 08:00:00 — always valid; fallback to midnight if chrono invariants change.
-    NaiveTime::from_hms_opt(8, 0, 0).unwrap_or(NaiveTime::MIN)
-}
-
-fn default_maintenance_timezone() -> String {
-    "UTC".to_string()
-}
-
-fn default_drain_timeout_secs() -> u64 {
-    3600
-}
-
-impl Default for MaintenanceWindowConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            quiet_window_start: default_quiet_window_start(),
-            quiet_window_end: default_quiet_window_end(),
-            timezone: default_maintenance_timezone(),
-            drain_timeout_secs: default_drain_timeout_secs(),
-        }
-    }
-}
-
-impl MaintenanceWindowConfig {
-    /// Returns `true` when `now` falls inside the configured quiet window.
-    ///
-    /// Always returns `false` when `enabled = false`.
-    /// Handles cross-midnight windows: if `quiet_window_end < quiet_window_start`,
-    /// the window spans midnight and is active when `time >= start || time < end`.
-    /// Equal start and end produce a zero-length window (always returns `false`).
-    /// Falls back to UTC if the timezone string cannot be parsed.
-    pub fn in_quiet_window(&self, now: DateTime<Utc>) -> bool {
-        if !self.enabled {
-            return false;
-        }
-        let tz = self
-            .timezone
-            .parse::<chrono_tz::Tz>()
-            .unwrap_or(chrono_tz::UTC);
-        let local = now.with_timezone(&tz);
-        let t = local.time();
-        let start = self.quiet_window_start;
-        let end = self.quiet_window_end;
-        if end < start {
-            // Cross-midnight: active from start to midnight, and midnight to end.
-            t >= start || t < end
-        } else {
-            t >= start && t < end
-        }
-    }
-
-    /// Returns the number of seconds until the quiet window ends.
-    ///
-    /// Uses timezone-aware `DateTime` arithmetic so the result is correct on
-    /// DST transition days. Returns 0 when `enabled = false`.
-    pub fn secs_until_window_end(&self, now: DateTime<Utc>) -> u64 {
-        if !self.enabled {
-            return 0;
-        }
-        let tz = self
-            .timezone
-            .parse::<chrono_tz::Tz>()
-            .unwrap_or(chrono_tz::UTC);
-        let local: chrono::DateTime<chrono_tz::Tz> = now.with_timezone(&tz);
-        let today = local.date_naive();
-        let end_naive = today.and_time(self.quiet_window_end);
-        // earliest() resolves DST ambiguity (fall-back); returns None on spring-forward
-        // gaps, which we treat as "window end has passed".
-        let diff_secs = match tz.from_local_datetime(&end_naive).earliest() {
-            Some(end_dt) => end_dt.signed_duration_since(local).num_seconds(),
-            None => 0,
-        };
-        if diff_secs > 0 {
-            diff_secs as u64
-        } else {
-            // End time has already passed today; for cross-midnight windows the end
-            // falls tomorrow — compute against tomorrow's wall-clock end time.
-            let tomorrow = today + Duration::days(1);
-            let end_tomorrow_naive = tomorrow.and_time(self.quiet_window_end);
-            tz.from_local_datetime(&end_tomorrow_naive)
-                .earliest()
-                .map(|end_dt| end_dt.signed_duration_since(local).num_seconds().max(0) as u64)
-                .unwrap_or(0)
+            ready_to_merge_min_age_secs: default_ready_to_merge_min_age_secs(),
+            ready_to_merge_alert_ttl_secs: default_ready_to_merge_alert_ttl_secs(),
         }
     }
 }
@@ -783,155 +681,22 @@ mod tests {
         assert_eq!(cfg.memory_poll_interval_secs, 5);
     }
 
-    // ── MaintenanceWindowConfig tests ────────────────────────────────────────
-
-    fn utc_at(hour: u32, min: u32) -> DateTime<Utc> {
-        use chrono::TimeZone;
-        Utc.with_ymd_and_hms(2024, 3, 15, hour, min, 0)
-            .single()
-            .expect("valid datetime")
-    }
-
-    fn window(start_h: u32, start_m: u32, end_h: u32, end_m: u32) -> MaintenanceWindowConfig {
-        MaintenanceWindowConfig {
-            enabled: true,
-            quiet_window_start: NaiveTime::from_hms_opt(start_h, start_m, 0).unwrap(),
-            quiet_window_end: NaiveTime::from_hms_opt(end_h, end_m, 0).unwrap(),
-            timezone: "UTC".to_string(),
-            drain_timeout_secs: 3600,
-        }
+    #[test]
+    fn reconciliation_config_defaults_include_ready_to_merge_age_limits() {
+        let cfg = ReconciliationConfig::default();
+        assert_eq!(cfg.ready_to_merge_min_age_secs, 300);
+        assert_eq!(cfg.ready_to_merge_alert_ttl_secs, 3600);
     }
 
     #[test]
-    fn test_disabled_always_false() {
-        let mut cfg = window(6, 0, 8, 0);
-        cfg.enabled = false;
-        // Any time should return false when disabled.
-        assert!(!cfg.in_quiet_window(utc_at(7, 0)));
-        assert!(!cfg.in_quiet_window(utc_at(6, 0)));
-    }
-
-    #[test]
-    fn test_inside_window() {
-        let cfg = window(6, 0, 8, 0);
-        assert!(cfg.in_quiet_window(utc_at(7, 0)));
-    }
-
-    #[test]
-    fn test_before_window() {
-        let cfg = window(6, 0, 8, 0);
-        assert!(!cfg.in_quiet_window(utc_at(5, 59)));
-    }
-
-    #[test]
-    fn test_after_window() {
-        let cfg = window(6, 0, 8, 0);
-        assert!(!cfg.in_quiet_window(utc_at(8, 1)));
-    }
-
-    #[test]
-    fn test_boundary_start_inclusive() {
-        let cfg = window(6, 0, 8, 0);
-        assert!(cfg.in_quiet_window(utc_at(6, 0)));
-    }
-
-    #[test]
-    fn test_boundary_end_exclusive() {
-        let cfg = window(6, 0, 8, 0);
-        assert!(!cfg.in_quiet_window(utc_at(8, 0)));
-    }
-
-    #[test]
-    fn test_cross_midnight_inside() {
-        // Window 23:00–02:00, now 00:30 → inside.
-        let cfg = window(23, 0, 2, 0);
-        assert!(cfg.in_quiet_window(utc_at(0, 30)));
-    }
-
-    #[test]
-    fn test_cross_midnight_outside() {
-        // Window 23:00–02:00, now 12:00 → outside.
-        let cfg = window(23, 0, 2, 0);
-        assert!(!cfg.in_quiet_window(utc_at(12, 0)));
-    }
-
-    #[test]
-    fn test_dst_spring_forward_no_panic() {
-        // America/New_York spring-forward 2024-03-10 02:00 → 03:00.
-        // 02:30 local is a gap — must not panic.
-        use chrono::TimeZone;
-        let cfg = MaintenanceWindowConfig {
-            enabled: true,
-            quiet_window_start: NaiveTime::from_hms_opt(2, 0, 0).unwrap(),
-            quiet_window_end: NaiveTime::from_hms_opt(4, 0, 0).unwrap(),
-            timezone: "America/New_York".to_string(),
-            drain_timeout_secs: 3600,
-        };
-        // 07:30 UTC = 02:30 EST (before spring forward), which is in the gap.
-        let now = Utc
-            .with_ymd_and_hms(2024, 3, 10, 7, 30, 0)
-            .single()
-            .unwrap();
-        // Should not panic; result can be true or false depending on gap handling.
-        cfg.in_quiet_window(now);
-    }
-
-    #[test]
-    fn test_dst_fall_back_no_panic() {
-        // America/New_York fall-back 2024-11-03 02:00 → 01:00 (ambiguous).
-        use chrono::TimeZone;
-        let cfg = MaintenanceWindowConfig {
-            enabled: true,
-            quiet_window_start: NaiveTime::from_hms_opt(1, 0, 0).unwrap_or(NaiveTime::MIN),
-            quiet_window_end: NaiveTime::from_hms_opt(3, 0, 0).unwrap_or(NaiveTime::MIN),
-            timezone: "America/New_York".to_string(),
-            drain_timeout_secs: 3600,
-        };
-        // 06:30 UTC = 01:30 EST (ambiguous on fall-back day).
-        let now = Utc
-            .with_ymd_and_hms(2024, 11, 3, 6, 30, 0)
-            .single()
-            .unwrap();
-        // Should not panic; result can be true or false depending on ambiguity handling.
-        cfg.in_quiet_window(now);
-    }
-
-    #[test]
-    fn test_secs_until_end_normal() {
-        let cfg = window(6, 0, 8, 0);
-        // At 07:00, window ends at 08:00 → 3600 seconds.
-        let secs = cfg.secs_until_window_end(utc_at(7, 0));
-        assert_eq!(secs, 3600);
-    }
-
-    #[test]
-    fn test_secs_until_end_cross_midnight() {
-        // Window 23:00–02:00, now 23:30. End is 02:00 next day → 2.5h = 9000s.
-        let cfg = window(23, 0, 2, 0);
-        let secs = cfg.secs_until_window_end(utc_at(23, 30));
-        assert_eq!(secs, 9000);
-    }
-
-    #[test]
-    fn test_maintenance_window_config_default_disabled() {
-        let cfg = MaintenanceWindowConfig::default();
-        assert!(!cfg.enabled);
-        assert_eq!(cfg.timezone, "UTC");
-        assert_eq!(cfg.drain_timeout_secs, 3600);
-    }
-
-    #[test]
-    fn test_maintenance_window_config_toml_roundtrip() {
+    fn reconciliation_config_toml_overrides_ready_to_merge_age_limits() {
         let toml = r#"
-            enabled = true
-            quiet_window_start = "06:00:00"
-            quiet_window_end = "08:00:00"
-            timezone = "America/New_York"
-            drain_timeout_secs = 7200
+            ready_to_merge_min_age_secs = 42
+            ready_to_merge_alert_ttl_secs = 84
         "#;
-        let cfg: MaintenanceWindowConfig = toml::from_str(toml).expect("toml parse failed");
-        assert!(cfg.enabled);
-        assert_eq!(cfg.timezone, "America/New_York");
-        assert_eq!(cfg.drain_timeout_secs, 7200);
+        let cfg: ReconciliationConfig =
+            toml::from_str(toml).unwrap_or_else(|err| panic!("toml parse failed: {err}"));
+        assert_eq!(cfg.ready_to_merge_min_age_secs, 42);
+        assert_eq!(cfg.ready_to_merge_alert_ttl_secs, 84);
     }
 }

--- a/crates/harness-server/src/handlers/reconcile.rs
+++ b/crates/harness-server/src/handlers/reconcile.rs
@@ -17,18 +17,11 @@ pub async fn handle(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ReconcileParams>,
 ) -> Result<Json<crate::reconciliation::ReconciliationReport>, StatusCode> {
-    let max_calls = state
-        .core
-        .server
-        .config
-        .reconciliation
-        .max_gh_calls_per_minute;
-
-    let report = crate::reconciliation::run_once_with_runtime_token(
+    let report = crate::reconciliation::run_once_with_runtime_config(
         &state.core.tasks,
         state.core.workflow_runtime_store.as_deref(),
         state.core.issue_workflow_store.as_deref(),
-        max_calls,
+        &state.core.server.config.reconciliation,
         params.dry_run,
         state.core.server.config.server.github_token.as_deref(),
     )

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -210,17 +210,11 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // Run one reconciliation tick against GitHub before any recovery so that
     // recovery decisions are made on fresh GitHub truth.
     if state.core.server.config.reconciliation.enabled {
-        let max_calls = state
-            .core
-            .server
-            .config
-            .reconciliation
-            .max_gh_calls_per_minute;
-        crate::reconciliation::run_once_with_runtime_token(
+        crate::reconciliation::run_once_with_runtime_config(
             &state.core.tasks,
             state.core.workflow_runtime_store.as_deref(),
             state.core.issue_workflow_store.as_deref(),
-            max_calls,
+            &state.core.server.config.reconciliation,
             false,
             state.core.server.config.server.github_token.as_deref(),
         )

--- a/crates/harness-server/src/http/startup_tests.rs
+++ b/crates/harness-server/src/http/startup_tests.rs
@@ -20,7 +20,7 @@ fn http_listener_starts_before_background_work() {
     let Some(serve_task_index) = source.find("let serve_handle = tokio::spawn") else {
         panic!("serve should start Axum before background work");
     };
-    let Some(reconciliation_index) = source.find("run_once_with_runtime_token") else {
+    let Some(reconciliation_index) = source.find("run_once_with_runtime_config") else {
         panic!("serve should still run startup reconciliation");
     };
     let Some(reconciliation_gate_index) =

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -7,7 +7,6 @@ use harness_workflow::runtime::{
     WorkflowDecisionTransition, WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore,
     GITHUB_ISSUE_PR_DEFINITION_ID,
 };
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
@@ -15,6 +14,24 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
+
+#[path = "reconciliation_github.rs"]
+mod reconciliation_github;
+#[path = "reconciliation_legacy.rs"]
+mod reconciliation_legacy;
+#[path = "reconciliation_periodic.rs"]
+mod reconciliation_periodic;
+
+use self::reconciliation_github::fetch_pr_state_by_url;
+#[cfg(test)]
+use self::reconciliation_github::{
+    classify_issue_state, classify_pr_state, GitHubIssueState, GitHubPullState,
+};
+pub(crate) use self::reconciliation_github::{
+    fetch_issue_state_with_token, fetch_pr_state_by_slug_with_token, GitHubState,
+};
+use self::reconciliation_legacy::{apply_transition, resolve_github_state};
+pub use reconciliation_periodic::start;
 
 /// One candidate task for reconciliation check.
 struct Candidate {
@@ -32,11 +49,33 @@ struct Candidate {
 struct RuntimeWorkflowCandidate {
     workflow_id: String,
     state: String,
+    updated_at: chrono::DateTime<chrono::Utc>,
     repo: Option<String>,
     project_root: Option<PathBuf>,
     issue_number: Option<u64>,
     pr_number: u64,
     pr_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RuntimeWorkflowReconciliationSettings {
+    ready_to_merge_min_age_secs: u64,
+    ready_to_merge_alert_ttl_secs: u64,
+}
+
+impl RuntimeWorkflowReconciliationSettings {
+    fn from_config(config: &ReconciliationConfig) -> Self {
+        Self {
+            ready_to_merge_min_age_secs: config.ready_to_merge_min_age_secs,
+            ready_to_merge_alert_ttl_secs: config.ready_to_merge_alert_ttl_secs,
+        }
+    }
+}
+
+impl Default for RuntimeWorkflowReconciliationSettings {
+    fn default() -> Self {
+        Self::from_config(&ReconciliationConfig::default())
+    }
 }
 
 /// A single resolved transition produced by `run_once`.
@@ -64,6 +103,20 @@ pub struct WorkflowReconciliationTransition {
     pub pr_url: Option<String>,
 }
 
+/// A workflow-runtime condition that reconciliation observed but did not transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowReconciliationAlert {
+    pub workflow_id: String,
+    pub state: String,
+    pub reason: String,
+    pub age_secs: u64,
+    pub ttl_secs: u64,
+    pub repo: Option<String>,
+    pub issue_number: Option<u64>,
+    pub pr_number: u64,
+    pub pr_url: Option<String>,
+}
+
 /// Summary returned by `run_once` and serialised in the HTTP handler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconciliationReport {
@@ -72,27 +125,8 @@ pub struct ReconciliationReport {
     pub transitions: Vec<ReconciliationTransition>,
     #[serde(default)]
     pub workflow_transitions: Vec<WorkflowReconciliationTransition>,
-}
-
-/// External GitHub state observed for one candidate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum GitHubState {
-    PrMerged,
-    PrClosed,
-    IssueClosed,
-    Open,
-    Unknown,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubPullState {
-    state: String,
-    merged_at: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubIssueState {
-    state: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workflow_alerts: Vec<WorkflowReconciliationAlert>,
 }
 
 /// Rate-limit state: at most `max_per_minute` GitHub API calls per 60-second window.
@@ -187,6 +221,7 @@ fn runtime_candidate_from_instance(
     Some(RuntimeWorkflowCandidate {
         workflow_id: instance.id.clone(),
         state: instance.state.clone(),
+        updated_at: instance.updated_at,
         repo: optional_json_string(&instance.data, "repo"),
         project_root: optional_json_string(&instance.data, "project_id").map(PathBuf::from),
         issue_number: instance
@@ -234,103 +269,6 @@ pub(crate) fn parse_external_id(eid: Option<&str>) -> (Option<u64>, Option<u64>)
     }
 }
 
-fn github_api_base_url() -> String {
-    std::env::var("HARNESS_GITHUB_API_BASE_URL")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "https://api.github.com".to_string())
-        .trim_end_matches('/')
-        .to_string()
-}
-
-async fn github_get_json<T: DeserializeOwned>(path: &str, github_token: Option<&str>) -> Option<T> {
-    let client = reqwest::Client::new();
-    let mut request = client
-        .get(format!("{}{}", github_api_base_url(), path))
-        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
-        .header(reqwest::header::USER_AGENT, "harness-server");
-    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
-        request = request.bearer_auth(token);
-    }
-    let response = match tokio::time::timeout(Duration::from_secs(10), request.send()).await {
-        Ok(Ok(response)) if response.status().is_success() => response,
-        Ok(Ok(response)) => {
-            tracing::debug!(status = %response.status(), path, "GitHub state check failed");
-            return None;
-        }
-        Ok(Err(e)) => {
-            tracing::debug!(error = %e, path, "GitHub state check invocation error");
-            return None;
-        }
-        Err(_) => {
-            tracing::debug!(path, "GitHub state check timed out after 10s");
-            return None;
-        }
-    };
-    response.json::<T>().await.ok()
-}
-
-fn classify_pr_state(state: &GitHubPullState) -> GitHubState {
-    let merged_at_empty = state.merged_at.as_deref().unwrap_or("").trim().is_empty();
-    match (state.state.as_str(), merged_at_empty) {
-        ("open", _) | ("OPEN", _) => GitHubState::Open,
-        ("merged", _) | ("MERGED", _) | ("closed", false) | ("CLOSED", false) => {
-            GitHubState::PrMerged
-        }
-        ("closed", true) | ("CLOSED", true) => GitHubState::PrClosed,
-        _ => GitHubState::Unknown,
-    }
-}
-
-fn classify_issue_state(state: &GitHubIssueState) -> GitHubState {
-    match state.state.as_str() {
-        "closed" | "CLOSED" => GitHubState::IssueClosed,
-        "open" | "OPEN" => GitHubState::Open,
-        _ => GitHubState::Unknown,
-    }
-}
-
-/// Fetch GitHub PR state from a full URL (e.g. `https://github.com/.../pull/42`).
-async fn fetch_pr_state_by_url(pr_url: &str, github_token: Option<&str>) -> GitHubState {
-    let Some((owner, repo, pr_number)) = harness_core::prompts::parse_github_pr_url(pr_url) else {
-        tracing::debug!(pr_url, "GitHub PR state check skipped for unparseable URL");
-        return GitHubState::Unknown;
-    };
-    fetch_pr_state_by_slug_with_token(&format!("{owner}/{repo}"), pr_number, github_token).await
-}
-
-pub(crate) async fn fetch_pr_state_by_slug_with_token(
-    repo_slug: &str,
-    pr_num: u64,
-    github_token: Option<&str>,
-) -> GitHubState {
-    let Some(state) = github_get_json::<GitHubPullState>(
-        &format!("/repos/{repo_slug}/pulls/{pr_num}"),
-        github_token,
-    )
-    .await
-    else {
-        return GitHubState::Unknown;
-    };
-    classify_pr_state(&state)
-}
-
-pub(crate) async fn fetch_issue_state_with_token(
-    repo_slug: &str,
-    issue_num: u64,
-    github_token: Option<&str>,
-) -> GitHubState {
-    let Some(state) = github_get_json::<GitHubIssueState>(
-        &format!("/repos/{repo_slug}/issues/{issue_num}"),
-        github_token,
-    )
-    .await
-    else {
-        return GitHubState::Unknown;
-    };
-    classify_issue_state(&state)
-}
-
 /// Core reconciliation logic. Callable from the periodic loop and HTTP handler.
 pub async fn run_once(
     store: &Arc<TaskStore>,
@@ -365,11 +303,53 @@ pub async fn run_once_with_runtime_token(
     dry_run: bool,
     github_token: Option<&str>,
 ) -> ReconciliationReport {
+    run_once_with_runtime_settings(
+        store,
+        runtime_store,
+        issue_workflows,
+        max_gh_calls_per_minute,
+        RuntimeWorkflowReconciliationSettings::default(),
+        dry_run,
+        github_token,
+    )
+    .await
+}
+
+pub async fn run_once_with_runtime_config(
+    store: &Arc<TaskStore>,
+    runtime_store: Option<&WorkflowRuntimeStore>,
+    issue_workflows: Option<&IssueWorkflowStore>,
+    config: &ReconciliationConfig,
+    dry_run: bool,
+    github_token: Option<&str>,
+) -> ReconciliationReport {
+    run_once_with_runtime_settings(
+        store,
+        runtime_store,
+        issue_workflows,
+        config.max_gh_calls_per_minute,
+        RuntimeWorkflowReconciliationSettings::from_config(config),
+        dry_run,
+        github_token,
+    )
+    .await
+}
+
+async fn run_once_with_runtime_settings(
+    store: &Arc<TaskStore>,
+    runtime_store: Option<&WorkflowRuntimeStore>,
+    issue_workflows: Option<&IssueWorkflowStore>,
+    max_gh_calls_per_minute: u32,
+    runtime_settings: RuntimeWorkflowReconciliationSettings,
+    dry_run: bool,
+    github_token: Option<&str>,
+) -> ReconciliationReport {
     let (candidates, skipped_terminal) = collect_candidates(store);
     let mut rate = RateLimiter::new(max_gh_calls_per_minute);
     let mut repo_slug_cache = HashMap::new();
     let mut transitions = Vec::new();
     let mut workflow_transitions = Vec::new();
+    let mut workflow_alerts = Vec::new();
     let mut runtime_candidate_count = 0usize;
     let mut runtime_skipped_terminal = 0usize;
 
@@ -414,15 +394,17 @@ pub async fn run_once_with_runtime_token(
             runtime_store,
             issue_workflows,
             &mut rate,
+            runtime_settings,
             dry_run,
             github_token,
         )
         .await
         {
-            Ok((candidate_count, skipped, transitions)) => {
+            Ok((candidate_count, skipped, transitions, alerts)) => {
                 runtime_candidate_count = candidate_count;
                 runtime_skipped_terminal = skipped;
                 workflow_transitions = transitions;
+                workflow_alerts = alerts;
             }
             Err(error) => {
                 tracing::warn!("workflow runtime reconciliation failed: {error}");
@@ -437,6 +419,7 @@ pub async fn run_once_with_runtime_token(
         skipped_terminal: skipped_terminal + runtime_skipped_terminal,
         transitions,
         workflow_transitions,
+        workflow_alerts,
     }
 }
 
@@ -465,14 +448,31 @@ async fn run_runtime_workflow_reconciliation_once(
     runtime_store: &WorkflowRuntimeStore,
     issue_workflows: Option<&IssueWorkflowStore>,
     rate: &mut RateLimiter,
+    settings: RuntimeWorkflowReconciliationSettings,
     dry_run: bool,
     github_token: Option<&str>,
-) -> anyhow::Result<(usize, usize, Vec<WorkflowReconciliationTransition>)> {
+) -> anyhow::Result<(
+    usize,
+    usize,
+    Vec<WorkflowReconciliationTransition>,
+    Vec<WorkflowReconciliationAlert>,
+)> {
     let (candidates, skipped_terminal) = collect_runtime_candidates(runtime_store).await?;
     let mut transitions = Vec::new();
+    let mut alerts = Vec::new();
+    let now = chrono::Utc::now();
 
     for candidate in &candidates {
+        if candidate.state == "ready_to_merge"
+            && runtime_candidate_age_secs(candidate, now) < settings.ready_to_merge_min_age_secs
+        {
+            continue;
+        }
         let gh_state = resolve_runtime_github_state(candidate, rate, github_token).await;
+        if let Some(alert) = ready_to_merge_open_alert(candidate, gh_state, settings, now) {
+            alerts.push(alert);
+            continue;
+        }
         let Some((target_state, reason)) = runtime_transition_for_github_state(gh_state) else {
             continue;
         };
@@ -513,7 +513,42 @@ async fn run_runtime_workflow_reconciliation_once(
         });
     }
 
-    Ok((candidates.len(), skipped_terminal, transitions))
+    Ok((candidates.len(), skipped_terminal, transitions, alerts))
+}
+
+fn runtime_candidate_age_secs(
+    candidate: &RuntimeWorkflowCandidate,
+    now: chrono::DateTime<chrono::Utc>,
+) -> u64 {
+    now.signed_duration_since(candidate.updated_at)
+        .num_seconds()
+        .max(0) as u64
+}
+
+fn ready_to_merge_open_alert(
+    candidate: &RuntimeWorkflowCandidate,
+    gh_state: GitHubState,
+    settings: RuntimeWorkflowReconciliationSettings,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<WorkflowReconciliationAlert> {
+    if candidate.state != "ready_to_merge" || gh_state != GitHubState::Open {
+        return None;
+    }
+    let age_secs = runtime_candidate_age_secs(candidate, now);
+    if age_secs < settings.ready_to_merge_alert_ttl_secs {
+        return None;
+    }
+    Some(WorkflowReconciliationAlert {
+        workflow_id: candidate.workflow_id.clone(),
+        state: candidate.state.clone(),
+        reason: "ready_to_merge PR remains open past reconciliation alert TTL".to_string(),
+        age_secs,
+        ttl_secs: settings.ready_to_merge_alert_ttl_secs,
+        repo: candidate.repo.clone(),
+        issue_number: candidate.issue_number,
+        pr_number: candidate.pr_number,
+        pr_url: candidate.pr_url.clone(),
+    })
 }
 
 async fn resolve_runtime_github_state(
@@ -750,787 +785,6 @@ async fn record_runtime_issue_side_effects(
     }
 }
 
-/// Determine the current GitHub state for one candidate, consuming rate-limit budget.
-async fn resolve_github_state(
-    candidate: &Candidate,
-    rate: &mut RateLimiter,
-    repo_slug_cache: &mut HashMap<PathBuf, Option<String>>,
-    github_token: Option<&str>,
-) -> GitHubState {
-    // PR URL takes precedence — most candidates in `implementing`/`reviewing`
-    // will have one.
-    if let Some(pr_url) = &candidate.pr_url {
-        rate.acquire().await;
-        return fetch_pr_state_by_url(pr_url, github_token).await;
-    }
-    let repo_slug = resolve_repo_slug(candidate, repo_slug_cache).await;
-    let Some(repo_slug) = repo_slug else {
-        tracing::debug!(
-            task_id = %candidate.id.0,
-            "GitHub state check skipped because repository slug is unavailable"
-        );
-        return GitHubState::Unknown;
-    };
-    if let Some(pr_num) = candidate.pr_num_from_ext {
-        rate.acquire().await;
-        return fetch_pr_state_by_slug_with_token(&repo_slug, pr_num, github_token).await;
-    }
-    if let Some(issue_num) = candidate.issue_num {
-        rate.acquire().await;
-        return fetch_issue_state_with_token(&repo_slug, issue_num, github_token).await;
-    }
-    GitHubState::Unknown
-}
-
-async fn resolve_repo_slug(
-    candidate: &Candidate,
-    repo_slug_cache: &mut HashMap<PathBuf, Option<String>>,
-) -> Option<String> {
-    match candidate.repo.as_deref() {
-        Some(repo) if !repo.trim().is_empty() => Some(repo.to_string()),
-        _ => match candidate.project_root.as_ref() {
-            Some(project_root) => {
-                if let Some(cached) = cached_repo_slug(repo_slug_cache, project_root) {
-                    return cached.clone();
-                }
-
-                let detected =
-                    crate::task_executor::pr_detection::detect_repo_slug(project_root).await;
-                repo_slug_cache.insert(project_root.clone(), detected.clone());
-                detected
-            }
-            None => None,
-        },
-    }
-}
-
-fn cached_repo_slug(
-    repo_slug_cache: &HashMap<PathBuf, Option<String>>,
-    project_root: &PathBuf,
-) -> Option<Option<String>> {
-    repo_slug_cache.get(project_root).cloned()
-}
-
-/// Apply a status transition to a task, returning `true` on success.
-async fn apply_transition(
-    store: &Arc<TaskStore>,
-    task_id: &TaskId,
-    new_status: TaskStatus,
-    reason: &str,
-) -> bool {
-    let result = mutate_and_persist(store, task_id, |s| {
-        // TOCTOU guard: skip if already terminal (e.g. completed between
-        // candidate collection and now).
-        if s.status.is_terminal() {
-            return;
-        }
-        tracing::info!(
-            task_id = %task_id.0,
-            from = s.status.as_ref(),
-            to = new_status.as_ref(),
-            reason,
-            "reconciliation: applying transition"
-        );
-        s.status = new_status.clone();
-        s.scheduler.mark_terminal(&new_status);
-    })
-    .await;
-
-    match result {
-        Ok(()) => true,
-        Err(e) => {
-            tracing::error!(task_id = %task_id.0, "reconciliation: persist failed: {e}");
-            false
-        }
-    }
-}
-
-/// Spawn the periodic reconciliation loop as a background task.
-///
-/// Returns immediately without spawning when `config.enabled` is false.
-pub fn start(state: Arc<AppState>, config: ReconciliationConfig) {
-    if !config.enabled {
-        tracing::debug!("reconciliation: periodic loop disabled");
-        return;
-    }
-
-    tokio::spawn(async move {
-        reconciliation_loop(state, config).await;
-    });
-}
-
-async fn reconciliation_loop(state: Arc<AppState>, config: ReconciliationConfig) {
-    let interval = Duration::from_secs(config.interval_secs);
-    // Brief init delay so the server is fully up before the first tick.
-    sleep(Duration::from_secs(15)).await;
-
-    loop {
-        let report = run_once_with_runtime_token(
-            &state.core.tasks,
-            state.core.workflow_runtime_store.as_deref(),
-            state.core.issue_workflow_store.as_deref(),
-            config.max_gh_calls_per_minute,
-            false,
-            state.core.server.config.server.github_token.as_deref(),
-        )
-        .await;
-        record_repo_backlog_reconciliation_transitions(&state, &report).await;
-
-        // Clean up workspaces for tasks that were just terminated by reconciliation,
-        // so the workspace is gone within the same tick (issue #969).
-        if let Some(ref wmgr) = state.concurrency.workspace_mgr {
-            let transitioned_ids: Vec<crate::task_runner::TaskId> = report
-                .transitions
-                .iter()
-                .filter(|t| t.applied)
-                .map(|t| harness_core::types::TaskId(t.task_id.clone()))
-                .collect();
-            if !transitioned_ids.is_empty() {
-                if let Err(e) = wmgr.cleanup_terminal(&transitioned_ids).await {
-                    tracing::warn!("reconciliation: workspace cleanup failed: {e}");
-                }
-            }
-        }
-
-        tracing::info!(
-            candidates = report.candidates,
-            skipped_terminal = report.skipped_terminal,
-            transitions = report.transitions.len(),
-            workflow_transitions = report.workflow_transitions.len(),
-            "reconciliation: tick complete"
-        );
-        sleep(interval).await;
-    }
-}
-
-async fn record_repo_backlog_reconciliation_transitions(
-    state: &Arc<AppState>,
-    report: &ReconciliationReport,
-) {
-    for transition in &report.transitions {
-        if !transition.applied || transition.reason != "reconciled: PR merged externally" {
-            continue;
-        }
-        let task_id = harness_core::types::TaskId(transition.task_id.clone());
-        let Some(task) = state.core.tasks.get(&task_id) else {
-            continue;
-        };
-        let Some(pr_number) = task
-            .pr_url
-            .as_deref()
-            .and_then(harness_core::prompts::parse_github_pr_url)
-            .map(|(_, _, pr_number)| pr_number)
-            .or_else(|| parse_external_id(task.external_id.as_deref()).1)
-        else {
-            continue;
-        };
-        let issue_number = task
-            .issue
-            .or_else(|| parse_external_id(task.external_id.as_deref()).0);
-        let project_root = task
-            .project_root
-            .as_deref()
-            .unwrap_or(&state.core.project_root);
-        crate::workflow_runtime_repo_backlog::record_merged_pr(
-            state.core.workflow_runtime_store.as_deref(),
-            state.core.issue_workflow_store.as_deref(),
-            crate::workflow_runtime_repo_backlog::MergedPrRuntimeContext {
-                project_root,
-                repo: task.repo.as_deref(),
-                issue_number,
-                pr_number,
-                pr_url: task.pr_url.as_deref(),
-                detail: &transition.reason,
-            },
-        )
-        .await;
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::task_runner::TaskState;
-    use harness_core::types::TaskId;
-    use std::collections::HashMap;
-    use std::sync::OnceLock;
-    use tokio::sync::Mutex;
-
-    fn make_task(
-        id: &str,
-        status: TaskStatus,
-        pr_url: Option<&str>,
-        external_id: Option<&str>,
-    ) -> TaskState {
-        let tid = TaskId(id.to_string());
-        let mut task = TaskState::new(tid);
-        task.status = status;
-        task.pr_url = pr_url.map(|s| s.to_string());
-        task.external_id = external_id.map(|s| s.to_string());
-        task
-    }
-
-    fn async_env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    struct ScopedEnvVar {
-        key: String,
-        original: Option<String>,
-    }
-
-    impl ScopedEnvVar {
-        fn set(key: &str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            unsafe { std::env::set_var(key, value) };
-            Self {
-                key: key.to_string(),
-                original,
-            }
-        }
-    }
-
-    impl Drop for ScopedEnvVar {
-        fn drop(&mut self) {
-            if let Some(value) = &self.original {
-                unsafe { std::env::set_var(&self.key, value) };
-            } else {
-                unsafe { std::env::remove_var(&self.key) };
-            }
-        }
-    }
-
-    async fn github_state_server(routes: Vec<(&'static str, &'static str)>) -> String {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind GitHub mock");
-        let addr = listener.local_addr().expect("GitHub mock address");
-        let routes: HashMap<String, &'static str> = routes
-            .into_iter()
-            .map(|(path, body)| (path.to_string(), body))
-            .collect();
-
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut socket, _)) = listener.accept().await else {
-                    return;
-                };
-                let routes = routes.clone();
-                tokio::spawn(async move {
-                    let mut buf = [0_u8; 2048];
-                    let Ok(n) = socket.read(&mut buf).await else {
-                        return;
-                    };
-                    let request = String::from_utf8_lossy(&buf[..n]);
-                    let request_line = request.lines().next().unwrap_or_default();
-                    let path = request_line
-                        .split_whitespace()
-                        .nth(1)
-                        .unwrap_or_default()
-                        .to_string();
-                    let (status, response_body) = match routes.get(&path).copied() {
-                        Some(body) => ("200 OK", body),
-                        None => ("404 Not Found", "{}"),
-                    };
-                    let response = format!(
-                        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
-                        response_body.len()
-                    );
-                    let _ = socket.write_all(response.as_bytes()).await;
-                });
-            }
-        });
-
-        format!("http://{addr}")
-    }
-
-    fn write_git_remote_config(path: &std::path::Path, origin: &str) {
-        let dotgit = path.join(".git");
-        std::fs::create_dir_all(&dotgit).expect("create .git");
-        std::fs::write(
-            dotgit.join("config"),
-            format!("[remote \"origin\"]\n\turl = {origin}\n"),
-        )
-        .expect("write git config");
-    }
-
-    // ── Pure function tests (no DB required) ─────────────────────────────
-
-    #[test]
-    fn parse_external_id_issue() {
-        assert_eq!(parse_external_id(Some("issue:42")), (Some(42), None));
-    }
-
-    #[test]
-    fn parse_external_id_pr() {
-        assert_eq!(parse_external_id(Some("pr:7")), (None, Some(7)));
-    }
-
-    #[test]
-    fn parse_external_id_none() {
-        assert_eq!(parse_external_id(None), (None, None));
-    }
-
-    #[test]
-    fn candidate_from_task_skips_terminal() {
-        let mut t = make_task(
-            "x",
-            TaskStatus::Done,
-            Some("https://github.com/a/b/pull/1"),
-            None,
-        );
-        assert!(candidate_from_task(&t).is_none());
-        t.status = TaskStatus::Cancelled;
-        assert!(candidate_from_task(&t).is_none());
-    }
-
-    #[test]
-    fn candidate_from_task_skips_no_refs() {
-        let t = make_task("x", TaskStatus::Implementing, None, None);
-        assert!(candidate_from_task(&t).is_none());
-    }
-
-    #[test]
-    fn candidate_from_task_picks_pr_url() {
-        let t = make_task(
-            "x",
-            TaskStatus::Implementing,
-            Some("https://github.com/a/b/pull/2"),
-            None,
-        );
-        let c = candidate_from_task(&t).unwrap();
-        assert!(c.pr_url.is_some());
-        assert_eq!(c.issue_num, None);
-    }
-
-    #[test]
-    fn candidate_from_task_carries_project_root() {
-        let mut t = make_task("x", TaskStatus::Pending, None, Some("issue:9"));
-        t.project_root = Some(PathBuf::from("/tmp/projects/alpha"));
-        let c = candidate_from_task(&t).unwrap();
-        assert_eq!(c.project_root, Some(PathBuf::from("/tmp/projects/alpha")));
-    }
-
-    #[test]
-    fn candidate_from_task_picks_issue_external_id() {
-        let t = make_task("x", TaskStatus::Pending, None, Some("issue:9"));
-        let c = candidate_from_task(&t).unwrap();
-        assert_eq!(c.issue_num, Some(9));
-        assert!(c.pr_url.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_repo_slug_uses_candidate_project_root_when_repo_missing() {
-        let repo_a = tempfile::tempdir().expect("repo a tempdir");
-        let repo_b = tempfile::tempdir().expect("repo b tempdir");
-        write_git_remote_config(repo_a.path(), "https://github.com/example/repo-a.git");
-        write_git_remote_config(repo_b.path(), "https://github.com/example/repo-b.git");
-        assert_eq!(
-            crate::task_executor::pr_detection::detect_repo_slug(repo_a.path()).await,
-            Some("example/repo-a".to_string())
-        );
-
-        let candidate = Candidate {
-            id: TaskId("task-1".to_string()),
-            pr_url: None,
-            repo: None,
-            project_root: Some(repo_b.path().to_path_buf()),
-            issue_num: Some(9),
-            pr_num_from_ext: None,
-        };
-
-        let mut cache = HashMap::new();
-        let repo_slug = resolve_repo_slug(&candidate, &mut cache).await;
-        assert_eq!(repo_slug, Some("example/repo-b".to_string()));
-    }
-
-    #[tokio::test]
-    async fn run_once_uses_each_task_project_root_when_repo_is_missing() {
-        let _env_guard = async_env_lock().lock().await;
-        if !crate::test_helpers::db_tests_enabled().await {
-            return;
-        }
-        let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
-        let repo_a = tempfile::tempdir().expect("repo a tempdir");
-        let repo_b = tempfile::tempdir().expect("repo b tempdir");
-        write_git_remote_config(repo_a.path(), "https://github.com/example/repo-a.git");
-        write_git_remote_config(repo_b.path(), "https://github.com/example/repo-b.git");
-
-        let api_base = github_state_server(vec![
-            ("/repos/example/repo-a/issues/9", r#"{"state":"open"}"#),
-            ("/repos/example/repo-a/issues/41", r#"{"state":"open"}"#),
-            ("/repos/example/repo-b/issues/9", r#"{"state":"closed"}"#),
-        ])
-        .await;
-        let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
-
-        let dir = tempfile::tempdir().expect("task store tempdir");
-        let store = match TaskStore::open(&dir.path().join("tasks.db")).await {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return,
-            Err(err) => panic!("open task store: {err}"),
-        };
-
-        let mut repo_task = make_task("repo-task", TaskStatus::Pending, None, Some("issue:41"));
-        repo_task.repo = Some("example/repo-a".to_string());
-        repo_task.project_root = Some(repo_a.path().to_path_buf());
-        store.insert(&repo_task).await;
-
-        let mut repo_less_task =
-            make_task("repo-less-task", TaskStatus::Pending, None, Some("issue:9"));
-        repo_less_task.project_root = Some(repo_b.path().to_path_buf());
-        store.insert(&repo_less_task).await;
-
-        let report = run_once(&store, 20, false).await;
-
-        assert_eq!(report.transitions.len(), 1);
-        assert_eq!(report.transitions[0].task_id, repo_less_task.id.0);
-        assert_eq!(
-            report.transitions[0].reason,
-            "reconciled: issue closed before PR"
-        );
-
-        let repo_task_after = store.get(&repo_task.id).expect("repo task remains");
-        assert_eq!(repo_task_after.status, TaskStatus::Pending);
-
-        let repo_less_after = store
-            .get(&repo_less_task.id)
-            .expect("repo-less task remains");
-        assert_eq!(repo_less_after.status, TaskStatus::Cancelled);
-    }
-
-    #[test]
-    fn classify_pr_state_handles_merged_and_closed() {
-        assert_eq!(
-            classify_pr_state(&GitHubPullState {
-                state: "closed".to_string(),
-                merged_at: Some("2024-01-01T00:00:00Z".to_string()),
-            }),
-            GitHubState::PrMerged
-        );
-        assert_eq!(
-            classify_pr_state(&GitHubPullState {
-                state: "closed".to_string(),
-                merged_at: None,
-            }),
-            GitHubState::PrClosed
-        );
-    }
-
-    #[test]
-    fn classify_issue_state_handles_open_and_closed() {
-        assert_eq!(
-            classify_issue_state(&GitHubIssueState {
-                state: "open".to_string(),
-            }),
-            GitHubState::Open
-        );
-        assert_eq!(
-            classify_issue_state(&GitHubIssueState {
-                state: "closed".to_string(),
-            }),
-            GitHubState::IssueClosed
-        );
-    }
-
-    #[test]
-    fn transition_mapping_matches_external_states() {
-        assert_eq!(
-            transition_for_github_state(GitHubState::PrMerged),
-            Some((TaskStatus::Done, "reconciled: PR merged externally"))
-        );
-        assert_eq!(
-            transition_for_github_state(GitHubState::PrClosed),
-            Some((TaskStatus::Cancelled, "reconciled: PR closed externally"))
-        );
-        assert_eq!(transition_for_github_state(GitHubState::Open), None);
-    }
-
-    #[test]
-    fn runtime_candidate_from_instance_requires_non_terminal_bound_pr() {
-        let active = WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            "pr_open",
-            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
-        )
-        .with_id("workflow-1")
-        .with_data(json!({
-            "project_id": "/tmp/project",
-            "repo": "owner/repo",
-            "issue_number": 42,
-            "pr_number": 77,
-            "pr_url": "https://github.com/owner/repo/pull/77",
-        }));
-        let candidate = runtime_candidate_from_instance(&active).expect("candidate");
-        assert_eq!(candidate.workflow_id, "workflow-1");
-        assert_eq!(candidate.pr_number, 77);
-        assert_eq!(candidate.repo.as_deref(), Some("owner/repo"));
-
-        let terminal = WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            "done",
-            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
-        )
-        .with_data(json!({ "pr_number": 77 }));
-        assert!(runtime_candidate_from_instance(&terminal).is_none());
-
-        let missing_pr = WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            "pr_open",
-            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
-        );
-        assert!(runtime_candidate_from_instance(&missing_pr).is_none());
-    }
-
-    #[tokio::test]
-    async fn run_once_reconciles_runtime_merged_pr_workflow() -> anyhow::Result<()> {
-        let _env_guard = async_env_lock().lock().await;
-        if !crate::test_helpers::db_tests_enabled().await {
-            return Ok(());
-        }
-        let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
-        let database_url = crate::test_helpers::test_database_url()?;
-        let api_base = github_state_server(vec![(
-            "/repos/owner/repo/pulls/77",
-            r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
-        )])
-        .await;
-        let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
-        let dir = tempfile::tempdir()?;
-        let task_store = match TaskStore::open(&dir.path().join("tasks.db")).await {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let runtime_store = match WorkflowRuntimeStore::open_with_database_url(
-            &dir.path().join("runtime"),
-            Some(&database_url),
-        )
-        .await
-        {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let issue_store = match IssueWorkflowStore::open_with_database_url(
-            &dir.path().join("issue"),
-            Some(&database_url),
-        )
-        .await
-        {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let project_root = dir.path().join("project");
-        std::fs::create_dir(&project_root)?;
-        let project_id = project_root.to_string_lossy();
-        issue_store
-            .record_issue_scheduled(&project_id, Some("owner/repo"), 42, "task-1", &[], false)
-            .await?;
-        issue_store
-            .record_pr_detected(
-                &project_id,
-                Some("owner/repo"),
-                42,
-                "task-1",
-                77,
-                "https://github.com/owner/repo/pull/77",
-            )
-            .await?;
-        let workflow_id =
-            harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 42);
-        let instance = WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            "pr_open",
-            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
-        )
-        .with_id(&workflow_id)
-        .with_data(json!({
-            "project_id": project_id.as_ref(),
-            "repo": "owner/repo",
-            "issue_number": 42,
-            "task_id": "task-1",
-            "pr_number": 77,
-            "pr_url": "https://github.com/owner/repo/pull/77",
-        }));
-        runtime_store.upsert_instance(&instance).await?;
-
-        let report = run_once_with_runtime_token(
-            &task_store,
-            Some(&runtime_store),
-            Some(&issue_store),
-            20,
-            false,
-            None,
-        )
-        .await;
-
-        assert_eq!(report.workflow_transitions.len(), 1);
-        assert_eq!(report.workflow_transitions[0].from, "pr_open");
-        assert_eq!(report.workflow_transitions[0].to, "done");
-        assert!(report.workflow_transitions[0].applied);
-        let updated = runtime_store
-            .get_instance(&workflow_id)
-            .await?
-            .expect("workflow should remain persisted");
-        assert_eq!(updated.state, "done");
-        assert_eq!(updated.data["last_decision"], "reconcile_pr_merged");
-        let issue_workflow = issue_store
-            .get_by_issue(&project_id, Some("owner/repo"), 42)
-            .await?
-            .expect("issue workflow should exist");
-        assert_eq!(
-            issue_workflow.state,
-            harness_workflow::issue_lifecycle::IssueLifecycleState::Done
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn run_once_reconciles_runtime_closed_pr_workflow() -> anyhow::Result<()> {
-        let _env_guard = async_env_lock().lock().await;
-        if !crate::test_helpers::db_tests_enabled().await {
-            return Ok(());
-        }
-        let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
-        let database_url = crate::test_helpers::test_database_url()?;
-        let api_base = github_state_server(vec![(
-            "/repos/owner/repo/pulls/88",
-            r#"{"state":"closed","merged_at":null}"#,
-        )])
-        .await;
-        let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
-        let dir = tempfile::tempdir()?;
-        let task_store = match TaskStore::open(&dir.path().join("tasks.db")).await {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let runtime_store = match WorkflowRuntimeStore::open_with_database_url(
-            &dir.path().join("runtime"),
-            Some(&database_url),
-        )
-        .await
-        {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let issue_store = match IssueWorkflowStore::open_with_database_url(
-            &dir.path().join("issue"),
-            Some(&database_url),
-        )
-        .await
-        {
-            Ok(store) => store,
-            Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(()),
-            Err(err) => return Err(err),
-        };
-        let project_root = dir.path().join("project");
-        std::fs::create_dir(&project_root)?;
-        let project_id = project_root.to_string_lossy();
-        issue_store
-            .record_issue_scheduled(&project_id, Some("owner/repo"), 43, "task-2", &[], false)
-            .await?;
-        issue_store
-            .record_pr_detected(
-                &project_id,
-                Some("owner/repo"),
-                43,
-                "task-2",
-                88,
-                "https://github.com/owner/repo/pull/88",
-            )
-            .await?;
-        let workflow_id =
-            harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 43);
-        let instance = WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            "awaiting_feedback",
-            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:43"),
-        )
-        .with_id(&workflow_id)
-        .with_data(json!({
-            "project_id": project_id.as_ref(),
-            "repo": "owner/repo",
-            "issue_number": 43,
-            "task_id": "task-2",
-            "pr_number": 88,
-            "pr_url": "https://github.com/owner/repo/pull/88",
-        }));
-        runtime_store.upsert_instance(&instance).await?;
-
-        let report = run_once_with_runtime_token(
-            &task_store,
-            Some(&runtime_store),
-            Some(&issue_store),
-            20,
-            false,
-            None,
-        )
-        .await;
-
-        assert_eq!(report.workflow_transitions.len(), 1);
-        assert_eq!(report.workflow_transitions[0].to, "cancelled");
-        assert!(report.workflow_transitions[0].applied);
-        let updated = runtime_store
-            .get_instance(&workflow_id)
-            .await?
-            .expect("workflow should remain persisted");
-        assert_eq!(updated.state, "cancelled");
-        assert_eq!(updated.data["last_decision"], "reconcile_pr_closed");
-        let issue_workflow = issue_store
-            .get_by_issue(&project_id, Some("owner/repo"), 43)
-            .await?
-            .expect("issue workflow should exist");
-        assert_eq!(
-            issue_workflow.state,
-            harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
-        );
-        Ok(())
-    }
-
-    // Reconciliation payload guard: ReconciliationReport and
-    // ReconciliationTransition are serialised over HTTP.  They must never
-    // contain a UUID workspace path.
-    #[test]
-    fn reconciliation_payload_has_no_workspace_paths() {
-        let report = ReconciliationReport {
-            candidates: 3,
-            skipped_terminal: 1,
-            transitions: vec![ReconciliationTransition {
-                task_id: "task-abc123".to_string(),
-                from: "implementing".to_string(),
-                to: "done".to_string(),
-                reason: "PR merged".to_string(),
-                applied: true,
-            }],
-            workflow_transitions: vec![WorkflowReconciliationTransition {
-                workflow_id: "project::repo:owner/repo::issue:42".to_string(),
-                from: "pr_open".to_string(),
-                to: "done".to_string(),
-                reason: "PR merged".to_string(),
-                applied: true,
-                repo: Some("owner/repo".to_string()),
-                issue_number: Some(42),
-                pr_number: 77,
-                pr_url: Some("https://github.com/owner/repo/pull/77".to_string()),
-            }],
-        };
-        let json =
-            serde_json::to_string(&report).expect("ReconciliationReport must serialise to JSON");
-        assert!(
-            !json.contains("/workspaces/"),
-            "ReconciliationReport JSON must not contain a workspace path, got: {json}"
-        );
-    }
-}
+#[path = "reconciliation_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -21,6 +21,8 @@ mod reconciliation_github;
 mod reconciliation_legacy;
 #[path = "reconciliation_periodic.rs"]
 mod reconciliation_periodic;
+#[path = "reconciliation_runtime.rs"]
+mod reconciliation_runtime;
 
 use self::reconciliation_github::fetch_pr_state_by_url;
 #[cfg(test)]
@@ -31,6 +33,9 @@ pub(crate) use self::reconciliation_github::{
     fetch_issue_state_with_token, fetch_pr_state_by_slug_with_token, GitHubState,
 };
 use self::reconciliation_legacy::{apply_transition, resolve_github_state};
+#[cfg(test)]
+use self::reconciliation_runtime::runtime_candidate_from_instance;
+use self::reconciliation_runtime::{collect_runtime_candidates, resolve_runtime_github_state};
 pub use reconciliation_periodic::start;
 
 /// One candidate task for reconciliation check.
@@ -49,7 +54,7 @@ struct Candidate {
 struct RuntimeWorkflowCandidate {
     workflow_id: String,
     state: String,
-    updated_at: chrono::DateTime<chrono::Utc>,
+    row_updated_at: chrono::DateTime<chrono::Utc>,
     repo: Option<String>,
     project_root: Option<PathBuf>,
     issue_number: Option<u64>,
@@ -206,51 +211,6 @@ fn collect_candidates(store: &TaskStore) -> (Vec<Candidate>, usize) {
         }
     }
     (candidates, skipped_terminal)
-}
-
-fn runtime_candidate_from_instance(
-    instance: &WorkflowInstance,
-) -> Option<RuntimeWorkflowCandidate> {
-    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID || instance.is_terminal() {
-        return None;
-    }
-    let pr_number = instance
-        .data
-        .get("pr_number")
-        .and_then(serde_json::Value::as_u64)?;
-    Some(RuntimeWorkflowCandidate {
-        workflow_id: instance.id.clone(),
-        state: instance.state.clone(),
-        updated_at: instance.updated_at,
-        repo: optional_json_string(&instance.data, "repo"),
-        project_root: optional_json_string(&instance.data, "project_id").map(PathBuf::from),
-        issue_number: instance
-            .data
-            .get("issue_number")
-            .and_then(serde_json::Value::as_u64),
-        pr_number,
-        pr_url: optional_json_string(&instance.data, "pr_url"),
-    })
-}
-
-async fn collect_runtime_candidates(
-    store: &WorkflowRuntimeStore,
-) -> anyhow::Result<(Vec<RuntimeWorkflowCandidate>, usize)> {
-    let mut candidates = Vec::new();
-    let mut skipped_terminal = 0usize;
-    for instance in store
-        .list_instances_by_definition(GITHUB_ISSUE_PR_DEFINITION_ID, None, None)
-        .await?
-    {
-        if instance.is_terminal() {
-            skipped_terminal += 1;
-            continue;
-        }
-        if let Some(candidate) = runtime_candidate_from_instance(&instance) {
-            candidates.push(candidate);
-        }
-    }
-    Ok((candidates, skipped_terminal))
 }
 
 fn optional_json_string(data: &serde_json::Value, key: &str) -> Option<String> {
@@ -520,7 +480,7 @@ fn runtime_candidate_age_secs(
     candidate: &RuntimeWorkflowCandidate,
     now: chrono::DateTime<chrono::Utc>,
 ) -> u64 {
-    now.signed_duration_since(candidate.updated_at)
+    now.signed_duration_since(candidate.row_updated_at)
         .num_seconds()
         .max(0) as u64
 }
@@ -549,27 +509,6 @@ fn ready_to_merge_open_alert(
         pr_number: candidate.pr_number,
         pr_url: candidate.pr_url.clone(),
     })
-}
-
-async fn resolve_runtime_github_state(
-    candidate: &RuntimeWorkflowCandidate,
-    rate: &mut RateLimiter,
-    github_token: Option<&str>,
-) -> GitHubState {
-    if let Some(pr_url) = candidate.pr_url.as_deref() {
-        rate.acquire().await;
-        return fetch_pr_state_by_url(pr_url, github_token).await;
-    }
-    if let Some(repo) = candidate.repo.as_deref() {
-        rate.acquire().await;
-        return fetch_pr_state_by_slug_with_token(repo, candidate.pr_number, github_token).await;
-    }
-    tracing::debug!(
-        workflow_id = %candidate.workflow_id,
-        pr = candidate.pr_number,
-        "workflow runtime GitHub state check skipped because repository slug is unavailable"
-    );
-    GitHubState::Unknown
 }
 
 async fn apply_runtime_workflow_transition(
@@ -785,6 +724,9 @@ async fn record_runtime_issue_side_effects(
     }
 }
 
+#[cfg(test)]
+#[path = "reconciliation_payload_tests.rs"]
+mod payload_tests;
 #[cfg(test)]
 #[path = "reconciliation_tests.rs"]
 mod tests;

--- a/crates/harness-server/src/reconciliation_github.rs
+++ b/crates/harness-server/src/reconciliation_github.rs
@@ -1,0 +1,121 @@
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// External GitHub state observed for one candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitHubState {
+    PrMerged,
+    PrClosed,
+    IssueClosed,
+    Open,
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GitHubPullState {
+    pub(super) state: String,
+    pub(super) merged_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GitHubIssueState {
+    pub(super) state: String,
+}
+
+fn github_api_base_url() -> String {
+    std::env::var("HARNESS_GITHUB_API_BASE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://api.github.com".to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+async fn github_get_json<T: DeserializeOwned>(path: &str, github_token: Option<&str>) -> Option<T> {
+    let client = reqwest::Client::new();
+    let mut request = client
+        .get(format!("{}{}", github_api_base_url(), path))
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header(reqwest::header::USER_AGENT, "harness-server");
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
+    }
+    let response = match tokio::time::timeout(Duration::from_secs(10), request.send()).await {
+        Ok(Ok(response)) if response.status().is_success() => response,
+        Ok(Ok(response)) => {
+            tracing::debug!(status = %response.status(), path, "GitHub state check failed");
+            return None;
+        }
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, path, "GitHub state check invocation error");
+            return None;
+        }
+        Err(_) => {
+            tracing::debug!(path, "GitHub state check timed out after 10s");
+            return None;
+        }
+    };
+    response.json::<T>().await.ok()
+}
+
+pub(super) fn classify_pr_state(state: &GitHubPullState) -> GitHubState {
+    let merged_at_empty = state.merged_at.as_deref().unwrap_or("").trim().is_empty();
+    match (state.state.as_str(), merged_at_empty) {
+        ("open", _) | ("OPEN", _) => GitHubState::Open,
+        ("merged", _) | ("MERGED", _) | ("closed", false) | ("CLOSED", false) => {
+            GitHubState::PrMerged
+        }
+        ("closed", true) | ("CLOSED", true) => GitHubState::PrClosed,
+        _ => GitHubState::Unknown,
+    }
+}
+
+pub(super) fn classify_issue_state(state: &GitHubIssueState) -> GitHubState {
+    match state.state.as_str() {
+        "closed" | "CLOSED" => GitHubState::IssueClosed,
+        "open" | "OPEN" => GitHubState::Open,
+        _ => GitHubState::Unknown,
+    }
+}
+
+/// Fetch GitHub PR state from a full URL (e.g. `https://github.com/.../pull/42`).
+pub(super) async fn fetch_pr_state_by_url(pr_url: &str, github_token: Option<&str>) -> GitHubState {
+    let Some((owner, repo, pr_number)) = harness_core::prompts::parse_github_pr_url(pr_url) else {
+        tracing::debug!(pr_url, "GitHub PR state check skipped for unparseable URL");
+        return GitHubState::Unknown;
+    };
+    fetch_pr_state_by_slug_with_token(&format!("{owner}/{repo}"), pr_number, github_token).await
+}
+
+pub(crate) async fn fetch_pr_state_by_slug_with_token(
+    repo_slug: &str,
+    pr_num: u64,
+    github_token: Option<&str>,
+) -> GitHubState {
+    let Some(state) = github_get_json::<GitHubPullState>(
+        &format!("/repos/{repo_slug}/pulls/{pr_num}"),
+        github_token,
+    )
+    .await
+    else {
+        return GitHubState::Unknown;
+    };
+    classify_pr_state(&state)
+}
+
+pub(crate) async fn fetch_issue_state_with_token(
+    repo_slug: &str,
+    issue_num: u64,
+    github_token: Option<&str>,
+) -> GitHubState {
+    let Some(state) = github_get_json::<GitHubIssueState>(
+        &format!("/repos/{repo_slug}/issues/{issue_num}"),
+        github_token,
+    )
+    .await
+    else {
+        return GitHubState::Unknown;
+    };
+    classify_issue_state(&state)
+}

--- a/crates/harness-server/src/reconciliation_legacy.rs
+++ b/crates/harness-server/src/reconciliation_legacy.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+/// Determine the current GitHub state for one candidate, consuming rate-limit budget.
+pub(super) async fn resolve_github_state(
+    candidate: &Candidate,
+    rate: &mut RateLimiter,
+    repo_slug_cache: &mut HashMap<PathBuf, Option<String>>,
+    github_token: Option<&str>,
+) -> GitHubState {
+    // PR URL takes precedence; most candidates in `implementing` or `reviewing` have one.
+    if let Some(pr_url) = &candidate.pr_url {
+        rate.acquire().await;
+        return fetch_pr_state_by_url(pr_url, github_token).await;
+    }
+    let repo_slug = resolve_repo_slug(candidate, repo_slug_cache).await;
+    let Some(repo_slug) = repo_slug else {
+        tracing::debug!(
+            task_id = %candidate.id.0,
+            "GitHub state check skipped because repository slug is unavailable"
+        );
+        return GitHubState::Unknown;
+    };
+    if let Some(pr_num) = candidate.pr_num_from_ext {
+        rate.acquire().await;
+        return fetch_pr_state_by_slug_with_token(&repo_slug, pr_num, github_token).await;
+    }
+    if let Some(issue_num) = candidate.issue_num {
+        rate.acquire().await;
+        return fetch_issue_state_with_token(&repo_slug, issue_num, github_token).await;
+    }
+    GitHubState::Unknown
+}
+
+pub(super) async fn resolve_repo_slug(
+    candidate: &Candidate,
+    repo_slug_cache: &mut HashMap<PathBuf, Option<String>>,
+) -> Option<String> {
+    match candidate.repo.as_deref() {
+        Some(repo) if !repo.trim().is_empty() => Some(repo.to_string()),
+        _ => match candidate.project_root.as_ref() {
+            Some(project_root) => {
+                if let Some(cached) = cached_repo_slug(repo_slug_cache, project_root) {
+                    return cached.clone();
+                }
+
+                let detected =
+                    crate::task_executor::pr_detection::detect_repo_slug(project_root).await;
+                repo_slug_cache.insert(project_root.clone(), detected.clone());
+                detected
+            }
+            None => None,
+        },
+    }
+}
+
+fn cached_repo_slug(
+    repo_slug_cache: &HashMap<PathBuf, Option<String>>,
+    project_root: &PathBuf,
+) -> Option<Option<String>> {
+    repo_slug_cache.get(project_root).cloned()
+}
+
+/// Apply a status transition to a task, returning `true` on success.
+pub(super) async fn apply_transition(
+    store: &Arc<TaskStore>,
+    task_id: &TaskId,
+    new_status: TaskStatus,
+    reason: &str,
+) -> bool {
+    let result = mutate_and_persist(store, task_id, |s| {
+        // TOCTOU guard: skip if already terminal.
+        if s.status.is_terminal() {
+            return;
+        }
+        tracing::info!(
+            task_id = %task_id.0,
+            from = s.status.as_ref(),
+            to = new_status.as_ref(),
+            reason,
+            "reconciliation: applying transition"
+        );
+        s.status = new_status.clone();
+        s.scheduler.mark_terminal(&new_status);
+    })
+    .await;
+
+    match result {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(task_id = %task_id.0, "reconciliation: persist failed: {e}");
+            false
+        }
+    }
+}

--- a/crates/harness-server/src/reconciliation_payload_tests.rs
+++ b/crates/harness-server/src/reconciliation_payload_tests.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[test]
+fn reconciliation_payload_has_no_workspace_paths() {
+    let report = ReconciliationReport {
+        candidates: 3,
+        skipped_terminal: 1,
+        transitions: vec![ReconciliationTransition {
+            task_id: "task-abc123".to_string(),
+            from: "implementing".to_string(),
+            to: "done".to_string(),
+            reason: "PR merged".to_string(),
+            applied: true,
+        }],
+        workflow_transitions: vec![WorkflowReconciliationTransition {
+            workflow_id: "project::repo:owner/repo::issue:42".to_string(),
+            from: "pr_open".to_string(),
+            to: "done".to_string(),
+            reason: "PR merged".to_string(),
+            applied: true,
+            repo: Some("owner/repo".to_string()),
+            issue_number: Some(42),
+            pr_number: 77,
+            pr_url: Some("https://github.com/owner/repo/pull/77".to_string()),
+        }],
+        workflow_alerts: vec![],
+    };
+    let json = serde_json::to_string(&report).expect("ReconciliationReport must serialise to JSON");
+    assert!(
+        !json.contains("/workspaces/"),
+        "ReconciliationReport JSON must not contain a workspace path, got: {json}"
+    );
+}

--- a/crates/harness-server/src/reconciliation_periodic.rs
+++ b/crates/harness-server/src/reconciliation_periodic.rs
@@ -51,6 +51,7 @@ async fn reconciliation_loop(state: Arc<AppState>, config: ReconciliationConfig)
             skipped_terminal = report.skipped_terminal,
             transitions = report.transitions.len(),
             workflow_transitions = report.workflow_transitions.len(),
+            workflow_alerts = report.workflow_alerts.len(),
             "reconciliation: tick complete"
         );
         sleep(interval).await;

--- a/crates/harness-server/src/reconciliation_periodic.rs
+++ b/crates/harness-server/src/reconciliation_periodic.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+/// Spawn the periodic reconciliation loop as a background task.
+///
+/// Returns immediately without spawning when `config.enabled` is false.
+pub fn start(state: Arc<AppState>, config: ReconciliationConfig) {
+    if !config.enabled {
+        tracing::debug!("reconciliation: periodic loop disabled");
+        return;
+    }
+
+    tokio::spawn(async move {
+        reconciliation_loop(state, config).await;
+    });
+}
+
+async fn reconciliation_loop(state: Arc<AppState>, config: ReconciliationConfig) {
+    let interval = Duration::from_secs(config.interval_secs);
+    // Brief init delay so the server is fully up before the first tick.
+    sleep(Duration::from_secs(15)).await;
+
+    loop {
+        let report = run_once_with_runtime_config(
+            &state.core.tasks,
+            state.core.workflow_runtime_store.as_deref(),
+            state.core.issue_workflow_store.as_deref(),
+            &config,
+            false,
+            state.core.server.config.server.github_token.as_deref(),
+        )
+        .await;
+        record_repo_backlog_reconciliation_transitions(&state, &report).await;
+
+        // Clean up workspaces for tasks that were just terminated by reconciliation.
+        if let Some(ref wmgr) = state.concurrency.workspace_mgr {
+            let transitioned_ids: Vec<crate::task_runner::TaskId> = report
+                .transitions
+                .iter()
+                .filter(|t| t.applied)
+                .map(|t| harness_core::types::TaskId(t.task_id.clone()))
+                .collect();
+            if !transitioned_ids.is_empty() {
+                if let Err(e) = wmgr.cleanup_terminal(&transitioned_ids).await {
+                    tracing::warn!("reconciliation: workspace cleanup failed: {e}");
+                }
+            }
+        }
+
+        tracing::info!(
+            candidates = report.candidates,
+            skipped_terminal = report.skipped_terminal,
+            transitions = report.transitions.len(),
+            workflow_transitions = report.workflow_transitions.len(),
+            "reconciliation: tick complete"
+        );
+        sleep(interval).await;
+    }
+}
+
+async fn record_repo_backlog_reconciliation_transitions(
+    state: &Arc<AppState>,
+    report: &ReconciliationReport,
+) {
+    for transition in &report.transitions {
+        if !transition.applied || transition.reason != "reconciled: PR merged externally" {
+            continue;
+        }
+        let task_id = harness_core::types::TaskId(transition.task_id.clone());
+        let Some(task) = state.core.tasks.get(&task_id) else {
+            continue;
+        };
+        let Some(pr_number) = task
+            .pr_url
+            .as_deref()
+            .and_then(harness_core::prompts::parse_github_pr_url)
+            .map(|(_, _, pr_number)| pr_number)
+            .or_else(|| parse_external_id(task.external_id.as_deref()).1)
+        else {
+            continue;
+        };
+        let issue_number = task
+            .issue
+            .or_else(|| parse_external_id(task.external_id.as_deref()).0);
+        let project_root = task
+            .project_root
+            .as_deref()
+            .unwrap_or(&state.core.project_root);
+        crate::workflow_runtime_repo_backlog::record_merged_pr(
+            state.core.workflow_runtime_store.as_deref(),
+            state.core.issue_workflow_store.as_deref(),
+            crate::workflow_runtime_repo_backlog::MergedPrRuntimeContext {
+                project_root,
+                repo: task.repo.as_deref(),
+                issue_number,
+                pr_number,
+                pr_url: task.pr_url.as_deref(),
+                detail: &transition.reason,
+            },
+        )
+        .await;
+    }
+}

--- a/crates/harness-server/src/reconciliation_ready_to_merge_tests.rs
+++ b/crates/harness-server/src/reconciliation_ready_to_merge_tests.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[tokio::test]
+async fn ready_to_merge_reconciliation_marks_closed_unmerged_pr_cancelled() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/102",
+        r#"{"state":"closed","merged_at":null}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let (project_id, workflow_id) =
+        persist_ready_to_merge_runtime(&stores, "project-closed", 47, "task-6", 102, 120, true)
+            .await?;
+    let report = run_once_with_runtime_config(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        &ready_to_merge_config(0, 3600),
+        false,
+        None,
+    )
+    .await;
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert!(report.workflow_alerts.is_empty());
+    assert_eq!(report.workflow_transitions[0].from, "ready_to_merge");
+    assert_eq!(report.workflow_transitions[0].to, "cancelled");
+    assert!(report.workflow_transitions[0].applied);
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected workflow to remain persisted"))?;
+    assert_eq!(updated.state, "cancelled");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_closed");
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 47)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected issue workflow to exist"))?;
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/reconciliation_runtime.rs
+++ b/crates/harness-server/src/reconciliation_runtime.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+pub(super) async fn collect_runtime_candidates(
+    store: &WorkflowRuntimeStore,
+) -> anyhow::Result<(Vec<RuntimeWorkflowCandidate>, usize)> {
+    let rows: Vec<(String, chrono::DateTime<chrono::Utc>)> = sqlx::query_as(
+        "SELECT data::text, updated_at
+         FROM workflow_instances
+         WHERE definition_id = $1
+         ORDER BY updated_at DESC",
+    )
+    .bind(GITHUB_ISSUE_PR_DEFINITION_ID)
+    .fetch_all(store.pool())
+    .await?;
+
+    let mut candidates = Vec::new();
+    let mut skipped_terminal = 0usize;
+    for (data, row_updated_at) in rows {
+        let instance: WorkflowInstance = serde_json::from_str(&data)?;
+        if instance.is_terminal() {
+            skipped_terminal += 1;
+            continue;
+        }
+        if let Some(candidate) = runtime_candidate_from_instance(&instance, row_updated_at) {
+            candidates.push(candidate);
+        }
+    }
+    Ok((candidates, skipped_terminal))
+}
+
+pub(super) fn runtime_candidate_from_instance(
+    instance: &WorkflowInstance,
+    row_updated_at: chrono::DateTime<chrono::Utc>,
+) -> Option<RuntimeWorkflowCandidate> {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID || instance.is_terminal() {
+        return None;
+    }
+    let pr_number = instance
+        .data
+        .get("pr_number")
+        .and_then(serde_json::Value::as_u64)?;
+    Some(RuntimeWorkflowCandidate {
+        workflow_id: instance.id.clone(),
+        state: instance.state.clone(),
+        row_updated_at,
+        repo: optional_json_string(&instance.data, "repo"),
+        project_root: optional_json_string(&instance.data, "project_id").map(PathBuf::from),
+        issue_number: instance
+            .data
+            .get("issue_number")
+            .and_then(serde_json::Value::as_u64),
+        pr_number,
+        pr_url: optional_json_string(&instance.data, "pr_url"),
+    })
+}
+
+pub(super) async fn resolve_runtime_github_state(
+    candidate: &RuntimeWorkflowCandidate,
+    rate: &mut RateLimiter,
+    github_token: Option<&str>,
+) -> GitHubState {
+    if let Some(pr_url) = candidate.pr_url.as_deref() {
+        rate.acquire().await;
+        return fetch_pr_state_by_url(pr_url, github_token).await;
+    }
+    if let Some(repo) = candidate.repo.as_deref() {
+        rate.acquire().await;
+        return fetch_pr_state_by_slug_with_token(repo, candidate.pr_number, github_token).await;
+    }
+    tracing::debug!(
+        workflow_id = %candidate.workflow_id,
+        pr = candidate.pr_number,
+        "workflow runtime GitHub state check skipped because repository slug is unavailable"
+    );
+    GitHubState::Unknown
+}

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -458,8 +458,10 @@ fn runtime_candidate_from_instance_requires_non_terminal_bound_pr() {
         "pr_number": 77,
         "pr_url": "https://github.com/owner/repo/pull/77",
     }));
-    let candidate = runtime_candidate_from_instance(&active).expect("candidate");
+    let row_updated_at = active.updated_at + chrono::Duration::seconds(60);
+    let candidate = runtime_candidate_from_instance(&active, row_updated_at).expect("candidate");
     assert_eq!(candidate.workflow_id, "workflow-1");
+    assert_eq!(candidate.row_updated_at, row_updated_at);
     assert_eq!(candidate.pr_number, 77);
     assert_eq!(candidate.repo.as_deref(), Some("owner/repo"));
 
@@ -470,7 +472,7 @@ fn runtime_candidate_from_instance_requires_non_terminal_bound_pr() {
         harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
     )
     .with_data(json!({ "pr_number": 77 }));
-    assert!(runtime_candidate_from_instance(&terminal).is_none());
+    assert!(runtime_candidate_from_instance(&terminal, chrono::Utc::now()).is_none());
 
     let missing_pr = WorkflowInstance::new(
         GITHUB_ISSUE_PR_DEFINITION_ID,
@@ -478,7 +480,27 @@ fn runtime_candidate_from_instance_requires_non_terminal_bound_pr() {
         "pr_open",
         harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
     );
-    assert!(runtime_candidate_from_instance(&missing_pr).is_none());
+    assert!(runtime_candidate_from_instance(&missing_pr, chrono::Utc::now()).is_none());
+}
+
+#[test]
+fn ready_to_merge_open_alert_uses_row_age() {
+    let now = chrono::Utc::now();
+    let candidate = RuntimeWorkflowCandidate {
+        workflow_id: "workflow-1".to_string(),
+        state: "ready_to_merge".to_string(),
+        row_updated_at: now,
+        repo: Some("owner/repo".to_string()),
+        project_root: None,
+        issue_number: Some(42),
+        pr_number: 77,
+        pr_url: Some("https://github.com/owner/repo/pull/77".to_string()),
+    };
+    let settings = RuntimeWorkflowReconciliationSettings {
+        ready_to_merge_min_age_secs: 0,
+        ready_to_merge_alert_ttl_secs: 60,
+    };
+    assert!(ready_to_merge_open_alert(&candidate, GitHubState::Open, settings, now).is_none());
 }
 
 #[tokio::test]
@@ -669,7 +691,7 @@ async fn ready_to_merge_reconciliation_waits_for_configured_age() -> anyhow::Res
         return Ok(());
     };
     let (_, workflow_id) =
-        persist_ready_to_merge_runtime(&stores, "project-young", 44, "task-3", 99, 0, false)
+        persist_ready_to_merge_runtime(&stores, "project-young", 44, "task-3", 99, 120, false)
             .await?;
     let report = run_once_with_runtime_config(
         &stores.task_store,
@@ -714,7 +736,7 @@ async fn ready_to_merge_reconciliation_marks_merged_pr_done() -> anyhow::Result<
         &stores.task_store,
         Some(&stores.runtime_store),
         Some(&stores.issue_store),
-        &ready_to_merge_config(60, 3600),
+        &ready_to_merge_config(0, 3600),
         false,
         None,
     )
@@ -735,7 +757,7 @@ async fn ready_to_merge_reconciliation_marks_merged_pr_done() -> anyhow::Result<
 }
 
 #[tokio::test]
-async fn ready_to_merge_reconciliation_alerts_for_old_open_pr() -> anyhow::Result<()> {
+async fn ready_to_merge_reconciliation_alerts_for_open_pr_after_ttl() -> anyhow::Result<()> {
     let _env_guard = async_env_lock().lock().await;
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
@@ -755,7 +777,7 @@ async fn ready_to_merge_reconciliation_alerts_for_old_open_pr() -> anyhow::Resul
         &stores.task_store,
         Some(&stores.runtime_store),
         Some(&stores.issue_store),
-        &ready_to_merge_config(60, 60),
+        &ready_to_merge_config(0, 0),
         false,
         None,
     )
@@ -765,36 +787,4 @@ async fn ready_to_merge_reconciliation_alerts_for_old_open_pr() -> anyhow::Resul
     assert_eq!(report.workflow_alerts[0].pr_number, 101);
     assert_eq!(report.workflow_alerts[0].state, "ready_to_merge");
     Ok(())
-}
-
-#[test]
-fn reconciliation_payload_has_no_workspace_paths() {
-    let report = ReconciliationReport {
-        candidates: 3,
-        skipped_terminal: 1,
-        transitions: vec![ReconciliationTransition {
-            task_id: "task-abc123".to_string(),
-            from: "implementing".to_string(),
-            to: "done".to_string(),
-            reason: "PR merged".to_string(),
-            applied: true,
-        }],
-        workflow_transitions: vec![WorkflowReconciliationTransition {
-            workflow_id: "project::repo:owner/repo::issue:42".to_string(),
-            from: "pr_open".to_string(),
-            to: "done".to_string(),
-            reason: "PR merged".to_string(),
-            applied: true,
-            repo: Some("owner/repo".to_string()),
-            issue_number: Some(42),
-            pr_number: 77,
-            pr_url: Some("https://github.com/owner/repo/pull/77".to_string()),
-        }],
-        workflow_alerts: vec![],
-    };
-    let json = serde_json::to_string(&report).expect("ReconciliationReport must serialise to JSON");
-    assert!(
-        !json.contains("/workspaces/"),
-        "ReconciliationReport JSON must not contain a workspace path, got: {json}"
-    );
 }

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::Mutex;
 
+#[path = "reconciliation_ready_to_merge_tests.rs"]
+mod ready_to_merge_tests;
+
 fn make_task(
     id: &str,
     status: TaskStatus,

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -1,0 +1,800 @@
+use super::*;
+use crate::task_runner::TaskState;
+use harness_core::types::TaskId;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex;
+
+fn make_task(
+    id: &str,
+    status: TaskStatus,
+    pr_url: Option<&str>,
+    external_id: Option<&str>,
+) -> TaskState {
+    let tid = TaskId(id.to_string());
+    let mut task = TaskState::new(tid);
+    task.status = status;
+    task.pr_url = pr_url.map(|s| s.to_string());
+    task.external_id = external_id.map(|s| s.to_string());
+    task
+}
+
+fn async_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct ScopedEnvVar {
+    key: String,
+    original: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self {
+            key: key.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if let Some(value) = &self.original {
+            unsafe { std::env::set_var(&self.key, value) };
+        } else {
+            unsafe { std::env::remove_var(&self.key) };
+        }
+    }
+}
+
+async fn github_state_server(routes: Vec<(&'static str, &'static str)>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind GitHub mock");
+    let addr = listener.local_addr().expect("GitHub mock address");
+    let routes: HashMap<String, &'static str> = routes
+        .into_iter()
+        .map(|(path, body)| (path.to_string(), body))
+        .collect();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let routes = routes.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let Ok(n) = socket.read(&mut buf).await else {
+                    return;
+                };
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let request_line = request.lines().next().unwrap_or_default();
+                let path = request_line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or_default()
+                    .to_string();
+                let (status, response_body) = match routes.get(&path).copied() {
+                    Some(body) => ("200 OK", body),
+                    None => ("404 Not Found", "{}"),
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    format!("http://{addr}")
+}
+
+fn write_git_remote_config(path: &std::path::Path, origin: &str) {
+    let dotgit = path.join(".git");
+    std::fs::create_dir_all(&dotgit).expect("create .git");
+    std::fs::write(
+        dotgit.join("config"),
+        format!("[remote \"origin\"]\n\turl = {origin}\n"),
+    )
+    .expect("write git config");
+}
+
+struct RuntimeStores {
+    dir: tempfile::TempDir,
+    task_store: Arc<TaskStore>,
+    runtime_store: WorkflowRuntimeStore,
+    issue_store: IssueWorkflowStore,
+}
+
+async fn open_runtime_stores() -> anyhow::Result<Option<RuntimeStores>> {
+    let database_url = crate::test_helpers::test_database_url()?;
+    let dir = tempfile::tempdir()?;
+    let task_store = match TaskStore::open(&dir.path().join("tasks.db")).await {
+        Ok(store) => store,
+        Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let runtime_store = match WorkflowRuntimeStore::open_with_database_url(
+        &dir.path().join("runtime"),
+        Some(&database_url),
+    )
+    .await
+    {
+        Ok(store) => store,
+        Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let issue_store = match IssueWorkflowStore::open_with_database_url(
+        &dir.path().join("issue"),
+        Some(&database_url),
+    )
+    .await
+    {
+        Ok(store) => store,
+        Err(err) if crate::test_helpers::is_pool_timeout(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    Ok(Some(RuntimeStores {
+        dir,
+        task_store,
+        runtime_store,
+        issue_store,
+    }))
+}
+
+fn ready_to_merge_config(min_age_secs: u64, alert_ttl_secs: u64) -> ReconciliationConfig {
+    ReconciliationConfig {
+        enabled: true,
+        interval_secs: 300,
+        max_gh_calls_per_minute: 20,
+        ready_to_merge_min_age_secs: min_age_secs,
+        ready_to_merge_alert_ttl_secs: alert_ttl_secs,
+    }
+}
+
+async fn record_issue_ready_to_merge(
+    issue_store: &IssueWorkflowStore,
+    project_id: &str,
+    issue_number: u64,
+    task_id: &str,
+    pr_number: u64,
+) -> anyhow::Result<()> {
+    issue_store
+        .record_issue_scheduled(
+            project_id,
+            Some("owner/repo"),
+            issue_number,
+            task_id,
+            &[],
+            false,
+        )
+        .await?;
+    issue_store
+        .record_pr_detected(
+            project_id,
+            Some("owner/repo"),
+            issue_number,
+            task_id,
+            pr_number,
+            &format!("https://github.com/owner/repo/pull/{pr_number}"),
+        )
+        .await?;
+    issue_store
+        .record_ready_to_merge_with_fallback(
+            project_id,
+            Some("owner/repo"),
+            pr_number,
+            Some("ready to merge before reconciliation"),
+            harness_workflow::issue_lifecycle::ReviewFallbackSnapshot {
+                tier: harness_workflow::issue_lifecycle::ReviewFallbackTier::C,
+                trigger: harness_workflow::issue_lifecycle::ReviewFallbackTrigger::Silence,
+                active_bot: Some("codex".to_string()),
+                activated_at: chrono::Utc::now(),
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+fn ready_to_merge_instance(
+    workflow_id: &str,
+    project_id: &str,
+    issue_number: u64,
+    task_id: &str,
+    pr_number: u64,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> WorkflowInstance {
+    let mut instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "ready_to_merge",
+        harness_workflow::runtime::WorkflowSubject::new("issue", format!("issue:{issue_number}")),
+    )
+    .with_id(workflow_id)
+    .with_data(json!({
+        "project_id": project_id,
+        "repo": "owner/repo",
+        "issue_number": issue_number,
+        "task_id": task_id,
+        "pr_number": pr_number,
+        "pr_url": format!("https://github.com/owner/repo/pull/{pr_number}"),
+    }));
+    instance.updated_at = updated_at;
+    instance
+}
+
+async fn persist_ready_to_merge_runtime(
+    stores: &RuntimeStores,
+    project_name: &str,
+    issue_number: u64,
+    task_id: &str,
+    pr_number: u64,
+    age_secs: i64,
+    record_issue_workflow: bool,
+) -> anyhow::Result<(String, String)> {
+    let project_root = stores.dir.path().join(project_name);
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy().to_string();
+    if record_issue_workflow {
+        record_issue_ready_to_merge(
+            &stores.issue_store,
+            &project_id,
+            issue_number,
+            task_id,
+            pr_number,
+        )
+        .await?;
+    }
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_id,
+        Some("owner/repo"),
+        issue_number,
+    );
+    let instance = ready_to_merge_instance(
+        &workflow_id,
+        &project_id,
+        issue_number,
+        task_id,
+        pr_number,
+        chrono::Utc::now() - chrono::Duration::seconds(age_secs),
+    );
+    stores.runtime_store.upsert_instance(&instance).await?;
+    Ok((project_id, workflow_id))
+}
+
+#[test]
+fn parse_external_id_handles_issue_pr_and_none() {
+    assert_eq!(parse_external_id(Some("issue:42")), (Some(42), None));
+    assert_eq!(parse_external_id(Some("pr:7")), (None, Some(7)));
+    assert_eq!(parse_external_id(None), (None, None));
+}
+
+#[test]
+fn candidate_from_task_skips_terminal() {
+    let mut t = make_task(
+        "x",
+        TaskStatus::Done,
+        Some("https://github.com/a/b/pull/1"),
+        None,
+    );
+    assert!(candidate_from_task(&t).is_none());
+    t.status = TaskStatus::Cancelled;
+    assert!(candidate_from_task(&t).is_none());
+}
+
+#[test]
+fn candidate_from_task_handles_references() {
+    let t = make_task("x", TaskStatus::Implementing, None, None);
+    assert!(candidate_from_task(&t).is_none());
+
+    let t = make_task(
+        "x",
+        TaskStatus::Implementing,
+        Some("https://github.com/a/b/pull/2"),
+        None,
+    );
+    let c = candidate_from_task(&t).unwrap();
+    assert!(c.pr_url.is_some());
+    assert_eq!(c.issue_num, None);
+
+    let mut t = make_task("x", TaskStatus::Pending, None, Some("issue:9"));
+    t.project_root = Some(PathBuf::from("/tmp/projects/alpha"));
+    let c = candidate_from_task(&t).unwrap();
+    assert_eq!(c.project_root, Some(PathBuf::from("/tmp/projects/alpha")));
+
+    let t = make_task("x", TaskStatus::Pending, None, Some("issue:9"));
+    let c = candidate_from_task(&t).unwrap();
+    assert_eq!(c.issue_num, Some(9));
+    assert!(c.pr_url.is_none());
+}
+
+#[tokio::test]
+async fn resolve_repo_slug_uses_candidate_project_root_when_repo_missing() {
+    let repo_a = tempfile::tempdir().expect("repo a tempdir");
+    let repo_b = tempfile::tempdir().expect("repo b tempdir");
+    write_git_remote_config(repo_a.path(), "https://github.com/example/repo-a.git");
+    write_git_remote_config(repo_b.path(), "https://github.com/example/repo-b.git");
+    assert_eq!(
+        crate::task_executor::pr_detection::detect_repo_slug(repo_a.path()).await,
+        Some("example/repo-a".to_string())
+    );
+
+    let candidate = Candidate {
+        id: TaskId("task-1".to_string()),
+        pr_url: None,
+        repo: None,
+        project_root: Some(repo_b.path().to_path_buf()),
+        issue_num: Some(9),
+        pr_num_from_ext: None,
+    };
+
+    let mut cache = HashMap::new();
+    let repo_slug = reconciliation_legacy::resolve_repo_slug(&candidate, &mut cache).await;
+    assert_eq!(repo_slug, Some("example/repo-b".to_string()));
+}
+
+#[tokio::test]
+async fn run_once_uses_each_task_project_root_when_repo_is_missing() {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return;
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let repo_a = tempfile::tempdir().expect("repo a tempdir");
+    let repo_b = tempfile::tempdir().expect("repo b tempdir");
+    write_git_remote_config(repo_a.path(), "https://github.com/example/repo-a.git");
+    write_git_remote_config(repo_b.path(), "https://github.com/example/repo-b.git");
+
+    let api_base = github_state_server(vec![
+        ("/repos/example/repo-a/issues/9", r#"{"state":"open"}"#),
+        ("/repos/example/repo-a/issues/41", r#"{"state":"open"}"#),
+        ("/repos/example/repo-b/issues/9", r#"{"state":"closed"}"#),
+    ])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+
+    let dir = tempfile::tempdir().expect("task store tempdir");
+    let store = match TaskStore::open(&dir.path().join("tasks.db")).await {
+        Ok(store) => store,
+        Err(err) if crate::test_helpers::is_pool_timeout(&err) => return,
+        Err(err) => panic!("open task store: {err}"),
+    };
+
+    let mut repo_task = make_task("repo-task", TaskStatus::Pending, None, Some("issue:41"));
+    repo_task.repo = Some("example/repo-a".to_string());
+    repo_task.project_root = Some(repo_a.path().to_path_buf());
+    store.insert(&repo_task).await;
+
+    let mut repo_less_task =
+        make_task("repo-less-task", TaskStatus::Pending, None, Some("issue:9"));
+    repo_less_task.project_root = Some(repo_b.path().to_path_buf());
+    store.insert(&repo_less_task).await;
+
+    let report = run_once(&store, 20, false).await;
+
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(report.transitions[0].task_id, repo_less_task.id.0);
+    assert_eq!(
+        report.transitions[0].reason,
+        "reconciled: issue closed before PR"
+    );
+
+    let repo_task_after = store.get(&repo_task.id).expect("repo task remains");
+    assert_eq!(repo_task_after.status, TaskStatus::Pending);
+
+    let repo_less_after = store
+        .get(&repo_less_task.id)
+        .expect("repo-less task remains");
+    assert_eq!(repo_less_after.status, TaskStatus::Cancelled);
+}
+
+#[test]
+fn classify_pr_state_handles_merged_and_closed() {
+    assert_eq!(
+        classify_pr_state(&GitHubPullState {
+            state: "closed".to_string(),
+            merged_at: Some("2024-01-01T00:00:00Z".to_string()),
+        }),
+        GitHubState::PrMerged
+    );
+    assert_eq!(
+        classify_pr_state(&GitHubPullState {
+            state: "closed".to_string(),
+            merged_at: None,
+        }),
+        GitHubState::PrClosed
+    );
+}
+
+#[test]
+fn classify_issue_state_handles_open_and_closed() {
+    assert_eq!(
+        classify_issue_state(&GitHubIssueState {
+            state: "open".to_string(),
+        }),
+        GitHubState::Open
+    );
+    assert_eq!(
+        classify_issue_state(&GitHubIssueState {
+            state: "closed".to_string(),
+        }),
+        GitHubState::IssueClosed
+    );
+}
+
+#[test]
+fn transition_mapping_matches_external_states() {
+    assert_eq!(
+        transition_for_github_state(GitHubState::PrMerged),
+        Some((TaskStatus::Done, "reconciled: PR merged externally"))
+    );
+    assert_eq!(
+        transition_for_github_state(GitHubState::PrClosed),
+        Some((TaskStatus::Cancelled, "reconciled: PR closed externally"))
+    );
+    assert_eq!(transition_for_github_state(GitHubState::Open), None);
+}
+
+#[test]
+fn runtime_candidate_from_instance_requires_non_terminal_bound_pr() {
+    let active = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+    )
+    .with_id("workflow-1")
+    .with_data(json!({
+        "project_id": "/tmp/project",
+        "repo": "owner/repo",
+        "issue_number": 42,
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let candidate = runtime_candidate_from_instance(&active).expect("candidate");
+    assert_eq!(candidate.workflow_id, "workflow-1");
+    assert_eq!(candidate.pr_number, 77);
+    assert_eq!(candidate.repo.as_deref(), Some("owner/repo"));
+
+    let terminal = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "done",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+    )
+    .with_data(json!({ "pr_number": 77 }));
+    assert!(runtime_candidate_from_instance(&terminal).is_none());
+
+    let missing_pr = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+    );
+    assert!(runtime_candidate_from_instance(&missing_pr).is_none());
+}
+
+#[tokio::test]
+async fn run_once_reconciles_runtime_merged_pr_workflow() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/77",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let project_root = stores.dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy();
+    stores
+        .issue_store
+        .record_issue_scheduled(&project_id, Some("owner/repo"), 42, "task-1", &[], false)
+        .await?;
+    stores
+        .issue_store
+        .record_pr_detected(
+            &project_id,
+            Some("owner/repo"),
+            42,
+            "task-1",
+            77,
+            "https://github.com/owner/repo/pull/77",
+        )
+        .await?;
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 42);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "pr_open",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_ref(),
+        "repo": "owner/repo",
+        "issue_number": 42,
+        "task_id": "task-1",
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+
+    let report = run_once_with_runtime_token(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        20,
+        false,
+        None,
+    )
+    .await;
+
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].from, "pr_open");
+    assert_eq!(report.workflow_transitions[0].to, "done");
+    assert!(report.workflow_transitions[0].applied);
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(updated.state, "done");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_merged");
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 42)
+        .await?
+        .expect("issue workflow should exist");
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_once_reconciles_runtime_closed_pr_workflow() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/88",
+        r#"{"state":"closed","merged_at":null}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let project_root = stores.dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy();
+    stores
+        .issue_store
+        .record_issue_scheduled(&project_id, Some("owner/repo"), 43, "task-2", &[], false)
+        .await?;
+    stores
+        .issue_store
+        .record_pr_detected(
+            &project_id,
+            Some("owner/repo"),
+            43,
+            "task-2",
+            88,
+            "https://github.com/owner/repo/pull/88",
+        )
+        .await?;
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 43);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "awaiting_feedback",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:43"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_ref(),
+        "repo": "owner/repo",
+        "issue_number": 43,
+        "task_id": "task-2",
+        "pr_number": 88,
+        "pr_url": "https://github.com/owner/repo/pull/88",
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+
+    let report = run_once_with_runtime_token(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        20,
+        false,
+        None,
+    )
+    .await;
+
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].to, "cancelled");
+    assert!(report.workflow_transitions[0].applied);
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(updated.state, "cancelled");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_closed");
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 43)
+        .await?
+        .expect("issue workflow should exist");
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Cancelled
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn ready_to_merge_reconciliation_waits_for_configured_age() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/99",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let (_, workflow_id) =
+        persist_ready_to_merge_runtime(&stores, "project-young", 44, "task-3", 99, 0, false)
+            .await?;
+    let report = run_once_with_runtime_config(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        &ready_to_merge_config(3600, 7200),
+        false,
+        None,
+    )
+    .await;
+    assert!(report.workflow_transitions.is_empty());
+    assert!(report.workflow_alerts.is_empty());
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected ready_to_merge workflow to remain persisted"))?;
+    assert_eq!(updated.state, "ready_to_merge");
+    Ok(())
+}
+
+#[tokio::test]
+async fn ready_to_merge_reconciliation_marks_merged_pr_done() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/100",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let (project_id, _) =
+        persist_ready_to_merge_runtime(&stores, "project-merged", 45, "task-4", 100, 120, true)
+            .await?;
+    let report = run_once_with_runtime_config(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        &ready_to_merge_config(60, 3600),
+        false,
+        None,
+    )
+    .await;
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].from, "ready_to_merge");
+    assert_eq!(report.workflow_transitions[0].to, "done");
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 45)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("expected issue workflow to exist"))?;
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn ready_to_merge_reconciliation_alerts_for_old_open_pr() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/101",
+        r#"{"state":"open","merged_at":null}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    persist_ready_to_merge_runtime(&stores, "project-open", 46, "task-5", 101, 120, false).await?;
+    let report = run_once_with_runtime_config(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        &ready_to_merge_config(60, 60),
+        false,
+        None,
+    )
+    .await;
+    assert!(report.workflow_transitions.is_empty());
+    assert_eq!(report.workflow_alerts.len(), 1);
+    assert_eq!(report.workflow_alerts[0].pr_number, 101);
+    assert_eq!(report.workflow_alerts[0].state, "ready_to_merge");
+    Ok(())
+}
+
+#[test]
+fn reconciliation_payload_has_no_workspace_paths() {
+    let report = ReconciliationReport {
+        candidates: 3,
+        skipped_terminal: 1,
+        transitions: vec![ReconciliationTransition {
+            task_id: "task-abc123".to_string(),
+            from: "implementing".to_string(),
+            to: "done".to_string(),
+            reason: "PR merged".to_string(),
+            applied: true,
+        }],
+        workflow_transitions: vec![WorkflowReconciliationTransition {
+            workflow_id: "project::repo:owner/repo::issue:42".to_string(),
+            from: "pr_open".to_string(),
+            to: "done".to_string(),
+            reason: "PR merged".to_string(),
+            applied: true,
+            repo: Some("owner/repo".to_string()),
+            issue_number: Some(42),
+            pr_number: 77,
+            pr_url: Some("https://github.com/owner/repo/pull/77".to_string()),
+        }],
+        workflow_alerts: vec![],
+    };
+    let json = serde_json::to_string(&report).expect("ReconciliationReport must serialise to JSON");
+    assert!(
+        !json.contains("/workspaces/"),
+        "ReconciliationReport JSON must not contain a workspace path, got: {json}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add config-driven age and alert TTL settings for ready_to_merge runtime reconciliation.
- Reconcile old ready_to_merge workflows against GitHub PR state: merged PRs move to done, old open PRs report a workflow alert without transitioning.
- Split oversized reconciliation/config modules mechanically to satisfy file-size guards while preserving existing tests.

Closes #1295

## Validation
- cargo test -p harness-server reconciliation::tests
- cargo test -p harness-core
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings