### PR TITLE
Implement local Codex CLI review provider

### DIFF
--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -55,12 +55,31 @@ max_tokens = 4096
 enabled = true
 reviewer_agent = "codex"
 max_rounds = 3
+required_providers = ["codex_cli_review"]
+advisory_providers = ["gemini_github_bot", "codex_github_bot"]
 # Hosted GitHub review bots are advisory. Leave this disabled unless you
 # explicitly want Harness to post /gemini review and wait for hosted bot output.
 review_bot_auto_trigger = false
 fallback_chain = ["gemini", "codex"]
 silence_rounds_threshold = 3
 silence_min_minutes_after_commit = 30
+
+[agents.review.codex_cli_review]
+enabled = true
+cli_path = "codex"
+model = "gpt-5.5"
+reasoning_effort = "xhigh"
+base_ref = "origin/main"
+timeout_secs = 1800
+output_format = "json"
+
+[agents.review.gemini_github_bot]
+enabled = true
+auto_trigger = false
+
+[agents.review.codex_github_bot]
+enabled = true
+auto_trigger = false
 
 [gc]
 max_drafts_per_run = 5

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -9,10 +9,12 @@ use harness_core::config::agents::SandboxMode;
 use harness_core::config::agents::{CodexAgentConfig, CodexCloudConfig};
 use harness_core::types::Capability;
 use harness_sandbox::{wrap_command, SandboxSpec};
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 #[path = "codex_exec_parser.rs"]
@@ -33,6 +35,18 @@ pub struct CodexAgent {
     /// Maximum seconds of idle silence on the output stream before the
     /// subprocess is declared a zombie and terminated. `None` = no timeout.
     pub stream_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexReviewRequest {
+    pub project_root: PathBuf,
+    pub instructions: Option<String>,
+    pub base_ref: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub sandbox_mode: SandboxMode,
+    pub approval_policy: Option<String>,
+    pub env_vars: HashMap<String, String>,
 }
 
 impl CodexAgent {
@@ -110,6 +124,143 @@ impl CodexAgent {
         args.push(req.project_root.as_os_str().to_os_string());
         args.push(OsString::from(req.prompt.clone()));
         args
+    }
+
+    fn review_args(&self, req: &CodexReviewRequest) -> Vec<OsString> {
+        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let reasoning_effort = req
+            .reasoning_effort
+            .as_deref()
+            .unwrap_or(&self.reasoning_effort);
+        let mut args = vec![
+            OsString::from("-C"),
+            req.project_root.as_os_str().to_os_string(),
+            OsString::from("-m"),
+            OsString::from(model),
+            OsString::from("-c"),
+            OsString::from(format!("model_reasoning_effort=\"{}\"", reasoning_effort)),
+        ];
+        push_codex_sandbox_args(&mut args, req.sandbox_mode);
+        if let Some(approval_policy) = req.approval_policy.as_deref() {
+            push_codex_approval_policy_args(&mut args, approval_policy);
+        }
+        if self.cloud.enabled {
+            args.push(OsString::from("--ephemeral"));
+        }
+
+        args.push(OsString::from("review"));
+        if let Some(base_ref) = req.base_ref.as_deref().filter(|value| !value.is_empty()) {
+            args.push(OsString::from("--base"));
+            args.push(OsString::from(base_ref));
+        }
+        if req.instructions.is_some() {
+            args.push(OsString::from("-"));
+        }
+        args
+    }
+
+    pub async fn execute_review(
+        &self,
+        req: CodexReviewRequest,
+    ) -> harness_core::error::Result<AgentResponse> {
+        self.run_setup_phase(&req.project_root).await?;
+
+        let review_args = self.review_args(&req);
+        let sandbox_spec = SandboxSpec::new(req.sandbox_mode, &req.project_root);
+        let wrapped_command =
+            wrap_command(&self.cli_path, &review_args, &sandbox_spec).map_err(|error| {
+                harness_core::error::HarnessError::AgentExecution(format!(
+                    "sandbox setup failed for codex review: {error}"
+                ))
+            })?;
+
+        let mut cmd = Command::new(&wrapped_command.program);
+        cmd.args(&wrapped_command.args)
+            .current_dir(&req.project_root)
+            .stdin(if req.instructions.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        crate::set_process_group(&mut cmd);
+        crate::strip_claude_env(&mut cmd);
+        cmd.envs(&req.env_vars);
+
+        if self.cloud.enabled {
+            for key in &self.cloud.setup_secret_env {
+                cmd.env_remove(key);
+            }
+        }
+
+        tracing::debug!(
+            agent = "codex",
+            mode = "review",
+            program = %wrapped_command.program.display(),
+            current_dir = %req.project_root.display(),
+            sandbox_engine = ?wrapped_command.engine,
+            arg_count = wrapped_command.args.len(),
+            has_stdin_instructions = req.instructions.is_some(),
+            "codex review spawn prepared"
+        );
+        let mut child = cmd.spawn().map_err(|error| {
+            let message = format!(
+                "failed to run codex review: {error}; mode=review; program={}; current_dir={}; sandbox_engine={:?}; arg_count={}",
+                wrapped_command.program.display(),
+                req.project_root.display(),
+                wrapped_command.engine,
+                wrapped_command.args.len()
+            );
+            tracing::error!(agent = "codex", mode = "review", error_kind = ?error.kind(), "{message}");
+            harness_core::error::HarnessError::AgentExecution(message)
+        })?;
+
+        if let Some(instructions) = req.instructions.as_deref() {
+            let Some(mut stdin) = child.stdin.take() else {
+                return Err(harness_core::error::HarnessError::AgentExecution(
+                    "failed to open stdin for codex review instructions".to_string(),
+                ));
+            };
+            stdin
+                .write_all(instructions.as_bytes())
+                .await
+                .map_err(|error| {
+                    harness_core::error::HarnessError::AgentExecution(format!(
+                        "failed to write codex review instructions: {error}"
+                    ))
+                })?;
+        }
+
+        let output = child.wait_with_output().await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to wait for codex review: {error}"
+            ))
+        })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        log_captured_stderr_diagnostics(&stderr, self.name());
+
+        if !output.status.success() {
+            let error_output = if stderr.trim().is_empty() {
+                stdout.as_str()
+            } else {
+                stderr.as_str()
+            };
+            return Err(codex_nonzero_exit_error(output.status, error_output, None));
+        }
+
+        Ok(AgentResponse {
+            output: stdout,
+            stderr,
+            items: Vec::new(),
+            token_usage: Default::default(),
+            model: "codex".to_string(),
+            exit_code: output.status.code(),
+        })
     }
 }
 
