### PR TITLE
Wire review provider policy into local review gate

### DIFF
--- a/crates/harness-core/src/review.rs
+++ b/crates/harness-core/src/review.rs
@@ -171,32 +171,11 @@ pub fn parse_review_report(
 
 pub fn evaluate_review_gate(
     reports: &[ReviewGateProviderReport],
+    required_provider_ids: &[String],
+    advisory_provider_ids: &[String],
     external_required: bool,
 ) -> ReviewGateResult {
-    let mut saw_required = false;
-    for input in reports {
-        if input.role == ReviewProviderRole::Required {
-            saw_required = true;
-            match input.report.decision {
-                ReviewDecision::ChangesRequested => {
-                    return gate_result(
-                        ReviewGateDecision::ChangesRequested,
-                        &input.report,
-                        "Required review provider requested changes.",
-                    );
-                }
-                ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
-                    return gate_result(
-                        ReviewGateDecision::Blocked,
-                        &input.report,
-                        "Required review provider did not complete successfully.",
-                    );
-                }
-                ReviewDecision::Approved => {}
-            }
-        }
-    }
-    if !saw_required {
+    if required_provider_ids.is_empty() {
         return ReviewGateResult {
             decision: ReviewGateDecision::Blocked,
             blocking_provider_id: None,
@@ -204,36 +183,69 @@ pub fn evaluate_review_gate(
         };
     }
 
-    if external_required {
-        let mut saw_advisory = false;
-        for input in reports {
-            if input.role == ReviewProviderRole::Advisory {
-                saw_advisory = true;
-                match input.report.decision {
-                    ReviewDecision::ChangesRequested => {
-                        return gate_result(
-                            ReviewGateDecision::ChangesRequested,
-                            &input.report,
-                            "External review provider requested changes.",
-                        );
-                    }
-                    ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
-                        return gate_result(
-                            ReviewGateDecision::Blocked,
-                            &input.report,
-                            "External review provider is required and did not approve.",
-                        );
-                    }
-                    ReviewDecision::Approved => {}
-                }
+    for provider_id in required_provider_ids {
+        let Some(input) = reports.iter().find(|input| {
+            input.role == ReviewProviderRole::Required && input.report.provider_id == *provider_id
+        }) else {
+            return missing_provider_result(
+                provider_id,
+                "Required review provider did not produce a report.",
+            );
+        };
+        match input.report.decision {
+            ReviewDecision::ChangesRequested => {
+                return gate_result(
+                    ReviewGateDecision::ChangesRequested,
+                    &input.report,
+                    "Required review provider requested changes.",
+                );
             }
+            ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
+                return gate_result(
+                    ReviewGateDecision::Blocked,
+                    &input.report,
+                    "Required review provider did not complete successfully.",
+                );
+            }
+            ReviewDecision::Approved => {}
         }
-        if !saw_advisory {
+    }
+
+    if external_required {
+        if advisory_provider_ids.is_empty() {
             return ReviewGateResult {
                 decision: ReviewGateDecision::Blocked,
                 blocking_provider_id: None,
                 summary: "No external review provider report was available.".to_string(),
             };
+        }
+        for provider_id in advisory_provider_ids {
+            let Some(input) = reports.iter().find(|input| {
+                input.role == ReviewProviderRole::Advisory
+                    && input.report.provider_id == *provider_id
+            }) else {
+                return missing_provider_result(
+                    provider_id,
+                    "External review provider did not produce a report.",
+                );
+            };
+            match input.report.decision {
+                ReviewDecision::ChangesRequested => {
+                    return gate_result(
+                        ReviewGateDecision::ChangesRequested,
+                        &input.report,
+                        "External review provider requested changes.",
+                    );
+                }
+                ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
+                    return gate_result(
+                        ReviewGateDecision::Blocked,
+                        &input.report,
+                        "External review provider is required and did not approve.",
+                    );
+                }
+                ReviewDecision::Approved => {}
+            }
         }
     }
 
@@ -241,6 +253,14 @@ pub fn evaluate_review_gate(
         decision: ReviewGateDecision::Approved,
         blocking_provider_id: None,
         summary: "All required review providers approved.".to_string(),
+    }
+}
+
+fn missing_provider_result(provider_id: &str, summary: &str) -> ReviewGateResult {
+    ReviewGateResult {
+        decision: ReviewGateDecision::Blocked,
+        blocking_provider_id: Some(provider_id.to_string()),
+        summary: summary.to_string(),
     }
 }
 
@@ -379,6 +399,10 @@ mod tests {
         }
     }
 
+    fn provider_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|id| (*id).to_string()).collect()
+    }
+
     #[test]
     fn parses_fenced_review_report_json() {
         let report = parse_review_report(
@@ -509,6 +533,8 @@ mod tests {
                 "codex_cli_review",
                 ReviewProviderRole::Required,
             )],
+            &provider_ids(&["codex_cli_review"]),
+            &[],
             false,
         );
 
@@ -520,7 +546,8 @@ mod tests {
         let mut failed = approved_report("codex_cli_review", ReviewProviderRole::Required);
         failed.report.decision = ReviewDecision::Failed;
 
-        let result = evaluate_review_gate(&[failed], false);
+        let result =
+            evaluate_review_gate(&[failed], &provider_ids(&["codex_cli_review"]), &[], false);
 
         assert_eq!(result.decision, ReviewGateDecision::Blocked);
         assert_eq!(
@@ -536,11 +563,16 @@ mod tests {
                 "gemini_github_bot",
                 ReviewProviderRole::Advisory,
             )],
+            &provider_ids(&["codex_cli_review"]),
+            &[],
             false,
         );
 
         assert_eq!(result.decision, ReviewGateDecision::Blocked);
-        assert_eq!(result.blocking_provider_id, None);
+        assert_eq!(
+            result.blocking_provider_id.as_deref(),
+            Some("codex_cli_review")
+        );
     }
 
     #[test]
@@ -553,6 +585,8 @@ mod tests {
                 approved_report("codex_cli_review", ReviewProviderRole::Required),
                 failed,
             ],
+            &provider_ids(&["codex_cli_review"]),
+            &provider_ids(&["gemini_github_bot"]),
             false,
         );
 
@@ -566,11 +600,16 @@ mod tests {
                 "codex_cli_review",
                 ReviewProviderRole::Required,
             )],
+            &provider_ids(&["codex_cli_review"]),
+            &provider_ids(&["gemini_github_bot"]),
             true,
         );
 
         assert_eq!(result.decision, ReviewGateDecision::Blocked);
-        assert_eq!(result.blocking_provider_id, None);
+        assert_eq!(
+            result.blocking_provider_id.as_deref(),
+            Some("gemini_github_bot")
+        );
     }
 
     #[test]
@@ -583,6 +622,8 @@ mod tests {
                 approved_report("codex_cli_review", ReviewProviderRole::Required),
                 failed,
             ],
+            &provider_ids(&["codex_cli_review"]),
+            &provider_ids(&["gemini_github_bot"]),
             true,
         );
 

--- a/crates/harness-server/src/handlers/gc.rs
+++ b/crates/harness-server/src/handlers/gc.rs
@@ -20,6 +20,7 @@ fn gc_adopt_task_request(
         max_rounds: Some(gc_config.adopt_max_rounds),
         turn_timeout_secs: gc_config.adopt_turn_timeout_secs,
         max_budget_usd: Some(gc_config.budget_per_signal_usd),
+        source: Some("gc_adopt".to_string()),
         ..Default::default()
     }
 }

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -17,8 +17,11 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
+#[path = "agent_review_provider_gate.rs"]
+mod provider_gate;
 #[path = "agent_review_workspace_snapshot.rs"]
 mod workspace_snapshot;
+use provider_gate::{local_review_provider_report, AgentReviewGateReport};
 use workspace_snapshot::WorkspaceSnapshot;
 
 /// Compute Jaccard word-similarity between two strings.
