### PR TITLE
Require complete review-thread snapshots for PR readiness

### DIFF
--- a/crates/harness-server/src/github_pr_snapshot.rs
+++ b/crates/harness-server/src/github_pr_snapshot.rs
@@ -367,10 +367,7 @@ fn snapshot_allows_ready(snapshot: &Value) -> bool {
 }
 
 fn snapshot_review_threads_incomplete(snapshot: &Value) -> bool {
-    snapshot
-        .get("review_threads_complete")
-        .and_then(Value::as_bool)
-        != Some(true)
+    !snapshot_review_threads_complete(snapshot)
 }
 
 fn snapshot_review_threads_complete(snapshot: &Value) -> bool {

--- a/crates/harness-server/src/github_pr_snapshot.rs
+++ b/crates/harness-server/src/github_pr_snapshot.rs
@@ -363,17 +363,21 @@ fn snapshot_allows_ready(snapshot: &Value) -> bool {
             .get("active_unresolved_review_threads_count")
             .and_then(Value::as_u64)
             == Some(0)
-        && snapshot
-            .get("review_threads_complete")
-            .and_then(Value::as_bool)
-            .unwrap_or(true)
+        && snapshot_review_threads_complete(snapshot)
 }
 
 fn snapshot_review_threads_incomplete(snapshot: &Value) -> bool {
     snapshot
         .get("review_threads_complete")
         .and_then(Value::as_bool)
-        == Some(false)
+        != Some(true)
+}
+
+fn snapshot_review_threads_complete(snapshot: &Value) -> bool {
+    snapshot
+        .get("review_threads_complete")
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 fn snapshot_check_failed(snapshot: &Value) -> bool {
@@ -571,6 +575,20 @@ mod tests {
         let signal = pr_feedback_signal_for_snapshot(&snapshot);
 
         assert_eq!(snapshot["review_threads_complete"], false);
+        assert_eq!(signal.signal_type, "FeedbackFound");
+    }
+
+    #[test]
+    fn missing_review_thread_completeness_emits_blocking_feedback() {
+        let target = GitHubPrSnapshotTarget::new("owner/repo", 77).unwrap();
+        let mut snapshot = normalize_github_pr_snapshot(&target, &ready_pr()).unwrap();
+        let Some(snapshot_object) = snapshot.as_object_mut() else {
+            panic!("snapshot should be an object");
+        };
+        snapshot_object.remove("review_threads_complete");
+
+        let signal = pr_feedback_signal_for_snapshot(&snapshot);
+
         assert_eq!(signal.signal_type, "FeedbackFound");
     }
 

--- a/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/pr_feedback_completion.rs
@@ -443,13 +443,10 @@ fn snapshot_review_threads_allow_ready(snapshot: &Value) -> bool {
 }
 
 fn snapshot_review_threads_are_complete(snapshot: &Value) -> bool {
-    !matches!(
-        field_bool(
-            snapshot,
-            &["review_threads_complete", "reviewThreadsComplete"]
-        ),
-        Some(false)
-    )
+    field_bool(
+        snapshot,
+        &["review_threads_complete", "reviewThreadsComplete"],
+    ) == Some(true)
 }
 
 fn snapshot_has_repair_action(snapshot: &Value) -> bool {

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -35,6 +35,7 @@ fn ready_snapshot_artifact() -> ActivityArtifact {
             "observed_at": "2026-06-06T00:00:00Z",
             "active_unresolved_review_threads": [],
             "active_unresolved_review_threads_count": 0,
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "APPROVED",
@@ -439,6 +440,63 @@ fn ready_to_merge_signal_with_current_pr_snapshot_starts_quality_gate() {
 }
 
 #[test]
+fn ready_to_merge_signal_with_missing_review_thread_completeness_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let mut artifact = ready_snapshot_artifact();
+    let Some(snapshot) = artifact.artifact.as_object_mut() else {
+        panic!("snapshot artifact should be an object");
+    };
+    snapshot.remove("review_threads_complete");
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Server-owned PR inspection claimed the PR is ready to merge.",
+    )
+    .with_artifact(artifact)
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = match reduce_runtime_job_completed(&instance, &event) {
+        Ok(Some(decision)) => decision,
+        Ok(None) => panic!("missing completeness evidence should block"),
+        Err(error) => panic!("event should parse: {error}"),
+    };
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+}
+
+#[test]
+fn ready_to_merge_signal_with_false_review_thread_completeness_blocks() {
+    let instance = pr_workflow_state("awaiting_feedback");
+    let mut artifact = ready_snapshot_artifact();
+    artifact.artifact["review_threads_complete"] = json!(false);
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Server-owned PR inspection claimed the PR is ready to merge.",
+    )
+    .with_artifact(artifact)
+    .with_signal(ActivitySignal::new(
+        "PrReadyToMerge",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = event_for_result(result);
+
+    let decision = match reduce_runtime_job_completed(&instance, &event) {
+        Ok(Some(decision)) => decision,
+        Ok(None) => panic!("false completeness evidence should block"),
+        Err(error) => panic!("event should parse: {error}"),
+    };
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("PR readiness evidence is missing"));
+}
+
+#[test]
 fn ready_to_merge_signal_from_agent_sweep_with_server_snapshot_blocks() {
     let instance = pr_workflow_state("awaiting_feedback");
     let result = ActivityResult::succeeded(
@@ -501,6 +559,7 @@ fn ready_to_merge_snapshot_accepts_quoted_pr_number() {
             "head_oid": "abc123",
             "observed_at": "2026-06-06T00:00:00Z",
             "active_unresolved_review_threads_count": 0,
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "APPROVED",
@@ -538,6 +597,7 @@ fn ready_to_merge_snapshot_for_different_pr_blocks() {
             "head_oid": "abc123",
             "observed_at": "2026-06-06T00:00:00Z",
             "active_unresolved_review_threads_count": 0,
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "APPROVED",
@@ -576,6 +636,7 @@ fn ready_to_merge_snapshot_with_required_review_blocks() {
             "head_oid": "abc123",
             "observed_at": "2026-06-06T00:00:00Z",
             "active_unresolved_review_threads_count": 0,
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "REVIEW_REQUIRED",
@@ -616,6 +677,7 @@ fn ready_to_merge_snapshot_with_unresolved_thread_array_blocks_even_when_count_z
             "active_unresolved_review_threads": [
                 {"id": "thread-1", "path": "src/lib.rs", "line": 10}
             ],
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "APPROVED",
@@ -706,6 +768,7 @@ fn child_pr_feedback_ready_snapshot_for_different_subject_pr_blocks() {
             "head_oid": "abc123",
             "observed_at": "2026-06-06T00:00:00Z",
             "active_unresolved_review_threads_count": 0,
+            "review_threads_complete": true,
             "status_check_rollup_state": "SUCCESS",
             "merge_state_status": "CLEAN",
             "review_decision": "APPROVED",


### PR DESCRIPTION
Summary:
- Require server PR snapshots to explicitly prove review-thread enumeration is complete before readiness.
- Treat missing review_threads_complete as blocking feedback in server snapshot classification.
- Add reducer and server regressions for missing/false completeness evidence.

Validation:
- cargo fmt --all -- --check
- cargo test -p harness-workflow pr_repair_evidence
- cargo test -p harness-server github_pr_snapshot
- cargo check -p harness-workflow --all-targets
- cargo check -p harness-server --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1315