### PR TITLE
fix(task_db): reject invalid scheduler state decode

### DIFF
--- a/crates/harness-core/src/error.rs
+++ b/crates/harness-core/src/error.rs
@@ -112,6 +112,12 @@ pub enum TaskDbDecodeError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("failed to deserialize scheduler_state for task `{task_id}`")]
+    SchedulerStateDeserialize {
+        task_id: String,
+        #[source]
+        source: serde_json::Error,
+    },
 }
 
 pub type Error = HarnessError;

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -2,6 +2,7 @@ mod migrations;
 mod queries_aux;
 mod queries_recovery;
 mod queries_tasks;
+mod raw_column_test_overrides;
 mod types;
 
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};

--- a/crates/harness-server/src/task_db/queries_recovery.rs
+++ b/crates/harness-server/src/task_db/queries_recovery.rs
@@ -5,7 +5,8 @@
 //! `queries_tasks.rs` under the project's per-file line ceiling.
 
 use crate::http::parse_pr_num_from_url;
-use crate::task_runner::TaskStatus;
+use crate::task_runner::{TaskSchedulerState, TaskStatus};
+use harness_core::error::TaskDbDecodeError;
 
 use super::types::{RecoveryResult, RecoveryRow};
 use super::TaskDb;
@@ -27,11 +28,7 @@ impl TaskDb {
             let Some((scheduler_state, expected_version)) = scheduler_state_row else {
                 return Ok(());
             };
-            let mut scheduler = Some(scheduler_state)
-                .and_then(|value| {
-                    serde_json::from_str::<crate::task_runner::TaskSchedulerState>(&value).ok()
-                })
-                .unwrap_or_default();
+            let mut scheduler = decode_scheduler_state(task_id, &scheduler_state)?;
             if let Ok(task_status) = status.parse::<TaskStatus>() {
                 scheduler.mark_terminal(&task_status);
             }
@@ -101,10 +98,7 @@ impl TaskDb {
         let mut result = RecoveryResult::default();
 
         for row in rows {
-            let mut scheduler = serde_json::from_str::<crate::task_runner::TaskSchedulerState>(
-                &row.scheduler_state,
-            )
-            .unwrap_or_default();
+            let mut scheduler = decode_scheduler_state(&row.id, &row.scheduler_state)?;
             let effective_pr_url = row
                 .task_pr_url
                 .as_deref()
@@ -213,9 +207,7 @@ impl TaskDb {
         .fetch_all(&self.pool)
         .await?;
         for (id, error, scheduler_state, expected_version) in &transient_failed_rows {
-            let mut scheduler =
-                serde_json::from_str::<crate::task_runner::TaskSchedulerState>(scheduler_state)
-                    .unwrap_or_default();
+            let mut scheduler = decode_scheduler_state(id, scheduler_state)?;
             scheduler.mark_terminal(&TaskStatus::Failed);
             let scheduler_json = serde_json::to_string(&scheduler)?;
             let err = format!(
@@ -243,4 +235,16 @@ impl TaskDb {
         result.transient_failed = transient_failed;
         Ok(result)
     }
+}
+
+fn decode_scheduler_state(
+    task_id: &str,
+    scheduler_state: &str,
+) -> Result<TaskSchedulerState, TaskDbDecodeError> {
+    serde_json::from_str::<TaskSchedulerState>(scheduler_state).map_err(|source| {
+        TaskDbDecodeError::SchedulerStateDeserialize {
+            task_id: task_id.to_string(),
+            source,
+        }
+    })
 }

--- a/crates/harness-server/src/task_db/raw_column_test_overrides.rs
+++ b/crates/harness-server/src/task_db/raw_column_test_overrides.rs
@@ -1,0 +1,22 @@
+use super::TaskDb;
+
+impl TaskDb {
+    /// Overwrite the `scheduler_state` column with arbitrary raw text.
+    ///
+    /// Used by integration tests to simulate a corrupted DB payload without going
+    /// through the normal serialization path. The name suffix `_for_test` signals
+    /// that production code must never call this.
+    #[doc(hidden)]
+    pub async fn overwrite_scheduler_state_for_test(
+        &self,
+        task_id: &str,
+        raw_scheduler_state: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE tasks SET scheduler_state = $1 WHERE id = $2")
+            .bind(raw_scheduler_state)
+            .bind(task_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -255,7 +255,10 @@ impl TaskRow {
             })?;
         let decoded_scheduler =
             serde_json::from_str::<crate::task_runner::TaskSchedulerState>(&scheduler_state)
-                .unwrap_or_default();
+                .map_err(|source| TaskDbDecodeError::SchedulerStateDeserialize {
+                    task_id: id.clone(),
+                    source,
+                })?;
 
         Ok(TaskState {
             id: harness_core::types::TaskId(id),
@@ -319,7 +322,10 @@ impl TaskSummaryRow {
         )?;
         let scheduler =
             serde_json::from_str::<crate::task_runner::TaskSchedulerState>(&self.scheduler_state)
-                .unwrap_or_default();
+                .map_err(|source| TaskDbDecodeError::SchedulerStateDeserialize {
+                task_id: self.id.clone(),
+                source,
+            })?;
         Ok(crate::task_runner::TaskSummary {
             id: TaskId(self.id),
             task_kind: decoded_task_kind,

--- a/crates/harness-server/tests/task_db_rounds.rs
+++ b/crates/harness-server/tests/task_db_rounds.rs
@@ -1,5 +1,5 @@
-//! Regression tests: corrupted `rounds` column must surface as a distinguishable
-//! error rather than silently defaulting to an empty list (issue #62).
+//! Regression tests: corrupted JSON columns must surface as distinguishable
+//! errors rather than silently defaulting to empty or queued values.
 
 use harness_core::error::TaskDbDecodeError;
 use harness_core::types::TaskId as CoreTaskId;
@@ -69,6 +69,92 @@ async fn get_distinguishes_missing_task_from_corrupted_rounds() -> anyhow::Resul
     assert!(
         is_rounds_err,
         "error must be TaskDbDecodeError::RoundsDeserialize; got: {err}"
+    );
+
+    std::mem::forget(tmp);
+    Ok(())
+}
+
+/// A corrupted `scheduler_state` column must return a typed decode error, not
+/// `Ok(Some(_))` with a default queued scheduler authority.
+#[tokio::test]
+async fn get_rejects_corrupted_scheduler_state() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    db.insert(&make_task("task-corrupted-scheduler")).await?;
+    db.overwrite_scheduler_state_for_test(
+        "task-corrupted-scheduler",
+        r#"{"authority_state":"not_a_real_state"}"#,
+    )
+    .await?;
+
+    let result = db.get("task-corrupted-scheduler").await;
+    let err = result.expect_err("corrupted scheduler_state must return Err, not Ok(Some(_))");
+
+    let is_scheduler_err = err
+        .downcast_ref::<TaskDbDecodeError>()
+        .is_some_and(|e| matches!(e, TaskDbDecodeError::SchedulerStateDeserialize { .. }));
+    assert!(
+        is_scheduler_err,
+        "error must be TaskDbDecodeError::SchedulerStateDeserialize; got: {err}"
+    );
+
+    std::mem::forget(tmp);
+    Ok(())
+}
+
+#[tokio::test]
+async fn valid_scheduler_state_round_trips_unchanged() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut task = make_task("task-valid-scheduler");
+    task.scheduler.claim_scheduler("test-scheduler");
+    db.insert(&task).await?;
+
+    let fetched = db
+        .get("task-valid-scheduler")
+        .await?
+        .expect("valid task must exist");
+    assert_eq!(fetched.scheduler, task.scheduler);
+
+    std::mem::forget(tmp);
+    Ok(())
+}
+
+#[tokio::test]
+async fn summaries_do_not_default_corrupted_scheduler_state() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut valid = make_task("task-valid-summary-scheduler");
+    valid.scheduler.claim_scheduler("summary-scheduler");
+    db.insert(&valid).await?;
+    db.insert(&make_task("task-corrupted-summary-scheduler"))
+        .await?;
+    db.overwrite_scheduler_state_for_test(
+        "task-corrupted-summary-scheduler",
+        r#"{"authority_state":"not_a_real_state"}"#,
+    )
+    .await?;
+
+    let summaries = db.list_summaries().await?;
+    assert!(
+        summaries
+            .iter()
+            .any(|summary| summary.id.0 == "task-valid-summary-scheduler"
+                && summary.scheduler == valid.scheduler),
+        "valid scheduler_state summary must decode unchanged"
+    );
+    assert!(
+        !summaries
+            .iter()
+            .any(|summary| summary.id.0 == "task-corrupted-summary-scheduler"),
+        "corrupted scheduler_state summary must not be returned as default queued state"
     );
 
     std::mem::forget(tmp);

--- a/crates/harness-server/tests/task_db_rounds.rs
+++ b/crates/harness-server/tests/task_db_rounds.rs
@@ -160,3 +160,99 @@ async fn summaries_do_not_default_corrupted_scheduler_state() -> anyhow::Result<
     std::mem::forget(tmp);
     Ok(())
 }
+
+#[tokio::test]
+async fn apply_replayed_state_rejects_corrupted_scheduler_state() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut task = make_task("task-corrupted-replay-scheduler");
+    task.status = TaskStatus::Implementing;
+    db.insert(&task).await?;
+    db.overwrite_scheduler_state_for_test(
+        "task-corrupted-replay-scheduler",
+        r#"{"authority_state":"not_a_real_state"}"#,
+    )
+    .await?;
+
+    let result = db
+        .apply_replayed_state("task-corrupted-replay-scheduler", None, Some("done"))
+        .await;
+    let err =
+        result.expect_err("event replay must reject corrupted scheduler_state, not default it");
+
+    let is_scheduler_err = err
+        .downcast_ref::<TaskDbDecodeError>()
+        .is_some_and(|e| matches!(e, TaskDbDecodeError::SchedulerStateDeserialize { .. }));
+    assert!(
+        is_scheduler_err,
+        "error must be TaskDbDecodeError::SchedulerStateDeserialize; got: {err}"
+    );
+
+    std::mem::forget(tmp);
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_recovery_rejects_corrupted_scheduler_state() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut task = make_task("task-corrupted-recovery-scheduler");
+    task.status = TaskStatus::Implementing;
+    db.insert(&task).await?;
+    db.overwrite_scheduler_state_for_test(
+        "task-corrupted-recovery-scheduler",
+        r#"{"authority_state":"not_a_real_state"}"#,
+    )
+    .await?;
+
+    let result = db.recover_in_progress().await;
+    let err =
+        result.expect_err("startup recovery must reject corrupted scheduler_state, not default it");
+
+    let is_scheduler_err = err
+        .downcast_ref::<TaskDbDecodeError>()
+        .is_some_and(|e| matches!(e, TaskDbDecodeError::SchedulerStateDeserialize { .. }));
+    assert!(
+        is_scheduler_err,
+        "error must be TaskDbDecodeError::SchedulerStateDeserialize; got: {err}"
+    );
+
+    std::mem::forget(tmp);
+    Ok(())
+}
+
+#[tokio::test]
+async fn transient_retry_recovery_rejects_corrupted_scheduler_state() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("tasks.db");
+    let db = TaskDb::open(&db_path).await?;
+
+    let mut task = make_task("task-corrupted-transient-scheduler");
+    task.error = Some("retrying after transient failure (attempt 2)".to_string());
+    db.insert(&task).await?;
+    db.overwrite_scheduler_state_for_test(
+        "task-corrupted-transient-scheduler",
+        r#"{"authority_state":"not_a_real_state"}"#,
+    )
+    .await?;
+
+    let result = db.recover_in_progress().await;
+    let err = result.expect_err(
+        "transient retry recovery must reject corrupted scheduler_state, not default it",
+    );
+
+    let is_scheduler_err = err
+        .downcast_ref::<TaskDbDecodeError>()
+        .is_some_and(|e| matches!(e, TaskDbDecodeError::SchedulerStateDeserialize { .. }));
+    assert!(
+        is_scheduler_err,
+        "error must be TaskDbDecodeError::SchedulerStateDeserialize; got: {err}"
+    );
+
+    std::mem::forget(tmp);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a typed `TaskDbDecodeError::SchedulerStateDeserialize` error
- fail task row scheduler_state decode instead of silently defaulting to queued authority
- apply the same scheduler_state decode mapping to task summaries and cover valid/corrupt rows

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server --test task_db_rounds`
- `cargo test`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1292