@@ -142,7 +145,12 @@ pub(crate) async fn run_agent_review(
     effective_max_turns: Option<u32>,
     review_head_probe: Option<ReviewHeadProbe<'_>>,
     turns_used: &mut u32,
-) -> anyhow::Result<(bool, bool, Option<Result<String, String>>)> {
+) -> anyhow::Result<(
+    bool,
+    bool,
+    Option<Result<String, String>>,
+    AgentReviewGateReport,
+)> {
     let max_rounds = review_config.max_rounds;
     // (normalized_issues, consecutive_count): tracks how many consecutive rounds produced identical issues.
     let mut impasse_tracker: Option<(Vec<String>, u32)> = None;
@@ -150,6 +158,7 @@ pub(crate) async fn run_agent_review(
     let mut fix_requires_pr_head_advance = false;
     let mut approved_review = false;
     let mut approved_review_head: Option<Result<String, String>> = None;
+    let mut latest_provider_report: AgentReviewGateReport = None;
     let mut last_issues: Vec<String> = Vec::new();
     for agent_round in 1..=max_rounds {
         update_status(store, task_id, TaskStatus::AgentReview, agent_round).await?;
@@ -276,7 +285,7 @@ pub(crate) async fn run_agent_review(
                     if let Err(error) = events.log(&event).await {
                         tracing::warn!("failed to log agent_review event: {error}");
                     }
-                    return Ok((false, false, approved_review_head));
+                    return Ok((false, false, approved_review_head, None));
                 }
                 run_on_error(interceptors, &review_req, &failure.error.to_string()).await;
                 mutate_and_persist(store, task_id, |s| {
@@ -365,6 +374,12 @@ pub(crate) async fn run_agent_review(
         let approved = prompts::is_approved(&output);
         let issues = prompts::extract_review_issues(&output);
         let review_detail = output;
+        latest_provider_report = Some(local_review_provider_report(
+            review_config,
+            &review_detail,
+            review_started_at,
+            Utc::now(),
+        ));
         last_issues = issues.clone();
 
         mutate_and_persist(store, task_id, |s| {
@@ -432,7 +447,12 @@ pub(crate) async fn run_agent_review(
                 Some(review_detail),
             )
             .await?;
-            return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+            return Ok((
+                false,
+                fix_requires_pr_head_advance,
+                approved_review_head,
+                latest_provider_report,
+            ));
         }
 
         // Detect impasse: track how many consecutive rounds produced identical issues.
@@ -463,7 +483,7 @@ pub(crate) async fn run_agent_review(
                 ));
             })
             .await?;
-            return Ok((false, false, approved_review_head));
+            return Ok((false, false, approved_review_head, latest_provider_report));
         }
 
         // 3+ consecutive rounds with identical issues → use the intervention prompt.
@@ -500,7 +520,12 @@ pub(crate) async fn run_agent_review(
                     None,
                 )
                 .await?;
-                return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                return Ok((
+                    false,
+                    fix_requires_pr_head_advance,
+                    approved_review_head,
+                    latest_provider_report,
+                ));
             }
         };
         let fix_prompt_built_at = Utc::now();
@@ -563,7 +588,12 @@ pub(crate) async fn run_agent_review(
                             Some(r.output.clone()),
                         )
                         .await?;
-                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                        return Ok((
+                            false,
+                            fix_requires_pr_head_advance,
+                            approved_review_head,
+                            latest_provider_report,
+                        ));
                     }
                     Err(error) => {
                         let error = format!(
@@ -579,7 +609,12 @@ pub(crate) async fn run_agent_review(
                             Some(r.output.clone()),
                         )
                         .await?;
-                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                        return Ok((
+                            false,
+                            fix_requires_pr_head_advance,
+                            approved_review_head,
+                            latest_provider_report,
+                        ));
                     }
                 };
                 if let Some(val_err) = run_post_execute(interceptors, &fix_req, &r).await {
@@ -602,7 +637,12 @@ pub(crate) async fn run_agent_review(
                             Some(r.output.clone()),
                         )
                         .await?;
-                        return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                        return Ok((
+                            false,
+                            fix_requires_pr_head_advance,
+                            approved_review_head,
+                            latest_provider_report,
+                        ));
                     }
                 };
                 if workspace_changed && !pushed_marker {
@@ -619,7 +659,12 @@ pub(crate) async fn run_agent_review(
                         Some(r.output.clone()),
                     )
                     .await?;
-                    return Ok((false, fix_requires_pr_head_advance, approved_review_head));
+                    return Ok((
+                        false,
+                        fix_requires_pr_head_advance,
+                        approved_review_head,
+                        latest_provider_report,
+                    ));
                 }
                 if workspace_changed || pushed_marker {
                     fix_requires_pr_head_advance = true;
@@ -685,7 +730,12 @@ pub(crate) async fn run_agent_review(
     }
 
     if approved_review {
-        return Ok((true, fix_requires_pr_head_advance, approved_review_head));
+        return Ok((
+            true,
+            fix_requires_pr_head_advance,
+            approved_review_head,
+            latest_provider_report,
+        ));
     }
 
     let detail = if last_issues.is_empty() {
@@ -702,5 +752,10 @@ pub(crate) async fn run_agent_review(
         format!("Agent review exhausted {max_rounds} rounds without approval.")
     };
     fail_agent_review(store, events, task_id, max_rounds, pr_url, error, detail).await?;
-    Ok((false, fix_requires_pr_head_advance, approved_review_head))
+    Ok((
+        false,
+        fix_requires_pr_head_advance,
+        approved_review_head,
+        latest_provider_report,
+    ))
 }

--- a/crates/harness-server/src/task_executor/agent_review.rs
+++ b/crates/harness-server/src/task_executor/agent_review.rs
@@ -17,11 +17,9 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
-#[path = "agent_review_provider_gate.rs"]
-mod provider_gate;
 #[path = "agent_review_workspace_snapshot.rs"]
 mod workspace_snapshot;
-use provider_gate::{local_review_provider_report, AgentReviewGateReport};
+use super::agent_review_provider_gate::{local_review_provider_report, AgentReviewGateReport};
 use workspace_snapshot::WorkspaceSnapshot;
 
 /// Compute Jaccard word-similarity between two strings.

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -51,6 +51,18 @@ pub(crate) fn evaluate_configured_review_gate(
     )
 }
 
