### PR TITLE
chore(workflow): remove unreachable state variants

### DIFF
--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -739,7 +739,6 @@ fn runtime_job_status(status: RuntimeJobStatus) -> &'static str {
         RuntimeJobStatus::Succeeded => "succeeded",
         RuntimeJobStatus::Failed => "failed",
         RuntimeJobStatus::Cancelled => "cancelled",
-        RuntimeJobStatus::Expired => "expired",
     }
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -44,9 +44,7 @@ impl RuntimeJobWorkerTick {
                 cancelled: 1,
                 ..Self::default()
             },
-            Some(
-                RuntimeJobStatus::Pending | RuntimeJobStatus::Running | RuntimeJobStatus::Expired,
-            ) => Self::default(),
+            Some(RuntimeJobStatus::Pending | RuntimeJobStatus::Running) => Self::default(),
             None => Self {
                 idle: true,
                 ..Self::default()

--- a/crates/harness-server/tests/state_invariants.rs
+++ b/crates/harness-server/tests/state_invariants.rs
@@ -130,7 +130,6 @@ fn all_lifecycle_states() -> Vec<IssueLifecycleState> {
         IssueLifecycleState::FeedbackClaimed,
         IssueLifecycleState::AddressingFeedback,
         IssueLifecycleState::ReadyToMerge,
-        IssueLifecycleState::Blocked,
         IssueLifecycleState::Done,
         IssueLifecycleState::Failed,
         IssueLifecycleState::Cancelled,
@@ -147,7 +146,6 @@ fn lifecycle_tag(state: &IssueLifecycleState) -> &'static str {
         IssueLifecycleState::FeedbackClaimed => "feedback_claimed",
         IssueLifecycleState::AddressingFeedback => "addressing_feedback",
         IssueLifecycleState::ReadyToMerge => "ready_to_merge",
-        IssueLifecycleState::Blocked => "blocked",
         IssueLifecycleState::Done => "done",
         IssueLifecycleState::Failed => "failed",
         IssueLifecycleState::Cancelled => "cancelled",
@@ -166,8 +164,7 @@ fn lifecycle_is_terminal(state: &IssueLifecycleState) -> bool {
         | IssueLifecycleState::AwaitingFeedback
         | IssueLifecycleState::FeedbackClaimed
         | IssueLifecycleState::AddressingFeedback
-        | IssueLifecycleState::ReadyToMerge
-        | IssueLifecycleState::Blocked => false,
+        | IssueLifecycleState::ReadyToMerge => false,
     }
 }
 

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -21,7 +21,6 @@ pub enum IssueLifecycleState {
     FeedbackClaimed,
     AddressingFeedback,
     ReadyToMerge,
-    Blocked,
     Done,
     Failed,
     Cancelled,

--- a/crates/harness-workflow/src/project_lifecycle.rs
+++ b/crates/harness-workflow/src/project_lifecycle.rs
@@ -48,7 +48,6 @@ pub enum ProjectWorkflowEventKind {
     SprintPlanningStarted,
     SprintPlannerEnqueued,
     DispatchStarted,
-    DispatchCompleted,
     MonitoringStarted,
     FeedbackSweepStarted,
     FeedbackSweepCompleted,
@@ -139,8 +138,7 @@ impl ProjectWorkflowInstance {
                 self.state = ProjectWorkflowState::PlanningBatch;
                 self.active_planner_task_id = event.task_id.clone();
             }
-            ProjectWorkflowEventKind::DispatchStarted
-            | ProjectWorkflowEventKind::DispatchCompleted => {
+            ProjectWorkflowEventKind::DispatchStarted => {
                 self.state = ProjectWorkflowState::Dispatching;
             }
             ProjectWorkflowEventKind::MonitoringStarted => {

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -506,7 +506,6 @@ pub enum RuntimeJobStatus {
     Succeeded,
     Failed,
     Cancelled,
-    Expired,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Summary
- remove unreachable `IssueLifecycleState::Blocked` and update state invariant coverage
- remove unreachable `RuntimeJobStatus::Expired` and its worker/usage-monitor consumer arms
- remove unreachable `ProjectWorkflowEventKind::DispatchCompleted` and simplify the dispatch transition arm

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p harness-server state_invariants`
- `cargo test -p harness-server --test state_invariants`
- `cargo test -p harness-workflow`
- `cargo test -p harness-server workflow_runtime_worker`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1297