@@ -615,3 +766,7 @@ mod tests;
 #[cfg(test)]
 #[path = "codex_failure_tests.rs"]
 mod failure_tests;
+
+#[cfg(test)]
+#[path = "codex_review_tests.rs"]
+mod review_tests;

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -149,6 +149,13 @@ impl CodexAgent {
         if let Some(approval_policy) = req.approval_policy.as_deref() {
             push_codex_approval_policy_args(&mut args, approval_policy);
         }
+        if let Some(instructions) = req
+            .instructions
+            .as_deref()
+            .filter(|_| review_uses_config_instructions(req))
+        {
+            push_codex_developer_instructions_args(&mut args, instructions);
+        }
         if self.cloud.enabled {
             args.push(OsString::from("--ephemeral"));
         }
@@ -281,6 +288,10 @@ fn review_uses_stdin_prompt(req: &CodexReviewRequest) -> bool {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .is_none()
+}
+
+fn review_uses_config_instructions(req: &CodexReviewRequest) -> bool {
+    req.instructions.is_some() && !review_uses_stdin_prompt(req)
 }
 
 #[derive(Debug)]
@@ -734,6 +745,14 @@ fn push_codex_approval_policy_args(args: &mut Vec<OsString>, approval_policy: &s
     args.push(OsString::from("-c"));
     args.push(OsString::from(format!(
         "approval_policy=\"{approval_policy}\""
+    )));
+}
+
+fn push_codex_developer_instructions_args(args: &mut Vec<OsString>, instructions: &str) {
+    let instructions = escape_codex_config_string(instructions);
+    args.push(OsString::from("-c"));
+    args.push(OsString::from(format!(
+        "developer_instructions=\"{instructions}\""
     )));
 }
 

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -132,6 +132,11 @@ impl CodexAgent {
             .reasoning_effort
             .as_deref()
             .unwrap_or(&self.reasoning_effort);
+        let base_ref = req
+            .base_ref
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
         let mut args = vec![
             OsString::from("-C"),
             req.project_root.as_os_str().to_os_string(),
@@ -149,11 +154,11 @@ impl CodexAgent {
         }
 
         args.push(OsString::from("review"));
-        if let Some(base_ref) = req.base_ref.as_deref().filter(|value| !value.is_empty()) {
+        if let Some(base_ref) = base_ref {
             args.push(OsString::from("--base"));
             args.push(OsString::from(base_ref));
         }
-        if req.instructions.is_some() {
+        if review_uses_stdin_prompt(req) {
             args.push(OsString::from("-"));
         }
         args
@@ -166,6 +171,7 @@ impl CodexAgent {
         self.run_setup_phase(&req.project_root).await?;
 
         let review_args = self.review_args(&req);
+        let use_stdin_prompt = review_uses_stdin_prompt(&req);
         let sandbox_spec = SandboxSpec::new(req.sandbox_mode, &req.project_root);
         let wrapped_command =
             wrap_command(&self.cli_path, &review_args, &sandbox_spec).map_err(|error| {
@@ -177,7 +183,7 @@ impl CodexAgent {
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
-            .stdin(if req.instructions.is_some() {
+            .stdin(if use_stdin_prompt {
                 Stdio::piped()
             } else {
                 Stdio::null()
@@ -203,7 +209,7 @@ impl CodexAgent {
             current_dir = %req.project_root.display(),
             sandbox_engine = ?wrapped_command.engine,
             arg_count = wrapped_command.args.len(),
-            has_stdin_instructions = req.instructions.is_some(),
+            has_stdin_instructions = use_stdin_prompt,
             "codex review spawn prepared"
         );
         let mut child = cmd.spawn().map_err(|error| {
@@ -218,7 +224,10 @@ impl CodexAgent {
             harness_core::error::HarnessError::AgentExecution(message)
         })?;
 
-        if let Some(instructions) = req.instructions.as_deref() {
+        if use_stdin_prompt {
+            let Some(instructions) = req.instructions.as_deref() else {
+                unreachable!("review stdin prompt requires instructions");
+            };
             let Some(mut stdin) = child.stdin.take() else {
                 return Err(harness_core::error::HarnessError::AgentExecution(
                     "failed to open stdin for codex review instructions".to_string(),
@@ -262,6 +271,16 @@ impl CodexAgent {
             exit_code: output.status.code(),
         })
     }
+}
+
+fn review_uses_stdin_prompt(req: &CodexReviewRequest) -> bool {
+    req.instructions.is_some()
+        && req
+            .base_ref
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
 }
 
 #[derive(Debug)]

--- a/crates/harness-agents/src/codex_review_tests.rs
+++ b/crates/harness-agents/src/codex_review_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+use std::fs;
+
+#[test]
+fn review_args_use_native_review_subcommand_with_base_and_stdin_prompt() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
+    let request = CodexReviewRequest {
+        project_root: PathBuf::from("/tmp/project"),
+        instructions: Some("Return a harness-review-report block.".to_string()),
+        base_ref: Some("origin/main".to_string()),
+        model: Some("gpt-test".to_string()),
+        reasoning_effort: Some("xhigh".to_string()),
+        sandbox_mode: SandboxMode::ReadOnlyWithNetwork,
+        approval_policy: Some("never".to_string()),
+        env_vars: Default::default(),
+    };
+
+    let args: Vec<String> = agent
+        .review_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+
+    assert!(!args.iter().any(|arg| arg == "exec"));
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-C", "/tmp/project"]));
+    assert!(args.windows(2).any(|window| window == ["-m", "gpt-test"]));
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-c", "model_reasoning_effort=\"xhigh\""]));
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-c", "approval_policy=\"never\""]));
+    assert!(args
+        .windows(3)
+        .any(|window| window == ["review", "--base", "origin/main"]));
+    assert_eq!(args.last().map(String::as_str), Some("-"));
+}
+
+#[tokio::test]
+async fn execute_review_runs_native_review_and_returns_raw_stdout() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let args_file = dir.path().join("args.txt");
+    let stdin_file = dir.path().join("stdin.txt");
+    let script = format!(
+        r#"
+#!/bin/sh
+set -eu
+printf '%s\n' "$@" > '{}'
+cat > '{}'
+printf '%s\n' '```harness-review-report'
+printf '%s\n' '{{"decision":"approved","summary":"ok","findings":[]}}'
+printf '%s\n' '```'
+"#,
+        args_file.display(),
+        stdin_file.display(),
+    );
+    let script_path = dir.path().join("mock-codex-review.sh");
+    fs::write(&script_path, script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms)?;
+    }
+    let agent = CodexAgent::new(script_path, SandboxMode::DangerFullAccess);
+
+    let response = agent
+        .execute_review(CodexReviewRequest {
+            project_root: dir.path().to_path_buf(),
+            instructions: Some("structured review instructions".to_string()),
+            base_ref: Some("origin/main".to_string()),
+            model: Some("gpt-test".to_string()),
+            reasoning_effort: Some("high".to_string()),
+            sandbox_mode: SandboxMode::DangerFullAccess,
+            approval_policy: Some("never".to_string()),
+            env_vars: Default::default(),
+        })
+        .await?;
+
+    let args = fs::read_to_string(args_file)?;
+    assert!(args.lines().any(|line| line == "review"));
+    assert!(args.lines().any(|line| line == "--base"));
+    assert!(args.lines().any(|line| line == "origin/main"));
+    assert!(args.lines().any(|line| line == "-"));
+    assert_eq!(
+        fs::read_to_string(stdin_file)?,
+        "structured review instructions"
+    );
+    assert!(response.output.contains("```harness-review-report"));
+    assert_eq!(response.exit_code, Some(0));
+    Ok(())
+}

--- a/crates/harness-agents/src/codex_review_tests.rs
+++ b/crates/harness-agents/src/codex_review_tests.rs
@@ -1,19 +1,23 @@
 use super::*;
 use std::fs;
 
-#[test]
-fn review_args_use_native_review_subcommand_with_base_and_stdin_prompt() {
-    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
-    let request = CodexReviewRequest {
+fn review_request(base_ref: Option<&str>) -> CodexReviewRequest {
+    CodexReviewRequest {
         project_root: PathBuf::from("/tmp/project"),
         instructions: Some("Return a harness-review-report block.".to_string()),
-        base_ref: Some("origin/main".to_string()),
+        base_ref: base_ref.map(str::to_string),
         model: Some("gpt-test".to_string()),
         reasoning_effort: Some("xhigh".to_string()),
         sandbox_mode: SandboxMode::ReadOnlyWithNetwork,
         approval_policy: Some("never".to_string()),
         env_vars: Default::default(),
-    };
+    }
+}
+
+#[test]
+fn review_args_use_native_review_subcommand_with_base_without_stdin_prompt() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
+    let request = review_request(Some("origin/main"));
 
     let args: Vec<String> = agent
         .review_args(&request)
@@ -35,17 +39,32 @@ fn review_args_use_native_review_subcommand_with_base_and_stdin_prompt() {
     assert!(args
         .windows(3)
         .any(|window| window == ["review", "--base", "origin/main"]));
+    assert!(!args.iter().any(|arg| arg == "-"));
+}
+
+#[test]
+fn review_args_use_stdin_prompt_without_base() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
+    let request = review_request(None);
+
+    let args: Vec<String> = agent
+        .review_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+
+    assert!(args.iter().any(|arg| arg == "review"));
+    assert!(!args.iter().any(|arg| arg == "--base"));
     assert_eq!(args.last().map(String::as_str), Some("-"));
 }
 
 #[tokio::test]
-async fn execute_review_runs_native_review_and_returns_raw_stdout() -> anyhow::Result<()> {
+async fn execute_review_omits_stdin_when_base_ref_is_set() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let args_file = dir.path().join("args.txt");
     let stdin_file = dir.path().join("stdin.txt");
     let script = format!(
-        r#"
-#!/bin/sh
+        r#"#!/bin/sh
 set -eu
 printf '%s\n' "$@" > '{}'
 cat > '{}'
@@ -84,11 +103,8 @@ printf '%s\n' '```'
     assert!(args.lines().any(|line| line == "review"));
     assert!(args.lines().any(|line| line == "--base"));
     assert!(args.lines().any(|line| line == "origin/main"));
-    assert!(args.lines().any(|line| line == "-"));
-    assert_eq!(
-        fs::read_to_string(stdin_file)?,
-        "structured review instructions"
-    );
+    assert!(!args.lines().any(|line| line == "-"));
+    assert_eq!(fs::read_to_string(stdin_file)?, "");
     assert!(response.output.contains("```harness-review-report"));
     assert_eq!(response.exit_code, Some(0));
     Ok(())

--- a/crates/harness-agents/src/codex_review_tests.rs
+++ b/crates/harness-agents/src/codex_review_tests.rs
@@ -36,6 +36,11 @@ fn review_args_use_native_review_subcommand_with_base_without_stdin_prompt() {
     assert!(args
         .windows(2)
         .any(|window| window == ["-c", "approval_policy=\"never\""]));
+    assert!(args.windows(2).any(|window| {
+        window[0] == "-c"
+            && window[1]
+                .starts_with("developer_instructions=\"Return a harness-review-report block.")
+    }));
     assert!(args
         .windows(3)
         .any(|window| window == ["review", "--base", "origin/main"]));
@@ -55,6 +60,9 @@ fn review_args_use_stdin_prompt_without_base() {
 
     assert!(args.iter().any(|arg| arg == "review"));
     assert!(!args.iter().any(|arg| arg == "--base"));
+    assert!(!args
+        .iter()
+        .any(|arg| arg.starts_with("developer_instructions=")));
     assert_eq!(args.last().map(String::as_str), Some("-"));
 }
 
@@ -103,6 +111,9 @@ printf '%s\n' '```'
     assert!(args.lines().any(|line| line == "review"));
     assert!(args.lines().any(|line| line == "--base"));
     assert!(args.lines().any(|line| line == "origin/main"));
+    assert!(args.lines().any(|line| {
+        line.starts_with("developer_instructions=\"structured review instructions")
+    }));
     assert!(!args.lines().any(|line| line == "-"));
     assert_eq!(fs::read_to_string(stdin_file)?, "");
     assert!(response.output.contains("```harness-review-report"));

--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -1,7 +1,16 @@
 use harness_agents::claude::ClaudeCodeAgent;
-use harness_core::{agent::AgentRequest, agent::CodeAgent, config::HarnessConfig, prompts};
+use harness_agents::codex::{CodexAgent, CodexReviewRequest};
+use harness_core::{
+    agent::AgentRequest,
+    agent::CodeAgent,
+    config::{agents::SandboxMode, HarnessConfig},
+    prompts,
+    review::{parse_review_report, ReviewDecision, ReviewProviderKind},
+};
 use std::path::PathBuf;
 use tokio::time::{sleep, Duration};
+
+const CODEX_CLI_REVIEW_PROVIDER_ID: &str = "codex_cli_review";
 
 fn create_agent(config: &HarnessConfig) -> ClaudeCodeAgent {
     ClaudeCodeAgent::new(
@@ -81,6 +90,117 @@ pub async fn loop_pr(
         },
     )
     .await
+}
+
+pub async fn review(
+    config: &HarnessConfig,
+    pr: u64,
+    provider: String,
+    base: Option<String>,
+    project: PathBuf,
+) -> anyhow::Result<()> {
+    if provider != CODEX_CLI_REVIEW_PROVIDER_ID {
+        anyhow::bail!(
+            "unsupported review provider `{provider}`; supported provider: {CODEX_CLI_REVIEW_PROVIDER_ID}"
+        );
+    }
+
+    let mut review_config = config.agents.review.codex_cli_review.clone();
+    if let Some(base) = base {
+        review_config.base_ref = base;
+    }
+    if review_config.base_ref.trim().is_empty() {
+        anyhow::bail!("codex_cli_review requires a non-empty base ref");
+    }
+
+    let mut agent = CodexAgent::new(
+        review_config.cli_path.clone(),
+        SandboxMode::ReadOnlyWithNetwork,
+    )
+    .with_stream_timeout(Some(review_config.timeout_secs));
+    agent.default_model = review_config.model.clone();
+    agent.reasoning_effort = review_config.reasoning_effort.clone();
+
+    let started_at = chrono::Utc::now();
+    let response = tokio::time::timeout(
+        Duration::from_secs(review_config.timeout_secs.max(1)),
+        agent.execute_review(CodexReviewRequest {
+            project_root: project,
+            instructions: Some(codex_cli_review_instructions(
+                pr,
+                &review_config.base_ref,
+                &review_config.output_format,
+            )),
+            base_ref: Some(review_config.base_ref.clone()),
+            model: Some(review_config.model),
+            reasoning_effort: Some(review_config.reasoning_effort),
+            sandbox_mode: SandboxMode::ReadOnlyWithNetwork,
+            approval_policy: Some("never".to_string()),
+            env_vars: Default::default(),
+        }),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "codex_cli_review timed out after {}s",
+            review_config.timeout_secs.max(1)
+        )
+    })??;
+    let completed_at = chrono::Utc::now();
+
+    let report = parse_review_report(
+        CODEX_CLI_REVIEW_PROVIDER_ID,
+        ReviewProviderKind::LocalCli,
+        &response.output,
+        started_at,
+        completed_at,
+    );
+    println!("{}", serde_json::to_string_pretty(&report)?);
+
+    match report.decision {
+        ReviewDecision::Approved => Ok(()),
+        ReviewDecision::ChangesRequested => {
+            anyhow::bail!("codex_cli_review requested changes for PR #{pr}")
+        }
+        ReviewDecision::Failed | ReviewDecision::TimedOut | ReviewDecision::Skipped => {
+            anyhow::bail!(
+                "codex_cli_review did not approve PR #{pr}: {}",
+                report.summary
+            )
+        }
+    }
+}
+
+fn codex_cli_review_instructions(pr: u64, base_ref: &str, output_format: &str) -> String {
+    let report_format = if output_format.eq_ignore_ascii_case("json") {
+        "Return exactly one fenced `harness-review-report` JSON block with this shape:\n\
+         ```harness-review-report\n\
+         {\"decision\":\"approved|changes_requested|failed|timed_out|skipped\",\
+         \"summary\":\"concise summary\",\
+         \"findings\":[{\"severity\":\"critical|high|medium|low\",\
+         \"category\":\"security|correctness|data_integrity|concurrency|performance|test_gap|maintainability|other\",\
+         \"path\":\"optional path or null\",\
+         \"line\":123,\
+         \"message\":\"finding\",\
+         \"evidence\":\"optional evidence or null\",\
+         \"recommendation\":\"optional recommendation or null\",\
+         \"blocking\":true,\
+         \"confidence\":0.9}]}\n\
+         ```"
+    } else {
+        "If everything is safe, put APPROVED on the last line. Otherwise list each blocking issue on its own line prefixed with ISSUE:."
+    };
+
+    format!(
+        "You are the configured codex_cli_review provider for PR #{pr}.\n\
+         Review the local workspace against base ref `{base_ref}` as a read-only provider.\n\n\
+         Requirements:\n\
+         - Inspect the PR intent, diff, and changed files before deciding.\n\
+         - Focus on security, logic, data integrity, error handling, and missing tests.\n\
+         - Do not modify files, commit, push, or post GitHub comments.\n\
+         - Treat unparseable or incomplete evidence as a failed provider review.\n\
+         {report_format}"
+    )
 }
 
 /// Resolve `owner/repo` slug from a PR URL.

--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -251,6 +251,19 @@ pub struct LoopArgs {
     pub project: std::path::PathBuf,
 }
 
+#[derive(Args)]
+pub struct ReviewArgs {
+    /// Review provider to run
+    #[arg(long, default_value = "codex_cli_review")]
+    pub provider: String,
+    /// Base ref for local PR diff review
+    #[arg(long)]
+    pub base: Option<String>,
+    /// Project directory
+    #[arg(long, default_value = ".")]
+    pub project: std::path::PathBuf,
+}
+
 #[derive(Subcommand)]
 pub enum PrCommand {
     /// Implement a GitHub issue, create a PR, then run the review loop
@@ -266,6 +279,13 @@ pub enum PrCommand {
         pr: u64,
         #[command(flatten)]
         args: LoopArgs,
+    },
+    /// Run a local review provider for an existing PR branch
+    Review {
+        /// GitHub PR number
+        pr: u64,
+        #[command(flatten)]
+        args: ReviewArgs,
     },
 }
 
@@ -828,6 +848,9 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 crate::cmd::pr::loop_pr(&config, pr, args.wait, args.max_rounds, args.project)
                     .await?;
             }
+            PrCommand::Review { pr, args } => {
+                crate::cmd::pr::review(&config, pr, args.provider, args.base, args.project).await?;
+            }
         },
 
         Command::Plan { cmd } => match cmd {
@@ -1330,6 +1353,34 @@ mod tests {
                 assert_eq!(args.max_rounds, 3);
             }
             _ => panic!("expected Pr Loop command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_pr_review_with_provider_and_base() {
+        let cli = Cli::try_parse_from([
+            "harness",
+            "pr",
+            "review",
+            "99",
+            "--provider",
+            "codex_cli_review",
+            "--base",
+            "origin/main",
+            "--project",
+            "/tmp/project",
+        ])
+        .expect("pr review should parse");
+        match cli.command {
+            Command::Pr {
+                cmd: PrCommand::Review { pr, args },
+            } => {
+                assert_eq!(pr, 99);
+                assert_eq!(args.provider, "codex_cli_review");
+                assert_eq!(args.base.as_deref(), Some("origin/main"));
+                assert_eq!(args.project, PathBuf::from("/tmp/project"));
+            }
+            _ => panic!("expected Pr Review command"),
         }
     }
 

--- a/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
+++ b/crates/harness-server/src/task_executor/agent_review_provider_gate.rs
@@ -1,12 +1,13 @@
 use crate::task_runner::{mutate_and_persist, RoundResult, TaskId, TaskStore};
 use chrono::{DateTime, Utc};
-use harness_core::agent::{AgentRequest, CodeAgent};
+use harness_agents::codex::CodexReviewRequest;
+use harness_core::agent::AgentResponse;
 use harness_core::config::agents::{AgentReviewConfig, SandboxMode};
 use harness_core::review::{
     evaluate_review_gate, parse_review_report, ReviewDecision, ReviewGateProviderReport,
     ReviewGateResult, ReviewProviderKind, ReviewProviderRole, ReviewReport,
 };
-use harness_core::types::{ContextItem, ExecutionPhase};
+use harness_core::types::ContextItem;
 use std::collections::HashMap;
 use std::path::Path;
 use tokio::time::Duration;
@@ -15,6 +16,24 @@ pub(crate) type AgentReviewGateReport = Option<ReviewGateProviderReport>;
 
 const CODEX_CLI_REVIEW_PROVIDER_ID: &str = "codex_cli_review";
 const CODEX_AGENT_REVIEW_PROVIDER_ID: &str = "codex_agent_review";
+
+#[async_trait::async_trait]
+trait CodexCliReviewRunner: Send + Sync {
+    async fn execute_review(
+        &self,
+        req: CodexReviewRequest,
+    ) -> harness_core::error::Result<AgentResponse>;
+}
+
+#[async_trait::async_trait]
+impl CodexCliReviewRunner for harness_agents::codex::CodexAgent {
+    async fn execute_review(
+        &self,
+        req: CodexReviewRequest,
+    ) -> harness_core::error::Result<AgentResponse> {
+        harness_agents::codex::CodexAgent::execute_review(self, req).await
+    }
+}
 
 pub(crate) struct CodexCliReviewProviderRequest<'a> {
     pub(crate) review_config: &'a AgentReviewConfig,
@@ -106,28 +125,29 @@ pub(crate) async fn run_codex_cli_review_provider(
         .reasoning_effort
         .clone();
 
-    run_codex_cli_review_provider_with_agent(store, task_id, &provider, request, turns_used).await
+    run_codex_cli_review_provider_with_runner(store, task_id, &provider, request, turns_used).await
 }
 
-pub(crate) async fn run_codex_cli_review_provider_with_agent(
+async fn run_codex_cli_review_provider_with_runner(
     store: &TaskStore,
     task_id: &TaskId,
-    provider: &dyn CodeAgent,
+    provider: &dyn CodexCliReviewRunner,
     request: CodexCliReviewProviderRequest<'_>,
     turns_used: &mut u32,
 ) -> anyhow::Result<ReviewGateProviderReport> {
     let started_at = Utc::now();
-    let agent_request = AgentRequest {
-        prompt: codex_cli_review_prompt(
-            request.pr_url,
-            request.project_type,
-            &request.review_config.codex_cli_review.base_ref,
-            &request.review_config.codex_cli_review.output_format,
-        ),
+    let instructions = codex_cli_review_prompt(
+        request.pr_url,
+        request.project_type,
+        &request.review_config.codex_cli_review.base_ref,
+        &request.review_config.codex_cli_review.output_format,
+        request.context_items.len(),
+    );
+    let review_request = CodexReviewRequest {
         project_root: request.project.to_path_buf(),
-        context: request.context_items.to_vec(),
-        execution_phase: Some(ExecutionPhase::SimpleReview),
-        sandbox_mode: Some(SandboxMode::ReadOnlyWithNetwork),
+        instructions: Some(instructions),
+        base_ref: Some(request.review_config.codex_cli_review.base_ref.clone()),
+        sandbox_mode: SandboxMode::ReadOnlyWithNetwork,
         approval_policy: Some("never".to_string()),
         model: Some(request.review_config.codex_cli_review.model.clone()),
         reasoning_effort: Some(
@@ -138,13 +158,12 @@ pub(crate) async fn run_codex_cli_review_provider_with_agent(
                 .clone(),
         ),
         env_vars: request.cargo_env.clone(),
-        ..Default::default()
     };
 
     let timeout_secs = request.review_config.codex_cli_review.timeout_secs.max(1);
     let response = tokio::time::timeout(
         Duration::from_secs(timeout_secs),
-        provider.execute(agent_request),
+        provider.execute_review(review_request),
     )
     .await;
     *turns_used = turns_used.saturating_add(1);
@@ -199,6 +218,7 @@ fn codex_cli_review_prompt(
     project_type: &str,
     base_ref: &str,
     output_format: &str,
+    context_item_count: usize,
 ) -> String {
     let json_format = if output_format.eq_ignore_ascii_case("json") {
         "\nReturn exactly one fenced `harness-review-report` JSON block with this shape:\n\
@@ -222,7 +242,8 @@ fn codex_cli_review_prompt(
     format!(
         "You are the configured codex_cli_review provider for PR {pr_url}.\n\
          Review the local workspace against base ref `{base_ref}` as a read-only provider.\n\
-         Project type: {project_type}.\n\n\
+         Project type: {project_type}.\n\
+         Harness context item count: {context_item_count}.\n\n\
          Requirements:\n\
          - Inspect the PR intent, diff, and changed files before deciding.\n\
          - Focus on security, logic, data integrity, error handling, and missing tests.\n\
@@ -306,26 +327,20 @@ fn provider_policy_references(review_config: &AgentReviewConfig, provider_id: &s
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::agent::{AgentResponse, StreamItem};
-    use harness_core::types::{Capability, TokenUsage};
+    use harness_core::types::TokenUsage;
     use tokio::sync::Mutex;
 
     struct RecordingProvider {
         output: String,
-        requests: Mutex<Vec<AgentRequest>>,
+        requests: Mutex<Vec<CodexReviewRequest>>,
     }
 
     #[async_trait::async_trait]
-    impl CodeAgent for RecordingProvider {
-        fn name(&self) -> &str {
-            "recording_codex"
-        }
-
-        fn capabilities(&self) -> Vec<Capability> {
-            Vec::new()
-        }
-
-        async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+    impl CodexCliReviewRunner for RecordingProvider {
+        async fn execute_review(
+            &self,
+            req: CodexReviewRequest,
+        ) -> harness_core::error::Result<AgentResponse> {
             self.requests.lock().await.push(req);
             Ok(AgentResponse {
                 output: self.output.clone(),
@@ -335,27 +350,6 @@ mod tests {
                 model: "recording_codex".to_string(),
                 exit_code: Some(0),
             })
-        }
-
-        async fn execute_stream(
-            &self,
-            req: AgentRequest,
-            tx: tokio::sync::mpsc::Sender<StreamItem>,
-        ) -> harness_core::error::Result<()> {
-            self.requests.lock().await.push(req);
-            if tx
-                .send(StreamItem::MessageDelta {
-                    text: self.output.clone(),
-                })
-                .await
-                .is_err()
-            {
-                return Ok(());
-            }
-            if tx.send(StreamItem::Done).await.is_err() {
-                return Ok(());
-            }
-            Ok(())
         }
     }
 
@@ -378,7 +372,7 @@ mod tests {
         config.codex_cli_review.timeout_secs = 5;
         let mut turns_used = 0;
 
-        let report = run_codex_cli_review_provider_with_agent(
+        let report = run_codex_cli_review_provider_with_runner(
             &store,
             &task_id,
             &provider,
@@ -399,12 +393,14 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].model.as_deref(), Some("gpt-test"));
         assert_eq!(requests[0].reasoning_effort.as_deref(), Some("xhigh"));
-        assert_eq!(
-            requests[0].sandbox_mode,
-            Some(SandboxMode::ReadOnlyWithNetwork)
-        );
+        assert_eq!(requests[0].sandbox_mode, SandboxMode::ReadOnlyWithNetwork);
         assert_eq!(requests[0].approval_policy.as_deref(), Some("never"));
-        assert!(requests[0].prompt.contains("origin/main"));
+        assert_eq!(requests[0].base_ref.as_deref(), Some("origin/main"));
+        let Some(instructions) = requests[0].instructions.as_deref() else {
+            panic!("review instructions should be provided through stdin");
+        };
+        assert!(instructions.contains("origin/main"));
+        assert!(instructions.contains("```harness-review-report"));
         assert_eq!(report.role, ReviewProviderRole::Required);
         assert_eq!(report.report.provider_id, CODEX_CLI_REVIEW_PROVIDER_ID);
         assert_eq!(report.report.decision, ReviewDecision::Approved);
@@ -424,6 +420,7 @@ mod tests {
             "rust",
             "origin/main",
             "json",
+            0,
         );
 
         assert!(prompt.contains("```harness-review-report"));

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -63,7 +63,14 @@ cli_path = "codex"
 enabled = true
 reviewer_agent = "codex"
 max_rounds = 3
+required_providers = ["codex_cli_review"]
+advisory_providers = ["gemini_github_bot", "codex_github_bot"]
 review_bot_auto_trigger = false
+
+[agents.review.codex_cli_review]
+enabled = true
+base_ref = "origin/main"
+output_format = "json"
 
 [gc]
 max_drafts_per_run = 5
@@ -355,7 +362,21 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 | `enabled` | `true` | Enable independent agent review after PR creation. |
 | `reviewer_agent` | `"codex"` | Agent used for review. It may match the implementor when configured explicitly; Harness runs it as a separate review turn. |
 | `max_rounds` | `3` | Maximum review-fix cycles |
+| `required_providers` | `["codex_cli_review"]` | Local review providers that must approve before local completion can pass. |
+| `advisory_providers` | `["gemini_github_bot", "codex_github_bot"]` | Hosted GitHub review bots that are recorded but non-blocking unless external review is explicitly required. |
 | `review_bot_auto_trigger` | `false` | Post and wait for a hosted review bot command. When omitted with `enabled = false`, Harness keeps the hosted-bot path; when disabled, local completion requires local review approval, validation, PR-head advancement after local review fixes that changed the workspace or reported a pushed commit, unchanged reviewed PR head after CI polling, green GitHub PR checks, an open PR or already merged PR, and a configured GitHub token. |
+
+### `[agents.review.codex_cli_review]`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Enable native local `codex review` execution. |
+| `cli_path` | `"codex"` | Path to the Codex CLI binary. |
+| `model` | Codex default | Model used for the local review provider. |
+| `reasoning_effort` | Codex default | Reasoning effort passed to Codex CLI. |
+| `base_ref` | `"origin/main"` | Base ref passed to `codex review --base`. |
+| `timeout_secs` | `1800` | Maximum local review runtime. |
+| `output_format` | `"json"` | Request a fenced `harness-review-report` block for normalized gating. |
 
 ### `[review]`
 
@@ -646,6 +667,9 @@ harness skill list         # List discovered skills
 harness plan init spec.md           # Initialize execution plan
 harness plan status exec-plan.md    # Check plan status
 
+# PR review
+harness pr review 123 --provider codex_cli_review --base origin/main
+
 # Version
 harness --version
 ```
@@ -667,7 +691,7 @@ or macOS sandbox setting.
 
 ### Codex review shows "unexpected argument"
 
-Codex CLI updated. Check `codex exec --help` for current flags and update `crates/harness-agents/src/codex.rs`.
+Codex CLI updated. Check `codex review --help` for current flags and update `crates/harness-agents/src/codex.rs`.
 
 ### All tasks show `no_pr` status
 


### PR DESCRIPTION
## Summary

- run `codex_cli_review` through native `codex review` instead of `codex exec`
- add `harness pr review <pr> --provider codex_cli_review` with normalized `ReviewReport` output
- document local-first review provider defaults while keeping hosted Gemini/Codex bots advisory

## Validation

- cargo fmt --all -- --check
- cargo test -p harness-core review
- cargo test -p harness-core config
- cargo test --package harness-agents
- cargo test -p harness-server agent_review_provider_gate
- cargo test -p harness-server local_review_completion_gate
- cargo test -p harness-cli pr
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Fixes #1106