+pub(crate) fn evaluate_configured_local_review_gate(
+    reports: &[ReviewGateProviderReport],
+    review_config: &AgentReviewConfig,
+) -> ReviewGateResult {
+    evaluate_review_gate(
+        reports,
+        &review_config.required_providers,
+        &review_config.advisory_providers,
+        false,
+    )
+}
+
 pub(crate) fn codex_agent_review_config(review_config: &AgentReviewConfig) -> AgentReviewConfig {
     let mut config = review_config.clone();
     config.max_rounds = review_config.codex_agent_review.max_rounds;
@@ -467,6 +479,35 @@ mod tests {
         assert_eq!(
             result.blocking_provider_id.as_deref(),
             Some("gemini_github_bot")
+        );
+    }
+
+    #[test]
+    fn local_review_gate_defers_external_required_to_hosted_loop() {
+        let mut config = AgentReviewConfig {
+            external_required: true,
+            review_bot_auto_trigger: true,
+            ..AgentReviewConfig::default()
+        };
+        config.required_providers = vec![CODEX_CLI_REVIEW_PROVIDER_ID.to_string()];
+        config.advisory_providers = vec!["gemini_github_bot".to_string()];
+        let now = Utc::now();
+        let local_report = ReviewGateProviderReport {
+            role: ReviewProviderRole::Required,
+            report: parse_review_report(
+                CODEX_CLI_REVIEW_PROVIDER_ID,
+                ReviewProviderKind::LocalCli,
+                "APPROVED",
+                now,
+                now,
+            ),
+        };
+
+        let result = evaluate_configured_local_review_gate(&[local_report], &config);
+
+        assert_eq!(
+            result.decision,
+            harness_core::review::ReviewGateDecision::Approved
         );
     }
 

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -1,0 +1,62 @@
+use chrono::{DateTime, Utc};
+use harness_core::config::agents::AgentReviewConfig;
+use harness_core::review::{
+    parse_review_report, ReviewGateProviderReport, ReviewProviderKind, ReviewProviderRole,
+};
+
+pub(crate) type AgentReviewGateReport = Option<ReviewGateProviderReport>;
+
+pub(crate) fn local_review_provider_report(
+    review_config: &AgentReviewConfig,
+    raw_output: &str,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+) -> ReviewGateProviderReport {
+    let provider_id = configured_local_review_provider_id(review_config);
+    ReviewGateProviderReport {
+        role: configured_review_provider_role(review_config, provider_id),
+        report: parse_review_report(
+            provider_id,
+            configured_local_review_provider_kind(provider_id),
+            raw_output,
+            started_at,
+            completed_at,
+        ),
+    }
+}
+
+fn configured_local_review_provider_id(review_config: &AgentReviewConfig) -> &'static str {
+    if review_config
+        .required_providers
+        .iter()
+        .chain(review_config.advisory_providers.iter())
+        .any(|provider| provider == "codex_agent_review")
+        || review_config.codex_agent_review.enabled
+    {
+        "codex_agent_review"
+    } else {
+        "codex_cli_review"
+    }
+}
+
+fn configured_review_provider_role(
+    review_config: &AgentReviewConfig,
+    provider_id: &str,
+) -> ReviewProviderRole {
+    if review_config
+        .required_providers
+        .iter()
+        .any(|provider| provider == provider_id)
+    {
+        ReviewProviderRole::Required
+    } else {
+        ReviewProviderRole::Advisory
+    }
+}
+
+fn configured_local_review_provider_kind(provider_id: &str) -> ReviewProviderKind {
+    match provider_id {
+        "codex_cli_review" => ReviewProviderKind::LocalCli,
+        _ => ReviewProviderKind::LocalAgent,
+    }
+}

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -3,8 +3,8 @@ use chrono::{DateTime, Utc};
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::config::agents::{AgentReviewConfig, SandboxMode};
 use harness_core::review::{
-    parse_review_report, ReviewDecision, ReviewGateProviderReport, ReviewProviderKind,
-    ReviewProviderRole, ReviewReport,
+    evaluate_review_gate, parse_review_report, ReviewDecision, ReviewGateProviderReport,
+    ReviewGateResult, ReviewProviderKind, ReviewProviderRole, ReviewReport,
 };
 use harness_core::types::{ContextItem, ExecutionPhase};
 use std::collections::HashMap;
@@ -33,6 +33,22 @@ pub(crate) fn should_run_codex_cli_review(review_config: &AgentReviewConfig) -> 
 pub(crate) fn should_run_codex_agent_review(review_config: &AgentReviewConfig) -> bool {
     review_config.codex_agent_review.enabled
         || provider_policy_references(review_config, CODEX_AGENT_REVIEW_PROVIDER_ID)
+}
+
+pub(crate) fn requires_hosted_review_loop(review_config: &AgentReviewConfig) -> bool {
+    review_config.review_bot_auto_trigger
+}
+
+pub(crate) fn evaluate_configured_review_gate(
+    reports: &[ReviewGateProviderReport],
+    review_config: &AgentReviewConfig,
+) -> ReviewGateResult {
+    evaluate_review_gate(
+        reports,
+        &review_config.required_providers,
+        &review_config.advisory_providers,
+        review_config.external_required,
+    )
 }
 
 pub(crate) fn codex_agent_review_config(review_config: &AgentReviewConfig) -> AgentReviewConfig {
@@ -408,6 +424,50 @@ mod tests {
         assert!(!should_run_codex_agent_review(&config));
         config.codex_agent_review.enabled = true;
         assert!(should_run_codex_agent_review(&config));
+    }
+
+    #[test]
+    fn external_required_does_not_enable_legacy_hosted_review_loop() {
+        let mut config = AgentReviewConfig {
+            external_required: true,
+            ..AgentReviewConfig::default()
+        };
+
+        assert!(!requires_hosted_review_loop(&config));
+        config.review_bot_auto_trigger = true;
+        assert!(requires_hosted_review_loop(&config));
+    }
+
+    #[test]
+    fn configured_gate_blocks_missing_external_required_report() {
+        let mut config = AgentReviewConfig {
+            external_required: true,
+            ..AgentReviewConfig::default()
+        };
+        config.required_providers = vec![CODEX_CLI_REVIEW_PROVIDER_ID.to_string()];
+        config.advisory_providers = vec!["gemini_github_bot".to_string()];
+        let now = Utc::now();
+        let local_report = ReviewGateProviderReport {
+            role: ReviewProviderRole::Required,
+            report: parse_review_report(
+                CODEX_CLI_REVIEW_PROVIDER_ID,
+                ReviewProviderKind::LocalCli,
+                "APPROVED",
+                now,
+                now,
+            ),
+        };
+
+        let result = evaluate_configured_review_gate(&[local_report], &config);
+
+        assert_eq!(
+            result.decision,
+            harness_core::review::ReviewGateDecision::Blocked
+        );
+        assert_eq!(
+            result.blocking_provider_id.as_deref(),
+            Some("gemini_github_bot")
+        );
     }
 
     #[test]

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -35,6 +35,12 @@ pub(crate) fn should_run_codex_agent_review(review_config: &AgentReviewConfig) -
         || provider_policy_references(review_config, CODEX_AGENT_REVIEW_PROVIDER_ID)
 }
 
+pub(crate) fn codex_agent_review_config(review_config: &AgentReviewConfig) -> AgentReviewConfig {
+    let mut config = review_config.clone();
+    config.max_rounds = review_config.codex_agent_review.max_rounds;
+    config
+}
+
 pub(crate) fn local_review_provider_report(
     review_config: &AgentReviewConfig,
     raw_output: &str,
@@ -167,8 +173,8 @@ fn codex_cli_review_prompt(
     output_format: &str,
 ) -> String {
     let json_format = if output_format.eq_ignore_ascii_case("json") {
-        "\nReturn exactly one fenced `review_report` JSON block with this shape:\n\
-         ```review_report\n\
+        "\nReturn exactly one fenced `harness-review-report` JSON block with this shape:\n\
+         ```harness-review-report\n\
          {\"decision\":\"approved|changes_requested|failed|timed_out|skipped\",\
          \"summary\":\"concise summary\",\
          \"findings\":[{\"severity\":\"critical|high|medium|low\",\
@@ -384,10 +390,40 @@ mod tests {
     }
 
     #[test]
+    fn codex_cli_review_prompt_uses_parseable_report_fence() {
+        let prompt = codex_cli_review_prompt(
+            "https://github.com/owner/repo/pull/1",
+            "rust",
+            "origin/main",
+            "json",
+        );
+
+        assert!(prompt.contains("```harness-review-report"));
+        assert!(!prompt.contains("```review_report"));
+    }
+
+    #[test]
     fn codex_agent_review_runs_only_when_configured_or_referenced() {
         let mut config = AgentReviewConfig::default();
         assert!(!should_run_codex_agent_review(&config));
         config.codex_agent_review.enabled = true;
         assert!(should_run_codex_agent_review(&config));
+    }
+
+    #[test]
+    fn codex_agent_review_config_uses_provider_round_limit() {
+        let mut config = AgentReviewConfig {
+            max_rounds: 8,
+            ..AgentReviewConfig::default()
+        };
+        config.codex_agent_review.max_rounds = 2;
+
+        let provider_config = codex_agent_review_config(&config);
+
+        assert_eq!(provider_config.max_rounds, 2);
+        assert_eq!(
+            provider_config.required_providers,
+            config.required_providers
+        );
     }
 }

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -1,10 +1,39 @@
+use crate::task_runner::{mutate_and_persist, RoundResult, TaskId, TaskStore};
 use chrono::{DateTime, Utc};
-use harness_core::config::agents::AgentReviewConfig;
+use harness_core::agent::{AgentRequest, CodeAgent};
+use harness_core::config::agents::{AgentReviewConfig, SandboxMode};
 use harness_core::review::{
-    parse_review_report, ReviewGateProviderReport, ReviewProviderKind, ReviewProviderRole,
+    parse_review_report, ReviewDecision, ReviewGateProviderReport, ReviewProviderKind,
+    ReviewProviderRole, ReviewReport,
 };
+use harness_core::types::{ContextItem, ExecutionPhase};
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::time::Duration;
 
 pub(crate) type AgentReviewGateReport = Option<ReviewGateProviderReport>;
+
+const CODEX_CLI_REVIEW_PROVIDER_ID: &str = "codex_cli_review";
+const CODEX_AGENT_REVIEW_PROVIDER_ID: &str = "codex_agent_review";
+
+pub(crate) struct CodexCliReviewProviderRequest<'a> {
+    pub(crate) review_config: &'a AgentReviewConfig,
+    pub(crate) context_items: &'a [ContextItem],
+    pub(crate) project: &'a Path,
+    pub(crate) pr_url: &'a str,
+    pub(crate) project_type: &'a str,
+    pub(crate) cargo_env: &'a HashMap<String, String>,
+}
+
+pub(crate) fn should_run_codex_cli_review(review_config: &AgentReviewConfig) -> bool {
+    review_config.codex_cli_review.enabled
+        && provider_policy_references(review_config, CODEX_CLI_REVIEW_PROVIDER_ID)
+}
+
+pub(crate) fn should_run_codex_agent_review(review_config: &AgentReviewConfig) -> bool {
+    review_config.codex_agent_review.enabled
+        || provider_policy_references(review_config, CODEX_AGENT_REVIEW_PROVIDER_ID)
+}
 
 pub(crate) fn local_review_provider_report(
     review_config: &AgentReviewConfig,
@@ -25,18 +54,189 @@ pub(crate) fn local_review_provider_report(
     }
 }
 
