### PR TITLE
Harden workflow command status boundaries

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -10,8 +10,8 @@ use harness_workflow::issue_lifecycle::{
 };
 use harness_workflow::runtime::{
     CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeKind, RuntimeProfile,
-    RuntimeProfileSelector, WorkflowCommandRecord, WorkflowCommandType, WorkflowDefinition,
-    WorkflowInstance, WorkflowRuntimeStore,
+    RuntimeProfileSelector, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowCommandType,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore,
 };
 use sha2::{Digest, Sha256};
 
@@ -625,7 +625,9 @@ async fn dispatch_runtime_command_with_project_policy(
         Ok(Some(profile_selector)) => profile_selector,
         Ok(None) => {
             let command_id = command.id.clone();
-            store.mark_command_status(&command_id, "skipped").await?;
+            store
+                .mark_command_status(&command_id, WorkflowCommandStatus::Skipped)
+                .await?;
             let reason = "workflow runtime dispatch or worker is disabled for the command project"
                 .to_string();
             return Ok(CommandDispatchOutcome::Skipped { command_id, reason });
@@ -633,7 +635,9 @@ async fn dispatch_runtime_command_with_project_policy(
         Err(RuntimeDispatchProfileSelectionError::WorkflowConfig(error)) => {
             let command_id = command.id.clone();
             let reason = format!("workflow runtime project config failed to load: {error}");
-            store.mark_command_status(&command_id, "failed").await?;
+            store
+                .mark_command_status(&command_id, WorkflowCommandStatus::Failed)
+                .await?;
             store
                 .append_event(
                     &command.workflow_id,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -164,7 +164,7 @@ impl WorkflowRuntimeCommandNode {
             id: record.id,
             workflow_id: record.workflow_id,
             decision_id: record.decision_id,
-            status: record.status,
+            status: record.status.to_string(),
             command: record.command,
             runtime_job_count,
             runtime_jobs,

--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -243,7 +243,7 @@ impl RuntimeTaskSseCursor {
             let changed = self
                 .command_statuses
                 .get(&command.id)
-                .is_none_or(|status| status != &command.status);
+                .is_none_or(|status| status != command.status.as_str());
             if changed {
                 self.push_text(format!(
                     "[command] {} status={} activity={}",
@@ -252,7 +252,7 @@ impl RuntimeTaskSseCursor {
                     command.command.runtime_activity_key()
                 ));
                 self.command_statuses
-                    .insert(command.id.clone(), command.status.clone());
+                    .insert(command.id.clone(), command.status.to_string());
             }
         }
 

--- a/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
@@ -326,7 +326,12 @@ async fn runtime_pr_feedback_sweep_recovers_pr_binding_from_bind_pr_command() ->
         "issue-230-bind-pr-80",
     );
     store
-        .enqueue_command_with_status(&workflow.id, None, &bind_pr, "skipped")
+        .enqueue_command_with_status(
+            &workflow.id,
+            None,
+            &bind_pr,
+            harness_workflow::runtime::WorkflowCommandStatus::Skipped,
+        )
         .await?;
 
     let tick = super::background::run_runtime_pr_feedback_sweep_tick(&state, 10).await?;

--- a/crates/harness-server/src/http/tests/runtime_worker_followup_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_followup_tests.rs
@@ -81,7 +81,10 @@ async fn runtime_job_worker_requeues_pr_feedback_child_inspect_after_stale_dedup
         .enqueue_command(&child_id, None, &stale_command)
         .await?;
     store
-        .mark_command_status(&stale_command_id, "completed")
+        .mark_command_status(
+            &stale_command_id,
+            harness_workflow::runtime::WorkflowCommandStatus::Completed,
+        )
         .await?;
 
     let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -3,9 +3,9 @@ use crate::task_runner::{mutate_and_persist, TaskId, TaskStatus, TaskStore};
 use harness_core::config::misc::ReconciliationConfig;
 use harness_workflow::issue_lifecycle::IssueWorkflowStore;
 use harness_workflow::runtime::{
-    DecisionValidator, ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
-    WorkflowDecisionTransition, WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore,
-    GITHUB_ISSUE_PR_DEFINITION_ID,
+    DecisionValidator, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
+    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowEvidence,
+    WorkflowInstance, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -609,7 +609,7 @@ async fn apply_runtime_workflow_transition(
             payload: event_payload,
             decision: &decision,
             final_instance: &instance,
-            command_status: "completed",
+            command_status: WorkflowCommandStatus::Completed,
         })
         .await?
     else {

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -27,7 +27,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 use harness_workflow::runtime::{
-    RuntimeJobStatus, WorkflowCommandRecord, WorkflowRuntimeStore, REPO_BACKLOG_POLL_ACTIVITY,
+    RuntimeJobStatus, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowRuntimeStore,
+    REPO_BACKLOG_POLL_ACTIVITY,
 };
 
 use crate::http::AppState;
@@ -162,9 +163,9 @@ async fn workflow_has_active_repo_backlog_work(
 ) -> anyhow::Result<bool> {
     let commands = store.commands_for(workflow_id).await?;
     for command in commands.iter().rev().filter(is_repo_backlog_poll_command) {
-        match command.status.as_str() {
-            "pending" | "dispatching" => return Ok(true),
-            "dispatched" => {
+        match command.status {
+            WorkflowCommandStatus::Pending | WorkflowCommandStatus::Dispatching => return Ok(true),
+            WorkflowCommandStatus::Dispatched => {
                 let jobs = store.runtime_jobs_for_command(&command.id).await?;
                 if jobs.iter().any(|job| {
                     matches!(
@@ -230,7 +231,7 @@ mod tests {
     use super::*;
     use harness_core::db::resolve_database_url;
     use harness_workflow::runtime::{
-        RuntimeKind, WorkflowCommand, WorkflowInstance, WorkflowSubject,
+        RuntimeKind, WorkflowCommand, WorkflowCommandStatus, WorkflowInstance, WorkflowSubject,
     };
     use serde_json::json;
     use std::sync::Arc;
@@ -440,7 +441,9 @@ mod tests {
                 json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
             )
             .await?;
-        store.mark_command_status(&command_id, "dispatched").await?;
+        store
+            .mark_command_status(&command_id, WorkflowCommandStatus::Dispatched)
+            .await?;
 
         let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
 

--- a/crates/harness-server/src/workflow_runtime_plan_issue.rs
+++ b/crates/harness-server/src/workflow_runtime_plan_issue.rs
@@ -1,14 +1,14 @@
 use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
     build_plan_issue_decision, DecisionValidator, PlanIssueDecisionInput, PlanIssueWorkflowAction,
-    ValidationContext, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
-    WorkflowRuntimeStore, WorkflowSubject,
+    ValidationContext, WorkflowCommandStatus, WorkflowDecisionRecord, WorkflowDefinition,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
 };
 use serde_json::json;
 use std::path::Path;
 use std::sync::Arc;
 
-const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
+const COMMAND_STATUS_HANDLED_INLINE: WorkflowCommandStatus = WorkflowCommandStatus::HandledInline;
 
 pub(crate) enum PlanIssueRuntimeAction {
     RunReplan,

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -4,11 +4,11 @@ use harness_workflow::runtime::{
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
     DecisionValidator, LocalReviewCompletedInput, LocalReviewDecisionInput, LocalReviewOutcome,
     PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
-    PrFeedbackSweepDecisionInput, ValidationContext, WorkflowCommand, WorkflowCommandType,
-    WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition, WorkflowEvidence,
-    WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore, WorkflowSubject,
-    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY,
+    PrFeedbackSweepDecisionInput, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
+    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition,
+    WorkflowEvidence, WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -1032,7 +1032,7 @@ async fn commit_runtime_decision(
             payload: event_payload,
             decision: &decision,
             final_instance: &final_instance,
-            command_status: "pending",
+            command_status: WorkflowCommandStatus::Pending,
         })
         .await?;
     Ok(match record {
@@ -1041,8 +1041,13 @@ async fn commit_runtime_decision(
     })
 }
 
-fn is_active_pr_feedback_command_status(status: &str) -> bool {
-    matches!(status, "pending" | "dispatching" | "dispatched")
+fn is_active_pr_feedback_command_status(status: WorkflowCommandStatus) -> bool {
+    matches!(
+        status,
+        WorkflowCommandStatus::Pending
+            | WorkflowCommandStatus::Dispatching
+            | WorkflowCommandStatus::Dispatched
+    )
 }
 
 async fn has_active_local_review_command(
@@ -1054,7 +1059,7 @@ async fn has_active_local_review_command(
         .await?
         .into_iter()
         .any(|record| {
-            is_active_pr_feedback_command_status(record.status.as_str())
+            is_active_pr_feedback_command_status(record.status)
                 && record.command.activity_name() == Some(LOCAL_REVIEW_ACTIVITY)
         }))
 }
@@ -1086,12 +1091,12 @@ async fn has_active_pr_feedback_command_with_activity(
             .await?
             .into_iter()
             .any(|record| {
-                is_active_pr_feedback_command_status(record.status.as_str())
+                is_active_pr_feedback_command_status(record.status)
                     && matches!(
                         record.command.activity_name(),
                         Some("sweep_pr_feedback" | "address_pr_feedback")
                     )
-                    || is_active_pr_feedback_command_status(record.status.as_str())
+                    || is_active_pr_feedback_command_status(record.status)
                         && record.command.command_type
                             == harness_workflow::runtime::WorkflowCommandType::StartChildWorkflow
                         && record
@@ -1150,8 +1155,10 @@ async fn has_recent_failed_child_pr_feedback_command(
         .await?
         .into_iter()
         .any(|record| {
-            matches!(record.status.as_str(), "failed" | "blocked")
-                && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
+            matches!(
+                record.status,
+                WorkflowCommandStatus::Failed | WorkflowCommandStatus::Blocked
+            ) && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
                 && record.updated_at >= cutoff
                 && failed_child_suppression_still_applies(record.updated_at, latest_pr_activity_at)
         }))
@@ -1189,7 +1196,7 @@ async fn has_active_child_pr_feedback_command(
         .await?
         .into_iter()
         .any(|record| {
-            is_active_pr_feedback_command_status(record.status.as_str())
+            is_active_pr_feedback_command_status(record.status)
                 && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
         }))
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests/suppression.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests/suppression.rs
@@ -126,7 +126,10 @@ async fn failed_pr_feedback_child_suppresses_duplicate_feedback_sweep() -> anyho
         .enqueue_command(&child.id, None, &child_command)
         .await?;
     store
-        .mark_command_status(&child_command_id, "failed")
+        .mark_command_status(
+            &child_command_id,
+            harness_workflow::runtime::WorkflowCommandStatus::Failed,
+        )
         .await?;
 
     assert!(
@@ -205,7 +208,10 @@ async fn explicit_pr_feedback_request_starts_local_review_before_remote_suppress
         .enqueue_command(&child.id, None, &child_command)
         .await?;
     store
-        .mark_command_status(&child_command_id, "failed")
+        .mark_command_status(
+            &child_command_id,
+            harness_workflow::runtime::WorkflowCommandStatus::Failed,
+        )
         .await?;
 
     let outcome = request_pr_feedback_sweep_for_pr(
@@ -293,7 +299,10 @@ async fn failed_pr_feedback_child_respects_disabled_suppression_window() -> anyh
         .enqueue_command(&child.id, None, &child_command)
         .await?;
     store
-        .mark_command_status(&child_command_id, "failed")
+        .mark_command_status(
+            &child_command_id,
+            harness_workflow::runtime::WorkflowCommandStatus::Failed,
+        )
         .await?;
 
     assert!(
@@ -405,7 +414,10 @@ async fn orphan_pending_child_does_not_block_next_feedback_sweep() -> anyhow::Re
     );
 
     store
-        .mark_command_status(&child_command_id, "completed")
+        .mark_command_status(
+            &child_command_id,
+            harness_workflow::runtime::WorkflowCommandStatus::Completed,
+        )
         .await?;
     assert!(
         !has_active_pr_feedback_command(

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -4,9 +4,9 @@ use harness_workflow::runtime::{
     build_repo_backlog_poll_decision, build_stale_active_workflow_decision,
     repo_backlog_workflow_id, DecisionValidator, MergedPrDecisionInput, OpenIssueDecisionInput,
     RepoBacklogPollDecisionInput, StaleWorkflowDecisionInput, ValidationContext,
-    WorkflowCommandRecord, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
-    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject, REPO_BACKLOG_DEFINITION_ID,
-    REPO_BACKLOG_POLL_ACTIVITY,
+    WorkflowCommandRecord, WorkflowCommandStatus, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -408,8 +408,10 @@ fn repo_backlog_validation_context(
 fn has_active_repo_backlog_poll_command(commands: &[WorkflowCommandRecord]) -> bool {
     commands.iter().any(|record| {
         matches!(
-            record.status.as_str(),
-            "pending" | "dispatching" | "dispatched"
+            record.status,
+            WorkflowCommandStatus::Pending
+                | WorkflowCommandStatus::Dispatching
+                | WorkflowCommandStatus::Dispatched
         ) && is_repo_backlog_poll_command(record)
     })
 }
@@ -460,7 +462,7 @@ mod tests {
     use chrono::{DateTime, Utc};
     use harness_core::db::resolve_database_url;
     use harness_workflow::issue_lifecycle::IssueLifecycleState;
-    use harness_workflow::runtime::WorkflowCommand;
+    use harness_workflow::runtime::{WorkflowCommand, WorkflowCommandStatus};
 
     async fn open_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
         let database_url = resolve_database_url(None)?;
@@ -565,7 +567,9 @@ mod tests {
                 state: "scanning".to_string()
             }
         );
-        store.mark_command_status(&commands[0].id, "failed").await?;
+        store
+            .mark_command_status(&commands[0].id, WorkflowCommandStatus::Failed)
+            .await?;
         let mut failed_instance = store
             .get_instance(&workflow_id)
             .await?
@@ -599,20 +603,21 @@ mod tests {
 
     #[test]
     fn repo_backlog_poll_active_command_includes_dispatching() {
-        let command = repo_backlog_poll_command_record("dispatching", Utc::now());
+        let command =
+            repo_backlog_poll_command_record(WorkflowCommandStatus::Dispatching, Utc::now());
 
         assert!(has_active_repo_backlog_poll_command(&[command]));
     }
 
     fn repo_backlog_poll_command_record(
-        status: impl Into<String>,
+        status: WorkflowCommandStatus,
         updated_at: DateTime<Utc>,
     ) -> WorkflowCommandRecord {
         WorkflowCommandRecord {
             id: "command-1".to_string(),
             workflow_id: "repo-backlog".to_string(),
             decision_id: None,
-            status: status.into(),
+            status,
             dispatch_owner: None,
             dispatch_lease_expires_at: None,
             command: WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "dedupe"),

--- a/crates/harness-server/src/workflow_runtime_worker/workspace.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/workspace.rs
@@ -2,9 +2,10 @@ use crate::http::AppState;
 use crate::task_runner::TaskId;
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
-    RuntimeJob, WorkflowCommandRecord, WorkflowInstance, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    RuntimeJob, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowInstance,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -353,8 +354,10 @@ async fn run_workflow_hook(
 }
 
 pub(super) fn is_active_pr_feedback_inspect_command(record: &WorkflowCommandRecord) -> bool {
-    matches!(record.status.as_str(), "pending" | "dispatched")
-        && is_pr_feedback_inspect_command(record)
+    matches!(
+        record.status,
+        WorkflowCommandStatus::Pending | WorkflowCommandStatus::Dispatched
+    ) && is_pr_feedback_inspect_command(record)
 }
 
 pub(super) fn is_pr_feedback_inspect_command(record: &WorkflowCommandRecord) -> bool {

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,5 +1,6 @@
 use super::model::{RuntimeJob, RuntimeKind, RuntimeProfile, WorkflowCommandRecord};
 use super::repo_backlog::REPO_BACKLOG_POLL_ACTIVITY;
+use super::status::WorkflowCommandStatus;
 use super::store::{RuntimeJobEnqueueOutcome, WorkflowRuntimeStore};
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
@@ -7,8 +8,8 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
-const COMMAND_STATUS_SKIPPED: &str = "skipped";
-const COMMAND_STATUS_CANCELLED: &str = "cancelled";
+const COMMAND_STATUS_SKIPPED: WorkflowCommandStatus = WorkflowCommandStatus::Skipped;
+const COMMAND_STATUS_CANCELLED: WorkflowCommandStatus = WorkflowCommandStatus::Cancelled;
 const DEFAULT_REPO_BACKLOG_POLL_RUNTIME_PROFILE: &str = "codex-backlog-exec";
 const DEFAULT_REPO_BACKLOG_POLL_TIMEOUT_SECS: u64 = 3600;
 

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -15,6 +15,7 @@ pub mod prompt_task;
 pub mod quality_gate;
 pub mod reducer;
 pub mod repo_backlog;
+pub mod status;
 pub mod store;
 mod store_migrations;
 pub mod submission;
@@ -74,6 +75,7 @@ pub use repo_backlog::{
     StaleWorkflowDecisionInput, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
     REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
+pub use status::WorkflowCommandStatus;
 pub use store::{
     WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
 };

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -1,3 +1,4 @@
+use super::status::WorkflowCommandStatus;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -329,7 +330,7 @@ pub struct WorkflowCommandRecord {
     pub workflow_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decision_id: Option<String>,
-    pub status: String,
+    pub status: WorkflowCommandStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dispatch_owner: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/harness-workflow/src/runtime/status.rs
+++ b/crates/harness-workflow/src/runtime/status.rs
@@ -47,17 +47,17 @@ impl TryFrom<&str> for WorkflowCommandStatus {
     type Error = anyhow::Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Ok(match value {
-            "pending" => Self::Pending,
-            "dispatching" => Self::Dispatching,
-            "dispatched" => Self::Dispatched,
-            "handled_inline" => Self::HandledInline,
-            "completed" => Self::Completed,
-            "failed" => Self::Failed,
-            "blocked" => Self::Blocked,
-            "cancelled" => Self::Cancelled,
-            "skipped" => Self::Skipped,
+        match value {
+            "pending" => Ok(Self::Pending),
+            "dispatching" => Ok(Self::Dispatching),
+            "dispatched" => Ok(Self::Dispatched),
+            "handled_inline" => Ok(Self::HandledInline),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "blocked" => Ok(Self::Blocked),
+            "cancelled" => Ok(Self::Cancelled),
+            "skipped" => Ok(Self::Skipped),
             other => anyhow::bail!("unknown workflow command status: {other}"),
-        })
+        }
     }
 }

--- a/crates/harness-workflow/src/runtime/status.rs
+++ b/crates/harness-workflow/src/runtime/status.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowCommandStatus {
+    Pending,
+    Dispatching,
+    Dispatched,
+    HandledInline,
+    Completed,
+    Failed,
+    Blocked,
+    Cancelled,
+    Skipped,
+}
+
+impl WorkflowCommandStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Dispatching => "dispatching",
+            Self::Dispatched => "dispatched",
+            Self::HandledInline => "handled_inline",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Blocked => "blocked",
+            Self::Cancelled => "cancelled",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+impl fmt::Display for WorkflowCommandStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl PartialEq<&str> for WorkflowCommandStatus {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl TryFrom<&str> for WorkflowCommandStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            "pending" => Self::Pending,
+            "dispatching" => Self::Dispatching,
+            "dispatched" => Self::Dispatched,
+            "handled_inline" => Self::HandledInline,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "blocked" => Self::Blocked,
+            "cancelled" => Self::Cancelled,
+            "skipped" => Self::Skipped,
+            other => anyhow::bail!("unknown workflow command status: {other}"),
+        })
+    }
+}

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1932,13 +1932,13 @@ impl WorkflowRuntimeStore {
             "SELECT job.command_id, job.data
              FROM unnest($1::text[]) AS selected(command_id)
              JOIN LATERAL (
-                 SELECT command_id, data::text AS data, (data->>'created_at')::timestamptz AS created_at, id
+                 SELECT command_id, data::text AS data, created_at, (data->>'created_at')::timestamptz AS job_created_at
                  FROM runtime_jobs
                  WHERE command_id = selected.command_id
-                 ORDER BY (data->>'created_at')::timestamptz DESC
+                 ORDER BY created_at DESC, (data->>'created_at')::timestamptz DESC
                  LIMIT $2
              ) AS job ON true
-             ORDER BY job.command_id ASC, job.created_at ASC",
+             ORDER BY job.command_id ASC, job.created_at ASC, job.job_created_at ASC",
         )
         .bind(command_ids)
         .bind(per_command_limit)
@@ -2007,7 +2007,7 @@ async fn runtime_job_for_command_tx(
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT data::text FROM runtime_jobs
          WHERE command_id = $1
-         ORDER BY (data->>'created_at')::timestamptz DESC
+         ORDER BY created_at DESC, (data->>'created_at')::timestamptz DESC
          LIMIT 1",
     )
     .bind(command_id)

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -9,6 +9,7 @@ use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
 use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
 use super::reducer::{reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID};
 use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
+use super::status::WorkflowCommandStatus;
 use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
 use super::validator::{DecisionValidator, ValidationContext};
 use anyhow::Context;
@@ -20,7 +21,6 @@ use sqlx::postgres::PgPool;
 use std::collections::BTreeMap;
 use std::path::Path;
 use uuid::Uuid;
-const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,
 }
@@ -47,7 +47,7 @@ pub struct WorkflowDecisionTransition<'a> {
     pub payload: Value,
     pub decision: &'a WorkflowDecision,
     pub final_instance: &'a WorkflowInstance,
-    pub command_status: &'a str,
+    pub command_status: WorkflowCommandStatus,
 }
 pub struct WorkflowRejectedDecisionTransition<'a> {
     pub expected_state: &'a str,
@@ -69,14 +69,12 @@ type WorkflowCommandRecordRow = (
     DateTime<Utc>,
     DateTime<Utc>,
 );
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeJobEnqueueOutcome {
     Enqueued(RuntimeJob),
     AlreadyExists(RuntimeJob),
-    CommandNotPending { status: String },
+    CommandNotPending { status: WorkflowCommandStatus },
 }
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeActivityCompletion {
     pub runtime_job: RuntimeJob,
@@ -84,7 +82,6 @@ pub struct RuntimeActivityCompletion {
     pub workflow_event: Option<WorkflowEvent>,
     pub decision: Option<WorkflowDecisionRecord>,
 }
-
 fn workflow_command_record_from_row(
     (
         id,
@@ -102,7 +99,7 @@ fn workflow_command_record_from_row(
         id,
         workflow_id,
         decision_id,
-        status,
+        status: WorkflowCommandStatus::try_from(status.as_str())?,
         dispatch_owner,
         dispatch_lease_expires_at,
         command: serde_json::from_str(&data)?,
@@ -110,12 +107,10 @@ fn workflow_command_record_from_row(
         updated_at,
     })
 }
-
 impl WorkflowRuntimeStore {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         Self::open_with_database_url(path, None).await
     }
-
     pub async fn open_with_database_url(
         path: &Path,
         configured_database_url: Option<&str>,
@@ -126,7 +121,6 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self { pool })
     }
-
     pub async fn open_with_database_url_and_schema(
         configured_database_url: Option<&str>,
         schema: &str,
@@ -137,7 +131,6 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self { pool })
     }
-
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
@@ -147,11 +140,9 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self { pool })
     }
-
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
-
     pub async fn upsert_definition(&self, definition: &WorkflowDefinition) -> anyhow::Result<()> {
         let data = to_jsonb_string(definition)?;
         sqlx::query(
@@ -188,7 +179,6 @@ impl WorkflowRuntimeStore {
             .transpose()
             .map_err(Into::into)
     }
-
     pub async fn upsert_prompt_payload(
         &self,
         prompt_ref: &str,
@@ -210,7 +200,6 @@ impl WorkflowRuntimeStore {
         .await?;
         Ok(())
     }
-
     pub async fn get_prompt_payload(&self, prompt_ref: &str) -> anyhow::Result<Option<String>> {
         if prompt_ref.trim().is_empty() {
             return Ok(None);
@@ -346,9 +335,9 @@ impl WorkflowRuntimeStore {
             .bind(&command_type)
             .bind(&command.dedupe_key)
             .bind(if command.requires_runtime_job() {
-                transition.command_status
+                transition.command_status.as_str()
             } else {
-                COMMAND_STATUS_HANDLED_INLINE
+                WorkflowCommandStatus::HandledInline.as_str()
             })
             .bind(&command_data)
             .execute(&mut *tx)
@@ -845,8 +834,13 @@ impl WorkflowRuntimeStore {
         decision_id: Option<&str>,
         command: &WorkflowCommand,
     ) -> anyhow::Result<String> {
-        self.enqueue_command_with_status(workflow_id, decision_id, command, "pending")
-            .await
+        self.enqueue_command_with_status(
+            workflow_id,
+            decision_id,
+            command,
+            WorkflowCommandStatus::Pending,
+        )
+        .await
     }
 
     pub async fn enqueue_command_with_status(
@@ -854,7 +848,7 @@ impl WorkflowRuntimeStore {
         workflow_id: &str,
         decision_id: Option<&str>,
         command: &WorkflowCommand,
-        status: &str,
+        status: WorkflowCommandStatus,
     ) -> anyhow::Result<String> {
         let data = to_jsonb_string(command)?;
         let command_type = enum_str(&command.command_type)?;
@@ -880,7 +874,7 @@ impl WorkflowRuntimeStore {
         .bind(decision_id)
         .bind(&command_type)
         .bind(&command.dedupe_key)
-        .bind(status)
+        .bind(status.as_str())
         .bind(&data)
         .fetch_one(&self.pool)
         .await?;
@@ -1013,7 +1007,11 @@ impl WorkflowRuntimeStore {
         Ok(records)
     }
 
-    pub async fn mark_command_status(&self, command_id: &str, status: &str) -> anyhow::Result<()> {
+    pub async fn mark_command_status(
+        &self,
+        command_id: &str,
+        status: WorkflowCommandStatus,
+    ) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE workflow_commands
              SET status = $1,
@@ -1022,7 +1020,7 @@ impl WorkflowRuntimeStore {
                  updated_at = CURRENT_TIMESTAMP
              WHERE id = $2",
         )
-        .bind(status)
+        .bind(status.as_str())
         .bind(command_id)
         .execute(&self.pool)
         .await?;
@@ -1032,7 +1030,7 @@ impl WorkflowRuntimeStore {
     pub async fn mark_pending_command_status(
         &self,
         command_id: &str,
-        status: &str,
+        status: WorkflowCommandStatus,
     ) -> anyhow::Result<bool> {
         let result = sqlx::query(
             "UPDATE workflow_commands
@@ -1042,7 +1040,7 @@ impl WorkflowRuntimeStore {
                  updated_at = CURRENT_TIMESTAMP
              WHERE id = $2 AND status = 'pending'",
         )
-        .bind(status)
+        .bind(status.as_str())
         .bind(command_id)
         .execute(&self.pool)
         .await?;
@@ -1159,12 +1157,14 @@ impl WorkflowRuntimeStore {
         let Some((command_status, command_dispatch_owner)) = command_row else {
             anyhow::bail!("workflow command not found: {command_id}");
         };
+        let command_status = WorkflowCommandStatus::try_from(command_status.as_str())?;
 
         let eligible = match dispatch_owner {
             Some(owner) => {
-                command_status == "dispatching" && command_dispatch_owner.as_deref() == Some(owner)
+                command_status == WorkflowCommandStatus::Dispatching
+                    && command_dispatch_owner.as_deref() == Some(owner)
             }
-            None => command_status == "pending",
+            None => command_status == WorkflowCommandStatus::Pending,
         };
 
         if !eligible {
@@ -1482,11 +1482,11 @@ impl WorkflowRuntimeStore {
                  updated_at = CURRENT_TIMESTAMP
              WHERE id = $2",
         )
-        .bind(command_status)
+        .bind(command_status.as_str())
         .bind(&command.id)
         .execute(&mut *tx)
         .await?;
-        command.status = command_status.to_string();
+        command.status = command_status;
         command.dispatch_owner = None;
         command.dispatch_lease_expires_at = None;
 
@@ -1589,9 +1589,9 @@ impl WorkflowRuntimeStore {
                         if record.accepted {
                             for followup in &record.decision.commands {
                                 let status = if followup.requires_runtime_job() {
-                                    "pending"
+                                    WorkflowCommandStatus::Pending
                                 } else {
-                                    COMMAND_STATUS_HANDLED_INLINE
+                                    WorkflowCommandStatus::HandledInline
                                 };
                                 insert_workflow_command_tx(
                                     &mut tx,
@@ -2007,7 +2007,7 @@ async fn runtime_job_for_command_tx(
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT data::text FROM runtime_jobs
          WHERE command_id = $1
-         ORDER BY created_at ASC
+         ORDER BY created_at DESC, id DESC
          LIMIT 1",
     )
     .bind(command_id)
@@ -2048,7 +2048,7 @@ async fn insert_workflow_command_tx(
     workflow_id: &str,
     decision_id: Option<&str>,
     command: &WorkflowCommand,
-    status: &str,
+    status: WorkflowCommandStatus,
 ) -> anyhow::Result<String> {
     let data = to_jsonb_string(command)?;
     let command_type = enum_str(&command.command_type)?;
@@ -2074,7 +2074,7 @@ async fn insert_workflow_command_tx(
     .bind(decision_id)
     .bind(&command_type)
     .bind(&command.dedupe_key)
-    .bind(status)
+    .bind(status.as_str())
     .bind(&data)
     .fetch_one(&mut **tx)
     .await?;
@@ -2279,12 +2279,12 @@ fn apply_mark_done_side_effect(
     Ok(())
 }
 
-fn command_status_for_activity(status: ActivityStatus) -> &'static str {
+fn command_status_for_activity(status: ActivityStatus) -> WorkflowCommandStatus {
     match status {
-        ActivityStatus::Succeeded => "completed",
-        ActivityStatus::Failed => "failed",
-        ActivityStatus::Blocked => "blocked",
-        ActivityStatus::Cancelled => "cancelled",
+        ActivityStatus::Succeeded => WorkflowCommandStatus::Completed,
+        ActivityStatus::Failed => WorkflowCommandStatus::Failed,
+        ActivityStatus::Blocked => WorkflowCommandStatus::Blocked,
+        ActivityStatus::Cancelled => WorkflowCommandStatus::Cancelled,
     }
 }
 

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1932,13 +1932,13 @@ impl WorkflowRuntimeStore {
             "SELECT job.command_id, job.data
              FROM unnest($1::text[]) AS selected(command_id)
              JOIN LATERAL (
-                 SELECT command_id, data::text AS data, created_at, id
+                 SELECT command_id, data::text AS data, (data->>'created_at')::timestamptz AS created_at, id
                  FROM runtime_jobs
                  WHERE command_id = selected.command_id
-                 ORDER BY created_at DESC, id DESC
+                 ORDER BY (data->>'created_at')::timestamptz DESC
                  LIMIT $2
              ) AS job ON true
-             ORDER BY job.command_id ASC, job.created_at ASC, job.id ASC",
+             ORDER BY job.command_id ASC, job.created_at ASC",
         )
         .bind(command_ids)
         .bind(per_command_limit)
@@ -2007,7 +2007,7 @@ async fn runtime_job_for_command_tx(
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT data::text FROM runtime_jobs
          WHERE command_id = $1
-         ORDER BY created_at DESC, id DESC
+         ORDER BY (data->>'created_at')::timestamptz DESC
          LIMIT 1",
     )
     .bind(command_id)

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -167,7 +167,7 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
         version: 8,
         description: "index runtime job command pagination",
         sql: "CREATE INDEX IF NOT EXISTS idx_runtime_jobs_command_created
-              ON runtime_jobs (command_id, created_at DESC, id DESC)",
+              ON runtime_jobs (command_id, created_at DESC)",
     },
     Migration {
         version: 9,

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -185,4 +185,35 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
             updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
+    Migration {
+        version: 11,
+        description: "constrain workflow runtime status vocabularies",
+        sql: "DO $$
+              BEGIN
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_commands_status_check'
+                    AND conrelid = 'workflow_commands'::regclass
+                ) THEN
+                  ALTER TABLE workflow_commands
+                    ADD CONSTRAINT workflow_commands_status_check
+                    CHECK (status IN (
+                      'pending', 'dispatching', 'dispatched', 'handled_inline',
+                      'completed', 'failed', 'blocked', 'cancelled', 'skipped'
+                    ));
+                END IF;
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'runtime_jobs_status_check'
+                    AND conrelid = 'runtime_jobs'::regclass
+                ) THEN
+                  ALTER TABLE runtime_jobs
+                    ADD CONSTRAINT runtime_jobs_status_check
+                    CHECK (status IN (
+                      'pending', 'running', 'succeeded',
+                      'failed', 'cancelled', 'expired'
+                    ));
+                END IF;
+              END $$",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -19,12 +19,13 @@ use super::{
     PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptSubmissionDecisionInput,
     QualityGateDecisionInput, QualityGateWorkflowAction, RepoBacklogPollDecisionInput,
     RepoBacklogWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
-    RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowDecisionTransition,
-    WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    RuntimeProfileSelector, RuntimeWorker, StaleWorkflowDecisionInput, WorkflowCommandStatus,
+    WorkflowDecisionTransition, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
+    LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -41,6 +42,7 @@ mod p1_followups;
 mod pr_repair_evidence;
 mod replay_determinism;
 mod retry;
+mod runtime_store;
 
 fn issue_instance(state: &str) -> WorkflowInstance {
     WorkflowInstance::new(
@@ -4362,7 +4364,7 @@ async fn runtime_worker_records_completion_event_and_command_status() -> anyhow:
     assert_eq!(completed.id, job.id);
     assert_eq!(
         store.commands_for(&workflow.id).await?[0].status,
-        "completed"
+        WorkflowCommandStatus::Completed
     );
     let workflow_events = store.events_for(&workflow.id).await?;
     let event = workflow_events
@@ -4451,12 +4453,12 @@ async fn runtime_worker_persists_bind_pr_payload_for_pr_open_transition() -> any
 
     let commands = store.commands_for(&workflow.id).await?;
     assert_eq!(commands.len(), 2);
-    assert_eq!(commands[0].status, "completed");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::Completed);
     assert_eq!(
         commands[1].command.command_type,
         WorkflowCommandType::BindPr
     );
-    assert_ne!(commands[1].status, "pending");
+    assert_ne!(commands[1].status, WorkflowCommandStatus::Pending);
     Ok(())
 }
 
@@ -4528,7 +4530,7 @@ async fn runtime_worker_blocks_invalid_inline_bind_pr_before_persisting_command(
     }));
     assert!(commands.iter().any(|record| {
         record.command.command_type == WorkflowCommandType::MarkBlocked
-            && record.status == "handled_inline"
+            && record.status == WorkflowCommandStatus::HandledInline
     }));
 
     let decisions = store.decisions_for(&workflow.id).await?;
@@ -4585,14 +4587,14 @@ async fn runtime_worker_blocks_implementation_success_without_pr_evidence() -> a
 
     let commands = store.commands_for(&workflow.id).await?;
     assert_eq!(commands[0].id, command_id);
-    assert_eq!(commands[0].status, "completed");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::Completed);
     assert!(commands.iter().any(|record| {
         record.command.command_type == WorkflowCommandType::MarkBlocked
-            && record.status == "handled_inline"
+            && record.status == WorkflowCommandStatus::HandledInline
     }));
     assert!(commands.iter().any(|record| {
         record.command.command_type == WorkflowCommandType::RequestOperatorAttention
-            && record.status == "handled_inline"
+            && record.status == WorkflowCommandStatus::HandledInline
     }));
 
     let decisions = store.decisions_for(&workflow.id).await?;
@@ -4664,10 +4666,10 @@ async fn runtime_worker_finishes_closed_issue_success_without_pr() -> anyhow::Re
 
     let commands = store.commands_for(&workflow.id).await?;
     assert_eq!(commands[0].id, command_id);
-    assert_eq!(commands[0].status, "completed");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::Completed);
     assert!(commands.iter().any(|record| {
         record.command.command_type == WorkflowCommandType::MarkDone
-            && record.status == "handled_inline"
+            && record.status == WorkflowCommandStatus::HandledInline
     }));
 
     let decisions = store.decisions_for(&workflow.id).await?;
@@ -4751,7 +4753,9 @@ async fn runtime_worker_keeps_repo_backlog_dispatching_until_child_starts_finish
     assert_eq!(final_update.state, "idle");
 
     let commands = store.commands_for(&workflow.id).await?;
-    assert!(commands.iter().all(|command| command.status == "completed"));
+    assert!(commands
+        .iter()
+        .all(|command| command.status == WorkflowCommandStatus::Completed));
     Ok(())
 }
 
@@ -4796,7 +4800,7 @@ async fn runtime_completion_counts_dispatching_sibling_as_active() -> anyhow::Re
         .await?;
     assert_eq!(claimed.len(), 1);
     assert_eq!(claimed[0].id, second_command_id);
-    assert_eq!(claimed[0].status, "dispatching");
+    assert_eq!(claimed[0].status, WorkflowCommandStatus::Dispatching);
 
     let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
     let executor = StaticRuntimeExecutor {
@@ -5226,7 +5230,7 @@ async fn runtime_worker_does_not_propagate_retrying_pr_feedback_child() -> anyho
     );
     let child_commands = store.commands_for(&child.id).await?;
     assert!(child_commands.iter().any(|record| {
-        record.status == "pending"
+        record.status == WorkflowCommandStatus::Pending
             && record.command.activity_name() == Some(PR_FEEDBACK_INSPECT_ACTIVITY)
             && record.command.command["retry_attempt"] == 1
     }));
@@ -5398,8 +5402,8 @@ async fn runtime_worker_blocks_when_profile_max_turns_is_exhausted() -> anyhow::
         .unwrap_or_default()
         .contains("exhausted max_turns"));
     let commands = store.commands_for(&workflow.id).await?;
-    assert_eq!(commands[0].status, "completed");
-    assert_eq!(commands[1].status, "blocked");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::Completed);
+    assert_eq!(commands[1].status, WorkflowCommandStatus::Blocked);
     Ok(())
 }
 
@@ -5650,7 +5654,7 @@ async fn durable_store_apply_decision_transition_can_create_initial_instance() -
             }),
             decision: &decision,
             final_instance: &final_instance,
-            command_status: "pending",
+            command_status: WorkflowCommandStatus::Pending,
         })
         .await?
         .expect("missing initial instance should be created inside the transition");
@@ -5727,7 +5731,7 @@ async fn durable_store_apply_decision_transition_does_not_rewind_existing_instan
             }),
             decision: &decision,
             final_instance: &final_instance,
-            command_status: "pending",
+            command_status: WorkflowCommandStatus::Pending,
         })
         .await?;
 
@@ -5935,7 +5939,7 @@ async fn runtime_command_dispatcher_enqueues_runtime_job_for_activity_command() 
     );
     assert_eq!(
         store.commands_for(&instance.id).await?[0].status,
-        "dispatched"
+        WorkflowCommandStatus::Dispatched
     );
     assert!(dispatcher.dispatch_once().await?.is_none());
     Ok(())
@@ -5954,13 +5958,18 @@ async fn runtime_store_can_insert_non_pending_command_atomically() -> anyhow::Re
     let command =
         WorkflowCommand::enqueue_activity("implement_issue", "issue-123-implement-inline");
     let command_id = store
-        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .enqueue_command_with_status(
+            &instance.id,
+            None,
+            &command,
+            WorkflowCommandStatus::HandledInline,
+        )
         .await?;
 
     let commands = store.commands_for(&instance.id).await?;
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].id, command_id);
-    assert_eq!(commands[0].status, "handled_inline");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::HandledInline);
     assert!(
         store.pending_commands(10).await?.is_empty(),
         "inline commands must never be visible to the dispatcher as pending"
@@ -5982,13 +5991,18 @@ async fn runtime_store_non_pending_status_updates_existing_pending_command() -> 
         WorkflowCommand::enqueue_activity("implement_issue", "issue-123-implement-inline");
     let pending_id = store.enqueue_command(&instance.id, None, &command).await?;
     let inline_id = store
-        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .enqueue_command_with_status(
+            &instance.id,
+            None,
+            &command,
+            WorkflowCommandStatus::HandledInline,
+        )
         .await?;
 
     assert_eq!(inline_id, pending_id);
     let commands = store.commands_for(&instance.id).await?;
     assert_eq!(commands.len(), 1);
-    assert_eq!(commands[0].status, "handled_inline");
+    assert_eq!(commands[0].status, WorkflowCommandStatus::HandledInline);
     assert!(
         store.pending_commands(10).await?.is_empty(),
         "dedupe conflict must not leave an inline command visible as pending"
@@ -6021,13 +6035,18 @@ async fn runtime_store_dedupe_status_update_does_not_regress_dispatched_command(
     assert!(matches!(outcome, RuntimeJobEnqueueOutcome::Enqueued(_)));
 
     let duplicate_id = store
-        .enqueue_command_with_status(&instance.id, None, &command, "handled_inline")
+        .enqueue_command_with_status(
+            &instance.id,
+            None,
+            &command,
+            WorkflowCommandStatus::HandledInline,
+        )
         .await?;
 
     assert_eq!(duplicate_id, command_id);
     assert_eq!(
         store.commands_for(&instance.id).await?[0].status,
-        "dispatched"
+        WorkflowCommandStatus::Dispatched
     );
     Ok(())
 }
@@ -6101,7 +6120,7 @@ async fn runtime_store_pending_command_enqueue_is_idempotent_across_concurrent_c
     assert_eq!(jobs[0].id, first_job_id);
     assert_eq!(
         store.commands_for(&instance.id).await?[0].status,
-        "dispatched"
+        WorkflowCommandStatus::Dispatched
     );
     Ok(())
 }
@@ -6124,7 +6143,7 @@ async fn runtime_store_claims_pending_commands_with_dispatch_lease() -> anyhow::
         .await?;
     assert_eq!(claimed.len(), 1);
     assert_eq!(claimed[0].id, command_id);
-    assert_eq!(claimed[0].status, "dispatching");
+    assert_eq!(claimed[0].status, WorkflowCommandStatus::Dispatching);
     assert_eq!(claimed[0].dispatch_owner.as_deref(), Some("dispatcher-a"));
     assert!(claimed[0].dispatch_lease_expires_at.is_some());
     assert!(store.pending_commands(10).await?.is_empty());
@@ -6415,7 +6434,10 @@ async fn runtime_command_dispatcher_skips_non_runtime_commands() -> anyhow::Resu
         .runtime_jobs_for_command(&command_id)
         .await?
         .is_empty());
-    assert_eq!(store.commands_for(&instance.id).await?[0].status, "skipped");
+    assert_eq!(
+        store.commands_for(&instance.id).await?[0].status,
+        WorkflowCommandStatus::Skipped
+    );
     Ok(())
 }
 
@@ -6457,7 +6479,7 @@ async fn runtime_command_dispatcher_skips_terminal_workflow_before_enqueue() -> 
         .is_empty());
     assert_eq!(
         store.commands_for(&instance.id).await?[0].status,
-        "cancelled"
+        WorkflowCommandStatus::Cancelled
     );
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[tokio::test]
+async fn dedupe_returns_latest_runtime_job_for_command() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = project_issue_instance("/project-a", 123, "replanning");
+    store.upsert_instance(&instance).await?;
+    let command = WorkflowCommand::enqueue_activity("replan_issue", "issue-123-replan-latest");
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    let older = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({"attempt": 1}),
+        )
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let newer = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({"attempt": 2}),
+        )
+        .await?;
+
+    let outcome = store
+        .enqueue_runtime_job_for_pending_command(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({"attempt": 3}),
+            None,
+        )
+        .await?;
+
+    assert_ne!(older.id, newer.id);
+    match outcome {
+        RuntimeJobEnqueueOutcome::AlreadyExists(job) => assert_eq!(job.id, newer.id),
+        other => panic!("unexpected latest-job dedupe outcome: {other:?}"),
+    }
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -29,6 +29,19 @@ async fn dedupe_returns_latest_runtime_job_for_command() -> anyhow::Result<()> {
             json!({"attempt": 2}),
         )
         .await?;
+    let shared_db_created_at = older.created_at;
+    sqlx::query("UPDATE runtime_jobs SET id = $1, created_at = $2 WHERE id = $3")
+        .bind("ffffffff-ffff-4fff-bfff-ffffffffffff")
+        .bind(shared_db_created_at)
+        .bind(&older.id)
+        .execute(store.pool())
+        .await?;
+    sqlx::query("UPDATE runtime_jobs SET id = $1, created_at = $2 WHERE id = $3")
+        .bind("00000000-0000-4000-8000-000000000000")
+        .bind(shared_db_created_at)
+        .bind(&newer.id)
+        .execute(store.pool())
+        .await?;
 
     let outcome = store
         .enqueue_runtime_job_for_pending_command(

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[tokio::test]
-async fn dedupe_returns_latest_runtime_job_for_command() -> anyhow::Result<()> {
+async fn dedupe_uses_runtime_job_timestamps_not_uuid_order() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());
     }
@@ -29,6 +29,8 @@ async fn dedupe_returns_latest_runtime_job_for_command() -> anyhow::Result<()> {
             json!({"attempt": 2}),
         )
         .await?;
+    assert!(older.created_at < newer.created_at);
+
     let shared_db_created_at = older.created_at;
     sqlx::query("UPDATE runtime_jobs SET id = $1, created_at = $2 WHERE id = $3")
         .bind("ffffffff-ffff-4fff-bfff-ffffffffffff")
@@ -52,6 +54,11 @@ async fn dedupe_returns_latest_runtime_job_for_command() -> anyhow::Result<()> {
             None,
         )
         .await?;
+
+    let jobs = store
+        .runtime_jobs_for_commands_limited(std::slice::from_ref(&command_id), 1)
+        .await?;
+    assert_eq!(jobs[&command_id][0].id, newer.id);
 
     assert_ne!(older.id, newer.id);
     match outcome {

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -3,6 +3,7 @@ use super::model::{
     WorkflowCommandRecord, WorkflowCommandType, WorkflowInstance,
 };
 use super::reducer::reduce_runtime_job_completed;
+use super::status::WorkflowCommandStatus;
 use super::store::WorkflowRuntimeStore;
 use super::validator::{DecisionValidator, ValidationContext};
 use anyhow::Context;
@@ -11,7 +12,7 @@ use chrono::{Duration, Utc};
 use serde_json::{json, Value};
 use std::time::Duration as StdDuration;
 
-const COMMAND_STATUS_HANDLED_INLINE: &str = "handled_inline";
+const COMMAND_STATUS_HANDLED_INLINE: WorkflowCommandStatus = WorkflowCommandStatus::HandledInline;
 
 #[async_trait]
 pub trait RuntimeJobExecutor: Send + Sync {


### PR DESCRIPTION
## Summary

- Add `WorkflowCommandStatus` for the existing command status vocabulary while preserving snake_case JSON/API strings.
- Route workflow command records, store write APIs, transition command status, dispatcher/worker status writes, and server call sites through the typed status boundary.
- Add database `CHECK` constraints for `workflow_commands.status` and `runtime_jobs.status`.
- Return the latest runtime job for command dedupe by ordering `created_at DESC, id DESC`, with a regression test for multiple jobs on one command.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p harness-workflow runtime_store`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Refs #1226
