### PR TITLE
fix: release repo backlog issue dependencies

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -43,11 +43,9 @@ pub(crate) async fn resolve_issue_dependency_status(
     tasks: &TaskStore,
     task_id: &TaskId,
 ) -> anyhow::Result<RuntimeDependencyStatus> {
-    Ok(
-        resolve_issue_dependency_status_by_exact_id(store, tasks, task_id)
-            .await?
-            .unwrap_or(RuntimeDependencyStatus::Waiting),
-    )
+    resolve_issue_dependency_status_by_exact_id(store, tasks, task_id)
+        .await
+        .map(|status| status.unwrap_or(RuntimeDependencyStatus::Waiting))
 }
 
 async fn resolve_issue_dependency_status_by_exact_id(
@@ -55,12 +53,13 @@ async fn resolve_issue_dependency_status_by_exact_id(
     tasks: &TaskStore,
     task_id: &TaskId,
 ) -> anyhow::Result<Option<RuntimeDependencyStatus>> {
-    match tasks.dep_status(task_id).await {
-        Some(TaskStatus::Done) => return Ok(Some(RuntimeDependencyStatus::Done)),
-        Some(TaskStatus::Failed) => return Ok(Some(RuntimeDependencyStatus::Failed)),
-        Some(TaskStatus::Cancelled) => return Ok(Some(RuntimeDependencyStatus::Cancelled)),
-        Some(_) => return Ok(Some(RuntimeDependencyStatus::Waiting)),
-        None => {}
+    if let Some(status) = tasks.dep_status(task_id).await {
+        return Ok(Some(match status {
+            TaskStatus::Done => RuntimeDependencyStatus::Done,
+            TaskStatus::Failed => RuntimeDependencyStatus::Failed,
+            TaskStatus::Cancelled => RuntimeDependencyStatus::Cancelled,
+            _ => RuntimeDependencyStatus::Waiting,
+        }));
     }
 
     let Some(store) = store else {

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -38,12 +38,6 @@ pub(crate) enum RuntimeDependencyStatus {
     Waiting,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RepoBacklogIssueDependency {
-    repo_key: String,
-    issue_number: u64,
-}
-
 pub(crate) async fn resolve_issue_dependency_status(
     store: Option<&WorkflowRuntimeStore>,
     tasks: &TaskStore,
@@ -153,34 +147,37 @@ async fn canonical_repo_backlog_issue_dependency_instance(
     waiting_instance: &WorkflowInstance,
     task_id: &TaskId,
 ) -> anyhow::Result<Option<WorkflowInstance>> {
-    let Some(dependency) = parse_repo_backlog_issue_dependency(task_id.as_str()) else {
+    let Some((dependency_repo, issue_number)) =
+        parse_repo_backlog_issue_dependency(task_id.as_str())
+    else {
         return Ok(None);
     };
-    let Some(project_id) = optional_string_field(&waiting_instance.data, "project_id") else {
+    let Some(project_id) = waiting_instance
+        .data
+        .get("project_id")
+        .and_then(serde_json::Value::as_str)
+    else {
         return Ok(None);
     };
-    let repo = optional_string_field(&waiting_instance.data, "repo");
-    if dependency.repo_key != repo.as_deref().unwrap_or("<none>") {
+    let repo = waiting_instance
+        .data
+        .get("repo")
+        .and_then(serde_json::Value::as_str);
+    if dependency_repo != repo.unwrap_or("<none>") {
         return Ok(None);
     }
-    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
-        &project_id,
-        repo.as_deref(),
-        dependency.issue_number,
-    );
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(project_id, repo, issue_number);
     store.get_instance(&workflow_id).await
 }
 
-fn parse_repo_backlog_issue_dependency(task_id: &str) -> Option<RepoBacklogIssueDependency> {
+fn parse_repo_backlog_issue_dependency(task_id: &str) -> Option<(&str, u64)> {
     let rest = task_id.strip_prefix("repo-backlog:")?;
     let (repo_key, issue_number) = rest.rsplit_once(":issue:")?;
     if repo_key.is_empty() {
         return None;
     }
-    Some(RepoBacklogIssueDependency {
-        repo_key: repo_key.to_string(),
-        issue_number: issue_number.parse().ok()?,
-    })
+    Some((repo_key, issue_number.parse().ok()?))
 }
 
 pub(crate) async fn release_ready_issue_dependencies(

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -38,23 +38,62 @@ pub(crate) enum RuntimeDependencyStatus {
     Waiting,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoBacklogIssueDependency {
+    repo_key: String,
+    issue_number: u64,
+}
+
 pub(crate) async fn resolve_issue_dependency_status(
     store: Option<&WorkflowRuntimeStore>,
     tasks: &TaskStore,
     task_id: &TaskId,
 ) -> anyhow::Result<RuntimeDependencyStatus> {
+    Ok(
+        resolve_issue_dependency_status_by_exact_id(store, tasks, task_id)
+            .await?
+            .unwrap_or(RuntimeDependencyStatus::Waiting),
+    )
+}
+
+async fn resolve_issue_dependency_status_by_exact_id(
+    store: Option<&WorkflowRuntimeStore>,
+    tasks: &TaskStore,
+    task_id: &TaskId,
+) -> anyhow::Result<Option<RuntimeDependencyStatus>> {
     match tasks.dep_status(task_id).await {
-        Some(TaskStatus::Done) => return Ok(RuntimeDependencyStatus::Done),
-        Some(TaskStatus::Failed) => return Ok(RuntimeDependencyStatus::Failed),
-        Some(TaskStatus::Cancelled) => return Ok(RuntimeDependencyStatus::Cancelled),
-        Some(_) => return Ok(RuntimeDependencyStatus::Waiting),
+        Some(TaskStatus::Done) => return Ok(Some(RuntimeDependencyStatus::Done)),
+        Some(TaskStatus::Failed) => return Ok(Some(RuntimeDependencyStatus::Failed)),
+        Some(TaskStatus::Cancelled) => return Ok(Some(RuntimeDependencyStatus::Cancelled)),
+        Some(_) => return Ok(Some(RuntimeDependencyStatus::Waiting)),
         None => {}
     }
 
     let Some(store) = store else {
-        return Ok(RuntimeDependencyStatus::Waiting);
+        return Ok(None);
     };
     let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+        return Ok(None);
+    };
+    runtime_dependency_status_from_instance(store, &instance)
+        .await
+        .map(Some)
+}
+
+async fn resolve_issue_dependency_status_for_instance(
+    store: &WorkflowRuntimeStore,
+    tasks: &TaskStore,
+    waiting_instance: &WorkflowInstance,
+    task_id: &TaskId,
+) -> anyhow::Result<RuntimeDependencyStatus> {
+    if let Some(status) =
+        resolve_issue_dependency_status_by_exact_id(Some(store), tasks, task_id).await?
+    {
+        return Ok(status);
+    }
+    let Some(instance) =
+        canonical_repo_backlog_issue_dependency_instance(store, waiting_instance, task_id).await?
+    else {
         return Ok(RuntimeDependencyStatus::Waiting);
     };
     runtime_dependency_status_from_instance(store, &instance).await
@@ -109,6 +148,41 @@ fn runtime_event_has_closed_issue_evidence(event: &WorkflowEvent) -> bool {
         .is_some_and(activity_result_value_has_closed_issue_evidence)
 }
 
+async fn canonical_repo_backlog_issue_dependency_instance(
+    store: &WorkflowRuntimeStore,
+    waiting_instance: &WorkflowInstance,
+    task_id: &TaskId,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    let Some(dependency) = parse_repo_backlog_issue_dependency(task_id.as_str()) else {
+        return Ok(None);
+    };
+    let Some(project_id) = optional_string_field(&waiting_instance.data, "project_id") else {
+        return Ok(None);
+    };
+    let repo = optional_string_field(&waiting_instance.data, "repo");
+    if dependency.repo_key != repo.as_deref().unwrap_or("<none>") {
+        return Ok(None);
+    }
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_id,
+        repo.as_deref(),
+        dependency.issue_number,
+    );
+    store.get_instance(&workflow_id).await
+}
+
+fn parse_repo_backlog_issue_dependency(task_id: &str) -> Option<RepoBacklogIssueDependency> {
+    let rest = task_id.strip_prefix("repo-backlog:")?;
+    let (repo_key, issue_number) = rest.rsplit_once(":issue:")?;
+    if repo_key.is_empty() {
+        return None;
+    }
+    Some(RepoBacklogIssueDependency {
+        repo_key: repo_key.to_string(),
+        issue_number: issue_number.parse().ok()?,
+    })
+}
+
 pub(crate) async fn release_ready_issue_dependencies(
     store: &WorkflowRuntimeStore,
     tasks: &TaskStore,
@@ -138,7 +212,9 @@ pub(crate) async fn release_ready_issue_dependencies(
         let mut all_done = true;
         let mut terminal_failure: Option<(TaskId, &'static str)> = None;
         for dep_id in &depends_on {
-            match resolve_issue_dependency_status(Some(store), tasks, dep_id).await? {
+            match resolve_issue_dependency_status_for_instance(store, tasks, &instance, dep_id)
+                .await?
+            {
                 RuntimeDependencyStatus::Done => {}
                 RuntimeDependencyStatus::Failed => {
                     terminal_failure = Some((dep_id.clone(), "failed"));

--- a/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
@@ -268,6 +268,87 @@ async fn issue_submission_releases_dependency_on_completed_runtime_handle() -> a
 }
 
 #[tokio::test]
+async fn issue_submission_releases_dependency_by_repo_backlog_issue_handle_when_canonical_workflow_completed(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let task_store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let labels = vec!["bug".to_string()];
+    let direct_dep_id = TaskId::from_str("direct-runtime-dep-handle");
+    let dep_result = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 78,
+            task_id: &direct_dep_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let mut dep_workflow = store
+        .get_instance(&dep_result.workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("dependency workflow should exist"))?;
+    dep_workflow.state = "done".to_string();
+    store.upsert_instance(&dep_workflow).await?;
+
+    let repo_backlog_dep_id = TaskId::from_str("repo-backlog:owner/repo:issue:78");
+    assert!(
+        store
+            .get_instance_by_task_id(repo_backlog_dep_id.as_str())
+            .await?
+            .is_none(),
+        "planner dependency handle should not exist as a runtime task id"
+    );
+
+    let task_id = TaskId::from_str("runtime-dependent-on-repo-backlog-handle");
+    let blocked = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 79,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: std::slice::from_ref(&repo_backlog_dep_id),
+            dependencies_blocked: true,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+
+    let released = release_ready_issue_dependencies(&store, &task_store, 10).await?;
+    assert_eq!(released.released, 1);
+    assert_eq!(released.waiting, 0);
+    assert_eq!(released.failed, 0);
+    let workflow = store
+        .get_instance(&blocked.workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("dependent workflow should remain persisted"))?;
+    assert_eq!(workflow.state, "planning");
+    let commands = store.commands_for(&blocked.workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].command.activity_name(), Some("plan_issue"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn issue_submission_keeps_blocked_runtime_dependency_without_closed_evidence_waiting(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {


### PR DESCRIPTION
Summary
- Preserve exact task-id dependency resolution before any fallback.
- Release awaiting issue workflows when a missing repo-backlog issue handle maps to the same project/repo canonical GitHub issue workflow and that workflow is terminal.
- Add a regression test for the planner handle race from issue #1303.

Validation
- cargo test -p harness-server workflow_runtime_submission::dependency_tests::issue_submission_releases_dependency_by_repo_backlog_issue_handle_when_canonical_workflow_completed (failed before fix: released=0, passed after fix)
- cargo test -p harness-server workflow_runtime_submission::dependency_tests
- cargo fmt --all -- --check
- git diff --check
- cargo check -p harness-server --all-targets
- cargo test
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1303