-fn configured_local_review_provider_id(review_config: &AgentReviewConfig) -> &'static str {
-    if review_config
-        .required_providers
-        .iter()
-        .chain(review_config.advisory_providers.iter())
-        .any(|provider| provider == "codex_agent_review")
-        || review_config.codex_agent_review.enabled
-    {
-        "codex_agent_review"
+pub(crate) async fn run_codex_cli_review_provider(
+    store: &TaskStore,
+    task_id: &TaskId,
+    request: CodexCliReviewProviderRequest<'_>,
+    turns_used: &mut u32,
+) -> anyhow::Result<ReviewGateProviderReport> {
+    let mut provider = harness_agents::codex::CodexAgent::new(
+        request.review_config.codex_cli_review.cli_path.clone(),
+        SandboxMode::ReadOnlyWithNetwork,
+    )
+    .with_stream_timeout(Some(request.review_config.codex_cli_review.timeout_secs));
+    provider.default_model = request.review_config.codex_cli_review.model.clone();
+    provider.reasoning_effort = request
+        .review_config
+        .codex_cli_review
+        .reasoning_effort
+        .clone();
+
+    run_codex_cli_review_provider_with_agent(store, task_id, &provider, request, turns_used).await
+}
+
+pub(crate) async fn run_codex_cli_review_provider_with_agent(
+    store: &TaskStore,
+    task_id: &TaskId,
+    provider: &dyn CodeAgent,
+    request: CodexCliReviewProviderRequest<'_>,
+    turns_used: &mut u32,
+) -> anyhow::Result<ReviewGateProviderReport> {
+    let started_at = Utc::now();
+    let agent_request = AgentRequest {
+        prompt: codex_cli_review_prompt(
+            request.pr_url,
+            request.project_type,
+            &request.review_config.codex_cli_review.base_ref,
+            &request.review_config.codex_cli_review.output_format,
+        ),
+        project_root: request.project.to_path_buf(),
+        context: request.context_items.to_vec(),
+        execution_phase: Some(ExecutionPhase::SimpleReview),
+        sandbox_mode: Some(SandboxMode::ReadOnlyWithNetwork),
+        approval_policy: Some("never".to_string()),
+        model: Some(request.review_config.codex_cli_review.model.clone()),
+        reasoning_effort: Some(
+            request
+                .review_config
+                .codex_cli_review
+                .reasoning_effort
+                .clone(),
+        ),
+        env_vars: request.cargo_env.clone(),
+        ..Default::default()
+    };
+
+    let timeout_secs = request.review_config.codex_cli_review.timeout_secs.max(1);
+    let response = tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        provider.execute(agent_request),
+    )
+    .await;
+    *turns_used = turns_used.saturating_add(1);
+    let completed_at = Utc::now();
+    let report = match response {
+        Ok(Ok(response)) => ReviewGateProviderReport {
+            role: configured_review_provider_role(
+                request.review_config,
+                CODEX_CLI_REVIEW_PROVIDER_ID,
+            ),
+            report: parse_review_report(
+                CODEX_CLI_REVIEW_PROVIDER_ID,
+                ReviewProviderKind::LocalCli,
+                &response.output,
+                started_at,
+                completed_at,
+            ),
+        },
+        Ok(Err(error)) => provider_failure_report(
+            request.review_config,
+            ReviewDecision::Failed,
+            started_at,
+            completed_at,
+            format!("Codex CLI review provider failed: {error}"),
+        ),
+        Err(_) => provider_failure_report(
+            request.review_config,
+            ReviewDecision::TimedOut,
+            started_at,
+            completed_at,
+            format!("Codex CLI review provider timed out after {timeout_secs}s."),
+        ),
+    };
+
+    mutate_and_persist(store, task_id, |state| {
+        state.rounds.push(RoundResult::new(
+            *turns_used,
+            CODEX_CLI_REVIEW_PROVIDER_ID,
+            review_decision_label(report.report.decision),
+            Some(report.report.summary.clone()),
+            None,
+            None,
+        ));
+    })
+    .await?;
+
+    Ok(report)
+}
+
+fn codex_cli_review_prompt(
+    pr_url: &str,
+    project_type: &str,
+    base_ref: &str,
+    output_format: &str,
+) -> String {
+    let json_format = if output_format.eq_ignore_ascii_case("json") {
+        "\nReturn exactly one fenced `review_report` JSON block with this shape:\n\
+         ```review_report\n\
+         {\"decision\":\"approved|changes_requested|failed|timed_out|skipped\",\
+         \"summary\":\"concise summary\",\
+         \"findings\":[{\"severity\":\"critical|high|medium|low\",\
+         \"category\":\"security|correctness|data_integrity|concurrency|performance|test_gap|maintainability|other\",\
+         \"path\":\"optional path or null\",\
+         \"line\":123,\
+         \"message\":\"finding\",\
+         \"evidence\":\"optional evidence or null\",\
+         \"recommendation\":\"optional recommendation or null\",\
+         \"blocking\":true,\
+         \"confidence\":0.9}]}\n\
+         ```"
     } else {
-        "codex_cli_review"
+        "\nIf everything is safe, put APPROVED on the last line. Otherwise list each blocking issue on its own line prefixed with ISSUE:."
+    };
+
+    format!(
+        "You are the configured codex_cli_review provider for PR {pr_url}.\n\
+         Review the local workspace against base ref `{base_ref}` as a read-only provider.\n\
+         Project type: {project_type}.\n\n\
+         Requirements:\n\
+         - Inspect the PR intent, diff, and changed files before deciding.\n\
+         - Focus on security, logic, data integrity, error handling, and missing tests.\n\
+         - Do not modify files, commit, push, or mark review threads resolved.\n\
+         - Treat unparseable or incomplete evidence as a failed provider review.\n\
+         {json_format}"
+    )
+}
+
+fn provider_failure_report(
+    review_config: &AgentReviewConfig,
+    decision: ReviewDecision,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+    summary: String,
+) -> ReviewGateProviderReport {
+    ReviewGateProviderReport {
+        role: configured_review_provider_role(review_config, CODEX_CLI_REVIEW_PROVIDER_ID),
+        report: ReviewReport {
+            provider_id: CODEX_CLI_REVIEW_PROVIDER_ID.to_string(),
+            provider_kind: ReviewProviderKind::LocalCli,
+            decision,
+            summary: summary.clone(),
+            findings: Vec::new(),
+            raw_output: Some(summary),
+            started_at,
+            completed_at,
+            elapsed_ms: completed_at
+                .signed_duration_since(started_at)
+                .num_milliseconds()
+                .max(0) as u64,
+        },
     }
+}
+
+fn review_decision_label(decision: ReviewDecision) -> String {
+    match decision {
+        ReviewDecision::Approved => "approved",
+        ReviewDecision::ChangesRequested => "changes_requested",
+        ReviewDecision::Failed => "failed",
+        ReviewDecision::TimedOut => "timed_out",
+        ReviewDecision::Skipped => "skipped",
+    }
+    .to_string()
+}
+
+fn configured_local_review_provider_id(_review_config: &AgentReviewConfig) -> &'static str {
+    CODEX_AGENT_REVIEW_PROVIDER_ID
 }
 
 fn configured_review_provider_role(
@@ -56,7 +256,138 @@ fn configured_review_provider_role(
 
 fn configured_local_review_provider_kind(provider_id: &str) -> ReviewProviderKind {
     match provider_id {
-        "codex_cli_review" => ReviewProviderKind::LocalCli,
+        CODEX_CLI_REVIEW_PROVIDER_ID => ReviewProviderKind::LocalCli,
         _ => ReviewProviderKind::LocalAgent,
+    }
+}
+
+fn provider_policy_references(review_config: &AgentReviewConfig, provider_id: &str) -> bool {
+    review_config
+        .required_providers
+        .iter()
+        .chain(review_config.advisory_providers.iter())
+        .any(|provider| provider == provider_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::agent::{AgentResponse, StreamItem};
+    use harness_core::types::{Capability, TokenUsage};
+    use tokio::sync::Mutex;
+
+    struct RecordingProvider {
+        output: String,
+        requests: Mutex<Vec<AgentRequest>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CodeAgent for RecordingProvider {
+        fn name(&self) -> &str {
+            "recording_codex"
+        }
+
+        fn capabilities(&self) -> Vec<Capability> {
+            Vec::new()
+        }
+
+        async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+            self.requests.lock().await.push(req);
+            Ok(AgentResponse {
+                output: self.output.clone(),
+                stderr: String::new(),
+                items: Vec::new(),
+                token_usage: TokenUsage::default(),
+                model: "recording_codex".to_string(),
+                exit_code: Some(0),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            req: AgentRequest,
+            tx: tokio::sync::mpsc::Sender<StreamItem>,
+        ) -> harness_core::error::Result<()> {
+            self.requests.lock().await.push(req);
+            if tx
+                .send(StreamItem::MessageDelta {
+                    text: self.output.clone(),
+                })
+                .await
+                .is_err()
+            {
+                return Ok(());
+            }
+            if tx.send(StreamItem::Done).await.is_err() {
+                return Ok(());
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn codex_cli_review_provider_uses_configured_request() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join(["tasks", "db"].join("."))).await?;
+        let task_id = TaskId::new();
+        store
+            .insert(&crate::task_runner::TaskState::new(task_id.clone()))
+            .await;
+        let provider = RecordingProvider {
+            output: "APPROVED".to_string(),
+            requests: Mutex::new(Vec::new()),
+        };
+        let mut config = AgentReviewConfig::default();
+        config.codex_cli_review.model = "gpt-test".to_string();
+        config.codex_cli_review.reasoning_effort = "xhigh".to_string();
+        config.codex_cli_review.base_ref = "origin/main".to_string();
+        config.codex_cli_review.timeout_secs = 5;
+        let mut turns_used = 0;
+
+        let report = run_codex_cli_review_provider_with_agent(
+            &store,
+            &task_id,
+            &provider,
+            CodexCliReviewProviderRequest {
+                review_config: &config,
+                context_items: &[],
+                project: dir.path(),
+                pr_url: "https://github.com/owner/repo/pull/1",
+                project_type: "rust",
+                cargo_env: &HashMap::new(),
+            },
+            &mut turns_used,
+        )
+        .await?;
+
+        let requests = provider.requests.lock().await;
+        assert_eq!(turns_used, 1);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].model.as_deref(), Some("gpt-test"));
+        assert_eq!(requests[0].reasoning_effort.as_deref(), Some("xhigh"));
+        assert_eq!(
+            requests[0].sandbox_mode,
+            Some(SandboxMode::ReadOnlyWithNetwork)
+        );
+        assert_eq!(requests[0].approval_policy.as_deref(), Some("never"));
+        assert!(requests[0].prompt.contains("origin/main"));
+        assert_eq!(report.role, ReviewProviderRole::Required);
+        assert_eq!(report.report.provider_id, CODEX_CLI_REVIEW_PROVIDER_ID);
+        assert_eq!(report.report.decision, ReviewDecision::Approved);
+        let Some(state) = store.get(&task_id) else {
+            panic!("task state should be present");
+        };
+        assert!(state.rounds.iter().any(|round| {
+            round.action == CODEX_CLI_REVIEW_PROVIDER_ID && round.result == "approved"
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn codex_agent_review_runs_only_when_configured_or_referenced() {
+        let mut config = AgentReviewConfig::default();
+        assert!(!should_run_codex_agent_review(&config));
+        config.codex_agent_review.enabled = true;
+        assert!(should_run_codex_agent_review(&config));
     }
 }

--- a/crates/harness-server/src/task_executor/agent_review_tests.rs
+++ b/crates/harness-server/src/task_executor/agent_review_tests.rs
@@ -218,7 +218,7 @@ async fn reviewer_request_uses_read_only_network_sandbox() -> anyhow::Result<()>
         provider_report
             .as_ref()
             .map(|report| report.report.provider_id.as_str()),
-        Some("codex_cli_review")
+        Some("codex_agent_review")
     );
     assert_eq!(
         approved_head

--- a/crates/harness-server/src/task_executor/agent_review_tests.rs
+++ b/crates/harness-server/src/task_executor/agent_review_tests.rs
@@ -188,7 +188,7 @@ async fn reviewer_request_uses_read_only_network_sandbox() -> anyhow::Result<()>
     let reviewer = SequenceAgent::new("reviewer", vec!["APPROVED"]);
     let mut turns_used = 0;
 
-    let (approved, pushed, approved_head) = run_agent_review(
+    let (approved, pushed, approved_head, provider_report) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -214,6 +214,12 @@ async fn reviewer_request_uses_read_only_network_sandbox() -> anyhow::Result<()>
     let reviewer_requests = reviewer.recorded_requests().await;
     assert!(approved);
     assert!(!pushed);
+    assert_eq!(
+        provider_report
+            .as_ref()
+            .map(|report| report.report.provider_id.as_str()),
+        Some("codex_cli_review")
+    );
     assert_eq!(
         approved_head
             .as_ref()
@@ -246,7 +252,7 @@ async fn claude_reviewer_request_uses_configured_sandbox() -> anyhow::Result<()>
     let reviewer = SequenceAgent::new("claude", vec!["APPROVED"]);
     let mut turns_used = 0;
 
-    let (approved, pushed, _) = run_agent_review(
+    let (approved, pushed, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -292,7 +298,7 @@ async fn unresolved_issues_after_max_rounds_fail_local_review() -> anyhow::Resul
     let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: unresolved defect"]);
     let mut turns_used = 0;
 
-    let (approved, pushed, _) = run_agent_review(
+    let (approved, pushed, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -359,7 +365,7 @@ async fn final_impasse_round_does_not_push_unreviewed_fix() -> anyhow::Result<()
     );
     let mut turns_used = 0;
 
-    let (approved, pushed, _) = run_agent_review(
+    let (approved, pushed, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -429,7 +435,7 @@ async fn changed_fix_round_requires_pr_head_advance() -> anyhow::Result<()> {
     let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
     let mut turns_used = 0;
 
-    let (approved, requires_head_advance, _) = run_agent_review(
+    let (approved, requires_head_advance, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -481,7 +487,7 @@ async fn changed_fix_round_rejects_false_noop_marker() -> anyhow::Result<()> {
     let reviewer = SequenceAgent::new("reviewer", vec!["ISSUE: defect", "APPROVED"]);
     let mut turns_used = 0;
 
-    let (approved, requires_head_advance, _) = run_agent_review(
+    let (approved, requires_head_advance, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -544,7 +550,7 @@ async fn noop_fix_round_ignores_validation_cache_artifacts() -> anyhow::Result<(
     })];
     let mut turns_used = 0;
 
-    let (approved, requires_head_advance, _) = run_agent_review(
+    let (approved, requires_head_advance, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -599,7 +605,7 @@ async fn noop_fix_round_rejects_validation_source_artifacts() -> anyhow::Result<
     })];
     let mut turns_used = 0;
 
-    let (approved, requires_head_advance, _) = run_agent_review(
+    let (approved, requires_head_advance, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,
@@ -653,7 +659,7 @@ async fn malformed_reviewer_output_fails_local_review() -> anyhow::Result<()> {
     let reviewer = SequenceAgent::new("reviewer", vec!["looks fine to me"]);
     let mut turns_used = 0;
 
-    let (approved, _, _) = run_agent_review(
+    let (approved, _, _, _) = run_agent_review(
         &store,
         &task_id,
         &implementor,

--- a/crates/harness-server/src/task_executor/local_review_completion.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion.rs
@@ -2,6 +2,7 @@ use super::{review_loop, run_test_gate};
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskStatus, TaskStore,
 };
+use harness_core::review::{ReviewGateDecision, ReviewGateResult};
 use harness_core::validation::ShellValidationExecutor;
 use harness_workflow::runtime::PrFeedbackOutcome;
 use std::collections::HashMap;
@@ -678,6 +679,53 @@ pub(crate) async fn fail_missing_local_review_gate(
             "review_gate_config",
             "failed",
             Some(format!("pr={}", pr_url.unwrap_or(""))),
+            None,
+            None,
+        ));
+    })
+    .await?;
+    store.log_event(crate::event_replay::TaskEvent::Failed {
+        task_id: task_id.0.clone(),
+        ts: crate::event_replay::now_ts(),
+        reason: error,
+    });
+    Ok(())
+}
+
+pub(crate) async fn fail_review_provider_gate(
+    store: &TaskStore,
+    task_id: &TaskId,
+    turns_used: u32,
+    pr_url: Option<&str>,
+    gate: &ReviewGateResult,
+) -> anyhow::Result<()> {
+    let provider = gate.blocking_provider_id.as_deref().unwrap_or("unknown");
+    let error = match gate.decision {
+        ReviewGateDecision::ChangesRequested => {
+            format!(
+                "Review provider gate requested changes from {provider}: {}",
+                gate.summary
+            )
+        }
+        ReviewGateDecision::Blocked => {
+            format!(
+                "Review provider gate blocked completion for {provider}: {}",
+                gate.summary
+            )
+        }
+        ReviewGateDecision::Approved => {
+            "Review provider gate was unexpectedly failed after approval.".to_string()
+        }
+    };
+    mutate_and_persist(store, task_id, |s| {
+        s.status = TaskStatus::Failed;
+        s.turn = turns_used;
+        s.error = Some(error.clone());
+        s.rounds.push(RoundResult::new(
+            turns_used,
+            "review_provider_gate",
+            "failed",
+            Some(format!("provider={provider}; pr={}", pr_url.unwrap_or(""))),
             None,
             None,
         ));

--- a/crates/harness-server/src/task_executor/local_review_completion_gate_tests.rs
+++ b/crates/harness-server/src/task_executor/local_review_completion_gate_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use harness_core::review::{ReviewGateDecision, ReviewGateResult};
 
 #[tokio::test]
 async fn hosted_bot_disabled_completion_blocks_pr_ci_failure() -> anyhow::Result<()> {
@@ -464,5 +465,46 @@ async fn hosted_bot_disabled_requires_local_review_approval() -> anyhow::Result<
         .rounds
         .iter()
         .any(|round| round.action == "review_gate_config" && round.result == "failed"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_bot_disabled_blocks_missing_required_provider_report() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store
+        .insert(&crate::task_runner::TaskState::new(task_id.clone()))
+        .await;
+    let gate = ReviewGateResult {
+        decision: ReviewGateDecision::Blocked,
+        blocking_provider_id: Some("codex_cli_review".to_string()),
+        summary: "Required review provider did not produce a report.".to_string(),
+    };
+
+    fail_review_provider_gate(
+        &store,
+        &task_id,
+        4,
+        Some("https://github.com/owner/repo/pull/1"),
+        &gate,
+    )
+    .await?;
+
+    let state = store.get(&task_id).expect("task state should be present");
+    assert_eq!(state.status, TaskStatus::Failed);
+    assert!(
+        state
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("codex_cli_review"),
+        "unexpected error: {:?}",
+        state.error
+    );
+    assert!(state
+        .rounds
+        .iter()
+        .any(|round| round.action == "review_provider_gate" && round.result == "failed"));
     Ok(())
 }

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -27,7 +27,8 @@ use crate::task_runner::{mutate_and_persist, CreateTaskRequest, TaskId, TaskStat
 #[cfg(test)]
 use local_review_completion::{
     complete_after_local_review_without_hosted_bot, fail_missing_local_review_gate,
-    LocalReviewPrChecks, LocalReviewPrHead, LocalReviewPrState, LocalReviewReadyToMergeFeedback,
+    fail_review_provider_gate, LocalReviewPrChecks, LocalReviewPrHead, LocalReviewPrState,
+    LocalReviewReadyToMergeFeedback,
 };
 #[cfg(test)]
 use pr_detection::{

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent_review;
+mod agent_review_provider_gate;
 #[cfg(test)]
 mod agent_review_tests;
 pub(crate) mod conflict_resolver;

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -567,8 +567,9 @@ pub(crate) async fn run_task(
     let mut agent_pushed_commit = false;
     let mut local_review_head_approved: Option<Result<String, String>> = None;
     let mut local_review_reports = Vec::new();
-    let enforce_provider_gate =
-        review_config.enabled && review_config.strategy != ReviewStrategy::LegacyHostedBot;
+    let enforce_provider_gate = review_config.enabled
+        && req.source.as_deref() != Some("gc_adopt")
+        && review_config.strategy != ReviewStrategy::LegacyHostedBot;
     if enforce_provider_gate
         && !skip_agent_review
         && agent_review_provider_gate::should_run_codex_agent_review(review_config)

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -15,7 +15,7 @@ use crate::task_runner::{
 use anyhow::Context;
 use harness_core::agent::CodeAgent;
 use harness_core::config::agents::ReviewStrategy;
-use harness_core::review::{evaluate_review_gate, ReviewGateDecision};
+use harness_core::review::ReviewGateDecision;
 use harness_core::{config::project::load_project_config, prompts};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -553,7 +553,7 @@ pub(crate) async fn run_task(
 
     let repo_slug_for_review = review_repo_slug(pr_url.as_deref(), &repo_slug);
     let requires_hosted_review =
-        review_config.review_bot_auto_trigger || review_config.external_required;
+        agent_review_provider_gate::requires_hosted_review_loop(review_config);
     let should_probe_pr_head = !requires_hosted_review && pr_num > 0;
     let local_review_head_before = if should_probe_pr_head {
         Some(
@@ -644,13 +644,9 @@ pub(crate) async fn run_task(
         *turns_used_acc = turns_used;
     }
     if enforce_provider_gate {
-        // External provider evidence is produced by the hosted review loop below.
-        // The local gate only evaluates reports from providers run in this phase.
-        let review_gate = evaluate_review_gate(
+        let review_gate = agent_review_provider_gate::evaluate_configured_review_gate(
             &local_review_reports,
-            &review_config.required_providers,
-            &[],
-            false,
+            review_config,
         );
         if review_gate.decision != ReviewGateDecision::Approved {
             fail_review_provider_gate(store, task_id, turns_used, pr_url.as_deref(), &review_gate)

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -14,6 +14,7 @@ use crate::task_runner::{
 };
 use anyhow::Context;
 use harness_core::agent::CodeAgent;
+use harness_core::config::agents::ReviewStrategy;
 use harness_core::review::{evaluate_review_gate, ReviewGateDecision};
 use harness_core::{config::project::load_project_config, prompts};
 use std::collections::HashMap;
@@ -566,7 +567,9 @@ pub(crate) async fn run_task(
     let mut agent_pushed_commit = false;
     let mut local_review_head_approved: Option<Result<String, String>> = None;
     let mut local_review_reports = Vec::new();
-    if review_config.enabled
+    let enforce_provider_gate =
+        review_config.enabled && review_config.strategy != ReviewStrategy::LegacyHostedBot;
+    if enforce_provider_gate
         && !skip_agent_review
         && agent_review_provider_gate::should_run_codex_agent_review(review_config)
     {
@@ -612,7 +615,7 @@ pub(crate) async fn run_task(
             tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
         }
     }
-    if review_config.enabled
+    if enforce_provider_gate
         && agent_review_provider_gate::should_run_codex_cli_review(review_config)
     {
         let provider_report = agent_review_provider_gate::run_codex_cli_review_provider(
@@ -632,7 +635,7 @@ pub(crate) async fn run_task(
         local_review_reports.push(provider_report);
         *turns_used_acc = turns_used;
     }
-    if review_config.enabled {
+    if enforce_provider_gate {
         let review_gate = evaluate_review_gate(
             &local_review_reports,
             &review_config.required_providers,
@@ -679,7 +682,7 @@ pub(crate) async fn run_task(
     // Skip hosted review bot wait when auto-trigger is disabled, but keep a
     // validation gate so local review cannot mark a red PR complete.
     if !review_config.review_bot_auto_trigger {
-        if !review_config.enabled {
+        if !enforce_provider_gate {
             fail_missing_local_review_gate(store, task_id, turns_used, pr_url.as_deref()).await?;
             return Ok(());
         }

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -644,10 +644,17 @@ pub(crate) async fn run_task(
         *turns_used_acc = turns_used;
     }
     if enforce_provider_gate {
-        let review_gate = agent_review_provider_gate::evaluate_configured_review_gate(
-            &local_review_reports,
-            review_config,
-        );
+        let review_gate = if requires_hosted_review {
+            agent_review_provider_gate::evaluate_configured_local_review_gate(
+                &local_review_reports,
+                review_config,
+            )
+        } else {
+            agent_review_provider_gate::evaluate_configured_review_gate(
+                &local_review_reports,
+                review_config,
+            )
+        };
         if review_gate.decision != ReviewGateDecision::Approved {
             fail_review_provider_gate(store, task_id, turns_used, pr_url.as_deref(), &review_gate)
                 .await?;

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -6,7 +6,8 @@ use super::local_review_completion::{
 };
 use super::pr_detection::{detect_repo_slug, find_existing_pr_for_issue_with_token};
 use super::{
-    agent_review, gates, implement_pipeline, non_implementation, review_loop, triage_pipeline,
+    agent_review, agent_review_provider_gate, gates, implement_pipeline, non_implementation,
+    review_loop, triage_pipeline,
 };
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, TaskId, TaskKind, TaskStatus, TaskStore,
@@ -563,10 +564,12 @@ pub(crate) async fn run_task(
 
     // Agent review loop (if enabled and reviewer available, and not skipped by triage complexity)
     let mut agent_pushed_commit = false;
-    let mut local_review_approved = false;
     let mut local_review_head_approved: Option<Result<String, String>> = None;
     let mut local_review_reports = Vec::new();
-    if review_config.enabled && !skip_agent_review {
+    if review_config.enabled
+        && !skip_agent_review
+        && agent_review_provider_gate::should_run_codex_agent_review(review_config)
+    {
         if let Some(reviewer) = reviewer {
             tracing::info!(pr_url = %pr_url.as_deref().unwrap_or(""), "starting agent review");
             let review_head_probe =
@@ -603,40 +606,33 @@ pub(crate) async fn run_task(
             if !review_ok {
                 return Ok(());
             }
-            local_review_approved = true;
-            crate::workflow_runtime_pr_feedback::record_local_review_passed(
-                workflow_runtime_store.as_deref(),
-                crate::workflow_runtime_pr_feedback::LocalReviewPassedRuntimeContext {
-                    project_root: &project_root,
-                    repo: req.repo.as_deref(),
-                    issue_number: req.issue,
-                    task_id,
-                    pr_number: pr_num,
-                    pr_url: pr_url.as_deref(),
-                    summary: "Local agent review approved the PR.",
-                },
-            )
-            .await;
             agent_pushed_commit = fix_requires_pr_head_advance;
-            if !review_config.review_bot_auto_trigger {
-                local_review_head_approved = approved_review_head;
-            }
+            local_review_head_approved = approved_review_head;
         } else {
             tracing::warn!("agent review enabled but no reviewer agent configured; skipping");
         }
     }
-    let local_fix_requires_pr_head_advance = agent_pushed_commit;
-    agent_pushed_commit |= implementation_pushed_commit;
-
-    let wait_secs = resolved.review_wait_secs.unwrap_or(req.wait_secs);
-
-    // Skip hosted review bot wait when auto-trigger is disabled, but keep a
-    // validation gate so local review cannot mark a red PR complete.
-    if !review_config.review_bot_auto_trigger {
-        if !local_review_approved {
-            fail_missing_local_review_gate(store, task_id, turns_used, pr_url.as_deref()).await?;
-            return Ok(());
-        }
+    if review_config.enabled
+        && agent_review_provider_gate::should_run_codex_cli_review(review_config)
+    {
+        let provider_report = agent_review_provider_gate::run_codex_cli_review_provider(
+            store,
+            task_id,
+            agent_review_provider_gate::CodexCliReviewProviderRequest {
+                review_config,
+                context_items: &context_items,
+                project: &project,
+                pr_url: pr_url.as_deref().unwrap_or(""),
+                project_type: project_config.review_type.as_str(),
+                cargo_env: &cargo_env,
+            },
+            &mut turns_used,
+        )
+        .await?;
+        local_review_reports.push(provider_report);
+        *turns_used_acc = turns_used;
+    }
+    if review_config.enabled {
         let review_gate = evaluate_review_gate(
             &local_review_reports,
             &review_config.required_providers,
@@ -646,6 +642,45 @@ pub(crate) async fn run_task(
         if review_gate.decision != ReviewGateDecision::Approved {
             fail_review_provider_gate(store, task_id, turns_used, pr_url.as_deref(), &review_gate)
                 .await?;
+            return Ok(());
+        }
+        if !review_config.review_bot_auto_trigger
+            && local_review_head_approved.is_none()
+            && should_probe_pr_head
+        {
+            local_review_head_approved = Some(
+                review_loop::fetch_pr_head_sha_for_gate(
+                    &repo_slug_for_review,
+                    pr_num,
+                    server_config.server.github_token.as_deref(),
+                )
+                .await,
+            );
+        }
+        crate::workflow_runtime_pr_feedback::record_local_review_passed(
+            workflow_runtime_store.as_deref(),
+            crate::workflow_runtime_pr_feedback::LocalReviewPassedRuntimeContext {
+                project_root: &project_root,
+                repo: req.repo.as_deref(),
+                issue_number: req.issue,
+                task_id,
+                pr_number: pr_num,
+                pr_url: pr_url.as_deref(),
+                summary: "Configured local review providers approved the PR.",
+            },
+        )
+        .await;
+    }
+    let local_fix_requires_pr_head_advance = agent_pushed_commit;
+    agent_pushed_commit |= implementation_pushed_commit;
+
+    let wait_secs = resolved.review_wait_secs.unwrap_or(req.wait_secs);
+
+    // Skip hosted review bot wait when auto-trigger is disabled, but keep a
+    // validation gate so local review cannot mark a red PR complete.
+    if !review_config.review_bot_auto_trigger {
+        if !review_config.enabled {
+            fail_missing_local_review_gate(store, task_id, turns_used, pr_url.as_deref()).await?;
             return Ok(());
         }
         let (before_review_sha, before_review_error) = match local_review_head_before.as_ref() {

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -320,6 +320,9 @@ pub(crate) async fn run_task(
     let effective_max_rounds = hosted_review_max_rounds;
     let mut effective_review_config = resolved.review.clone();
     effective_review_config.max_rounds = agent_review_max_rounds;
+    if let Some(max_rounds) = req.max_rounds {
+        effective_review_config.codex_agent_review.max_rounds = max_rounds;
+    }
     let review_config = &effective_review_config;
     // max_turns: per-request override wins; global config is the fallback.
     // Counts every agent API call (impl + validation retries + review rounds).
@@ -549,7 +552,9 @@ pub(crate) async fn run_task(
     }
 
     let repo_slug_for_review = review_repo_slug(pr_url.as_deref(), &repo_slug);
-    let should_probe_pr_head = !review_config.review_bot_auto_trigger && pr_num > 0;
+    let requires_hosted_review =
+        review_config.review_bot_auto_trigger || review_config.external_required;
+    let should_probe_pr_head = !requires_hosted_review && pr_num > 0;
     let local_review_head_before = if should_probe_pr_head {
         Some(
             review_loop::fetch_pr_head_sha_for_gate(
@@ -576,6 +581,8 @@ pub(crate) async fn run_task(
     {
         if let Some(reviewer) = reviewer {
             tracing::info!(pr_url = %pr_url.as_deref().unwrap_or(""), "starting agent review");
+            let codex_agent_review_config =
+                agent_review_provider_gate::codex_agent_review_config(review_config);
             let review_head_probe =
                 should_probe_pr_head.then_some(agent_review::ReviewHeadProbe::GitHub {
                     repo_slug: &repo_slug_for_review,
@@ -588,7 +595,7 @@ pub(crate) async fn run_task(
                     task_id,
                     agent,
                     reviewer,
-                    review_config,
+                    &codex_agent_review_config,
                     &context_items,
                     &project,
                     interceptors.as_ref(),
@@ -637,21 +644,20 @@ pub(crate) async fn run_task(
         *turns_used_acc = turns_used;
     }
     if enforce_provider_gate {
+        // External provider evidence is produced by the hosted review loop below.
+        // The local gate only evaluates reports from providers run in this phase.
         let review_gate = evaluate_review_gate(
             &local_review_reports,
             &review_config.required_providers,
-            &review_config.advisory_providers,
-            review_config.external_required,
+            &[],
+            false,
         );
         if review_gate.decision != ReviewGateDecision::Approved {
             fail_review_provider_gate(store, task_id, turns_used, pr_url.as_deref(), &review_gate)
                 .await?;
             return Ok(());
         }
-        if !review_config.review_bot_auto_trigger
-            && local_review_head_approved.is_none()
-            && should_probe_pr_head
-        {
+        if !requires_hosted_review && local_review_head_approved.is_none() && should_probe_pr_head {
             local_review_head_approved = Some(
                 review_loop::fetch_pr_head_sha_for_gate(
                     &repo_slug_for_review,
@@ -682,7 +688,7 @@ pub(crate) async fn run_task(
 
     // Skip hosted review bot wait when auto-trigger is disabled, but keep a
     // validation gate so local review cannot mark a red PR complete.
-    if !review_config.review_bot_auto_trigger {
+    if !requires_hosted_review {
         if !enforce_provider_gate {
             fail_missing_local_review_gate(store, task_id, turns_used, pr_url.as_deref()).await?;
             return Ok(());

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -1,7 +1,8 @@
 use super::helpers::update_status;
 use super::local_review_completion::{
     complete_after_local_review_without_hosted_bot, fail_missing_local_review_gate,
-    LocalReviewPrChecks, LocalReviewPrHead, LocalReviewPrState, LocalReviewReadyToMergeFeedback,
+    fail_review_provider_gate, LocalReviewPrChecks, LocalReviewPrHead, LocalReviewPrState,
+    LocalReviewReadyToMergeFeedback,
 };
 use super::pr_detection::{detect_repo_slug, find_existing_pr_for_issue_with_token};
 use super::{
@@ -12,6 +13,7 @@ use crate::task_runner::{
 };
 use anyhow::Context;
 use harness_core::agent::CodeAgent;
+use harness_core::review::{evaluate_review_gate, ReviewGateDecision};
 use harness_core::{config::project::load_project_config, prompts};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -563,6 +565,7 @@ pub(crate) async fn run_task(
     let mut agent_pushed_commit = false;
     let mut local_review_approved = false;
     let mut local_review_head_approved: Option<Result<String, String>> = None;
+    let mut local_review_reports = Vec::new();
     if review_config.enabled && !skip_agent_review {
         if let Some(reviewer) = reviewer {
             tracing::info!(pr_url = %pr_url.as_deref().unwrap_or(""), "starting agent review");
@@ -572,7 +575,7 @@ pub(crate) async fn run_task(
                     pr_num,
                     github_token: server_config.server.github_token.as_deref(),
                 });
-            let (review_ok, fix_requires_pr_head_advance, approved_review_head) =
+            let (review_ok, fix_requires_pr_head_advance, approved_review_head, provider_report) =
                 agent_review::run_agent_review(
                     store,
                     task_id,
@@ -593,6 +596,9 @@ pub(crate) async fn run_task(
                     &mut turns_used,
                 )
                 .await?;
+            if let Some(report) = provider_report {
+                local_review_reports.push(report);
+            }
             *turns_used_acc = turns_used;
             if !review_ok {
                 return Ok(());
@@ -629,6 +635,17 @@ pub(crate) async fn run_task(
     if !review_config.review_bot_auto_trigger {
         if !local_review_approved {
             fail_missing_local_review_gate(store, task_id, turns_used, pr_url.as_deref()).await?;
+            return Ok(());
+        }
+        let review_gate = evaluate_review_gate(
+            &local_review_reports,
+            &review_config.required_providers,
+            &review_config.advisory_providers,
+            review_config.external_required,
+        );
+        if review_gate.decision != ReviewGateDecision::Approved {
+            fail_review_provider_gate(store, task_id, turns_used, pr_url.as_deref(), &review_gate)
+                .await?;
             return Ok(());
         }
         let (before_review_sha, before_review_error) = match local_review_head_before.as_ref() {

--- a/crates/harness-server/src/task_runner/spawn_tests/spawn_resume_tests.rs
+++ b/crates/harness-server/src/task_runner/spawn_tests/spawn_resume_tests.rs
@@ -4,6 +4,7 @@ use tokio::time::Duration;
 
 fn legacy_hosted_bot_server_config() -> std::sync::Arc<harness_core::config::HarnessConfig> {
     let mut config = harness_core::config::HarnessConfig::default();
+    config.agents.review.strategy = harness_core::config::agents::ReviewStrategy::LegacyHostedBot;
     config.agents.review.review_bot_auto_trigger = true;
     std::sync::Arc::new(config)
 }

--- a/crates/harness-server/src/task_runner/spawn_tests/spawn_skills_tests.rs
+++ b/crates/harness-server/src/task_runner/spawn_tests/spawn_skills_tests.rs
@@ -7,6 +7,7 @@ use tokio::time::Duration;
 
 fn legacy_hosted_bot_server_config() -> std::sync::Arc<harness_core::config::HarnessConfig> {
     let mut config = harness_core::config::HarnessConfig::default();
+    config.agents.review.strategy = harness_core::config::agents::ReviewStrategy::LegacyHostedBot;
     config.agents.review.review_bot_auto_trigger = true;
     std::sync::Arc::new(config)
 }


### PR DESCRIPTION
## Summary
- Evaluate review gate reports against configured required and advisory provider IDs.
- Convert local agent review output into typed review provider reports before local completion.
- Fail closed when required or external-required provider reports are missing or unsuccessful.

## Validation
- cargo fmt --all -- --check
- cargo test -p harness-core review
- cargo test -p harness-server agent_review
- cargo test -p harness-server local_review_completion_gate
- cargo check -p harness-server --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo check -p harness-server --all-targets (after rebase)

Closes #1166